### PR TITLE
fix a too general assertion

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -135,13 +135,13 @@ void RocksDBMetaCollection::unlockWrite() noexcept {
 /// @brief read locks a collection, with a timeout
 ErrorCode RocksDBMetaCollection::lockRead(double timeout) {
   TRI_IF_FAILURE("assertLockTimeoutLow") {
-    if (_logicalCollection.name() == "UnitTestsLockTimeout") {
+    if (_logicalCollection.vocbase().name() == "UnitTestsLockTimeout") {
       // In the test we expect that fast path locking is done with 2s timeout.
       TRI_ASSERT(timeout < 10);
     }
   }
   TRI_IF_FAILURE("assertLockTimeoutHigh") {
-    if (_logicalCollection.name() == "UnitTestsLockTimeout") {
+    if (_logicalCollection.vocbase().name() == "UnitTestsLockTimeout") {
       // In the test we expect that an lazy locking happens on the follower
       // with the default timeout of more than 2 seconds:
       TRI_ASSERT(timeout > 10);

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -135,13 +135,17 @@ void RocksDBMetaCollection::unlockWrite() noexcept {
 /// @brief read locks a collection, with a timeout
 ErrorCode RocksDBMetaCollection::lockRead(double timeout) {
   TRI_IF_FAILURE("assertLockTimeoutLow") {
-    // In the test we expect that fast path locking is done with 2s timeout.
-    TRI_ASSERT(timeout < 10);
+    if (_logicalCollection.name() == "UnitTestsLockTimeout") {
+      // In the test we expect that fast path locking is done with 2s timeout.
+      TRI_ASSERT(timeout < 10);
+    }
   }
   TRI_IF_FAILURE("assertLockTimeoutHigh") {
-    // In the test we expect that an lazy locking happens on the follower
-    // with the default timeout of more than 2 seconds:
-    TRI_ASSERT(timeout > 10);
+    if (_logicalCollection.name() == "UnitTestsLockTimeout") {
+      // In the test we expect that an lazy locking happens on the follower
+      // with the default timeout of more than 2 seconds:
+      TRI_ASSERT(timeout > 10);
+    }
   }
   return doLock(timeout, AccessMode::Type::READ);
 }

--- a/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
+++ b/tests/js/client/shell/shell-dropped-followers-elcheapo-commit-cluster.js
@@ -53,7 +53,7 @@ function createCollectionWithTwoShardsSameLeaderAndFollower(cn) {
   // Make leaders the same:
   if (leader !== plan[shards[1]].leader) {
     let moveShardJob = {
-      database: "_system",
+      database: db._name(),
       collection: cn,
       shard: shards[1],
       fromServer: plan[shards[1]].leader,
@@ -92,7 +92,7 @@ function createCollectionWithTwoShardsSameLeaderAndFollower(cn) {
   // Make followers the same:
   if (follower !== plan[shards[1]].followers[0]) {
     let moveShardJob = {
-      database: "_system",
+      database: db._name(),
       collection: cn,
       shard: shards[1],
       fromServer: plan[shards[1]].followers[0],
@@ -117,15 +117,15 @@ function createCollectionWithTwoShardsSameLeaderAndFollower(cn) {
 }
 
 function switchConnectionToCoordinator(collInfo) {
-  arango.reconnect(collInfo.endpointMap[collInfo.coordinator], "_system", "root", "");
+  arango.reconnect(collInfo.endpointMap[collInfo.coordinator], db._name(), "root", "");
 }
 
 function switchConnectionToLeader(collInfo) {
-  arango.reconnect(collInfo.endpointMap[collInfo.leader], "_system", "root", "");
+  arango.reconnect(collInfo.endpointMap[collInfo.leader], db._name(), "root", "");
 }
 
 function switchConnectionToFollower(collInfo) {
-  arango.reconnect(collInfo.endpointMap[collInfo.follower], "_system", "root", "");
+  arango.reconnect(collInfo.endpointMap[collInfo.follower], db._name(), "root", "");
 }
 
 function dropFollowersElCheapoSuite() {
@@ -306,13 +306,15 @@ function lockTimeoutSuite() {
   return {
     setUp: function () {
       getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
-      db._drop(cn);
+      db._createDatabase(cn);
+      db._useDatabase(cn);
       collInfo = createCollectionWithTwoShardsSameLeaderAndFollower(cn);
     },
 
     tearDown: function () {
       getEndpointsByType("dbserver").forEach((ep) => debugClearFailAt(ep));
-      db._drop(cn);
+      db._useDatabase('_system');
+      db._dropDatabase(cn);
     },
     
     testLockTimeouts: function() {
@@ -325,8 +327,10 @@ function lockTimeoutSuite() {
       arango.PUT("/_admin/debug/failat/assertLockTimeoutHigh",{});
       switchConnectionToCoordinator(collInfo);
 
-      let r = db._query(`FOR i IN 1..100 INSERT {Hallo:i} INTO ${cn} RETURN NEW`).toArray();
-
+      // we are not testing much inside this test here, except that the
+      // DB servers don't run into the assertion failure in RocksDBMetaCollection
+      // while trying to acquire the collection lock.
+      db._query(`FOR i IN 1..100 INSERT {Hallo:i} INTO ${cn} RETURN NEW`).toArray();
     },
   };
 }


### PR DESCRIPTION
### Scope & Purpose

A certain test was assuming that all queries would have specific AQL timeout values set.
This assumption however cannot be satisfied, because there may be other, cluster-internal queries going on concurrently to the test, e.g. statistics gathering, cleanup etc.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: 
  - [x] Backport for 3.10: this PR

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 