### PR TITLE
Fixed issue BTS-1741

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.10.13 (XXXX-XX-XX)
 ---------------------
 
+* BTS-1741: fix updates of values in unique persistent indexes with stored
+  values defined for them. When such an index value was updated, it was
+  possible that the stored value was not correctly updated, so that subsequent
+  reads of the index value would run into exceptions such as 
+  `Expecting type Array or Object`.
+
 * APM-828: Per collection/database/user monitoring.
 
   This adds optional metrics for tracking per-shard requests on DB-Servers.

--- a/tests/js/common/shell/shell-index-stored-values.js
+++ b/tests/js/common/shell/shell-index-stored-values.js
@@ -954,6 +954,39 @@ function indexStoredValuesResultsSuite() {
         assertEqual(base * 3, result[i].value3);
       }
     },
+
+    testResultAfterUpdate: function () {
+      c.ensureIndex({ type: "persistent", fields: ["value1"], storedValues: ["value2", "value3"] });
+      const n = 100;
+     
+      db._query(`FOR i IN 0..${n - 1} FOR doc IN ${cn} FILTER doc.value1 == i UPDATE doc WITH { value2: 10 * i, value3: 5 * i } IN ${cn}`);
+
+      for (let i = 0; i < n; ++i) {
+        let result = db._query(`FOR doc IN ${cn} FILTER doc.value1 == ${i} RETURN [doc.value2, doc.value3]`).toArray();
+        assertEqual(1, result.length);
+
+        let doc = result[0];
+        assertEqual(10 * i, doc[0]);
+        assertEqual(5 * i, doc[1]);
+      }
+    },
+    
+    testResultAfterUpdateUnique: function () {
+      c.ensureIndex({ type: "persistent", fields: ["value1"], storedValues: ["value2", "value3"], unique: true });
+      const n = 100;
+     
+      db._query(`FOR i IN 0..${n - 1} FOR doc IN ${cn} FILTER doc.value1 == i UPDATE doc WITH { value2: 10 * i, value3: 5 * i } IN ${cn}`);
+
+      for (let i = 0; i < n; ++i) {
+        let result = db._query(`FOR doc IN ${cn} FILTER doc.value1 == ${i} RETURN [doc.value2, doc.value3]`).toArray();
+        assertEqual(1, result.length);
+
+        let doc = result[0];
+        assertEqual(10 * i, doc[0]);
+        assertEqual(5 * i, doc[1]);
+      }
+    },
+
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20508

Fix https://arangodb.atlassian.net/browse/BTS-1741

* BTS-1741: fix updates of values in unique persistent indexes with stored values defined for them. When such an index value was updated, it was possible that the stored value was not correctly updated, so that subsequent reads of the index value would run into exceptions such as `Expecting type Array or Object`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20505
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1741
- [ ] Design document: 