### PR TITLE
More Push-Down-Materialize with Joins

### DIFF
--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -375,11 +375,11 @@ struct OptimizerRule {
     lateMaterialiationOffsetInfoRule,
 #endif
 
-    pushDownLateMaterialization,
-
     // replace adjacent index nodes with a join node if the indexes qualify
     // for it.
     joinIndexNodesRule,
+
+    pushDownLateMaterialization,
 
     // introduce a new out variable for late materialization blocks
     materializeIntoSeparateVariable,

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -1116,6 +1116,59 @@ const IndexJoinTestSuite = function () {
         assertEqual(a, b.x);
       }
     },
+
+    testLateMaterializedPushPastJoin: function () {
+      const A = createCollection("A", ["x"]);
+      A.ensureIndex({type: "persistent", fields: ["x"], storedValues: ["z"]});
+      fillCollection("A", attributeGenerator(100, {x: x => `${x}`, z: x => 0}));
+      const B = createCollection("B", ["x"]);
+      B.ensureIndex({type: "persistent", fields: ["x"]});
+      fillCollection("B", singleAttributeGenerator(100, "x", x => `${x}`));
+
+      const query = `
+        for doc1 in A
+          sort doc1.x
+          for doc2 in B
+            filter doc2.x == doc1.x
+            sort doc2.x
+            limit 20
+            filter doc1.z == 0
+            return [doc1, doc2]
+      `;
+      const plan = db._createStatement({query, options: queryOptions}).explain().plan;
+      const nodes = plan.nodes.map(x => x.type);
+
+      assertEqual(nodes.indexOf("JoinNode"), 1);
+      const join = plan.nodes[1];
+      assertEqual(join.type, "JoinNode");
+
+      assertEqual(join.indexInfos.length, 2);
+      assertEqual(normalize(join.indexInfos[0].projections), [["z"]]);
+      assertEqual(normalize(join.indexInfos[1].projections), [["x"]]);
+      assertEqual(join.indexInfos[0].isLateMaterialized, true);
+      assertEqual(join.indexInfos[0].producesOutput, true);
+      assertEqual(join.indexInfos[0].indexCoversProjections, true);
+      assertEqual(join.indexInfos[1].isLateMaterialized, true);
+      assertEqual(join.indexInfos[1].producesOutput, true);
+      assertEqual(join.indexInfos[1].indexCoversProjections, true);
+
+      // We expect the materialize nodes to be pushed past the limit node
+      const relevantNodes = nodes.filter(x =>
+          ["LimitNode", "MaterializeNode", "FilterNode", "RemoteNode"].indexOf(x) !== -1);
+      if (isCluster) {
+        assertEqual(relevantNodes, ["LimitNode", "MaterializeNode", "MaterializeNode",
+          "RemoteNode", "LimitNode", "FilterNode"]);
+      } else {
+        assertEqual(relevantNodes, ["LimitNode", "FilterNode", "MaterializeNode", "MaterializeNode"]);
+      }
+
+      const result = db._createStatement(query).execute().toArray();
+      assertEqual(result.length, 20);
+      for (const [a, b] of result) {
+        assertEqual(a.x, b.x);
+      }
+    },
+
   };
 };
 


### PR DESCRIPTION
### Scope & Purpose
Consider the following query:
```
        for doc1 in A
          sort doc1.x
          for doc2 in B
            filter doc2.x == doc1.x
            sort doc2.x
            limit 20
            filter doc1.z == 0
            return [doc1, doc2]
```
Before this PR, this query was optimized as
```
Execution plan:
 Id   NodeType          Par   Est.   Comment
  1   SingletonNode              1   * ROOT
 19   JoinNode                 100     - JOIN
 19   JoinNode                 100       - FOR doc1 IN A   /* index scan + document lookup with late materialization */
 19   JoinNode                   1       - FOR doc2 IN B   /* index scan + document lookup with late materialization */
 17   MaterializeNode          100     - MATERIALIZE doc2 INTO #10
  8   CalculationNode          100     - LET #4 = #10.`x`   /* attribute expression */
  9   SortNode                 100     - SORT #4 ASC   /* sorting strategy: constrained heap */
 10   LimitNode                 20     - LIMIT 0, 20
 18   MaterializeNode           20     - MATERIALIZE doc1 INTO #9
 11   CalculationNode     ✓     20     - LET #5 = (#9.`z` == 0)   /* simple expression */
 12   FilterNode          ✓     20     - FILTER #5
 13   CalculationNode     ✓     20     - LET #6 = [ #9, #10 ]   /* simple expression */
 14   ReturnNode                20     - RETURN #6

Indexes used:
 By   Name                      Type         Collection   Unique   Sparse   Cache   Selectivity   Fields    Stored values   Ranges
 19   idx_1792333231698214912   persistent   A            false    false    false      100.00 %   [ `x` ]   [ `z` ]         *
 19   idx_1792333231830335488   persistent   B            false    false    false      100.00 %   [ `x` ]   [  ]            (doc2.`x` == doc1.`x`)

```
Notice that node `17 MaterializeNode` is not pushed down further, because the value is used in node `8`. However, in theory this value (`doc2.x`) is covered by the index. For normal index scans, the optimizer would have added the projections to the index and move the materialize node past the sort and limit.

In this case it bails out, the reasons for this is two-fold:

First, previously the `push-down-late-materialize` nodes rule was executed _before_ the join rule. At that point the plan looks differently: 
```
 Id   NodeType          Par   Est.   Comment
  1   SingletonNode              1   * ROOT
 16   IndexNode                100     - FOR doc1 IN A   /* persistent index scan, scan only */    /* with late materialization */
 18   MaterializeNode          100       - MATERIALIZE doc1 INTO #10
 15   IndexNode                100       - FOR doc2 IN B   /* persistent index scan, index only (projections: `x`) */    LET #11 = doc2.`x`   /* with late materialization */
  9   SortNode                 100         - SORT #11 ASC   /* sorting strategy: constrained heap */
 10   LimitNode                 20         - LIMIT 0, 20
 11   CalculationNode     ✓     20         - LET #5 = (#10.`z` == 0)   /* simple expression */
 12   FilterNode          ✓     20         - FILTER #5
 17   MaterializeNode           20         - MATERIALIZE doc2 INTO #9
 13   CalculationNode     ✓     20         - LET #6 = [ #10, #9 ]   /* simple expression */
 14   ReturnNode                20         - RETURN #6
```
Node 18 is above a for loop and _in general_ it is not wise to move a materialize node past a for loop (or IndexScan) as it could increase the number of lookups dramatically. Thus the node was not pushed down and once the Join rule ran, it looked like a missed optimization.

Secondly, if one would reverse the `push-down-late-materialization` rule and the join rule, the optimizer previously didn't know how to add projections to a join node.

Both has been addressed in this PR and thus the final version is
```
 Id   NodeType          Par   Est.   Comment
  1   SingletonNode              1   * ROOT
 19   JoinNode                 100     - JOIN
 19   JoinNode                 100       - FOR doc1 IN A   LET #11 = doc1.`z`   /* index scan with late materialization (projections: `z`) */
 19   JoinNode                   1       - FOR doc2 IN B   LET #12 = doc2.`x`   /* index scan with late materialization (projections: `x`) */
  9   SortNode                 100     - SORT #12 ASC   /* sorting strategy: constrained heap */
 10   LimitNode                 20     - LIMIT 0, 20
 11   CalculationNode     ✓     20     - LET #5 = (#11 == 0)   /* simple expression */
 12   FilterNode          ✓     20     - FILTER #5
 17   MaterializeNode           20     - MATERIALIZE doc2 INTO #10
 18   MaterializeNode           20     - MATERIALIZE doc1 INTO #9
 13   CalculationNode     ✓     20     - LET #6 = [ #9, #10 ]   /* simple expression */
 14   ReturnNode                20     - RETURN #6
```
