### PR TITLE
allow changing writeConcern of dependent collections

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Allow changing writeConcern of dependent collections.
+
+  Previously changing the `writeConcern` property of collections that also have
+  their `distributeShardsLike` property set was disallowed. This is now 
+  allowed.
+
 * Updated ArangoDB Starter to v0.18.1-preview-1.
 
 * Reduce default amount of per-collection document removals by TTL background 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1056,19 +1056,7 @@ Result LogicalCollection::properties(velocypack::Slice slice) {
            (ServerState::instance()->isSingleServer() &&
             (isSatellite() || isSmart()))) &&
           writeConcern != this->writeConcern()) {  // check if changed
-        if (!_sharding->distributeShardsLike().empty()) {
-          CollectionNameResolver resolver(vocbase());
-          std::string name = resolver.getCollectionNameCluster(DataSourceId{
-              basics::StringUtils::uint64(_sharding->distributeShardsLike())});
-          if (name.empty()) {
-            name = _sharding->distributeShardsLike();
-          }
-          return Result(
-              TRI_ERROR_FORBIDDEN,
-              absl::StrCat("Cannot change writeConcern, please change the "
-                           "writeConcern of the prototype collection '",
-                           name, "'"));
-        } else if (_type == TRI_COL_TYPE_EDGE && isSmart()) {
+        if (_type == TRI_COL_TYPE_EDGE && isSmart()) {
           return Result(TRI_ERROR_NOT_IMPLEMENTED,
                         "Changing writeConcern "
                         "not supported for SmartGraph edge collections");


### PR DESCRIPTION
### Scope & Purpose

Allow changing writeConcern of dependent collections.

Previously changing the `writeConcern` property of collections that also have
their `distributeShardsLike` property set was disallowed. This is now allowed.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 