### PR TITLE
FE-433: prevent rendering of tabs if the route doesn't match

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/infoView.js
@@ -68,6 +68,14 @@
             isCluster: frontendConfig.isCluster
           };
 
+          // only render if the info view is still active
+          var isCurrentView =
+            window.location.hash.indexOf(
+              "cInfo/" + encodeURIComponent(this.collectionName)
+            ) > -1;
+          if (!isCurrentView) {
+            return;
+          }
           window.modalView.show(
             'modalCollectionInfo.ejs',
             'Collection: ' + (this.model.get('name').length > 64 ? this.model.get('name').substr(0, 64) + "..." : this.model.get('name')),

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/settingsView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/settingsView.js
@@ -217,6 +217,13 @@
             );
             var templates = ['modalTable.ejs'];
             var tabBar = ['General', 'Indexes'];
+            var isCurrentView =
+              window.location.hash.indexOf(
+                "cSettings/" + encodeURIComponent(this.collectionName)
+              ) > -1;
+            if (!isCurrentView) {
+              return;
+            }
             window.modalView.show(
               templates,
               'Modify Collection',


### PR DESCRIPTION
### Scope & Purpose

Currently, on settings and info tab, there's some async API calls made before the render can happen. 

Eg. (all this on a slow network, but can also happen on large collections for eg)
1. open a collection, click on 'Settings'
2. Before it finishes loading, click on another tab, like 'Content'
3. At first you will see Content tab, but after a second it gets replaced with 'Settings'

See:
<img width="756" alt="image" src="https://github.com/arangodb/arangodb/assets/2976363/2e94456f-7c22-4ba1-b8f3-63bd7d0dda1e">

This adds a fix for adding a check after the async calls and before render. If the current route doesn't match, we return early



- [x] :hankey: Bugfix


### Checklist

- [x] Tests
  - [x] Manually tested
- [x] :book: CHANGELOG entry made
- [x] backports
	- [x] 3.12: https://github.com/arangodb/arangodb/pull/20705
	- [x] 3.11: https://github.com/arangodb/arangodb/pull/20657

#### Related Information


- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-433

