### PR TITLE
For replication2 activate failure points only on leaders

### DIFF
--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1667,9 +1667,17 @@ Result IResearchDataStore::insert(transaction::Methods& trx,
       // passed a test. This can lead to the race that we activate a
       // failurePoint for the next insert, that is still applied to the previous
       // insert on the followers.
+      bool isAllLeaders = false;
+      state.allCollections([&](TransactionCollection const& c) {
+        // The transaction can only be all followers are all leaders, never a
+        // mix So just take first collections information
+        isAllLeaders = c.collection()->isLeadingShard();
+        // always return false, do abort iteration.
+        return false;
+      });
       if (trx.vocbase().replicationVersion() !=
               arangodb::replication::Version::TWO ||
-          !state.isFollowerTransaction()) {
+          isAllLeaders) {
         return {TRI_ERROR_DEBUG};
       }
     }
@@ -1679,13 +1687,21 @@ Result IResearchDataStore::insert(transaction::Methods& trx,
   TRI_IF_FAILURE("ArangoSearch::BlockInsertsWithoutIndexCreationHint") {
     // For replication two only the Leader should throw this error.
     // Note: Due to the asynchronous nature of replication2, there is a chance
-    // a follower is applying an operation after the leader successfully passed
-    // a test. This can lead to the race that we activate a failurePoint for the
-    // next insert, that is still applied to the previous insert on the
-    // followers.
+    // a follower is applying an operation after the leader successfully
+    // passed a test. This can lead to the race that we activate a
+    // failurePoint for the next insert, that is still applied to the previous
+    // insert on the followers.
+    bool isAllLeaders = false;
+    state.allCollections([&](TransactionCollection const& c) {
+      // The transaction can only be all followers are all leaders, never a mix
+      // So just take first collections information
+      isAllLeaders = c.collection()->isLeadingShard();
+      // always return false, do abort iteration.
+      return false;
+    });
     if (trx.vocbase().replicationVersion() !=
             arangodb::replication::Version::TWO ||
-        !state.isFollowerTransaction()) {
+        isAllLeaders) {
       return {TRI_ERROR_DEBUG};
     }
   }


### PR DESCRIPTION
### Scope & Purpose

*The two failure points modified in this PR potentially produce debug errors on the followers for Replication2.
Replication2 assumes the follower cannot fail to insert a document, if the leader can do it, otherwise we would break protocol guarantees.*

in the test activating the failure point I have seen the following, valid!, race happening:

1) Insert documents on Leader
2) Replicate Documents to Follower
3) Follower confirms it has written the Replication to Replication2 Log, but not yet applied.
4) Leader continues with the test, and successfully passes the next assertion.
5) Failure Point activated
6) Do another Insert
7) Leader successfully triggers the failure point an throws error as expected.
8) Now the Follower applies the insert (1) to Storage, and hits the FailurePoint (which was intended for (7) ) causing havoc to the replication protocol.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

