### PR TITLE
Zkd External CF Name

### DIFF
--- a/arangod/RocksDBEngine/RocksDBColumnFamilyManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBColumnFamilyManager.cpp
@@ -36,13 +36,14 @@ std::array<char const*,
     RocksDBColumnFamilyManager::_internalNames = {
         "default",    "Documents",  "PrimaryIndex",  "EdgeIndex",
         "VPackIndex", "GeoIndex",   "FulltextIndex", "ReplicatedLogs",
-        "ZkdIndex",   "MdiPrefixed"};
+        "ZkdIndex",   "MdiPrefixed"};  // We have to keep `ZkdIndex` cf name for
+                                       // backwards compatibility.
 
 std::array<char const*,
            arangodb::RocksDBColumnFamilyManager::numberOfColumnFamilies>
     RocksDBColumnFamilyManager::_externalNames = {
         "definitions", "documents", "primary",         "edge", "vpack",
-        "geo",         "fulltext",  "replicated-logs", "zkd",  "mdi-prefixed"};
+        "geo",         "fulltext",  "replicated-logs", "mdi",  "mdi-prefixed"};
 
 std::array<rocksdb::ColumnFamilyHandle*,
            RocksDBColumnFamilyManager::numberOfColumnFamilies>

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -1568,6 +1568,11 @@ limited number of edge collections/shards/indexes.)");
         std::size_t index = static_cast<
             std::underlying_type<RocksDBColumnFamilyManager::Family>::type>(
             family);
+        auto introducedIn = 30800;
+        if (family == RocksDBColumnFamilyManager::Family::MdiVPackIndex ||
+            family == RocksDBColumnFamilyManager::Family::MdiIndex) {
+          introducedIn = 31200;
+        }
         options
             ->addOption("--rocksdb.max-write-buffer-number-" + name,
                         "If non-zero, overrides the value of "
@@ -1576,7 +1581,7 @@ limited number of edge collections/shards/indexes.)");
                         new UInt64Parameter(&_maxWriteBufferNumberCf[index]),
                         arangodb::options::makeDefaultFlags(
                             arangodb::options::Flags::Uncommon))
-            .setIntroducedIn(30800);
+            .setIntroducedIn(introducedIn);
       };
   for (auto family : families) {
     addMaxWriteBufferNumberCf(family);


### PR DESCRIPTION
### Scope & Purpose
Rename the external name of the ZkdIndex cf to mdi.