### PR TITLE
Disable more Flaky View Recovery tests

### DIFF
--- a/tests/js/client/recovery/search/view-search-alias-populate-truncate-no-flushthread.js
+++ b/tests/js/client/recovery/search/view-search-alias-populate-truncate-no-flushthread.js
@@ -68,6 +68,13 @@ function recoverySuite () {
 
 
     testIResearchLinkPopulateTruncate: function () {
+      if (db._properties().replicationVersion === "2") {
+        // TODO: Temporarily disabled.
+        // Should be re-enabled as soon as https://arangodb.atlassian.net/browse/CINFRA-876
+        // is fixed.
+        return;
+      }
+
       let checkView = function(viewName, indexName) {
         let v = db._view(viewName);
         assertEqual(v.name(), viewName);

--- a/tests/js/client/recovery/search/view-search-alias-populate-truncate.js
+++ b/tests/js/client/recovery/search/view-search-alias-populate-truncate.js
@@ -66,6 +66,13 @@ function recoverySuite () {
 
 
     testIResearchLinkPopulateTruncate: function () {
+      if (db._properties().replicationVersion === "2") {
+        // TODO: Temporarily disabled.
+        // Should be re-enabled as soon as https://arangodb.atlassian.net/browse/CINFRA-876
+        // is fixed.
+        return;
+      }
+
       let checkView = function(viewName, indexName) {
         let v = db._view(viewName);
         assertEqual(v.name(), viewName);


### PR DESCRIPTION
### Scope & Purpose

Addition to: https://github.com/arangodb/arangodb/pull/20490
*The tests in here are flaky and require some help from Search Core team to be sorted out. Disable them for now on Replication2 only*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

