### PR TITLE
Fixed check if a Shard is a leader for Replication2 in TTL BG thread

### DIFF
--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -332,7 +332,7 @@ class TtlThread final : public ServerThread<ArangodServer> {
         }
 
         if (ServerState::instance()->isDBServer() &&
-            !collection->followers()->getLeader().empty()) {
+            !collection->isLeadingShard()) {
           // we are a follower for this shard. do not remove any data here, but
           // let the leader carry out the removal and replicate it
           continue;

--- a/tests/js/client/shell/multi/shell-ttl-nocov.js
+++ b/tests/js/client/shell/multi/shell-ttl-nocov.js
@@ -1014,15 +1014,15 @@ function TtlSuite () {
             docs = [];
           }
         }
-      
+
         let oldStats = internal.ttlStatistics();
         let oldCount = 50000;  
         assertEqual(db[vn].count(), oldCount);
-      
+
         // reenable
         internal.ttlProperties({ active: true, frequency: 1000, maxTotalRemoves: 1000, maxCollectionRemoves: 2000 });
     
-        let stats = waitUntil(30 * deltaTimeout, stats => stats.runs > oldStats.runs);
+        let stats = waitUntil(30 * deltaTimeout, stats => stats.runs > oldStats.runs + 3);
 
         // number of runs, deletions and limitReached must have changed
         assertNotEqual(stats.runs, oldStats.runs);
@@ -1034,14 +1034,14 @@ function TtlSuite () {
         if (oldCount > 0) {
           // wait again for next removal 
           oldStats = stats;
-          stats = waitUntil(30 * deltaTimeout, stats => stats.runs > oldStats.runs);
+          stats = waitUntil(30 * deltaTimeout, stats => stats.runs > oldStats.runs + 3);
 
           assertNotEqual(stats.runs, oldStats.runs);
           assertTrue(stats.limitReached > oldStats.limitReached);
           assertTrue(stats.documentsRemoved > oldStats.documentsRemoved);
           // wait again, as fetching the stats and acquiring the collection count is not atomic
           oldStats = stats;
-          stats = waitUntil(30 * deltaTimeout, stats => stats.runs > oldStats.runs);
+          stats = waitUntil(30 * deltaTimeout, stats => stats.runs > oldStats.runs + 3);
           assertTrue(db._collection(vn).count() < oldCount || db._collection(vn).count() === 0);
         }
       } finally {


### PR DESCRIPTION
### Scope & Purpose

*The TTL background thread to skip over followers only worked on Replication1. Now we use the shared mechanism that works in both cases.

Also slightly adapted the test to be more resilient against "bad luck" the test can only wait if any DBServer has performed a TTL cleanup, if things are unlucky we have a server that only has Followers, so it does nothing, which would cause the test to fail. Now we wait for at least 4 runs of TTL, which increases the odds that at least one leader hat the chance to perform one.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

