### PR TITLE
Simplify and fix cmake frontend build

### DIFF
--- a/cmake/frontend/aardvark.cmake
+++ b/cmake/frontend/aardvark.cmake
@@ -5,14 +5,16 @@
 find_package(Nodejs 16 REQUIRED)
 find_package(Yarn REQUIRED)
 
+set(FRONTEND_DESTINATION ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/APP/react)
+
 add_custom_target(frontend ALL
   COMMENT "create frontend build"
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/APP/react
+  WORKING_DIRECTORY ${FRONTEND_DESTINATION}
   COMMAND yarn install
   COMMAND yarn build
 )
 
 add_custom_target(frontend_clean
-  COMMAND ${CMAKE_COMMAND} -E remove_directory ${FRONTEND_DESTINATION}
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${FRONTEND_DESTINATION}/build
   COMMENT "Removing frontend artefacts"
   )

--- a/cmake/frontend/aardvark.cmake
+++ b/cmake/frontend/aardvark.cmake
@@ -5,14 +5,8 @@
 find_package(Nodejs 16 REQUIRED)
 find_package(Yarn REQUIRED)
 
-set(FRONTEND_DESTINATION ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/APP/react/build)
-
 add_custom_target(frontend ALL
-  DEPENDS ${FRONTEND_DESTINATION}
-)
-add_custom_command(# frontend
   COMMENT "create frontend build"
-  OUTPUT ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/APP/react/build
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/APP/react
   COMMAND yarn install
   COMMAND yarn build


### PR DESCRIPTION
### Scope & Purpose

The output dependency did not work as intended, because the existence of the build folder alone was already enough for make to conclude that there was nothing to do.
