### PR TITLE
[Bug-Fix] Do not copy UI's node_modules folder in V8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Bug-Fix: Fixes the unnecessary copy of the `node_modules` folder located
+  in the frontend directory. This will also improve the startup speed of
+  the V8 feature.
+
 * Updated ArangoDB Starter to v0.18.0-preview-2.
 
 * APM-828: Per collection/database/user monitoring.

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -692,8 +692,9 @@ void V8DealerFeature::copyInstallationFiles() {
     // needed in release builds
     std::string const versionAppendix = std::regex_replace(
         rest::Version::getServerVersion(), std::regex("-.*$"), "");
-    std::string const eslintPath =
-        FileUtils::buildFilename("js", "node", "node_modules", "eslint");
+    std::string const uiNodeModulesPath =
+        FileUtils::buildFilename("js", "apps", "system", "_admin", "aardvark",
+                                 "APP", "react", "node_modules");
 
     // .bin directories could be harmful, and .map files are large and
     // unnecessary
@@ -702,7 +703,7 @@ void V8DealerFeature::copyInstallationFiles() {
 
     size_t copied = 0;
 
-    auto filter = [&eslintPath, &binDirectory,
+    auto filter = [&uiNodeModulesPath, &binDirectory,
                    &copied](std::string const& filename) -> bool {
       if (filename.ends_with(".map")) {
         // filename ends with ".map". filter it out!
@@ -715,9 +716,7 @@ void V8DealerFeature::copyInstallationFiles() {
 
       std::string normalized = filename;
       FileUtils::normalizePath(normalized);
-      if ((normalized.size() >= eslintPath.size() &&
-           normalized.compare(normalized.size() - eslintPath.size(),
-                              eslintPath.size(), eslintPath) == 0)) {
+      if (normalized.ends_with(uiNodeModulesPath)) {
         // filter it out!
         return true;
       }

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -694,6 +694,9 @@ void V8DealerFeature::copyInstallationFiles() {
         rest::Version::getServerVersion(), std::regex("-.*$"), "");
     std::string const eslintPath =
         FileUtils::buildFilename("js", "node", "node_modules", "eslint");
+    std::string const uiNodeModulesPath =
+        FileUtils::buildFilename("js", "apps", "system", "_admin", "aardvark",
+                                 "APP", "react", "node_modules");
 
     // .bin directories could be harmful, and .map files are large and
     // unnecessary
@@ -702,7 +705,19 @@ void V8DealerFeature::copyInstallationFiles() {
 
     size_t copied = 0;
 
-    auto filter = [&eslintPath, &binDirectory,
+    auto doFilterPath = [](std::string_view normalizedPath,
+                           std::string_view filterPath) -> bool {
+      if ((normalizedPath.size() >= filterPath.size() &&
+           normalizedPath.compare(normalizedPath.size() - filterPath.size(),
+                                  filterPath.size(), filterPath) == 0)) {
+        // filter it out!
+        return true;
+      }
+      return false;
+    };
+
+    auto filter = [&eslintPath, &uiNodeModulesPath, &doFilterPath,
+                   &binDirectory,
                    &copied](std::string const& filename) -> bool {
       if (filename.ends_with(".map")) {
         // filename ends with ".map". filter it out!
@@ -715,9 +730,8 @@ void V8DealerFeature::copyInstallationFiles() {
 
       std::string normalized = filename;
       FileUtils::normalizePath(normalized);
-      if ((normalized.size() >= eslintPath.size() &&
-           normalized.compare(normalized.size() - eslintPath.size(),
-                              eslintPath.size(), eslintPath) == 0)) {
+      if (doFilterPath(normalized, eslintPath) ||
+          doFilterPath(normalized, uiNodeModulesPath)) {
         // filter it out!
         return true;
       }

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -694,9 +694,6 @@ void V8DealerFeature::copyInstallationFiles() {
         rest::Version::getServerVersion(), std::regex("-.*$"), "");
     std::string const eslintPath =
         FileUtils::buildFilename("js", "node", "node_modules", "eslint");
-    std::string const uiNodeModulesPath =
-        FileUtils::buildFilename("js", "apps", "system", "_admin", "aardvark",
-                                 "APP", "react", "node_modules");
 
     // .bin directories could be harmful, and .map files are large and
     // unnecessary
@@ -705,19 +702,7 @@ void V8DealerFeature::copyInstallationFiles() {
 
     size_t copied = 0;
 
-    auto doFilterPath = [](std::string_view normalizedPath,
-                           std::string_view filterPath) -> bool {
-      if ((normalizedPath.size() >= filterPath.size() &&
-           normalizedPath.compare(normalizedPath.size() - filterPath.size(),
-                                  filterPath.size(), filterPath) == 0)) {
-        // filter it out!
-        return true;
-      }
-      return false;
-    };
-
-    auto filter = [&eslintPath, &uiNodeModulesPath, &doFilterPath,
-                   &binDirectory,
+    auto filter = [&eslintPath, &binDirectory,
                    &copied](std::string const& filename) -> bool {
       if (filename.ends_with(".map")) {
         // filename ends with ".map". filter it out!
@@ -730,8 +715,9 @@ void V8DealerFeature::copyInstallationFiles() {
 
       std::string normalized = filename;
       FileUtils::normalizePath(normalized);
-      if (doFilterPath(normalized, eslintPath) ||
-          doFilterPath(normalized, uiNodeModulesPath)) {
+      if ((normalized.size() >= eslintPath.size() &&
+           normalized.compare(normalized.size() - eslintPath.size(),
+                              eslintPath.size(), eslintPath) == 0)) {
         // filter it out!
         return true;
       }


### PR DESCRIPTION
### Scope & Purpose

This PR fixes the unnecessary copy of the `node_modules` folder located in the frontend area.
This issue has been (accidentally) found by our Windows test runs.
It got uncovered as Windows run into issues with the maximum path length:

```
Microsoft Windows has a MAX_PATH limit of ~256 characters.
```

This will now also speed up the server start as the V8Feature will NOT copy those files anymore
(As usually any node_modules directory consists of a lot of files and a lot of sub-directories).

- [x] :hankey: Bugfix

### Checklist

- [x] :book: CHANGELOG entry made
