### PR TITLE
add progress reporting for RocksDB .sst file checksum computation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Add startup progress reporting for RocksDB .sst file checksum computation.
+
 * Upgrade OpenSSL to 3.2.1.
 
 * Remove arangosync binary.

--- a/arangod/RocksDBEngine/RocksDBChecksumEnv.cpp
+++ b/arangod/RocksDBEngine/RocksDBChecksumEnv.cpp
@@ -86,6 +86,10 @@ bool ChecksumHelper::isBlobFile(std::string_view fileName) noexcept {
   return fileName.ends_with(".blob");
 }
 
+bool ChecksumHelper::isHashFile(std::string_view fileName) noexcept {
+  return fileName.ends_with(".hash");
+}
+
 bool ChecksumHelper::writeShaFile(std::string const& fileName,
                                   std::string const& checksum) {
   TRI_ASSERT(isSstFile(fileName) || isBlobFile(fileName));
@@ -154,8 +158,7 @@ void ChecksumHelper::checkMissingShaFiles() {
 
               // check file extension
               auto isInteresting = [](std::string_view name) noexcept -> bool {
-                return name.ends_with(".sst") || name.ends_with(".blob") ||
-                       name.ends_with(".hash");
+                return isSstFile(name) || isBlobFile(name) || isHashFile(name);
               };
 
               if (!isInteresting(lhs) || !isInteresting(rhs)) {
@@ -163,17 +166,17 @@ void ChecksumHelper::checkMissingShaFiles() {
                 return lhs < rhs;
               }
 
-              if (lhs.ends_with(".hash")) {
+              if (isHashFile(lhs)) {
                 // cannot have 2 hash files for the same prefix
-                TRI_ASSERT(!rhs.ends_with(".hash"));
+                TRI_ASSERT(!isHashFile(rhs));
 
                 // prefixes of lhs and rhs are identical - .hash files should be
                 // sorted first (before .sst or .blob files)
                 return true;
               }
-              if (rhs.ends_with(".hash")) {
+              if (isSstFile(rhs)) {
                 // cannot have 2 hash files for the same prefix
-                TRI_ASSERT(!lhs.ends_with(".hash"));
+                TRI_ASSERT(!isSstFile(lhs));
 
                 // prefixes of lhs and rhs are identical - .hash files should be
                 // sorted first (before .sst or .blob files)
@@ -184,6 +187,9 @@ void ChecksumHelper::checkMissingShaFiles() {
               // and .sst files. everything else does not matter
               return lhs < rhs;
             });
+
+  // input files for which we need to produce hash files
+  std::vector<std::string> toProduce;
 
   for (auto it = fileList.begin(); it != fileList.end(); ++it) {
     if (it->size() < 5) {
@@ -229,7 +235,16 @@ void ChecksumHelper::checkMissingShaFiles() {
     } else if (isSstFile(*it) || isBlobFile(*it)) {
       // we have a .sst or .blob file which was not preceeded by a .hash file.
       // this means we need to recalculate the sha hash for it!
-      std::string tempPath = basics::FileUtils::buildFilename(_rootPath, *it);
+      toProduce.emplace_back(basics::FileUtils::buildFilename(_rootPath, *it));
+    }
+  }
+
+  if (!toProduce.empty()) {
+    LOG_TOPIC("ff71d", INFO, arangodb::Logger::ENGINES)
+        << "calculating SHA256 checksums for " << toProduce.size()
+        << " RocksDB .sst file(s)";
+    size_t produced = 0;
+    for (auto const& tempPath : toProduce) {
       LOG_TOPIC("d6c86", DEBUG, arangodb::Logger::ENGINES)
           << "checkMissingShaFiles: Computing checksum for " << tempPath;
       auto checksumCalc = ChecksumCalculator();
@@ -241,6 +256,29 @@ void ChecksumHelper::checkMissingShaFiles() {
         checksumCalc.computeFinalChecksum();
         writeShaFile(tempPath, checksumCalc.getChecksum());
       }
+
+      produced++;
+      // progress reporting - we are only interested in very rough progress
+      // so that we don't spam that startup log too much. we intentionally
+      // report only every 100 .sst files, so in most restart situations
+      // there will be no progress reporting. progress reporting will become
+      // visible however if there are 100s or 1000s of hashes to compute.
+      // this situation should only happen when upgrading from Community
+      // Edition to Enterprise Edition or so.
+      if (produced != toProduce.size() && (produced % 100 == 0)) {
+        int progress =
+            static_cast<int>(static_cast<double>(produced) /
+                             static_cast<double>(toProduce.size()) * 100.0);
+        LOG_TOPIC("cf86b", INFO, arangodb::Logger::ENGINES)
+            << "calculated " << produced << "/" << toProduce.size()
+            << " checksums (" << progress << "% of files)...";
+      }
+    }
+
+    if (toProduce.size() >= 10) {
+      // only report end if there was some noteworthy amount of work to do
+      LOG_TOPIC("96bbd", INFO, arangodb::Logger::ENGINES)
+          << "finished calculating SHA256 checksums for RocksDB .sst files";
     }
   }
 }

--- a/arangod/RocksDBEngine/RocksDBChecksumEnv.cpp
+++ b/arangod/RocksDBEngine/RocksDBChecksumEnv.cpp
@@ -174,9 +174,9 @@ void ChecksumHelper::checkMissingShaFiles() {
                 // sorted first (before .sst or .blob files)
                 return true;
               }
-              if (isSstFile(rhs)) {
+              if (isHashFile(rhs)) {
                 // cannot have 2 hash files for the same prefix
-                TRI_ASSERT(!isSstFile(lhs));
+                TRI_ASSERT(!isHashFile(lhs));
 
                 // prefixes of lhs and rhs are identical - .hash files should be
                 // sorted first (before .sst or .blob files)

--- a/arangod/RocksDBEngine/RocksDBChecksumEnv.h
+++ b/arangod/RocksDBEngine/RocksDBChecksumEnv.h
@@ -60,6 +60,7 @@ class ChecksumHelper {
 
   [[nodiscard]] static bool isSstFile(std::string_view fileName) noexcept;
   [[nodiscard]] static bool isBlobFile(std::string_view fileName) noexcept;
+  [[nodiscard]] static bool isHashFile(std::string_view fileName) noexcept;
 
   void checkMissingShaFiles();
 

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -1103,7 +1103,7 @@ bool TRI_ProcessFile(
 
   auto guard = scopeGuard([&fd]() noexcept { TRI_CLOSE(fd); });
 
-  char buffer[4096];
+  char buffer[16384];
 
   while (true) {
     TRI_read_return_t n = TRI_READ(fd, &buffer[0], sizeof(buffer));


### PR DESCRIPTION
### Scope & Purpose

Add progress reporting for RocksDB .sst file checksum computation.
Upon startup, ArangoDB Enterprise Edition will check if for every RocksDB .sst file there is a corresponding .hash file with the SHA256 hash value of the .sst file's contents. Otherwise such .hash file will be created at startup.
Normally, the .hash file creation is triggered by RocksDB whenever an .sst file is written to disk. So there should not be many .hash files missing on a restart. In case of a crash, a few .hash files may be missing and may be recomputed. This should be quick and unintrusive.
However, when upgrading an existing database from the Community Edition to the Enterprise Edition, there will be no .hash files initially, as they are only written out in the Enterprise Edition. So the startup will lead to all these files being computed, which can take a long time. For exactly this scenario there is now a progress reporting, so whoever runs into this situation can self-diagnose what is going on.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 