### PR TITLE
also clean weights when result is cleaned up

### DIFF
--- a/arangod/Graph/PathManagement/SingleProviderPathResult.cpp
+++ b/arangod/Graph/PathManagement/SingleProviderPathResult.cpp
@@ -58,6 +58,7 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::clear()
     -> void {
   _vertices.clear();
   _edges.clear();
+  _weights.clear();
 }
 
 template<class ProviderType, class PathStoreType, class Step>
@@ -100,7 +101,7 @@ auto SingleProviderPathResult<ProviderType, PathStoreType, Step>::populatePath()
       prependWeight(s.getWeight());
     } else {
       prependWeight(0);
-    };
+    }
     return true;
   });
 }


### PR DESCRIPTION
### Scope & Purpose

When cleaning up the path result, only `_vertices` and `_edges` were previously cleared. `_weights` were not cleared. This looks fishy.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 