### PR TITLE
Suppress all data races coming from within V8 and improve build settings

### DIFF
--- a/3rdParty/v8-build/CMakeLists.txt
+++ b/3rdParty/v8-build/CMakeLists.txt
@@ -358,11 +358,9 @@ else ()
 
   set(V8_LDFLAGS    "${CMAKE_EXE_LINKER_FLAGS} $ENV{V8_LDFLAGS}")
 
-  # build V8 without debug information
-  if (USE_MINIMAL_DEBUGINFO)
-    set(V8_CFLAGS   "${V8_CFLAGS} -g0")
-    set(V8_CXXFLAGS "${V8_CXXFLAGS} -g0")
-  endif ()
+  # for V8 we minimal debug information is more than enough
+  set(V8_CFLAGS   "${V8_CFLAGS} -g1 -gno-column-info -gz")
+  set(V8_CXXFLAGS "${V8_CXXFLAGS} -g1 -gno-column-info -gz")
   
   add_c_flags_if_supported(V8_CFLAGS -Wno-suggest-override -Wno-implicit-const-int-float-conversion -Wno-non-virtual-dtor -Wno-final-dtor-non-final-class -Wno-implicit-const-int-float-conversion)
   add_cxx_flags_if_supported(V8_CXXFLAGS -Wno-suggest-override -Wno-implicit-const-int-float-conversion -Wno-non-virtual-dtor -Wno-final-dtor-non-final-class -Wno-implicit-const-int-float-conversion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1062,7 +1062,7 @@ else () # NOT MSVC
     set(DEBUGINFO_FLAGS "-g1 -gno-column-info -gz")
   else ()
     # full debug symbols
-    set(DEBUGINFO_FLAGS "-g")
+    set(DEBUGINFO_FLAGS "-g -gz")
   endif ()
 
   # c

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -60,6 +60,9 @@ deadlock:consensus::Agent::setPersistedState
 # TODO Fix data race in arangodbtests
 race:DummyConnection::sendRequest
 
-# V8 internals
-race:v8::platform::DefaultJobWorker
-race:v8::platform::DefaultJobState
+# ATM we build V8 with sanitizers _disabled_, so the V8 code is not instrumented
+# which means the sanitizer cannot observe the synchronizations inside that code.
+# So when the V8 code calls back into instrumented code (e.g. the C runtime), TSan
+# might report potential data races because of these missing synchronizations.
+# For that reason we simply need to ignore _all_ data races coming from V8.
+race:v8::*


### PR DESCRIPTION
### Scope & Purpose

ATM we build V8 with sanitizers _disabled_, so the V8 code is not instrumented which means the sanitizer cannot observe the synchronizations inside that code. So when the V8 code calls back into instrumented code (e.g. the C runtime), TSan might report potential data races because of these missing synchronizations. For that reason we simply need to ignore _all_ data races coming from V8.

In addition this PR changes the build settings in V8 to only generate minimal debug information. For V8 we don't care about local variables etc.; function names are enough so that we can generate back traces. Also, this PR enables compression of debug sections for all executables to significantly reduce their sizes.