### PR TITLE
Fix BTS-1808

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* BTS-1808: fix arangodump format for ZKD indexes. Previously the structural
+  dump of ZKD indexes was missing the "fieldValueTypes" attribute, which was
+  necessary to restore a ZKD index at least in the cluster.
+
 * Updated ArangoDB Starter to v0.18.4-preview-1 and arangosync to v2.19.7-preview-1
 
 

--- a/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBZkdIndex.cpp
@@ -631,6 +631,10 @@ void RocksDBZkdIndexBase::toVelocyPack(
 
     builder.close();
   }
+
+  // TODO: currently hard-coded to "double". future implementations
+  // of ZKD indexes may make this dynamic
+  builder.add("fieldValueTypes", VPackValue("double"));
 }
 
 Index::FilterCosts RocksDBZkdIndexBase::supportsFilterCondition(


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-1808

* BTS-1808: fix arangodump format for ZKD indexes. Previously the structural dump of ZKD indexes was missing the "fieldValueTypes" attribute, which was necessary to restore a ZKD index at least in the cluster.

A test for this is contained in most recent versions of `rta_makedata`.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [x] Backport for 3.10: https://github.com/arangodb/arangodb/pull/20710

#### Related Information

- [ ] Docs PR: 
- [] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1808
- [ ] Design document: 