### PR TITLE
apply fix for UBSan "object-size" errors

### DIFF
--- a/ubsan_arangodb_suppressions.txt
+++ b/ubsan_arangodb_suppressions.txt
@@ -36,7 +36,3 @@ pointer-overflow:3rdParty/lz4/lib/lz4.c
 # It's intentional perform operations with nullptr
 # TODO(MBkkt) I think it can be fixed with using uintptr_t instead of pointer
 pointer-overflow:3rdParty/iresearch/core/search/bitset_doc_iterator.cpp
-
-# potential issues in immer library, needs to be sorted out
-object-size:immer/immer/detail/hamts/node.hpp
-object-size:immer/immer/detail/combine_standard_layout.hpp


### PR DESCRIPTION
### Scope & Purpose

Running tests with clang-16 and the undefined behavior sanitizer (UBSan) produces errors such as the following in the immer library:
```
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior 3rdParty/immer/immer/detail/hamts/node.hpp:224:26 in
3rdParty/immer/immer/detail/hamts/node.hpp:229:12: runtime error: member access within address 0x60300009a570 with insufficient space for an object of type 'node_t' (aka 'immer::detail::hamts::node<std::pair<std::basic_string<char>, std::shared_ptr<const arangodb::consensus::Node>>, immer::map<std::basic_string<char>, std::shared_ptr<const arangodb::consensus::Node>, arangodb::consensus::Node::TransparentHash, arangodb::consensus::Node::TransparentEqual, immer::memory_policy<arangodb::consensus::Node::AccountingHeap<arangodb::immer::thread_local_free_list_heap_policy<immer::cpp_heap>>, immer::refcount_policy, immer::spinlock_policy, immer::no_transience_policy, false, true>>::hash_key, immer::map<std::basic_string<char>, std::shared_ptr<const arangodb::consensus::Node>, arangodb::consensus::Node::TransparentHash, arangodb::consensus::Node::TransparentEqual, immer::memory_policy<arangodb::consensus::Node::AccountingHeap<arangodb::immer::thread_local_free_list_heap_policy<immer::cpp_heap>>, immer::refcount_policy, immer::spinlock_policy, immer::no_transience_policy, false, true>>::equal_key, immer::memory_policy<arangodb::consensus::Node::AccountingHeap<arangodb::immer::thread_local_free_list_heap_policy<immer::cpp_heap>>, immer::refcount_policy, immer::spinlock_policy, immer::no_transience_policy, false, true>, 5>')
0x60300009a570: note: pointer points here
 00 00 00 00  01 00 00 00 be be be be  be be be be be be be be  be be be be be be be be  00 00 00 00
              ^
```
the issue was reported to the upstream version of immer via https://github.com/arximboldi/immer/issues/274.

the fix for the particular issue was written by @maierlars.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 