### PR TITLE
[bug-fix] Fixed Cluster Failure Points while using authentication

### DIFF
--- a/js/client/bootstrap/modules/internal.js
+++ b/js/client/bootstrap/modules/internal.js
@@ -129,13 +129,18 @@
     return 'http' + endpoint.substr(pos);
   };
   
-  exports.debugClearFailAt = function(failAt) {
+  exports.debugClearFailAt = function(failAt, jwtBearerToken) {
     const request = require('@arangodb/request');
     const instanceInfo = JSON.parse(exports.env.INSTANCEINFO);
     instanceInfo.arangods.forEach((a) => {
-      let res = request.delete({
-        url: endpointToURL(a.endpoint) + '/_admin/debug/failat' + (failAt === undefined ? '' : '/' + failAt),
-        body: ""});
+      const req = {
+        url: endpointToURL(a.endpoint) + '/_admin/debug/failat/' + (failAt === undefined ? '' : '/' + failAt),
+        body: ""
+      };
+      if (jwtBearerToken) {
+        req.auth = { bearer: jwtBearerToken };
+      }
+      let res = request.delete(req);
       if (res.status !== 200) {
         throw "Error removing failure point";
       }
@@ -145,13 +150,19 @@
   // On server side the API with failurePointName is called removeFailAt
   exports.debugRemoveFailAt = exports.debugClearFailAt;
   
-  exports.debugSetFailAt = function(failAt) {
+  exports.debugSetFailAt = function(failAt, jwtBearerToken) {
     const request = require('@arangodb/request');
     const instanceInfo = JSON.parse(exports.env.INSTANCEINFO);
     instanceInfo.arangods.forEach((a) => {
-      let res = request.put({
+      const req = {
         url: endpointToURL(a.endpoint) + '/_admin/debug/failat/' + failAt,
-        body: ""});
+        body: ""
+      };
+      if (jwtBearerToken) {
+        req.auth = { bearer: jwtBearerToken };
+      }
+      let res = request.put(req);
+
       if (res.status !== 200) {
         throw "Error setting failure point";
       }
@@ -172,16 +183,14 @@
   
   
   exports.debugCanUseFailAt = function() {
-    const request = require('@arangodb/request');
-    const instanceInfo = JSON.parse(exports.env.INSTANCEINFO);
-    let res = request.get({
-      url: endpointToURL(instanceInfo.arangods[0].endpoint) + '/_admin/debug/failat',
-      body: ""
-    });
-    if (res.status !== 200) {
+    const res = arango.GET_RAW("_admin/debug/failat");
+    if (res.code !== 200) {
+      if (res.code === 401) {
+        throw `Error asking for failure point.`;
+      }
       return false;
     }
-    return res.body === "true";
+    return res.parsedBody === true;
   };
   
   // //////////////////////////////////////////////////////////////////////////////

--- a/js/client/bootstrap/modules/internal.js
+++ b/js/client/bootstrap/modules/internal.js
@@ -1,5 +1,6 @@
 /* jshint -W051:true */
 /* eslint-disable */
+/* global arango */
 ;(function () {
   'use strict'
   /* eslint-enable */

--- a/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-per-user-cluster.js
+++ b/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-per-user-cluster.js
@@ -139,15 +139,6 @@ function BaseTestSuite(targetUser) {
   };
 
   return {
-    setUpAll : function () {
-      // set this failure point so that metrics updates are pushed immediately
-      internal.debugSetFailAt("alwaysPublishShardMetrics");
-    },
-      
-    tearDownAll : function () {
-      internal.debugRemoveFailAt("alwaysPublishShardMetrics");
-    },
-
     testDoesNotPolluteNormalMetricsAPI : function () {
       const cn = getUniqueCollectionName();
 
@@ -1807,9 +1798,12 @@ function TestUser1Suite() {
       users.grantDatabase(user, name, 'rw');
     
       arango.reconnect(endpoint, db._name(), user, '');
+      // set this failure point so that metrics updates are pushed immediately
+      internal.debugSetFailAt("alwaysPublishShardMetrics", jwt);
     },
 
     tearDownAll: function () {
+      internal.debugRemoveFailAt("alwaysPublishShardMetrics", jwt);
       arango.reconnect(endpoint, '_system', oldUser, '');
 
       db._useDatabase("_system");
@@ -1843,9 +1837,12 @@ function TestUser2Suite() {
       users.grantDatabase(user, name, 'rw');
     
       arango.reconnect(endpoint, db._name(), user, '');
+      // set this failure point so that metrics updates are pushed immediately
+      internal.debugSetFailAt("alwaysPublishShardMetrics", jwt);
     },
 
     tearDownAll: function () {
+      internal.debugRemoveFailAt("alwaysPublishShardMetrics", jwt);
       arango.reconnect(endpoint, '_system', oldUser, '');
 
       db._useDatabase("_system");


### PR DESCRIPTION
### Scope & Purpose

*Test-Environment only fix. Failurepoints in Clusters with authentication stopped working in devel. Unfortunately the Suite still reports Success it just does not run tests as it claims FailurePoints are not available, which is allowed in general. This PR fixes the test for availability to actually ask the coordinator. Furthermore the call to activate FailurePoints now expects a JWT token, so it can activate them on DBSevers / Agents as well.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

