### PR TITLE
Verify transaction database name

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,13 @@
 devel
 -----
 
-* 
+* Fix BTS-1807: transactions are bound to the user who started it, and the
+  database it was started for. However, there was a code path that was missing
+  the database check, which allowed the transaction id to be used in a request
+  to a different database. The request would not return an error, but it would
+  actually be executed in the context of the original database, and not the one
+  specified in the request.
+  With this fix, such a request will now return an ERROR_TRANSACTION_NOT_FOUND.
 
 
 3.12.0-alpha.1 (XXXX-XX-XX)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ devel
 -----
 
 * Fix BTS-1807: transactions are bound to the user who started it, and the
-  database it was started for. However, there was a code path that was missing
+  database they were started for. However, there was a code path that was missing
   the database check, which allowed the transaction id to be used in a request
   to a different database. The request would not return an error, but it would
   actually be executed in the context of the original database, and not the one

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3560,7 +3560,7 @@ Result RestReplicationHandler::isLockHeld(TransactionId id) const {
   transaction::Manager* mgr = transaction::ManagerFeature::manager();
   TRI_ASSERT(mgr != nullptr);
 
-  transaction::Status stats = mgr->getManagedTrxStatus(id, _vocbase.name());
+  transaction::Status stats = mgr->getManagedTrxStatus(id);
   if (stats == transaction::Status::UNDEFINED) {
     return {TRI_ERROR_HTTP_NOT_FOUND,
             "no hold read lock job found for id " + std::to_string(id.id())};

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -146,7 +146,7 @@ void RestTransactionHandler::executeGetState() {
     return;
   }
 
-  transaction::Status status = mgr->getManagedTrxStatus(tid, _vocbase.name());
+  transaction::Status status = mgr->getManagedTrxStatus(tid);
 
   if (status == transaction::Status::UNDEFINED) {
     generateError(rest::ResponseCode::NOT_FOUND,

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -22,8 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Manager.h"
-#include <optional>
-#include <string_view>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Query.h"
@@ -38,12 +36,9 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
-#include "CrashHandler/CrashHandler.h"
 #include "Futures/Utilities.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "Logger/LogMacros.h"
-#include "Metrics/GaugeBuilder.h"
-#include "Metrics/MetricsFeature.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
 #include "Network/Utils.h"
@@ -72,6 +67,8 @@
 #include <fuerte/jwt.h>
 #include <velocypack/Iterator.h>
 
+#include <optional>
+#include <string_view>
 #include <thread>
 
 namespace {

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -181,8 +181,7 @@ class Manager final : public IManager {
   void returnManagedTrx(TransactionId, bool isSideUser) noexcept;
 
   /// @brief get the meta transaction state
-  transaction::Status getManagedTrxStatus(TransactionId,
-                                          std::string const& database) const;
+  transaction::Status getManagedTrxStatus(TransactionId) const;
 
   Result commitManagedTrx(TransactionId, std::string const& database);
   Result abortManagedTrx(TransactionId, std::string const& database) override;
@@ -278,10 +277,10 @@ class Manager final : public IManager {
   std::shared_ptr<ManagedContext> buildManagedContextUnderLock(
       TransactionId tid, ManagedTrx& mtrx);
 
-  Result updateTransaction(
-      TransactionId tid, transaction::Status status, bool clearServers,
-      std::string const& database =
-          "" /* leave empty to operate across all databases */);
+  Result updateTransaction(TransactionId tid, transaction::Status status,
+                           bool clearServers,
+                           /* use nullopt to operate across all databases */
+                           std::optional<std::string_view> database);
 
   /// @brief calls the callback function for each managed transaction
   void iterateManagedTrx(
@@ -294,6 +293,9 @@ class Manager final : public IManager {
   bool storeManagedState(TransactionId const& tid,
                          std::shared_ptr<arangodb::TransactionState> state,
                          double ttl);
+
+  bool isAuthorized(ManagedTrx const& trx) const;
+  bool isAuthorized(ManagedTrx const& trx, std::string_view database) const;
 
  private:
   ManagerFeature& _feature;

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -277,10 +277,11 @@ class Manager final : public IManager {
   std::shared_ptr<ManagedContext> buildManagedContextUnderLock(
       TransactionId tid, ManagedTrx& mtrx);
 
-  Result updateTransaction(TransactionId tid, transaction::Status status,
-                           bool clearServers,
-                           /* use nullopt to operate across all databases */
-                           std::optional<std::string_view> database);
+  Result updateTransaction(
+      TransactionId tid, transaction::Status status, bool clearServers,
+      // TODO - use a better solution
+      std::string const& database =
+          "" /* leave empty to operate across all databases */);
 
   /// @brief calls the callback function for each managed transaction
   void iterateManagedTrx(

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -93,6 +93,9 @@ class ExecContext : public RequestContext {
   /// @brief current user, may be empty for internal users
   std::string const& user() const { return _user; }
 
+  /// @brief current database
+  std::string const& database() const { return _database; }
+
   // std::string const& database() const { return _database; }
   /// @brief authentication level on _system. Always RW for superuser
   auth::Level systemAuthLevel() const noexcept { return _systemDbAuthLevel; }

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -193,8 +193,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
 
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
   {  // lease again
     auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
@@ -209,8 +208,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
     ASSERT_TRUE(opRes.ok());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
   // perform same operation
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
@@ -218,8 +216,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name())
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::ABORTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
 TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
@@ -256,8 +253,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
     ASSERT_TRUE(opRes.ok());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
   // perform same operation
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
@@ -265,8 +261,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::COMMITTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
 }
 
 TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
@@ -310,8 +305,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
     ASSERT_TRUE(opRes.ok());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
   // perform same operation
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
@@ -319,8 +313,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::COMMITTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
 }
 
 TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
@@ -357,8 +350,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
               mgr->commitManagedTrx(tid, vocbase.name()).errorNumber());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
   // perform same operation
@@ -366,8 +358,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
   // cannot abort committed transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::COMMITTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
 }
 
 TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
@@ -410,8 +401,7 @@ TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
     ASSERT_TRUE(!responsible);
   }
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::ABORTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
 TEST_F(TransactionManagerTest, lock_conflict) {
@@ -442,8 +432,7 @@ TEST_F(TransactionManagerTest, lock_conflict) {
     ASSERT_ANY_THROW(mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false));
   }
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::ABORTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
 TEST_F(TransactionManagerTest, lock_conflict_side_user) {
@@ -480,8 +469,7 @@ TEST_F(TransactionManagerTest, lock_conflict_side_user) {
     ASSERT_TRUE(!responsible);
   }
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::ABORTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
 TEST_F(TransactionManagerTest, garbage_collection_shutdown) {
@@ -510,11 +498,9 @@ TEST_F(TransactionManagerTest, garbage_collection_shutdown) {
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
   ASSERT_TRUE(mgr->garbageCollect(/*abortAll*/ true));
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::ABORTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
 TEST_F(TransactionManagerTest, aql_standalone_transaction) {
@@ -589,8 +575,7 @@ TEST_F(TransactionManagerTest, abort_transactions_with_matcher) {
     ASSERT_TRUE(opRes.ok());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::RUNNING);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
   mgr->abortManagedTrx(
       [](TransactionState const& state, std::string const& /*user*/) -> bool {
@@ -599,8 +584,7 @@ TEST_F(TransactionManagerTest, abort_transactions_with_matcher) {
         return tcoll != nullptr;
       });
 
-  ASSERT_EQ(mgr->getManagedTrxStatus(tid, vocbase.name()),
-            transaction::Status::ABORTED);
+  ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
 TEST_F(TransactionManagerTest, permission_denied_readonly) {

--- a/tests/js/client/shell/transaction/shell-transaction.inc
+++ b/tests/js/client/shell/transaction/shell-transaction.inc
@@ -5731,6 +5731,8 @@ function transactionDatabaseSuite() {
         fail();
       } catch(err) {
         assertEqual(internal.errors.ERROR_TRANSACTION_NOT_FOUND.code, err.errorNum);
+      } finally {
+        db._useDatabase(dbn1);
       }
     },
   };

--- a/tests/js/client/shell/transaction/shell-transaction.inc
+++ b/tests/js/client/shell/transaction/shell-transaction.inc
@@ -43,7 +43,7 @@ const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
 const analyzers = require('@arangodb/analyzers');
 const ArangoTransaction = require('@arangodb/arango-transaction').ArangoTransaction;
 const isCluster = internal.isCluster();
-const isReplication2Enabled = require('internal').db._version(true).details['replication2-enabled'] === 'true';
+const isReplication2Enabled = internal.db._version(true).details['replication2-enabled'] === 'true';
 
 const compareStringIds = function (l, r) {
   'use strict';
@@ -5717,6 +5717,20 @@ function transactionDatabaseSuite() {
       } finally {
         db._useDatabase(dbn1);
         trx1.abort();
+      }
+    },
+
+    testTransactionsAreDatabaseLocal: function() {
+      db._useDatabase(dbn1);
+      const opts = { collections: { write: [cn] } };
+      const trx = db._createTransaction(opts);
+      trx.collection(cn).insert({ _key: "test" });
+      try {
+        db._useDatabase(dbn2);
+        trx.collection(cn).document("test");
+        fail();
+      } catch(err) {
+        assertEqual(internal.errors.ERROR_TRANSACTION_NOT_FOUND.code, err.errorNum);
       }
     },
   };


### PR DESCRIPTION
### Scope & Purpose

Transactions are bound to the user who started it, and the database it was started for. However, there was a code path that was missing the database check, which allowed the transaction id to be used in a request to a different database. The request would not return an error, but it would actually be executed in the context of the original database, and not the one specified in the request.

With this fix, such a request will now return an ERROR_TRANSACTION_NOT_FOUND.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**
- [x] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [x] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1807
