### PR TITLE
[CINFRA] Fix shutdown hanger

### DIFF
--- a/arangod/ClusterEngine/ClusterCollection.cpp
+++ b/arangod/ClusterEngine/ClusterCollection.cpp
@@ -207,7 +207,8 @@ bool ClusterCollection::cacheEnabled() const noexcept {
 
 futures::Future<std::shared_ptr<Index>> ClusterCollection::createIndex(
     velocypack::Slice info, bool restore, bool& created,
-    std::shared_ptr<std::function<arangodb::Result(double)>> progress) {
+    std::shared_ptr<std::function<arangodb::Result(double)>> progress,
+    Replication2Callback replicationCb) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
   // prevent concurrent dropping

--- a/arangod/ClusterEngine/ClusterCollection.h
+++ b/arangod/ClusterEngine/ClusterCollection.h
@@ -81,8 +81,8 @@ class ClusterCollection final : public PhysicalCollection {
 
   futures::Future<std::shared_ptr<Index>> createIndex(
       velocypack::Slice info, bool restore, bool& created,
-      std::shared_ptr<std::function<arangodb::Result(double)>> =
-          nullptr) override;
+      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr,
+      Replication2Callback replicationCb = nullptr) override;
 
   std::unique_ptr<IndexIterator> getAllIterator(
       transaction::Methods* trx, ReadOwnWrites readOwnWrites) const override;

--- a/arangod/Replication2/StateMachines/Document/DocumentStateErrorHandler.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateErrorHandler.cpp
@@ -105,21 +105,6 @@ auto DocumentStateErrorHandler::handleOpResult(
         << " failed because a TTL index already exists, ignoring: " << res;
     return TRI_ERROR_NO_ERROR;
   }
-  if (res.is(TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_FOUND)) {
-    // During index creation, the `RocksDBCollection::createIndex` method tries
-    // to fetch the document state, in order to potentially replicate the
-    // operation. However, if the document state is to be dropped, the fetch
-    // operation will fail. In that case, it is alright to abandon the index
-    // creation attempt, since the document state is about to be wiped
-    // completely. We must prevent the server from crashing.
-    LOG_CTX("1ea43", DEBUG, _loggerContext)
-        << "Index creation " << op.properties.toJson() << " on shard "
-        << op.shard
-        << " failed because the document state is no longer available, "
-           "ignoring: "
-        << res;
-    return TRI_ERROR_NO_ERROR;
-  }
   return res;
 }
 

--- a/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.cpp
@@ -128,8 +128,8 @@ auto DocumentStateShardHandler::getAvailableShards()
 
 auto DocumentStateShardHandler::ensureIndex(
     ShardID shard, velocypack::SharedSlice properties,
-    std::shared_ptr<methods::Indexes::ProgressTracker> progress) noexcept
-    -> Result {
+    std::shared_ptr<methods::Indexes::ProgressTracker> progress,
+    methods::Indexes::Replication2Callback callback) noexcept -> Result {
   auto col = lookupShard(shard);
   if (col.fail()) {
     return {col.errorNumber(),
@@ -137,7 +137,8 @@ auto DocumentStateShardHandler::ensureIndex(
   }
 
   auto res = _maintenance->executeCreateIndex(std::move(col).get(), properties,
-                                              std::move(progress));
+                                              std::move(progress),
+                                              std::move(callback));
   std::ignore = _maintenance->addDirty();
 
   if (res.fail()) {
@@ -146,7 +147,7 @@ auto DocumentStateShardHandler::ensureIndex(
         fmt::format(
             "Error: {}! Replicated log {} failed to ensure index on shard {}! "
             "Index: {}",
-            res.errorMessage(), _gid, std::move(shard), properties.toJson()));
+            res.errorMessage(), _gid, shard, properties.toJson()));
   }
   return res;
 }

--- a/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.h
+++ b/arangod/Replication2/StateMachines/Document/DocumentStateShardHandler.h
@@ -61,7 +61,8 @@ struct IDocumentStateShardHandler {
 
   virtual auto ensureIndex(
       ShardID shard, velocypack::SharedSlice properties,
-      std::shared_ptr<methods::Indexes::ProgressTracker> progress) noexcept
+      std::shared_ptr<methods::Indexes::ProgressTracker> progress,
+      methods::Indexes::Replication2Callback callback = nullptr) noexcept
       -> Result = 0;
 
   virtual auto dropIndex(ShardID shard, IndexId indexId) -> Result = 0;
@@ -97,10 +98,10 @@ class DocumentStateShardHandler : public IDocumentStateShardHandler {
   auto getAvailableShards()
       -> std::vector<std::shared_ptr<LogicalCollection>> override;
 
-  auto ensureIndex(
-      ShardID shard, velocypack::SharedSlice properties,
-      std::shared_ptr<methods::Indexes::ProgressTracker> progress) noexcept
-      -> Result override;
+  auto ensureIndex(ShardID shard, velocypack::SharedSlice properties,
+                   std::shared_ptr<methods::Indexes::ProgressTracker> progress,
+                   methods::Indexes::Replication2Callback callback =
+                       nullptr) noexcept -> Result override;
 
   auto dropIndex(ShardID shard, IndexId indexId) noexcept -> Result override;
 

--- a/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.cpp
+++ b/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.cpp
@@ -109,12 +109,13 @@ auto MaintenanceActionExecutor::executeModifyCollection(
 
 auto MaintenanceActionExecutor::executeCreateIndex(
     std::shared_ptr<LogicalCollection> col, velocypack::SharedSlice properties,
-    std::shared_ptr<methods::Indexes::ProgressTracker> progress) noexcept
-    -> Result {
+    std::shared_ptr<methods::Indexes::ProgressTracker> progress,
+    methods::Indexes::Replication2Callback callback) noexcept -> Result {
   VPackBuilder output;
   auto res = basics::catchToResult([&]() {
     return methods::Indexes::ensureIndex(*col, properties.slice(), true, output,
-                                         std::move(progress))
+                                         std::move(progress),
+                                         std::move(callback))
         .get();
   });
 

--- a/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.h
+++ b/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.h
@@ -52,8 +52,8 @@ struct IMaintenanceActionExecutor {
   virtual auto executeCreateIndex(
       std::shared_ptr<LogicalCollection> col,
       velocypack::SharedSlice properties,
-      std::shared_ptr<methods::Indexes::ProgressTracker> progress) noexcept
-      -> Result = 0;
+      std::shared_ptr<methods::Indexes::ProgressTracker> progress,
+      methods::Indexes::Replication2Callback callback) noexcept -> Result = 0;
 
   virtual auto executeDropIndex(std::shared_ptr<LogicalCollection> col,
                                 IndexId indexId) noexcept -> Result = 0;
@@ -83,7 +83,8 @@ class MaintenanceActionExecutor : public IMaintenanceActionExecutor {
   auto executeCreateIndex(
       std::shared_ptr<LogicalCollection> col,
       velocypack::SharedSlice properties,
-      std::shared_ptr<methods::Indexes::ProgressTracker> progress) noexcept
+      std::shared_ptr<methods::Indexes::ProgressTracker> progress,
+      methods::Indexes::Replication2Callback callback) noexcept
       -> Result override;
 
   auto executeDropIndex(std::shared_ptr<LogicalCollection> col,

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -71,8 +71,8 @@ class RocksDBCollection final : public RocksDBMetaCollection {
 
   futures::Future<std::shared_ptr<Index>> createIndex(
       velocypack::Slice info, bool restore, bool& created,
-      std::shared_ptr<std::function<arangodb::Result(double)>> =
-          nullptr) override;
+      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr,
+      Replication2Callback replicationCb = nullptr) override;
 
   std::unique_ptr<IndexIterator> getAllIterator(
       transaction::Methods* trx, ReadOwnWrites readOwnWrites) const override;

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -150,11 +150,15 @@ class PhysicalCollection {
   virtual futures::Future<OperationResult> figures(
       bool details, OperationOptions const& options);
 
+  using Replication2Callback =
+      fu2::unique_function<futures::Future<ResultT<replication2::LogIndex>>()>;
+
   /// @brief create or restore an index
   /// @param restore utilize specified ID, assume index has to be created
   virtual futures::Future<std::shared_ptr<Index>> createIndex(
       velocypack::Slice info, bool restore, bool& created,
-      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr) = 0;
+      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr,
+      Replication2Callback replicationCb = nullptr) = 0;
 
   virtual Result dropIndex(IndexId iid);
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1136,9 +1136,11 @@ std::shared_ptr<Index> LogicalCollection::lookupIndex(VPackSlice info) const {
 
 futures::Future<std::shared_ptr<Index>> LogicalCollection::createIndex(
     VPackSlice info, bool& created,
-    std::shared_ptr<std::function<arangodb::Result(double)>> progress) {
+    std::shared_ptr<std::function<arangodb::Result(double)>> progress,
+    Replication2Callback replicationCb) {
   auto idx = co_await _physical->createIndex(info, /*restore*/ false, created,
-                                             std::move(progress));
+                                             std::move(progress),
+                                             std::move(replicationCb));
   if (idx) {
     vocbase().versionTracker().track("create index");
   }

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -326,10 +326,14 @@ class LogicalCollection : public LogicalDataSource {
 
   // SECTION: Indexes
 
+  using Replication2Callback =
+      fu2::unique_function<futures::Future<ResultT<replication2::LogIndex>>()>;
+
   /// @brief Create a new Index based on VelocyPack description
   virtual futures::Future<std::shared_ptr<Index>> createIndex(
       velocypack::Slice, bool&,
-      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr);
+      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr,
+      Replication2Callback replicationCb = nullptr);
 
   /// @brief Find index by definition
   std::shared_ptr<Index> lookupIndex(velocypack::Slice) const;

--- a/tests/Mocks/PhysicalCollectionMock.cpp
+++ b/tests/Mocks/PhysicalCollectionMock.cpp
@@ -968,7 +968,8 @@ PhysicalCollectionMock::PhysicalCollectionMock(
 arangodb::futures::Future<std::shared_ptr<arangodb::Index>>
 PhysicalCollectionMock::createIndex(
     arangodb::velocypack::Slice info, bool restore, bool& created,
-    std::shared_ptr<std::function<arangodb::Result(double)>>) {
+    std::shared_ptr<std::function<arangodb::Result(double)>> progress,
+    Replication2Callback replicationCb) {
   before();
 
   std::vector<std::pair<arangodb::LocalDocumentId, arangodb::velocypack::Slice>>

--- a/tests/Mocks/PhysicalCollectionMock.h
+++ b/tests/Mocks/PhysicalCollectionMock.h
@@ -53,8 +53,8 @@ class PhysicalCollectionMock : public arangodb::PhysicalCollection {
   PhysicalCollectionMock(arangodb::LogicalCollection& collection);
   arangodb::futures::Future<std::shared_ptr<arangodb::Index>> createIndex(
       arangodb::velocypack::Slice info, bool restore, bool& created,
-      std::shared_ptr<std::function<arangodb::Result(double)>> =
-          nullptr) override;
+      std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr,
+      Replication2Callback replicationCb = nullptr) override;
   void deferDropCollection(
       std::function<bool(arangodb::LogicalCollection&)> const& callback)
       override;

--- a/tests/Replication2/Mocks/DocumentStateMocks.h
+++ b/tests/Replication2/Mocks/DocumentStateMocks.h
@@ -270,7 +270,8 @@ struct MockMaintenanceActionExecutor
               (noexcept, override));
   MOCK_METHOD(Result, executeCreateIndex,
               (std::shared_ptr<LogicalCollection>, velocypack::SharedSlice,
-               std::shared_ptr<methods::Indexes::ProgressTracker>),
+               std::shared_ptr<methods::Indexes::ProgressTracker>,
+               LogicalCollection::Replication2Callback),
               (noexcept, override));
   MOCK_METHOD(Result, executeDropIndex,
               (std::shared_ptr<LogicalCollection>, IndexId),
@@ -289,7 +290,8 @@ struct MockDocumentStateShardHandler
   MOCK_METHOD(Result, dropShard, (ShardID const&), (noexcept, override));
   MOCK_METHOD(Result, ensureIndex,
               (ShardID, velocypack::SharedSlice properties,
-               std::shared_ptr<methods::Indexes::ProgressTracker>),
+               std::shared_ptr<methods::Indexes::ProgressTracker>,
+               LogicalCollection::Replication2Callback),
               (noexcept, override));
   MOCK_METHOD(Result, dropIndex, (ShardID, IndexId), (noexcept, override));
   MOCK_METHOD(Result, dropAllShards, (), (noexcept, override));


### PR DESCRIPTION
### Scope & Purpose

**Problem**
The problem has been occurring mainly withing Search tests that create indexes and drop servers. I will briefly explain it below:

_Thread 1_
- one Actor thread is executing the `CreateIndex` operation
- gets stuck at `RocksDBCollection::createIndex()` while trying to fetch the replicated state, because fetching the replicated state requires locking `VocBaseLogManager::_guardedData`

_Thread 2_
- an `UpdateReplicatedLogAction` maintenance job that tries to resign the log
- it has already acquired the `VocBaseLogManager::_guardedData` lock during `VocBaseLogManager::updateReplicatedState()`
- resigning the log requires all the Actors to do a soft shutdown
- shutting down is not possible, as one of the Actors is stuck in _Thread 1_

**Solution**
It is possible to avoid fetching the replicated state, by passing in a callback all the way up to the `createIndex()` method. As this callback is only used for replication purposes, only leaders will have it set. _Note that now index creation, on the leader, will no longer go through the actor framework._

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification