### PR TITLE
[CINFRA] Index Creation Error

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -615,6 +615,8 @@ futures::Future<std::shared_ptr<Index>> RocksDBCollection::createIndex(
 
     // step 4½. replicate index creation
     if (vocbase.replicationVersion() == replication::Version::TWO) {
+      // May throw TRI_ERROR_REPLICATED_STATE_NOT_FOUND in case the log manager
+      // is dropping the replicated state
       auto documentStateLeader =
           _logicalCollection.getDocumentState()->getLeader();
       if (documentStateLeader != nullptr) {


### PR DESCRIPTION
### Scope & Purpose

In a [previous PR](https://github.com/arangodb/arangodb/pull/20581), the replication step of the `CreateIndex` operation has been moved into the `RocksDBCollection::createIndex` method, mainly with the purpose of avoiding deadlocks caused by the ordering of transaction and index operations in the replicated log.

However, this now leaves a time window during which the replicated state is fetched during index creation, but there is nothing to stop the state from becoming unavailable. Dropping the state in this case doesn't cause any harm - it is ok to abort the index creation and move on, it's not going to matter anymore whether the index has been finished or not.

This PR adds a quick fix to that, by marking the `REPLICATED_STATE_NOT_FOUND` error as safe in the context of a `CreateIndex` operation. Ideally, the shared pointed of the `DocumentState` should be passed all the way to the `RocksDBCollection::createIndex` method, but that would require a more significant refactoring.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification