### PR TITLE
Fix wildcard analyzer for inverted index

### DIFF
--- a/arangod/IResearch/IResearchFilterFactory.cpp
+++ b/arangod/IResearch/IResearchFilterFactory.cpp
@@ -3860,8 +3860,7 @@ Result fromFuncLike(char const* funcName, irs::boolean_filter* filter,
       auto& wildcardFilter = append<wildcard::Filter>(*filter, filterCtx);
       wildcardFilter.boost(filterCtx.boost);
       *wildcardFilter.mutable_field() = std::move(name);
-      *wildcardFilter.mutable_options() = {pattern, *analyzer._pool,
-                                           filterCtx.query.ctx};
+      *wildcardFilter.mutable_options() = {pattern, *analyzer._pool, ctx.ctx};
     } else {
       auto& wildcardFilter = append<irs::by_wildcard>(*filter, filterCtx);
       wildcardFilter.boost(filterCtx.boost);

--- a/arangod/IResearch/Wildcard/Options.cpp
+++ b/arangod/IResearch/Wildcard/Options.cpp
@@ -94,6 +94,7 @@ Options::Options(std::string_view pattern, AnalyzerPool const& analyzer,
     hasPos = analyzer.features().hasFeatures(irs::IndexFeatures::POS);
   }
   if (needsMatcher || !hasPos) {
+    TRI_ASSERT(ctx);
     matcher = ctx->buildLikeMatcher(pattern, true);
   }
 }

--- a/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
+++ b/tests/js/client/aql/aql-arangosearch-wildcard-analyzer.js
@@ -52,13 +52,17 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
       internal.debugSetFailAt("wildcard::Filter::dissallowMatcher");
     }
     let c = db._query("FOR d in c FILTER d.s LIKE '" + pattern + "' RETURN d.s").toArray().sort();
-    let w = db._query("FOR d in v SEARCH ANALYZER(d.s LIKE '" + pattern + "', 'w') RETURN d.s").toArray().sort();
-    let i = db._query("FOR d in v SEARCH ANALYZER(d.s LIKE '" + pattern + "', 'identity') RETURN d.s").toArray().sort();
+    let i = db._query("FOR d in v1 SEARCH ANALYZER(d.s LIKE '" + pattern + "', 'identity') RETURN d.s").toArray().sort();
+    let w1 = db._query("FOR d in v1 SEARCH ANALYZER(d.s LIKE '" + pattern + "', 'w') RETURN d.s").toArray().sort();
+    let w2 = db._query("FOR d in v2 SEARCH d.s LIKE '" + pattern + "' RETURN d.s").toArray().sort();
+    let ii = db._query("FOR d in c OPTIONS { indexHint: 'i', forceIndexHint: true } FILTER d.s LIKE '" + pattern + "' RETURN d.s").toArray().sort();
     if (!ignoreCollection) {
-      assertEqual(c, w);
+      assertEqual(c, i);
     }
-    assertEqual(w, i);
-    return w;
+    assertEqual(i, w1);
+    assertEqual(i, w2);
+    assertEqual(i, ii);
+    return i;
   };
 
   return {
@@ -85,8 +89,10 @@ function ArangoSearchWildcardAnalyzer(hasPos) {
       c.insert({s:   "f"});
       c.insert({s: "abcdef qwerty"});
       c.insert({s: "qwerty abcdef"});
-      db._createView("v", "arangosearch",
+      db._createView("v1", "arangosearch",
           { links: { c: { fields: {s: {}}, analyzers: ["w", "identity"] } } });
+      c.ensureIndex({name: "i", type: "inverted", fields: ["s"], analyzer: "w"});
+      db._createView("v2", "search-alias", { indexes: [ { collection: "c", index: "i" } ] });
     },
 
     tearDownAll : function () { 


### PR DESCRIPTION
### Scope & Purpose

There wasn't test for such case.
In such test was segfault, because InvertedIndex doesn't support expressions.
It was fixed via new expression context with aql internal functions cache for inverted indexes.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

