### PR TITLE
[BTS-1774] Fix potential nullptr access in StateHandleManager

### DIFF
--- a/arangod/Replication2/ReplicatedLog/Components/StateHandleManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StateHandleManager.cpp
@@ -93,7 +93,11 @@ void StateHandleManager::acquireSnapshot(const ParticipantId& leader,
 auto StateHandleManager::getInternalStatus() const -> replicated_state::Status {
   auto guard = guardedData.getLockedGuard();
   if (guard->stateHandle == nullptr) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
+    // We can only have a nullptr here if we have resigned,
+    // also this stateHandleManager is only used in the follower
+    // So we can directly return FollowerResigned here.
+    return {replicated_state::Status::Follower{
+        replicated_state::Status::Follower::Resigned{}}};
   }
   return guard->stateHandle->getInternalStatus();
 }

--- a/arangod/Replication2/ReplicatedLog/Components/StateHandleManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/StateHandleManager.cpp
@@ -78,7 +78,9 @@ void StateHandleManager::becomeFollower(
   // to null via resign. As becomeFollower is part of the
   // single threaded setup process, no one could have called
   // resign.
-  TRI_ASSERT(guard->stateHandle != nullptr) << "We did hand out references to StateHandleManager before completing the setup";
+  TRI_ASSERT(guard->stateHandle != nullptr)
+      << "We did hand out references to StateHandleManager before completing "
+         "the setup";
   guard->stateHandle->becomeFollower(std::move(ptr));
 }
 

--- a/tests/Replication2/CMakeLists.txt
+++ b/tests/Replication2/CMakeLists.txt
@@ -38,6 +38,7 @@ set(ARANGODB_REPLICATION2_TEST_SOURCES
   ReplicatedLog/Integration/MaintenanceTests.cpp
   ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
   ReplicatedState/StateManagerTest.cpp
+  ReplicatedState/StateHandleManagerTest.cpp
   ReplicatedState/StateMachines/DocumentState/CoreTest.cpp
   ReplicatedState/StateMachines/DocumentState/ErrorHandlerTest.cpp
   ReplicatedState/StateMachines/DocumentState/FollowerTest.cpp

--- a/tests/Replication2/Mocks/FollowerCommitManagerMock.h
+++ b/tests/Replication2/Mocks/FollowerCommitManagerMock.h
@@ -1,0 +1,40 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2024-2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <gmock/gmock.h>
+
+#include "Replication2/ReplicatedLog/Components/IFollowerCommitManager.h"
+
+namespace arangodb::replication2::test {
+struct FollowerCommitManagerMock : replicated_log::IFollowerCommitManager {
+  MOCK_METHOD((std::pair<std::optional<LogIndex>, DeferredAction>),
+              updateCommitIndex, (LogIndex commitIndex, bool snapshotAvailable),
+              (noexcept, override));
+  MOCK_METHOD(LogIndex, getCommitIndex, (), (const, noexcept, override));
+  MOCK_METHOD(replicated_log::ILogParticipant::WaitForFuture, waitFor,
+              (LogIndex index), (noexcept, override));
+  MOCK_METHOD(replicated_log::ILogParticipant::WaitForIteratorFuture,
+              waitForIterator, (LogIndex index), (noexcept, override));
+};
+}  // namespace arangodb::replication2::test

--- a/tests/Replication2/ReplicatedState/StateHandleManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateHandleManagerTest.cpp
@@ -32,8 +32,7 @@ using namespace arangodb;
 using namespace arangodb::replication2;
 using namespace arangodb::replication2::replicated_log;
 
-struct StateHandleManagerTest
-    : testing::Test {};
+struct StateHandleManagerTest : testing::Test {};
 
 TEST_F(StateHandleManagerTest, resign) {
   auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
@@ -45,7 +44,8 @@ TEST_F(StateHandleManagerTest, resign) {
   // Times is good enough here, the return value will be ignored anyway.
   EXPECT_CALL(*originalPtr, resignCurrentState).Times(1);
   auto stateHandle = mgr.resign();
-  EXPECT_EQ(originalPtr, stateHandle.get()) << "We expect the initial stateHandle to be returned when we resign";
+  EXPECT_EQ(originalPtr, stateHandle.get())
+      << "We expect the initial stateHandle to be returned when we resign";
 }
 
 TEST_F(StateHandleManagerTest, acquireSnaphot) {
@@ -59,7 +59,8 @@ TEST_F(StateHandleManagerTest, acquireSnaphot) {
 
   // Times is good enough here, we are a void method.
   // Important part is that the input values are forwarded correctly.
-  EXPECT_CALL(*mockPtr, acquireSnapshot(leaderId, LogIndex{0}, version)).Times(1);
+  EXPECT_CALL(*mockPtr, acquireSnapshot(leaderId, LogIndex{0}, version))
+      .Times(1);
 
   mgr.acquireSnapshot(leaderId, version);
 }
@@ -96,7 +97,8 @@ TEST_F(StateHandleManagerTest, becomeFollower) {
   // Times is good enough here, we are a void method.
   // Important part is that the input values are forwarded correctly.
   EXPECT_CALL(*mockPtr, becomeFollower)
-      .WillOnce([&](std::unique_ptr<IReplicatedLogFollowerMethods> methods) -> void {
+      .WillOnce([&](std::unique_ptr<IReplicatedLogFollowerMethods> methods)
+                    -> void {
         EXPECT_EQ(methodsPtr, methods.get())
             << "Did not call the mocked method with the correct methods object";
       });
@@ -122,17 +124,19 @@ TEST_F(StateHandleManagerTest, updateCommitIndex_no_resolveIndex) {
         return std::make_pair<std::optional<LogIndex>, DeferredAction>(
             std::nullopt, std::move(actionDummy));
       });
-  // As we do not return a LogIndex above we are not allowed to call updateCommitIndex
-  // on the Replicated State Handle.
+  // As we do not return a LogIndex above we are not allowed to call
+  // updateCommitIndex on the Replicated State Handle.
   EXPECT_CALL(*mockPtr, updateCommitIndex).Times(0);
 
   StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
 
-  auto action = mgr.updateCommitIndex(expectedIndex,expectedSnapshotAvailable);
+  auto action = mgr.updateCommitIndex(expectedIndex, expectedSnapshotAvailable);
   EXPECT_TRUE(action) << "We expect to have an action";
-  EXPECT_FALSE(deferredActionCalled) << "Already called action, it was not deferred";
+  EXPECT_FALSE(deferredActionCalled)
+      << "Already called action, it was not deferred";
   action.fire();
-  EXPECT_TRUE(deferredActionCalled) << "Deferred different action then expected";
+  EXPECT_TRUE(deferredActionCalled)
+      << "Deferred different action then expected";
 }
 
 TEST_F(StateHandleManagerTest, updateCommitIndex_with_resolveIndex) {
@@ -154,16 +158,19 @@ TEST_F(StateHandleManagerTest, updateCommitIndex_with_resolveIndex) {
             LogIndex{23}, std::move(actionDummy));
       });
   EXPECT_CALL(*mockPtr, updateCommitIndex).WillOnce([](LogIndex index) {
-    EXPECT_EQ(index, LogIndex{23}) << "Was not called with update commit index result";
+    EXPECT_EQ(index, LogIndex{23})
+        << "Was not called with update commit index result";
   });
 
   StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
 
-  auto action = mgr.updateCommitIndex(expectedIndex,expectedSnapshotAvailable);
+  auto action = mgr.updateCommitIndex(expectedIndex, expectedSnapshotAvailable);
   EXPECT_TRUE(action) << "We expect to have an action";
-  EXPECT_FALSE(deferredActionCalled) << "Already called action, it was not deferred";
+  EXPECT_FALSE(deferredActionCalled)
+      << "Already called action, it was not deferred";
   action.fire();
-  EXPECT_TRUE(deferredActionCalled) << "Deferred different action then expected";
+  EXPECT_TRUE(deferredActionCalled)
+      << "Deferred different action then expected";
 }
 
 TEST_F(StateHandleManagerTest, updateCommitIndex_after_resign) {
@@ -183,12 +190,11 @@ TEST_F(StateHandleManagerTest, updateCommitIndex_after_resign) {
   auto stateHandle = mgr.resign();
   ASSERT_TRUE(stateHandle != nullptr);
 
-  auto action = mgr.updateCommitIndex(expectedIndex,expectedSnapshotAvailable);
+  auto action = mgr.updateCommitIndex(expectedIndex, expectedSnapshotAvailable);
   // Action has to be empty and cannot do any harm, lets fire it.
   EXPECT_FALSE(action) << "We actually got an action back, that is not allowed";
   action.fire();
 }
-
 
 TEST_F(StateHandleManagerTest, get_internal_status) {
   auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();

--- a/tests/Replication2/ReplicatedState/StateHandleManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateHandleManagerTest.cpp
@@ -1,0 +1,36 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2024-2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+#include <gtest/gtest.h>
+
+#include "Mocks/LogLevels.h"
+#include "Logger/Logger.h"
+
+using namespace arangodb;
+
+struct StateHandleManagerTest
+    : testing::Test,
+      tests::LogSuppressor<Logger::REPLICATED_STATE, LogLevel::TRACE> {};
+
+TEST_F(StateHandleManagerTest, Test) {
+  ASSERT_EQ(true, false);
+}

--- a/tests/Replication2/ReplicatedState/StateHandleManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateHandleManagerTest.cpp
@@ -22,15 +22,222 @@
 
 #include <gtest/gtest.h>
 
-#include "Mocks/LogLevels.h"
-#include "Logger/Logger.h"
+#include "Replication2/ReplicatedLog/Components/StateHandleManager.h"
+#include "Replication2/ReplicatedLog/ReplicatedLog.h"
+
+#include "Replication2/Mocks/ReplicatedStateHandleMock.h"
+#include "Replication2/Mocks/FollowerCommitManagerMock.h"
 
 using namespace arangodb;
+using namespace arangodb::replication2;
+using namespace arangodb::replication2::replicated_log;
 
 struct StateHandleManagerTest
-    : testing::Test,
-      tests::LogSuppressor<Logger::REPLICATED_STATE, LogLevel::TRACE> {};
+    : testing::Test {};
 
-TEST_F(StateHandleManagerTest, Test) {
-  ASSERT_EQ(true, false);
+TEST_F(StateHandleManagerTest, resign) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto originalPtr = stateHandlePtr.get();
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+
+  // Times is good enough here, the return value will be ignored anyway.
+  EXPECT_CALL(*originalPtr, resignCurrentState).Times(1);
+  auto stateHandle = mgr.resign();
+  EXPECT_EQ(originalPtr, stateHandle.get()) << "We expect the initial stateHandle to be returned when we resign";
+}
+
+TEST_F(StateHandleManagerTest, acquireSnaphot) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto mockPtr = stateHandlePtr.get();
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+  ParticipantId leaderId{"leader"};
+  uint64_t version{42};
+
+  // Times is good enough here, we are a void method.
+  // Important part is that the input values are forwarded correctly.
+  EXPECT_CALL(*mockPtr, acquireSnapshot(leaderId, LogIndex{0}, version)).Times(1);
+
+  mgr.acquireSnapshot(leaderId, version);
+}
+
+TEST_F(StateHandleManagerTest, acquireSnaphot_after_resign) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto mockPtr = stateHandlePtr.get();
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+  ParticipantId leaderId{"leader"};
+  uint64_t version{42};
+
+  // We call resign once
+  EXPECT_CALL(*mockPtr, resignCurrentState).Times(1);
+  // We cannot call acquireSnapshot after resigning.
+  EXPECT_CALL(*mockPtr, acquireSnapshot).Times(0);
+
+  auto stateHandle = mgr.resign();
+  ASSERT_TRUE(stateHandle != nullptr);
+  mgr.acquireSnapshot(leaderId, version);
+}
+
+TEST_F(StateHandleManagerTest, becomeFollower) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto mockPtr = stateHandlePtr.get();
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+
+  auto methods = std::unique_ptr<IReplicatedLogFollowerMethods>{};
+  auto methodsPtr = methods.get();
+
+  // Times is good enough here, we are a void method.
+  // Important part is that the input values are forwarded correctly.
+  EXPECT_CALL(*mockPtr, becomeFollower)
+      .WillOnce([&](std::unique_ptr<IReplicatedLogFollowerMethods> methods) -> void {
+        EXPECT_EQ(methodsPtr, methods.get())
+            << "Did not call the mocked method with the correct methods object";
+      });
+
+  mgr.becomeFollower(std::move(methods));
+}
+
+TEST_F(StateHandleManagerTest, updateCommitIndex_no_resolveIndex) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto mockPtr = stateHandlePtr.get();
+  bool deferredActionCalled = false;
+
+  LogIndex expectedIndex{42};
+  bool expectedSnapshotAvailable = true;
+
+  EXPECT_CALL(followerCommitManager, updateCommitIndex)
+      .WillOnce([&](LogIndex index, bool snapshotAvailable) {
+        EXPECT_EQ(expectedIndex, index);
+        EXPECT_EQ(expectedSnapshotAvailable, snapshotAvailable);
+        DeferredAction actionDummy{
+            [&]() noexcept { deferredActionCalled = true; }};
+        return std::make_pair<std::optional<LogIndex>, DeferredAction>(
+            std::nullopt, std::move(actionDummy));
+      });
+  // As we do not return a LogIndex above we are not allowed to call updateCommitIndex
+  // on the Replicated State Handle.
+  EXPECT_CALL(*mockPtr, updateCommitIndex).Times(0);
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+
+  auto action = mgr.updateCommitIndex(expectedIndex,expectedSnapshotAvailable);
+  EXPECT_TRUE(action) << "We expect to have an action";
+  EXPECT_FALSE(deferredActionCalled) << "Already called action, it was not deferred";
+  action.fire();
+  EXPECT_TRUE(deferredActionCalled) << "Deferred different action then expected";
+}
+
+TEST_F(StateHandleManagerTest, updateCommitIndex_with_resolveIndex) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto mockPtr = stateHandlePtr.get();
+  bool deferredActionCalled = false;
+
+  LogIndex expectedIndex{42};
+  bool expectedSnapshotAvailable = true;
+
+  EXPECT_CALL(followerCommitManager, updateCommitIndex)
+      .WillOnce([&](LogIndex index, bool snapshotAvailable) {
+        EXPECT_EQ(expectedIndex, index);
+        EXPECT_EQ(expectedSnapshotAvailable, snapshotAvailable);
+        DeferredAction actionDummy{
+            [&]() noexcept { deferredActionCalled = true; }};
+        return std::make_pair<std::optional<LogIndex>, DeferredAction>(
+            LogIndex{23}, std::move(actionDummy));
+      });
+  EXPECT_CALL(*mockPtr, updateCommitIndex).WillOnce([](LogIndex index) {
+    EXPECT_EQ(index, LogIndex{23}) << "Was not called with update commit index result";
+  });
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+
+  auto action = mgr.updateCommitIndex(expectedIndex,expectedSnapshotAvailable);
+  EXPECT_TRUE(action) << "We expect to have an action";
+  EXPECT_FALSE(deferredActionCalled) << "Already called action, it was not deferred";
+  action.fire();
+  EXPECT_TRUE(deferredActionCalled) << "Deferred different action then expected";
+}
+
+TEST_F(StateHandleManagerTest, updateCommitIndex_after_resign) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  auto mockPtr = stateHandlePtr.get();
+  LogIndex expectedIndex{42};
+  bool expectedSnapshotAvailable = true;
+
+  EXPECT_CALL(*mockPtr, resignCurrentState).Times(1);
+  // We are not allowed to call any updateCommitIndex after we resign
+  EXPECT_CALL(followerCommitManager, updateCommitIndex).Times(0);
+  EXPECT_CALL(*mockPtr, updateCommitIndex).Times(0);
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+
+  auto stateHandle = mgr.resign();
+  ASSERT_TRUE(stateHandle != nullptr);
+
+  auto action = mgr.updateCommitIndex(expectedIndex,expectedSnapshotAvailable);
+  // Action has to be empty and cannot do any harm, lets fire it.
+  EXPECT_FALSE(action) << "We actually got an action back, that is not allowed";
+  action.fire();
+}
+
+
+TEST_F(StateHandleManagerTest, get_internal_status) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  // We need to setup all expected calls for the stateHandlePtr here.
+  // we will move it out of our scope.
+  EXPECT_CALL(*stateHandlePtr, getInternalStatus)
+      .WillOnce([]() -> replicated_state::Status {
+        return {replicated_state::Status::Follower{
+            replicated_state::Status::Follower::Constructed{LogIndex{0}}}};
+      });
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+
+  auto status = mgr.getInternalStatus();
+  ASSERT_TRUE(
+      std::holds_alternative<replicated_state::Status::Follower>(status.value));
+  auto followerStatus =
+      std::get<replicated_state::Status::Follower>(status.value);
+  ASSERT_TRUE(
+      std::holds_alternative<replicated_state::Status::Follower::Constructed>(
+          followerStatus.value));
+  auto constructedFollowerStatus =
+      std::get<replicated_state::Status::Follower::Constructed>(
+          followerStatus.value);
+  EXPECT_EQ(constructedFollowerStatus.appliedIndex, LogIndex{0});
+}
+
+TEST_F(StateHandleManagerTest, get_internal_status_after_resign) {
+  auto stateHandlePtr = std::make_unique<test::ReplicatedStateHandleMock>();
+  test::FollowerCommitManagerMock followerCommitManager{};
+  // We need to setup all expected calls for the stateHandlePtr here.
+  // we will move it out of our scope.
+  // We are not allowed to call this method after resigning.
+  // We are asked to resign.
+  EXPECT_CALL(*stateHandlePtr, resignCurrentState).Times(1);
+  // Then we are asked for InternalStatus, that is not allowed.
+  EXPECT_CALL(*stateHandlePtr, getInternalStatus).Times(0);
+
+  StateHandleManager mgr{std::move(stateHandlePtr), followerCommitManager};
+  auto stateHandle = mgr.resign();
+  ASSERT_TRUE(stateHandle != nullptr);
+
+  auto status = mgr.getInternalStatus();
+  ASSERT_TRUE(
+      std::holds_alternative<replicated_state::Status::Follower>(status.value));
+  auto followerStatus =
+      std::get<replicated_state::Status::Follower>(status.value);
+  ASSERT_TRUE(
+      std::holds_alternative<replicated_state::Status::Follower::Resigned>(
+          followerStatus.value));
 }


### PR DESCRIPTION
### Scope & Purpose

*We use a protected structure in the StateHandleManager where we make sure it cannot be access in parallel.
However there exists a path where the protected element gets a nullptr shortly before it is freed, namely resign(). Between resign and deallocation however there can be another shared_ptr instance that access the protected element. The functions fixed here just dereferenced it without doing nullptr tests.

For two of them it is save because they share the same outside lock, so I added an ASSERT that we do not have a nullptr.
For one (the case we triggered) I added a throw.
For the last one (acquireSnapshot) the method is actually a noexcept and does not return anything. So I made it only do action if it is still possible.
*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1774
- [ ] Design document: 

