### PR TITLE
improvements for TTL index removal queries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,10 +6,10 @@ v3.10.13 (XXXX-XX-XX)
 * Updated ArangoDB Starter to v0.18.0.
 
 * BTS-1741: fix updates of values in unique persistent indexes with stored
-  values defined for them. When such an index value was updated, it was
-  possible that the stored value was not correctly updated, so that subsequent
-  reads of the index value would run into exceptions such as 
-  `Expecting type Array or Object`.
+  values defined for them. When such an index value was updated, it was possible
+  that the stored value was not correctly updated, so that subsequent reads of
+  the index value would run into exceptions such as `Expecting type Array or
+  Object`.
 
 * APM-828: Per collection/database/user monitoring.
 
@@ -28,11 +28,11 @@ v3.10.13 (XXXX-XX-XX)
   - `enabled-per-shard`: this will make DB-Servers collect per-shard usage
     metrics.
   - `enabled-per-shard-per-user`: this will make DB-Servers collect per-shard
-    and per-user metrics. This is more granular than `enabled-per-shard` but
-    can produce a lot of metrics.
+    and per-user metrics. This is more granular than `enabled-per-shard` but can
+    produce a lot of metrics.
   
-  If enabled, the metrics are only exposed on DB servers and not on 
-  Coordinators or single servers.
+  If enabled, the metrics are only exposed on DB servers and not on Coordinators
+  or single servers.
 
   Whenever a shard is accessed in read or write mode by one of the following
   operations, the metrics are populated dynamically, either with a per-user
@@ -57,15 +57,15 @@ v3.10.13 (XXXX-XX-XX)
     read counter will be increased once for each shard that is affected by the
     operation.
 
-  The metrics are increased when any of the above operations start, and they
-  are not decreased should an operation abort or if an operation does not
-  lead to any actual reads or writes.
+  The metrics are increased when any of the above operations start, and they are
+  not decreased should an operation abort or if an operation does not lead to
+  any actual reads or writes.
 
-  Note that internal operations, such as internal queries executed for 
+  Note that internal operations, such as internal queries executed for
   statistics gathering, internal garbage collection, and TTL index cleanup are
-  not counted in these metrics. Additionally, all requests that use the 
-  superuser JWT for authentication and that do not have a specific user set,
-  are not counted.
+  not counted in these metrics. Additionally, all requests that use the
+  superuser JWT for authentication and that do not have a specific user set, are
+  not counted.
   Requests are also only counted if they have an ArangoDB user associated with
   them, so that the cluster must also be running with authentication turned on.
 
@@ -75,24 +75,24 @@ v3.10.13 (XXXX-XX-XX)
   endpoint GET `/_admin/usage-metrics`. They are not exposed via the existing
   metrics API endpoint GET `/_admin/metrics`.
 
- Add additional metrics for tracking the number of bytes read or written per
+  Add additional metrics for tracking the number of bytes read or written per
   shard on DB-Servers:
 
   - `arangodb_collection_requests_bytes_read_total`:
-    This metric exposes the per-shard number of bytes read by read operation 
+    This metric exposes the per-shard number of bytes read by read operation
     requests on DB-Servers. 
     It is increased by AQL queries that read documents or edges and for single-
     or multi-document read operations.
-    The metric is normally increased only on the leader, but it can also 
+    The metric is normally increased only on the leader, but it can also
     increase on followers if "reads from followers" are enabled.
 
-    For every read operation, the metric will be increased by the approximate 
+    For every read operation, the metric will be increased by the approximate
     number of bytes read to retrieve the underlying document or edge data. This
     is also true if a document or edge is served from an in-memory cache.
-    If an operation reads multiple documents/edges, it will increase the 
-    counter multiple times, each time with the approximate number of bytes read
-    for the particular document/edge.
-    
+    If an operation reads multiple documents/edges, it will increase the counter
+    multiple times, each time with the approximate number of bytes read for the
+    particular document/edge.
+
     The numbers reported by this metric normally relate to the cumulated sizes
     of documents/edges read.
     The metric is also increased for transactions that are started but later
@@ -105,52 +105,51 @@ v3.10.13 (XXXX-XX-XX)
     This metric exposes the per-shard number of bytes written by write operation
     requests on DB-Servers, on both leaders and followers.
     It is increased by AQL queries and single-/multi-document write operations.
-    The metric is first increased only the leader, but for every replication 
+    The metric is first increased only the leader, but for every replication
     request to followers it is also increased on followers.
-    
-    For every write operation, the metric will be increased by the approximate 
-    number of bytes written for the document or edge in question. 
-    If an operation writes multiple documents/edges, it will increase the 
-    counter multiple times, each time with the approximate number of bytes 
+
+    For every write operation, the metric will be increased by the approximate
+    number of bytes written for the document or edge in question.
+    If an operation writes multiple documents/edges, it will increase the
+    counter multiple times, each time with the approximate number of bytes
     written for the particular document/edge.
 
-    An AQL query will also increase the counter for every document or edge 
-    written, each time with the approximate number of bytes written for 
+    An AQL query will also increase the counter for every document or edge
+    written, each time with the approximate number of bytes written for
     document/edge.
-    
+
     The numbers reported by this metric normally relate to the cumulated sizes
     of documents/edges written. For remove operations however only a fixed
-    number of bytes is counted per removed document/edge. For truncate 
+    number of bytes is counted per removed document/edge. For truncate
     operations, the metrics will be affected differently depending on how the
     truncate is executed internally.
     For truncates on smaller shards, the truncate operation will be executed as
     the removal of the individual documents in the shard. Thus the metric will
     also be increased as if the documents were removed individually. Truncate
-    operations on larger shards however will be executed via a special 
-    operation in the storage engine, which marks a whole range of documents as
-    removed, but defers the actual removal until much later (compaction 
-    process). If a truncate is executed like this, the metric will not be 
-    increased at all.
+    operations on larger shards however will be executed via a special operation
+    in the storage engine, which marks a whole range of documents as removed,
+    but defers the actual removal until much later (compaction process). If a
+    truncate is executed like this, the metric will not be increased at all.
     Writes into secondary indexes are not counted at all.
 
     The metric is also increased for transactions that are started but later
     aborted.
-  
-  These metrics are not exposed by default. It is only present if the startup 
-  option `--server.export-shard-usage-metrics` is set to either 
+
+  These metrics are not exposed by default. It is only present if the startup
+  option `--server.export-shard-usage-metrics` is set to either
   `enabled-per-shard` or `enabled-per-shard-per-user`. With the former setting,
   the metric will have different labels for each shard that was read from. With
-  the latter setting, the metric will have different labels for each 
-  combination of shard and user that accessed the shard.
-  
-  If enabled, the metrics are only exposed on DB servers and not on 
-  Coordinators or single servers.
-  
-  Note that internal operations, such as internal queries executed for 
+  the latter setting, the metric will have different labels for each combination
+  of shard and user that accessed the shard.
+
+  If enabled, the metrics are only exposed on DB servers and not on Coordinators
+  or single servers.
+
+  Note that internal operations, such as internal queries executed for
   statistics gathering, internal garbage collection, and TTL index cleanup are
-  not counted in these metrics. Additionally, all requests that use the 
-  superuser JWT for authentication and that do not have a specific user set,
-  are not counted.
+  not counted in these metrics. Additionally, all requests that use the
+  superuser JWT for authentication and that do not have a specific user set, are
+  not counted.
   Requests are also only counted if they have an ArangoDB user associated with
   them, so that the cluster must also be running with authentication turned on.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.10.13 (XXXX-XX-XX)
 ---------------------
 
+* Reduce default amount of per-collection document removals by TTL background 
+  index creation thread from 1m to 100k in each iteration. This change gives
+  other collections a chance of being cleaned up as well.
+
 * New API to show progress in background index creation.
 
 * Updated ArangoDB Starter to v0.18.0.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,14 +430,14 @@ function(determine_repository_version source_dir build_repository have_build_rep
       set(${have_build_repository} "1" PARENT_SCOPE)
     endif()
   elseif(BUILD_REPO_INFO STREQUAL "release")
+    if ("${ARANGODB_VERSION_RELEASE_NUMBER}" STREQUAL "" AND ARANGODB_VERSION_RELEASE_TYPE MATCHES "^[1-9][0-9]*$")
+      string(REPLACE "-" "." RELEASE_TAG ${ARANGODB_VERSION})
+    else()
+      set(RELEASE_TAG ${ARANGODB_VERSION})
+    endif()
+    set(RELEASE_TAG "v${RELEASE_TAG}")
     execute_process(
       WORKING_DIRECTORY ${source_dir}
-      if("${ARANGODB_VERSION_RELEASE_NUMBER}" STREQUAL "" AND ARANGODB_VERSION_RELEASE_TYPE MATCHES "^[1-9][0-9]*$")
-        string(REPLACE "-" "." RELEASE_TAG ${ARANGODB_VERSION})
-      else()
-        set(RELEASE_TAG ${ARANGODB_VERSION})
-      endif()
-      set(RELEASE_TAG "v${RELEASE_TAG}")
       COMMAND ${GIT_EXE} describe --all --tags --match ${RELEASE_TAG}
       OUTPUT_VARIABLE TAG_RAW)
     if (NOT TAG_RAW)

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -337,6 +337,10 @@ class TtlThread final : public ServerThread<ArangodServer> {
           if (index->type() != Index::TRI_IDX_TYPE_TTL_INDEX) {
             continue;
           }
+          if (index->isHidden()) {
+            // Filter out indexes that are currently still being built
+            continue;
+          }
 
           // serialize the index description so we can read the "expireAfter"
           // attribute

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -65,6 +65,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <random>
 #include <thread>
 
 using namespace arangodb;
@@ -278,7 +279,10 @@ class TtlThread final : public ServerThread<ArangodServer> {
       coordinators = ci.getCurrentCoordinators();
     }
 
-    constexpr size_t maxResultsPerQuery = 4000;
+    std::random_device rd;
+    std::mt19937 randGen(rd());
+
+    constexpr uint64_t maxResultsPerQuery = 4000;
 
     double const stamp = TRI_microtime();
     uint64_t limitLeft = properties.maxTotalRemoves;
@@ -291,7 +295,7 @@ class TtlThread final : public ServerThread<ArangodServer> {
     // databases in the removals. the total amount of documents to remove
     // is limited, so a deterministic input could favor the first few
     // databases in the list.
-    std::random_shuffle(databases.begin(), databases.end());
+    std::shuffle(databases.begin(), databases.end(), randGen);
     for (auto const& name : databases) {
       if (!isActive()) {
         // feature deactivated (for example, due to running on current follower
@@ -317,7 +321,7 @@ class TtlThread final : public ServerThread<ArangodServer> {
       // collections in the removals. the total amount of documents to remove
       // is limited, so a deterministic input could favor the first few
       // collections in the list.
-      std::random_shuffle(collections.begin(), collections.end());
+      std::shuffle(collections.begin(), collections.end(), randGen);
 
       for (auto const& collection : collections) {
         if (!isActive()) {

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -45,6 +45,7 @@
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 #include "Network/Methods.h"
+#include "Network/NetworkFeature.h"
 #include "Network/Utils.h"
 #include "Network/types.h"
 #include "ProgramOptions/Parameters.h"
@@ -62,6 +63,7 @@
 #include <velocypack/Builder.h>
 #include <velocypack/Slice.h>
 
+#include <algorithm>
 #include <chrono>
 #include <thread>
 

--- a/arangod/RestServer/TtlFeature.h
+++ b/arangod/RestServer/TtlFeature.h
@@ -59,7 +59,7 @@ struct TtlProperties {
   static constexpr uint64_t minFrequency = 1 * 1000;  // milliseconds
   uint64_t frequency = 30 * 1000;                     // milliseconds
   uint64_t maxTotalRemoves = 1000000;
-  uint64_t maxCollectionRemoves = 1000000;
+  uint64_t maxCollectionRemoves = 40000;
 
   void toVelocyPack(arangodb::velocypack::Builder& out, bool isActive) const;
   Result fromVelocyPack(arangodb::velocypack::Slice const& properties);

--- a/arangod/RestServer/TtlFeature.h
+++ b/arangod/RestServer/TtlFeature.h
@@ -59,7 +59,7 @@ struct TtlProperties {
   static constexpr uint64_t minFrequency = 1 * 1000;  // milliseconds
   uint64_t frequency = 30 * 1000;                     // milliseconds
   uint64_t maxTotalRemoves = 1000000;
-  uint64_t maxCollectionRemoves = 40000;
+  uint64_t maxCollectionRemoves = 100000;
 
   void toVelocyPack(arangodb::velocypack::Builder& out, bool isActive) const;
   Result fromVelocyPack(arangodb::velocypack::Slice const& properties);

--- a/tests/js/common/shell/shell-ttl.js
+++ b/tests/js/common/shell/shell-ttl.js
@@ -1012,13 +1012,16 @@ function TtlSuite () {
         assertTrue(dt >= "2019-01-");
 
         let docs = [];
-        for (let i = 0; i < 10000; ++i) {
+        for (let i = 0; i < 50000; ++i) {
           docs.push({ _key: 'test' + (i % 10) + ':test' + i, testi: 'test' + (i % 10), dateCreated: dt, value: i });
+          if (docs.length === 5000) {
+            db[vn].insert(docs);
+            docs = [];
+          }
         }
-        db[vn].insert(docs);
       
         let oldStats = internal.ttlStatistics();
-        let oldCount = 10000;  
+        let oldCount = 50000;  
         assertEqual(db[vn].count(), oldCount);
       
         // reenable
@@ -1032,18 +1035,20 @@ function TtlSuite () {
         assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
         assertTrue(db._collection(vn).count() < oldCount);
         oldCount = db._collection(vn).count();
-     
-        // wait again for next removal 
-        oldStats = stats;
-        stats = waitForNextRun(db[vn], oldStats, 30);
+    
+        if (oldCount > 0) {
+          // wait again for next removal 
+          oldStats = stats;
+          stats = waitForNextRun(db[vn], oldStats, 30);
 
-        assertNotEqual(stats.runs, oldStats.runs);
-        assertTrue(stats.limitReached > oldStats.limitReached);
-        assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
-        // wait again, as fetching the stats and acquiring the collection count is not atomic
-        oldStats = stats;
-        stats = waitForNextRun(db[vn], oldStats, 30);
-        assertTrue(db._collection(vn).count() < oldCount || db._collection(vn).count() === 0);
+          assertNotEqual(stats.runs, oldStats.runs);
+          assertTrue(stats.limitReached > oldStats.limitReached);
+          assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
+          // wait again, as fetching the stats and acquiring the collection count is not atomic
+          oldStats = stats;
+          stats = waitForNextRun(db[vn], oldStats, 30);
+          assertTrue(db._collection(vn).count() < oldCount || db._collection(vn).count() === 0);
+        }
       } finally {
         graphs._drop(gn, true);
       }
@@ -1069,13 +1074,16 @@ function TtlSuite () {
         db[en].ensureIndex({ type: "ttl", fields: ["dateCreated"], expireAfter: 1 });
         
         let docs = [];
-        for (let i = 0; i < 10000; ++i) {
+        for (let i = 0; i < 50000; ++i) {
           docs.push({ _from: vn + '/test' + i + ':test' + (i % 10), _to: vn + '/test' + ((i + 1) % 100) + ':test' + (i % 10), testi: i % 10, dateCreated: dt, value: i });
+          if (docs.length === 5000) {
+            db[en].insert(docs);
+            docs = [];
+          }
         }
-        db[en].insert(docs);
               
         let oldStats = internal.ttlStatistics();
-        let oldCount = 10000;
+        let oldCount = 50000;
         assertEqual(db[en].count(), oldCount);
       
         // reenable
@@ -1089,18 +1097,20 @@ function TtlSuite () {
         assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
         assertTrue(db._collection(en).count() < oldCount);
         oldCount = db._collection(en).count();
-     
-        // wait again for next removal 
-        oldStats = stats;
-        stats = waitForNextRun(db[en], oldStats, 30);
+    
+        if (oldCount > 0) {
+          // wait again for next removal 
+          oldStats = stats;
+          stats = waitForNextRun(db[en], oldStats, 30);
 
-        assertNotEqual(stats.runs, oldStats.runs);
-        assertTrue(stats.limitReached > oldStats.limitReached);
-        assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
-        // wait again, as fetching the stats and acquiring the collection count is not atomic
-        oldStats = stats;
-        stats = waitForNextRun(db[en], oldStats, 30);
-        assertTrue(db._collection(en).count() < oldCount || db._collection(en).count() === 0);
+          assertNotEqual(stats.runs, oldStats.runs);
+          assertTrue(stats.limitReached > oldStats.limitReached);
+          assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
+          // wait again, as fetching the stats and acquiring the collection count is not atomic
+          oldStats = stats;
+          stats = waitForNextRun(db[en], oldStats, 30);
+          assertTrue(db._collection(en).count() < oldCount || db._collection(en).count() === 0);
+        }
       } finally {
         graphs._drop(gn, true);
       }

--- a/tests/js/common/shell/shell-ttl.js
+++ b/tests/js/common/shell/shell-ttl.js
@@ -47,6 +47,11 @@ function TtlSuite () {
       numServers = Object.values(collection.shards(true)).filter(function(value, index, self) {
         return self.indexOf(value) === index;
       }).length;
+      if (numServers === 0) {
+        // SmartGraph edge collection. hard-code
+        numServers = 3;
+      }
+
       // if there are multiple servers involved, we increase by 4, in order to avoid continuing
       // in case the the *same* server reports multiple times. this would break the simple
       // "how many times did it run check" in case the jobs are executed in the following order:
@@ -62,9 +67,10 @@ function TtlSuite () {
       numServers = 1;
     }
 
+    tries *= 5;
     let stats;
     while (tries-- > 0) {
-      internal.wait(1, false);
+      internal.wait(0.25, false);
     
       stats = internal.ttlStatistics();
       if (stats.runs - oldRuns >= numServers) {
@@ -981,6 +987,123 @@ function TtlSuite () {
       oldStats = stats;
       stats = waitForNextRun(c, oldStats, 20);
       assertTrue(db._collection(cn).count() < oldCount || db._collection(cn).count() === 0);
+    },
+    
+    testRemovalsSmartGraphVertex : function () {
+      if (!internal.isCluster() || !internal.isEnterprise()) {
+        return;
+      }
+
+      const vn = "UnitTestsVertex";
+      const en = "UnitTestsEdge";
+      const gn = "UnitTestsGraph";
+
+      const graphs = require("@arangodb/smart-graph");
+      graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor: 2, smartGraphAttribute: "testi" });
+
+      try {
+        internal.ttlProperties({ active: false });
+
+        // populate smart vertex collection
+        db[vn].ensureIndex({ type: "ttl", fields: ["dateCreated"], expireAfter: 1 });
+
+        // dt is one minute in the past
+        let dt = new Date((new Date()).getTime() - 1000 * 60).toISOString();
+        assertTrue(dt >= "2019-01-");
+
+        let docs = [];
+        for (let i = 0; i < 10000; ++i) {
+          docs.push({ _key: 'test' + (i % 10) + ':test' + i, testi: 'test' + (i % 10), dateCreated: dt, value: i });
+        }
+        db[vn].insert(docs);
+      
+        let oldStats = internal.ttlStatistics();
+        let oldCount = 10000;  
+        assertEqual(db[vn].count(), oldCount);
+      
+        // reenable
+        internal.ttlProperties({ active: true, frequency: 1000, maxTotalRemoves: 1000, maxCollectionRemoves: 2000 });
+    
+        let stats = waitForNextRun(db[vn], oldStats, 30);
+
+        // number of runs, deletions and limitReached must have changed
+        assertNotEqual(stats.runs, oldStats.runs);
+        assertTrue(stats.limitReached > oldStats.limitReached);
+        assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
+        assertTrue(db._collection(vn).count() < oldCount);
+        oldCount = db._collection(vn).count();
+     
+        // wait again for next removal 
+        oldStats = stats;
+        stats = waitForNextRun(db[vn], oldStats, 30);
+
+        assertNotEqual(stats.runs, oldStats.runs);
+        assertTrue(stats.limitReached > oldStats.limitReached);
+        assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
+        // wait again, as fetching the stats and acquiring the collection count is not atomic
+        oldStats = stats;
+        stats = waitForNextRun(db[vn], oldStats, 30);
+        assertTrue(db._collection(vn).count() < oldCount || db._collection(vn).count() === 0);
+      } finally {
+        graphs._drop(gn, true);
+      }
+    },
+    
+    testRemovalsSmartGraphEdge : function () {
+      if (!internal.isCluster() || !internal.isEnterprise()) {
+        return;
+      }
+
+      const vn = "UnitTestsVertex";
+      const en = "UnitTestsEdge";
+      const gn = "UnitTestsGraph";
+
+      const graphs = require("@arangodb/smart-graph");
+      graphs._create(gn, [graphs._relation(en, vn, vn)], null, { numberOfShards: 3, replicationFactor: 2, smartGraphAttribute: "testi" });
+
+      try {
+        internal.ttlProperties({ active: false });
+
+        // populate smart edge collection
+        let dt = new Date((new Date()).getTime() - 1000 * 60).toISOString();
+        db[en].ensureIndex({ type: "ttl", fields: ["dateCreated"], expireAfter: 1 });
+        
+        let docs = [];
+        for (let i = 0; i < 10000; ++i) {
+          docs.push({ _from: vn + '/test' + i + ':test' + (i % 10), _to: vn + '/test' + ((i + 1) % 100) + ':test' + (i % 10), testi: i % 10, dateCreated: dt, value: i });
+        }
+        db[en].insert(docs);
+              
+        let oldStats = internal.ttlStatistics();
+        let oldCount = 10000;
+        assertEqual(db[en].count(), oldCount);
+      
+        // reenable
+        internal.ttlProperties({ active: true, frequency: 1000, maxTotalRemoves: 1000, maxCollectionRemoves: 2000 });
+    
+        let stats = waitForNextRun(db[en], oldStats, 30);
+
+        // number of runs, deletions and limitReached must have changed
+        assertNotEqual(stats.runs, oldStats.runs);
+        assertTrue(stats.limitReached > oldStats.limitReached);
+        assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
+        assertTrue(db._collection(en).count() < oldCount);
+        oldCount = db._collection(en).count();
+     
+        // wait again for next removal 
+        oldStats = stats;
+        stats = waitForNextRun(db[en], oldStats, 30);
+
+        assertNotEqual(stats.runs, oldStats.runs);
+        assertTrue(stats.limitReached > oldStats.limitReached);
+        assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
+        // wait again, as fetching the stats and acquiring the collection count is not atomic
+        oldStats = stats;
+        stats = waitForNextRun(db[en], oldStats, 30);
+        assertTrue(db._collection(en).count() < oldCount || db._collection(en).count() === 0);
+      } finally {
+        graphs._drop(gn, true);
+      }
     },
   
   };


### PR DESCRIPTION
### Scope & Purpose

Improvements for TTL index removal queries:

- do not have max query runtime affect TTL index removal queries
- do not favor certain databases/collections/shards in the removals, but give them more or less equal probability of being picked
- reduce the default amount of documents to be removed per collection (`--ttl.max-collection-removes` startup option`) from 1m to 40k. this allows different databases/collections/shards to be picked in a single TTL background thread iteration
- do not use an AQL query for removing documents from the TTL index. using an AQL query initiated on the DB server is not ideal because it will intermediate commit on followers but can be rolled back on leaders


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 