### PR TITLE
[CINFRA] Let Hotbackup remove ReplicatedLogs and CollectionGroups from current

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5087,6 +5087,10 @@ Result ClusterInfo::agencyReplan(VPackSlice const plan) {
       trxOperations.emplace_back(absl::StrCat("Plan/", subEntry),
                                  AgencyValueOperationType::SET, entry);
     }
+    if (auto entry = plan.get({"arango", "Current", subEntry}); !entry.isNone()) {
+      trxOperations.emplace_back(absl::StrCat("Current/", subEntry),
+                                 AgencyValueOperationType::SET, entry);
+    }
   }
 
   // Apply only Collections and DBServers

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5087,7 +5087,8 @@ Result ClusterInfo::agencyReplan(VPackSlice const plan) {
       trxOperations.emplace_back(absl::StrCat("Plan/", subEntry),
                                  AgencyValueOperationType::SET, entry);
     }
-    if (auto entry = plan.get({"arango", "Current", subEntry}); !entry.isNone()) {
+    if (auto entry = plan.get({"arango", "Current", subEntry});
+        !entry.isNone()) {
       trxOperations.emplace_back(absl::StrCat("Current/", subEntry),
                                  AgencyValueOperationType::SET, entry);
     }


### PR DESCRIPTION
### Scope & Purpose

*The HotRestore did not erase ReplicatedLogs and CollectionGroups from Current (Replication2). This could leave behind the two in case the log was created after the Hotbackup was taken, eventually causing issues when removing dead servers being responsible in Current for Logs that in fact do not exist anymore.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

