### PR TITLE
Materialize Projections into Registers

### DIFF
--- a/arangod/Aql/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode.h
@@ -1257,7 +1257,7 @@ class MaterializeNode : public ExecutionNode {
   void getVariablesUsedHere(VarSet& vars) const override;
 
   /// @brief getVariablesSetHere
-  std::vector<Variable const*> getVariablesSetHere() const override final;
+  std::vector<Variable const*> getVariablesSetHere() const override;
 
   /// @brief return out variable
   aql::Variable const& outVariable() const noexcept { return *_outVariable; }
@@ -1333,9 +1333,12 @@ class MaterializeRocksDBNode : public MaterializeNode,
   bool alwaysCopiesRows() const override { return false; }
   bool isIncreaseDepth() const override { return false; }
 
+  std::vector<Variable const*> getVariablesSetHere() const override final;
+
   void projections(Projections proj) noexcept {
     _projections = std::move(proj);
   }
+  Projections& projections() noexcept { return _projections; }
   Projections const& projections() const noexcept { return _projections; }
 
  protected:

--- a/arangod/Aql/MaterializeExecutor.h
+++ b/arangod/Aql/MaterializeExecutor.h
@@ -53,15 +53,16 @@ struct Collection;
 
 class MaterializerExecutorInfos {
  public:
-  MaterializerExecutorInfos(RegisterId inNmDocId, RegisterId outDocRegId,
-                            aql::QueryContext& query,
-                            Collection const* collection,
-                            Projections projections)
+  MaterializerExecutorInfos(
+      RegisterId inNmDocId, RegisterId outDocRegId, aql::QueryContext& query,
+      Collection const* collection, Projections projections,
+      containers::FlatHashMap<VariableId, RegisterId> variablesToRegisters)
       : _inNonMaterializedDocRegId(inNmDocId),
         _outMaterializedDocumentRegId(outDocRegId),
         _query(query),
         _collection(collection),
-        _projections(std::move(projections)) {}
+        _projections(std::move(projections)),
+        _variablesToRegisters(std::move(variablesToRegisters)) {}
 
   MaterializerExecutorInfos() = delete;
   MaterializerExecutorInfos(MaterializerExecutorInfos&&) = default;
@@ -82,6 +83,8 @@ class MaterializerExecutorInfos {
 
   Projections const& projections() const noexcept { return _projections; }
 
+  RegisterId getRegisterForVariable(VariableId var) const noexcept;
+
  private:
   /// @brief register to store local document id
   RegisterId const _inNonMaterializedDocRegId;
@@ -90,6 +93,7 @@ class MaterializerExecutorInfos {
   aql::QueryContext& _query;
   Collection const* _collection;
   Projections const _projections;
+  containers::FlatHashMap<VariableId, RegisterId> const _variablesToRegisters;
 };
 
 struct MaterializeExecutorBase {

--- a/tests/js/client/aql/aql-index-batch-materialize.js
+++ b/tests/js/client/aql/aql-index-batch-materialize.js
@@ -238,10 +238,9 @@ function IndexBatchMaterializeTestSuite() {
           LIMIT 100
           FILTER d1.z < 18
           RETURN d1.w`;
-
       const {materializeNode, indexNode, nodes} = expectOptimization(query);
       assertEqual(normalize(indexNode.projections), [["b"], ["z"]]);
-      assertEqual(normalize(materializeNode.projections), [["b"], ["w"], ["z"]]);
+      assertEqual(normalize(materializeNode.projections), [["w"]]);
       assertNotEqual(nodes.indexOf('SortNode'), -1);
       assertNotEqual(nodes.indexOf('MaterializeNode'), -1);
       assertTrue(nodes.indexOf('SortNode') < nodes.indexOf('MaterializeNode'));


### PR DESCRIPTION
### Scope & Purpose
This is the final step in the materialize rework. We add support for projections into register to the materialize executor.
Now the execution looks like this
```
Execution plan:
 Id   NodeType          Par   Est.   Comment
  1   SingletonNode              1   * ROOT
 12   IndexNode               1000     - FOR d1 IN MyTestCollection   /* persistent index scan, index only (projections: `b`, `z`) */    LET #8 = d1.`b`, #9 = d1.`z`   /* with late materialization */
  6   SortNode                1000       - SORT #8 ASC   /* sorting strategy: constrained heap */
  7   LimitNode                100       - LIMIT 0, 100
  8   CalculationNode     ✓    100       - LET #3 = (#9 < 18)   /* simple expression */
  9   FilterNode          ✓    100       - FILTER #3
 13   MaterializeNode          100       - MATERIALIZE d1 INTO #6 /* (projections: `w`) */   LET #7 = #6.`w`
 11   ReturnNode               100       - RETURN #7

```