### PR TITLE
Fix testRestoreIndexesFulltextLengthZero

### DIFF
--- a/arangod/Indexes/IndexFactory.cpp
+++ b/arangod/Indexes/IndexFactory.cpp
@@ -129,7 +129,8 @@ bool IndexTypeFactory::equal(Index::IndexType type, velocypack::Slice lhs,
   // sparse must be identical if present
   if (Index::IndexType::TRI_IDX_TYPE_GEO2_INDEX != type &&
       Index::IndexType::TRI_IDX_TYPE_GEO1_INDEX != type &&
-      Index::IndexType::TRI_IDX_TYPE_GEO_INDEX != type) {
+      Index::IndexType::TRI_IDX_TYPE_GEO_INDEX != type &&
+      Index::IndexType::TRI_IDX_TYPE_FULLTEXT_INDEX != type) {
     bool lhsSparse = basics::VelocyPackHelper::getBooleanValue(
         lhs, StaticStrings::IndexSparse, false);
     bool rhsSparse = basics::VelocyPackHelper::getBooleanValue(

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -23,12 +23,14 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "RestoreFeature.h"
+#include <exception>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/BumpFileDescriptorsFeature.h"
 #include "Basics/FileUtils.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/Result.h"
+#include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringBuffer.h"
 #include "Basics/StringUtils.h"
@@ -970,7 +972,7 @@ arangodb::Result processInputDirectory(
               << formatSize(stats.totalSent) << " total size"
               << ", queued jobs: " << std::get<0>(queueStats)
               << ", total workers: " << std::get<1>(queueStats)
-              << ", busy workers: " << std::get<2>(queueStats);
+              << ", idle workers: " << std::get<2>(queueStats);
           start = now;
         }
 

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -23,14 +23,12 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "RestoreFeature.h"
-#include <exception>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/BumpFileDescriptorsFeature.h"
 #include "Basics/FileUtils.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/Result.h"
-#include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringBuffer.h"
 #include "Basics/StringUtils.h"
@@ -1487,10 +1485,6 @@ Result RestoreFeature::RestoreMainJob::restoreData(
       parameters.get(std::vector<std::string_view>({"parameters", "type"})), 2);
   std::string const collectionType(type == 2 ? "document" : "edge");
 
-  LOG_TOPIC("4b2a7", DEBUG, Logger::RESTORE)
-      << "# About to start loading data into collection '" << collectionName
-      << "'...";
-
   auto&& currentStatus = progressTracker.getStatus(collectionName);
 
   if (currentStatus.state >= arangodb::RestoreFeature::RESTORED) {
@@ -1538,18 +1532,11 @@ Result RestoreFeature::RestoreMainJob::restoreData(
       sharedState->readCompleteInputfile = true;
     }
 
-    LOG_TOPIC("f01ba", DEBUG, Logger::RESTORE)
-        << "# Read complete input file for collection " << collectionName
-        << " - returning early";
-
     updateProgress();
     return {};
   }
 
   TRI_ASSERT(datafile);
-
-  LOG_TOPIC("f01bc", DEBUG, Logger::RESTORE)
-      << "# Have datafile for collection " << collectionName;
 
   // check if we are dealing with compressed file(s)
   bool const isCompressed = datafile->path().ends_with(".gz");
@@ -1576,7 +1563,7 @@ Result RestoreFeature::RestoreMainJob::restoreData(
     }
   }
 
-  if (options.progress || true) {
+  if (options.progress) {
     LOG_TOPIC("95913", INFO, Logger::RESTORE)
         << "# Loading data into " << collectionType << " collection '"
         << collectionName << "', data size: " << formatSize(fileSize)
@@ -1823,11 +1810,6 @@ arangodb::Result RestoreFeature::RestoreMainJob::restoreIndexes(
       if (options.force) {
         result.reset();
       }
-    }
-
-    if (options.progress) {
-      LOG_TOPIC("d08f3", INFO, Logger::RESTORE)
-          << "# Finished indexes for collection '" << collectionName << "'...";
     }
   }
 

--- a/client-tools/Utils/ClientTaskQueue.h
+++ b/client-tools/Utils/ClientTaskQueue.h
@@ -246,17 +246,17 @@ inline bool ClientTaskQueue<JobData>::isQueueEmpty() const noexcept {
 template<typename JobData>
 inline std::tuple<size_t, size_t, size_t> ClientTaskQueue<JobData>::statistics()
     const noexcept {
-  size_t busy = 0;
+  size_t idle = 0;
   size_t workers = 0;
 
   std::lock_guard lock{_queueCondition.mutex};
   for (auto const& worker : _workers) {
     ++workers;
     if (worker->isIdle()) {
-      ++busy;
+      ++idle;
     }
   }
-  return std::make_tuple(_jobs.size(), workers, busy);
+  return std::make_tuple(_jobs.size(), workers, idle);
 }
 
 template<typename JobData>

--- a/client-tools/Utils/ClientTaskQueue.h
+++ b/client-tools/Utils/ClientTaskQueue.h
@@ -347,6 +347,7 @@ inline std::unique_ptr<JobData> ClientTaskQueue<JobData>::fetchJob(
   if (!_jobs.empty()) {
     worker.setBusy();
     job = std::move(_jobs.front());
+    TRI_ASSERT(job != nullptr);
     _jobs.pop();
   }
 
@@ -406,6 +407,7 @@ inline void ClientTaskQueue<JobData>::Worker::run() {
       _queue.notifyIdle();
     }
 
+    TRI_ASSERT(isIdle());
     _queue.waitForWork();
   }
 }

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -39,7 +39,7 @@ shell_api_multi priority=500 single suffix=http -- $EncryptionAtRest
 shell_api_multi !mac priority=500 single suffix=https -- $EncryptionAtRest --protocol ssl
 
 # Shell client tests Single Server; distribute evenly
-shell_client priority=250 parallelity=2 buckets=2 single size=2xlarge -- $EncryptionAtRest
+shell_client priority=250 parallelity=2 buckets=2 single size=2xlarge -- $EncryptionAtRest --extraArgs:log.level restore=trace
 shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
 shell_client_multi !mac priority=1500 parallelity=2 single suffix=http -- --http true
 
@@ -92,7 +92,7 @@ shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 
 # different number of buckets in cluster
 shell_client_aql !mac priority=1000 size=medium+ cluster buckets=17 -- --dumpAgencyOnError true
-shell_client priority=500 cluster size=medium+ buckets=6 -- --dumpAgencyOnError true
+shell_client priority=500 cluster size=medium+ buckets=6 -- --dumpAgencyOnError true --extraArgs:log.level restore=trace
 shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5 -- --dumpAgencyOnError true
 shell_client_replication2_recovery priority=500 size=small cluster -- --dumpAgencyOnError true
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -39,7 +39,7 @@ shell_api_multi priority=500 single suffix=http -- $EncryptionAtRest
 shell_api_multi !mac priority=500 single suffix=https -- $EncryptionAtRest --protocol ssl
 
 # Shell client tests Single Server; distribute evenly
-shell_client priority=250 parallelity=2 buckets=2 single size=2xlarge -- $EncryptionAtRest --extraArgs:log.level restore=trace
+shell_client priority=250 parallelity=2 buckets=2 single size=2xlarge -- $EncryptionAtRest
 shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
 shell_client_multi !mac priority=1500 parallelity=2 single suffix=http -- --http true
 
@@ -92,7 +92,7 @@ shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 
 # different number of buckets in cluster
 shell_client_aql !mac priority=1000 size=medium+ cluster buckets=17 -- --dumpAgencyOnError true
-shell_client priority=500 cluster size=medium+ buckets=6 -- --dumpAgencyOnError true --extraArgs:log.level restore=trace
+shell_client priority=500 cluster size=medium+ buckets=6 -- --dumpAgencyOnError true
 shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5 -- --dumpAgencyOnError true
 shell_client_replication2_recovery priority=500 size=small cluster -- --dumpAgencyOnError true
 


### PR DESCRIPTION
### Scope & Purpose

This PR fixes a sporadic failure of the testRestoreIndexesFulltextLengthZero test, but the underlying issue that caused this sporadic failure is even more severe.

Similar to a previous bugfix (#20526), the fulltext index is always sparse, which must be considered in the index compare function. Because this was not the case, the maintenance would first create the index and report to the agency, but in the next iteration when we compare the local indexes against the plan, the comparison would yield false, so we drop the index again - so the db servers keep creating, dropping, creating, dropping, ....

In case the supervision observes the situation where all servers have reported the index in current, it clears the `isBuilding` flag which indicates to the client that the request has been finished successfully. That is why in many cases the test is green. But even then, the servers keep dropping and recreating the index indefinitely.

- [x] :hankey: Bugfix