### PR TITLE
fix a too general assertion

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1709,6 +1709,19 @@ void RocksDBMetaCollection::unlockWrite() noexcept { _exclusiveLock.unlock(); }
 
 /// @brief read locks a collection, with a timeout
 futures::Future<ErrorCode> RocksDBMetaCollection::lockRead(double timeout) {
+  TRI_IF_FAILURE("assertLockTimeoutLow") {
+    if (_logicalCollection.vocbase().name() == "UnitTestsLockTimeout") {
+      // In the test we expect that fast path locking is done with 2s timeout.
+      TRI_ASSERT(timeout < 10);
+    }
+  }
+  TRI_IF_FAILURE("assertLockTimeoutHigh") {
+    if (_logicalCollection.vocbase().name() == "UnitTestsLockTimeout") {
+      // In the test we expect that an lazy locking happens on the follower
+      // with the default timeout of more than 2 seconds:
+      TRI_ASSERT(timeout > 10);
+    }
+  }
   return doLock(timeout, AccessMode::Type::READ);
 }
 


### PR DESCRIPTION
### Scope & Purpose

A certain test was assuming that all queries would have specific AQL timeout values set.
This assumption however cannot be satisfied, because there may be other, cluster-internal queries going on concurrently to the test, e.g. statistics gathering, cleanup etc.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20563
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20562

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 