### PR TITLE
Temporarily disable search recovery/truncate tests, linked a ticket to fix them

### DIFF
--- a/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate-no-flushthread.js
+++ b/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate-no-flushthread.js
@@ -77,6 +77,12 @@ function recoverySuite () {
     // //////////////////////////////////////////////////////////////////////////////
 
     testIResearchLinkPopulateTruncate: function () {
+      if (db._properties().replicationVersion === "2") {
+        // TODO: Temporarily disabled.
+        // Should be re-enabled as soon as https://arangodb.atlassian.net/browse/CINFRA-876
+        // is fixed.
+        return;
+      }
       var v = db._view(vn);
       assertEqual(v.name(), vn);
       assertEqual(v.type(), 'arangosearch');

--- a/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate.js
+++ b/tests/js/client/recovery/search/view-arangosearch-link-populate-truncate.js
@@ -73,6 +73,12 @@ function recoverySuite () {
     // //////////////////////////////////////////////////////////////////////////////
 
     testIResearchLinkPopulateTruncate: function () {
+      if (db._properties().replicationVersion === "2") {
+        // TODO: Temporarily disabled.
+        // Should be re-enabled as soon as https://arangodb.atlassian.net/browse/CINFRA-876
+        // is fixed.
+        return;
+      }
       var v = db._view(vn);
       assertEqual(v.name(), vn);
       assertEqual(v.type(), 'arangosearch');


### PR DESCRIPTION
### Scope & Purpose

*This temporarily disables two recovery tests for replication2.*

Description of what happens, and can also be enabled again as soon as the following ticket is fixed:
https://arangodb.atlassian.net/browse/CINFRA-876

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

