### PR TITLE
Test Only Fix: ReplicationVersion in scripts/unittests

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -388,7 +388,9 @@ class instance {
     }
 
 
-    this.args['database.default-replication-version'] = this.options.replicationVersion;
+    if (this.options.hasOwnProperty("replicationVersion")) {
+      this.args['database.default-replication-version'] = this.options.replicationVersion;
+    }
 
     for (const [key, value] of Object.entries(this.options.extraArgs)) {
       let splitkey = key.split('.');

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -184,7 +184,6 @@ const optionsDefaults = {
   'buildType': (platform.substr(0, 3) === 'win') ? 'RelWithDebInfo':'',
   'cleanup': true,
   'cluster': false,
-  'replicationVersion': '1',
   'concurrency': 3,
   'configDir': 'etc/testing',
   'coordinators': 1,


### PR DESCRIPTION
### Scope & Purpose

*When you run scripts/unittests --replicationVersion 2  it is supposed to set the settings for replication version 2. In case you omit this value it would always set replication version 1 and ignore what is defined in etc/testing/xxx.conf. Now there is no default value in the testing options anymore, so if you omit above option etc/testing/xxxx.conf will win again.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

