### PR TITLE
lower memory usage high water mark multiplier for in-memory cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1064,16 +1064,8 @@ devel
   The high water multiplier is used to calculate the effective memory usage 
   limit for the in-memory cache subsystem. The cache's configured memory usage 
   limit (`--cache.size`) is multiplied by the high water multiplier, and the 
-  resulting value is used as the effective memory limit. It defaults to 95%
+  resulting value is used as the effective memory limit. It defaults to 56%
   of the configured cache size.
-
-  Note that this is a behavior change. Previous versions of ArangoDB set the
-  high water multiplier to effectively 56% of the configured memory. The value
-  was hard-coded in versions before 3.11.3, and is exposed since then with a
-  default value of 56%. 
-  3.12 now sets the default value for the high water multiplier to 95%, so that
-  the configured memory limit for the cache subsystem is actually better
-  honored than before.
 
 * Wrap imports into SmartGraph edge collections via the REST import API
   (POST `/_api/import`) into a managed transaction, so that edge data is

--- a/arangod/Cache/CacheOptionsProvider.h
+++ b/arangod/Cache/CacheOptionsProvider.h
@@ -51,7 +51,7 @@ struct CacheOptions {
   // it is set to 56% of the configured memory limit by default only because
   // of compatibility reasons. the value was set to 0.7 * 0.8 of the memory
   // limit, i.e. 0.56.
-  double highwaterMultiplier = 0.95;
+  double highwaterMultiplier = 0.56;
   // whether or not we want recent hit rates. if this is turned off,
   // we only get global hit rates over the entire lifetime of a cache
   bool enableWindowedStats = true;


### PR DESCRIPTION
### Scope & Purpose

Lower memory usage high water mark multiplier for in-memory caches to 56% of the configured cache size value.
These 56% are the same value that was used in previous version of ArangoDB. We temporarily increased the value in devel, but it turned out that the cache can still overcommit memory because its memory reclamation procedure is asynchronous and can run in parallel to other tasks that insert new data.
To stay on the safe side and not overcommit more memory usage than before, the default high water multiplier value is reverted to 56%, the same value as used in all previous versions.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 