### PR TITLE
allow more optimization for specific COLLECT ops

### DIFF
--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -2639,8 +2639,10 @@ void arangodb::aql::removeUnnecessaryCalculationsRule(
         // in this case we must not perform the replacements
         while (current != nullptr) {
           if (current->getType() == EN::COLLECT) {
-            if (ExecutionNode::castTo<CollectNode const*>(current)
-                    ->hasOutVariable()) {
+            CollectNode const* collectNode =
+                ExecutionNode::castTo<CollectNode const*>(current);
+            if (collectNode->hasOutVariable() &&
+                !collectNode->hasExpressionVariable()) {
               hasCollectWithOutVariable = true;
               break;
             }


### PR DESCRIPTION
### Scope & Purpose

Allow removal of CalculationNodes that are just aliases if a query contains a COLLECT ... INTO expression with an expression output variable, e.g. `INTO x = expr`.

Query execution plan without this PR:
```
Query String (98 chars, cacheable: false):
 for doc in prices   collect ticker = doc.TICKER   into dates = doc.date   return { ticker, dates }

Execution plan:
 Id   NodeType          Calls    Par     Items   Filtered   Runtime [s]   Comment
  1   SingletonNode         1      -         1          0       0.00001   * ROOT
  9   IndexNode          5773   5772   5772655          0       1.65867     - FOR doc IN prices   /* persistent index scan, index only (projections: `TICKER`, `date`) */    LET #8 = doc.`TICKER`, #9 = doc.`date`   
  3   CalculationNode    5773   5771   5772655          0       0.90096       - LET #3 = #8   /* simple expression */
  4   CalculationNode    5773   5770   5772655          0       0.87934       - LET #4 = #9   /* simple expression */
  5   CollectNode           3      2      2265          0       0.93481       - COLLECT ticker = #3 INTO dates = #4   /* sorted */
  6   CalculationNode       3      0      2265          0       0.04486       - LET #5 = { "ticker" : ticker, "dates" : dates }   /* simple expression */
  7   ReturnNode            3      -      2265          0       0.00007       - RETURN #5
```

Query execution plan with this PR:
```
Query String (98 chars, cacheable: false):
 for doc in prices   collect ticker = doc.TICKER   into dates = doc.date   return { ticker, dates }

Execution plan:
 Id   NodeType          Calls    Par     Items   Filtered   Runtime [s]   Comment
  1   SingletonNode         1      -         1          0       0.00001   * ROOT
  9   IndexNode          5773   5772   5772655          0       1.65314     - FOR doc IN prices   /* persistent index scan, index only (projections: `TICKER`, `date`) */    LET #8 = doc.`TICKER`, #9 = doc.`date`   
  5   CollectNode           3      2      2265          0       0.81658       - COLLECT ticker = #8 INTO dates = #9   /* sorted */
  6   CalculationNode       3      0      2265          0       0.04152       - LET #5 = { "ticker" : ticker, "dates" : dates }   /* simple expression */
  7   ReturnNode            3      -      2265          0       0.00006       - RETURN #5
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 