### PR TITLE
APM-828: Per collection/database/user monitoring.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,50 @@
 devel
 -----
 
+* APM-828: Per collection/database/user monitoring.
+
+  This adds optional metrics for tracking per-shard requests on DB-Servers.
+  The exported counters are:
+  - `arangodb_collection_leader_reads_total`: number of read requests on 
+    leaders, per shard, and optionally also split by user.
+  - `arangodb_collection_leader_writes_total`: number of write requests on
+    leaders, per shard, and optionally also split by user.
+          
+  The new startup option `--server.export-shard-usage-metrics` can be used to
+  opt in to these metrics. It can be set to one of the following values on
+  DB-Servers:
+  - `disabled`: no shard usage metrics are recorded nor exported. This is the
+    default value.
+  - `enabled-per-shard`: this will make DB-Servers collect per-shard usage
+    metrics.
+  - `enabled-per-shard-per-user`: this will make DB-Servers collect per-shard
+    and per-user metrics. This is more granular than `enabled-per-shard` but
+    can produce a lot of metrics.
+
+  Whenever a shard is accessed in read or write mode by one of the following 
+  operations, the metrics are populated dynamically, either with a per-user
+  label or not.
+
+  The following operations increase the counters:
+  - AQL queries: an AQL query will increase the read or write counters exactly
+    once for each involved shard. For shards that are accessed in read/write 
+    mode, only the write counter will be increased.
+  - Single-document insert, update, replace, and remove operations: for each
+    such operation, the write counter will be increased once for the affected
+    shard.
+  - Multi-document insert, update, replace, and remove operations: for each
+    such operation, the write counter will be increased once for each shard
+    that is affected by the operation. Note that this includes collection
+    truncate operations.
+  - Single- and multi-document read operations: for each such operation, the
+    read counter will be increased once for each shard that is affected by the
+    operation.
+
+  If DB-Servers are configured to collect these usage metrics, the startup
+  option `--server.usage-tracking-include-system-collections` can be used to
+  include/exclude system collections from the usage metrics. They are excluded
+  by default.
+
 * FE-377: remove broken link from JSON editor.
 
 * Fix: we cannot update a link, but have to drop and recreate it. Until now,

--- a/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
@@ -1,0 +1,29 @@
+name: arangodb_collection_leader_reads_total
+introducedIn: "3.12.0"
+help: |
+  Number of read operation requests on leaders.
+unit: number
+type: counter
+category: Transactions
+complexity: advanced
+exposedBy:
+  - dbserver
+description: |
+  This metric exposes the number of per-shard read operation requests on DB-Servers.
+  It is increased by AQL queries and single-/multi-document read operations.
+
+  An AQL query will increase the counter exactly once for shard that is involved
+  in the query in read-only mode, regardless if and how many documents/edges the
+  query actually reads from the shard. For shards that are accessed by an AQL query
+  in read/write mode, only the write counter will be increased.
+
+  For every single- or multi-document read operation, the counter will be
+  increased exactly once for each shard that is affected by the operation, even
+  if multiple documents are read from the same shard.
+  
+  This metric is not exposed by default. It is only present if the startup option 
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
+  `enabled-per-shard-per-user`. With the former setting, the metric will have
+  different labels for each shard that was read from. With the latter setting,
+  the metric will have different labels for each combination of shard and user
+  that accessed the shard.

--- a/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
@@ -1,0 +1,31 @@
+name: arangodb_collection_leader_writes_total
+introducedIn: "3.12.0"
+help: |
+  Number of write operation requests on leaders.
+unit: number
+type: counter
+category: Transactions
+complexity: advanced
+exposedBy:
+  - dbserver
+description: |
+  This metric exposes the number of per-shard write operation requests on DB-Servers.
+  It is increased by AQL queries and single-/multi-document write operations.
+
+  An AQL query will increase the counter exactly once for shard that is involved
+  in the query in write-only or read-write mode, regardless if and how many documents/edges
+  will insert or modify in the shard.
+
+  For every single- or multi-document write operation, the counter will be
+  increased exactly once for each shard that is affected by the operation, even
+  if multiple documents are inserted, modified or removed from the same shard.
+
+  For collection truncate operations, the counter is also increased exactly once for
+  each shard affected by the truncate.
+  
+  This metric is not exposed by default. It is only present if the startup option 
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
+  `enabled-per-shard-per-user`. With the former setting, the metric will have
+  different labels for each shard that was read from. With the latter setting,
+  the metric will have different labels for each combination of shard and user
+  that accessed the shard.

--- a/arangod/Aql/ClusterQuery.h
+++ b/arangod/Aql/ClusterQuery.h
@@ -49,11 +49,14 @@ class ClusterQuery : public Query {
 
   auto const& traversers() const { return _traversers; }
 
-  void prepareClusterQuery(
-      velocypack::Slice querySlice, velocypack::Slice collections,
-      velocypack::Slice variables, velocypack::Slice snippets,
-      velocypack::Slice traversals, velocypack::Builder& answer,
-      QueryAnalyzerRevisions const& analyzersRevision, bool fastPathLocking);
+  void prepareClusterQuery(velocypack::Slice querySlice,
+                           velocypack::Slice collections,
+                           velocypack::Slice variables,
+                           velocypack::Slice snippets,
+                           velocypack::Slice traversals, std::string_view user,
+                           velocypack::Builder& answer,
+                           QueryAnalyzerRevisions const& analyzersRevision,
+                           bool fastPathLocking);
 
   futures::Future<Result> finalizeClusterQuery(ErrorCode errorCode);
 

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -270,7 +270,7 @@ class ExecutionBlockImpl final : public ExecutionBlock {
 
   [[nodiscard]] QueryContext const& getQuery() const;
 
-  [[nodiscard]] auto executor() noexcept -> Executor&;
+  [[nodiscard]] auto executor() -> Executor&;
 
   [[nodiscard]] auto fetcher() noexcept -> Fetcher&;
 

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -370,8 +370,12 @@ std::unique_ptr<OutputAqlItemRow> ExecutionBlockImpl<Executor>::createOutputRow(
 }
 
 template<class Executor>
-auto ExecutionBlockImpl<Executor>::executor() noexcept -> Executor& {
+auto ExecutionBlockImpl<Executor>::executor() -> Executor& {
   TRI_ASSERT(_executor.has_value());
+  if (!_executor.has_value()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "no executor available in query");
+  }
   return *_executor;
 }
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -334,8 +334,8 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
     co_return;
   }
   q->prepareClusterQuery(querySlice, collectionBuilder.slice(), variablesSlice,
-                         snippetsSlice, traverserSlice, answerBuilder,
-                         analyzersRevision, fastPath);
+                         snippetsSlice, traverserSlice, _request->value("user"),
+                         answerBuilder, analyzersRevision, fastPath);
 
   answerBuilder.close();  // result
   answerBuilder.close();

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1137,8 +1137,8 @@ futures::Future<OperationResult> figuresOnCoordinator(
   for (auto const& p : *shards) {
     auto future = network::sendRequestRetry(
         pool, "shard:" + p.first, fuerte::RestVerb::Get,
-        "/_api/collection/" + p.first + "/figures", VPackBuffer<uint8_t>(),
-        reqOpts);
+        absl::StrCat("/_api/collection/", std::string{p.first}, "/figures"),
+        VPackBuffer<uint8_t>(), reqOpts);
     futures.emplace_back(std::move(future));
   }
 
@@ -1228,8 +1228,8 @@ futures::Future<OperationResult> countOnCoordinator(
 
     futures.emplace_back(network::sendRequestRetry(
         pool, "shard:" + p.first, fuerte::RestVerb::Get,
-        "/_api/collection/" + p.first + "/count", VPackBuffer<uint8_t>(),
-        reqOpts, std::move(headers)));
+        absl::StrCat("/_api/collection/", std::string{p.first}, "/count"),
+        VPackBuffer<uint8_t>(), reqOpts, std::move(headers)));
   }
 
   auto cb = [options](std::vector<Try<network::Response>>&& results) mutable
@@ -1558,6 +1558,12 @@ futures::Future<OperationResult> insertDocumentOnCoordinator(
           OperationOptions::stringifyOverwriteMode(options.overwriteMode));
     }
 
+    if (!ExecContext::current().user().empty()) {
+      // send name of current user, if set. note that we cannot send
+      // empty URL parameters with our networking tools right now.
+      reqOpts.param("user", ExecContext::current().user());
+    }
+
     // Now prepare the requests:
     auto* pool = trx.vocbase().server().getFeature<NetworkFeature>().pool();
     std::vector<Future<network::Response>> futures;
@@ -1702,6 +1708,12 @@ futures::Future<OperationResult> removeDocumentOnCoordinator(
                   (options.refillIndexCaches == RefillIndexCaches::kRefill)
                       ? "true"
                       : "false");
+  }
+
+  if (!ExecContext::current().user().empty()) {
+    // send name of current user, if set. note that we cannot send
+    // empty URL parameters with our networking tools right now.
+    reqOpts.param("user", ExecContext::current().user());
   }
 
   bool const isManaged =
@@ -1880,6 +1892,11 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
   reqOpts.skipScheduler = api == transaction::MethodsApi::Synchronous;
   reqOpts.param(StaticStrings::Compact,
                 (options.truncateCompact ? "true" : "false"));
+  if (!ExecContext::current().user().empty()) {
+    // send name of current user, if set. note that we cannot send
+    // empty URL parameters with our networking tools right now.
+    reqOpts.param("user", ExecContext::current().user());
+  }
 
   std::vector<Future<network::Response>> futures;
   futures.reserve(shardIds->size());
@@ -1900,8 +1917,8 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
     addTransactionHeaderForShard(trx, *shardIds, /*shard*/ p.first, headers);
     auto future = network::sendRequestRetry(
         pool, "shard:" + p.first, fuerte::RestVerb::Put,
-        "/_api/collection/" + p.first + "/truncate", std::move(buffer), reqOpts,
-        std::move(headers));
+        absl::StrCat("/_api/collection/", std::string{p.first}, "/truncate"),
+        std::move(buffer), reqOpts, std::move(headers));
     futures.emplace_back(std::move(future));
   }
 
@@ -1973,6 +1990,12 @@ Future<OperationResult> getDocumentOnCoordinator(
     reqOpts.param(StaticStrings::SilentString,
                   options.silent ? "true" : "false");
     reqOpts.param("onlyget", "true");
+  }
+
+  if (!ExecContext::current().user().empty()) {
+    // send name of current user, if set. note that we cannot send
+    // empty URL parameters with our networking tools right now.
+    reqOpts.param("user", ExecContext::current().user());
   }
 
   if (canUseFastPath) {
@@ -2117,8 +2140,8 @@ Future<OperationResult> getDocumentOnCoordinator(
 
       futures.emplace_back(network::sendRequestRetry(
           pool, "shard:" + shard, restVerb,
-          "/_api/document/" + shard + "/" +
-              StringUtils::urlEncode(key.data(), key.size()),
+          absl::StrCat("/_api/document/", std::string{shard}, "/",
+                       StringUtils::urlEncode(key.data(), key.size())),
           VPackBuffer<uint8_t>(), reqOpts, std::move(headers)));
     }
   } else {
@@ -2136,7 +2159,8 @@ Future<OperationResult> getDocumentOnCoordinator(
       }
 
       futures.emplace_back(network::sendRequestRetry(
-          pool, "shard:" + shard, restVerb, "/_api/document/" + shard,
+          pool, "shard:" + shard, restVerb,
+          absl::StrCat("/_api/document/", std::string{shard}),
           /*cannot move*/ buffer, reqOpts, std::move(headers)));
     }
   }
@@ -2198,8 +2222,7 @@ Result fetchEdgesFromEngines(
   for (auto const& engine : *engines) {
     futures.emplace_back(network::sendRequestRetry(
         pool, "server:" + engine.first, fuerte::RestVerb::Put,
-        ::edgeUrl + StringUtils::itoa(engine.second), leased->bufferRef(),
-        reqOpts));
+        absl::StrCat(::edgeUrl, engine.second), leased->bufferRef(), reqOpts));
   }
 
   for (Future<network::Response>& f : futures) {
@@ -2296,8 +2319,7 @@ Result fetchEdgesFromEngines(transaction::Methods& trx,
   for (auto const& engine : *engines) {
     futures.emplace_back(network::sendRequestRetry(
         pool, "server:" + engine.first, fuerte::RestVerb::Put,
-        ::edgeUrl + StringUtils::itoa(engine.second), leased->bufferRef(),
-        reqOpts));
+        absl::StrCat(::edgeUrl, engine.second), leased->bufferRef(), reqOpts));
   }
 
   for (Future<network::Response>& f : futures) {
@@ -2391,7 +2413,7 @@ void fetchVerticesFromEngines(
   for (auto const& engine : *engines) {
     futures.emplace_back(network::sendRequestRetry(
         pool, "server:" + engine.first, fuerte::RestVerb::Put,
-        ::vertexUrl + StringUtils::itoa(engine.second), leased->bufferRef(),
+        absl::StrCat(::vertexUrl, engine.second), leased->bufferRef(),
         reqOpts));
   }
 
@@ -2549,6 +2571,12 @@ futures::Future<OperationResult> modifyDocumentOnCoordinator(
   }
   if (options.returnOld) {
     reqOpts.param(StaticStrings::ReturnOldString, "true");
+  }
+
+  if (!ExecContext::current().user().empty()) {
+    // send name of current user, if set. note that we cannot send
+    // empty URL parameters with our networking tools right now.
+    reqOpts.param("user", ExecContext::current().user());
   }
 
   bool isManaged =

--- a/arangod/Metrics/MetricsFeature.h
+++ b/arangod/Metrics/MetricsFeature.h
@@ -41,26 +41,48 @@ namespace arangodb::metrics {
 
 class MetricsFeature final : public ArangodFeature {
  public:
+  enum class UsageTrackingMode {
+    // no tracking
+    kDisabled,
+    // tracking per shard (one-dimensional)
+    kEnabledPerShard,
+    // tracking per shard and per user (two-dimensional)
+    kEnabledPerShardPerUser,
+  };
+
   static constexpr std::string_view name() noexcept { return "Metrics"; }
 
   explicit MetricsFeature(Server& server);
 
   bool exportAPI() const noexcept;
   bool ensureWhitespace() const noexcept;
+  bool usageTrackingIncludeSystemCollections() const noexcept;
+  UsageTrackingMode usageTrackingMode() const noexcept;
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) final;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) final;
 
+  // tries to add metric. throws if such metric already exists
   template<typename MetricBuilder>
   auto add(MetricBuilder&& builder) -> typename MetricBuilder::MetricT& {
-    return static_cast<typename MetricBuilder::MetricT&>(*doAdd(builder));
+    return static_cast<typename MetricBuilder::MetricT&>(
+        *doAdd(builder, /*failIfExists*/ true));
   }
+
   template<typename MetricBuilder>
   auto addShared(MetricBuilder&& builder)  // TODO(MBkkt) Remove this method
       -> std::shared_ptr<typename MetricBuilder::MetricT> {
     return std::static_pointer_cast<typename MetricBuilder::MetricT>(
-        doAdd(builder));
+        doAdd(builder, /*failIfExists*/ true));
   }
+
+  // tries to add metric. does not fail if such metric already exists
+  template<typename MetricBuilder>
+  auto addOrUse(MetricBuilder&& builder) -> typename MetricBuilder::MetricT& {
+    return static_cast<typename MetricBuilder::MetricT&>(
+        *doAdd(builder, /*failIfExists*/ false));
+  }
+
   Metric* get(MetricKeyView const& key) const;
   bool remove(Builder const& builder);
 
@@ -88,7 +110,7 @@ class MetricsFeature final : public ArangodFeature {
   void batchRemove(std::string_view name, std::string_view labels);
 
  private:
-  std::shared_ptr<Metric> doAdd(Builder& builder);
+  std::shared_ptr<Metric> doAdd(Builder& builder, bool failIfExists);
   std::shared_lock<std::shared_mutex> initGlobalLabels() const;
 
   mutable std::shared_mutex _mutex;
@@ -109,6 +131,10 @@ class MetricsFeature final : public ArangodFeature {
   // ensure that there is whitespace before the reported value, regardless
   // of whether it is preceeded by labels or not.
   bool _ensureWhitespace;
+
+  std::string _usageTrackingModeString;
+  UsageTrackingMode _usageTrackingMode;
+  bool _usageTrackingIncludeSystemCollections;
 };
 
 }  // namespace arangodb::metrics

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -528,13 +528,19 @@ futures::Future<RestStatus> RestCollectionHandler::handleCommandPut() {
       // their own write ops to follower C one after the after, then C will
       // first see only shards from A and then only from B).
       res.reset(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-                std::string("Transaction with id '") +
-                    std::to_string(_activeTrx->tid().id()) +
-                    "' does not contain collection '" + coll->name() +
-                    "' with the required access mode.");
+                absl::StrCat("Transaction with id '", _activeTrx->tid().id(),
+                             "' does not contain collection '", coll->name(),
+                             "' with the required access mode."));
       generateError(res);
       _activeTrx.reset();
       co_return RestStatus::DONE;
+    }
+
+    if (opts.isSynchronousReplicationFrom.empty() &&
+        ServerState::instance()->isDBServer()) {
+      _activeTrx->state()->trackRequest(
+          *_activeTrx->resolver(), _vocbase.name(), coll->name(),
+          _request->value("user"), AccessMode::Type::WRITE, "truncate");
     }
 
     OperationResult opres =

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -241,7 +241,6 @@ futures::Future<futures::Unit> RestDocumentHandler::insertDocument() {
   trxOpts.delaySnapshot = !isMultiple;  // for now we only enable this for
                                         // single document operations
 
-  // find and load collection given by name or identifier
   _activeTrx = co_await createTransaction(
       cname, AccessMode::Type::WRITE, opOptions,
       transaction::OperationOriginREST{"inserting document(s)"},
@@ -270,10 +269,17 @@ futures::Future<futures::Unit> RestDocumentHandler::insertDocument() {
     // from A and then only from B).
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-        std::string("Transaction with id '") +
-            std::to_string(_activeTrx->tid().id()) +
-            "' does not contain collection '" + cname +
-            "' with the required access mode.");
+        absl::StrCat("Transaction with id '", _activeTrx->tid().id(),
+                     "' does not contain collection '", cname,
+                     "' with the required access mode."));
+  }
+
+  // track request only on leader
+  if (opOptions.isSynchronousReplicationFrom.empty() &&
+      ServerState::instance()->isDBServer()) {
+    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
+                                      cname, _request->value("user"),
+                                      AccessMode::Type::WRITE, "insert");
   }
 
   OperationResult opres =
@@ -394,6 +400,13 @@ futures::Future<futures::Unit> RestDocumentHandler::readSingleDocument(
   if (!res.ok()) {
     generateTransactionError(collection, OperationResult(res, options), "");
     co_return;
+  }
+
+  // track request on both leader and follower (in case of dirty-read requests)
+  if (ServerState::instance()->isDBServer()) {
+    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
+                                      collection, _request->value("user"),
+                                      AccessMode::Type::READ, "read");
   }
 
   if (_activeTrx->state()->options().allowDirtyReads) {
@@ -598,6 +611,15 @@ futures::Future<futures::Unit> RestDocumentHandler::modifyDocument(
     co_return;
   }
 
+  // track request only on leader
+  if (opOptions.isSynchronousReplicationFrom.empty() &&
+      ServerState::instance()->isDBServer()) {
+    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
+                                      cname, _request->value("user"),
+                                      AccessMode::Type::WRITE,
+                                      isPatch ? "update" : "replace");
+  }
+
   if (ServerState::instance()->isDBServer() &&
       (_activeTrx->state()->collection(cname, AccessMode::Type::WRITE) ==
            nullptr ||
@@ -611,10 +633,9 @@ futures::Future<futures::Unit> RestDocumentHandler::modifyDocument(
     // from A and then only from B).
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-        std::string("Transaction with id '") +
-            std::to_string(_activeTrx->tid().id()) +
-            "' does not contain collection '" + cname +
-            "' with the required access mode.");
+        absl::StrCat("Transaction with id '", _activeTrx->tid().id(),
+                     "' does not contain collection '", cname,
+                     "' with the required access mode."));
   }
 
   auto f = futures::Future<OperationResult>::makeEmpty();
@@ -746,6 +767,14 @@ futures::Future<futures::Unit> RestDocumentHandler::removeDocument() {
     co_return;
   }
 
+  // track request only on leader
+  if (opOptions.isSynchronousReplicationFrom.empty() &&
+      ServerState::instance()->isDBServer()) {
+    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
+                                      cname, _request->value("user"),
+                                      AccessMode::Type::WRITE, "remove");
+  }
+
   if (ServerState::instance()->isDBServer() &&
       (_activeTrx->state()->collection(cname, AccessMode::Type::WRITE) ==
            nullptr ||
@@ -759,10 +788,9 @@ futures::Future<futures::Unit> RestDocumentHandler::removeDocument() {
     // from A and then only from B).
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-        std::string("Transaction with id '") +
-            std::to_string(_activeTrx->tid().id()) +
-            "' does not contain collection '" + cname +
-            "' with the required access mode.");
+        absl::StrCat("Transaction with id '", _activeTrx->tid().id(),
+                     "' does not contain collection '", cname,
+                     "' with the required access mode."));
   }
 
   OperationResult opRes =
@@ -811,6 +839,12 @@ futures::Future<futures::Unit> RestDocumentHandler::readManyDocuments() {
     // there, the flag is ignored.
   }
 
+  bool success;
+  VPackSlice const search = this->parseVPackBody(success);
+  if (!success) {  // error message generated in parseVPackBody
+    co_return;
+  }
+
   _activeTrx = co_await createTransaction(
       cname, AccessMode::Type::READ, opOptions,
       transaction::OperationOriginREST{"fetching documents"});
@@ -826,10 +860,11 @@ futures::Future<futures::Unit> RestDocumentHandler::readManyDocuments() {
     co_return;
   }
 
-  bool success;
-  VPackSlice const search = this->parseVPackBody(success);
-  if (!success) {  // error message generated in parseVPackBody
-    co_return;
+  // track request on both leader and follower (in case of dirty-read requests)
+  if (ServerState::instance()->isDBServer()) {
+    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
+                                      cname, _request->value("user"),
+                                      AccessMode::Type::READ, "read-multiple");
   }
 
   if (_activeTrx->state()->options().allowDirtyReads) {

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
@@ -22,12 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "ReplicatedRocksDBTransactionState.h"
-#include <rocksdb/types.h>
 
-#include <algorithm>
-#include <limits>
-#include <numeric>
-
+#include "Basics/application-exit.h"
 #include "Futures/Utilities.h"
 #include "Replication2/StateMachines/Document/DocumentLeaderState.h"
 #include "Replication2/StateMachines/Document/DocumentFollowerState.h"
@@ -36,7 +32,11 @@
 #include "RocksDBEngine/RocksDBTransactionMethods.h"
 #include "VocBase/Identifiers/TransactionId.h"
 
-#include <Basics/application-exit.h>
+#include <rocksdb/types.h>
+
+#include <algorithm>
+#include <limits>
+#include <numeric>
 
 using namespace arangodb;
 

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -67,11 +67,8 @@
 struct TRI_vocbase_t;
 
 namespace arangodb {
+class CollectionNameResolver;
 struct ResourceMonitor;
-
-namespace aql {
-class QueryContext;
-}
 
 namespace transaction {
 class CounterGuard;
@@ -362,6 +359,11 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
   void coordinatorRerollTransactionId();
 
   std::shared_ptr<transaction::CounterGuard> counterGuard();
+
+  virtual void trackRequest(CollectionNameResolver const& resolver,
+                            std::string_view database, std::string_view shard,
+                            std::string_view user, AccessMode::Type accessMode,
+                            std::string_view context);
 
  protected:
   virtual std::unique_ptr<TransactionCollection> createTransactionCollection(

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -801,7 +801,8 @@ static void JS_ExecuteAqlJson(v8::FunctionCallbackInfo<v8::Value> const& args) {
   VPackBuilder ignoreResponse;
   query->prepareClusterQuery(VPackSlice::emptyObjectSlice(), collections,
                              variables, snippetBuilder.slice(),
-                             VPackSlice::noneSlice(), ignoreResponse,
+                             VPackSlice::noneSlice(),
+                             ExecContext::current().user(), ignoreResponse,
                              analyzersRevision, false /* fastPath */);
 
   aql::QueryResult queryResult = query->executeSync();


### PR DESCRIPTION
### Scope & Purpose

Partial implementation of https://arangodb.atlassian.net/browse/APM-828

Per collection/database/user monitoring.

  This adds optional metrics for tracking per-shard requests on DB-Servers.
  The exported counters are:
  - `arangodb_collection_leader_reads_total`: number of read requests on leaders, per shard, and optionally also split by user.
  - `arangodb_collection_leader_writes_total`: number of write requests on leaders, per shard, and optionally also split by user.

  The new startup option `--server.export-shard-usage-metrics` can be used to
  opt in to these metrics. It can be set to one of the following values on
  DB-Servers:
  - `disabled`: no shard usage metrics are recorded nor exported. This is the default value.
  - `enabled-per-shard`: this will make DB-Servers collect per-shard usage metrics.
  - `enabled-per-shard-per-user`: this will make DB-Servers collect per-shard and per-user metrics. This is more granular than `enabled-per-shard` but can produce a lot of metrics.

  Whenever a shard is accessed in read or write mode by one of the following
  operations, the metrics are populated dynamically, either with a per-user
  label or not.

  The following operations increase the counters:
  - AQL queries: an AQL query will increase the read or write counters exactly once for each involved shard. For shards that are accessed in read/write mode, only the write counter will be increased.
  - Single-document insert, update, replace, and remove operations: for each such operation, the write counter will be increased once for the affected shard.
  - Multi-document insert, update, replace, and remove operations: for each such operation, the write counter will be increased once for each shard that is affected by the operation. Note that this includes collection truncate operations.
  - Single- and multi-document read operations: for each such operation, the read counter will be increased once for each shard that is affected by the operation.

  If DB-Servers are configured to collect these usage metrics, the startup
  option `--server.usage-tracking-include-system-collections` can be used to
  include/exclude system collections from the usage metrics. They are excluded
  by default.


- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/APM-828
- [ ] Design document: 