### PR TITLE
enable debug logging for chaos tests

### DIFF
--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -553,10 +553,12 @@ function BaseChaosSuite(testOpts) {
             trx = null;
           } catch (e) {
             if (require("@arangodb").errors.ERROR_TRANSACTION_NOT_FOUND.code === e.errorNum) {
+              log(`aborting trx abort/commit loop because trx was not found`);
               break;
             }
             // due to contention we could have a lock timeout here
             if (require("@arangodb").errors.ERROR_LOCKED.code !== e.errorNum) {
+              log(`aborting trx abort/commit loop because of unexpected error ${JSON.stringify(e)}`);
               throw e;
             }
             log("unable to " + (willAbort ? "abort" : "commit") + " transaction: " + String(e));

--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -430,7 +430,7 @@ function BaseChaosSuite(testOpts) {
         let query = (...args) => db._query(...args);
         let trx = null;
         
-        const logAllOps = false; // can be set to true for debugging purposes
+        const logAllOps = true; // can be set to true for debugging purposes
         const log = (msg) => {
           if (logAllOps) {
             if (trx) {


### PR DESCRIPTION
### Scope & Purpose

Enable debug logging for chaos tests.
This is only a temporary means so that we can better understand chaos test failures.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 