### PR TITLE
Fix compilation of Replication2 unit tests on non-maintainer builds

### DIFF
--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/SnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/SnapshotTest.cpp
@@ -204,6 +204,9 @@ TEST_F(DocumentStateSnapshotTest, snapshot_fetch_multiple_shards) {
               collectionReaderMock3);
         }
         TRI_ASSERT(false) << "Unexpected shard name: " << shard->name();
+        // The following is only to keep the compiler happy in non-maintainer
+        // builds:
+        return std::unique_ptr<MockCollectionReaderDelegator>(nullptr);
       });
 
   auto snapshot = Snapshot(


### PR DESCRIPTION
### Scope & Purpose

This fixes a compilation error in non-maintainer builds in the unit
tests.
We just add a return statement which is never reached, but the compiler
is not aware of this.

- [*] :hankey: Bugfix

