### PR TITLE
(temporarily) suppress UBSan warnings for immer library

### DIFF
--- a/ubsan_arangodb_suppressions.txt
+++ b/ubsan_arangodb_suppressions.txt
@@ -36,3 +36,6 @@ pointer-overflow:3rdParty/lz4/lib/lz4.c
 # It's intentional perform operations with nullptr
 # TODO(MBkkt) I think it can be fixed with using uintptr_t instead of pointer
 pointer-overflow:3rdParty/iresearch/core/search/bitset_doc_iterator.cpp
+
+# potential issue in immer library, needs to be sorted out
+object-size:immer/immer/detail/hamts/node.hpp


### PR DESCRIPTION
### Scope & Purpose

(temporarily) suppress UBSan warnings for immer library.
This is a workaround so that the remaining sanitizer errors actually get visible again.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 