### PR TITLE
[BTS-1789] Fix local expansion for join nodes

### DIFF
--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -190,6 +190,9 @@ void CloneWorker::setUsedShardsOnClone(ExecutionNode* node,
       if (joinNode != nullptr) {
         // found a JoinNode, now add the `i` th shard for used collections
         for (auto& idx : joinNode->getIndexInfos()) {
+          if (idx.usedAsSatellite) {
+            continue;
+          }
           auto const& shards = permuter->second.at(idx.collection->name());
           idx.usedShard = *std::next(shards.begin(), _shardId);
         }

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -1060,6 +1060,22 @@ const IndexJoinTestSuite = function () {
       }
     },
 
+    testJoinInClusterShardedLocalExpansions: function () {
+      const A = db._create("A", {numberOfShards: 10, replicationFactor: 1, writeConcern: 1, waitForSync: true});
+      fillCollection(A.name(), singleAttributeGenerator(20, "x", x => x));
+      const query = `FOR c1 IN A FOR c2 IN A FILTER c1._key == c2._key RETURN c1._key`;
+      const result = db._query(query, null, {}).toArray();
+      assertEqual(result.length, A.count());
+    },
+
+    testJoinInClusterShardedLocalExpansionsMaterialize: function () {
+      const A = db._create("A", {numberOfShards: 10, replicationFactor: 1, writeConcern: 1, waitForSync: true});
+      fillCollection(A.name(), singleAttributeGenerator(10000, "x", x => x));
+      const query = `FOR c1 IN A FOR c2 IN A FILTER c1._key == c2._key RETURN c1`;
+      const result = db._query(query, null, {}).toArray();
+      assertEqual(result.length, A.count());
+    },
+
     testLateMaterialized: function () {
       const A = createCollection("A", ["x"]);
       A.ensureIndex({type: "persistent", fields: ["x"]});


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1450

Local expansion for joins for shards on the same dbserver was not enabled. This could lead to wrong results, because only one shard was read from each server.