### PR TITLE
Refactor how sanitizer logs paths are maintained... 

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -324,17 +324,6 @@ jobs:
               --cluster << parameters.cluster >> \
               --extraArgs " << parameters.extraArgs >>" \
               --definition tests/test-definitions.txt
-      - when:
-          condition: << pipeline.parameters.sanitizer >> != ""
-          steps:
-            - run:
-                name: Gather sanitizer logs
-                when: always
-                command: |
-                  # testing.js adjusts the sanitizer log path for each instance and then copies them to
-                  # the project root folder, so we have to move them to the work folder manually
-                  ls -la
-                  find . -maxdepth 1 -name '*san.log.*' -type f -print0 | xargs -0r mv -t ./work/
       - run:
           name: Copy test results
           when: always

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -226,7 +226,7 @@ class instance {
     this.jwtFiles = null;
 
     this.sanOptions = _.clone(this.options.sanOptions);
-    this.sanFiles = [];
+    this.sanitizerLogPaths = {};
 
     this._makeArgsArangod();
 
@@ -473,8 +473,9 @@ class instance {
       }
       for (const [key, value] of Object.entries(this.sanOptions)) {
         let oneLogFile = fs.join(rootDir, key.toLowerCase().split('_')[0] + '.log');
+        const origPath = this.sanOptions[key]['log_path'];
         this.sanOptions[key]['log_path'] = oneLogFile;
-        this.sanFiles.push(oneLogFile);
+        this.sanitizerLogPaths[key] = { upstream: origPath, local: oneLogFile };
       }
     }
   }
@@ -790,13 +791,17 @@ class instance {
 
   fetchSanFileAfterExit() {
     if (this.options.isSan) {
-      this.sanFiles.forEach(fileName => {
-        let fn = `${fileName}.arangod.${this.pid}`;
+      for (const [key, value] of Object.entries(this.sanitizerLogPaths)) {
+        const { upstream, local } = value;
+        let fn = `${local}.arangod.${this.pid}`;
         if (this.options.extremeVerbosity) {
           print(`checking for ${fn}: ${fs.exists(fn)}`);
         }
         if (fs.exists(fn)) {
           let content = fs.read(fn);
+          if (upstream) {
+            fs.write(`${upstream}.arangod.${this.pid}`, content);
+          }
           if (content.length > 10) {
             crashUtils.GDB_OUTPUT += `Report of '${this.name}' in ${fn} contains: \n`;
             crashUtils.GDB_OUTPUT += content;


### PR DESCRIPTION
### Scope & Purpose

...and make sure report files are written to the path that was originally configured in the sanitizer options.

This should make sure that the sanitizer reports are published as artifacts.
