### PR TITLE
CINFRA: Test fix: Wait for leadership to be established.

### DIFF
--- a/tests/js/server/replication2/replication2-supervision-wait-for-sync-false.js
+++ b/tests/js/server/replication2/replication2-supervision-wait-for-sync-false.js
@@ -79,6 +79,7 @@ const replicatedLogWaitForSyncFalseSupervisionSuite = function () {
       lh.stopServer(oldLeader);
 
       lh.waitFor(lp.replicatedLogLeaderPlanChanged(database, log.id(), oldLeader));
+      lh.waitFor(lp.replicatedLogLeaderEstablished(database, log.id(), undefined, servers));
 
       // insert a log entry
       const {

--- a/tests/js/server/replication2/replication2-supervision-wait-for-sync-false.js
+++ b/tests/js/server/replication2/replication2-supervision-wait-for-sync-false.js
@@ -79,7 +79,7 @@ const replicatedLogWaitForSyncFalseSupervisionSuite = function () {
       lh.stopServer(oldLeader);
 
       lh.waitFor(lp.replicatedLogLeaderPlanChanged(database, log.id(), oldLeader));
-      lh.waitFor(lp.replicatedLogLeaderEstablished(database, log.id(), undefined, servers));
+      lh.waitFor(lp.replicatedLogLeaderEstablished(database, log.id(), undefined, followers));
 
       // insert a log entry
       const {


### PR DESCRIPTION
### Scope & Purpose

*The test here performs a server crash and then wants to write on the new leader. It did only wait for a new server to be planned as leader, but not actually taking leadership. The race should now be gone.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

