### PR TITLE
APM-828: add additional metrics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,8 +24,11 @@ v3.10.13 (XXXX-XX-XX)
   - `enabled-per-shard`: this will make DB-Servers collect per-shard usage
     metrics.
   - `enabled-per-shard-per-user`: this will make DB-Servers collect per-shard
-    and per-user metrics. This is more granular than `enabled-per-shard` but can
-    produce a lot of metrics.
+    and per-user metrics. This is more granular than `enabled-per-shard` but
+    can produce a lot of metrics.
+  
+  If enabled, the metrics are only exposed on DB servers and not on 
+  Coordinators or single servers.
 
   Whenever a shard is accessed in read or write mode by one of the following
   operations, the metrics are populated dynamically, either with a per-user
@@ -50,17 +53,17 @@ v3.10.13 (XXXX-XX-XX)
     read counter will be increased once for each shard that is affected by the
     operation.
 
-  Note: if an AQL query for a single collection gets optimized into a single or
-  multi-document operation, then the description for single or multi-document
-  operations apply.
+  The metrics are increased when any of the above operations start, and they
+  are not decreased should an operation abort or if an operation does not
+  lead to any actual reads or writes.
 
-  The metrics are increased when any of the above operations start, and they are
-  not decreased should an operation abort or if an operation does not lead to
-  any actual reads or writes.
-  Note that internal operations, such as internal queries executed for statistics
-  gathering, internal garbage collection, TTL index cleanup are not counted in
-  these metrics. Additionally all requests that are using the superuser JWT for 
-  authentication and that do not have a specific user set, will not be counted.
+  Note that internal operations, such as internal queries executed for 
+  statistics gathering, internal garbage collection, and TTL index cleanup are
+  not counted in these metrics. Additionally, all requests that use the 
+  superuser JWT for authentication and that do not have a specific user set,
+  are not counted.
+  Requests are also only counted if they have an ArangoDB user associated with
+  them, so that the cluster must also be running with authentication turned on.
 
   As there can be many of these dynamic metrics based on the number of shards
   and/or users in the deployment, these metrics are turned off by default (see
@@ -113,7 +116,17 @@ v3.10.13 (XXXX-XX-XX)
     
     The numbers reported by this metric normally relate to the cumulated sizes
     of documents/edges written. For remove operations however only a fixed
-    number of bytes is counted per removed document/edge.
+    number of bytes is counted per removed document/edge. For truncate 
+    operations, the metrics will be affected differently depending on how the
+    truncate is executed internally.
+    For truncates on smaller shards, the truncate operation will be executed as
+    the removal of the individual documents in the shard. Thus the metric will
+    also be increased as if the documents were removed individually. Truncate
+    operations on larger shards however will be executed via a special 
+    operation in the storage engine, which marks a whole range of documents as
+    removed, but defers the actual removal until much later (compaction 
+    process). If a truncate is executed like this, the metric will not be 
+    increased at all.
     Writes into secondary indexes are not counted at all.
 
     The metric is also increased for transactions that are started but later
@@ -126,11 +139,16 @@ v3.10.13 (XXXX-XX-XX)
   the latter setting, the metric will have different labels for each 
   combination of shard and user that accessed the shard.
   
+  If enabled, the metrics are only exposed on DB servers and not on 
+  Coordinators or single servers.
+  
   Note that internal operations, such as internal queries executed for 
-  statistics gathering, internal garbage collection, TTL index cleanup are not
-  counted in these metrics. Additionally all requests that are using the 
-  superuser JWT for authentication and that do not have a specific user set, 
-  will not be counted.
+  statistics gathering, internal garbage collection, and TTL index cleanup are
+  not counted in these metrics. Additionally, all requests that use the 
+  superuser JWT for authentication and that do not have a specific user set,
+  are not counted.
+  Requests are also only counted if they have an ArangoDB user associated with
+  them, so that the cluster must also be running with authentication turned on.
 
 * Validate that the attribute stored in the `smartGraphAttribute` of SmartGraph
   vertex collections exists and is not changed afterwards by update or replace

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -51,12 +51,80 @@ v3.10.13 (XXXX-XX-XX)
   The metrics are increased when any of the above operations start, and they are
   not decreased should an operation abort or if an operation does not lead to
   any actual reads or writes.
+  Note that internal operations, such as internal queries executed for statistics
+  gathering, internal garbage collection, TTL index cleanup are not counted in
+  these metrics. Additionally all requests that are using the superuser JWT for 
+  authentication and that do not have a specific user set, will not be counted.
 
   As there can be many of these dynamic metrics based on the number of shards
   and/or users in the deployment, these metrics are turned off by default (see
   above), and if turned on, are only exposed only via a new HTTP REST API
   endpoint GET `/_admin/usage-metrics`. They are not exposed via the existing
   metrics API endpoint GET `/_admin/metrics`.
+
+ Add additional metrics for tracking the number of bytes read or written per
+  shard on DB-Servers:
+
+  - `arangodb_collection_requests_bytes_read_total`:
+    This metric exposes the per-shard number of bytes read by read operation 
+    requests on DB-Servers. 
+    It is increased by AQL queries that read documents or edges and for single-
+    or multi-document read operations.
+    The metric is normally increased only on the leader, but it can also 
+    increase on followers if "reads from followers" are enabled.
+
+    For every read operation, the metric will be increased by the approximate 
+    number of bytes read to retrieve the underlying document or edge data. This
+    is also true if a document or edge is served from an in-memory cache.
+    If an operation reads multiple documents/edges, it will increase the 
+    counter multiple times, each time with the approximate number of bytes read
+    for the particular document/edge.
+    
+    The numbers reported by this metric normally relate to the cumulated sizes
+    of documents/edges read.
+    The metric is also increased for transactions that are started but later
+    aborted.
+    Note that the metric is not increased for secondary index point lookups or
+    scans, or for scans in a collection that iterate over documents but do not
+    read them.
+
+  - `arangodb_collection_requests_bytes_written_total`:
+    This metric exposes the per-shard number of bytes written by write operation
+    requests on DB-Servers, on both leaders and followers.
+    It is increased by AQL queries and single-/multi-document write operations.
+    The metric is first increased only the leader, but for every replication 
+    request to followers it is also increased on followers.
+    
+    For every write operation, the metric will be increased by the approximate 
+    number of bytes written for the document or edge in question. 
+    If an operation writes multiple documents/edges, it will increase the 
+    counter multiple times, each time with the approximate number of bytes 
+    written for the particular document/edge.
+
+    An AQL query will also increase the counter for every document or edge 
+    written, each time with the approximate number of bytes written for 
+    document/edge.
+    
+    The numbers reported by this metric normally relate to the cumulated sizes
+    of documents/edges written. For remove operations however only a fixed
+    number of bytes is counted per removed document/edge.
+    Writes into secondary indexes are not counted at all.
+
+    The metric is also increased for transactions that are started but later
+    aborted.
+  
+  These metrics are not exposed by default. It is only present if the startup 
+  option `--server.export-shard-usage-metrics` is set to either 
+  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
+  the metric will have different labels for each shard that was read from. With
+  the latter setting, the metric will have different labels for each 
+  combination of shard and user that accessed the shard.
+  
+  Note that internal operations, such as internal queries executed for 
+  statistics gathering, internal garbage collection, TTL index cleanup are not
+  counted in these metrics. Additionally all requests that are using the 
+  superuser JWT for authentication and that do not have a specific user set, 
+  will not be counted.
 
 * Validate that the attribute stored in the `smartGraphAttribute` of SmartGraph
   vertex collections exists and is not changed afterwards by update or replace

--- a/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
@@ -12,23 +12,23 @@ description: |
   This metric exposes the number of per-shard read operation requests on DB-Servers.
   It is increased by AQL queries and single-/multi-document read operations.
 
-  An AQL query will increase the counter exactly once for a shard that is involved
+  An AQL query increases the counter exactly once for a shard that is involved
   in the query in read-only mode, regardless if and how many documents/edges the
   query actually reads from the shard. For shards that are accessed by an AQL query
-  in read/write mode, only the write counter will be increased.
+  in read/write mode, only the write counter is increased.
 
-  For every single- or multi-document read operation, the counter will be
+  For every single- or multi-document read operation, the counter is
   increased exactly once for each shard that is affected by the operation, even
   if multiple documents are read from the same shard.
   
-  This metric is not exposed by default. It is only present if the startup option 
-  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
-  `enabled-per-shard-per-user`. With the former setting, the metric will have
-  different labels for each shard that was read from. With the latter setting,
-  the metric will have different labels for each combination of shard and user
-  that accessed the shard.
+  This metric is not exposed by default. It is only present if the
+  `--server.export-shard-usage-metrics` startup option is set to either
+  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
+  the metric has different labels for each shard that was read from. With the
+  latter setting, the metric has different labels for each combination of shard
+  and user that accessed the shard.
 
   Note that internal operations, such as internal queries executed for statistics
-  gathering, internal garbage collection, TTL index cleanup are not counted in
-  these metrics. Additionally all requests that are using the superuser JWT for 
-  authentication and that do not have a specific user set, will not be counted.
+  gathering, internal garbage collection, and TTL index cleanup are not counted in
+  these metrics. Additionally, all requests that use the superuser JWT for
+  authentication and that do not have a specific user set, are not counted.

--- a/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
@@ -21,14 +21,16 @@ description: |
   increased exactly once for each shard that is affected by the operation, even
   if multiple documents are read from the same shard.
   
-  This metric is not exposed by default. It is only present if the
-  `--server.export-shard-usage-metrics` startup option is set to either
-  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
-  the metric has different labels for each shard that was read from. With the
-  latter setting, the metric has different labels for each combination of shard
-  and user that accessed the shard.
+  This metric is not exposed by default. It is only present if the startup option
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or 
+  `enabled-per-shard-per-user`. With the former setting, the metric has different 
+  labels for each shard that was read from. With the latter setting, the metric 
+  has different labels for each combination of shard and user that accessed the shard.
+  The metric is only exposed on DB servers and not on Coordinators or single servers.
 
   Note that internal operations, such as internal queries executed for statistics
   gathering, internal garbage collection, and TTL index cleanup are not counted in
   these metrics. Additionally, all requests that use the superuser JWT for
   authentication and that do not have a specific user set, are not counted.
+  Requests are also only counted if they have an ArangoDB user associated with them,
+  so that the cluster must also be running with authentication turned on.

--- a/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_reads_total.yaml
@@ -27,3 +27,8 @@ description: |
   different labels for each shard that was read from. With the latter setting,
   the metric will have different labels for each combination of shard and user
   that accessed the shard.
+
+  Note that internal operations, such as internal queries executed for statistics
+  gathering, internal garbage collection, TTL index cleanup are not counted in
+  these metrics. Additionally all requests that are using the superuser JWT for 
+  authentication and that do not have a specific user set, will not be counted.

--- a/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
@@ -29,3 +29,8 @@ description: |
   different labels for each shard that was read from. With the latter setting,
   the metric will have different labels for each combination of shard and user
   that accessed the shard.
+  
+  Note that internal operations, such as internal queries executed for statistics
+  gathering, internal garbage collection, TTL index cleanup are not counted in
+  these metrics. Additionally all requests that are using the superuser JWT for 
+  authentication and that do not have a specific user set, will not be counted.

--- a/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
@@ -12,25 +12,25 @@ description: |
   This metric exposes the number of per-shard write operation requests on DB-Servers.
   It is increased by AQL queries and single-/multi-document write operations.
 
-  An AQL query will increase the counter exactly once for a shard that is involved
-  in the query in write-only or read-write mode, regardless if and how many documents/edges
-  will insert or modify in the shard.
+  An AQL query increases the counter exactly once for a shard that is involved
+  in the query in write-only or read-write mode, regardless if and how many
+  documents/edges are inserted or modified in the shard.
 
-  For every single- or multi-document write operation, the counter will be
+  For every single- or multi-document write operation, the counter is
   increased exactly once for each shard that is affected by the operation, even
-  if multiple documents are inserted, modified or removed from the same shard.
+  if multiple documents are inserted, modified, or removed from the same shard.
 
   For collection truncate operations, the counter is also increased exactly once for
   each shard affected by the truncate.
   
-  This metric is not exposed by default. It is only present if the startup option 
-  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
-  `enabled-per-shard-per-user`. With the former setting, the metric will have
-  different labels for each shard that was read from. With the latter setting,
-  the metric will have different labels for each combination of shard and user
-  that accessed the shard.
+  This metric is not exposed by default. It is only present if the
+  `--server.export-shard-usage-metrics` startup option is set to either
+  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
+  the metric has different labels for each shard that was read from. With the
+  latter setting, the metric has different labels for each combination of shard
+  and user that accessed the shard.
   
   Note that internal operations, such as internal queries executed for statistics
-  gathering, internal garbage collection, TTL index cleanup are not counted in
-  these metrics. Additionally all requests that are using the superuser JWT for 
-  authentication and that do not have a specific user set, will not be counted.
+  gathering, internal garbage collection, and TTL index cleanup are not counted in
+  these metrics. Additionally, all requests that use the superuser JWT for
+  authentication and that do not have a specific user set, are not counted.

--- a/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_leader_writes_total.yaml
@@ -23,14 +23,16 @@ description: |
   For collection truncate operations, the counter is also increased exactly once for
   each shard affected by the truncate.
   
-  This metric is not exposed by default. It is only present if the
-  `--server.export-shard-usage-metrics` startup option is set to either
-  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
-  the metric has different labels for each shard that was read from. With the
-  latter setting, the metric has different labels for each combination of shard
-  and user that accessed the shard.
+  This metric is not exposed by default. It is only present if the startup option
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or 
+  `enabled-per-shard-per-user`. With the former setting, the metric has different 
+  labels for each shard that was read from. With the latter setting, the metric 
+  has different labels for each combination of shard and user that accessed the shard.
+  The metric is only exposed on DB servers and not on Coordinators or single servers.
   
   Note that internal operations, such as internal queries executed for statistics
   gathering, internal garbage collection, and TTL index cleanup are not counted in
   these metrics. Additionally, all requests that use the superuser JWT for
   authentication and that do not have a specific user set, are not counted.
+  Requests are also only counted if they have an ArangoDB user associated with them,
+  so that the cluster must also be running with authentication turned on.

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
@@ -31,14 +31,16 @@ description: |
   scans, or for scans in a collection that iterate over documents but do not
   read them.
   
-  This metric is not exposed by default. It is only present if the
-  `--server.export-shard-usage-metrics` startup option is set to either
-  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
-  the metric has different labels for each shard that was read from. With the
-  latter setting, the metric has different labels for each combination of shard
-  and user that accessed the shard.
+  This metric is not exposed by default. It is only present if the startup option
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or 
+  `enabled-per-shard-per-user`. With the former setting, the metric has different 
+  labels for each shard that was read from. With the latter setting, the metric 
+  has different labels for each combination of shard and user that accessed the shard.
+  The metric is only exposed on DB servers and not on Coordinators or single servers.
   
   Note that internal operations, such as internal queries executed for statistics
   gathering, internal garbage collection, and TTL index cleanup are not counted in
   these metrics. Additionally, all requests that use the superuser JWT for
   authentication and that do not have a specific user set, are not counted.
+  Requests are also only counted if they have an ArangoDB user associated with them,
+  so that the cluster must also be running with authentication turned on.

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_collection_requests_bytes_read_total
-introducedIn: "3.12.0"
+introducedIn: "3.10.13"
 help: |
   Number of bytes read in read requests on leaders.
 unit: number

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
@@ -1,0 +1,44 @@
+name: arangodb_collection_requests_bytes_read_total
+introducedIn: "3.12.0"
+help: |
+  Number of bytes read in read requests on leaders.
+unit: number
+type: counter
+category: Transactions
+complexity: advanced
+exposedBy:
+  - dbserver
+description: |
+  This metric exposes the per-shard number of bytes read by read operation 
+  requests on DB-Servers. 
+  It is increased by AQL queries that read documents or edges and for single-
+  or multi-document read operations.
+  The metric is normally increased only on the leader, but it can also increase
+  on followers if "reads from followers" are enabled.
+
+  For every read operation, the metric will be increased by the approximate 
+  number of bytes read to retrieve the underlying document or edge data. This
+  is also true if a document or edge is served from an in-memory cache.
+  If an operation reads multiple documents/edges, it will increase the counter
+  multiple times, each time with the approximate number of bytes read for the
+  particular document/edge.
+  
+  The numbers reported by this metric normally relate to the cumulated sizes of
+  documents/edges read.
+  The metric is also increased for transactions that are started but later
+  aborted.
+  Note that the metric is not increased for secondary index point lookups or
+  scans, or for scans in a collection that iterate over documents but do not
+  read them.
+  
+  This metric is not exposed by default. It is only present if the startup option 
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
+  `enabled-per-shard-per-user`. With the former setting, the metric will have
+  different labels for each shard that was read from. With the latter setting,
+  the metric will have different labels for each combination of shard and user
+  that accessed the shard.
+  
+  Note that internal operations, such as internal queries executed for statistics
+  gathering, internal garbage collection, TTL index cleanup are not counted in
+  these metrics. Additionally all requests that are using the superuser JWT for 
+  authentication and that do not have a specific user set, will not be counted.

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_read_total.yaml
@@ -9,17 +9,17 @@ complexity: advanced
 exposedBy:
   - dbserver
 description: |
-  This metric exposes the per-shard number of bytes read by read operation 
-  requests on DB-Servers. 
+  This metric exposes the per-shard number of bytes read by read operation
+  requests on DB-Servers.
   It is increased by AQL queries that read documents or edges and for single-
   or multi-document read operations.
   The metric is normally increased only on the leader, but it can also increase
   on followers if "reads from followers" are enabled.
 
-  For every read operation, the metric will be increased by the approximate 
+  For every read operation, the metric is increased by the approximate
   number of bytes read to retrieve the underlying document or edge data. This
   is also true if a document or edge is served from an in-memory cache.
-  If an operation reads multiple documents/edges, it will increase the counter
+  If an operation reads multiple documents/edges, it increases the counter
   multiple times, each time with the approximate number of bytes read for the
   particular document/edge.
   
@@ -31,14 +31,14 @@ description: |
   scans, or for scans in a collection that iterate over documents but do not
   read them.
   
-  This metric is not exposed by default. It is only present if the startup option 
-  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
-  `enabled-per-shard-per-user`. With the former setting, the metric will have
-  different labels for each shard that was read from. With the latter setting,
-  the metric will have different labels for each combination of shard and user
-  that accessed the shard.
+  This metric is not exposed by default. It is only present if the
+  `--server.export-shard-usage-metrics` startup option is set to either
+  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
+  the metric has different labels for each shard that was read from. With the
+  latter setting, the metric has different labels for each combination of shard
+  and user that accessed the shard.
   
   Note that internal operations, such as internal queries executed for statistics
-  gathering, internal garbage collection, TTL index cleanup are not counted in
-  these metrics. Additionally all requests that are using the superuser JWT for 
-  authentication and that do not have a specific user set, will not be counted.
+  gathering, internal garbage collection, and TTL index cleanup are not counted in
+  these metrics. Additionally, all requests that use the superuser JWT for
+  authentication and that do not have a specific user set, are not counted.

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
@@ -26,18 +26,28 @@ description: |
   
   The numbers reported by this metric normally relate to the cumulated sizes of
   documents/edges written. For remove operations, however, only a fixed number of
-  bytes is counted per removed document/edge.
+  bytes is counted per removed document/edge. For truncate operations, the metrics
+  will be affected differently depending on how the truncate is executed internally.
+  For truncates on smaller shards, the truncate operation will be executed as the
+  removal of the individual documents in the shard. Thus the metric will also be
+  increased as if the documents were removed individually. Truncate operations on
+  larger shards however will be executed via a special operation in the storage
+  engine, which marks a whole range of documents as removed, but defers the actual
+  removal until much later (compaction process). If a truncate is executed like
+  this, the metric will not be increased at all.
   Writes into secondary indexes are not counted at all.
   The metric is also increased for transactions that are started but later aborted.
 
-  This metric is not exposed by default. It is only present if the
-  `--server.export-shard-usage-metrics` startup option is set to either
-  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
-  the metric has different labels for each shard that was read from. With the
-  latter setting, the metric has different labels for each combination of shard
-  and user that accessed the shard.
+  This metric is not exposed by default. It is only present if the startup option
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or 
+  `enabled-per-shard-per-user`. With the former setting, the metric has different 
+  labels for each shard that was read from. With the latter setting, the metric 
+  has different labels for each combination of shard and user that accessed the shard.
+  The metric is only exposed on DB servers and not on Coordinators or single servers.
   
   Note that internal operations, such as internal queries executed for statistics
   gathering, internal garbage collection, and TTL index cleanup are not counted in
   these metrics. Additionally, all requests that use the superuser JWT for
   authentication and that do not have a specific user set, are not counted.
+  Requests are also only counted if they have an ArangoDB user associated with them,
+  so that the cluster must also be running with authentication turned on.

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
@@ -15,30 +15,29 @@ description: |
   The metric is first increased only the leader, but for every replication request
   to followers it is also increased on followers.
   
-  For every write operation, the metric will be increased by the approximate 
-  number of bytes written for the document or edge in question. 
-  If an operation writes multiple documents/edges, it will increase the counter
+  For every write operation, the metric is increased by the approximate
+  number of bytes written for the document or edge in question.
+  If an operation writes multiple documents/edges, it increases the counter
   multiple times, each time with the approximate number of bytes written for the
   particular document/edge.
 
-  An AQL query will also increase the counter for every document or edge written,
+  An AQL query also increases the counter for every document or edge written,
   each time with the approximate number of bytes written for document/edge.
   
   The numbers reported by this metric normally relate to the cumulated sizes of
-  documents/edges written. For remove operations however only a fixed number of 
+  documents/edges written. For remove operations, however, only a fixed number of
   bytes is counted per removed document/edge.
   Writes into secondary indexes are not counted at all.
-  The metric is also increased for transactions that are started but later
-  aborted.
+  The metric is also increased for transactions that are started but later aborted.
 
-  This metric is not exposed by default. It is only present if the startup option 
-  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
-  `enabled-per-shard-per-user`. With the former setting, the metric will have
-  different labels for each shard that was read from. With the latter setting,
-  the metric will have different labels for each combination of shard and user
-  that accessed the shard.
+  This metric is not exposed by default. It is only present if the
+  `--server.export-shard-usage-metrics` startup option is set to either
+  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
+  the metric has different labels for each shard that was read from. With the
+  latter setting, the metric has different labels for each combination of shard
+  and user that accessed the shard.
   
   Note that internal operations, such as internal queries executed for statistics
-  gathering, internal garbage collection, TTL index cleanup are not counted in
-  these metrics. Additionally all requests that are using the superuser JWT for 
-  authentication and that do not have a specific user set, will not be counted.
+  gathering, internal garbage collection, and TTL index cleanup are not counted in
+  these metrics. Additionally, all requests that use the superuser JWT for
+  authentication and that do not have a specific user set, are not counted.

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
@@ -1,5 +1,5 @@
 name: arangodb_collection_requests_bytes_written_total
-introducedIn: "3.12.0"
+introducedIn: "3.10.13"
 help: |
   Number of bytes written in write requests on leaders and followers.
 unit: number

--- a/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
+++ b/Documentation/Metrics/arangodb_collection_requests_bytes_written_total.yaml
@@ -1,0 +1,44 @@
+name: arangodb_collection_requests_bytes_written_total
+introducedIn: "3.12.0"
+help: |
+  Number of bytes written in write requests on leaders and followers.
+unit: number
+type: counter
+category: Transactions
+complexity: advanced
+exposedBy:
+  - dbserver
+description: |
+  This metric exposes the per-shard number of bytes written by write operation
+  requests on DB-Servers, on both leaders and followers.
+  It is increased by AQL queries and single-/multi-document write operations.
+  The metric is first increased only the leader, but for every replication request
+  to followers it is also increased on followers.
+  
+  For every write operation, the metric will be increased by the approximate 
+  number of bytes written for the document or edge in question. 
+  If an operation writes multiple documents/edges, it will increase the counter
+  multiple times, each time with the approximate number of bytes written for the
+  particular document/edge.
+
+  An AQL query will also increase the counter for every document or edge written,
+  each time with the approximate number of bytes written for document/edge.
+  
+  The numbers reported by this metric normally relate to the cumulated sizes of
+  documents/edges written. For remove operations however only a fixed number of 
+  bytes is counted per removed document/edge.
+  Writes into secondary indexes are not counted at all.
+  The metric is also increased for transactions that are started but later
+  aborted.
+
+  This metric is not exposed by default. It is only present if the startup option 
+  `--server.export-shard-usage-metrics` is set to either `enabled-per-shard` or
+  `enabled-per-shard-per-user`. With the former setting, the metric will have
+  different labels for each shard that was read from. With the latter setting,
+  the metric will have different labels for each combination of shard and user
+  that accessed the shard.
+  
+  Note that internal operations, such as internal queries executed for statistics
+  gathering, internal garbage collection, TTL index cleanup are not counted in
+  these metrics. Additionally all requests that are using the superuser JWT for 
+  authentication and that do not have a specific user set, will not be counted.

--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -135,6 +135,7 @@ void ClusterQuery::prepareClusterQuery(
       transaction::Hints::Hint::FROM_TOPLEVEL_AQL);  // only used on toplevel
   if (_trx->state()->isDBServer()) {
     _trx->state()->acceptAnalyzersRevision(analyzersRevision);
+    _trx->setUsername(user);
   }
 
   TRI_IF_FAILURE("Query::setupLockTimeout") {
@@ -156,12 +157,13 @@ void ClusterQuery::prepareClusterQuery(
   _trx->state()->options().lockTimeout = origLockTimeout;
 
   if (ServerState::instance()->isDBServer()) {
-    _collections.visit(
-        [&](std::string const&, aql::Collection const& c) -> bool {
-          _trx->state()->trackRequest(*_trx->resolver(), _vocbase.name(),
-                                      c.name(), user, c.accessType(), "aql");
-          return true;
-        });
+    _collections.visit([&](std::string const&,
+                           aql::Collection const& c) -> bool {
+      // this code will only execute on leaders
+      _trx->state()->trackShardRequest(*_trx->resolver(), _vocbase.name(),
+                                       c.name(), user, c.accessType(), "aql");
+      return true;
+    });
   }
 
   enterState(QueryExecutionState::ValueType::PARSING);

--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -543,7 +543,7 @@ IndexIterator::CoveringCallback aql::getCallback(
             output.advanceRow();
             return false;
           },
-          context.getReadOwnWrites());
+          context.getReadOwnWrites(), /*countBytes*/ true);
     }
 
     return true;

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -358,11 +358,7 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
   options.database = _query.vocbase().name();
   options.timeout = network::Timeout(SETUP_TIMEOUT);
   options.skipScheduler = true;  // hack to speed up future.get()
-  if (!ExecContext::current().user().empty()) {
-    // send name of current user, if set. note that we cannot send
-    // empty URL parameters with our networking tools right now.
-    options.param("user", ExecContext::current().user());
-  }
+  network::addUserParameter(options, trx.username());
 
   TRI_IF_FAILURE("Query::setupTimeout") {
     options.timeout = network::Timeout(

--- a/arangod/Aql/IResearchViewExecutor.cpp
+++ b/arangod/Aql/IResearchViewExecutor.cpp
@@ -885,10 +885,10 @@ bool IResearchViewExecutorBase<Impl, ExecutionTraits>::writeRow(
   }
   if constexpr (Traits::MaterializeType == MaterializeType::Materialize) {
     // read document from underlying storage engine, if we got an id
-    if (ADB_UNLIKELY(
-            !collection.getPhysical()
-                 ->read(&_trx, documentId, ctx.callback, ReadOwnWrites::no)
-                 .ok())) {
+    if (ADB_UNLIKELY(!collection.getPhysical()
+                          ->read(&_trx, documentId, ctx.callback,
+                                 ReadOwnWrites::no, /*countBytes*/ true)
+                          .ok())) {
       return false;
     }
   } else if constexpr ((Traits::MaterializeType &

--- a/arangod/Aql/MaterializeExecutor.cpp
+++ b/arangod/Aql/MaterializeExecutor.cpp
@@ -123,7 +123,7 @@ arangodb::aql::MaterializeExecutor<T>::produceRows(
         collection->getPhysical()
             ->read(&_trx,
                    LocalDocumentId(input.getValue(docRegId).slice().getUInt()),
-                   callback, ReadOwnWrites::no)
+                   callback, ReadOwnWrites::no, /*countBytes*/ true)
             .ok();
 
     if (written) {

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -327,7 +327,8 @@ void RestAqlHandler::setupClusterQuery() {
     return;
   }
   q->prepareClusterQuery(querySlice, collectionBuilder.slice(), variablesSlice,
-                         snippetsSlice, traverserSlice, _request->value("user"),
+                         snippetsSlice, traverserSlice,
+                         _request->value(StaticStrings::UserString),
                          answerBuilder, analyzersRevision, fastPath);
 
   answerBuilder.close();  // result

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1277,6 +1277,8 @@ futures::Future<OperationResult> countOnCoordinator(
     reqOpts.timeout = network::Timeout(10.0);
   }
 
+  network::addUserParameter(reqOpts, trx.username());
+
   std::vector<Future<network::Response>> futures;
   futures.reserve(shardIds->size());
 
@@ -1607,11 +1609,7 @@ futures::Future<OperationResult> createDocumentOnCoordinator(
           OperationOptions::stringifyOverwriteMode(options.overwriteMode));
     }
 
-    if (!ExecContext::current().user().empty()) {
-      // send name of current user, if set. note that we cannot send
-      // empty URL parameters with our networking tools right now.
-      reqOpts.param("user", ExecContext::current().user());
-    }
+    network::addUserParameter(reqOpts, trx.username());
 
     // Now prepare the requests:
     auto* pool = trx.vocbase().server().getFeature<NetworkFeature>().pool();
@@ -1754,11 +1752,7 @@ futures::Future<OperationResult> removeDocumentOnCoordinator(
                       : "false");
   }
 
-  if (!ExecContext::current().user().empty()) {
-    // send name of current user, if set. note that we cannot send
-    // empty URL parameters with our networking tools right now.
-    reqOpts.param("user", ExecContext::current().user());
-  }
+  network::addUserParameter(reqOpts, trx.username());
 
   bool const isManaged =
       trx.state()->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED);
@@ -1936,11 +1930,7 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
   reqOpts.skipScheduler = api == transaction::MethodsApi::Synchronous;
   reqOpts.param(StaticStrings::Compact,
                 (options.truncateCompact ? "true" : "false"));
-  if (!ExecContext::current().user().empty()) {
-    // send name of current user, if set. note that we cannot send
-    // empty URL parameters with our networking tools right now.
-    reqOpts.param("user", ExecContext::current().user());
-  }
+  network::addUserParameter(reqOpts, trx.username());
 
   std::vector<Future<network::Response>> futures;
   futures.reserve(shardIds->size());
@@ -2037,11 +2027,7 @@ Future<OperationResult> getDocumentOnCoordinator(
     reqOpts.param("onlyget", "true");
   }
 
-  if (!ExecContext::current().user().empty()) {
-    // send name of current user, if set. note that we cannot send
-    // empty URL parameters with our networking tools right now.
-    reqOpts.param("user", ExecContext::current().user());
-  }
+  network::addUserParameter(reqOpts, trx.username());
 
   if (canUseFastPath) {
     // All shard keys are known in all documents.
@@ -2629,11 +2615,7 @@ futures::Future<OperationResult> modifyDocumentOnCoordinator(
     reqOpts.param(StaticStrings::ReturnOldString, "true");
   }
 
-  if (!ExecContext::current().user().empty()) {
-    // send name of current user, if set. note that we cannot send
-    // empty URL parameters with our networking tools right now.
-    reqOpts.param("user", ExecContext::current().user());
-  }
+  network::addUserParameter(reqOpts, trx.username());
 
   const bool isManaged =
       trx.state()->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED);
@@ -4826,7 +4808,7 @@ arangodb::Result getEngineStatsFromDBServers(ClusterFeature& feature,
   }
   report.close();
 
-  return Result();
+  return {};
 }
 
 }  // namespace arangodb

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -158,6 +158,8 @@ Future<network::Response> beginTransactionRequest(TransactionState& state,
   reqOpts.timeout = network::Timeout(lockTimeout + 5.0);
   reqOpts.skipScheduler = api == transaction::MethodsApi::Synchronous;
 
+  network::addUserParameter(reqOpts, state.username());
+
   auto* pool = state.vocbase().server().getFeature<NetworkFeature>().pool();
   network::Headers headers;
   headers.try_emplace(StaticStrings::TransactionId, std::to_string(tid.id()));

--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -359,7 +359,8 @@ Result ClusterCollection::lookupKey(
 Result ClusterCollection::read(transaction::Methods* /*trx*/,
                                std::string_view /*key*/,
                                IndexIterator::DocumentCallback const& /*cb*/,
-                               ReadOwnWrites /*readOwnWrites*/) const {
+                               ReadOwnWrites /*readOwnWrites*/,
+                               bool /*countBytes*/) const {
   return Result(TRI_ERROR_NOT_IMPLEMENTED);
 }
 
@@ -367,14 +368,17 @@ Result ClusterCollection::read(transaction::Methods* /*trx*/,
 Result ClusterCollection::read(transaction::Methods* /*trx*/,
                                LocalDocumentId const& /*documentId*/,
                                IndexIterator::DocumentCallback const& /*cb*/,
-                               ReadOwnWrites /*readOwnWrites*/) const {
+                               ReadOwnWrites /*readOwnWrites*/,
+                               bool /*countBytes*/) const {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 
-Result ClusterCollection::lookupDocument(
-    transaction::Methods& /*trx*/, LocalDocumentId /*documentId*/,
-    velocypack::Builder& /*builder*/, bool /*readCache*/, bool /*fillCache*/,
-    ReadOwnWrites /*readOwnWrites*/) const {
+Result ClusterCollection::lookupDocument(transaction::Methods& /*trx*/,
+                                         LocalDocumentId /*documentId*/,
+                                         velocypack::Builder& /*builder*/,
+                                         bool /*readCache*/, bool /*fillCache*/,
+                                         ReadOwnWrites /*readOwnWrites*/,
+                                         bool /*countBytes*/) const {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 
@@ -382,7 +386,8 @@ Result ClusterCollection::lookupDocument(
 bool ClusterCollection::readDocument(transaction::Methods* /*trx*/,
                                      LocalDocumentId const& /*documentId*/,
                                      ManagedDocumentResult& /*result*/,
-                                     ReadOwnWrites /*readOwnWrites*/) const {
+                                     ReadOwnWrites /*readOwnWrites*/,
+                                     bool /*countBytes*/) const {
   THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
 }
 

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -121,21 +121,21 @@ class ClusterCollection final : public PhysicalCollection {
                    ReadOwnWrites) const override;
 
   Result read(transaction::Methods*, std::string_view key,
-              IndexIterator::DocumentCallback const& cb,
-              ReadOwnWrites) const override;
+              IndexIterator::DocumentCallback const& cb, ReadOwnWrites,
+              bool countBytes) const override;
 
   Result read(transaction::Methods* trx, LocalDocumentId const& token,
-              IndexIterator::DocumentCallback const& cb,
-              ReadOwnWrites) const override;
+              IndexIterator::DocumentCallback const& cb, ReadOwnWrites,
+              bool countBytes) const override;
 
   bool readDocument(transaction::Methods* trx, LocalDocumentId const& token,
-                    ManagedDocumentResult& result,
-                    ReadOwnWrites) const override;
+                    ManagedDocumentResult& result, ReadOwnWrites,
+                    bool countBytes) const override;
 
   Result lookupDocument(transaction::Methods& trx, LocalDocumentId token,
                         velocypack::Builder& builder, bool readCache,
-                        bool fillCache,
-                        ReadOwnWrites readOwnWrites) const override;
+                        bool fillCache, ReadOwnWrites readOwnWrites,
+                        bool countBytes) const override;
 
   Result insert(transaction::Methods& trx, RevisionId newRevisionId,
                 velocypack::Slice newDocument,

--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -187,7 +187,7 @@ bool RefactoredTraverserCache::appendEdge(EdgeDocumentToken const& idToken,
                 }
                 return true;
               },
-              ReadOwnWrites::no)
+              ReadOwnWrites::no, /*countBytes*/ true)
           .ok();
   if (ADB_UNLIKELY(!res)) {
     // We already had this token, inconsistent state. Return NULL in Production

--- a/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
+++ b/arangod/Graph/Cursors/RefactoredSingleServerEdgeCursor.cpp
@@ -384,7 +384,7 @@ void RefactoredSingleServerEdgeCursor<Step>::readAll(
                   callback(std::move(edgeToken), edgeDoc, cursorID);
                   return true;
                 },
-                ReadOwnWrites::no)
+                ReadOwnWrites::no, /*countBytes*/ true)
             .ok();
       });
     }

--- a/arangod/Graph/SingleServerEdgeCursor.cpp
+++ b/arangod/Graph/SingleServerEdgeCursor.cpp
@@ -131,7 +131,7 @@ void SingleServerEdgeCursor::getDocAndRunCallback(
         }
         return true;
       },
-      ReadOwnWrites::no);
+      ReadOwnWrites::no, /*countBytes*/ true);
 }
 
 bool SingleServerEdgeCursor::advanceCursor(
@@ -308,7 +308,7 @@ void SingleServerEdgeCursor::readAll(EdgeCursor::Callback const& callback) {
                     callback(EdgeDocumentToken(cid, token), edgeDoc, cursorId);
                     return true;
                   },
-                  ReadOwnWrites::no)
+                  ReadOwnWrites::no, /*countBytes*/ true)
               .ok();
         });
       }

--- a/arangod/Graph/TraverserCache.cpp
+++ b/arangod/Graph/TraverserCache.cpp
@@ -115,7 +115,8 @@ VPackSlice TraverserCache::lookupToken(EdgeDocumentToken const& idToken) {
   }
 
   if (!col->getPhysical()->readDocument(_trx, idToken.localDocumentId(), _mmdr,
-                                        ReadOwnWrites::no)) {
+                                        ReadOwnWrites::no,
+                                        /*countBytes*/ true)) {
     // We already had this token, inconsistent state. Return NULL in Production
     LOG_TOPIC("3acb3", ERR, arangodb::Logger::GRAPHS)
         << "Could not extract indexed edge document, return 'null' instead. "

--- a/arangod/Indexes/IndexIterator.cpp
+++ b/arangod/Indexes/IndexIterator.cpp
@@ -105,7 +105,7 @@ bool IndexIterator::nextDocumentImpl(DocumentCallback const& cb,
   return nextImpl(
       [this, &cb](LocalDocumentId const& token) {
         return _collection->getPhysical()
-            ->read(_trx, token, cb, _readOwnWrites)
+            ->read(_trx, token, cb, _readOwnWrites, /*countBytes*/ true)
             .ok();
       },
       limit);

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -106,13 +106,19 @@ Prometheus itself doesn't need it.)")
               arangodb::options::Flags::DefaultNoComponents,
               arangodb::options::Flags::OnDBServer))
       .setIntroducedIn(31013)
-      .setLongDescription(R"(This option can be used to make DB servers export
-detailed shard usage metrics. By default, this option is set to 'disabled' so
-that no shard usage metrics are exported. 
-Setting the option to 'enabled-per-shard' will make DB-Servers collect per-shard
-usage metrics whenever a shard is accessed.
-Setting the option to 'enabled-per-shard-per-user' will make DB-Servers collect
-usage metrics per shard and per user whenever a shard is accessed. 
+      .setIntroducedIn(31107)
+      .setLongDescription(R"(This option can be used to make DB-Servers export
+detailed shard usage metrics.
+
+- By default, this option is set to `disabled` so that no shard usage metrics
+  are exported.
+
+- Set the option to `enabled-per-shard` to make DB-Servers collect per-shard
+  usage metrics whenever a shard is accessed.
+
+- Set this option to `enabled-per-shard-per-user` to make DB-Servers collect
+  usage metrics per shard and per user whenever a shard is accessed.
+
 Note that enabling shard usage metrics can produce a lot of metrics if there 
 are many shards and/or users in the system.)");
 }

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -106,7 +106,6 @@ Prometheus itself doesn't need it.)")
               arangodb::options::Flags::DefaultNoComponents,
               arangodb::options::Flags::OnDBServer))
       .setIntroducedIn(31013)
-      .setIntroducedIn(31107)
       .setLongDescription(R"(This option can be used to make DB-Servers export
 detailed shard usage metrics.
 

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -41,8 +41,7 @@
 
 #include <fuerte/types.h>
 
-namespace arangodb {
-namespace network {
+namespace arangodb::network {
 
 Headers addAuthorizationHeader(
     std::unordered_map<std::string, std::string> const& originalHeaders) {
@@ -369,5 +368,13 @@ void addSourceHeader(consensus::Agent* agent, fuerte::Request& req) {
   }
 }
 
-}  // namespace network
-}  // namespace arangodb
+void addUserParameter(RequestOptions& reqOpts, std::string_view value) {
+  if (!value.empty()) {
+    // if no user name is set, we cannot add it to the request options
+    // as a URL parameter, because they will assert that the provided
+    // value is non-empty
+    reqOpts.param(StaticStrings::UserString, value);
+  }
+}
+
+}  // namespace arangodb::network

--- a/arangod/Network/Utils.h
+++ b/arangod/Network/Utils.h
@@ -47,6 +47,7 @@ class ClusterInfo;
 class NetworkFeature;
 
 namespace network {
+struct RequestOptions;
 
 Headers addAuthorizationHeader(
     std::unordered_map<std::string, std::string> const& originalHeaders);
@@ -97,6 +98,9 @@ fuerte::RestVerb arangoRestVerbToFuerte(rest::RequestType);
 rest::RequestType fuerteRestVerbToArango(fuerte::RestVerb);
 
 void addSourceHeader(consensus::Agent* agent, fuerte::Request& req);
+
+/// @brief add "user" request parameter
+void addUserParameter(RequestOptions& reqOpts, std::string_view value);
 
 }  // namespace network
 }  // namespace arangodb

--- a/arangod/Network/types.h
+++ b/arangod/Network/types.h
@@ -25,9 +25,10 @@
 
 #include <fuerte/types.h>
 #include <chrono>
+#include <map>
+#include <string>
 
-namespace arangodb {
-namespace network {
+namespace arangodb::network {
 
 struct Response;
 typedef std::string DestinationId;
@@ -41,5 +42,4 @@ struct EndpointSpec {
   std::string endpoint;
 };
 
-}  // namespace network
-}  // namespace arangodb
+}  // namespace arangodb::network

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -135,7 +135,8 @@ arangodb::Result removeRevisions(
       tempBuilder->clear();
       res = physical->lookupDocument(trx, documentId, *tempBuilder,
                                      /*readCache*/ true, /*fillCache*/ false,
-                                     arangodb::ReadOwnWrites::yes);
+                                     arangodb::ReadOwnWrites::yes,
+                                     /*countBytes*/ false);
 
       if (res.ok()) {
         res = physical->remove(trx, documentId, rid, tempBuilder->slice(),
@@ -232,7 +233,8 @@ arangodb::Result fetchRevisions(
       tempBuilder->clear();
       r = physical->lookupDocument(trx, documentId, *tempBuilder,
                                    /*readCache*/ true, /*fillCache*/ false,
-                                   arangodb::ReadOwnWrites::yes);
+                                   arangodb::ReadOwnWrites::yes,
+                                   /*countBytes*/ false);
 
       if (r.ok()) {
         TRI_ASSERT(tempBuilder->slice().isObject());
@@ -413,7 +415,8 @@ arangodb::Result fetchRevisions(
           // replicated in unexpected order.
           arangodb::ManagedDocumentResult mdr;
           if (physical->readDocument(&trx, arangodb::LocalDocumentId(rid.id()),
-                                     mdr, arangodb::ReadOwnWrites::yes)) {
+                                     mdr, arangodb::ReadOwnWrites::yes,
+                                     /*countBytes*/ false)) {
             // already have exactly this revision. no need to insert
             sl.erase(rid);
             break;

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -44,6 +44,7 @@
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Collections.h"
 
+#include <absl/strings/str_cat.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 
@@ -556,11 +557,13 @@ RestStatus RestCollectionHandler::handleCommandPut() {
       return RestStatus::DONE;
     }
 
+    // track request only on leader
     if (opts.isSynchronousReplicationFrom.empty() &&
         ServerState::instance()->isDBServer()) {
-      _activeTrx->state()->trackRequest(
+      _activeTrx->state()->trackShardRequest(
           *_activeTrx->resolver(), _vocbase.name(), coll->name(),
-          _request->value("user"), AccessMode::Type::WRITE, "truncate");
+          _request->value(StaticStrings::UserString), AccessMode::Type::WRITE,
+          "truncate");
     }
 
     return waitForFuture(
@@ -841,9 +844,10 @@ RestCollectionHandler::collectionRepresentationAsync(
 
 RestStatus RestCollectionHandler::standardResponse() {
   generateOk(rest::ResponseCode::OK, _builder);
-  _response->setHeaderNC(StaticStrings::Location,
-                         "/_db/" + StringUtils::urlEncode(_vocbase.name()) +
-                             _request->requestPath());
+  _response->setHeaderNC(
+      StaticStrings::Location,
+      absl::StrCat("/_db/", StringUtils::urlEncode(_vocbase.name()),
+                   _request->requestPath()));
   return RestStatus::DONE;
 }
 

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -269,9 +269,10 @@ RestStatus RestDocumentHandler::insertDocument() {
   // track request only on leader
   if (opOptions.isSynchronousReplicationFrom.empty() &&
       ServerState::instance()->isDBServer()) {
-    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
-                                      cname, _request->value("user"),
-                                      AccessMode::Type::WRITE, "insert");
+    _activeTrx->state()->trackShardRequest(
+        *_activeTrx->resolver(), _vocbase.name(), cname,
+        _request->value(StaticStrings::UserString), AccessMode::Type::WRITE,
+        "insert");
   }
 
   return waitForFuture(
@@ -399,9 +400,10 @@ RestStatus RestDocumentHandler::readSingleDocument(bool generateBody) {
 
   // track request on both leader and follower (in case of dirty-read requests)
   if (ServerState::instance()->isDBServer()) {
-    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
-                                      collection, _request->value("user"),
-                                      AccessMode::Type::READ, "read");
+    _activeTrx->state()->trackShardRequest(
+        *_activeTrx->resolver(), _vocbase.name(), collection,
+        _request->value(StaticStrings::UserString), AccessMode::Type::READ,
+        "read");
   }
 
   if (_activeTrx->state()->options().allowDirtyReads) {
@@ -606,10 +608,10 @@ RestStatus RestDocumentHandler::modifyDocument(bool isPatch) {
   // track request only on leader
   if (opOptions.isSynchronousReplicationFrom.empty() &&
       ServerState::instance()->isDBServer()) {
-    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
-                                      cname, _request->value("user"),
-                                      AccessMode::Type::WRITE,
-                                      isPatch ? "update" : "replace");
+    _activeTrx->state()->trackShardRequest(
+        *_activeTrx->resolver(), _vocbase.name(), cname,
+        _request->value(StaticStrings::UserString), AccessMode::Type::WRITE,
+        isPatch ? "update" : "replace");
   }
 
   if (ServerState::instance()->isDBServer() &&
@@ -765,9 +767,10 @@ RestStatus RestDocumentHandler::removeDocument() {
   // track request only on leader
   if (opOptions.isSynchronousReplicationFrom.empty() &&
       ServerState::instance()->isDBServer()) {
-    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
-                                      cname, _request->value("user"),
-                                      AccessMode::Type::WRITE, "remove");
+    _activeTrx->state()->trackShardRequest(
+        *_activeTrx->resolver(), _vocbase.name(), cname,
+        _request->value(StaticStrings::UserString), AccessMode::Type::WRITE,
+        "remove");
   }
 
   if (ServerState::instance()->isDBServer() &&
@@ -868,9 +871,10 @@ RestStatus RestDocumentHandler::readManyDocuments() {
 
   // track request on both leader and follower (in case of dirty-read requests)
   if (ServerState::instance()->isDBServer()) {
-    _activeTrx->state()->trackRequest(*_activeTrx->resolver(), _vocbase.name(),
-                                      cname, _request->value("user"),
-                                      AccessMode::Type::READ, "read-multiple");
+    _activeTrx->state()->trackShardRequest(
+        *_activeTrx->resolver(), _vocbase.name(), cname,
+        _request->value(StaticStrings::UserString), AccessMode::Type::READ,
+        "read-multiple");
   }
 
   if (_activeTrx->state()->options().allowDirtyReads) {

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1106,7 +1106,7 @@ Result RocksDBCollection::lookupKey(
 }
 
 bool RocksDBCollection::lookupRevision(transaction::Methods* trx,
-                                       VPackSlice const& key,
+                                       velocypack::Slice key,
                                        RevisionId& revisionId,
                                        ReadOwnWrites readOwnWrites) const {
   TRI_ASSERT(key.isString());
@@ -1128,7 +1128,8 @@ bool RocksDBCollection::lookupRevision(transaction::Methods* trx,
 
 Result RocksDBCollection::read(transaction::Methods* trx, std::string_view key,
                                IndexIterator::DocumentCallback const& cb,
-                               ReadOwnWrites readOwnWrites) const {
+                               ReadOwnWrites readOwnWrites,
+                               bool countBytes) const {
   TRI_IF_FAILURE("LogicalCollection::read") { return Result(TRI_ERROR_DEBUG); }
 
   ::ReadTimeTracker timeTracker(
@@ -1154,7 +1155,7 @@ Result RocksDBCollection::read(transaction::Methods* trx, std::string_view key,
     }
 
     res = lookupDocumentVPack(trx, documentId, ps, /*readCache*/ true,
-                              /*fillCache*/ true, readOwnWrites);
+                              /*fillCache*/ true, readOwnWrites, countBytes);
     if (res.ok()) {
       cb(documentId, VPackSlice(reinterpret_cast<uint8_t const*>(ps.data())));
     }
@@ -1168,7 +1169,8 @@ Result RocksDBCollection::read(transaction::Methods* trx, std::string_view key,
 Result RocksDBCollection::read(transaction::Methods* trx,
                                LocalDocumentId const& documentId,
                                IndexIterator::DocumentCallback const& cb,
-                               ReadOwnWrites readOwnWrites) const {
+                               ReadOwnWrites readOwnWrites,
+                               bool countBytes) const {
   ::ReadTimeTracker timeTracker(
       _statistics._readWriteMetrics,
       [](TransactionStatistics::ReadWriteMetrics& metrics,
@@ -1180,14 +1182,15 @@ Result RocksDBCollection::read(transaction::Methods* trx,
   }
 
   return lookupDocumentVPack(trx, documentId, cb, /*withCache*/ true,
-                             readOwnWrites);
+                             readOwnWrites, countBytes);
 }
 
 // read using a local document id
 bool RocksDBCollection::readDocument(transaction::Methods* trx,
                                      LocalDocumentId const& documentId,
                                      ManagedDocumentResult& result,
-                                     ReadOwnWrites readOwnWrites) const {
+                                     ReadOwnWrites readOwnWrites,
+                                     bool countBytes) const {
   ::ReadTimeTracker timeTracker(
       _statistics._readWriteMetrics,
       [](TransactionStatistics::ReadWriteMetrics& metrics,
@@ -1198,8 +1201,9 @@ bool RocksDBCollection::readDocument(transaction::Methods* trx,
   if (documentId.isSet()) {
     std::string* buffer = result.setManaged();
     rocksdb::PinnableSlice ps(buffer);
-    Result res = lookupDocumentVPack(trx, documentId, ps, /*readCache*/ true,
-                                     /*fillCache*/ true, readOwnWrites);
+    Result res =
+        lookupDocumentVPack(trx, documentId, ps, /*readCache*/ true,
+                            /*fillCache*/ true, readOwnWrites, countBytes);
     if (res.ok()) {
       if (ps.IsPinned()) {
         buffer->assign(ps.data(), ps.size());
@@ -1550,11 +1554,13 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
     return res.reset(TRI_ERROR_DEBUG);
   }
 
+  size_t const byteSize = static_cast<size_t>(doc.byteSize());
+
   rocksdb::Status s = mthds->PutUntracked(
       RocksDBColumnFamilyManager::get(
           RocksDBColumnFamilyManager::Family::Documents),
-      key.ref(),
-      rocksdb::Slice(doc.startAs<char>(), static_cast<size_t>(doc.byteSize())));
+      key.ref(), rocksdb::Slice(doc.startAs<char>(), byteSize));
+
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::document));
     res.withError([&doc](result::Error& err) {
@@ -1568,6 +1574,11 @@ Result RocksDBCollection::insertDocument(arangodb::transaction::Methods* trx,
   // we have successfully added a value to the WBWI. after this, we
   // can only restore the previous state via a full rebuild
   savepoint.tainted();
+
+  trx->state()->trackShardUsage(
+      *trx->resolver(), _logicalCollection.vocbase().name(),
+      _logicalCollection.name(), trx->username(), AccessMode::Type::WRITE,
+      "single-document insert", byteSize);
 
   {
     bool needReversal = false;
@@ -1659,7 +1670,7 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
     res.withError([&doc](result::Error& err) {
       TRI_ASSERT(doc.get(StaticStrings::KeyString).isString());
       err.appendErrorMessage("; key: ");
-      err.appendErrorMessage(doc.get(StaticStrings::KeyString).copyString());
+      err.appendErrorMessage(doc.get(StaticStrings::KeyString).stringView());
     });
     return res;
   }
@@ -1667,6 +1678,11 @@ Result RocksDBCollection::removeDocument(arangodb::transaction::Methods* trx,
   // we have successfully removed a value from the WBWI. after this, we
   // can only restore the previous state via a full rebuild
   savepoint.tainted();
+
+  trx->state()->trackShardUsage(
+      *trx->resolver(), _logicalCollection.vocbase().name(),
+      _logicalCollection.name(), trx->username(), AccessMode::Type::WRITE,
+      "document remove", key->size());
 
   {
     bool needReversal = false;
@@ -1781,7 +1797,7 @@ Result RocksDBCollection::modifyDocument(
     res.withError([&newDoc](result::Error& err) {
       TRI_ASSERT(newDoc.get(StaticStrings::KeyString).isString());
       err.appendErrorMessage("; key: ");
-      err.appendErrorMessage(newDoc.get(StaticStrings::KeyString).copyString());
+      err.appendErrorMessage(newDoc.get(StaticStrings::KeyString).stringView());
     });
     return res;
   }
@@ -1802,12 +1818,13 @@ Result RocksDBCollection::modifyDocument(
 
   key->constructDocument(objectId(), newDocumentId);
   TRI_ASSERT(key->containsLocalDocumentId(newDocumentId));
-  s = mthds->PutUntracked(
-      RocksDBColumnFamilyManager::get(
-          RocksDBColumnFamilyManager::Family::Documents),
-      key.ref(),
-      rocksdb::Slice(newDoc.startAs<char>(),
-                     static_cast<size_t>(newDoc.byteSize())));
+
+  size_t const byteSize = static_cast<size_t>(newDoc.byteSize());
+
+  s = mthds->PutUntracked(RocksDBColumnFamilyManager::get(
+                              RocksDBColumnFamilyManager::Family::Documents),
+                          key.ref(),
+                          rocksdb::Slice(newDoc.startAs<char>(), byteSize));
   if (!s.ok()) {
     return res.reset(rocksutils::convertStatus(s, rocksutils::document));
   }
@@ -1816,6 +1833,11 @@ Result RocksDBCollection::modifyDocument(
     // banish new document to avoid caching without committing first
     invalidateCacheEntry(key.ref());
   }
+
+  trx->state()->trackShardUsage(
+      *trx->resolver(), _logicalCollection.vocbase().name(),
+      _logicalCollection.name(), trx->username(), AccessMode::Type::WRITE,
+      "document update/replace", byteSize);
 
   {
     bool needReversal = false;
@@ -1867,7 +1889,8 @@ Result RocksDBCollection::lookupDocument(transaction::Methods& trx,
                                          LocalDocumentId documentId,
                                          velocypack::Builder& builder,
                                          bool readCache, bool fillCache,
-                                         ReadOwnWrites readOwnWrites) const {
+                                         ReadOwnWrites readOwnWrites,
+                                         bool countBytes) const {
   TRI_ASSERT(trx.state()->isRunning());
   TRI_ASSERT(objectId() != 0);
 
@@ -1884,6 +1907,12 @@ Result RocksDBCollection::lookupDocument(transaction::Methods& trx,
       builder.add(
           VPackSlice(reinterpret_cast<uint8_t const*>(f.value()->value())));
       TRI_ASSERT(builder.slice().isObject());
+      if (countBytes) {
+        trx.state()->trackShardUsage(
+            *trx.resolver(), _logicalCollection.vocbase().name(),
+            _logicalCollection.name(), trx.username(), AccessMode::Type::READ,
+            "document lookup from cache", f.value()->size());
+      }
       return {};  // all good
     }
 
@@ -1910,6 +1939,13 @@ Result RocksDBCollection::lookupDocument(transaction::Methods& trx,
     return rocksutils::convertStatus(s, rocksutils::document);
   }
 
+  if (countBytes) {
+    trx.state()->trackShardUsage(
+        *trx.resolver(), _logicalCollection.vocbase().name(),
+        _logicalCollection.name(), trx.username(), AccessMode::Type::READ,
+        "document lookup", ps.size());
+  }
+
   if (fillCache && useCache() && !lockTimeout) {
     TRI_ASSERT(_cache != nullptr);
     // write entry back to cache
@@ -1929,7 +1965,7 @@ Result RocksDBCollection::lookupDocument(transaction::Methods& trx,
 arangodb::Result RocksDBCollection::lookupDocumentVPack(
     transaction::Methods* trx, LocalDocumentId const& documentId,
     rocksdb::PinnableSlice& ps, bool readCache, bool fillCache,
-    ReadOwnWrites readOwnWrites) const {
+    ReadOwnWrites readOwnWrites, bool countBytes) const {
   TRI_ASSERT(trx->state()->isRunning());
   TRI_ASSERT(objectId() != 0);
   Result res;
@@ -1947,6 +1983,12 @@ arangodb::Result RocksDBCollection::lookupDocumentVPack(
       ps.PinSelf(
           rocksdb::Slice(reinterpret_cast<char const*>(f.value()->value()),
                          f.value()->valueSize()));
+      if (countBytes) {
+        trx->state()->trackShardUsage(
+            *trx->resolver(), _logicalCollection.vocbase().name(),
+            _logicalCollection.name(), trx->username(), AccessMode::Type::READ,
+            "document lookup from cache", f.value()->size());
+      }
       // TODO we could potentially use the PinSlice method ?!
       return {};  // all good
     }
@@ -1972,6 +2014,13 @@ arangodb::Result RocksDBCollection::lookupDocumentVPack(
     return rocksutils::convertStatus(s, rocksutils::document);
   }
 
+  if (countBytes) {
+    trx->state()->trackShardUsage(
+        *trx->resolver(), _logicalCollection.vocbase().name(),
+        _logicalCollection.name(), trx->username(), AccessMode::Type::READ,
+        "document lookup", ps.size());
+  }
+
   if (fillCache && useCache() && !lockTimeout) {
     TRI_ASSERT(_cache != nullptr);
     // write entry back to cache
@@ -1987,7 +2036,7 @@ arangodb::Result RocksDBCollection::lookupDocumentVPack(
 Result RocksDBCollection::lookupDocumentVPack(
     transaction::Methods* trx, LocalDocumentId const& documentId,
     IndexIterator::DocumentCallback const& cb, bool withCache,
-    ReadOwnWrites readOwnWrites) const {
+    ReadOwnWrites readOwnWrites, bool countBytes) const {
   TRI_ASSERT(trx->state()->isRunning());
   TRI_ASSERT(objectId() != 0);
 
@@ -2002,6 +2051,13 @@ Result RocksDBCollection::lookupDocumentVPack(
     if (f.found()) {
       cb(documentId,
          VPackSlice(reinterpret_cast<uint8_t const*>(f.value()->value())));
+
+      if (countBytes) {
+        trx->state()->trackShardUsage(
+            *trx->resolver(), _logicalCollection.vocbase().name(),
+            _logicalCollection.name(), trx->username(), AccessMode::Type::READ,
+            "document lookup from cache", f.value()->size());
+      }
       return {};
     }
   }
@@ -2018,6 +2074,13 @@ Result RocksDBCollection::lookupDocumentVPack(
 
   if (!s.ok()) {
     return rocksutils::convertStatus(s);
+  }
+
+  if (countBytes) {
+    trx->state()->trackShardUsage(
+        *trx->resolver(), _logicalCollection.vocbase().name(),
+        _logicalCollection.name(), trx->username(), AccessMode::Type::READ,
+        "document lookup", ps.size());
   }
 
   TRI_ASSERT(ps.size() > 0);

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -109,21 +109,21 @@ class RocksDBCollection final : public RocksDBMetaCollection {
                    std::pair<LocalDocumentId, RevisionId>& result,
                    ReadOwnWrites readOwnWrites) const override;
 
-  bool lookupRevision(transaction::Methods* trx, velocypack::Slice const& key,
+  bool lookupRevision(transaction::Methods* trx, velocypack::Slice key,
                       RevisionId& revisionId, ReadOwnWrites) const;
 
   Result read(transaction::Methods*, std::string_view key,
               IndexIterator::DocumentCallback const& cb,
-              ReadOwnWrites readOwnWrites) const override;
+              ReadOwnWrites readOwnWrites, bool countBytes) const override;
 
   /// @brief lookup with callback, not thread-safe on same transaction::Context
   Result read(transaction::Methods* trx, LocalDocumentId const& token,
               IndexIterator::DocumentCallback const& cb,
-              ReadOwnWrites readOwnWrites) const override;
+              ReadOwnWrites readOwnWrites, bool countBytes) const override;
 
   bool readDocument(transaction::Methods* trx, LocalDocumentId const& token,
-                    ManagedDocumentResult& result,
-                    ReadOwnWrites readOwnWrites) const override;
+                    ManagedDocumentResult& result, ReadOwnWrites readOwnWrites,
+                    bool countBytes) const override;
 
   Result insert(transaction::Methods& trx, RevisionId newRevisionId,
                 velocypack::Slice newDocument,
@@ -155,8 +155,8 @@ class RocksDBCollection final : public RocksDBMetaCollection {
   /// @param fillCache fill cache with found document
   Result lookupDocument(transaction::Methods& trx, LocalDocumentId documentId,
                         velocypack::Builder& builder, bool readCache,
-                        bool fillCache,
-                        ReadOwnWrites readOwnWrites) const override;
+                        bool fillCache, ReadOwnWrites readOwnWrites,
+                        bool countBytes) const override;
 
  private:
   // optimized truncate, using DeleteRange operations.
@@ -214,12 +214,14 @@ class RocksDBCollection final : public RocksDBMetaCollection {
                                        LocalDocumentId const& documentId,
                                        rocksdb::PinnableSlice& ps,
                                        bool readCache, bool fillCache,
-                                       ReadOwnWrites readOwnWrites) const;
+                                       ReadOwnWrites readOwnWrites,
+                                       bool countBytes) const;
 
   Result lookupDocumentVPack(transaction::Methods*,
                              LocalDocumentId const& documentId,
                              IndexIterator::DocumentCallback const& cb,
-                             bool withCache, ReadOwnWrites readOwnWrites) const;
+                             bool withCache, ReadOwnWrites readOwnWrites,
+                             bool countBytes) const;
 
   /// @brief create hash-cache
   void setupCache() const;

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -857,7 +857,8 @@ void RocksDBEdgeIndex::warmupInternal(transaction::Methods* trx,
     if (needsInsert) {
       LocalDocumentId const docId = RocksDBKey::edgeDocumentId(key);
       // warmup does not need to observe own writes
-      if (!rocksColl->readDocument(trx, docId, mdr, ReadOwnWrites::no)) {
+      if (!rocksColl->readDocument(trx, docId, mdr, ReadOwnWrites::no,
+                                   /*countBytes*/ false)) {
         // Data Inconsistency. revision id without a document...
         TRI_ASSERT(false);
         continue;

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -285,7 +285,7 @@ class RDBNearIterator final : public IndexIterator {
                          return true;
                          // geo index never needs to observe own writes
                        },
-                       ReadOwnWrites::no)
+                       ReadOwnWrites::no, /*countBytes*/ true)
                    .ok()) {
             return false;  // ignore document
           }
@@ -320,7 +320,7 @@ class RDBNearIterator final : public IndexIterator {
                            return true;
                            // geo index never needs to observe own writes
                          },
-                         ReadOwnWrites::no)
+                         ReadOwnWrites::no, /*countBytes*/ true)
                      .ok()) {
               return false;
             }
@@ -503,7 +503,7 @@ class RDBCoveringIterator final : public IndexIterator {
                          return true;
                          // geo index never needs to observe own writes
                        },
-                       ReadOwnWrites::no)
+                       ReadOwnWrites::no, /*countBytes*/ true)
                    .ok()) {
             return false;  // ignore document
           }
@@ -538,7 +538,7 @@ class RDBCoveringIterator final : public IndexIterator {
                            return true;
                            // geo index never needs to observe own writes
                          },
-                         ReadOwnWrites::no)
+                         ReadOwnWrites::no, /*countBytes*/ true)
                      .ok()) {
               return false;
             }

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -112,7 +112,7 @@ Result removeKeysOutsideRange(
           builder.clear();
           Result r = physical->lookupDocument(
               trx, documentId, builder, /*readCache*/ true,
-              /*fillCache*/ false, ReadOwnWrites::yes);
+              /*fillCache*/ false, ReadOwnWrites::yes, /*countBytes*/ false);
 
           if (r.ok()) {
             TRI_ASSERT(builder.slice().isObject());
@@ -158,7 +158,7 @@ Result removeKeysOutsideRange(
           builder.clear();
           Result r = physical->lookupDocument(
               trx, documentId, builder, /*readCache*/ true,
-              /*fillCache*/ false, ReadOwnWrites::yes);
+              /*fillCache*/ false, ReadOwnWrites::yes, /*countBytes*/ false);
 
           if (r.ok()) {
             TRI_ASSERT(builder.slice().isObject());
@@ -338,7 +338,8 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer,
           tempBuilder->clear();
           r = physical->lookupDocument(*trx, documentId, *tempBuilder,
                                        /*readCache*/ true, /*fillCache*/ false,
-                                       ReadOwnWrites::yes);
+                                       ReadOwnWrites::yes,
+                                       /*countBytes*/ false);
 
           if (r.ok()) {
             TRI_ASSERT(tempBuilder->slice().isObject());
@@ -406,7 +407,7 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer,
         tempBuilder->clear();
         r = physical->lookupDocument(*trx, documentId, *tempBuilder,
                                      /*readCache*/ true, /*fillCache*/ false,
-                                     ReadOwnWrites::yes);
+                                     ReadOwnWrites::yes, /*countBytes*/ false);
 
         if (r.ok()) {
           TRI_ASSERT(tempBuilder->slice().isObject());
@@ -574,7 +575,8 @@ Result syncChunkRocksDB(DatabaseInitialSyncer& syncer,
           tempBuilder->clear();
           r = physical->lookupDocument(*trx, documentId, *tempBuilder,
                                        /*readCache*/ true, /*fillCache*/ false,
-                                       ReadOwnWrites::yes);
+                                       ReadOwnWrites::yes,
+                                       /*countBytes*/ false);
 
           if (r.ok()) {
             TRI_ASSERT(tempBuilder->slice().isObject());
@@ -881,7 +883,8 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
               tempBuilder.clear();
               r = physical->lookupDocument(
                   *trx, documentId, tempBuilder, /*readCache*/ true,
-                  /*fillCache*/ false, ReadOwnWrites::yes);
+                  /*fillCache*/ false, ReadOwnWrites::yes,
+                  /*countBytes*/ false);
 
               if (r.ok()) {
                 TRI_ASSERT(tempBuilder.slice().isObject());
@@ -977,7 +980,7 @@ Result handleSyncKeysRocksDB(DatabaseInitialSyncer& syncer,
                   docRev = RevisionId::fromSlice(doc);
                   return true;
                 },
-                ReadOwnWrites::yes);
+                ReadOwnWrites::yes, /*countBytes*/ false);
           }
           compareChunk(docKey, docRev);
           return true;

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -1455,9 +1455,10 @@ Result RocksDBVPackIndex::checkOperation(transaction::Methods& trx,
               }
               return true;  // return value does not matter here
             },
-            ReadOwnWrites::yes);  // modifications always need to observe all
-                                  // changes in order to validate uniqueness
-                                  // constraints
+            ReadOwnWrites::yes,
+            /*countBytes*/ false);  // modifications always need to observe all
+                                    // changes in order to validate uniqueness
+                                    // constraints
         if (readResult.fail()) {
           addErrorMsg(readResult);
           THROW_ARANGO_EXCEPTION(readResult);
@@ -1567,9 +1568,10 @@ Result RocksDBVPackIndex::insert(transaction::Methods& trx,
               }
               return true;  // return value does not matter here
             },
-            ReadOwnWrites::yes);  // modifications always need to observe all
-                                  // changes in order to validate uniqueness
-                                  // constraints
+            ReadOwnWrites::yes,
+            /*countBytes*/ false);  // modifications always need to observe all
+                                    // changes in order to validate uniqueness
+                                    // constraints
         if (readResult.fail()) {
           addErrorMsg(readResult);
           THROW_ARANGO_EXCEPTION(readResult);

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -178,24 +178,25 @@ class PhysicalCollection {
 
   virtual Result read(transaction::Methods*, std::string_view key,
                       IndexIterator::DocumentCallback const& cb,
-                      ReadOwnWrites readOwnWrites) const = 0;
+                      ReadOwnWrites readOwnWrites, bool countBytes) const = 0;
 
   /// @brief read a documument referenced by token (internal method)
   virtual Result read(transaction::Methods* trx, LocalDocumentId const& token,
                       IndexIterator::DocumentCallback const& cb,
-                      ReadOwnWrites readOwnWrites) const = 0;
+                      ReadOwnWrites readOwnWrites, bool countBytes) const = 0;
 
   virtual Result lookupDocument(transaction::Methods& trx,
                                 LocalDocumentId token,
                                 velocypack::Builder& builder, bool readCache,
-                                bool fillCache,
-                                ReadOwnWrites readOwnWrites) const = 0;
+                                bool fillCache, ReadOwnWrites readOwnWrites,
+                                bool countBytes) const = 0;
 
   /// @brief read a documument referenced by token (internal method)
   virtual bool readDocument(transaction::Methods* trx,
                             LocalDocumentId const& token,
                             ManagedDocumentResult& result,
-                            ReadOwnWrites readOwnWrites) const = 0;
+                            ReadOwnWrites readOwnWrites,
+                            bool countBytes) const = 0;
 
   /**
    * @brief Perform document insert, may generate a '_key' value

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -56,8 +56,15 @@ DECLARE_COUNTER(arangodb_collection_leader_reads_total,
                 "Number of per-collection read requests on leaders");
 DECLARE_COUNTER(arangodb_collection_leader_writes_total,
                 "Number of per-collection write requests on leaders");
+DECLARE_COUNTER(arangodb_collection_requests_bytes_read_total,
+                "Number of per-collection bytes read on leaders and followers");
+DECLARE_COUNTER(
+    arangodb_collection_requests_bytes_written_total,
+    "Number of per-collection bytes written on leaders and followers");
 
 namespace {
+// build a dynamic shard-access metric with database/collection/shard,
+// and an optional user component.
 template<typename T>
 T getMetric(std::string_view database, std::string_view collection,
             std::string_view shard, std::string_view user, bool includeUser) {
@@ -161,22 +168,23 @@ TransactionState::Cookie::ptr TransactionState::cookie(
   return std::move(cookie);
 }
 
-void TransactionState::trackRequest(CollectionNameResolver const& resolver,
-                                    std::string_view database,
-                                    std::string_view shard,
-                                    std::string_view user,
-                                    AccessMode::Type accessMode,
-                                    std::string_view context) {
-  // no tracking performed on coordinators or single servers
-  TRI_ASSERT(isDBServer());
+void TransactionState::trackShardRequest(
+    CollectionNameResolver const& resolver, std::string_view database,
+    std::string_view shard, std::string_view user, AccessMode::Type accessMode,
+    std::string_view context) noexcept try {
   TRI_ASSERT(!database.empty());
   TRI_ASSERT(!shard.empty());
+
+  // no tracking performed on coordinators or single servers
+  if (!isDBServer()) {
+    return;
+  }
 
   auto& mf = _vocbase.server().getFeature<metrics::MetricsFeature>();
 
   auto mode = mf.usageTrackingMode();
   if (mode == metrics::MetricsFeature::UsageTrackingMode::kDisabled) {
-    // tracking is turned off
+    // tracking is turned off. this is the default setting.
     return;
   }
 
@@ -212,6 +220,109 @@ void TransactionState::trackRequest(CollectionNameResolver const& resolver,
       << collection << "', shard '" << shard << "', user '" << user
       << "', mode " << AccessMode::typeString(accessMode)
       << ", context: " << context;
+} catch (...) {
+  // method can be called from destructors, we cannot throw here
+}
+
+void TransactionState::trackShardUsage(
+    CollectionNameResolver const& resolver, std::string_view database,
+    std::string_view shard, std::string_view user, AccessMode::Type accessMode,
+    std::string_view context, size_t nBytes) noexcept try {
+  TRI_ASSERT(!database.empty());
+  TRI_ASSERT(!shard.empty());
+
+  // no tracking performed on coordinators or single servers
+  if (!isDBServer()) {
+    return;
+  }
+
+  if (nBytes == 0) {
+    // nothing to be tracked. should normally not happen except for
+    // collection scans etc. that did not encounter any documents.
+    return;
+  }
+
+  auto& mf = _vocbase.server().getFeature<metrics::MetricsFeature>();
+
+  auto mode = mf.usageTrackingMode();
+  if (mode == metrics::MetricsFeature::UsageTrackingMode::kDisabled) {
+    // tracking is turned off. this is the default setting.
+    return;
+  }
+
+  if (user.empty()) {
+    // access via superuser JWT or authentication is turned off,
+    // or request is not instrumented to receive the current user
+    return;
+  }
+
+  bool includeUser =
+      (mode ==
+       metrics::MetricsFeature::UsageTrackingMode::kEnabledPerShardPerUser);
+
+  DataSourceId cid = resolver.getCollectionIdLocal(shard);
+  std::string collection = resolver.getCollectionNameCluster(cid);
+
+  if (AccessMode::isRead(accessMode)) {
+    // build metric for reads and increase it
+    auto& metric =
+        mf.addDynamic(getMetric<arangodb_collection_requests_bytes_read_total>(
+            database, collection, shard, user, includeUser));
+    metric.count(nBytes);
+  } else {
+    // build metric for writes and increase it
+    auto& metric = mf.addDynamic(
+        getMetric<arangodb_collection_requests_bytes_written_total>(
+            database, collection, shard, user, includeUser));
+    metric.count(nBytes);
+  }
+
+  LOG_TOPIC("d3599", TRACE, Logger::FIXME)
+      << "tracking access for database '" << database << "', collection '"
+      << collection << "', shard '" << shard << "', user '" << user
+      << "', mode " << AccessMode::typeString(accessMode)
+      << ", context: " << context << ", nbytes: " << nBytes;
+} catch (...) {
+  // method can be called from destructors, we cannot throw here
+}
+
+void TransactionState::setUsername(std::string_view name) {
+  if (name.empty()) {
+    // no username to set here
+    return;
+  }
+  {
+    std::shared_lock lock(_usernameLock);
+    if (!_username.empty()) {
+      // username already set
+      return;
+    }
+  }
+  // slow path: username not yet set. we need to protect this
+  // operation with a mutex so that other concurrent threads
+  // that try to read the username do not see any garbled
+  // value.
+  std::unique_lock lock(_usernameLock);
+  if (_username.empty()) {
+    // only set if still empty
+    _username = std::string{name};
+  }
+}
+
+std::string_view TransactionState::username() const noexcept {
+  {
+    std::shared_lock lock(_usernameLock);
+    if (!_username.empty()) {
+      // if username is already set, it will not change anymore,
+      // so we can return a view into the username string.
+      return _username;
+    }
+  }
+  // if the username was not yet set, some other thread may
+  // still set it concurrently. in this case it is not safe
+  // to return a view into the string, because the string may
+  // be modified later/concurrently.
+  return StaticStrings::Empty;
 }
 
 /// @brief add a collection to a transaction
@@ -459,7 +570,7 @@ Result TransactionState::checkCollectionPermission(
 
   // no need to check for superuser, cluster_sync tests break otherwise
   if (exec.isSuperuser()) {
-    return Result{};
+    return {};
   }
 
   auto level = exec.collectionAuthLevel(_vocbase.name(), cname);

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -39,6 +39,8 @@
 #include "VocBase/Identifiers/TransactionId.h"
 #include "VocBase/voc-types.h"
 
+#include <mutex>
+#include <shared_mutex>
 #include <string_view>
 #include <variant>
 
@@ -333,10 +335,26 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
   /// Only allowed on coordinators.
   void coordinatorRerollTransactionId();
 
-  virtual void trackRequest(CollectionNameResolver const& resolver,
-                            std::string_view database, std::string_view shard,
-                            std::string_view user, AccessMode::Type accessMode,
-                            std::string_view context);
+  /// @brief set name of user who originated the transaction. will
+  /// only be set if no user has been registered with the transaction yet.
+  /// this user name is informational only and can be used for logging,
+  /// metrics etc. it should not be used for permission checks.
+  void setUsername(std::string_view name);
+
+  /// @brief return name of user who originated the transaction. may be
+  /// empty. this user name is informational only and can be used for logging,
+  /// metrics etc. it should not be used for permission checks.
+  std::string_view username() const noexcept;
+
+  void trackShardRequest(CollectionNameResolver const& resolver,
+                         std::string_view database, std::string_view shard,
+                         std::string_view user, AccessMode::Type accessMode,
+                         std::string_view context) noexcept;
+
+  void trackShardUsage(CollectionNameResolver const& resolver,
+                       std::string_view database, std::string_view shard,
+                       std::string_view user, AccessMode::Type accessMode,
+                       std::string_view context, size_t nBytes) noexcept;
 
  protected:
   virtual std::unique_ptr<TransactionCollection> createTransactionCollection(
@@ -426,6 +444,13 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
 
   QueryAnalyzerRevisions _analyzersRevision;
   bool _registeredTransaction = false;
+
+  /// @brief name of user who originated the transaction. may be empty.
+  /// this user name is informational only and can be used for logging,
+  /// metrics etc.
+  /// it should not be used for permission checks.
+  std::shared_mutex mutable _usernameLock;
+  std::string _username;
 };
 
 }  // namespace arangodb

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -304,8 +304,8 @@ void Manager::registerAQLTrx(std::shared_ptr<TransactionState> const& state) {
     if (!it.second) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_TRANSACTION_INTERNAL,
-          std::string("transaction ID ") + std::to_string(tid.id()) +
-              "' already used (while registering AQL trx)");
+          absl::StrCat("transaction ID ", tid.id(),
+                       "' already used (while registering AQL trx)"));
     }
   }
 }
@@ -851,9 +851,8 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
       }
 
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_LOCKED, std::string("cannot read-lock, transaction ") +
-                                std::to_string(tid.id()) +
-                                " is already in use");
+          TRI_ERROR_LOCKED, absl::StrCat("cannot read-lock, transaction ",
+                                         tid.id(), " is already in use"));
     }
 
     locker.unlock();  // failure;
@@ -896,9 +895,8 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
     }
     if (!ServerState::isDBServer(role) && now > endTime) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_LOCKED, std::string("cannot write-lock, transaction ") +
-                                std::to_string(tid.id()) +
-                                " is already in use");
+          TRI_ERROR_LOCKED, absl::StrCat("cannot write-lock, transaction ",
+                                         tid.id(), " is already in use"));
     } else if ((i % 32) == 0) {
       LOG_TOPIC("9e972", DEBUG, Logger::TRANSACTIONS)
           << "waiting on trx write-lock " << tid;
@@ -1037,7 +1035,7 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
   bool wasExpired = false;
   auto buildErrorMessage = [](TransactionId tid, transaction::Status status,
                               bool found) -> std::string {
-    std::string msg = "transaction " + std::to_string(tid.id());
+    std::string msg = absl::StrCat("transaction ", tid.id());
     if (found) {
       msg += " inaccessible";
     } else {
@@ -1095,9 +1093,9 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
       } else {
         operation = "abort";
       }
-      std::string msg = absl::StrCat("updating", hint, "transaction status on ",
-                                     operation, " failed. transaction ",
-                                     std::to_string(tid.id()), " is in use");
+      std::string msg =
+          absl::StrCat("updating", hint, "transaction status on ", operation,
+                       " failed. transaction ", tid.id(), " is in use");
       LOG_TOPIC("dfc30", DEBUG, Logger::TRANSACTIONS) << msg;
       return res.reset(TRI_ERROR_LOCKED, std::move(msg));
     }

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -166,10 +166,8 @@ class Methods {
   TRI_vocbase_t& vocbase() const;
 
   /// @brief return internals of transaction
-  inline TransactionState* state() const { return _state.get(); }
-  inline std::shared_ptr<TransactionState> const& stateShrdPtr() const {
-    return _state;
-  }
+  TransactionState* state() const noexcept { return _state.get(); }
+  std::shared_ptr<TransactionState> stateShrdPtr() const { return _state; }
 
   Result resolveId(char const* handle, size_t length,
                    std::shared_ptr<LogicalCollection>& collection,
@@ -180,10 +178,21 @@ class Methods {
     return _transactionContext;
   }
 
-  TEST_VIRTUAL inline transaction::Context* transactionContextPtr() const {
+  TEST_VIRTUAL transaction::Context* transactionContextPtr() const {
     TRI_ASSERT(_transactionContext != nullptr);
     return _transactionContext.get();
   }
+
+  /// @brief set name of user who originated the transaction. will
+  /// only be set if no user has been registered with the transaction yet.
+  /// this user name is informational only and can be used for logging,
+  /// metrics etc. it should not be used for permission checks.
+  void setUsername(std::string_view name);
+
+  /// @brief return name of user who originated the transaction. may be
+  /// empty. this user name is informational only and can be used for logging,
+  /// metrics etc. it should not be used for permission checks.
+  std::string_view username() const noexcept;
 
   // is this instance responsible for commit / abort
   bool isMainTransaction() const { return _mainTransaction; }

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -73,6 +73,7 @@ std::string const StaticStrings::Overwrite("overwrite");
 std::string const StaticStrings::OverwriteMode("overwriteMode");
 std::string const StaticStrings::Compact("compact");
 std::string const StaticStrings::DontWaitForCommit("dontWaitForCommit");
+std::string const StaticStrings::UserString("user");
 
 // replication headers
 std::string const StaticStrings::ReplicationHeaderCheckMore(

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -76,6 +76,7 @@ class StaticStrings {
   static std::string const OverwriteMode;
   static std::string const Compact;
   static std::string const DontWaitForCommit;
+  static std::string const UserString;
 
   // replication headers
   static std::string const ReplicationHeaderCheckMore;

--- a/tests/Aql/SpliceSubqueryOptimizerRuleTest.cpp
+++ b/tests/Aql/SpliceSubqueryOptimizerRuleTest.cpp
@@ -511,7 +511,7 @@ TEST_F(SpliceSubqueryNodeOptimizerRuleTest, splice_subquery_with_upsert) {
         EXPECT_EQ(std::string{"myKey"}, document.get("_key").copyString());
         return true;
       },
-      arangodb::ReadOwnWrites::no);
+      arangodb::ReadOwnWrites::no, /*countBytes*/ false);
   ASSERT_TRUE(called);
   ASSERT_TRUE(result.ok());
 }

--- a/tests/Graph/TraverserCacheTest.cpp
+++ b/tests/Graph/TraverserCacheTest.cpp
@@ -300,7 +300,7 @@ TEST_F(TraverserCacheTest, it_should_insert_an_edge_into_a_result_builder) {
         EXPECT_EQ(edgeKey, edgeDocument.get("_key").copyString());
         return true;
       },
-      arangodb::ReadOwnWrites::no);
+      arangodb::ReadOwnWrites::no, /*countBytes*/ false);
   ASSERT_TRUE(called);
   ASSERT_TRUE(result.ok());
   ASSERT_NE(fetchedDocumentId, 0);

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1342,7 +1342,7 @@ arangodb::IndexEstMap PhysicalCollectionMock::clusterIndexEstimates(
 arangodb::Result PhysicalCollectionMock::read(
     arangodb::transaction::Methods*, std::string_view key,
     arangodb::IndexIterator::DocumentCallback const& cb,
-    arangodb::ReadOwnWrites) const {
+    arangodb::ReadOwnWrites, bool /*countBytes*/) const {
   before();
   auto it = _documents.find(key);
   if (it != _documents.end()) {
@@ -1355,7 +1355,7 @@ arangodb::Result PhysicalCollectionMock::read(
 arangodb::Result PhysicalCollectionMock::read(
     arangodb::transaction::Methods* trx, arangodb::LocalDocumentId const& token,
     arangodb::IndexIterator::DocumentCallback const& cb,
-    arangodb::ReadOwnWrites) const {
+    arangodb::ReadOwnWrites, bool /*countBytes*/) const {
   before();
   for (auto const& entry : _documents) {
     auto& doc = entry.second;
@@ -1369,7 +1369,8 @@ arangodb::Result PhysicalCollectionMock::read(
 
 bool PhysicalCollectionMock::readDocument(
     arangodb::transaction::Methods* trx, arangodb::LocalDocumentId const& token,
-    arangodb::ManagedDocumentResult& result, arangodb::ReadOwnWrites) const {
+    arangodb::ManagedDocumentResult& result, arangodb::ReadOwnWrites,
+    bool /*countBytes*/) const {
   before();
   for (auto const& entry : _documents) {
     auto& doc = entry.second;
@@ -1384,7 +1385,8 @@ bool PhysicalCollectionMock::readDocument(
 arangodb::Result PhysicalCollectionMock::lookupDocument(
     arangodb::transaction::Methods& /*trx*/, arangodb::LocalDocumentId token,
     arangodb::velocypack::Builder& builder, bool /*readCache*/,
-    bool /*fillCache*/, arangodb::ReadOwnWrites /*readOwnWrites*/) const {
+    bool /*fillCache*/, arangodb::ReadOwnWrites /*readOwnWrites*/,
+    bool /*countBytes*/) const {
   before();
   for (auto const& entry : _documents) {
     auto& doc = entry.second;

--- a/tests/Mocks/StorageEngineMock.h
+++ b/tests/Mocks/StorageEngineMock.h
@@ -116,20 +116,21 @@ class PhysicalCollectionMock : public arangodb::PhysicalCollection {
   virtual arangodb::Result read(
       arangodb::transaction::Methods*, std::string_view key,
       arangodb::IndexIterator::DocumentCallback const& cb,
-      arangodb::ReadOwnWrites) const override;
+      arangodb::ReadOwnWrites, bool countBytes) const override;
   virtual arangodb::Result read(
       arangodb::transaction::Methods* trx,
       arangodb::LocalDocumentId const& token,
       arangodb::IndexIterator::DocumentCallback const& cb,
-      arangodb::ReadOwnWrites) const override;
+      arangodb::ReadOwnWrites, bool countBytes) const override;
   virtual bool readDocument(arangodb::transaction::Methods* trx,
                             arangodb::LocalDocumentId const& token,
                             arangodb::ManagedDocumentResult& result,
-                            arangodb::ReadOwnWrites) const override;
+                            arangodb::ReadOwnWrites,
+                            bool countBytes) const override;
   virtual arangodb::Result lookupDocument(
       arangodb::transaction::Methods& trx, arangodb::LocalDocumentId token,
       arangodb::velocypack::Builder& builder, bool readCache, bool fillCache,
-      arangodb::ReadOwnWrites readOwnWrites) const override;
+      arangodb::ReadOwnWrites readOwnWrites, bool countBytes) const override;
   virtual arangodb::Result remove(
       arangodb::transaction::Methods& trx,
       arangodb::LocalDocumentId previousDocumentId,

--- a/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-cluster.js
+++ b/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-cluster.js
@@ -1,0 +1,1744 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertNotEqual, assertTrue, assertFalse */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2024, ArangoDB Inc, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2024, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'server.export-shard-usage-metrics': "enabled-per-shard",
+  };
+}
+
+const jsunity = require('jsunity');
+const db = require('@arangodb').db;
+const { getDBServers, getCoordinators } = require("@arangodb/test-helper");
+const request = require("@arangodb/request");
+
+function testSuite() {
+  const baseName = "UnitTestsCollection";
+  let nextCollectionId = 0;
+
+  let getUniqueCollectionName = () => {
+    return baseName + nextCollectionId++;
+  };
+
+  let getRawMetrics = function() {
+    let lines = [];
+    getDBServers().forEach((server) => {
+      let res = request({ method: "GET", url: server.url + "/_admin/usage-metrics" });
+      lines = lines.concat(res.body.split(/\n/).filter((l) => l.match(/^arangodb_collection_requests_bytes_(read|written)_total/)));
+    });
+    return lines;
+  };
+
+  let getParsedMetrics = function(database, collection) {
+    let collections = collection;
+    if (!Array.isArray(collections)) {
+      collections = [ collections ];
+    }
+    let metrics = getRawMetrics();
+    let result = {};
+    metrics.forEach((line) => {
+      let matches = line.match(/^arangodb_collection_requests_bytes_(read|written)_total\s*\{(.*)?\}\s*(\d+)$/);
+      if (!matches) {
+        return;
+      }
+      let type = matches[1];
+      // translate type used in metric name (read|written) to reads|written
+      if (type === 'read') {
+        type = 'reads';
+      } else {
+        assertEqual('written', type);
+        type = 'writes';
+      }
+      let amount = parseInt(matches[3]);
+      let labels = matches[2];
+
+      let found = {};
+      labels.split(',').forEach((label) => {
+        let [key,value] = label.split('=');
+        found[key] = value.replace(/"/g, '');
+      });
+      
+      assertTrue(found.hasOwnProperty("shard"), found);
+      assertTrue(found.hasOwnProperty("db"), found);
+      assertTrue(found.hasOwnProperty("collection"), found);
+      
+      if (found["db"] !== database || !collections.includes(found["collection"])) {
+        return;
+      }
+
+      if (!result.hasOwnProperty(type)) {
+        // reads/writes
+        result[type] = {};
+      }
+      
+      let shard = found["shard"];
+      if (!result[type].hasOwnProperty(shard)) {
+        result[type][shard] = 0;
+      }
+      result[type][shard] += amount;
+    });
+
+    return result;
+  };
+
+  return {
+    testDoesNotPolluteNormalMetricsAPI : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        // must insert first to read something back
+        let docs = [];
+        for (let i = 0; i < 10; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        for (let i = 0; i < 10; ++i) {
+          c.document("test" + i);
+        }
+        
+        // check if the normal metrics endpoint exports any shard-specific metrics
+        let lines = [];
+        getDBServers().forEach((server) => {
+          let res = request({ method: "GET", url: server.url + "/_admin/metrics" });
+          lines = lines.concat(res.body.split(/\n/).filter((l) => l.match(/^arangodb_collection_requests_bytes_(read|written)_total/)));
+        });
+        assertEqual([], lines);
+
+        // check if the usage-metrics endpoint exports any regular metrics
+        lines = [];
+        getDBServers().forEach((server) => {
+          let res = request({ method: "GET", url: server.url + "/_admin/usage-metrics" });
+          // we look for any metric name starting with "rocksdb_" here as a placeholder
+          lines = lines.concat(res.body.split(/\n/).filter((l) => l.match(/^rocksdb_/)));
+        });
+        assertEqual([], lines);
+      } finally {
+        db._drop(cn);
+      }
+    },
+
+    testNoMetricsJustForCreatingCollection : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        let parsed = getParsedMetrics(db._name(), cn);
+        assertEqual({}, parsed);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsWhenReadingFromCollectionSingleReads : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to read something back
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+          
+          for (let i = 0; i < n; ++i) {
+            c.document("test" + i);
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertTrue(parsed.reads[shards[0]] > n * 40, {parsed, replicationFactor});
+          assertTrue(parsed.reads[shards[0]] < n * 50, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenReadingFromCollectionSingleReadsLarge : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to read something back
+          const n = 50;
+          let payloadLength = 0;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            let payload = Array(n).join("abc");
+            docs.push({ _key: "test" + i, payload });
+            payloadLength += 10 + payload.length; // 10 for general overhead and attribute name
+          }
+          c.insert(docs);
+          
+          for (let i = 0; i < n; ++i) {
+            c.document("test" + i);
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertTrue(parsed.reads[shards[0]] > n * 40 + 0.95 * payloadLength, {parsed, replicationFactor});
+          assertTrue(parsed.reads[shards[0]] < n * 50 + 1.05 * payloadLength, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + 0.95 * payloadLength * replicationFactor, {parsed, replicationFactor, payloadLength});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + 1.05 * payloadLength * replicationFactor, {parsed, replicationFactor, payloadLength});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenReadingFromCollectionBatchRead : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to read something back
+          const n = 20;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+         
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push("test" + i);
+          }
+          c.document(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertTrue(parsed.reads[shards[0]] > n * 40, {parsed, replicationFactor});
+          assertTrue(parsed.reads[shards[0]] < n * 50, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleInserts : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 30;
+          for (let i = 0; i < n; ++i) {
+            c.insert({ value: i });
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchInsert : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 25;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ value: i });
+          }
+          c.insert(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleRemoves : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to remove something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          for (let i = 0; i < n; ++i) {
+            c.remove("test" + i);
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 10-20 bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 10 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 20 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchRemove : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to remove something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          c.remove(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 10-20 bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 10 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 20 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleUpdates : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to updatee something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          for (let i = 0; i < n; ++i) {
+            c.update("test" + i, { value: i + 1 });
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchUpdate : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to updatee something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i + 1 });
+          }
+          c.update(docs, docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchUpdateLarge : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to update something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          const payload = Array(1024).join("xyz");
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, payload });
+          }
+          c.update(docs, docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 3100 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 3150 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleReplaces : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to replace something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          for (let i = 0; i < n; ++i) {
+            c.replace("test" + i, { value: i + 1 });
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchReplace : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to replace something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i + 1 });
+          }
+          c.replace(docs, docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleInsertsMultiShard : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 100;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+
+          assertEqual(shards.length, Object.keys(parsed.writes).length, {replicationFactor, shards});
+          let totalWritten = 0;
+          Object.keys(parsed.writes).forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 40-50 bytes for each insert
+          assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+          assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsReadOnlyAQL : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+        
+        let parsed = getParsedMetrics(db._name(), cn);
+        assertFalse(parsed.hasOwnProperty("reads"), parsed);
+        assertFalse(parsed.hasOwnProperty("writes"), parsed);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        // run query again, now with documents
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+          
+        parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > n * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLLarge : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const payload = Array(1024).join("xxx");
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, payload });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // assume 3100-3150 bytes read per document 
+        assertTrue(parsed.reads[shards[0]] > n * 3100, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 3150, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLProjection : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} RETURN doc.value`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > n * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLPrimaryIndexFullDocumentLookup : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        for (let i = 0; i < 10; ++i) {
+          db._query(`FOR doc IN ${cn} FILTER doc._key == 'test${i}' RETURN doc.value`);
+        }
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > 10 * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < 10 * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLPrimaryIndexKeyOnlyLookup : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        for (let i = 0; i < 10; ++i) {
+          db._query(`FOR doc IN ${cn} FILTER doc._key == 'test${i}' RETURN doc._key`);
+        }
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > 10 * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < 10 * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLLateMaterialize : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        c.ensureIndex({ type: "persistent", fields: ["value"] });
+
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 500;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} FILTER doc.value >= 25 RETURN doc`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // assume 40-50 bytes read per document
+        assertTrue(parsed.reads[shards[0]] > (n - 25) * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < (n - 25) * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsAQLSkipLimit : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 1000;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} LIMIT ${n - 5}, 5 RETURN doc.value`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // assume 40-50 bytes read per document
+        assertTrue(parsed.reads[shards[0]] > 5 * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < 5 * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsAQLScanOnly : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 1000;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        // do not actually read the documents
+        db._query(`FOR doc IN ${cn} RETURN 1`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        assertFalse(parsed.hasOwnProperty("reads"), parsed);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLMultiShard : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn, {numberOfShards: 3});
+      try {
+        let shards = c.shards();
+        assertEqual(3, shards.length);
+
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+        
+        let parsed = getParsedMetrics(db._name(), cn);
+        assertFalse(parsed.hasOwnProperty("reads"), parsed);
+        assertFalse(parsed.hasOwnProperty("writes"), parsed);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        // run query again, now with documents
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+          
+        parsed = getParsedMetrics(db._name(), cn);
+          
+        assertEqual(shards.length, Object.keys(parsed.writes).length, {shards});
+        let totalRead = 0;
+        Object.keys(parsed.reads).forEach((shard) => {
+          totalRead += parsed.reads[shard];
+        });
+
+        // count 40-50 bytes for each document read
+        assertTrue(totalRead > n * 40, {parsed, shards, totalRead});
+        assertTrue(totalRead < n * 50, {parsed, shards, totalRead});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsWriteAQL : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 100;
+          db._query(`FOR i IN 1..${n} INSERT {} INTO ${cn}`);
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+
+          // count 30-40 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 30 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 40 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWriteAQLMultiShard : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 100;
+          db._query(`FOR i IN 1..${n} INSERT {} INTO ${cn}`);
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+
+          assertEqual(shards.length, Object.keys(parsed.writes).length, {replicationFactor, shards});
+          let totalWritten = 0;
+          Object.keys(parsed.writes).forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 30-40 bytes for each insert
+          assertTrue(totalWritten > n * 30 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+          assertTrue(totalWritten < n * 40 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+
+    testHasMetricsReadOnlyAQLMultiCollections : function () {
+      let c1 = db._create(getUniqueCollectionName());
+      let c2 = db._create(getUniqueCollectionName());
+      try {
+        const n = 100;
+        db._query(`FOR i IN 1..${n} INSERT {} INTO ${c1.name()}`);
+
+        // we must ensure that the execution order is doc1 -> doc2, and not vice versa.
+        // otherwise we would get to different results
+        db._query(`FOR doc1 IN ${c1.name()} FOR doc2 IN ${c2.name()} RETURN [doc1, doc2]`, null, {optimizer: {rules: ["-interchange-adjacent-enumerations"] } });
+        
+        let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we assume 30-40 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        let shards = c1.shards();
+        assertTrue(parsed.reads[shards[0]] > n * 30, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 40, {parsed});
+       
+        // we shouldn't have read any document from c2
+        shards = c2.shards();
+        assertFalse(parsed.reads.hasOwnProperty(shards[0]), {parsed, shards});
+        
+        // insert documents into c2
+        db._query(`FOR i IN 1..${n / 2} INSERT {} INTO ${c2.name()}`);
+        
+        // run the read query again
+        db._query(`FOR doc1 IN ${c1.name()} FOR doc2 IN ${c2.name()} RETURN [doc1, doc2]`, null, {optimizer: {rules: ["-interchange-adjacent-enumerations"] } });
+
+        parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we assume 30-40 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        shards = c1.shards();
+        // c1 values should have doubled
+        assertTrue(parsed.reads[shards[0]] > (n * 2) * 30, {parsed});
+        assertTrue(parsed.reads[shards[0]] < (n * 2) * 40, {parsed});
+        
+        shards = c2.shards();
+        // now we have reads for c2 as well
+        assertTrue(parsed.reads[shards[0]] > (n * n / 2) * 30, {parsed});
+        assertTrue(parsed.reads[shards[0]] < (n * n / 2) * 40, {parsed});
+      } finally {
+        db._drop(c2.name());
+        db._drop(c1.name());
+      }
+    },
+    
+    testHasMetricsReadWriteAQLMultiCollections : function () {
+      let c1 = db._create(getUniqueCollectionName(), {numberOfShards: 5, replicationFactor: 1});
+      let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor: 1});
+
+      try {
+        const n = 66;
+        db._query(`FOR i IN 1..${n} INSERT {value: i} INTO ${c1.name()}`);
+
+        const payload = Array(512).join("abcd");
+        db._query(`LET payload = '${payload}' FOR doc IN ${c1.name()} INSERT {payload} INTO ${c2.name()} RETURN doc`);
+        
+        let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        
+        let shards = c1.shards();
+        let totalWritten = 0;
+        let totalRead = 0;
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          assertTrue(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          totalWritten += parsed.writes[shard];
+          totalRead += parsed.reads[shard];
+        });
+
+        // count 40-50 bytes for each insert into c1
+        assertTrue(totalWritten > n * 40, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 50, {parsed, shards, totalWritten});
+        
+        assertTrue(totalRead > n * 40, {parsed, shards, totalRead});
+        assertTrue(totalRead < n * 50, {parsed, shards, totalRead});
+        
+        shards = c2.shards();
+        totalWritten = 0;
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          assertFalse(parsed.reads.hasOwnProperty(shard), {parsed, shards});
+          totalWritten += parsed.writes[shard];
+        });
+        // count 2050-2150 bytes for each insert into c2
+        assertTrue(totalWritten > n * 2050, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 2150, {parsed, shards, totalWritten});
+      } finally {
+        db._drop(c2.name());
+        db._drop(c1.name());
+      }
+    },
+    
+    testHasMetricsExclusiveAQLMultiCollections : function () {
+      let c1 = db._create(getUniqueCollectionName(), {numberOfShards: 5, replicationFactor: 1});
+      let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor: 1});
+
+      try {
+        const n = 89;
+        db._query(`FOR i IN 1..${n} INSERT {} INTO ${c1.name()} OPTIONS {exclusive: true} INSERT {} INTO ${c2.name()} OPTIONS {exclusive: true}`);
+        
+        let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+        let shards = c1.shards();
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+        });
+        let totalWritten = 0;
+        shards.forEach((shard) => {
+          totalWritten += parsed.writes[shard];
+        });
+
+        // count 30-40 bytes for each insert into c1
+        assertTrue(totalWritten > n * 30, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 40, {parsed, shards, totalWritten});
+        
+        shards = c2.shards();
+        totalWritten = 0;
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          totalWritten += parsed.writes[shard];
+        });
+        // count 30-40 bytes for each insert into c2
+        assertTrue(totalWritten > n * 30, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 40, {parsed, shards, totalWritten});
+      } finally {
+        db._drop(c2.name());
+        db._drop(c1.name());
+      }
+    },
+    
+    testHasMetricsAQLFollowerShards : function () {
+      [1, 2].forEach((replicationFactor) => {
+        let c1 = db._create(getUniqueCollectionName(), {numberOfShards: 5, replicationFactor});
+        let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor});
+
+        try {
+          const n = 24;
+          const payload = Array(100).join("foo");
+          db._query(`LET payload = '${payload}' FOR i IN 1..${n} INSERT {} INTO ${c1.name()} INSERT {payload} INTO ${c2.name()}`);
+        
+          let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = c1.shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 30-40 bytes for each insert into c1
+          assertTrue(totalWritten > n * 30 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 40 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+        
+          shards = c2.shards();
+          totalWritten = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalWritten += parsed.writes[shard];
+          });
+          // count 360-370 bytes for each insert into c2
+          assertTrue(totalWritten > n * 360 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 370 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+        } finally {
+          db._drop(c2.name());
+          db._drop(c1.name());
+        }
+      });
+    },
+    
+    testHasMetricsSecondaryIndexes : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          c.ensureIndex({ type: "persistent", fields: ["value1"] });
+          c.ensureIndex({ type: "persistent", fields: ["value2"] });
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const payload = Array(1024).join("z");
+          const n = 42;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value1: "testmann" + i, value2: payload + i });
+          }
+          c.insert(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // we assume 1050-1150 bytes written per document
+          assertTrue(parsed.writes[shards[0]] > n * 1050 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 1150 * replicationFactor, {parsed, replicationFactor});
+
+          // read data back via secondary indexes. note that this returns _key so does full document lookups
+          for (let i = 0; i < n; ++i) {
+            db._query(`FOR doc IN ${cn} FILTER doc.value1 == 'testmann${i}' RETURN doc._key`);
+          }
+            
+          parsed = getParsedMetrics(db._name(), cn);
+
+          assertTrue(parsed.hasOwnProperty("writes"), parsed);
+          assertTrue(parsed.reads[shards[0]] > n * 1050, {parsed});
+          assertTrue(parsed.reads[shards[0]] < n * 1150, {parsed});
+          
+          // read data back via secondary indexes, but only return indexed value
+          for (let i = 0; i < n; ++i) {
+            db._query(`FOR doc IN ${cn} FILTER doc.value1 == 'testmann${i}' RETURN doc.value1`);
+          }
+
+          parsed = getParsedMetrics(db._name(), cn);
+
+          // number of bytes read shouldn't have changed
+          assertTrue(parsed.hasOwnProperty("writes"), parsed);
+          assertTrue(parsed.reads[shards[0]] > n * 1050, {parsed});
+          assertTrue(parsed.reads[shards[0]] < n * 1150, {parsed});
+          
+          // try to read back non-existing values
+          for (let i = 0; i < n; ++i) {
+            db._query(`FOR doc IN ${cn} FILTER doc.value2 == 'fuchsbau${i}' RETURN doc`);
+          }
+
+          parsed = getParsedMetrics(db._name(), cn);
+
+          // number of bytes read shouldn't have changed
+          assertTrue(parsed.hasOwnProperty("writes"), parsed);
+          assertTrue(parsed.reads[shards[0]] > n * 1050, {parsed});
+          assertTrue(parsed.reads[shards[0]] < n * 1150, {parsed});
+          
+          // remove all docs
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push("test" + i);
+          }
+
+          c.remove(docs);
+          
+          parsed = getParsedMetrics(db._name(), cn);
+          
+          // we assume 1050-1150 bytes written per document (for the insert) plus a few bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 1050 * replicationFactor + n * 10 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 1150 * replicationFactor + n * 20 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+   
+    testHasMetricsMultipleDatabases : function () {
+      const cn = getUniqueCollectionName();
+
+      const databases = [baseName + "1", baseName + "2", baseName + "3"];
+
+      try {
+        databases.forEach((name) => {
+          db._createDatabase(name);
+        });
+
+        databases.forEach((name, iter) => {
+          db._useDatabase(name);
+      
+          let c = db._create(cn, {replicationFactor: 1});
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = (iter + 1) * 15;
+          for (let i = 0; i < n; ++i) {
+            c.insert({ value: i });
+          }
+        
+          let parsed = getParsedMetrics(db._name(), cn);
+          // count 40-50 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 40, {parsed, shards});
+          assertTrue(parsed.writes[shards[0]] < n * 50, {parsed, shards});
+        });
+      } finally {
+        db._useDatabase("_system");
+        databases.forEach((name) => {
+          try {
+            db._dropDatabase(name);
+          } catch (err) {
+          }
+        });
+      }
+    },
+    
+    testHasMetricsWhenTruncating : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // truncate an empty collection
+          c.truncate();
+        
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+          assertFalse(parsed.hasOwnProperty("writes"), {parsed});
+        
+          // truncate a small collection
+          const n = 100;
+          db._query(`FOR i IN 1..${n} INSERT {value: i} INTO ${cn}`);
+        
+          parsed = getParsedMetrics(db._name(), cn);
+          // count 40-50 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, shards, replicationFactor});
+        
+          c.truncate();
+         
+          parsed = getParsedMetrics(db._name(), cn);
+          // count 10-20 bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 10 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 20 * replicationFactor, {parsed, shards, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenTruncatingLarge : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 40000;
+          db._query(`FOR i IN 1..${n} INSERT {value: i} INTO ${cn}`);
+        
+          let parsed = getParsedMetrics(db._name(), cn);
+          // count 40-50 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, shards, replicationFactor});
+        
+          c.truncate();
+         
+          parsed = getParsedMetrics(db._name(), cn);
+          // truncate will have performed a DeleteRange - metrics should not have changed!
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, shards, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+   
+    testHasMetricsWhenInsertIntoSmartGraph : function () {
+      const isEnterprise = require("internal").isEnterprise();
+      if (!isEnterprise) {
+        return;
+      }
+
+      [1, 2].forEach((replicationFactor) => {
+        const vn = getUniqueCollectionName();
+        const en = getUniqueCollectionName();
+        const gn = "UnitTestsGraph";
+        const graphs = require("@arangodb/smart-graph");
+
+        let cleanup = function () {
+          try {
+            graphs._drop(gn, true);
+          } catch (err) {}
+          db._drop(vn);
+          db._drop(en);
+        };
+
+        graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor, smartGraphAttribute: "testi" });
+        try {
+          const n = 29;
+
+          // smart vertex collection
+          for (let i = 0; i < n; ++i) {
+            db[vn].insert({ _key: "test" + (i % 10) + ":test" + i, testi: "test" + (i % 10) });
+          }
+
+          let parsed = getParsedMetrics(db._name(), vn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = db[vn].shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 50-60 bytes for each insert into vn
+          assertTrue(totalWritten > n * 50 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 60 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+
+          // smart edge collection
+          let keys = [];
+          for (let i = 0; i < (n - 1); ++i) {
+            keys.push(db[en].insert({ _from: vn + "/test" + i + ":test" + (i % 10), _to: vn + "/test" + ((i + 1) % 100) + ":test" + (i % 10), testi: (i % 10) })._key);
+          }
+          keys.push(db[en].insert({ _from: vn + "/test0:test0", _to: vn + "/testmann-does-not-exist:test0", testi: "test0" })._key);
+
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+
+          // no insert into local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have inserts into from/to parts
+          shards = db["_from_" + en].shards();
+          let totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.writes[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          let totalTo = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalTo += parsed.writes[shard];
+          });
+
+          // count 120-170 bytes for each insert into en
+          assertTrue(totalFrom > n * 120 * replicationFactor, {parsed, shards, totalFrom, replicationFactor});
+          assertTrue(totalFrom < n * 170 * replicationFactor, {parsed, shards, totalFrom, replicationFactor});
+         
+          assertTrue(totalTo > n * 120 * replicationFactor, {parsed, shards, totalTo, replicationFactor});
+          assertTrue(totalTo < n * 170 * replicationFactor, {parsed, shards, totalTo, replicationFactor});
+          
+          // now perform reads
+          keys.forEach((key) => {
+            db[en].document(key);
+          });
+
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+          
+          // no reads into local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have reads in from/to parts
+          shards = db["_from_" + en].shards();
+          totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.reads[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // count 120-170 bytes for each read
+          assertTrue(totalFrom > n * 120, {parsed, shards, totalFrom});
+          assertTrue(totalFrom < n * 170, {parsed, shards, totalFrom});
+        } finally {
+          cleanup();
+        }
+      });
+    },
+   
+    testHasMetricsWhenAQLingSmartGraph : function () {
+      const isEnterprise = require("internal").isEnterprise();
+      if (!isEnterprise) {
+        return;
+      }
+ 
+      [1, 2].forEach((replicationFactor) => {
+        const vn = getUniqueCollectionName();
+        const en = getUniqueCollectionName();
+        const gn = "UnitTestsGraph";
+        const graphs = require("@arangodb/smart-graph");
+
+        let cleanup = function () {
+          try {
+            graphs._drop(gn, true);
+          } catch (err) {}
+          db._drop(vn);
+          db._drop(en);
+        };
+        
+        graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor, smartGraphAttribute: "testi" });
+        try {
+          const n = 24;
+          db._query(`FOR i IN 1..${n} INSERT {_key: CONCAT('test', (i % 10), ':test', i), testi: CONCAT('test', (i % 10))} INTO ${vn}`);
+          
+          let parsed = getParsedMetrics(db._name(), vn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = db[vn].shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 50-60 bytes for each insert into vn
+          assertTrue(totalWritten > n * 50 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 60 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+
+          let keys = db._query(`FOR i IN 1..${n} INSERT {_from: CONCAT('${vn}/test', i, ':test', (i % 10)), _to: CONCAT('${vn}/test', ((i + 1) % 100), ':test', (i % 10)), testi: (i % 10)} INTO ${en} RETURN NEW._key`).toArray();
+          
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+          
+          // no insert into local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have inserts into from/to parts
+          shards = db["_from_" + en].shards();
+          let totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.writes[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          let totalTo = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalTo += parsed.writes[shard];
+          });
+
+          db._query(`FOR doc IN ${en} FILTER doc._key IN @keys RETURN doc`, { keys });
+
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+         
+          // no reads in local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have reads in from/to parts
+          shards = db["_from_" + en].shards();
+          totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.reads[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // count 120-170 bytes for each read
+          assertTrue(totalFrom > n * 120, {parsed, shards, totalFrom});
+          assertTrue(totalFrom < n * 170, {parsed, shards, totalFrom});
+        } finally {
+          cleanup();
+        }
+
+      });
+    },
+    
+    testNoMetricsWhenUsingEmptyStreamingTrx : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          let trx = db._createTransaction({ collections: { write: cn } });
+
+          try {
+            let parsed = getParsedMetrics(db._name(), cn);
+            assertFalse(parsed.hasOwnProperty("reads"), parsed);
+            assertFalse(parsed.hasOwnProperty("writes"), parsed);
+          } finally {
+            trx.abort();
+          }
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+  
+    testHasMetricsWhenUsingStreamingTrx : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 50;
+          let trx = db._createTransaction({ collections: { write: cn } });
+
+          try {
+            let c = trx.collection(cn);
+
+            for (let i = 0; i < n; ++i) {
+              c.insert({ value: i });
+            }
+            
+            let parsed = getParsedMetrics(db._name(), cn);
+            assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          
+            let totalWritten = 0;
+            shards.forEach((shard) => {
+              totalWritten += parsed.writes[shard];
+            });
+            assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, totalWritten});
+
+            // issue read query inside streaming trx
+            trx.query(`FOR doc IN ${cn} RETURN doc`).toArray();
+            
+            parsed = getParsedMetrics(db._name(), cn);
+          
+            let totalRead = 0;
+            totalWritten = 0;
+            shards.forEach((shard) => {
+              totalWritten += parsed.writes[shard];
+              totalRead += parsed.reads[shard];
+            });
+            // total written should remain unchanged
+            assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            
+            assertTrue(totalRead > n * 40, {parsed, totalRead});
+            assertTrue(totalRead < n * 50, {parsed, totalRead});
+
+            // write into the collection
+            trx.query(`FOR i IN 1..5000 INSERT {} INTO ${cn}`);
+            
+            parsed = getParsedMetrics(db._name(), cn);
+          
+            totalRead = 0;
+            totalWritten = 0;
+            shards.forEach((shard) => {
+              totalWritten += parsed.writes[shard];
+              totalRead += parsed.reads[shard];
+            });
+            assertTrue(totalWritten > n * 40 * replicationFactor + 5000 * 30 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            assertTrue(totalWritten < n * 50 * replicationFactor + 5000 * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            
+            // total read should remain unchanged
+            assertTrue(totalRead > n * 40, {parsed, totalRead});
+            assertTrue(totalRead < n * 50, {parsed, totalRead});
+
+          } finally {
+            trx.abort();
+          }
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenUsingJavaScriptReadTrx : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn, {numberOfShards: 3, replicationFactor: 1});
+      try {
+        let shards = c.shards();
+        assertEqual(3, shards.length);
+
+        const n = 50;
+
+        db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i)} INTO ${cn}`);
+
+        db._executeTransaction({ 
+          collections: { write: cn }, 
+          params: { cn, n }, 
+          action: (params) => {
+            let db = require("internal").db;
+            let c = db._collection(params.cn);
+
+            for (let i = 0; i < params.n; ++i) {
+              c.document("test" + i);
+            }
+          }
+        });
+
+        let parsed = getParsedMetrics(db._name(), cn);
+          
+        let totalWritten = 0;
+        let totalRead = 0;
+        shards.forEach((shard) => {
+          totalWritten += parsed.writes[shard];
+          totalRead += parsed.reads[shard];
+        });
+        assertTrue(totalWritten > n * 20, {parsed, totalWritten});
+        assertTrue(totalWritten < n * 40, {parsed, totalWritten});
+        
+        assertTrue(totalRead > n * 20, {parsed, totalWritten});
+        assertTrue(totalRead < n * 40, {parsed, totalWritten});
+      } finally {
+        db._drop(cn);
+      } 
+    },
+    
+    testHasMetricsWhenUsingJavaScriptWriteTrx : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 50;
+          db._executeTransaction({ 
+            collections: { write: cn }, 
+            params: { cn, n }, 
+            action: (params) => {
+              let db = require("internal").db;
+              let c = db._collection(params.cn);
+
+              for (let i = 0; i < params.n; ++i) {
+                c.insert({ value: i });
+              }
+            }
+          });
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+          assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+          assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, totalWritten});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsGeneralGraphOperations : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const vn = getUniqueCollectionName();
+        const en = getUniqueCollectionName();
+        const gn = "UnitTestsGraph";
+        const graphs = require("@arangodb/general-graph");
+
+        let cleanup = function () {
+          try {
+            graphs._drop(gn, true);
+          } catch (err) {}
+          db._drop(vn);
+          db._drop(en);
+        };
+
+        graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor });
+        try {
+          const n = 29;
+
+          let g = graphs._graph(gn);
+          // vertex collection
+          for (let i = 0; i < n; ++i) {
+            g[vn].insert({ _key: "test" + i, value: i });
+          }
+
+          let parsed = getParsedMetrics(db._name(), vn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = db[vn].shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 40-50 bytes for each insert into vn
+          assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+
+          // edge collection
+          for (let i = 0; i < (n - 1); ++i) {
+            g[en].insert({ _key: "test" + i, _from: vn + "/test" + i, _to: vn + "/test" + i });
+          }
+
+          parsed = getParsedMetrics(db._name(), en);
+
+          shards = db[en].shards();
+          totalWritten = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 90-105 bytes for each insert into en
+          assertTrue(totalWritten > n * 90 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 105 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+        } finally {
+          cleanup();
+        }
+      });
+    },
+
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-per-user-cluster.js
+++ b/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-per-user-cluster.js
@@ -1,0 +1,1837 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertNotEqual, assertTrue, assertFalse, arango */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2024, ArangoDB Inc, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB Inc, Cologne, Germany
+///
+/// @author Jan Steemann
+/// @author Copyright 2024, ArangoDB Inc, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jwtSecret = 'abc123';
+
+if (getOptions === true) {
+  return {
+    'server.export-shard-usage-metrics': "enabled-per-shard-per-user",
+    'server.authentication': 'true',
+    'server.jwt-secret': jwtSecret,
+  };
+}
+
+const jsunity = require('jsunity');
+const db = require('@arangodb').db;
+const { getDBServers, deriveTestSuite } = require("@arangodb/test-helper");
+const request = require("@arangodb/request");
+const users = require("@arangodb/users");
+const crypto = require('@arangodb/crypto');
+
+const jwt = crypto.jwtEncode(jwtSecret, {
+  "server_id": "ABCD",
+  "iss": "arangodb", "exp": Math.floor(Date.now() / 1000) + 3600
+}, 'HS256');
+
+function BaseTestSuite(targetUser) {
+  const baseName = "UnitTestsCollection";
+  let nextCollectionId = 0;
+
+  let getUniqueCollectionName = () => {
+    return baseName + nextCollectionId++;
+  };
+
+  let getRawMetrics = function() {
+    let lines = [];
+    getDBServers().forEach((server) => {
+      let res = request({ method: "GET", url: server.url + "/_admin/usage-metrics", auth: { bearer: jwt } });
+      assertEqual(200, res.status);
+      lines = lines.concat(res.body.split(/\n/).filter((l) => l.match(/^arangodb_collection_requests_bytes_(read|written)_total/)));
+    });
+    return lines;
+  };
+
+  let getParsedMetrics = function(database, collection) {
+    let collections = collection;
+    if (!Array.isArray(collections)) {
+      collections = [ collections ];
+    }
+    let metrics = getRawMetrics();
+    let result = {};
+    metrics.forEach((line) => {
+      let matches = line.match(/^arangodb_collection_requests_bytes_(read|written)_total\s*\{(.*)?\}\s*(\d+)$/);
+      if (!matches) {
+        return;
+      }
+      let type = matches[1];
+      // translate type used in metric name (read|written) to reads|written
+      if (type === 'read') {
+        type = 'reads';
+      } else {
+        assertEqual('written', type);
+        type = 'writes';
+      }
+      let amount = parseInt(matches[3]);
+      let labels = matches[2];
+
+      let found = {};
+      labels.split(',').forEach((label) => {
+        let [key,value] = label.split('=');
+        found[key] = value.replace(/"/g, '');
+      });
+      
+      assertTrue(found.hasOwnProperty("shard"), found);
+      assertTrue(found.hasOwnProperty("db"), found);
+      assertTrue(found.hasOwnProperty("collection"), found);
+      assertTrue(found.hasOwnProperty("user"), found);
+  
+      if (found["db"] !== database || !collections.includes(found["collection"])) {
+        return;
+      }
+
+      if (found["user"] !== targetUser) {
+        return;
+      }
+
+      if (!result.hasOwnProperty(type)) {
+        // reads/writes
+        result[type] = {};
+      }
+      
+      let shard = found["shard"];
+      if (!result[type].hasOwnProperty(shard)) {
+        result[type][shard] = 0;
+      }
+      result[type][shard] += amount;
+    });
+
+    return result;
+  };
+
+  return {
+    testDoesNotPolluteNormalMetricsAPI : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        // must insert first to read something back
+        let docs = [];
+        for (let i = 0; i < 10; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        for (let i = 0; i < 10; ++i) {
+          c.document("test" + i);
+        }
+        
+        // check if the normal metrics endpoint exports any shard-specific metrics
+        let lines = [];
+        getDBServers().forEach((server) => {
+          let res = request({ method: "GET", url: server.url + "/_admin/metrics" });
+          lines = lines.concat(res.body.split(/\n/).filter((l) => l.match(/^arangodb_collection_requests_bytes_(read|written)_total/)));
+        });
+        assertEqual([], lines);
+
+        // check if the usage-metrics endpoint exports any regular metrics
+        lines = [];
+        getDBServers().forEach((server) => {
+          let res = request({ method: "GET", url: server.url + "/_admin/usage-metrics" });
+          // we look for any metric name starting with "rocksdb_" here as a placeholder
+          lines = lines.concat(res.body.split(/\n/).filter((l) => l.match(/^rocksdb_/)));
+        });
+        assertEqual([], lines);
+      } finally {
+        db._drop(cn);
+      }
+    },
+
+    testNoMetricsJustForCreatingCollection : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        let parsed = getParsedMetrics(db._name(), cn);
+        assertEqual({}, parsed);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsWhenReadingFromCollectionSingleReads : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to read something back
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+          
+          for (let i = 0; i < n; ++i) {
+            c.document("test" + i);
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertTrue(parsed.reads[shards[0]] > n * 40, {parsed, replicationFactor});
+          assertTrue(parsed.reads[shards[0]] < n * 50, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenReadingFromCollectionSingleReadsLarge : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to read something back
+          const n = 50;
+          let payloadLength = 0;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            let payload = Array(n).join("abc");
+            docs.push({ _key: "test" + i, payload });
+            payloadLength += 10 + payload.length; // 10 for general overhead and attribute name
+          }
+          c.insert(docs);
+          
+          for (let i = 0; i < n; ++i) {
+            c.document("test" + i);
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertTrue(parsed.reads[shards[0]] > n * 40 + 0.95 * payloadLength, {parsed, replicationFactor});
+          assertTrue(parsed.reads[shards[0]] < n * 50 + 1.05 * payloadLength, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + 0.95 * payloadLength * replicationFactor, {parsed, replicationFactor, payloadLength});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + 1.05 * payloadLength * replicationFactor, {parsed, replicationFactor, payloadLength});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenReadingFromCollectionBatchRead : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to read something back
+          const n = 20;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+         
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push("test" + i);
+          }
+          c.document(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertTrue(parsed.reads[shards[0]] > n * 40, {parsed, replicationFactor});
+          assertTrue(parsed.reads[shards[0]] < n * 50, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleInserts : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 30;
+          for (let i = 0; i < n; ++i) {
+            c.insert({ value: i });
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchInsert : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 25;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ value: i });
+          }
+          c.insert(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleRemoves : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to remove something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          for (let i = 0; i < n; ++i) {
+            c.remove("test" + i);
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 10-20 bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 10 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 20 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchRemove : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to remove something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          c.remove(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 10-20 bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 10 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 20 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleUpdates : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to updatee something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          for (let i = 0; i < n; ++i) {
+            c.update("test" + i, { value: i + 1 });
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchUpdate : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to updatee something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i + 1 });
+          }
+          c.update(docs, docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchUpdateLarge : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to update something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          const payload = Array(1024).join("xyz");
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, payload });
+          }
+          c.update(docs, docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 3100 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 3150 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleReplaces : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to replace something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          for (let i = 0; i < n; ++i) {
+            c.replace("test" + i, { value: i + 1 });
+          }
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionBatchReplace : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // must insert first to replace something later
+          const n = 50;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i + 1 });
+          }
+          c.replace(docs, docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // count 40-50 bytes for each insert, and 40-50 bytes for each update
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 40 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 50 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenWritingIntoCollectionSingleInsertsMultiShard : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 100;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value: i });
+          }
+          c.insert(docs);
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+
+          assertEqual(shards.length, Object.keys(parsed.writes).length, {replicationFactor, shards});
+          let totalWritten = 0;
+          Object.keys(parsed.writes).forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 40-50 bytes for each insert
+          assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+          assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsReadOnlyAQL : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+        
+        let parsed = getParsedMetrics(db._name(), cn);
+        assertFalse(parsed.hasOwnProperty("reads"), parsed);
+        assertFalse(parsed.hasOwnProperty("writes"), parsed);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        // run query again, now with documents
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+          
+        parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > n * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLLarge : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const payload = Array(1024).join("xxx");
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, payload });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // assume 3100-3150 bytes read per document 
+        assertTrue(parsed.reads[shards[0]] > n * 3100, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 3150, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLProjection : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} RETURN doc.value`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > n * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLPrimaryIndexFullDocumentLookup : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        for (let i = 0; i < 10; ++i) {
+          db._query(`FOR doc IN ${cn} FILTER doc._key == 'test${i}' RETURN doc.value`);
+        }
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > 10 * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < 10 * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLPrimaryIndexKeyOnlyLookup : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        for (let i = 0; i < 10; ++i) {
+          db._query(`FOR doc IN ${cn} FILTER doc._key == 'test${i}' RETURN doc._key`);
+        }
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we still assume 40-50 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        assertTrue(parsed.reads[shards[0]] > 10 * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < 10 * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLLateMaterialize : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        c.ensureIndex({ type: "persistent", fields: ["value"] });
+
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 500;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} FILTER doc.value >= 25 RETURN doc`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // assume 40-50 bytes read per document
+        assertTrue(parsed.reads[shards[0]] > (n - 25) * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < (n - 25) * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsAQLSkipLimit : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 1000;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        db._query(`FOR doc IN ${cn} LIMIT ${n - 5}, 5 RETURN doc.value`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // assume 40-50 bytes read per document
+        assertTrue(parsed.reads[shards[0]] > 5 * 40, {parsed});
+        assertTrue(parsed.reads[shards[0]] < 5 * 50, {parsed});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsAQLScanOnly : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn);
+      try {
+        let shards = c.shards();
+        assertEqual(1, shards.length);
+
+        const n = 1000;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        // do not actually read the documents
+        db._query(`FOR doc IN ${cn} RETURN 1`);
+          
+        let parsed = getParsedMetrics(db._name(), cn);
+
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        assertFalse(parsed.hasOwnProperty("reads"), parsed);
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsReadOnlyAQLMultiShard : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn, {numberOfShards: 3});
+      try {
+        let shards = c.shards();
+        assertEqual(3, shards.length);
+
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+        
+        let parsed = getParsedMetrics(db._name(), cn);
+        assertFalse(parsed.hasOwnProperty("reads"), parsed);
+        assertFalse(parsed.hasOwnProperty("writes"), parsed);
+
+        const n = 100;
+        let docs = [];
+        for (let i = 0; i < n; ++i) {
+          docs.push({ _key: "test" + i, value: i });
+        }
+        c.insert(docs);
+        
+        // run query again, now with documents
+        db._query(`FOR doc IN ${cn} RETURN doc`);
+          
+        parsed = getParsedMetrics(db._name(), cn);
+          
+        assertEqual(shards.length, Object.keys(parsed.writes).length, {shards});
+        let totalRead = 0;
+        Object.keys(parsed.reads).forEach((shard) => {
+          totalRead += parsed.reads[shard];
+        });
+
+        // count 40-50 bytes for each document read
+        assertTrue(totalRead > n * 40, {parsed, shards, totalRead});
+        assertTrue(totalRead < n * 50, {parsed, shards, totalRead});
+      } finally {
+        db._drop(cn);
+      }
+    },
+    
+    testHasMetricsWriteAQL : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 100;
+          db._query(`FOR i IN 1..${n} INSERT {} INTO ${cn}`);
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+
+          // count 30-40 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 30 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 40 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWriteAQLMultiShard : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 100;
+          db._query(`FOR i IN 1..${n} INSERT {} INTO ${cn}`);
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+
+          assertEqual(shards.length, Object.keys(parsed.writes).length, {replicationFactor, shards});
+          let totalWritten = 0;
+          Object.keys(parsed.writes).forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 30-40 bytes for each insert
+          assertTrue(totalWritten > n * 30 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+          assertTrue(totalWritten < n * 40 * replicationFactor, {parsed, replicationFactor, shards, totalWritten});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+
+    testHasMetricsReadOnlyAQLMultiCollections : function () {
+      let c1 = db._create(getUniqueCollectionName());
+      let c2 = db._create(getUniqueCollectionName());
+      try {
+        const n = 100;
+        db._query(`FOR i IN 1..${n} INSERT {} INTO ${c1.name()}`);
+
+        // we must ensure that the execution order is doc1 -> doc2, and not vice versa.
+        // otherwise we would get to different results
+        db._query(`FOR doc1 IN ${c1.name()} FOR doc2 IN ${c2.name()} RETURN [doc1, doc2]`, null, {optimizer: {rules: ["-interchange-adjacent-enumerations"] } });
+        
+        let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we assume 30-40 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        let shards = c1.shards();
+        assertTrue(parsed.reads[shards[0]] > n * 30, {parsed});
+        assertTrue(parsed.reads[shards[0]] < n * 40, {parsed});
+       
+        // we shouldn't have read any document from c2
+        shards = c2.shards();
+        assertFalse(parsed.reads.hasOwnProperty(shards[0]), {parsed, shards});
+        
+        // insert documents into c2
+        db._query(`FOR i IN 1..${n / 2} INSERT {} INTO ${c2.name()}`);
+        
+        // run the read query again
+        db._query(`FOR doc1 IN ${c1.name()} FOR doc2 IN ${c2.name()} RETURN [doc1, doc2]`, null, {optimizer: {rules: ["-interchange-adjacent-enumerations"] } });
+
+        parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        
+        assertTrue(parsed.hasOwnProperty("writes"), parsed);
+        // we assume 30-40 bytes read per document, as we still need to
+        // read it entirely from the storage engine
+        shards = c1.shards();
+        // c1 values should have doubled
+        assertTrue(parsed.reads[shards[0]] > (n * 2) * 30, {parsed});
+        assertTrue(parsed.reads[shards[0]] < (n * 2) * 40, {parsed});
+        
+        shards = c2.shards();
+        // now we have reads for c2 as well
+        assertTrue(parsed.reads[shards[0]] > (n * n / 2) * 30, {parsed});
+        assertTrue(parsed.reads[shards[0]] < (n * n / 2) * 40, {parsed});
+      } finally {
+        db._drop(c2.name());
+        db._drop(c1.name());
+      }
+    },
+    
+    testHasMetricsReadWriteAQLMultiCollections : function () {
+      let c1 = db._create(getUniqueCollectionName(), {numberOfShards: 5, replicationFactor: 1});
+      let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor: 1});
+
+      try {
+        const n = 66;
+        db._query(`FOR i IN 1..${n} INSERT {value: i} INTO ${c1.name()}`);
+
+        const payload = Array(512).join("abcd");
+        db._query(`LET payload = '${payload}' FOR doc IN ${c1.name()} INSERT {payload} INTO ${c2.name()} RETURN doc`);
+        
+        let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        
+        let shards = c1.shards();
+        let totalWritten = 0;
+        let totalRead = 0;
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          assertTrue(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          totalWritten += parsed.writes[shard];
+          totalRead += parsed.reads[shard];
+        });
+
+        // count 40-50 bytes for each insert into c1
+        assertTrue(totalWritten > n * 40, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 50, {parsed, shards, totalWritten});
+        
+        assertTrue(totalRead > n * 40, {parsed, shards, totalRead});
+        assertTrue(totalRead < n * 50, {parsed, shards, totalRead});
+        
+        shards = c2.shards();
+        totalWritten = 0;
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          assertFalse(parsed.reads.hasOwnProperty(shard), {parsed, shards});
+          totalWritten += parsed.writes[shard];
+        });
+        // count 2050-2150 bytes for each insert into c2
+        assertTrue(totalWritten > n * 2050, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 2150, {parsed, shards, totalWritten});
+      } finally {
+        db._drop(c2.name());
+        db._drop(c1.name());
+      }
+    },
+    
+    testHasMetricsExclusiveAQLMultiCollections : function () {
+      let c1 = db._create(getUniqueCollectionName(), {numberOfShards: 5, replicationFactor: 1});
+      let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor: 1});
+
+      try {
+        const n = 89;
+        db._query(`FOR i IN 1..${n} INSERT {} INTO ${c1.name()} OPTIONS {exclusive: true} INSERT {} INTO ${c2.name()} OPTIONS {exclusive: true}`);
+        
+        let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+        assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+        let shards = c1.shards();
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+        });
+        let totalWritten = 0;
+        shards.forEach((shard) => {
+          totalWritten += parsed.writes[shard];
+        });
+
+        // count 30-40 bytes for each insert into c1
+        assertTrue(totalWritten > n * 30, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 40, {parsed, shards, totalWritten});
+        
+        shards = c2.shards();
+        totalWritten = 0;
+        shards.forEach((shard) => {
+          assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          totalWritten += parsed.writes[shard];
+        });
+        // count 30-40 bytes for each insert into c2
+        assertTrue(totalWritten > n * 30, {parsed, shards, totalWritten});
+        assertTrue(totalWritten < n * 40, {parsed, shards, totalWritten});
+      } finally {
+        db._drop(c2.name());
+        db._drop(c1.name());
+      }
+    },
+    
+    testHasMetricsAQLFollowerShards : function () {
+      [1, 2].forEach((replicationFactor) => {
+        let c1 = db._create(getUniqueCollectionName(), {numberOfShards: 5, replicationFactor});
+        let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor});
+
+        try {
+          const n = 24;
+          const payload = Array(100).join("foo");
+          db._query(`LET payload = '${payload}' FOR i IN 1..${n} INSERT {} INTO ${c1.name()} INSERT {payload} INTO ${c2.name()}`);
+        
+          let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = c1.shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 30-40 bytes for each insert into c1
+          assertTrue(totalWritten > n * 30 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 40 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+        
+          shards = c2.shards();
+          totalWritten = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalWritten += parsed.writes[shard];
+          });
+          // count 360-370 bytes for each insert into c2
+          assertTrue(totalWritten > n * 360 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 370 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+        } finally {
+          db._drop(c2.name());
+          db._drop(c1.name());
+        }
+      });
+    },
+    
+    testHasMetricsSecondaryIndexes : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          c.ensureIndex({ type: "persistent", fields: ["value1"] });
+          c.ensureIndex({ type: "persistent", fields: ["value2"] });
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const payload = Array(1024).join("z");
+          const n = 42;
+          let docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push({ _key: "test" + i, value1: "testmann" + i, value2: payload + i });
+          }
+          c.insert(docs);
+          
+          let parsed = getParsedMetrics(db._name(), cn);
+
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          // we assume 1050-1150 bytes written per document
+          assertTrue(parsed.writes[shards[0]] > n * 1050 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 1150 * replicationFactor, {parsed, replicationFactor});
+
+          // read data back via secondary indexes. note that this returns _key so does full document lookups
+          for (let i = 0; i < n; ++i) {
+            db._query(`FOR doc IN ${cn} FILTER doc.value1 == 'testmann${i}' RETURN doc._key`);
+          }
+            
+          parsed = getParsedMetrics(db._name(), cn);
+
+          assertTrue(parsed.hasOwnProperty("writes"), parsed);
+          assertTrue(parsed.reads[shards[0]] > n * 1050, {parsed});
+          assertTrue(parsed.reads[shards[0]] < n * 1150, {parsed});
+          
+          // read data back via secondary indexes, but only return indexed value
+          for (let i = 0; i < n; ++i) {
+            db._query(`FOR doc IN ${cn} FILTER doc.value1 == 'testmann${i}' RETURN doc.value1`);
+          }
+
+          parsed = getParsedMetrics(db._name(), cn);
+
+          // number of bytes read shouldn't have changed
+          assertTrue(parsed.hasOwnProperty("writes"), parsed);
+          assertTrue(parsed.reads[shards[0]] > n * 1050, {parsed});
+          assertTrue(parsed.reads[shards[0]] < n * 1150, {parsed});
+          
+          // try to read back non-existing values
+          for (let i = 0; i < n; ++i) {
+            db._query(`FOR doc IN ${cn} FILTER doc.value2 == 'fuchsbau${i}' RETURN doc`);
+          }
+
+          parsed = getParsedMetrics(db._name(), cn);
+
+          // number of bytes read shouldn't have changed
+          assertTrue(parsed.hasOwnProperty("writes"), parsed);
+          assertTrue(parsed.reads[shards[0]] > n * 1050, {parsed});
+          assertTrue(parsed.reads[shards[0]] < n * 1150, {parsed});
+          
+          // remove all docs
+          docs = [];
+          for (let i = 0; i < n; ++i) {
+            docs.push("test" + i);
+          }
+
+          c.remove(docs);
+          
+          parsed = getParsedMetrics(db._name(), cn);
+          
+          // we assume 1050-1150 bytes written per document (for the insert) plus a few bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 1050 * replicationFactor + n * 10 * replicationFactor, {parsed, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 1150 * replicationFactor + n * 20 * replicationFactor, {parsed, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+   
+    testHasMetricsMultipleDatabases : function () {
+      const cn = getUniqueCollectionName();
+
+      const databases = [baseName + "1", baseName + "2", baseName + "3"];
+
+      try {
+        let old = db._name();
+        db._useDatabase('_system');
+        databases.forEach((name) => {
+          db._createDatabase(name);
+        });
+        db._useDatabase(old);
+
+        databases.forEach((name, iter) => {
+          db._useDatabase(name);
+      
+          let c = db._create(cn, {replicationFactor: 1});
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = (iter + 1) * 15;
+          for (let i = 0; i < n; ++i) {
+            c.insert({ value: i });
+          }
+        
+          let parsed = getParsedMetrics(db._name(), cn);
+          // count 40-50 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 40, {parsed, shards});
+          assertTrue(parsed.writes[shards[0]] < n * 50, {parsed, shards});
+        });
+      } finally {
+        db._useDatabase("_system");
+        databases.forEach((name) => {
+          try {
+            db._dropDatabase(name);
+          } catch (err) {
+          }
+        });
+      }
+    },
+    
+    testHasMetricsWhenTruncating : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          // truncate an empty collection
+          c.truncate();
+        
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+          assertFalse(parsed.hasOwnProperty("writes"), {parsed});
+        
+          // truncate a small collection
+          const n = 100;
+          db._query(`FOR i IN 1..${n} INSERT {value: i} INTO ${cn}`);
+        
+          parsed = getParsedMetrics(db._name(), cn);
+          // count 40-50 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, shards, replicationFactor});
+        
+          c.truncate();
+         
+          parsed = getParsedMetrics(db._name(), cn);
+          // count 10-20 bytes for each remove
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor + n * 10 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor + n * 20 * replicationFactor, {parsed, shards, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenTruncatingLarge : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(1, shards.length);
+
+          const n = 40000;
+          db._query(`FOR i IN 1..${n} INSERT {value: i} INTO ${cn}`);
+        
+          let parsed = getParsedMetrics(db._name(), cn);
+          // count 40-50 bytes for each insert
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, shards, replicationFactor});
+        
+          c.truncate();
+         
+          parsed = getParsedMetrics(db._name(), cn);
+          // truncate will have performed a DeleteRange - metrics should not have changed!
+          assertTrue(parsed.writes[shards[0]] > n * 40 * replicationFactor, {parsed, shards, replicationFactor});
+          assertTrue(parsed.writes[shards[0]] < n * 50 * replicationFactor, {parsed, shards, replicationFactor});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+   
+    testHasMetricsWhenInsertIntoSmartGraph : function () {
+      const isEnterprise = require("internal").isEnterprise();
+      if (!isEnterprise) {
+        return;
+      }
+
+      [1, 2].forEach((replicationFactor) => {
+        const vn = getUniqueCollectionName();
+        const en = getUniqueCollectionName();
+        const gn = "UnitTestsGraph";
+        const graphs = require("@arangodb/smart-graph");
+
+        let cleanup = function () {
+          try {
+            graphs._drop(gn, true);
+          } catch (err) {}
+          db._drop(vn);
+          db._drop(en);
+        };
+
+        graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor, smartGraphAttribute: "testi" });
+        try {
+          const n = 29;
+
+          // smart vertex collection
+          for (let i = 0; i < n; ++i) {
+            db[vn].insert({ _key: "test" + (i % 10) + ":test" + i, testi: "test" + (i % 10) });
+          }
+
+          let parsed = getParsedMetrics(db._name(), vn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = db[vn].shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 50-60 bytes for each insert into vn
+          assertTrue(totalWritten > n * 50 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 60 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+
+          // smart edge collection
+          let keys = [];
+          for (let i = 0; i < (n - 1); ++i) {
+            keys.push(db[en].insert({ _from: vn + "/test" + i + ":test" + (i % 10), _to: vn + "/test" + ((i + 1) % 100) + ":test" + (i % 10), testi: (i % 10) })._key);
+          }
+          keys.push(db[en].insert({ _from: vn + "/test0:test0", _to: vn + "/testmann-does-not-exist:test0", testi: "test0" })._key);
+
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+
+          // no insert into local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have inserts into from/to parts
+          shards = db["_from_" + en].shards();
+          let totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.writes[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          let totalTo = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalTo += parsed.writes[shard];
+          });
+
+          // count 120-170 bytes for each insert into en
+          assertTrue(totalFrom > n * 120 * replicationFactor, {parsed, shards, totalFrom, replicationFactor});
+          assertTrue(totalFrom < n * 170 * replicationFactor, {parsed, shards, totalFrom, replicationFactor});
+         
+          assertTrue(totalTo > n * 120 * replicationFactor, {parsed, shards, totalTo, replicationFactor});
+          assertTrue(totalTo < n * 170 * replicationFactor, {parsed, shards, totalTo, replicationFactor});
+          
+          // now perform reads
+          keys.forEach((key) => {
+            db[en].document(key);
+          });
+
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+          
+          // no reads into local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have reads in from/to parts
+          shards = db["_from_" + en].shards();
+          totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.reads[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // count 120-170 bytes for each read
+          assertTrue(totalFrom > n * 120, {parsed, shards, totalFrom});
+          assertTrue(totalFrom < n * 170, {parsed, shards, totalFrom});
+        } finally {
+          cleanup();
+        }
+      });
+    },
+   
+    testHasMetricsWhenAQLingSmartGraph : function () {
+      const isEnterprise = require("internal").isEnterprise();
+      if (!isEnterprise) {
+        return;
+      }
+ 
+      [1, 2].forEach((replicationFactor) => {
+        const vn = getUniqueCollectionName();
+        const en = getUniqueCollectionName();
+        const gn = "UnitTestsGraph";
+        const graphs = require("@arangodb/smart-graph");
+
+        let cleanup = function () {
+          try {
+            graphs._drop(gn, true);
+          } catch (err) {}
+          db._drop(vn);
+          db._drop(en);
+        };
+        
+        graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor, smartGraphAttribute: "testi" });
+        try {
+          const n = 24;
+          db._query(`FOR i IN 1..${n} INSERT {_key: CONCAT('test', (i % 10), ':test', i), testi: CONCAT('test', (i % 10))} INTO ${vn}`);
+          
+          let parsed = getParsedMetrics(db._name(), vn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = db[vn].shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 50-60 bytes for each insert into vn
+          assertTrue(totalWritten > n * 50 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 60 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+
+          let keys = db._query(`FOR i IN 1..${n} INSERT {_from: CONCAT('${vn}/test', i, ':test', (i % 10)), _to: CONCAT('${vn}/test', ((i + 1) % 100), ':test', (i % 10)), testi: (i % 10)} INTO ${en} RETURN NEW._key`).toArray();
+          
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+          
+          // no insert into local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have inserts into from/to parts
+          shards = db["_from_" + en].shards();
+          let totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.writes[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          let totalTo = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalTo += parsed.writes[shard];
+          });
+
+          db._query(`FOR doc IN ${en} FILTER doc._key IN @keys RETURN doc`, { keys });
+
+          parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
+         
+          // no reads in local part
+          shards = db["_local_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // we must have reads in from/to parts
+          shards = db["_from_" + en].shards();
+          totalFrom = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+            totalFrom += parsed.reads[shard];
+          });
+          
+          shards = db["_to_" + en].shards();
+          shards.forEach((shard) => {
+            assertFalse(parsed.reads.hasOwnProperty(shard), {shards, parsed});
+          });
+
+          // count 120-170 bytes for each read
+          assertTrue(totalFrom > n * 120, {parsed, shards, totalFrom});
+          assertTrue(totalFrom < n * 170, {parsed, shards, totalFrom});
+        } finally {
+          cleanup();
+        }
+
+      });
+    },
+    
+    testNoMetricsWhenUsingEmptyStreamingTrx : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          let trx = db._createTransaction({ collections: { write: cn } });
+
+          try {
+            let parsed = getParsedMetrics(db._name(), cn);
+            assertFalse(parsed.hasOwnProperty("reads"), parsed);
+            assertFalse(parsed.hasOwnProperty("writes"), parsed);
+          } finally {
+            trx.abort();
+          }
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+  
+    testHasMetricsWhenUsingStreamingTrx : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 50;
+          let trx = db._createTransaction({ collections: { write: cn } });
+
+          try {
+            let c = trx.collection(cn);
+
+            for (let i = 0; i < n; ++i) {
+              c.insert({ value: i });
+            }
+            
+            let parsed = getParsedMetrics(db._name(), cn);
+            assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          
+            let totalWritten = 0;
+            shards.forEach((shard) => {
+              totalWritten += parsed.writes[shard];
+            });
+            assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, totalWritten});
+
+            // issue read query inside streaming trx
+            trx.query(`FOR doc IN ${cn} RETURN doc`).toArray();
+            
+            parsed = getParsedMetrics(db._name(), cn);
+          
+            let totalRead = 0;
+            totalWritten = 0;
+            shards.forEach((shard) => {
+              totalWritten += parsed.writes[shard];
+              totalRead += parsed.reads[shard];
+            });
+            // total written should remain unchanged
+            assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            
+            assertTrue(totalRead > n * 40, {parsed, totalRead});
+            assertTrue(totalRead < n * 50, {parsed, totalRead});
+
+            // write into the collection
+            trx.query(`FOR i IN 1..5000 INSERT {} INTO ${cn}`);
+            
+            parsed = getParsedMetrics(db._name(), cn);
+          
+            totalRead = 0;
+            totalWritten = 0;
+            shards.forEach((shard) => {
+              totalWritten += parsed.writes[shard];
+              totalRead += parsed.reads[shard];
+            });
+            assertTrue(totalWritten > n * 40 * replicationFactor + 5000 * 30 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            assertTrue(totalWritten < n * 50 * replicationFactor + 5000 * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+            
+            // total read should remain unchanged
+            assertTrue(totalRead > n * 40, {parsed, totalRead});
+            assertTrue(totalRead < n * 50, {parsed, totalRead});
+
+          } finally {
+            trx.abort();
+          }
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsWhenUsingJavaScriptReadTrx : function () {
+      const cn = getUniqueCollectionName();
+
+      let c = db._create(cn, {numberOfShards: 3, replicationFactor: 1});
+      try {
+        let shards = c.shards();
+        assertEqual(3, shards.length);
+
+        const n = 50;
+
+        db._query(`FOR i IN 0..${n - 1} INSERT {_key: CONCAT('test', i)} INTO ${cn}`);
+
+        db._executeTransaction({ 
+          collections: { write: cn }, 
+          params: { cn, n }, 
+          action: (params) => {
+            let db = require("internal").db;
+            let c = db._collection(params.cn);
+
+            for (let i = 0; i < params.n; ++i) {
+              c.document("test" + i);
+            }
+          }
+        });
+
+        let parsed = getParsedMetrics(db._name(), cn);
+          
+        let totalWritten = 0;
+        let totalRead = 0;
+        shards.forEach((shard) => {
+          totalWritten += parsed.writes[shard];
+          totalRead += parsed.reads[shard];
+        });
+        assertTrue(totalWritten > n * 20, {parsed, totalWritten});
+        assertTrue(totalWritten < n * 40, {parsed, totalWritten});
+        
+        assertTrue(totalRead > n * 20, {parsed, totalWritten});
+        assertTrue(totalRead < n * 40, {parsed, totalWritten});
+      } finally {
+        db._drop(cn);
+      } 
+    },
+    
+    testHasMetricsWhenUsingJavaScriptWriteTrx : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const cn = getUniqueCollectionName();
+
+        let c = db._create(cn, {numberOfShards: 3, replicationFactor});
+        try {
+          let shards = c.shards();
+          assertEqual(3, shards.length);
+
+          const n = 50;
+          db._executeTransaction({ 
+            collections: { write: cn }, 
+            params: { cn, n }, 
+            action: (params) => {
+              let db = require("internal").db;
+              let c = db._collection(params.cn);
+
+              for (let i = 0; i < params.n; ++i) {
+                c.insert({ value: i });
+              }
+            }
+          });
+
+          let parsed = getParsedMetrics(db._name(), cn);
+          assertFalse(parsed.hasOwnProperty("reads"), parsed);
+          
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+          assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, replicationFactor, totalWritten});
+          assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, replicationFactor, totalWritten});
+        } finally {
+          db._drop(cn);
+        }
+      });
+    },
+    
+    testHasMetricsGeneralGraphOperations : function () {
+      [1, 2].forEach((replicationFactor) => {
+        const vn = getUniqueCollectionName();
+        const en = getUniqueCollectionName();
+        const gn = "UnitTestsGraph";
+        const graphs = require("@arangodb/general-graph");
+
+        let cleanup = function () {
+          try {
+            graphs._drop(gn, true);
+          } catch (err) {}
+          db._drop(vn);
+          db._drop(en);
+        };
+      
+        graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor });
+        try {
+          const n = 29;
+
+          let g = graphs._graph(gn);
+          // vertex collection
+          for (let i = 0; i < n; ++i) {
+            g[vn].insert({ _key: "test" + i, value: i });
+          }
+
+          let parsed = getParsedMetrics(db._name(), vn);
+          assertFalse(parsed.hasOwnProperty("reads"), {parsed});
+        
+          let shards = db[vn].shards();
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+          });
+          let totalWritten = 0;
+          shards.forEach((shard) => {
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 40-50 bytes for each insert into vn
+          assertTrue(totalWritten > n * 40 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 50 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+
+          // edge collection
+          for (let i = 0; i < (n - 1); ++i) {
+            g[en].insert({ _key: "test" + i, _from: vn + "/test" + i, _to: vn + "/test" + i });
+          }
+
+          parsed = getParsedMetrics(db._name(), en);
+
+          shards = db[en].shards();
+          totalWritten = 0;
+          shards.forEach((shard) => {
+            assertTrue(parsed.writes.hasOwnProperty(shard), {shards, parsed});
+            totalWritten += parsed.writes[shard];
+          });
+
+          // count 90-105 bytes for each insert into en
+          assertTrue(totalWritten > n * 90 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+          assertTrue(totalWritten < n * 105 * replicationFactor, {parsed, shards, totalWritten, replicationFactor});
+        } finally {
+          cleanup();
+        }
+      });
+    },
+
+  };
+}
+
+function TestUser1Suite() {
+  'use strict';
+
+  const name = 'UnitTestsMetrics';
+  const user = 'user1';
+
+  const protocol = 'tcp';
+  let endpoint = arango.getEndpoint().replace(/^[a-zA-Z0-9\+]+:/, protocol + ':');
+  let oldUser = arango.connectedUser();
+
+  let suite = {
+    setUpAll: function () {
+      users.save(user, "");
+      users.grantDatabase(user, '_system', 'rw');
+
+      db._createDatabase(name);
+      db._useDatabase(name);
+
+      users.grantDatabase(user, name, 'rw');
+    
+      arango.reconnect(endpoint, db._name(), user, '');
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(endpoint, '_system', oldUser, '');
+
+      db._useDatabase("_system");
+      db._dropDatabase(name);
+      users.remove(user);
+    },
+  };
+
+  deriveTestSuite(BaseTestSuite(user), suite, '_' + user);
+  return suite;
+}
+
+function TestUser2Suite() {
+  'use strict';
+
+  const name = 'UnitTestsMetricsOther';
+  const user = 'user2';
+
+  const protocol = 'tcp';
+  let endpoint = arango.getEndpoint().replace(/^[a-zA-Z0-9\+]+:/, protocol + ':');
+  let oldUser = arango.connectedUser();
+
+  let suite = {
+    setUpAll: function () {
+      users.save(user, "");
+      users.grantDatabase(user, '_system', 'rw');
+
+      db._createDatabase(name);
+      db._useDatabase(name);
+
+      users.grantDatabase(user, name, 'rw');
+    
+      arango.reconnect(endpoint, db._name(), user, '');
+    },
+
+    tearDownAll: function () {
+      arango.reconnect(endpoint, '_system', oldUser, '');
+
+      db._useDatabase("_system");
+      db._dropDatabase(name);
+      users.remove(user);
+    },
+  };
+
+  deriveTestSuite(BaseTestSuite(user), suite, '_' + user);
+  return suite;
+}
+
+jsunity.run(TestUser1Suite);
+jsunity.run(TestUser2Suite);
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-export-shard-usage-metrics-per-shard-cluster.js
+++ b/tests/js/client/server_parameters/test-export-shard-usage-metrics-per-shard-cluster.js
@@ -37,6 +37,12 @@ const request = require("@arangodb/request");
 
 function testSuite() {
   const baseName = "UnitTestsCollection";
+  
+  let nextCollectionId = 0;
+
+  let getUniqueCollectionName = () => {
+    return baseName + nextCollectionId++;
+  };
 
   let getRawMetrics = function() {
     let lines = [];
@@ -94,7 +100,7 @@ function testSuite() {
 
   return {
     testDoesNotPoluteNormalMetricsAPI : function () {
-      const cn = baseName + "0";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -131,7 +137,7 @@ function testSuite() {
     },
 
     testNoMetricsJustForCreatingCollection : function () {
-      const cn = baseName + "1";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -146,7 +152,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenReadingFromCollectionSingleReads : function () {
-      const cn = baseName + "2";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -172,7 +178,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenReadingFromCollectionBatchRead : function () {
-      const cn = baseName + "3";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -200,7 +206,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionSingleInserts : function () {
-      const cn = baseName + "4";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -219,7 +225,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionBatchInsert : function () {
-      const cn = baseName + "5";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -240,7 +246,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionSingleRemoves : function () {
-      const cn = baseName + "6";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -266,7 +272,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionBatchRemove : function () {
-      const cn = baseName + "7";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -290,7 +296,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionSingleUpdates : function () {
-      const cn = baseName + "8";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -316,7 +322,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionBatchUpdate : function () {
-      const cn = baseName + "9";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -344,7 +350,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionSingleReplaces : function () {
-      const cn = baseName + "10";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -370,7 +376,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionBatchReplace : function () {
-      const cn = baseName + "11";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -398,7 +404,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionSingleInsertsMultiShard : function () {
-      const cn = baseName + "12";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn, { numberOfShards: 3 });
       try {
@@ -419,7 +425,7 @@ function testSuite() {
     },
     
     testHasMetricsReadOnlyAQL : function () {
-      const cn = baseName + "13";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -436,7 +442,7 @@ function testSuite() {
     },
     
     testHasMetricsReadOnlyAQLMultiShard : function () {
-      const cn = baseName + "14";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn, {numberOfShards: 3});
       try {
@@ -455,7 +461,7 @@ function testSuite() {
     },
     
     testHasMetricsWriteAQL : function () {
-      const cn = baseName + "15";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -472,7 +478,7 @@ function testSuite() {
     },
     
     testHasMetricsWriteAQLMultiShard : function () {
-      const cn = baseName + "16";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn, {numberOfShards: 3});
       try {
@@ -491,12 +497,10 @@ function testSuite() {
     },
 
     testHasMetricsReadOnlyAQLMultiCollections : function () {
-      const cn = baseName + "17";
-
-      let c1 = db._create(cn);
-      let c2 = db._create(cn + "_2");
+      let c1 = db._create(getUniqueCollectionName());
+      let c2 = db._create(getUniqueCollectionName());
       try {
-        db._query("FOR doc1 IN " + c1.name() + " FOR doc2 IN " + c2.name() + " RETURN doc1");
+        db._query(`FOR doc1 IN ${c1.name()} FOR doc2 IN ${c2.name()} RETURN doc1`);
         
         let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
         
@@ -512,12 +516,10 @@ function testSuite() {
     },
     
     testHasMetricsReadWriteAQLMultiCollections : function () {
-      const cn = baseName + "18";
-
-      let c1 = db._create(cn, { numberOfShards: 5 });
-      let c2 = db._create(cn + "_2", { numberOfShards: 3 });
+      let c1 = db._create(getUniqueCollectionName(), { numberOfShards: 5 });
+      let c2 = db._create(getUniqueCollectionName(), { numberOfShards: 3 });
       try {
-        db._query("FOR doc IN " + c1.name() + " INSERT {} INTO " + c2.name());
+        db._query(`FOR doc IN ${c1.name()} INSERT {} INTO ${c2.name()}`);
         
         let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
         
@@ -533,12 +535,10 @@ function testSuite() {
     },
     
     testHasMetricsExclusiveAQLMultiCollections : function () {
-      const cn = baseName + "19";
-
-      let c1 = db._create(cn, { numberOfShards: 5 });
-      let c2 = db._create(cn + "_2", { numberOfShards: 3 });
+      let c1 = db._create(getUniqueCollectionName(), { numberOfShards: 5 });
+      let c2 = db._create(getUniqueCollectionName(), { numberOfShards: 3 });
       try {
-        db._query("FOR i IN 1..1000 INSERT {} INTO " + c1.name() + " OPTIONS {exclusive: true} INSERT {} INTO " + c2.name() +  " OPTIONS {exclusive: true}");
+        db._query(`FOR i IN 1..1000 INSERT {} INTO ${c1.name()} OPTIONS {exclusive: true} INSERT {} INTO ${c2.name()} OPTIONS {exclusive: true}`);
         
         let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
         
@@ -554,7 +554,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenWritingIntoCollectionSingleInsertsFollowerShards : function () {
-      const cn = baseName + "20";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn, { replicationFactor: 2 });
       try {
@@ -574,12 +574,10 @@ function testSuite() {
     },
     
     testHasMetricsAQLFollowerShards : function () {
-      const cn = baseName + "21";
-
-      let c1 = db._create(cn, { numberOfShards: 5, replicationFactor: 2 });
-      let c2 = db._create(cn + "_2", { numberOfShards: 3, replicationFactor: 2 });
+      let c1 = db._create(getUniqueCollectionName(), { numberOfShards: 5, replicationFactor: 2 });
+      let c2 = db._create(getUniqueCollectionName(), { numberOfShards: 3, replicationFactor: 2 });
       try {
-        db._query("FOR i IN 1..1000 INSERT {} INTO " + c1.name() + " OPTIONS {exclusive: true} INSERT {} INTO " + c2.name() +  " OPTIONS {exclusive: true}");
+        db._query(`FOR i IN 1..1000 INSERT {} INTO ${c1.name()} OPTIONS {exclusive: true} INSERT {} INTO ${c2.name()} OPTIONS {exclusive: true}`);
         
         let parsed = getParsedMetrics(db._name(), [c1.name(), c2.name()]);
         
@@ -596,7 +594,7 @@ function testSuite() {
     },
     
     testHasMetricsMultipleDatabases : function () {
-      const cn = baseName + "22";
+      const cn = getUniqueCollectionName();
 
       const databases = [baseName + "1", baseName + "2", baseName + "3"];
 
@@ -631,7 +629,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenTruncating : function () {
-      const cn = baseName + "23";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -648,7 +646,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenPerformingMixedOperations : function () {
-      const cn = baseName + "24";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn);
       try {
@@ -700,7 +698,7 @@ function testSuite() {
     },
     
     testHasMetricsWhenUsingCustomShardKey : function () {
-      const cn = baseName + "25";
+      const cn = getUniqueCollectionName();
 
       let c = db._create(cn, {shardKeys: ["qux"], numberOfShards: 3});
       try {
@@ -750,8 +748,8 @@ function testSuite() {
         return;
       }
 
-      const vn = baseName + "Vertices26";
-      const en = baseName + "Edges26";
+      const vn = getUniqueCollectionName();
+      const en = getUniqueCollectionName();
       const gn = "UnitTestsGraph";
       const graphs = require("@arangodb/smart-graph");
 
@@ -786,6 +784,10 @@ function testSuite() {
         Object.keys(counts).forEach((k) => {
           expected["writes"][k] = counts[k];
         });
+        counts = db["_to_" + en].count(true);
+        Object.keys(counts).forEach((k) => {
+          expected["writes"][k] = counts[k];
+        });
 
         assertEqual(expected, parsed);
 
@@ -813,8 +815,8 @@ function testSuite() {
         return;
       }
   
-      const vn = baseName + "Vertices27";
-      const en = baseName + "Edges27";
+      const vn = getUniqueCollectionName();
+      const en = getUniqueCollectionName();
       const gn = "UnitTestsGraph";
       const graphs = require("@arangodb/smart-graph");
 
@@ -828,7 +830,8 @@ function testSuite() {
       
       graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor: 2, smartGraphAttribute: "testi" });
       try {
-        db._query("FOR i IN 0..24 INSERT {_key: CONCAT('test', (i % 10), ':test', i), testi: CONCAT('test', (i % 10))} INTO " + vn);
+        // smart vertex collection
+        db._query(`FOR i IN 0..24 INSERT {_key: CONCAT('test', (i % 10), ':test', i), testi: CONCAT('test', (i % 10))} INTO ${vn}`);
         
         let parsed = getParsedMetrics(db._name(), vn);
         let expected = { "writes": {} };
@@ -837,7 +840,8 @@ function testSuite() {
         });
         assertEqual(expected, parsed);
 
-        let keys = db._query("FOR i IN 0..19 INSERT {_from: CONCAT('" + vn + "/test', i, ':test', (i % 10)), _to: CONCAT('" + vn + "/test', ((i + 1) % 100), ':test', (i % 10)), testi: (i % 10)} INTO " + en + " RETURN NEW._key").toArray();
+        // smart edge collection
+        let keys = db._query(`FOR i IN 0..19 INSERT {_from: CONCAT('${vn}/test', i, ':test', (i % 10)), _to: CONCAT('${vn}/test', ((i + 1) % 100), ':test', (i % 10)), testi: (i % 10)} INTO ${en} RETURN NEW._key`).toArray();
         
         parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
 
@@ -857,7 +861,7 @@ function testSuite() {
 
         assertEqual(expected, parsed);
 
-        db._query("FOR doc IN " + en + " FILTER doc._key IN @keys RETURN doc", { keys });
+        db._query(`FOR doc IN ${en} FILTER doc._key IN @keys RETURN doc`, { keys });
 
         parsed = getParsedMetrics(db._name(), ["_from_" + en, "_to_" + en, "_local_" + en]);
 

--- a/tests/js/client/server_parameters/test-export-shard-usage-metrics-per-shard-per-user-cluster.js
+++ b/tests/js/client/server_parameters/test-export-shard-usage-metrics-per-shard-per-user-cluster.js
@@ -36,10 +36,9 @@ if (getOptions === true) {
 
 const jsunity = require('jsunity');
 const db = require('@arangodb').db;
-const { getDBServers, getCoordinators } = require("@arangodb/test-helper");
+const { getDBServers } = require("@arangodb/test-helper");
 const request = require("@arangodb/request");
 const users = require("@arangodb/users");
-const helper = require('@arangodb/testutils/user-helper');
 const crypto = require('@arangodb/crypto');
   
 const jwt = crypto.jwtEncode(jwtSecret, {
@@ -1186,7 +1185,10 @@ function testSuite() {
         Object.keys(counts).forEach((k) => {
           expected["bar"]["writes"][k] = counts[k];
         });
-
+        counts = db["_to_" + en].count(true);
+        Object.keys(counts).forEach((k) => {
+          expected["bar"]["writes"][k] = counts[k];
+        });
         assertEqual(expected, parsed);
         
         connectWith("tcp", "foo", "");


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20489

APM-828, part 2: https://arangodb.atlassian.net/browse/APM-828

* Add additional metrics for tracking the number of bytes read or written per
  shard on DB-Servers:

  - `arangodb_collection_requests_bytes_read_total`:
    This metric exposes the per-shard number of bytes read by read operation 
    requests on DB-Servers. 
    It is increased by AQL queries that read documents or edges and for single-
    or multi-document read operations.
    The metric is normally increased only on the leader, but it can also 
    increase on followers if "reads from followers" are enabled.

    For every read operation, the metric will be increased by the approximate 
    number of bytes read to retrieve the underlying document or edge data. This
    is also true if a document or edge is served from an in-memory cache.
    If an operation reads multiple documents/edges, it will increase the 
    counter multiple times, each time with the approximate number of bytes read
    for the particular document/edge.
    
    The numbers reported by this metric normally relate to the cumulated sizes
    of documents/edges read.
    The metric is also increased for transactions that are started but later
    aborted.
    Note that the metric is not increased for secondary index point lookups or
    scans, or for scans in a collection that iterate over documents but do not
    read them.

  - `arangodb_collection_requests_bytes_written_total`:
    This metric exposes the per-shard number of bytes written by write operation
    requests on DB-Servers, on both leaders and followers.
    It is increased by AQL queries and single-/multi-document write operations.
    The metric is first increased only the leader, but for every replication 
    request to followers it is also increased on followers.
    
    For every write operation, the metric will be increased by the approximate 
    number of bytes written for the document or edge in question. 
    If an operation writes multiple documents/edges, it will increase the 
    counter multiple times, each time with the approximate number of bytes 
    written for the particular document/edge.

    An AQL query will also increase the counter for every document or edge 
    written, each time with the approximate number of bytes written for 
    document/edge.
    
    The numbers reported by this metric normally relate to the cumulated sizes
    of documents/edges written. For remove operations however only a fixed
    number of bytes is counted per removed document/edge.
    Writes into secondary indexes are not counted at all.

    The metric is also increased for transactions that are started but later
    aborted.
  
  These metrics are not exposed by default. It is only present if the startup 
  option `--server.export-shard-usage-metrics` is set to either 
  `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
  the metric will have different labels for each shard that was read from. With
  the latter setting, the metric will have different labels for each 
  combination of shard and user that accessed the shard.
  
  Note that internal operations, such as internal queries executed for 
  statistics gathering, internal garbage collection, TTL index cleanup are not
  counted in these metrics. Additionally all requests that are using the 
  superuser JWT for authentication and that do not have a specific user set, 
  will not be counted.


- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20499
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/APM-828
- [ ] Design document: 