### PR TITLE
emit a proper error message when profiling on a DB-Server

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -830,6 +830,9 @@ function processQuery(query, explain, planIndex) {
     stats = explain.stats;
 
   let plan = explain.plan;
+  if (plan === undefined) {
+    throw "incomplete query execution plan data - this should not happen unless when connected to a DB-Server. fetching query plans/profiles from a DB-Server is not supported!";
+  }
   if (planIndex !== undefined) {
     plan = explain.plans[planIndex];
   }
@@ -874,6 +877,7 @@ function processQuery(query, explain, planIndex) {
       }
     });
   };
+
   recursiveWalk(plan.nodes, 0, 'COOR');
 
   if (profileMode) { 


### PR DESCRIPTION
### Scope & Purpose

When running `db._profileQuery(...)` directly on a DB-Server, this previously resulted in the following, rather cryptic error message:
```
JavaScript exception in file '/home/jan/Arango311NoAsan/js/common/modules/@arangodb/aql/explainer.js' at 852,22: TypeError: Cannot read property 'nodes' of undefined
!  recursiveWalk(plan.nodes, 0, 'COOR');
!                     ^
stacktrace: TypeError: Cannot read property 'nodes' of undefined
```
This is because DB-Servers do not return profiling information, only Coordinators and single servers do.
Instead of returning this cryptic error message, trying to profile a query on a DB-Server will now result in the more understandable error
```
Incomplete query execution plan data - this should not happen unless when connected to a DB-Server. fetching query plans/profiles from a DB-Server is not supported!
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 