### PR TITLE
nightly fix startup 

### DIFF
--- a/tests/js/client/server_parameters/test-early-connections-noncluster.js
+++ b/tests/js/client/server_parameters/test-early-connections-noncluster.js
@@ -56,7 +56,7 @@ function testSuite() {
 
       // wait until normal REST API responds normally
       let iterations = 0;
-      while (iterations++ < 60) {
+      while (iterations++ < 180) {
         let result = request({ url: baseUrl() + "/_api/collection", method: "get", auth: { bearer: jwtRoot } });
         if (result.status === 200) {
           break;


### PR DESCRIPTION
When there is high load on the test system, 30s might not be enough for the single server to come up.