### PR TITLE
Bug fix/cinfra fix race link modify

### DIFF
--- a/arangod/Cluster/DropIndex.cpp
+++ b/arangod/Cluster/DropIndex.cpp
@@ -74,6 +74,17 @@ DropIndex::DropIndex(MaintenanceFeature& feature, ActionDescription const& d)
 
 DropIndex::~DropIndex() = default;
 
+void DropIndex::setState(ActionState state) {
+  if (_description.isRunEvenIfDuplicate() &&
+      (COMPLETE == state || FAILED == state) && _state != state) {
+    // calling unlockShard here is safe, because nothing before it
+    // can go throw. if some code is added before the unlock that
+    // can throw, it must be made sure that the unlock is always called
+    _feature.unlockShard(ShardID{_description.get(SHARD)});
+  }
+  ActionBase::setState(state);
+}
+
 bool DropIndex::first() {
   auto const& database = _description.get(DATABASE);
   auto const& shard = _description.get(SHARD);

--- a/arangod/Cluster/DropIndex.h
+++ b/arangod/Cluster/DropIndex.h
@@ -43,6 +43,7 @@ class DropIndex : public ActionBase {
 
   virtual ~DropIndex();
 
+  void setState(ActionState state) override final;
   virtual bool first() override final;
 
  private:

--- a/arangod/Cluster/EnsureIndex.cpp
+++ b/arangod/Cluster/EnsureIndex.cpp
@@ -97,6 +97,17 @@ arangodb::Result EnsureIndex::setProgress(double d) {
   return {};
 }
 
+void EnsureIndex::setState(ActionState state) {
+  if (_description.isRunEvenIfDuplicate() &&
+      (COMPLETE == state || FAILED == state) && _state != state) {
+    // calling unlockShard here is safe, because nothing before it
+    // can go throw. if some code is added before the unlock that
+    // can throw, it must be made sure that the unlock is always called
+    _feature.unlockShard(ShardID{_description.get(SHARD)});
+  }
+  ActionBase::setState(state);
+}
+
 bool EnsureIndex::first() {
   auto const& database = _description.get(DATABASE);
   auto const& collection = _description.get(COLLECTION);

--- a/arangod/Cluster/EnsureIndex.h
+++ b/arangod/Cluster/EnsureIndex.h
@@ -43,6 +43,7 @@ class EnsureIndex : public ActionBase {
 
   virtual ~EnsureIndex();
 
+  void setState(ActionState state) override final;
   virtual arangodb::Result setProgress(double d) override final;
   virtual bool first() override final;
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -451,10 +451,11 @@ static void handlePlanShard(
             // these actions to run in parallel to others and to similar ones.
             // Note however, that new index jobs are intentionally not
             // discovered when the shard is locked for maintenance.
-            auto indexTypeName = index.get(StaticStrings::IndexType).copyString();
-            // For replication2 there is a race on modify link, the DBServer can witness
-            // drop and create of the index at the same time.
-            // With this flag we serialize ViewIndex drop, and create on the same shard.
+            auto indexTypeName =
+                index.get(StaticStrings::IndexType).copyString();
+            // For replication2 there is a race on modify link, the DBServer can
+            // witness drop and create of the index at the same time. With this
+            // flag we serialize ViewIndex drop, and create on the same shard.
             // All other indexes can still be created in parallel.
             bool doLockShard =
                 replicationVersion == replication::Version::TWO &&
@@ -467,11 +468,11 @@ static void handlePlanShard(
                     {DATABASE, dbname},
                     {COLLECTION, colname},
                     {SHARD, shname},
-                    {StaticStrings::IndexType,
-                     std::move(indexTypeName)},
+                    {StaticStrings::IndexType, std::move(indexTypeName)},
                     {FIELDS, index.get(FIELDS).toJson()},
                     {ID, index.get(ID).copyString()}},
-                INDEX_PRIORITY, doLockShard, std::make_shared<VPackBuilder>(index)));
+                INDEX_PRIORITY, doLockShard,
+                std::make_shared<VPackBuilder>(index)));
           }
         }
       }
@@ -607,9 +608,9 @@ static void handleLocalShard(
             // want that they can run in parallel.
             // Exception are SearchIndexes, as they can conflict on attached
             // views during update.
-            // For replication2 there is a race on modify link, the DBServer can witness
-            // drop and create of the index at the same time.
-            // With this flag we serialize ViewIndex drop, and create on the same shard.
+            // For replication2 there is a race on modify link, the DBServer can
+            // witness drop and create of the index at the same time. With this
+            // flag we serialize ViewIndex drop, and create on the same shard.
             // All other indexes can still be dropped in parallel.
             bool doLockShard =
                 replicationVersion == replication::Version::TWO &&

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -87,8 +87,7 @@ static std::string_view const EDGE("edge");
 
 namespace {
 bool isViewIndex(std::string_view indexType) noexcept {
-  return indexType == iresearch::StaticStrings::ViewArangoSearchType ||
-         indexType == iresearch::IRESEARCH_INVERTED_INDEX_TYPE;
+  return indexType == iresearch::StaticStrings::ViewArangoSearchType;
 }
 };  // namespace
 


### PR DESCRIPTION
### Scope & Purpose

*This PR fixes a deserver side race during modifyLink on views. In Replication2 DBServers can actually see the index on a view being dropped, and a new one on the same fields being created in the same roundtrip. Therefore we now serialize creation of View indexes, and dropping of view indexes to One per Shard.
Note: We have the option to enhance this for One Per Shard Per View (where every view can at most have one per collection) with a bit more effort.
*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

