### PR TITLE
arangodump: Set all parallel dump versions

### DIFF
--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -933,8 +933,7 @@ servers running version 3.12 or higher.
 If the dump should be restored into versions of ArangoDB older than 3.12, this
 option should be turned off.)")
       .setIntroducedIn(31008)
-      .setIntroducedIn(31102)
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31102);
   // option was renamed in 3.12
   options->addOldOption("--use-experimental-dump", "--parallel-dump");
 
@@ -946,30 +945,27 @@ option should be turned off.)")
       .setLongDescription(R"(This option only has effect when the option
 `--parallel-dump` is set to `true`. Restoring split files also
 requires an arangorestore version that is capable of restoring data of a
-single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
+single collection/shard from multiple files.)")
       .setIntroducedIn(31010)
-      .setIntroducedIn(31102)
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31102);
 
   options
       ->addOption("--dbserver-worker-threads",
-                  "Number of worker threads on each dbserver.",
+                  "Number of worker threads on each DB-Server.",
                   new UInt64Parameter(&_options.dbserverWorkerThreads),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(31008)
-      .setIntroducedIn(31102)
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31102);
 
   options
       ->addOption("--dbserver-prefetch-batches",
-                  "Number of batches to prefetch on each dbserver.",
+                  "Number of batches to prefetch on each DB-Server.",
                   new UInt64Parameter(&_options.dbserverPrefetchBatches),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(31008)
-      .setIntroducedIn(31102)
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31102);
 
   options
       ->addOption("--local-writer-threads", "Number of local writer threads.",
@@ -977,8 +973,7 @@ single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(31008)
-      .setIntroducedIn(31102)
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31102);
 
   options
       ->addOption("--local-network-threads",
@@ -988,8 +983,7 @@ single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(31008)
-      .setIntroducedIn(31102)
-      .setIntroducedIn(31200);
+      .setIntroducedIn(31102);
 }
 
 void DumpFeature::validateOptions(

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -932,6 +932,8 @@ of the dump protocol on the server side. It is only supported with ArangoDB
 servers running version 3.12 or higher.
 If the dump should be restored into versions of ArangoDB older than 3.12, this
 option should be turned off.)")
+      .setIntroducedIn(31008)
+      .setIntroducedIn(31102)
       .setIntroducedIn(31200);
   // option was renamed in 3.12
   options->addOldOption("--use-experimental-dump", "--parallel-dump");
@@ -945,6 +947,8 @@ option should be turned off.)")
 `--parallel-dump` is set to `true`. Restoring split files also
 requires an arangorestore version that is capable of restoring data of a
 single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
+      .setIntroducedIn(31010)
+      .setIntroducedIn(31102)
       .setIntroducedIn(31200);
 
   options
@@ -953,6 +957,8 @@ single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
                   new UInt64Parameter(&_options.dbserverWorkerThreads),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31008)
+      .setIntroducedIn(31102)
       .setIntroducedIn(31200);
 
   options
@@ -961,6 +967,8 @@ single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
                   new UInt64Parameter(&_options.dbserverPrefetchBatches),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31008)
+      .setIntroducedIn(31102)
       .setIntroducedIn(31200);
 
   options
@@ -968,6 +976,8 @@ single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
                   new UInt64Parameter(&_options.localWriterThreads),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31008)
+      .setIntroducedIn(31102)
       .setIntroducedIn(31200);
 
   options
@@ -977,6 +987,8 @@ single collection/shard from multiple files, i.e. ArangoDB 3.12 or higher.)")
                   new UInt64Parameter(&_options.dbserverWorkerThreads),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31008)
+      .setIntroducedIn(31102)
       .setIntroducedIn(31200);
 }
 


### PR DESCRIPTION
### Scope & Purpose

Mainly for documentation (a user noticed the incorrect version numbers in older versions)

### Checklist

- [x] Backports
  - [x] Backport for 3.12.0: https://github.com/arangodb/arangodb/pull/20664
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20666
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20667

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] Docs PR: https://github.com/arangodb/docs-hugo/pull/484
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
