### PR TITLE
Get rid of initgroups avoid nsswitch, take 3

### DIFF
--- a/3rdParty/README_maintainers.md
+++ b/3rdParty/README_maintainers.md
@@ -35,7 +35,9 @@ Custom boost locator
 
 ## date
 
-Forward port of C++20 date/time class
+Forward port of C++20 date/time class. We have patched this slightly to
+avoid a totally unnecessary user database lookup which poses problems
+with static glibc builds and nsswitch.
 
 ## fakeit
 

--- a/3rdParty/date/src/tz.cpp
+++ b/3rdParty/date/src/tz.cpp
@@ -260,7 +260,12 @@ static
 std::string
 get_download_folder()
 {
-    return expand_path("~/Downloads");
+    // We use a fixed branch here instead of ~, which would lead to
+    // path name expansion. This can break on static glibc builds when
+    // running on older Linux versions with nss-modules which do not match
+    // the glibc version with which we build. This path is overwritten
+    // later anyway, so it does not matter.
+    return expand_path("/home/arangodb/Downloads");
 }
 
 #    endif // !defined(INSTALL)


### PR DESCRIPTION
It turns out that the date library we use (3rdParty) performs a user
database lookup for no good reason. Namely, when we set the folder
for tzdata, then a static string variable is first automatically
initialized to ~/Downloads, which is then immediately overwritten
by the path we set. Unfortunately, the ~ in the path is looked up
via the getpwuid glibc-internally. This poses problems on static
glibc builds when /etc/nsswitch.conf is configured in a certain way
and a different glibc version is available on the host system than
the one with which we build.

This PR fixes this by replacing `~/Downloads` with
`/home/arangodb/Downloads` which has no further consequences.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

