### PR TITLE
fix sporadic query setup errors

### DIFF
--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -512,13 +512,21 @@ RestStatus RestAqlHandler::continueExecute() {
   // extract the sub-request type
   rest::RequestType type = _request->requestType();
 
+  if (type == rest::RequestType::POST) {
+    // we can get here when the future produced in setupClusterQuery()
+    // completes. in this case we can simply declare success
+    TRI_ASSERT(suffixes.size() == 1 && suffixes[0] == "setup");
+    return RestStatus::DONE;
+  }
   if (type == rest::RequestType::PUT) {
-    // This cannot be changed!
     TRI_ASSERT(suffixes.size() == 2);
     return useQuery(suffixes[0], suffixes[1]);
   }
-  if (type == rest::RequestType::DELETE_REQ && suffixes[0] == "finish") {
-    return RestStatus::DONE;  // uses futures
+  if (type == rest::RequestType::DELETE_REQ) {
+    // we can get here when the future produced in handleFinishQuery()
+    // completes. in this case we can simply declare success
+    TRI_ASSERT(suffixes.size() == 2 && suffixes[0] == "finish");
+    return RestStatus::DONE;
   }
 
   generateError(

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -19,7 +19,6 @@
     "ERROR_NOT_IMPLEMENTED"        : { "code" : 9, "message" : "not implemented" },
     "ERROR_BAD_PARAMETER"          : { "code" : 10, "message" : "bad parameter" },
     "ERROR_FORBIDDEN"              : { "code" : 11, "message" : "forbidden" },
-    "ERROR_OUT_OF_MEMORY_MMAP"     : { "code" : 12, "message" : "out of memory in mmap" },
     "ERROR_CORRUPTED_CSV"          : { "code" : 13, "message" : "csv is corrupt" },
     "ERROR_FILE_NOT_FOUND"         : { "code" : 14, "message" : "file not found" },
     "ERROR_CANNOT_WRITE_FILE"      : { "code" : 15, "message" : "cannot write file" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -14,7 +14,6 @@ ERROR_DEAD_PID,8,"dead process identifier","Will be raised when a PID without a 
 ERROR_NOT_IMPLEMENTED,9,"not implemented","Will be raised when hitting an unimplemented feature."
 ERROR_BAD_PARAMETER,10,"bad parameter","Will be raised when the parameter does not fulfill the requirements."
 ERROR_FORBIDDEN,11,"forbidden","Will be raised when you are missing permission for the operation."
-ERROR_OUT_OF_MEMORY_MMAP,12,"out of memory in mmap","Will be raised when there is a memory shortage."
 ERROR_CORRUPTED_CSV,13,"csv is corrupt","Will be raised when encountering a corrupt csv line."
 ERROR_FILE_NOT_FOUND,14,"file not found","Will be raised when a file is not found."
 ERROR_CANNOT_WRITE_FILE,15,"cannot write file","Will be raised when a file cannot be written."


### PR DESCRIPTION
### Scope & Purpose

Fix sporadic query setup errors.
During testing there were sporadic errors when setting up AQL queries via the route POST `/_api/aql/setup`:

    AQL: continued non-continuable method for POST /_api/aql/setup

This error is due to setupClusterQuery() returning a future, which is being waited for using waitForFuture(). waitForFuture() returns RestStatus::DONE if the future was already executed, and everything is fine then.
If the future was not already executed, waitForFuture() returns RestStatus::WAITING, so that eventually the RestHandler is restarted via its continueExecute() method. For the RestAqlHandler, this always triggered the above error if restarting was done for the HTTP POST setup request.
The fix is to allow restarting the RestHandler in case of HTTP POST as well, and then simply return RestStatus::DONE.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 