### PR TITLE
split injection of bind parameters into query AST

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -67,6 +67,38 @@ using namespace arangodb::aql;
 
 namespace {
 
+/// @brief reverse comparison operators
+std::unordered_map<int, AstNodeType> const reversedOperators{
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_EQ),
+     NODE_TYPE_OPERATOR_BINARY_EQ},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GT),
+     NODE_TYPE_OPERATOR_BINARY_LT},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GE),
+     NODE_TYPE_OPERATOR_BINARY_LE},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LT),
+     NODE_TYPE_OPERATOR_BINARY_GT},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LE),
+     NODE_TYPE_OPERATOR_BINARY_GE}};
+
+/// @brief inverse comparison operators
+std::unordered_map<int, AstNodeType> const negatedOperators{
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_EQ),
+     NODE_TYPE_OPERATOR_BINARY_NE},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_NE),
+     NODE_TYPE_OPERATOR_BINARY_EQ},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GT),
+     NODE_TYPE_OPERATOR_BINARY_LE},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GE),
+     NODE_TYPE_OPERATOR_BINARY_LT},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LT),
+     NODE_TYPE_OPERATOR_BINARY_GE},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LE),
+     NODE_TYPE_OPERATOR_BINARY_GT},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_IN),
+     NODE_TYPE_OPERATOR_BINARY_NIN},
+    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_NIN),
+     NODE_TYPE_OPERATOR_BINARY_IN}};
+
 struct RecursiveAttributeFinderContext {
   Variable const* variable;
   bool couldExtractAttributePath;
@@ -288,38 +320,6 @@ LogicalDataSource::Category injectDataSourceInQuery(
 }
 
 }  // namespace
-
-/// @brief inverse comparison operators
-std::unordered_map<int, AstNodeType> const Ast::NegatedOperators{
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_EQ),
-     NODE_TYPE_OPERATOR_BINARY_NE},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_NE),
-     NODE_TYPE_OPERATOR_BINARY_EQ},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GT),
-     NODE_TYPE_OPERATOR_BINARY_LE},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GE),
-     NODE_TYPE_OPERATOR_BINARY_LT},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LT),
-     NODE_TYPE_OPERATOR_BINARY_GE},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LE),
-     NODE_TYPE_OPERATOR_BINARY_GT},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_IN),
-     NODE_TYPE_OPERATOR_BINARY_NIN},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_NIN),
-     NODE_TYPE_OPERATOR_BINARY_IN}};
-
-/// @brief reverse comparison operators
-std::unordered_map<int, AstNodeType> const Ast::ReversedOperators{
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_EQ),
-     NODE_TYPE_OPERATOR_BINARY_EQ},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GT),
-     NODE_TYPE_OPERATOR_BINARY_LT},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_GE),
-     NODE_TYPE_OPERATOR_BINARY_LE},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LT),
-     NODE_TYPE_OPERATOR_BINARY_GT},
-    {static_cast<int>(NODE_TYPE_OPERATOR_BINARY_LE),
-     NODE_TYPE_OPERATOR_BINARY_GE}};
 
 Ast::SpecialNodes::SpecialNodes()
     : NopNode{NODE_TYPE_NOP, AstNode::InternalNode{}},
@@ -1956,22 +1956,17 @@ AstNode* Ast::createNodeNaryOperator(AstNodeType type, AstNode const* child) {
   return node;
 }
 
-/// @brief injects bind parameters into the AST
-void Ast::injectBindParameters(BindParameters& parameters,
-                               CollectionNameResolver const& resolver) {
+/// @brief injects first-stage bind parameter values into the AST
+/// (i.e. collection bind parameters and bound attribute names,
+/// e.g. @@foo and `doc.@attr`).
+void Ast::injectBindParametersFirstStage(
+    BindParameters& parameters, CollectionNameResolver const& resolver) {
   if (_containsBindParameters || _containsTraversal) {
-    // inject bind parameters into query AST
     auto func = [&](AstNode* node) -> AstNode* {
-      if (node->type == NODE_TYPE_PARAMETER ||
-          node->type == NODE_TYPE_PARAMETER_DATASOURCE) {
+      if (node->type == NODE_TYPE_PARAMETER_DATASOURCE) {
         // found a bind parameter in the query string
-        std::string const param = node->getString();
-
-        if (param.empty()) {
-          // parameter name must not be empty
-          ::throwFormattedError(_query, TRI_ERROR_QUERY_BIND_PARAMETER_MISSING,
-                                param);
-        }
+        std::string param = node->getString();
+        TRI_ASSERT(!param.empty());
 
         auto [value, cachedNode] = parameters.get(param);
         if (value.isNone()) {
@@ -1980,144 +1975,95 @@ void Ast::injectBindParameters(BindParameters& parameters,
                                 param);
         }
 
-        if (node->type == NODE_TYPE_PARAMETER) {
-          auto const constantParameter = node->isConstant();
+        if (!value.isString()) {
+          // we can get here in case `WITH @col ...` when the value of @col
+          // is not a string
+          ::throwFormattedError(_query, TRI_ERROR_QUERY_BIND_PARAMETER_TYPE,
+                                param);
+          // query will have been aborted here
+        }
 
-          if (cachedNode != nullptr) {
-            // we have already processed this bind parameter and turned it into
-            // an AstNode before.
-            // now only create a shallow copy of the bind parameter.
-            node = shallowCopyForModify(cachedNode);
+        TRI_ASSERT(value.isString());
+        std::string_view name = value.stringView();
 
-            if (constantParameter) {
-              TRI_ASSERT(node->hasFlag(DETERMINED_CONSTANT));
-              TRI_ASSERT(node->hasFlag(VALUE_CONSTANT));
-            }
-            TRI_ASSERT(node->hasFlag(DETERMINED_SIMPLE));
-            TRI_ASSERT(node->hasFlag(VALUE_SIMPLE));
-            TRI_ASSERT(node->hasFlag(DETERMINED_RUNONDBSERVER));
-            TRI_ASSERT(node->hasFlag(VALUE_RUNONDBSERVER));
-            TRI_ASSERT(node->hasFlag(DETERMINED_NONDETERMINISTIC));
-            TRI_ASSERT(!node->hasFlag(VALUE_NONDETERMINISTIC));
-            TRI_ASSERT(node->hasFlag(FLAG_BIND_PARAMETER));
-          } else {
-            // bind parameter containing a value literal. not processed before.
-            node = nodeFromVPack(value, true);
+        // check if the collection was used in a data-modification query
+        bool isWriteCollection = false;
 
-            if (node != nullptr) {
-              if (constantParameter) {
-                // already mark node as constant here if parameters are constant
-                node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
-              }
-              // mark node as simple
-              node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
-              // mark node as executable on db-server
-              node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
-              // mark node as deterministic
-              node->setFlag(DETERMINED_NONDETERMINISTIC);
+        std::string_view paramRef(param);
 
-              // finally note that the node was created from a bind parameter
-              node->setFlag(FLAG_BIND_PARAMETER);
+        AstNode* newNode = nullptr;
+        for (auto const& it : _writeCollections) {
+          auto const& c = it.first;
 
-              // register the AstNode for this bind parameter, so when the query
-              // string refers to the same bind parameter multiple times, we
-              // don't have to regenerate an AstNode for it. in case a bind
-              // parameter is used multiple times in the query string, upon any
-              // following occurrences the AstNode registered here will be
-              // found, and only a shallow copy of the existing AstNode will be
-              // created. This helps to save memory and processing time for
-              // large bind parameter values.
-              parameters.registerNode(param, node);
-            }
+          if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
+              paramRef == c->getStringView()) {
+            // bind parameter still present in _writeCollections
+            TRI_ASSERT(newNode == nullptr);
+            isWriteCollection = true;
+            break;
+          } else if (c->type == NODE_TYPE_COLLECTION &&
+                     name == c->getStringView()) {
+            // bind parameter was already replaced with a proper collection
+            // node in _writeCollections
+            TRI_ASSERT(newNode == nullptr);
+            isWriteCollection = true;
+            newNode = const_cast<AstNode*>(c);
+            break;
           }
-        } else {
-          TRI_ASSERT(node->type == NODE_TYPE_PARAMETER_DATASOURCE);
+        }
 
-          if (!value.isString()) {
-            // we can get here in case `WITH @col ...` when the value of @col
-            // is not a string
-            ::throwFormattedError(_query, TRI_ERROR_QUERY_BIND_PARAMETER_TYPE,
-                                  param);
-            // query will have been aborted here
-          }
+        TRI_ASSERT(newNode == nullptr || isWriteCollection);
 
-          // bound data source parameter
-          TRI_ASSERT(value.isString());
-          std::string_view name = value.stringView();
-
-          // check if the collection was used in a data-modification query
-          bool isWriteCollection = false;
-
-          std::string_view paramRef(param);
-
-          AstNode* newNode = nullptr;
-          for (auto const& it : _writeCollections) {
-            auto const& c = it.first;
-
-            if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
-                paramRef == c->getStringView()) {
-              // bind parameter still present in _writeCollections
-              TRI_ASSERT(newNode == nullptr);
-              isWriteCollection = true;
-              break;
-            } else if (c->type == NODE_TYPE_COLLECTION &&
-                       name == c->getStringView()) {
-              // bind parameter was already replaced with a proper collection
-              // node in _writeCollections
-              TRI_ASSERT(newNode == nullptr);
-              isWriteCollection = true;
-              newNode = const_cast<AstNode*>(c);
-              break;
-            }
-          }
-
-          TRI_ASSERT(newNode == nullptr || isWriteCollection);
-
-          if (newNode == nullptr) {
-            newNode =
-                createNodeDataSource(resolver, name,
-                                     isWriteCollection ? AccessMode::Type::WRITE
-                                                       : AccessMode::Type::READ,
-                                     false, true);
-            TRI_ASSERT(newNode != nullptr);
-
-            if (isWriteCollection) {
-              // must update AST info now for all nodes that contained this
-              // parameter
-              for (auto& it : _writeCollections) {
-                auto& c = it.first;
-
-                if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
-                    paramRef == c->getStringView()) {
-                  c = newNode;
-                  // no break here. replace all occurrences
-                }
-              }
-            }
-          }
-
+        if (newNode == nullptr) {
+          newNode =
+              createNodeDataSource(resolver, name,
+                                   isWriteCollection ? AccessMode::Type::WRITE
+                                                     : AccessMode::Type::READ,
+                                   false, true);
           TRI_ASSERT(newNode != nullptr);
-          node = newNode;
 
-          if (cachedNode == nullptr) {
-            // store the just created AstNode for this bind parameter, to mark
-            // the bind parameter as being "used". It does not matter which
-            // AstNode we store for the bind parameter, but we have to store one
-            // if none was yet registered. Otherwise we'll run into an error
-            // "unused bind parameter
-            // '@...' later.
-            parameters.registerNode(param, node);
-          } else {
-            // double check that the already registered node has the correct
-            // type
-            TRI_ASSERT(cachedNode->type == NODE_TYPE_VIEW ||
-                       cachedNode->type == NODE_TYPE_COLLECTION);
-            TRI_ASSERT(cachedNode->getStringView() == name);
+          if (isWriteCollection) {
+            // must update AST info now for all nodes that contained this
+            // parameter
+            for (auto& it : _writeCollections) {
+              auto& c = it.first;
+
+              if (c->type == NODE_TYPE_PARAMETER_DATASOURCE &&
+                  paramRef == c->getStringView()) {
+                c = newNode;
+                // no break here. replace all occurrences
+              }
+            }
           }
+        }
+
+        TRI_ASSERT(newNode != nullptr);
+        node = newNode;
+
+        if (cachedNode == nullptr) {
+          // store the just created AstNode for this bind parameter, to mark
+          // the bind parameter as being "used". It does not matter which
+          // AstNode we store for the bind parameter, but we have to store one
+          // if none was yet registered. Otherwise we'll run into an error
+          // "unused bind parameter '@...'" later.
+          parameters.registerNode(param, node);
+        } else {
+          // double check that the already registered node has the correct
+          // type
+          TRI_ASSERT(cachedNode->type == NODE_TYPE_VIEW ||
+                     cachedNode->type == NODE_TYPE_COLLECTION);
+          TRI_ASSERT(cachedNode->getStringView() == name);
         }
       } else if (node->type == NODE_TYPE_BOUND_ATTRIBUTE_ACCESS) {
         // look at second sub-node. this is the (replaced) bind parameter
         auto name = node->getMember(1);
+
+        if (name->type == NODE_TYPE_PARAMETER) {
+          // on-the-fly replacement of bind parameter with its value equivalent
+          name = replaceValueBindParameter(name, parameters);
+        }
+
+        TRI_ASSERT(name->type != NODE_TYPE_PARAMETER);
 
         if (name->type == NODE_TYPE_VALUE) {
           if (name->value.type == VALUE_TYPE_STRING &&
@@ -2160,11 +2106,11 @@ void Ast::injectBindParameters(BindParameters& parameters,
         THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_BIND_PARAMETER_TYPE,
                                       node->getString().c_str());
       } else if (node->type == NODE_TYPE_TRAVERSAL) {
-        extractCollectionsFromGraph(node->getMember(2));
+        extractCollectionsFromGraph(parameters, node->getMember(2));
       } else if (node->type == NODE_TYPE_SHORTEST_PATH) {
-        extractCollectionsFromGraph(node->getMember(3));
+        extractCollectionsFromGraph(parameters, node->getMember(3));
       } else if (node->type == NODE_TYPE_ENUMERATE_PATHS) {
-        extractCollectionsFromGraph(node->getMember(4));
+        extractCollectionsFromGraph(parameters, node->getMember(4));
       }
 
       return node;
@@ -2205,16 +2151,89 @@ void Ast::injectBindParameters(BindParameters& parameters,
       }
     }
   }
+}
 
-  // visit all bind parameters to ensure that they have all been accessed via
-  // registerNode
-  parameters.visit(
-      [](std::string const& key, VPackSlice /*value*/, AstNode* node) {
-        if (node == nullptr) {
-          THROW_ARANGO_EXCEPTION_PARAMS(
-              TRI_ERROR_QUERY_BIND_PARAMETER_UNDECLARED, key.c_str());
-        }
-      });
+/// @brief injects second-stage bind parameter values into the AST
+/// (i.e. all value bind parameters)
+void Ast::injectBindParametersSecondStage(BindParameters& parameters) {
+  if (_containsBindParameters) {
+    auto func = [&](AstNode* node) -> AstNode* {
+      if (node->type == NODE_TYPE_PARAMETER) {
+        // found a bind parameter in the query string.
+        // replace it with its replaced value equivalent
+        node = replaceValueBindParameter(node, parameters);
+      }
+      return node;
+    };
+
+    _root = traverseAndModify(_root, func);
+  }
+}
+
+/// @brief replace a bind parameter with its value equivalent.
+AstNode* Ast::replaceValueBindParameter(AstNode* node,
+                                        BindParameters& parameters) {
+  TRI_ASSERT(node->type == NODE_TYPE_PARAMETER);
+
+  std::string const param = node->getString();
+  TRI_ASSERT(!param.empty());
+
+  auto [value, cachedNode] = parameters.get(param);
+  if (value.isNone()) {
+    // query uses a bind parameter that was not defined by the user
+    ::throwFormattedError(_query, TRI_ERROR_QUERY_BIND_PARAMETER_MISSING,
+                          param);
+  }
+
+  auto const constantParameter = node->isConstant();
+
+  if (cachedNode != nullptr) {
+    // we have already processed this bind parameter and turned it into
+    // an AstNode before.
+    // now only create a shallow copy of the bind parameter.
+    node = shallowCopyForModify(cachedNode);
+
+    TRI_ASSERT(!constantParameter || node->hasFlag(DETERMINED_CONSTANT));
+    TRI_ASSERT(!constantParameter || node->hasFlag(VALUE_CONSTANT));
+    TRI_ASSERT(node->hasFlag(DETERMINED_SIMPLE));
+    TRI_ASSERT(node->hasFlag(VALUE_SIMPLE));
+    TRI_ASSERT(node->hasFlag(DETERMINED_RUNONDBSERVER));
+    TRI_ASSERT(node->hasFlag(VALUE_RUNONDBSERVER));
+    TRI_ASSERT(node->hasFlag(DETERMINED_NONDETERMINISTIC));
+    TRI_ASSERT(!node->hasFlag(VALUE_NONDETERMINISTIC));
+    TRI_ASSERT(node->hasFlag(FLAG_BIND_PARAMETER));
+  } else {
+    // bind parameter containing a value literal. not processed before.
+    node = nodeFromVPack(value, true);
+
+    if (node != nullptr) {
+      if (constantParameter) {
+        // already mark node as constant here if parameters are constant
+        node->setFlag(DETERMINED_CONSTANT, VALUE_CONSTANT);
+      }
+      // mark node as simple
+      node->setFlag(DETERMINED_SIMPLE, VALUE_SIMPLE);
+      // mark node as executable on db-server
+      node->setFlag(DETERMINED_RUNONDBSERVER, VALUE_RUNONDBSERVER);
+      // mark node as deterministic
+      node->setFlag(DETERMINED_NONDETERMINISTIC);
+
+      // finally note that the node was created from a bind parameter
+      node->setFlag(FLAG_BIND_PARAMETER);
+
+      // register the AstNode for this bind parameter, so when the query
+      // string refers to the same bind parameter multiple times, we
+      // don't have to regenerate an AstNode for it. in case a bind
+      // parameter is used multiple times in the query string, upon any
+      // following occurrences the AstNode registered here will be
+      // found, and only a shallow copy of the existing AstNode will be
+      // created. This helps to save memory and processing time for
+      // large bind parameter values.
+      parameters.registerNode(param, node);
+    }
+  }
+
+  return node;
 }
 
 /// @brief replace an attribute access with just the variable
@@ -3122,16 +3141,15 @@ AstNode const* Ast::deduplicateArray(AstNode const* node) {
 }
 
 /// @brief check if an operator is reversible
-bool Ast::IsReversibleOperator(AstNodeType type) {
-  return (ReversedOperators.find(static_cast<int>(type)) !=
-          ReversedOperators.end());
+bool Ast::isReversibleOperator(AstNodeType type) noexcept {
+  return ::reversedOperators.contains(static_cast<int>(type));
 }
 
 /// @brief get the reversed operator for a comparison operator
-AstNodeType Ast::ReverseOperator(AstNodeType type) {
-  auto it = ReversedOperators.find(static_cast<int>(type));
+AstNodeType Ast::reverseOperator(AstNodeType type) {
+  auto it = ::reversedOperators.find(static_cast<int>(type));
 
-  if (it == ReversedOperators.end()) {
+  if (it == ::reversedOperators.end()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "invalid node type for inversed operator");
   }
@@ -3139,8 +3157,17 @@ AstNodeType Ast::ReverseOperator(AstNodeType type) {
   return (*it).second;
 }
 
+AstNodeType Ast::negateOperator(AstNodeType type) {
+  auto it = ::negatedOperators.find(static_cast<int>(type));
+  if (it == ::negatedOperators.end()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "unsupported operator type");
+  }
+  return (*it).second;
+}
+
 /// @brief get the n-ary operator type equivalent for a binary operator type
-AstNodeType Ast::NaryOperatorType(AstNodeType old) {
+AstNodeType Ast::naryOperatorType(AstNodeType old) {
   TRI_ASSERT(old == NODE_TYPE_OPERATOR_BINARY_AND ||
              old == NODE_TYPE_OPERATOR_BINARY_OR);
 
@@ -3155,13 +3182,14 @@ AstNodeType Ast::NaryOperatorType(AstNodeType old) {
                                  "invalid node type for n-ary operator");
 }
 
-bool Ast::IsAndOperatorType(AstNodeType tt) {
-  return tt == NODE_TYPE_OPERATOR_BINARY_AND ||
-         tt == NODE_TYPE_OPERATOR_NARY_AND;
+bool Ast::isAndOperatorType(AstNodeType type) noexcept {
+  return type == NODE_TYPE_OPERATOR_BINARY_AND ||
+         type == NODE_TYPE_OPERATOR_NARY_AND;
 }
 
-bool Ast::IsOrOperatorType(AstNodeType tt) {
-  return tt == NODE_TYPE_OPERATOR_BINARY_OR || tt == NODE_TYPE_OPERATOR_NARY_OR;
+bool Ast::isOrOperatorType(AstNodeType type) noexcept {
+  return type == NODE_TYPE_OPERATOR_BINARY_OR ||
+         type == NODE_TYPE_OPERATOR_NARY_OR;
 }
 
 /// @brief make condition from example
@@ -3335,10 +3363,8 @@ AstNode* Ast::optimizeNotExpression(AstNode* node) {
     auto lhs = operand->getMember(0);
     auto rhs = operand->getMember(1);
 
-    auto it = NegatedOperators.find(static_cast<int>(operand->type));
-    TRI_ASSERT(it != NegatedOperators.end());
-
-    return createNodeBinaryOperator((*it).second, lhs, rhs);
+    AstNodeType negated = negateOperator(operand->type);
+    return createNodeBinaryOperator(negated, lhs, rhs);
   }
 
   return node;
@@ -4261,8 +4287,15 @@ AstNode* Ast::createNodeCollectionNoValidation(std::string_view name,
   return node;
 }
 
-void Ast::extractCollectionsFromGraph(AstNode const* graphNode) {
+void Ast::extractCollectionsFromGraph(BindParameters& parameters,
+                                      AstNode* graphNode) {
   TRI_ASSERT(graphNode != nullptr);
+  if (graphNode->type == NODE_TYPE_PARAMETER) {
+    graphNode = replaceValueBindParameter(graphNode, parameters);
+  }
+
+  TRI_ASSERT(graphNode->type != NODE_TYPE_PARAMETER);
+
   if (graphNode->type == NODE_TYPE_VALUE) {
     TRI_ASSERT(graphNode->isStringValue());
     std::string graphName = graphNode->getString();

--- a/arangod/Aql/BindParameters.cpp
+++ b/arangod/Aql/BindParameters.cpp
@@ -37,23 +37,34 @@
 using namespace arangodb::aql;
 
 BindParameters::BindParameters(ResourceMonitor& resourceMonitor)
-    : _resourceMonitor(resourceMonitor), _processed(false) {}
+    : _resourceMonitor(resourceMonitor),
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _memoryUsage(0),
+#endif
+      _processed(false) {
+}
 
 BindParameters::BindParameters(
     ResourceMonitor& resourceMonitor,
     std::shared_ptr<arangodb::velocypack::Builder> builder)
     : _resourceMonitor(resourceMonitor),
       _builder(std::move(builder)),
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+      _memoryUsage(0),
+#endif
       _processed(false) {
   process();
 }
 
 BindParameters::~BindParameters() {
-  std::size_t memoryUsed = 0;
+  std::size_t totalUsed = 0;
   for (auto const& it : _parameters) {
-    memoryUsed += memoryUsage(it.first, it.second.first);
+    totalUsed += memoryUsage(it.first, it.second.first);
   }
-  _resourceMonitor.decreaseMemoryUsage(memoryUsed);
+  _resourceMonitor.decreaseMemoryUsage(totalUsed);
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  TRI_ASSERT(totalUsed == _memoryUsage);
+#endif
 }
 
 /// @brief create a hash value for the bind parameters
@@ -64,6 +75,20 @@ uint64_t BindParameters::hash() const {
   // we can get away with the fast hash function here, as we're only using the
   // hash for quickly checking whether we've seen the same set of parameters
   return _builder->slice().hash();
+}
+
+/// @brief validates that all bind parameters that were declared have
+/// actually been used in the query.
+/// will throw if there is at least one declared, but unused bind parameter.
+void BindParameters::validateAllUsed() const {
+  // visit all bind parameters to ensure that they have all been accessed via
+  // registerNode
+  visit([](std::string const& key, velocypack::Slice /*value*/, AstNode* node) {
+    if (node == nullptr) {
+      THROW_ARANGO_EXCEPTION_PARAMS(TRI_ERROR_QUERY_BIND_PARAMETER_UNDECLARED,
+                                    key.c_str());
+    }
+  });
 }
 
 /// @brief return a bind parameter value and its corresponding AstNode by
@@ -183,6 +208,9 @@ void BindParameters::process() {
         _parameters.try_emplace(std::move(key), value, nullptr).second;
     TRI_ASSERT(inserted);
 
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+    _memoryUsage += guard.tracked();
+#endif
     // now we are responsible for tracking the memory usage
     guard.steal();
   }

--- a/arangod/Aql/BindParameters.h
+++ b/arangod/Aql/BindParameters.h
@@ -41,9 +41,9 @@ class Builder;
 namespace aql {
 struct AstNode;
 
-typedef std::unordered_map<std::string,
-                           std::pair<arangodb::velocypack::Slice, AstNode*>>
-    BindParametersType;
+using BindParametersType =
+    std::unordered_map<std::string,
+                       std::pair<arangodb::velocypack::Slice, AstNode*>>;
 
 class BindParameters {
  public:
@@ -59,6 +59,11 @@ class BindParameters {
 
   /// @brief destroy the parameters
   ~BindParameters();
+
+  /// @brief validates that all bind parameters that were declared have
+  /// actually been used in the query.
+  /// will throw if there is at least one declared, but unused bind parameter.
+  void validateAllUsed() const;
 
   /// @brief return a bind parameter value and its corresponding AstNode by
   /// parameter name. will return VPackSlice::noneSlice() if the bind parameter
@@ -102,6 +107,11 @@ class BindParameters {
 
   /// @brief bind parameters map, indexed by name
   BindParametersType _parameters;
+
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  /// @brief memory used by bind parameters
+  size_t _memoryUsage;
+#endif
 
   /// @brief internal state
   bool _processed;

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -392,8 +392,8 @@ ConditionPart::ConditionPart(Variable const* variable,
     valueNode = operatorNode->getMember(1);
   } else {
     valueNode = operatorNode->getMember(0);
-    if (Ast::IsReversibleOperator(operatorType)) {
-      operatorType = Ast::ReverseOperator(operatorType);
+    if (Ast::isReversibleOperator(operatorType)) {
+      operatorType = Ast::reverseOperator(operatorType);
     }
   }
 
@@ -1762,8 +1762,8 @@ bool Condition::canRemove(ExecutionPlan const* plan, ConditionPart const& me,
               // non-constant condition
               else {
                 auto opType = operand->type;
-                if (aql::Ast::IsReversibleOperator(opType)) {
-                  opType = aql::Ast::ReverseOperator(opType);
+                if (aql::Ast::isReversibleOperator(opType)) {
+                  opType = aql::Ast::reverseOperator(opType);
                 }
                 if (me.operatorType == opType &&
                     normalize(me.valueNode) == normalize(lhs)) {
@@ -1889,7 +1889,7 @@ AstNode* Condition::transformNodePreorder(
     auto old = node;
 
     // create a new n-ary node
-    node = _ast->createNode(Ast::NaryOperatorType(old->type));
+    node = _ast->createNode(Ast::naryOperatorType(old->type));
     _ast->resources().reserveChildNodes(node, 2);
     node->addMember(
         transformNodePreorder(old->getMember(0), conditionOptimization));

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -1153,7 +1153,7 @@ void immutableSearchCondition(Optimizer* opt,
     uint32_t count = 0;
     while (true) {
       auto const type = condition->type;
-      if (!Ast::IsOrOperatorType(type) && !Ast::IsAndOperatorType(type)) {
+      if (!Ast::isOrOperatorType(type) && !Ast::isAndOperatorType(type)) {
         break;
       }
       auto const numMembers = condition->numMembers();

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -5885,19 +5885,19 @@ struct RemoveRedundantOr {
       if (hasRedundantConditionWalker(rhs) &&
           !hasRedundantConditionWalker(lhs) && lhs->isConstant()) {
         if (!isComparisonSet) {
-          comparison = Ast::ReverseOperator(type);
+          comparison = Ast::reverseOperator(type);
           bestValue = lhs;
           isComparisonSet = true;
           return true;
         }
 
-        int lowhigh = isCompatibleBound(Ast::ReverseOperator(type), lhs);
+        int lowhigh = isCompatibleBound(Ast::reverseOperator(type), lhs);
         if (lowhigh == 0) {
           return false;
         }
 
         if (compareBounds(type, lhs, lowhigh)) {
-          comparison = Ast::ReverseOperator(type);
+          comparison = Ast::reverseOperator(type);
           bestValue = lhs;
         }
         return true;
@@ -7242,10 +7242,10 @@ static bool applyGeoOptimization(ExecutionPlan* plan, LimitNode* ln,
   for (std::pair<ExecutionNode*, Expression*> pair : info.exesToModify) {
     AstNode* root = pair.second->nodeForModification();
     auto pre = [&](AstNode const* node) -> bool {
-      return node == root || Ast::IsAndOperatorType(node->type);
+      return node == root || Ast::isAndOperatorType(node->type);
     };
     auto visitor = [&](AstNode* node) -> AstNode* {
-      if (Ast::IsAndOperatorType(node->type)) {
+      if (Ast::isAndOperatorType(node->type)) {
         std::vector<AstNode*> keep;  // always shallow copy node
         for (std::size_t i = 0; i < node->numMembers(); i++) {
           AstNode* child = node->getMemberUnchecked(i);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -420,7 +420,10 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   parser.parse();
 
   // put in bind parameters
-  parser.ast()->injectBindParameters(_bindParameters, this->resolver());
+  parser.ast()->injectBindParametersFirstStage(_bindParameters,
+                                               this->resolver());
+  parser.ast()->injectBindParametersSecondStage(_bindParameters);
+  _bindParameters.validateAllUsed();
 
   if (parser.ast()->containsUpsertNode()) {
     // UPSERTs and intermediate commits do not play nice together, because the
@@ -1021,7 +1024,10 @@ QueryResult Query::explain() {
     parser.parse();
 
     // put in bind parameters
-    parser.ast()->injectBindParameters(_bindParameters, this->resolver());
+    parser.ast()->injectBindParametersFirstStage(_bindParameters,
+                                                 this->resolver());
+    parser.ast()->injectBindParametersSecondStage(_bindParameters);
+    _bindParameters.validateAllUsed();
 
     // optimize and validate the ast
     enterState(QueryExecutionState::ValueType::AST_OPTIMIZATION);

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -105,12 +105,7 @@ AstNodeType buildSingleComparatorType(AstNode const* condition) {
   TRI_ASSERT(quantifier->type == NODE_TYPE_QUANTIFIER);
   TRI_ASSERT(!Quantifier::isAny(quantifier));
   if (Quantifier::isNone(quantifier)) {
-    auto it = Ast::NegatedOperators.find(type);
-    if (it == Ast::NegatedOperators.end()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "unsupported operator type");
-    }
-    type = it->second;
+    type = Ast::negateOperator(type);
   }
   return type;
 }

--- a/arangod/Aql/grammar.cpp
+++ b/arangod/Aql/grammar.cpp
@@ -1111,7 +1111,7 @@ static const yytype_int16 yyrline[] =
     2192,  2195,  2201,  2204,  2210,  2242,  2245,  2248,  2252,  2261,
     2261,  2276,  2291,  2304,  2317,  2317,  2355,  2355,  2406,  2409,
     2415,  2419,  2426,  2429,  2432,  2435,  2438,  2444,  2449,  2454,
-    2465,  2473,  2480,  2488,  2495,  2498,  2503
+    2465,  2473,  2480,  2488,  2496,  2499,  2504
 };
 #endif
 
@@ -5724,38 +5724,39 @@ yyreduce:
   case 273: /* bind_parameter_datasource_expected: "bind parameter"  */
 #line 2488 "grammar.y"
                 {
+      // convert normal value bind parameter into datasource bind parameter
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       (yyval.node) = parser->ast()->createNodeParameterDatasource(name);
     }
-#line 5730 "grammar.cpp"
+#line 5731 "grammar.cpp"
     break;
 
   case 274: /* object_element_name: "identifier"  */
-#line 2495 "grammar.y"
+#line 2496 "grammar.y"
              {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 5738 "grammar.cpp"
+#line 5739 "grammar.cpp"
     break;
 
   case 275: /* object_element_name: "quoted string"  */
-#line 2498 "grammar.y"
+#line 2499 "grammar.y"
                     {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 5746 "grammar.cpp"
+#line 5747 "grammar.cpp"
     break;
 
   case 276: /* variable_name: "identifier"  */
-#line 2503 "grammar.y"
+#line 2504 "grammar.y"
              {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 5754 "grammar.cpp"
+#line 5755 "grammar.cpp"
     break;
 
 
-#line 5758 "grammar.cpp"
+#line 5759 "grammar.cpp"
 
       default: break;
     }

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -2486,6 +2486,7 @@ bind_parameter_datasource_expected:
       $$ = parser->ast()->createNodeParameterDatasource(name);
     }
   | T_PARAMETER {
+      // convert normal value bind parameter into datasource bind parameter
       std::string_view name($1.value, $1.length);
       $$ = parser->ast()->createNodeParameterDatasource(name);
     }

--- a/arangod/GeoIndex/Index.cpp
+++ b/arangod/GeoIndex/Index.cpp
@@ -323,7 +323,7 @@ void Index::handleNode(aql::AstNode const* node, aql::Variable const* ref,
 void Index::parseCondition(aql::AstNode const* node,
                            aql::Variable const* reference,
                            geo::QueryParams& params, bool legacy) {
-  if (aql::Ast::IsAndOperatorType(node->type)) {
+  if (aql::Ast::isAndOperatorType(node->type)) {
     for (size_t i = 0; i < node->numMembers(); i++) {
       handleNode(node->getMemberUnchecked(i), reference, params, legacy);
     }

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -1026,7 +1026,7 @@ AttributeAccessParts::AttributeAccessParts(aql::AstNode const* comparison,
     // got value == a.b  ->  flip the two sides
     attribute = comparison->getMember(1);
     value = comparison->getMember(0);
-    opType = aql::Ast::ReverseOperator(opType);
+    opType = aql::Ast::reverseOperator(opType);
   }
 
   TRI_ASSERT(attribute->type == aql::NODE_TYPE_ATTRIBUTE_ACCESS);

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -539,9 +539,9 @@ arangodb::aql::AstNode* SortedIndexAttributeMatcher::specializeCondition(
       }
 
       arangodb::aql::AstNodeType type = it->type;
-      if (arangodb::aql::Ast::IsReversibleOperator(type) &&
+      if (arangodb::aql::Ast::isReversibleOperator(type) &&
           it->getMember(1)->isAttributeAccessForVariable(reference, false)) {
-        type = arangodb::aql::Ast::ReverseOperator(type);
+        type = arangodb::aql::Ast::reverseOperator(type);
       }
 
       // do not let duplicate or related operators pass


### PR DESCRIPTION
### Scope & Purpose

Initial development for https://arangodb.atlassian.net/browse/EF-54

split injection of bind parameters into query AST into 2 different functions:

1. injection of all bind parameters that are absolutely required by the optimizer to figure out the sense of the query. this phase will inject collection bind parameter values (e.g. `@@collection`) and bind parameters that include attribute names (e.g. `doc.@attr`). no value bind parameters will be injected in this phase.
2. injection of all value bind parameters into the query.

by splitting the bind parameter injection into 2 functions, we can later move the second injection to a later point in the query processing, so that value bind parameters can get injected into the query after the final query plan has been created.
this could help future developments such as query plan caching or prepared statements.

note: this PR only splits the injection into two separate functions, but does not move the injection of value bind parameters to a later point. this can be attempted in separate PRs.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/EF-54
- [ ] Design document: 