### PR TITLE
improve performance of constrained sort executor

### DIFF
--- a/arangod/Aql/ConstrainedSortExecutor.cpp
+++ b/arangod/Aql/ConstrainedSortExecutor.cpp
@@ -211,7 +211,10 @@ ExecutorState ConstrainedSortExecutor::consumeInput(
     if (_returnNext == 0) {
       // Only once sort the rows again, s.t. the
       // contained list of elements is in the right ordering.
-      std::sort(_rows.begin(), _rows.end(), *_cmpHeap);
+      // we can get away with std::heap_sort() here as _rows
+      // already satisfies the heap property. this is less
+      // expensive than using the full-blown std::sort()
+      std::sort_heap(_rows.begin(), _rows.end(), *_cmpHeap);
     }
   }
   return inputRange.upstreamState();

--- a/arangod/Aql/ConstrainedSortExecutor.h
+++ b/arangod/Aql/ConstrainedSortExecutor.h
@@ -33,9 +33,6 @@
 #include <vector>
 
 namespace arangodb {
-namespace transaction {
-class Methods;
-}
 
 namespace aql {
 
@@ -121,7 +118,7 @@ class ConstrainedSortExecutor {
   size_t _rowsRead;
   size_t _skippedAfter;
   SharedAqlItemBlockPtr _heapBuffer;
-  std::unique_ptr<ConstrainedLessThan> _cmpHeap;  // in pointer to avoid
+  std::unique_ptr<ConstrainedLessThan> _cmpHeap;
   RegIdFlatSetStack _regsToKeep;
   RegIdSet _outputRegister = {};
   OutputAqlItemRow _heapOutputRow;


### PR DESCRIPTION
### Scope & Purpose

Improve performance of constrained sort executor.

As the final step in the constrained sort executor, the min/max heap is sorted to get a totally ordered result back.
The previous implementation used std::sort() for this, which is over the top. as we have already built up a heap, we can use std::sort_heap() to do the sorting. This can be algorithmically more efficient.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 