### PR TITLE
[Bug-Fix] Attempt to fix windows frontend build

### DIFF
--- a/cmake/frontend/aardvark.cmake
+++ b/cmake/frontend/aardvark.cmake
@@ -10,8 +10,7 @@ set(FRONTEND_DESTINATION ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/AP
 add_custom_target(frontend ALL
   COMMENT "create frontend build"
   WORKING_DIRECTORY ${FRONTEND_DESTINATION}
-  COMMAND yarn install
-  COMMAND yarn build
+  COMMAND cmd /c "yarn install && yarn build"
 )
 
 add_custom_target(frontend_clean


### PR DESCRIPTION
### Scope & Purpose

For some reason, windows does not like two commands called in a cmake `add_custom_target`.
Before:
```
COMMAND yarn install
COMMAND yarn build
```

Now: 
```
COMMAND cmd /c "yarn install && yarn build"
```

This approach has worked locally on my windows dev machine. Now need to verify this on both CIs. 

- [x] :hankey: Bugfix