### PR TITLE
fix wrong certificate path in startup scripts

### DIFF
--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -117,7 +117,7 @@ else
 fi
 
 if [ "$TRANSPORT" == "ssl" ]; then
-  SSLKEYFILE="--ssl.keyfile UnitTests/server.pem"
+  SSLKEYFILE="--ssl.keyfile etc/testing/server.pem"
   CURL="curl --insecure $CURL_AUTHENTICATION -s -f -X GET https:"
 else
   SSLKEYFILE=""

--- a/scripts/startStandAloneAgency.sh
+++ b/scripts/startStandAloneAgency.sh
@@ -142,7 +142,7 @@ if [ "$POOLSZ" == "" ]; then
 fi
 
 if [ "$TRANSPORT" == "ssl" ]; then
-  SSLKEYFILE="--ssl.keyfile UnitTests/server.pem"
+  SSLKEYFILE="--ssl.keyfile etc/testing/server.pem"
   CURL="curl --insecure -ks https://"
 else
   SSLKEYFILE=""


### PR DESCRIPTION
### Scope & Purpose

The path to self-signed server certificate previously was "UnitTests/server.pem", but the "UnitTests" directory got removed a while ago. The certificate file was then moved to "etc/testing/server.pem" without the startup scripts having being adjusted properly.
This PR fixes the certificate path in the startup scripts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20590
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
