### PR TITLE
[CINFRA] Metrics replication2 flaky test

### DIFF
--- a/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-per-user-cluster.js
+++ b/tests/js/client/server_parameters/test-export-shard-usage-metrics-bytes-per-shard-per-user-cluster.js
@@ -1080,7 +1080,7 @@ function BaseTestSuite(targetUser) {
         let c2 = db._create(getUniqueCollectionName(), {numberOfShards: 3, replicationFactor});
 
         try {
-          const n = 24;
+          const n = 64;
           const payload = Array(100).join("foo");
           db._query(`LET payload = '${payload}' FOR i IN 1..${n} INSERT {} INTO ${c1.name()} INSERT {payload} INTO ${c2.name()}`);
 


### PR DESCRIPTION
### Scope & Purpose

The user metrics test is flaky when using the replication2 setup: https://app.circleci.com/pipelines/github/arangodb/arangodb/22931/workflows/3abdccff-48dc-4582-aabf-d5486b65a1d5/jobs/1551236/tests#failed-test-0

For the collection that has 5 shards, sometimes 24 documents might not be enough to populate all of them, causing an assertion to fail, because fewer shards are used. By increasing the number of documents, the problem goes away.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification