### PR TITLE
lazily initialize dummyChildren global

### DIFF
--- a/arangod/Agency/Node.cpp
+++ b/arangod/Agency/Node.cpp
@@ -64,8 +64,6 @@ using namespace arangodb::basics;
 using namespace arangodb::velocypack;
 using namespace arangodb;
 
-const Node::Children Node::dummyChildren = Node::Children();
-
 /// @brief Split strings by forward slashes, omitting empty strings,
 /// and ignoring multiple subsequent forward slashes
 std::vector<std::string> Node::split(std::string_view str) {
@@ -682,6 +680,7 @@ Node::Children const& Node::children() const {
   if (auto children = std::get_if<Children>(&_value); children) {
     return *children;
   }
+  static Node::Children dummyChildren{};
   return dummyChildren;
 }
 

--- a/arangod/Agency/Node.h
+++ b/arangod/Agency/Node.h
@@ -433,8 +433,6 @@ class Node : public std::enable_shared_from_this<Node> {
   explicit Node(Args&&... args) : _value(std::forward<Args>(args)...) {}
 
   VariantType _value;
-
-  static Children const dummyChildren;
 };
 
 inline std::ostream& operator<<(std::ostream& o, Node const& n) {


### PR DESCRIPTION
### Scope & Purpose

Lazily initialize `dummyChildren` global variable.
This may or may not prevent initialization order issues across static variables.
Otherwise it should not do any harm.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 