### PR TITLE
do not expose hidden indexes by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.10.13 (XXXX-XX-XX)
 ---------------------
 
+* Do not make AQL query runtime timeout affect TTL index background thread 
+  removal queries.
+
 * New API to show progress in background index creation.
 
 * Updated ArangoDB Starter to v0.18.0.

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -218,83 +218,101 @@ RestStatus RestIndexHandler::getIndexes() {
         for (auto const& i : VPackArrayIterator(indexes.slice())) {
           tmp.add(i);
         }
-        try {  // this is a best effort progress display.
-          for (auto const& pi : VPackArrayIterator(plannedIndexes->slice())) {
-            if (pi.get("isBuilding").isTrue()) {
-              VPackObjectBuilder o(&tmp);
-              for (auto const& source :
-                   VPackObjectIterator(pi, /* useSequentialIterator */ true)) {
-                tmp.add(source.key.stringView(), source.value);
-              }
-              std::string iid = pi.get("id").copyString();
-              double progress = 0;
-              auto const shards = coll->shardIds();
-              auto const body = VPackBuffer<uint8_t>();
-              auto* pool =
-                  coll->vocbase().server().getFeature<NetworkFeature>().pool();
-              std::vector<Future<network::Response>> futures;
-              futures.reserve(shards->size());
-              std::string const prefix = "/_api/index/";
-              network::RequestOptions reqOpts;
-              reqOpts.param("withHidden", "true");
-              reqOpts.database = _vocbase.name();
-              // best effort. only displaying progress
-              reqOpts.timeout = network::Timeout(10.0);
-              for (auto const& shard : *shards) {
-                std::string const url =
-                    absl::StrCat(prefix, shard.first, "/", iid);
-                futures.emplace_back(network::sendRequestRetry(
-                    pool, "shard:" + shard.first, fuerte::RestVerb::Get, url,
-                    body, reqOpts));
-              }
-              for (Future<network::Response>& f : futures) {
-                network::Response const& r = f.get();
+        if (withHidden) {
+          try {  // this is a best effort progress display.
+            for (auto const& pi : VPackArrayIterator(plannedIndexes->slice())) {
+              if (pi.get("isBuilding").isTrue()) {
+                VPackObjectBuilder o(&tmp);
+                for (auto const& source : VPackObjectIterator(
+                         pi, /* useSequentialIterator */ true)) {
+                  tmp.add(source.key.stringView(), source.value);
+                }
+                std::string iid = pi.get("id").copyString();
+                double progress = 0;
+                auto const shards = coll->shardIds();
+                auto const body = VPackBuffer<uint8_t>();
+                auto* pool = coll->vocbase()
+                                 .server()
+                                 .getFeature<NetworkFeature>()
+                                 .pool();
+                std::vector<Future<network::Response>> futures;
+                futures.reserve(shards->size());
+                std::string const prefix = "/_api/index/";
+                network::RequestOptions reqOpts;
+                reqOpts.param("withHidden", withHidden ? "true" : "false");
+                reqOpts.database = _vocbase.name();
+                // best effort. only displaying progress
+                reqOpts.timeout = network::Timeout(10.0);
+                for (auto const& shard : *shards) {
+                  std::string const url =
+                      absl::StrCat(prefix, shard.first, "/", iid);
+                  futures.emplace_back(network::sendRequestRetry(
+                      pool, "shard:" + shard.first, fuerte::RestVerb::Get, url,
+                      body, reqOpts));
+                }
+                for (Future<network::Response>& f : futures) {
+                  network::Response const& r = f.get();
 
-                // Only best effort accounting. If something breaks here, we
-                // just ignore the output. Account for what we can and move on.
-                if (r.fail()) {
-                  LOG_TOPIC("afde4", INFO, Logger::CLUSTER)
-                      << "Communication error while fetching index data "
-                         "for collection "
-                      << coll->name() << " from " << r.destination;
-                  continue;
+                  // Only best effort accounting. If something breaks here, we
+                  // just ignore the output. Account for what we can and move
+                  // on.
+                  if (r.fail()) {
+                    LOG_TOPIC("afde4", INFO, Logger::CLUSTER)
+                        << "Communication error while fetching index data "
+                           "for collection "
+                        << coll->name() << " from " << r.destination;
+                    continue;
+                  }
+                  VPackSlice resSlice = r.slice();
+                  if (!resSlice.isObject() ||
+                      !resSlice.get(StaticStrings::Error).isBoolean()) {
+                    LOG_TOPIC("aabe4", INFO, Logger::CLUSTER)
+                        << "Result of collecting index data for collection "
+                        << coll->name() << " from " << r.destination
+                        << " is invalid";
+                    continue;
+                  }
+                  if (resSlice.get(StaticStrings::Error).getBoolean()) {
+                    // this can happen when the DB-Servers have not yet
+                    // started the creation of the index on a shard, for
+                    // example if the number of maintenance threads is low.
+                    auto errorNum = TRI_ERROR_NO_ERROR;
+                    if (VPackSlice errorNumSlice =
+                            resSlice.get(StaticStrings::ErrorNum);
+                        errorNumSlice.isNumber()) {
+                      errorNum = ::ErrorCode{errorNumSlice.getNumber<int>()};
+                    }
+                    // do not log an expected error such as "index not found",
+                    if (errorNum != TRI_ERROR_ARANGO_INDEX_NOT_FOUND) {
+                      LOG_TOPIC("a4bea", INFO, Logger::CLUSTER)
+                          << "Failed to collect index data for collection "
+                          << coll->name() << " from " << r.destination << ": "
+                          << resSlice.toJson();
+                    }
+                    continue;
+                  }
+                  if (resSlice.get("progress").isNumber()) {
+                    progress += resSlice.get("progress").getNumber<double>();
+                  } else {
+                    // Obviously, the index is already ready there.
+                    progress += 100.0;
+                    LOG_TOPIC("aeab4", DEBUG, Logger::CLUSTER)
+                        << "No progress entry on index " << iid << " from "
+                        << r.destination << ": " << resSlice.toJson()
+                        << " index already finished.";
+                  }
                 }
-                VPackSlice resSlice = r.slice();
-                if (!resSlice.isObject() ||
-                    !resSlice.get(StaticStrings::Error).isBoolean()) {
-                  LOG_TOPIC("aabe4", INFO, Logger::CLUSTER)
-                      << "Result of collecting index data for collection "
-                      << coll->name() << " from " << r.destination
-                      << " is invalid";
-                  continue;
+                if (progress != 0) {
+                  // Don't show progress 0, this is in particular relevant
+                  // when isBackground is false, in which case no progress
+                  // is reported by design.
+                  tmp.add("progress", VPackValue(progress / shards->size()));
                 }
-                if (resSlice.get(StaticStrings::Error).getBoolean()) {
-                  LOG_TOPIC("a4bea", INFO, Logger::CLUSTER)
-                      << "Failed to collect index data for collection "
-                      << coll->name() << " from " << r.destination;
-                  continue;
-                }
-                if (resSlice.get("progress").isNumber()) {
-                  progress += resSlice.get("progress").getNumber<double>();
-                } else {
-                  // Obviously, the index is already ready there.
-                  progress += 100.0;
-                  LOG_TOPIC("aeab4", DEBUG, Logger::CLUSTER)
-                      << "No progress entry on index " << iid << "  from "
-                      << r.destination << ": " << resSlice.toJson()
-                      << " index already finished.";
-                }
-              }
-              if (progress != 0) {
-                // Don't show progress 0, this is in particular relevant
-                // when isBackground is false, in which case no progress
-                // is reported by design.
-                tmp.add("progress", VPackValue(progress / shards->size()));
               }
             }
-          }
-        } catch (...) {
-        }  // best effort only
+          } catch (...) {
+          }  // best effort only
+        }
       }
     } else {
       tmp.add("indexes", indexes.slice());

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -207,11 +207,6 @@ RestStatus RestIndexHandler::getIndexes() {
             VPackValue(static_cast<int>(ResponseCode::OK)));
 
     if (ServerState::instance()->isCoordinator()) {
-      std::string ap = absl::StrCat("Plan/Collections/", _vocbase.name(), "/",
-                                    coll->planId().id(), "/indexes");
-      auto& ac = _vocbase.server().getFeature<ClusterFeature>().agencyCache();
-      auto [plannedIndexes, idx] = ac.get(ap);
-
       tmp.add(VPackValue("indexes"));
       {
         VPackArrayBuilder guard(&tmp);
@@ -219,6 +214,12 @@ RestStatus RestIndexHandler::getIndexes() {
           tmp.add(i);
         }
         if (withHidden) {
+          std::string ap = absl::StrCat("Plan/Collections/", _vocbase.name(),
+                                        "/", coll->planId().id(), "/indexes");
+          auto& ac =
+              _vocbase.server().getFeature<ClusterFeature>().agencyCache();
+          auto [plannedIndexes, idx] = ac.get(ap);
+
           try {  // this is a best effort progress display.
             for (auto const& pi : VPackArrayIterator(plannedIndexes->slice())) {
               if (pi.get("isBuilding").isTrue()) {

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -25,6 +25,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Query.h"
+#include "Aql/QueryOptions.h"
 #include "Aql/QueryRegistry.h"
 #include "Basics/ConditionLocker.h"
 #include "Basics/ConditionVariable.h"
@@ -336,9 +337,11 @@ class TtlThread final : public ServerThread<ArangodServer> {
               VPackValue(std::min(properties.maxCollectionRemoves, limitLeft)));
           bindVars->close();
 
+          aql::QueryOptions options;
+          options.maxRuntime = 0.0;
           auto query = aql::Query::create(
               transaction::StandaloneContext::Create(*vocbase),
-              aql::QueryString(::removeQuery), std::move(bindVars));
+              aql::QueryString(::removeQuery), std::move(bindVars), options);
           query->collections().add(collection->name(), AccessMode::Type::WRITE,
                                    aql::Collection::Hint::Shard);
           aql::QueryResult queryResult = query->executeSync();

--- a/tests/js/client/shell/shell-index.js
+++ b/tests/js/client/shell/shell-index.js
@@ -100,15 +100,16 @@ function IndexSuite() {
             internal.debugSetFailAt("fillIndex::unpause");
             seenProgress = true;
           }
-          sleep(0.1);
-          if (++count > 4000) {
-            // Value intentionally high for ASAN runs, this is 100x slower
-            // than observed on an old machine with debug build!
-            assertFalse(true, "Did not see index finished in time! " + JSON.stringify(idx));
-          }
-        } else {
+        } else if (seenProgress) {
           assertFalse(idx.hasOwnProperty("isBuilding"));
           break;
+        }
+          
+        sleep(0.1);
+        if (++count > 4000) {
+          // Value intentionally high for ASAN runs, this is 100x slower
+          // than observed on an old machine with debug build!
+          assertFalse(true, "Did not see index finished in time! " + JSON.stringify(idx));
         }
       }
       assertTrue(seenProgress, "Never saw progress being reported!");


### PR DESCRIPTION
### Scope & Purpose

A previous PR changed the coordinator `indexes()` method to list all available indexes to also return in-flight indexes.
This PR reverts this change.
It also suppresses the logging of expected error messages during progress reporting for shards that have not yet started creating their local index parts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 