### PR TITLE
Fixing Prerelease Incompatibility

### DIFF
--- a/js/common/modules/@arangodb/foxx/store.js
+++ b/js/common/modules/@arangodb/foxx/store.js
@@ -199,11 +199,11 @@ function extractMaxVersion (matchEngine, versionDoc) {
     }
     let versionRange = info.engines.arangodb;
 
-    if (!versionRange || semver.outside(serverVersion, versionRange, '<')) {
+    if (!versionRange || semver.outside(serverVersion, versionRange, '<', {includePrerelease: true})) {
       // Explicitly backwards-incompatible with the server version: ignore
       continue;
     }
-    if (!matchEngine || semver.satisfies(serverVersion, versionRange)) {
+    if (!matchEngine || semver.satisfies(serverVersion, versionRange, {includePrerelease: true})) {
       return version;
     }
   }


### PR DESCRIPTION
### Scope & Purpose

Once we branched off 3.12, the `shell-fishbowl-replacement.js` started failing. The version name (at the time of this PR) is `3.12.0-alpha1`. We're using the `semver` package to check whether a foxx module is compatible with the server version, and if so, include in the list of modules.

However, by default, prerelease versions (like '3.12.0-alpha1') will not satisfy ranges specified without a prerelease tag due to the way semantic versioning treats prerelease versions as lower than the corresponding version without the prerelease tag. If you want prerelease versions to be considered as satisfying the range, you need to include the `includePrerelease` option.

This is why we end up with less packaged than expected and the test fails.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Backports
  - [ ] Backport for 3.12: https://github.com/arangodb/arangodb/pull/20673