### PR TITLE
RocksDBEngine is only available on dbservers

### DIFF
--- a/arangod/RestHandler/RestDumpHandler.cpp
+++ b/arangod/RestHandler/RestDumpHandler.cpp
@@ -50,9 +50,14 @@ using namespace arangodb::rest;
 RestDumpHandler::RestDumpHandler(ArangodServer& server, GeneralRequest* request,
                                  GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response),
-      _engine(
-          server.getFeature<EngineSelectorFeature>().engine<RocksDBEngine>()),
-      _clusterInfo(server.getFeature<ClusterFeature>().clusterInfo()) {}
+      _clusterInfo(server.getFeature<ClusterFeature>().clusterInfo()) {
+  if (ServerState::instance()->isDBServer() ||
+      ServerState::instance()->isSingleServer()) {
+    _dumpManager = server.getFeature<EngineSelectorFeature>()
+                       .engine<RocksDBEngine>()
+                       .dumpManager();
+  }
+}
 
 // main function that dispatches the different routes and commands
 RestStatus RestDumpHandler::execute() {
@@ -157,15 +162,13 @@ void RestDumpHandler::handleCommandDumpStart() {
 
   auto useVPack = _request->parsedValue("useVPack", false);
 
-  auto* manager = _engine.dumpManager();
-
   // adjust permissions in single server case, so that the behavior
   // is identical to non-parallel dumps
   ExecContextSuperuserScope escope(ExecContext::current().isAdminUser() &&
                                    ServerState::instance()->isSingleServer());
 
   auto guard =
-      manager->createContext(std::move(opts), user, database, useVPack);
+      _dumpManager->createContext(std::move(opts), user, database, useVPack);
 
   resetResponse(rest::ResponseCode::CREATED);
   _response->setHeaderNC(StaticStrings::DumpId, guard->id());
@@ -190,10 +193,9 @@ void RestDumpHandler::handleCommandDumpNext() {
 
   auto lastBatch = _request->parsedValue<uint64_t>("lastBatch");
 
-  auto* manager = _engine.dumpManager();
-  // find() will throw in case the context cannot be found or the user does not
-  // match.
-  auto context = manager->find(id, database, user);
+  // find() will throw in case the context cannot be found or the user does
+  // not match.
+  auto context = _dumpManager->find(id, database, user);
   // immediately prolong lifetime of context, so it doesn't get invalidated
   // while we are using it.
   context->extendLifetime();
@@ -233,9 +235,8 @@ void RestDumpHandler::handleCommandDumpFinished() {
   auto database = _request->databaseName();
   auto user = getAuthorizedUser();
 
-  auto* manager = _engine.dumpManager();
   // will throw if dump context is not found or cannot be accessed
-  manager->remove(id, database, user);
+  _dumpManager->remove(id, database, user);
 
   generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
 }

--- a/arangod/RestHandler/RestDumpHandler.h
+++ b/arangod/RestHandler/RestDumpHandler.h
@@ -32,7 +32,7 @@
 
 namespace arangodb {
 class ClusterInfo;
-class RocksDBEngine;
+class RocksDBDumpManager;
 
 class RestDumpHandler : public RestVocbaseBaseHandler {
  public:
@@ -58,7 +58,7 @@ class RestDumpHandler : public RestVocbaseBaseHandler {
 
   Result validateRequest();
 
-  RocksDBEngine& _engine;
+  RocksDBDumpManager* _dumpManager = nullptr;
   ClusterInfo& _clusterInfo;
 };
 }  // namespace arangodb

--- a/arangod/StorageEngine/EngineSelectorFeature.cpp
+++ b/arangod/StorageEngine/EngineSelectorFeature.cpp
@@ -291,6 +291,7 @@ StorageEngine& EngineSelectorFeature::engine() {
 template<typename As, typename std::enable_if<
                           std::is_base_of<StorageEngine, As>::value, int>::type>
 As& EngineSelectorFeature::engine() {
+  TRI_ASSERT(dynamic_cast<As*>(_engine) != nullptr);
   return *static_cast<As*>(_engine);
 }
 template ClusterEngine& EngineSelectorFeature::engine<ClusterEngine>();

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -404,7 +404,8 @@ Result Databases::create(ArangodServer& server, ExecContext const& exec,
       return res;
     }
 
-    if (createInfo.replicationVersion() == replication::Version::TWO) {
+    if (ServerState::instance()->isDBServer() &&
+        createInfo.replicationVersion() == replication::Version::TWO) {
       if (!replication2::EnableReplication2) {
         using namespace std::string_view_literals;
         auto const message =


### PR DESCRIPTION
### Scope & Purpose

A new check that was added recently could result in undefined behavior on the coordinator, because we tried to access the RocksDBEngine which is not available on Coordinators.
To avoid such mistakes in the future this PR also adds an assertion that we do not cast to the wrong engine type.

- [x] :hankey: Bugfix