### PR TITLE
[CINFRA] Adjust replication2 test

### DIFF
--- a/tests/js/client/restart/test-restart-replication2-syncer-thread-off.js
+++ b/tests/js/client/restart/test-restart-replication2-syncer-thread-off.js
@@ -87,6 +87,10 @@ function testSuite() {
     },
 
     testRestartReplicationAndCreate: function () {
+      if (db._properties().replicationVersion === "2") {
+        // This test is not applicable if there are already existing replication2 databases.
+        return;
+      }
       db._createDatabase(databaseNameR1, {'replicationVersion': '1'});
 
       enableMaintenanceMode();


### PR DESCRIPTION
### Scope & Purpose

The test is meant to check that we disallow the creation of replication2 databases in case the syncer thread is off. However, if there are already replication2 databases on disk (which is the case of `_system` when replication2 is on by default), it is not allowed to switch the syncer thread off, and therefore the test does not make sense in that context.
This PR checks the version of the `_system` database and skips the test accordingly.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification