### PR TITLE
fix missing analyzers after hot restore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v3.11.7-1 (XXXX-XX-XX)
+---------------------
+
+* ES-1892: Fix hot restores missing user defined analyzers.
+
 v3.11.7 (2024-01-29)
 --------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
-v3.11.7-1 (XXXX-XX-XX)
----------------------
+v3.11.7.1 (XXXX-XX-XX)
+----------------------
 
 * ES-1892: Fix hot restores missing user defined analyzers.
+
 
 v3.11.7 (2024-01-29)
 --------------------

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6888,6 +6888,8 @@ arangodb::Result ClusterInfo::agencyReplan(VPackSlice const plan) {
        plan.get({"arango", "Plan", "Databases"})},
       {"Current/Views", AgencyValueOperationType::SET,
        VPackSlice::emptyObjectSlice()},
+      {"Plan/Analyzers", AgencyValueOperationType::SET,
+       plan.get({"arango", "Plan", "Analyzers"})},
       {"Plan/Views", AgencyValueOperationType::SET,
        plan.get({"arango", "Plan", "Views"})},
       {"Current/Version", AgencySimpleOperationType::INCREMENT_OP},

--- a/tests/js/server/dump/dump-cluster.js
+++ b/tests/js/server/dump/dump-cluster.js
@@ -62,7 +62,8 @@ jsunity.run(function dump_cluster_testsuite() {
       "testSmartGraphSharding",
       "testViewOnSmartEdgeCollection",
       "testSmartGraphAttribute",
-      "testLatestId"
+      "testLatestId",
+      "testAnalyzers"
     ];
   }
   deriveTestSuite(


### PR DESCRIPTION
### Scope & Purpose

*Hot fix 3.11.7-1 [ES-1892](https://arangodb.atlassian.net/browse/ES-1892)*

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 



[ES-1892]: https://arangodb.atlassian.net/browse/ES-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ