### PR TITLE
provide more control over build date generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,13 +231,26 @@ set(INSTALL_CONFIGFILES_LIST)
 # update files containing VERSION information
 # ------------------------------------------------------------------------------
 
-string(TIMESTAMP ARANGODB_BUILD_DATE "%Y-%m-%d %H:%M:%S")
-
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/lib/Basics/build.h.in"
   "${CMAKE_CURRENT_BINARY_DIR}/lib/Basics/build.h"
   NEWLINE_STYLE UNIX
 )
+
+option(ARANGODB_BUILD_DATE "Specific build date set from the outside (leave empty to auto-generate)" "")
+if (ARANGODB_BUILD_DATE STREQUAL "")
+  if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/lib/Basics/build-date.h")
+    # auto-generate build date
+    string(TIMESTAMP ARANGODB_BUILD_DATE "%Y-%m-%d %H:%M:%S")
+    set(GENERATE_BUILD_DATE ON)
+  else ()
+    # build-date.h file already exists. whatever is in there will be kept
+    set(GENERATE_BUILD_DATE OFF)
+  endif ()
+else ()
+  # forcefully recreate build-date.h file from provided date
+  set(GENERATE_BUILD_DATE ON)
+endif ()
 
 if (NOT DEFINED GENERATE_BUILD_DATE OR GENERATE_BUILD_DATE)
   set(GENERATE_BUILD_DATE ON CACHE INTERNAL "whether we should generate the build date")
@@ -246,9 +259,9 @@ if (NOT DEFINED GENERATE_BUILD_DATE OR GENERATE_BUILD_DATE)
     "${CMAKE_CURRENT_BINARY_DIR}/lib/Basics/build-date.h"
     NEWLINE_STYLE UNIX
     )
-else()
+else ()
   set(GENERATE_BUILD_DATE OFF CACHE INTERNAL "whether we should generate the build date")
-endif()
+endif ()
 
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/lib/Basics/VERSION.in"


### PR DESCRIPTION
### Scope & Purpose

provide more control over build date generation

- when setting the CMake variable `ARANGODB_BUILD_DATE` to an arbitrary date/time string, it will be picked up by the build and used as the build date string placed in `build/lib/Basics/build-date.h`.
- when not setting the CMake variable `ARANGODB_BUILD_DATE` or setting it to an empty string, it will be checked if the file `build/lib/Basics/build-date.h` already exists or not. if it already exists, the build date in the file will be kept unaltered. this is to avoid rebuilding files unnecessarily. if the file does not yet exist, the current date/time will be put into this file, so that upon the next cmake invocation, the file will be there and the build date will be reused.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 