### PR TITLE
Implement custom logic to cancel redundant workflows

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -11,6 +11,12 @@ parameters:
     type: string
     default: public.ecr.aws/b0b8h2r4/test-ubuntu:23.10-fc8ee57e
   # Unused here, but it will be forwarded from config and will cause errors if not defined
+  enterprise-branch:
+    type: string
+    default: ""
+  dont-cancel-pipelines:
+    type: boolean
+    default: false
   nightly:
     type: boolean
     default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ parameters:
   rebuild-test-docker-images:
     type: boolean
     default: false
+  dont-cancel-pipelines:
+    type: boolean
+    default: false
   build-docker-image:
     type: string
     default: ""
@@ -54,6 +57,50 @@ jobs:
                 echo "Intentional build failure - to run an actual build please trigger a pipeline manually."
                 exit 1
       - run: echo "Check successful - generating config."
+
+  cancel-redundant-pipelines:
+    docker:
+      - image: cimg/base:current
+    resource_class: small
+    steps:
+      - run:
+          name: "Cancel redundant pipelines"
+          command: |
+            if [ "<< pipeline.parameters.dont-cancel-pipelines >>" == "true" ]; then
+              echo "Cancelling of redundant pipelines is disabled, not cancelling any pipelines"
+            elif [ "<< pipeline.parameters.nightly >>" == "true" ]; then
+              echo "Nightly build - not cancelling any pipelines"
+            elif [[ "$CIRCLE_BRANCH" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)$ ]] || [ "$CIRCLE_BRANCH" == "devel" ]; then
+              echo "Branch is a release branch or devel, not cancelling any pipelines"
+            else
+              ## Get the name of the workflow and the related pipeline number
+              CURRENT_PIPELINE_NUM=$(curl --header "Circle-Token: $CIRCLECI_TOKEN" --request GET "https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}" | jq -r '.pipeline_number')
+
+              ## Get the IDs of pipelines created by the current user on the same branch. (Only consider pipelines that have a pipeline number inferior to the current pipeline)
+              PIPE_IDS=$(curl --header "Circle-Token: $CIRCLECI_TOKEN" --request GET "https://circleci.com/api/v2/project/gh/arangodb/arangodb/pipeline?branch=$CIRCLE_BRANCH" | \
+                jq -r --arg CIRCLE_USERNAME "$CIRCLE_USERNAME" --argjson CURRENT_PIPELINE_NUM "$CURRENT_PIPELINE_NUM" '.items[]|select(.state == "created")|select(.trigger.actor.login == $CIRCLE_USERNAME)|select(.number < $CURRENT_PIPELINE_NUM)|.id')
+
+              ## Get the IDs of currently running/on_hold workflows
+              if [ ! -z "$PIPE_IDS" ]; then
+                for PIPE_ID in $PIPE_IDS
+                do
+                  curl --header "Circle-Token: $CIRCLECI_TOKEN" --request GET "https://circleci.com/api/v2/pipeline/${PIPE_ID}/workflow" | \
+                    jq -r '.items[]|select(.status == "on_hold" or .status == "running") | .id' >> WF_to_cancel.txt
+                done
+              fi
+
+              ## Cancel any currently running/on_hold workflow with the same name
+              if [ -s WF_to_cancel.txt ]; then
+                echo "Cancelling the following workflow(s):"
+                cat WF_to_cancel.txt 
+                while read WF_ID;
+                  do
+                    curl --header "Circle-Token: $CIRCLECI_TOKEN" --request POST https://circleci.com/api/v2/workflow/$WF_ID/cancel
+                  done < WF_to_cancel.txt
+              else
+                echo "Nothing to cancel"
+              fi
+            fi
 
   generate-config:
     docker:
@@ -122,7 +169,11 @@ workflows:
       # we always create a workflow and let the build fail in check-build-trigger unless it has been triggered manually
       # or runs on the devel branch (see condition in check-build-trigger)
       - check-build-trigger
+      - cancel-redundant-pipelines:
+          context: [ circleci-token ]
+          requires:
+            - check-build-trigger
       - generate-config:
           definitions: "tests/test-definitions.txt"
           requires:
-            - check-build-trigger
+            - cancel-redundant-pipelines


### PR DESCRIPTION
### Scope & Purpose

devel port of #20683

Previously we had the CircleCI "auto-cancel redundant workflows" feature activated, which automatically cancelled any pending workflows whenever an new build was triggered for the same branch (including whenever something was pushed to that branch) - except for the default branch (in our case "devel"). While this could be helpful in some cases to avoid wasting build credits, it was sometimes also rather annoying (e.g., because pushing an CHANGELOG update would cancel the previously started build). Worse, for scheduled builds on branches other then devel, concurrently triggered pipelines would cancel other scheduled pipelines (e.g., the tsan pipeline could cancel the alubsan pipline or vice versa).

Instead of relying on the "auto-cancel redundant workflows" feature, this PR implements custom logic to cancel redundant pipelines. We only cancel any piplines if 1. this is not a nightly build (i.e., the `nightly` flag is false), 2. the `dont-cancel-pipelines` parameter has not been explicitly set to true (this allows one to manually start multiple pipelines for the same branch, e.g. to run different sanitizer builds), 3. the branch we are building is not a release branch or devel. If none of these conditions is fulfilled, we look up all the pipelines of the current branch which where triggered by the same user, lookup all the workflows of these pipelines, and finally cancel all these workflows. This happens as a separate job _after_ the `check-build-trigger` job, so if that job cancels the current pipeline because it was triggered by a push, the cancel-redundant-workflows job is not executed.

The implementation is based on this posting: https://discuss.circleci.com/t/workaround-auto-cancel-redundant-builds-on-the-default-branch/39468/1
