### PR TITLE
Default activate Replication2 specific tests for PRs and Nightly

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -13,10 +13,6 @@ parameters:
   build-windows-image:
     type: string
     default: "arangodb/build-windows-x64:10.0.17763.4737-VS-17.3.3-OpenSSL-3.1.4-4c65c2ae530"
-  # Unused here, but it will be forwarded from config and will cause errors if not defined
-  replication-two:
-    type: boolean
-    default: false
   skip-windows-tests:
     type: boolean
     default: true 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ parameters:
   build-windows-image:
     type: string
     default: ""
-  replication-two:
-    type: boolean
-    default: false # We use replication1 as default.
   skip-windows-tests:
     type: boolean
     default: true 
@@ -99,7 +96,7 @@ jobs:
           name: Generate config
           command: |
             pip install pyyaml
-            python3 ".circleci/generate_config.py" <<# pipeline.parameters.skip-windows-tests >> --skip-windows <</ pipeline.parameters.skip-windows-tests >> <<# pipeline.parameters.replication-two >> -rt <</ pipeline.parameters.replication-two >> -o generated_config.yml ./.circleci/base_config.yml << parameters.definitions >>
+            python3 ".circleci/generate_config.py" <<# pipeline.parameters.skip-windows-tests >> --skip-windows <</ pipeline.parameters.skip-windows-tests >> -o generated_config.yml ./.circleci/base_config.yml << parameters.definitions >>
 
       - continuation/continue:
           configuration_path: generated_config.yml # use newly generated config to continue

--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -85,9 +85,6 @@ def parse_arguments():
         "--all", help="output all test, ignore other filters", action="store_true"
     )
     parser.add_argument(
-        "-rt", "--replication_two", default=False, action='store_true', help="flag if we should enable replication two tests"
-    )
-    parser.add_argument(
         "--skip-windows", default=False, action='store_true', help="flag if we should skip windows tests"
     )
     return parser.parse_args()
@@ -305,10 +302,9 @@ def add_test_jobs_to_workflow(config, tests, workflow, edition, arch, dist, repl
             jobs.append(
                 {f"run-{dist}-tests": create_test_job(test, True, edition, arch, dist)}
             )
-            if repl2:
-                jobs.append(
-                    {f"run-{dist}-tests": create_test_job(test, True, edition, arch, dist, 2)}
-                )
+            jobs.append(
+                {f"run-{dist}-tests": create_test_job(test, True, edition, arch, dist, 2)}
+            )
         elif "single" in test["flags"]:
             jobs.append(
                 {f"run-{dist}-tests": create_test_job(test, False, edition, arch, dist)}
@@ -317,10 +313,9 @@ def add_test_jobs_to_workflow(config, tests, workflow, edition, arch, dist, repl
             jobs.append(
                 {f"run-{dist}-tests": create_test_job(test, True, edition, arch, dist)}
             )
-            if repl2:
-                jobs.append(
-                    {f"run-{dist}-tests": create_test_job(test, True, edition, arch, dist, 2)}
-                )
+            jobs.append(
+                {f"run-{dist}-tests": create_test_job(test, True, edition, arch, dist, 2)}
+            )
             jobs.append(
                 {f"run-{dist}-tests": create_test_job(test, False, edition, arch, dist)}
             )
@@ -334,27 +329,27 @@ def get_arch(workflow):
     raise Exception(f"Cannot extract architecture from workflow {workflow}")
 
 
-def generate_output(config, tests, enterprise, repl2, skip_windows):
+def generate_output(config, tests, enterprise, skip_windows):
     """generate output"""
     workflows = config["workflows"]
     edition = "ee" if enterprise else "ce"
     for workflow, jobs in workflows.items():
         if ("windows" in workflow) and enterprise and not skip_windows:
             arch = get_arch(workflow)
-            add_test_jobs_to_workflow(config, tests, workflow, edition, arch, "windows", repl2)
+            add_test_jobs_to_workflow(config, tests, workflow, edition, arch, "windows") 
         if (
             ("linux" in workflow)
             and (enterprise and "enterprise" in workflow)
             or (not enterprise and "community" in workflow)
         ):
             arch = get_arch(workflow)
-            add_test_jobs_to_workflow(config, tests, workflow, edition, arch, "linux", repl2)
+            add_test_jobs_to_workflow(config, tests, workflow, edition, arch, "linux")
 
 
 def generate_jobs(config, args, tests, enterprise):
     """generate job definitions"""
     tests = filter_tests(args, tests, enterprise)
-    generate_output(config, tests, enterprise, args.replication_two, args.skip_windows)
+    generate_output(config, tests, enterprise, args.skip_windows)
 
 
 def main():

--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -293,7 +293,7 @@ def create_test_job(test, cluster, edition, arch, dist, replication_version=1):
     return result
 
 
-def add_test_jobs_to_workflow(config, tests, workflow, edition, arch, dist, repl2):
+def add_test_jobs_to_workflow(config, tests, workflow, edition, arch, dist):
     jobs = config["workflows"][workflow]["jobs"]
     for test in tests:
         if "!" + dist in test["flags"]:


### PR DESCRIPTION
### Scope & Purpose

*CircleCI only change: Activate Replication2 tests in all environments now by default. So we run the tests in every PR and every nightly test.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

