### PR TITLE
FE-428: add null/undefined handling for rows in query table result

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
@@ -20,8 +20,11 @@ export const QueryTableView = ({
     result => result !== null && result !== undefined
   );
   if (!firstValidResult) {
+    // if there are no valid rows, everything is null or undefined
     return (
-      <Text padding="4">Could not produce a table, please check the JSON result tab</Text>
+      <Text padding="4">
+        Could not produce a table, please check the JSON result tab
+      </Text>
     );
   }
   const headers = Object.keys(firstValidResult);
@@ -46,6 +49,10 @@ export const QueryTableView = ({
               <Tr key={index}>
                 {headers.map((header, headerIndex) => {
                   if (row === null || row === undefined) {
+                    /**
+                     *  If any row is null, or undefined,
+                     *  we display it as in the first cell
+                     * */
                     if (headerIndex === 0) {
                       return (
                         <Td colSpan={headers.length} key={header}>
@@ -56,12 +63,10 @@ export const QueryTableView = ({
                     return null;
                   }
                   const value = row[header];
-                  if (typeof value === "string") {
-                    return <Td key={header}>{value}</Td>;
-                  }
+                  const isString = typeof value === "string";
                   return (
                     <Td whiteSpace="normal" key={header}>
-                      {JSON.stringify(value)}
+                      {isString ? value : JSON.stringify(value)}
                     </Td>
                   );
                 })}

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
@@ -51,7 +51,7 @@ export const QueryTableView = ({
                   if (row === null || row === undefined) {
                     /**
                      *  If any row is null, or undefined,
-                     *  we display it as in the first cell
+                     *  we display it in the first cell
                      * */
                     if (headerIndex === 0) {
                       return (

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
@@ -21,9 +21,7 @@ export const QueryTableView = ({
   );
   if (!firstValidResult) {
     return (
-      <>
-        <Text>Could not produce a table, please check the JSON result tab</Text>
-      </>
+      <Text padding="4">Could not produce a table, please check the JSON result tab</Text>
     );
   }
   const headers = Object.keys(firstValidResult);

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/queryResults/QueryTableView.tsx
@@ -3,6 +3,7 @@ import {
   TableContainer,
   Tbody,
   Td,
+  Text,
   Th,
   Thead,
   Tr
@@ -13,10 +14,19 @@ import { QueryResultType } from "../ArangoQuery.types";
 export const QueryTableView = ({
   queryResult
 }: {
-  queryResult: QueryResultType<{ [key: string]: any }[]>;
+  queryResult: QueryResultType<({ [key: string]: any } | null)[]>;
 }) => {
-  const firstRow = queryResult.result?.[0];
-  const headers = firstRow ? Object.keys(firstRow) : [];
+  const firstValidResult = queryResult.result?.find(
+    result => result !== null && result !== undefined
+  );
+  if (!firstValidResult) {
+    return (
+      <>
+        <Text>Could not produce a table, please check the JSON result tab</Text>
+      </>
+    );
+  }
+  const headers = Object.keys(firstValidResult);
   if (!headers.length) {
     return null;
   }
@@ -36,14 +46,24 @@ export const QueryTableView = ({
           {queryResult.result?.map((row, index) => {
             return (
               <Tr key={index}>
-                {headers.map(header => {
+                {headers.map((header, headerIndex) => {
+                  if (row === null || row === undefined) {
+                    if (headerIndex === 0) {
+                      return (
+                        <Td colSpan={headers.length} key={header}>
+                          {JSON.stringify(row)}
+                        </Td>
+                      );
+                    }
+                    return null;
+                  }
                   const value = row[header];
                   if (typeof value === "string") {
                     return <Td key={header}>{value}</Td>;
                   }
                   return (
                     <Td whiteSpace="normal" key={header}>
-                      {JSON.stringify(row[header])}
+                      {JSON.stringify(value)}
                     </Td>
                   );
                 })}


### PR DESCRIPTION
### Scope & Purpose

Fixes a UI crashing due to handling of nulls and relying on the first item in the collection. Now finds the first valid item.

if some item in the array is null, it will show like this:

<img width="779" alt="image" src="https://github.com/arangodb/arangodb/assets/2976363/9b6dd535-b907-4c7d-b6dd-27a573c33dc2">



- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested
- [ ] :book: CHANGELOG entry made

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-428


