### PR TITLE
Fix issue that prefetch tasks could flood the scheduler queue

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -389,6 +389,8 @@ class ExecutionBlockImpl final : public ExecutionBlock {
       bool abandoned;
     };
     std::atomic<State> _state{{Status::Pending, false}};
+    static_assert(decltype(_state)::is_always_lock_free == true);
+
     std::mutex mutable _lock;
     std::condition_variable mutable _bell;
     std::optional<PrefetchResult> _result;

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -36,6 +36,7 @@
 #include "Aql/RegisterInfos.h"
 #include "Logger/LogContext.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <mutex>
@@ -360,14 +361,18 @@ class ExecutionBlockImpl final : public ExecutionBlock {
    * consumed.
    */
   struct PrefetchTask {
-    enum class State { Pending, InProgress, Finished, Consumed };
+    enum class Status { Pending, InProgress, Finished, Consumed };
     using PrefetchResult =
         std::tuple<ExecutionState, SkipResult, typename Fetcher::DataRange>;
 
+    explicit PrefetchTask(ExecutionBlockImpl& block, AqlCallStack const& stack)
+        : _block(block), _stack(stack) {}
+
     bool isConsumed() const noexcept;
     bool tryClaim() noexcept;
+    bool tryClaimOrAbandon() noexcept;
     void waitFor() const noexcept;
-    void reset() noexcept;
+    bool rearmForNextCall(AqlCallStack const& stack);
     void discard(bool isFinished) noexcept;
     // note: this will throw if the PrefetchTask ran into an exception
     // during execution.
@@ -375,16 +380,24 @@ class ExecutionBlockImpl final : public ExecutionBlock {
     void wakeupWaiter() noexcept;
     void setFailure(Result&& result);
 
-    void execute(ExecutionBlockImpl& block, AqlCallStack& stack);
+    void execute();
 
    private:
-    std::atomic<State> _state{State::Pending};
+    void updateStatus(Status status, std::memory_order memoryOrder) noexcept;
+    struct State {
+      Status status;
+      bool abandoned;
+    };
+    std::atomic<State> _state{{Status::Pending, false}};
     std::mutex mutable _lock;
     std::condition_variable mutable _bell;
     std::optional<PrefetchResult> _result;
     // _firstFailure contains the first error that happened in the prefetch
     // task and it will not be resetted.
     Result _firstFailure;
+
+    ExecutionBlockImpl& _block;
+    AqlCallStack _stack;
   };
 
   /**

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -527,7 +527,11 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
         << printBlockInfo()
         << " local statemachine failed with exception: " << ex.what();
     if (_prefetchTask && !_prefetchTask->isConsumed()) {
-      _prefetchTask->waitFor();
+      if (!_prefetchTask->tryClaim()) {
+        _prefetchTask->waitFor();
+      } else {
+        _prefetchTask->discard(/*isFinished*/ false);
+      }
     }
     THROW_ARANGO_EXCEPTION(_firstFailure);
   } catch (std::exception const& ex) {
@@ -540,7 +544,11 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
         << printBlockInfo()
         << " local statemachine failed with exception: " << ex.what();
     if (_prefetchTask && !_prefetchTask->isConsumed()) {
-      _prefetchTask->waitFor();
+      if (!_prefetchTask->tryClaim()) {
+        _prefetchTask->waitFor();
+      } else {
+        _prefetchTask->discard(/*isFinished*/ false);
+      }
     }
     // Rewire the error, to be consistent with potentially next caller.
     THROW_ARANGO_EXCEPTION(_firstFailure);
@@ -946,47 +954,52 @@ auto ExecutionBlockImpl<Executor>::executeFetcher(ExecutionContext& ctx,
       // we can only use async prefetching if the call does not use a limit.
       // this is because otherwise the prefetching could lead to an overfetching
       // of data.
+      bool shouldSchedule = false;
       if (_prefetchTask == nullptr) {
-        _prefetchTask = std::make_shared<PrefetchTask>();
+        _prefetchTask = std::make_shared<PrefetchTask>(*this, ctx.stack);
+        shouldSchedule = true;
       } else {
-        _prefetchTask->reset();
+        shouldSchedule = _prefetchTask->rearmForNextCall(ctx.stack);
       }
 
       // TODO - we should avoid flooding the queue with too many tasks as that
       // can significantly delay processing of user REST requests.
+      // At the moment we may spawn one task per execution node
 
-      bool queued = SchedulerFeature::SCHEDULER->tryBoundedQueue(
-          RequestLane::INTERNAL_LOW,
-          [block = this, task = _prefetchTask, stack = ctx.stack]() mutable {
-            if (!task->tryClaim()) {
-              return;
-            }
-            // task is a copy of the PrefetchTask shared_ptr, and we will only
-            // attempt to execute the task if we successfully claimed the task.
-            // i.e., it does not matter if this task lingers around in the
-            // scheduler queue even after the execution block has been
-            // destroyed, because in this case we will not be able to claim the
-            // task and simply return early without accessing the block.
-            try {
-              task->execute(*block, stack);
-            } catch (basics::Exception const& ex) {
-              task->setFailure(
-                  {ex.code(),
-                   absl::StrCat(ex.what(), " [node #",
-                                block->getPlanNode()->id().id(), ": ",
-                                block->getPlanNode()->getTypeString(), "]")});
-            } catch (std::exception const& ex) {
-              task->setFailure(
-                  {TRI_ERROR_INTERNAL,
-                   absl::StrCat(ex.what(), " [node #",
-                                block->getPlanNode()->id().id(), ": ",
-                                block->getPlanNode()->getTypeString(), "]")});
-            }
-          });
+      if (shouldSchedule) {
+        bool queued = SchedulerFeature::SCHEDULER->tryBoundedQueue(
+            RequestLane::INTERNAL_LOW,
+            [block = this, task = _prefetchTask]() mutable {
+              if (!task->tryClaimOrAbandon()) {
+                return;
+              }
+              // task is a copy of the PrefetchTask shared_ptr, and we will only
+              // attempt to execute the task if we successfully claimed the
+              // task. i.e., it does not matter if this task lingers around in
+              // the scheduler queue even after the execution block has been
+              // destroyed, because in this case we will not be able to claim
+              // the task and simply return early without accessing the block.
+              try {
+                task->execute();
+              } catch (basics::Exception const& ex) {
+                task->setFailure(
+                    {ex.code(),
+                     absl::StrCat(ex.what(), " [node #",
+                                  block->getPlanNode()->id().id(), ": ",
+                                  block->getPlanNode()->getTypeString(), "]")});
+              } catch (std::exception const& ex) {
+                task->setFailure(
+                    {TRI_ERROR_INTERNAL,
+                     absl::StrCat(ex.what(), " [node #",
+                                  block->getPlanNode()->id().id(), ": ",
+                                  block->getPlanNode()->getTypeString(), "]")});
+              }
+            });
 
-      if (!queued) {
-        // clear prefetch task
-        _prefetchTask.reset();
+        if (!queued) {
+          // clear prefetch task
+          _prefetchTask.reset();
+        }
       }
     }
 
@@ -2405,42 +2418,94 @@ ExecutionBlockImpl<Executor>::ExecutionContext::ExecutionContext(
 
 template<class Executor>
 bool ExecutionBlockImpl<Executor>::PrefetchTask::isConsumed() const noexcept {
-  return _state.load(std::memory_order_relaxed) == State::Consumed;
+  return _state.load(std::memory_order_relaxed).status == Status::Consumed;
 }
 
 template<class Executor>
 bool ExecutionBlockImpl<Executor>::PrefetchTask::tryClaim() noexcept {
-  auto expected = State::Pending;
-  return _state.load(std::memory_order_relaxed) == expected &&
-         _state.compare_exchange_strong(expected, State::InProgress,
-                                        std::memory_order_relaxed);
+  auto state = _state.load(std::memory_order_relaxed);
+  while (true) {
+    if (state.status != Status::Pending) {
+      return false;
+    }
+    if (_state.compare_exchange_strong(state,
+                                       {Status::InProgress, state.abandoned},
+                                       std::memory_order_relaxed)) {
+      return true;
+    }
+  }
 }
 
 template<class Executor>
-void ExecutionBlockImpl<Executor>::PrefetchTask::reset() noexcept {
+bool ExecutionBlockImpl<Executor>::PrefetchTask::tryClaimOrAbandon() noexcept {
+  auto state = _state.load(std::memory_order_relaxed);
+  while (true) {
+    // this function is only called from the scheduled task, and we must only
+    // schedule one task at a time, so this task must not be abandoned yet!
+    TRI_ASSERT(state.abandoned == false);
+    if (state.status != Status::Pending) {
+      // task is not longer pending, so let's try to abandon it
+      // Note: if we fail here it is possible that the task is already rearmed
+      // and reset to pending, so we can retry to claim it in the next
+      // iteration.
+      if (_state.compare_exchange_weak(
+              state, {.status = state.status, .abandoned = true},
+              std::memory_order_relaxed)) {
+        // we successfully abandoned the task, so we can return false to
+        // indicate that we must not work on this task
+        return false;
+      }
+    } else {
+      TRI_ASSERT(state.status == Status::Pending);
+      if (_state.compare_exchange_weak(
+              state, {.status = Status::InProgress, .abandoned = false},
+              std::memory_order_acquire)) {
+        // successfully claimed the task!
+        return true;
+      }
+    }
+  }
+}
+
+template<class Executor>
+bool ExecutionBlockImpl<Executor>::PrefetchTask::rearmForNextCall(
+    AqlCallStack const& stack) {
   TRI_ASSERT(!_result);
-  _state.store(State::Pending);
+  _stack = stack;
   // intentionally do not reset _firstFailure
+  auto old = _state.exchange({Status::Pending, false});
+  TRI_ASSERT(old.status == Status::Consumed);
+  // if the task was abandoned, we want to reschedule it!
+  return old.abandoned;
 }
 
 template<class Executor>
 void ExecutionBlockImpl<Executor>::PrefetchTask::waitFor() const noexcept {
   // (1) - this acquire-load synchronizes with the release-store (3)
-  if (_state.load(std::memory_order_acquire) == State::Finished) {
+  if (_state.load(std::memory_order_acquire).status == Status::Finished) {
     return;
   }
   std::unique_lock<std::mutex> guard(_lock);
   _bell.wait(guard, [this]() {
     // (2) - this acquire-load synchronizes with the release-store (3)
-    return _state.load(std::memory_order_acquire) == State::Finished;
+    return _state.load(std::memory_order_acquire).status == Status::Finished;
   });
+}
+
+template<class Executor>
+void ExecutionBlockImpl<Executor>::PrefetchTask::updateStatus(
+    Status status, std::memory_order memoryOrder) noexcept {
+  auto state = _state.load(std::memory_order_relaxed);
+  while (not _state.compare_exchange_weak(
+      state, {status, state.abandoned}, memoryOrder, std::memory_order_relaxed))
+    ;
 }
 
 template<class Executor>
 auto ExecutionBlockImpl<Executor>::PrefetchTask::discard(
     bool isFinished) noexcept -> void {
   _result.reset();
-  _state.store(isFinished ? State::Finished : State::Consumed,
+  updateStatus(isFinished ? Status::Finished : Status::Consumed,
                std::memory_order_release);
 }
 
@@ -2448,8 +2513,9 @@ template<class Executor>
 auto ExecutionBlockImpl<Executor>::PrefetchTask::stealResult()
     -> PrefetchResult {
   TRI_ASSERT(_result || _firstFailure.fail())
-      << "prefetch task state: " << (int)_state.load(std::memory_order_relaxed);
-  _state.store(State::Consumed, std::memory_order_relaxed);
+      << "prefetch task state: "
+      << (int)_state.load(std::memory_order_relaxed).status;
+  updateStatus(Status::Consumed, std::memory_order_relaxed);
   if (_firstFailure.fail()) {
     _result.reset();
     THROW_ARANGO_EXCEPTION(_firstFailure);
@@ -2460,21 +2526,20 @@ auto ExecutionBlockImpl<Executor>::PrefetchTask::stealResult()
 }
 
 template<class Executor>
-void ExecutionBlockImpl<Executor>::PrefetchTask::execute(
-    ExecutionBlockImpl& block, AqlCallStack& stack) {
+void ExecutionBlockImpl<Executor>::PrefetchTask::execute() {
   if constexpr (std::is_same_v<Fetcher, MultiDependencySingleRowFetcher> ||
                 executorHasSideEffects<Executor>) {
     TRI_ASSERT(false);
   } else {
-    TRI_ASSERT(_state.load() == State::InProgress);
+    TRI_ASSERT(_state.load().status == Status::InProgress);
     TRI_ASSERT(!_result);
 
-    _result = block.fetcher().execute(stack);
+    _result = _block.fetcher().execute(_stack);
 
     TRI_ASSERT(_result.has_value());
 
     // (3) - this release-store synchronizes with the acquire-load (1, 2)
-    _state.store(State::Finished, std::memory_order_release);
+    updateStatus(Status::Finished, std::memory_order_release);
 
     wakeupWaiter();
   }


### PR DESCRIPTION
### Scope & Purpose

Async prefetching could post a task onto the scheduler. If this task is not picked up in time, we could claim that task for ourselves and simply to the work directly. However, we could post yet another task for the next batch. This could go on and on, filling up the scheduler queue. As a side effect, there was also a race where an old task could be executed with an old AqlCallStack. To avoid this, we now rearm the already posted task with the current AqlCallStack and set it to pending. This way we can ensure that either the updated task is available to be picked up, or if it was picked up before we could make it available again, we will realize and can then repost it on the scheduler.

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
