### PR TITLE
cleanup uses of getResponsibleServer

### DIFF
--- a/arangod/Aql/Collection.cpp
+++ b/arangod/Aql/Collection.cpp
@@ -106,34 +106,6 @@ size_t Collection::count(transaction::Methods* trx,
   return static_cast<size_t>(res.slice().getUInt());
 }
 
-std::unordered_set<std::string> Collection::responsibleServers() const {
-  std::unordered_set<std::string> result;
-  auto& clusterInfo =
-      _vocbase->server().getFeature<ClusterFeature>().clusterInfo();
-
-  auto shardIds = this->shardIds();
-  for (auto const& it : *shardIds) {
-    auto servers = clusterInfo.getResponsibleServer(it);
-    result.emplace((*servers)[0]);
-  }
-  return result;
-}
-
-size_t Collection::responsibleServers(
-    std::unordered_set<std::string>& result) const {
-  auto& clusterInfo =
-      _vocbase->server().getFeature<ClusterFeature>().clusterInfo();
-
-  size_t n = 0;
-  auto shardIds = this->shardIds();
-  for (auto const& it : *shardIds) {
-    auto servers = clusterInfo.getResponsibleServer(it);
-    result.emplace((*servers)[0]);
-    ++n;
-  }
-  return n;
-}
-
 std::string Collection::distributeShardsLike() const {
   return getCollection()->distributeShardsLike();
 }

--- a/arangod/Aql/Collection.h
+++ b/arangod/Aql/Collection.h
@@ -82,15 +82,8 @@ struct Collection {
   /// @brief count the number of documents in the collection
   size_t count(transaction::Methods* trx, transaction::CountType type) const;
 
-  /// @brief returns the responsible servers for the collection
-  std::unordered_set<std::string> responsibleServers() const;
-
   /// @brief returns the "distributeShardsLike" attribute for the collection
   std::string distributeShardsLike() const;
-
-  /// @brief fills the set with the responsible servers for the collection
-  /// returns the number of responsible servers found for the collection
-  size_t responsibleServers(std::unordered_set<std::string>&) const;
 
   /// @brief returns the shard ids of a collection
   std::shared_ptr<std::vector<ShardID> const> shardIds() const;


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1456

Removed unused code and potential access of an empty vector returned by getResponsibleServer.
