### PR TITLE
Fix: indexes are removed when collection is marked as deleted

### DIFF
--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -244,7 +244,8 @@ void RocksDBTransactionCollection::commitCounts(TransactionId trxId,
   for (auto& pair : _trackedIndexOperations) {
     auto idx = _collection->lookupIndex(pair.first);
     if (ADB_UNLIKELY(idx == nullptr)) {
-      TRI_ASSERT(false);  // Index reported estimates, but does not exist
+      // Index reported estimates, but does not exist
+      TRI_ASSERT(_collection->deleted());
       continue;
     }
     auto ridx = static_cast<RocksDBIndex*>(idx.get());


### PR DESCRIPTION
### Scope & Purpose

This PR fixes an assertion that sporadically occurs in replication2 tests (primarily in tsan/ubsan builds, but not exclusively).

In the test, we only communicate the leader, and once we have received the response from the leader, we consider the test finished, so the teardown cleans up and deletes the database. The problem is, that with replication2, the follower perform operations asynchronously, so it can happen that the test drops the database while the follower is still busy applying the changes. Even though we do not immediately drop the DB while it is still in use, we mark the DB and all its collections as deleted, and at the same time _remove all the indexes from the collection_. And this then caused the assertion failure when we try to commit the ongoing transaction and realize that we have tracked index updates, but can not longer find the index.

- [x] :hankey: Bugfix
