### PR TITLE
add experimental tracing of optimizer rules

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -700,7 +700,7 @@ void ExecutionPlan::enableRule(int rule) { _disabledRules.erase(rule); }
 void ExecutionPlan::disableRule(int rule) { _disabledRules.emplace(rule); }
 
 bool ExecutionPlan::isDisabledRule(int rule) const {
-  return (_disabledRules.find(rule) != _disabledRules.end());
+  return _disabledRules.contains(rule);
 }
 
 ExecutionNodeId ExecutionPlan::nextId() {

--- a/arangod/Aql/ExecutionPlan.h
+++ b/arangod/Aql/ExecutionPlan.h
@@ -120,6 +120,11 @@ class ExecutionPlan {
   /// @brief disable a specific rule
   void disableRule(int rule);
 
+  /// @brief return const reference to applied rules
+  std::vector<int> const& appliedRules() const noexcept {
+    return _appliedRules;
+  }
+
   /// @brief return the next value for a node id
   ExecutionNodeId nextId();
 

--- a/arangod/Aql/ExecutionStats.cpp
+++ b/arangod/Aql/ExecutionStats.cpp
@@ -33,8 +33,8 @@
 using namespace arangodb::aql;
 
 /// @brief convert the statistics to VelocyPack
-void ExecutionStats::toVelocyPack(VPackBuilder& builder,
-                                  bool reportFullCount) const {
+void ExecutionStats::toVelocyPack(VPackBuilder& builder, bool reportFullCount,
+                                  bool reportOptimizerTimes) const {
   builder.openObject();
   builder.add("writesExecuted", VPackValue(writesExecuted));
   builder.add("writesIgnored", VPackValue(writesIgnored));
@@ -54,6 +54,10 @@ void ExecutionStats::toVelocyPack(VPackBuilder& builder,
     builder.add("fullCount", VPackValue(fullCount > count ? fullCount : count));
   }
   builder.add("executionTime", VPackValue(executionTime));
+  if (reportOptimizerTimes) {
+    builder.add("activeRulesTime", VPackValue(activeRulesTime));
+    builder.add("inactiveRulesTime", VPackValue(inactiveRulesTime));
+  }
 
   builder.add("peakMemoryUsage", VPackValue(peakMemoryUsage));
   builder.add("intermediateCommits", VPackValue(intermediateCommits));
@@ -73,6 +77,7 @@ void ExecutionStats::toVelocyPack(VPackBuilder& builder,
     }
     builder.close();
   }
+
   builder.close();
 }
 

--- a/arangod/Aql/ExecutionStats.h
+++ b/arangod/Aql/ExecutionStats.h
@@ -43,7 +43,8 @@ struct ExecutionStats {
   explicit ExecutionStats(arangodb::velocypack::Slice slice);
 
   /// @brief convert the statistics to VelocyPack
-  void toVelocyPack(arangodb::velocypack::Builder&, bool reportFullCount) const;
+  void toVelocyPack(arangodb::velocypack::Builder&, bool reportFullCount,
+                    bool reportOptimizerTimes) const;
 
   /// @brief sets query execution time from the outside
   void setExecutionTime(double value);
@@ -115,6 +116,11 @@ struct ExecutionStats {
   /// @brief query execution time (wall-clock time). value will be set from
   /// the outside
   double executionTime = 0.0;
+
+  /// @brief time spent in optimizer rules that changed the plan
+  double activeRulesTime = 0.0;
+  /// @brief time spent in optimizer rules that did not change the plan
+  double inactiveRulesTime = 0.0;
 
   /// @brief peak memory usage of the query
   size_t peakMemoryUsage = 0;

--- a/arangod/Aql/Optimizer.h
+++ b/arangod/Aql/Optimizer.h
@@ -89,7 +89,15 @@ class Optimizer {
 
     /// @brief map with execution times per rule, only populated in
     /// case tracing is enabled, a nullptr otherwise!
-    std::unique_ptr<std::unordered_map<int, double>> executionTimes;
+    using TimesMap = std::unordered_map<int, double>;
+    std::unique_ptr<TimesMap> times;
+
+    TimesMap& ruleExecutionTimes();
+
+    /// @brief returns time spent in applied optimizer rules and in
+    /// not-applied optimizer rules
+    std::pair<double, double> ruleExecutionTotals(
+        std::vector<int> const& appliedRules) const;
 
     void toVelocyPack(velocypack::Builder& b) const;
   };
@@ -136,6 +144,11 @@ class Optimizer {
     _plans.list.clear();
     return std::move(res.first);
   }
+
+  /// @brief returns time spent in applied optimizer rules and in
+  /// not-applied optimizer rules
+  std::pair<double, double> ruleExecutionTotals(
+      std::vector<int> const& appliedRules) const;
 
   bool runOnlyRequiredRules(size_t extraPlans) const;
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -813,8 +813,10 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
                   VPackBuilder answerBuilder(buffer);
                   answerBuilder.openObject(/*unindexed*/ true);
                   answerBuilder.add(VPackValue("stats"));
-                  q->executionStats().toVelocyPack(answerBuilder,
-                                                   q->queryOptions().fullCount);
+                  q->executionStats().toVelocyPack(
+                      answerBuilder,
+                      q->queryOptions().fullCount, /*reportOptimizerTimes*/
+                      q->queryOptions().profile >= ProfileLevel::Basic);
                   q->warnings().toVelocyPack(answerBuilder);
                   answerBuilder.add(StaticStrings::Error,
                                     VPackValue(res.fail()));

--- a/js/client/modules/@arangodb/testutils/aql-profiler-test-helper.js
+++ b/js/client/modules/@arangodb/testutils/aql-profiler-test-helper.js
@@ -253,6 +253,11 @@ function assertIsProfileStatsObject (stats, {level, fullCount}) {
 
   expect(stats).to.be.an('object');
 
+  // the following are optional and experimental, so we don't
+  // consider them here.
+  delete stats.activeRulesTime;
+  delete stats.inactiveRulesTime;
+
   let statsKeys = [
     'writesExecuted',
     'writesIgnored',

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -279,7 +279,7 @@ function printRules(rules, stats) {
   }
 
   let maxNameLength = 0;
-  let times = Object.keys(stats.rules).map(function(key) {
+  let times = Object.keys(stats.rules).map((key) => {
     maxNameLength = Math.max(maxNameLength, key.length);
     return { name: key, time: stats.rules[key] };
   });
@@ -305,6 +305,7 @@ function printRules(rules, stats) {
 
   let statsLine = value(stats.rulesExecuted) + annotation(' rule(s) executed');
   statsLine += ', ' + value(stats.plansCreated) + annotation(' plan(s) created');
+  
   if (stats.hasOwnProperty('peakMemoryUsage')) {
     statsLine += ', ' + annotation('peak mem [b]') + ': ' + value(stats.peakMemoryUsage);
   }
@@ -351,10 +352,10 @@ function printStats(stats, isCoord) {
   let maxRLen = 'Requests'.length;
   let maxMemLen = 'Peak Mem [b]'.length;
   let maxETLen = 'Exec Time [s]'.length;
-  stats.executionTime = stats.executionTime.toFixed(5);
   stringBuilder.appendLine(' ' + header('Writes Exec') + spc + header('Writes Ign') + spc + header('Doc. Lookups') + spc + header('Scan Full') + spc +
     header('Scan Index') + spc + header('Cache Hits/Misses') + spc + header('Filtered') + spc + (isCoord ? header('Requests') + spc : '') +
-    header('Peak Mem [b]') + spc + header('Exec Time [s]'));
+    header('Peak Mem [b]') + spc + 
+    header('Exec Time [s]'));
 
   stringBuilder.appendLine(' ' + pad(1 + maxWELen - String(stats.writesExecuted).length) + value(stats.writesExecuted) + spc +
     pad(1 + maxWILen - String(stats.writesIgnored).length) + value(stats.writesIgnored) + spc +
@@ -363,9 +364,40 @@ function printStats(stats, isCoord) {
     pad(1 + maxSILen - String(stats.scannedIndex).length) + value(stats.scannedIndex) + spc +
     pad(1 + maxCHMLen - (String(stats.cacheHits || 0) + ' / ' + String(stats.cacheMisses || 0)).length) + value(stats.cacheHits || 0) + ' / ' + value(stats.cacheMisses || 0) + spc +
     pad(1 + maxFLen - String(stats.filtered || 0).length) + value(stats.filtered || 0) + spc +
-    (isCoord ? pad(1 + maxRLen - String(stats.httpRequests).length) + value(stats.httpRequests) + spc : '') +
+    (isCoord ? pad(1 + maxRLen - String(stats.httpRequests).length) + value(stats.httpRequests) + spc : '') + 
     pad(1 + maxMemLen - String(stats.peakMemoryUsage).length) + value(stats.peakMemoryUsage) + spc +
-    pad(1 + maxETLen - String(stats.executionTime).length) + value(stats.executionTime));
+    pad(1 + maxETLen - String(stats.executionTime.toFixed(5)).length) + value(stats.executionTime.toFixed(5)) + spc);
+  stringBuilder.appendLine();
+
+  let maxOptLen = 'Opt. Rules [s]'.length;
+  let maxActLen = 'Active Opt. Rules [s]'.length;
+  let maxInactLen = 'Inactive Opt. Rules [s]'.length;
+  let maxSavLen = 'Savings [%]'.length;
+
+  let optRulesTime = "n/a";
+  let activeRulesTime = "n/a";
+  let inactiveRulesTime = "n/a";
+  let maxSavings = "n/a";
+  if (stats.activeRulesTime !== undefined) {
+    optRulesTime = (stats.activeRulesTime + stats.inactiveRulesTime).toFixed(5);
+    activeRulesTime = stats.activeRulesTime.toFixed(5);
+    inactiveRulesTime = stats.inactiveRulesTime.toFixed(5);
+    if (stats.executionTime > 0) {
+      maxSavings = (100 * stats.inactiveRulesTime / stats.executionTime).toFixed(5); 
+    }
+  }
+
+  stringBuilder.appendLine(' ' + header('Opt. Rules [s]') + spc +
+    header('Active Opt. Rules [s]') + spc + 
+    header('Inactive Opt. Rules [s]') + spc +
+    header('Savings [%]'));
+  
+  stringBuilder.appendLine(' ' + 
+    pad(1 + maxOptLen - String(optRulesTime).length) + value(optRulesTime) + spc +
+    pad(1 + maxActLen - String(activeRulesTime).length) + value(activeRulesTime) + spc +
+    pad(1 + maxInactLen - String(inactiveRulesTime).length) + value(inactiveRulesTime) + spc +
+    pad(1 + maxSavLen - String(maxSavings).length) + value(maxSavings));
+  
   stringBuilder.appendLine();
 }
 

--- a/tests/Aql/AqlHelper.cpp
+++ b/tests/Aql/AqlHelper.cpp
@@ -32,7 +32,7 @@ using namespace arangodb::aql;
 std::ostream& arangodb::aql::operator<<(std::ostream& stream,
                                         ExecutionStats const& stats) {
   VPackBuilder builder{};
-  stats.toVelocyPack(builder, true);
+  stats.toVelocyPack(builder, true, false);
   return stream << builder.toJson();
 }
 


### PR DESCRIPTION
### Scope & Purpose

Add experimental output of total optimizer rules times:

- time spent in optimizer rules that were applied
- time spent in optimizer rules that were not applied
- total time spent in optimizer rules
- potential savings (in %) if only relevant optimizer rules were executed

This is for experimenting/prototyping only. Not intention to merge this soon.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 