### PR TITLE
Fix: counting with tombstones in iresearch can produce wrong results

### DIFF
--- a/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate-no-flushthread.js
+++ b/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate-no-flushthread.js
@@ -77,14 +77,17 @@ function recoverySuite () {
     // //////////////////////////////////////////////////////////////////////////////
 
     testIResearchLinkPopulateTruncate: function () {
-      var v = db._view(vn);
+      const v = db._view(vn);
       assertEqual(v.name(), vn);
       assertEqual(v.type(), 'arangosearch');
-      var p = v.properties().links;
+      const p = v.properties().links;
       assertTrue(p.hasOwnProperty(cn));
-      var result = db._query("FOR doc IN " + vn + " SEARCH doc.c >= 0 OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO length RETURN length").toArray();
-      var expectedResult = db._query("FOR doc IN " + cn + " FILTER doc.c >= 0 COLLECT WITH COUNT INTO length RETURN length").toArray();
-      assertEqual(result[0], expectedResult[0]);
+      // For the search query we do not use COLLECT WITH COUNT, because we have
+      // need late materialization to ensure proper counting. COLLECT WITH COUNT
+      // can return wrong results if the truncate used normal removes.
+      const result = db._query("FOR doc IN " + vn + " SEARCH doc.c >= 0 OPTIONS {waitForSync: true} RETURN doc._key").toArray();
+      const expectedResult = db._query("FOR doc IN " + cn + " FILTER doc.c >= 0 COLLECT WITH COUNT INTO length RETURN length").toArray();
+      assertEqual(result.length, expectedResult[0]);
     }
  };
 }

--- a/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate.js
+++ b/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate.js
@@ -73,14 +73,17 @@ function recoverySuite () {
     // //////////////////////////////////////////////////////////////////////////////
 
     testIResearchLinkPopulateTruncate: function () {
-      var v = db._view(vn);
+      const v = db._view(vn);
       assertEqual(v.name(), vn);
       assertEqual(v.type(), 'arangosearch');
-      var p = v.properties().links;
+      const p = v.properties().links;
       assertTrue(p.hasOwnProperty(cn));
-      var result = db._query("FOR doc IN " + vn + " SEARCH doc.c >= 0 OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO length RETURN length").toArray();
-      var expectedResult = db._query("FOR doc IN " + cn + " FILTER doc.c >= 0 COLLECT WITH COUNT INTO length RETURN length").toArray();
-      assertEqual(result[0], expectedResult[0]);
+      // For the search query we do not use COLLECT WITH COUNT, because we have
+      // need late materialization to ensure proper counting. COLLECT WITH COUNT
+      // can return wrong results if the truncate used normal removes.
+      const result = db._query("FOR doc IN " + vn + " SEARCH doc.c >= 0 OPTIONS {waitForSync: true} RETURN doc._key").toArray();
+      const expectedResult = db._query("FOR doc IN " + cn + " FILTER doc.c >= 0 COLLECT WITH COUNT INTO length RETURN length").toArray();
+      assertEqual(result.length, expectedResult[0]);
     }
  };
 }


### PR DESCRIPTION
### Scope & Purpose

In replication2 recovery we can replay the inserts + truncate, but the truncate is then executed with normal remove operations instead of a range-delete. The resulting tombstones in iresearch can lead to incorrect counting. This can be circumvented by returning the complete documents which uses late materialization.
