### PR TITLE
[EF-51] Extend ExecContext's lifetime

### DIFF
--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -447,7 +447,7 @@ class ExecutionBlockImpl final : public ExecutionBlock {
       LogContext logContext;
     };
 
-    void run(std::unique_ptr<ExecContext> execContext);
+    void run(std::shared_ptr<ExecContext const> execContext);
     std::atomic<State> _state{State::Waiting};
     Params* _params;
     ExecutionBlockImpl& _block;

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -2566,7 +2566,7 @@ template<class Executor>
 ExecutionBlockImpl<Executor>::CallstackSplit::CallstackSplit(
     ExecutionBlockImpl& block)
     : _block(block),
-      _thread(&CallstackSplit::run, this, ExecContext::current().clone()) {}
+      _thread(&CallstackSplit::run, this, ExecContext::currentAsShared()) {}
 
 template<class Executor>
 ExecutionBlockImpl<Executor>::CallstackSplit::~CallstackSplit() {
@@ -2608,8 +2608,8 @@ auto ExecutionBlockImpl<Executor>::CallstackSplit::execute(
 
 template<class Executor>
 void ExecutionBlockImpl<Executor>::CallstackSplit::run(
-    std::unique_ptr<ExecContext> execContext) {
-  ExecContextScope scope(execContext.get());
+    std::shared_ptr<ExecContext const> execContext) {
+  ExecContextScope scope(execContext);
   std::unique_lock<std::mutex> guard(_lock);
   while (true) {
     _bell.wait(guard, [this]() {

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -178,8 +178,8 @@ futures::Future<Result> RestHandler::forwardRequest(bool& forwarded) {
   // we must use the request's permissions here and set them in the
   // thread-local variable when calling forwardingTarget().
   // this is because forwardingTarget() may run permission checks.
-  ExecContext* exec = static_cast<ExecContext*>(_request->requestContext());
-  ExecContextScope scope(exec);
+  ExecContextScope scope(
+      basics::downCast<ExecContext>(_request->requestContext()));
 
   ResultT forwardResult = forwardingTarget();
   if (forwardResult.fail()) {
@@ -482,8 +482,8 @@ bool RestHandler::wakeupHandler() {
 
 void RestHandler::executeEngine(bool isContinue) {
   DTRACE_PROBE1(arangod, RestHandlerExecuteEngine, this);
-  ExecContext* exec = static_cast<ExecContext*>(_request->requestContext());
-  ExecContextScope scope(exec);
+  ExecContextScope scope(
+      basics::downCast<ExecContext>(_request->requestContext()));
 
   try {
     RestStatus result = RestStatus::DONE;

--- a/arangod/RestHandler/RestBatchHandler.cpp
+++ b/arangod/RestHandler/RestBatchHandler.cpp
@@ -214,8 +214,7 @@ bool RestBatchHandler::executeNextHandler() {
   }
 
   // inject the request context from the framing (batch) request
-  // the "false" means the context is not responsible for resource handling
-  request->setRequestContext(_request->requestContext(), false);
+  request->setRequestContext(_request->requestContext());
   request->setDatabaseName(_request->databaseName());
 
   if (bodyLength > 0) {

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -470,8 +470,7 @@ RestStatus RestIndexHandler::createIndex() {
   VPackBuilder indexInfo;
   indexInfo.add(body);
 
-  auto execContext = std::unique_ptr<VocbaseContext>(
-      VocbaseContext::create(*_request, _vocbase));
+  auto execContext = VocbaseContext::create(*_request, _vocbase);
   // this is necessary, because the execContext will release the vocbase in its
   // dtor
   if (!_vocbase.use()) {
@@ -484,7 +483,7 @@ RestStatus RestIndexHandler::createIndex() {
   auto cb = [this, self = shared_from_this(),
              execContext = std::move(execContext), collection = std::move(coll),
              body = std::move(indexInfo)] {
-    ExecContextScope scope(execContext.get());
+    ExecContextScope scope(std::move(execContext));
     {
       std::unique_lock<std::mutex> locker(_mutex);
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3459,7 +3459,7 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
   // if we are not using superuser scope here and the leader is
   // read-only, trying to grab the lock in exclusive mode will
   // return a "read-only" error.
-  ExecContextScope scope(&ExecContext::superuser());
+  ExecContextScope scope(ExecContext::superuserAsShared());
 
   transaction::Manager* mgr = transaction::ManagerFeature::manager();
   TRI_ASSERT(mgr != nullptr);

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -213,7 +213,7 @@ RestVocbaseBaseHandler::RestVocbaseBaseHandler(ArangodServer& server,
                                                GeneralRequest* request,
                                                GeneralResponse* response)
     : RestBaseHandler(server, request, response),
-      _context(*static_cast<VocbaseContext*>(request->requestContext())),
+      _context(static_cast<VocbaseContext&>(*request->requestContext())),
       _vocbase(_context.vocbase()),
       _scopeVocbaseValues(
           LogContext::makeValue()

--- a/arangod/RestServer/VocbaseContext.h
+++ b/arangod/RestServer/VocbaseContext.h
@@ -37,7 +37,8 @@ class VocbaseContext final : public arangodb::ExecContext {
  public:
   ~VocbaseContext();
 
-  static VocbaseContext* create(GeneralRequest& req, TRI_vocbase_t& vocbase);
+  static std::shared_ptr<VocbaseContext> create(GeneralRequest& req,
+                                                TRI_vocbase_t& vocbase);
   TEST_VIRTUAL TRI_vocbase_t& vocbase() const { return _vocbase; }
 
   /// @brief upgrade to internal superuser
@@ -71,7 +72,10 @@ class VocbaseContext final : public arangodb::ExecContext {
   /// should be used to indicate a canceled request / thread
   std::atomic<bool> _canceled;
 
-  VocbaseContext(GeneralRequest& req, TRI_vocbase_t& vocbase,
+  class ConstructorToken {};
+
+ public:
+  VocbaseContext(ConstructorToken, GeneralRequest& req, TRI_vocbase_t& vocbase,
                  ExecContext::Type type, auth::Level systemLevel,
                  auth::Level dbLevel, bool isAdminUser);
   VocbaseContext(VocbaseContext const&) = delete;

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -29,32 +29,43 @@
 #include "GeneralServer/AuthenticationFeature.h"
 #include "VocBase/vocbase.h"
 
+#include "Logger/LogMacros.h"
+
 using namespace arangodb;
 
-thread_local ExecContext const* ExecContext::CURRENT = nullptr;
+thread_local std::shared_ptr<ExecContext const> ExecContext::CURRENT = nullptr;
 
-ExecContext const ExecContext::Superuser(ExecContext::Type::Internal,
-                                         /*name*/ "", /*db*/ "",
-                                         auth::Level::RW, auth::Level::RW,
-                                         true);
+std::shared_ptr<ExecContext const> const ExecContext::Superuser =
+    std::make_shared<ExecContext const>(
+        ExecContext::ConstructorToken{}, ExecContext::Type::Internal,
+        /*name*/ "", /*db*/ "", auth::Level::RW, auth::Level::RW, true);
 
 /// Should always contain a reference to current user context
 /*static*/ ExecContext const& ExecContext::current() {
   if (ExecContext::CURRENT != nullptr) {
     return *ExecContext::CURRENT;
   }
-  return ExecContext::Superuser;
+  return *ExecContext::Superuser;
+}
+/// Note that this intentionally returns CURRENT, even if it is a nullptr: This
+/// makes it suitable to set CURRENT in another thread.
+/*static*/ std::shared_ptr<ExecContext const> ExecContext::currentAsShared() {
+  return ExecContext::CURRENT;
 }
 
 /// @brief an internal superuser context, is
 ///        a singleton instance, deleting is an error
 /*static*/ ExecContext const& ExecContext::superuser() {
+  return *ExecContext::Superuser;
+}
+/*static*/ std::shared_ptr<ExecContext const> ExecContext::superuserAsShared() {
   return ExecContext::Superuser;
 }
 
-ExecContext::ExecContext(ExecContext::Type type, std::string const& user,
-                         std::string const& database, auth::Level systemLevel,
-                         auth::Level dbLevel, bool isAdminUser)
+ExecContext::ExecContext(ConstructorToken, ExecContext::Type type,
+                         std::string const& user, std::string const& database,
+                         auth::Level systemLevel, auth::Level dbLevel,
+                         bool isAdminUser)
     : _user(user),
       _database(database),
       _type(type),
@@ -65,28 +76,13 @@ ExecContext::ExecContext(ExecContext::Type type, std::string const& user,
   TRI_ASSERT(_databaseAuthLevel != auth::Level::UNDEFINED);
 }
 
-std::unique_ptr<ExecContext> ExecContext::clone() const {
-  // ExecContext does not have a public ctor, so we can't use plain
-  // std::make_unique. this workaround makes it work though.
-  struct Cloner final : public ExecContext {
-    Cloner(ExecContext::Type type, std::string const& user,
-           std::string const& database, auth::Level systemLevel,
-           auth::Level dbLevel, bool isAdminUser)
-        : ExecContext(type, user, database, systemLevel, dbLevel, isAdminUser) {
-    }
-  };
-
-  return std::make_unique<Cloner>(_type, _user, _database, _systemDbAuthLevel,
-                                  _databaseAuthLevel, _isAdminUser);
-}
-
 /*static*/ bool ExecContext::isAuthEnabled() {
   AuthenticationFeature* af = AuthenticationFeature::instance();
   TRI_ASSERT(af != nullptr);
   return af->isActive();
 }
 
-std::unique_ptr<ExecContext> ExecContext::create(std::string const& user,
+std::shared_ptr<ExecContext> ExecContext::create(std::string const& user,
                                                  std::string const& dbname) {
   AuthenticationFeature* af = AuthenticationFeature::instance();
   TRI_ASSERT(af != nullptr);
@@ -111,11 +107,10 @@ std::unique_ptr<ExecContext> ExecContext::create(std::string const& user,
                                           true) == auth::Level::RW;
     }
   }
-  // we cannot use std::make_unique here, as ExecContext has a protected
-  // constructor
-  auto* ptr = new ExecContext(ExecContext::Type::Default, user, dbname, sysLvl,
-                              dbLvl, isAdminUser);
-  return std::unique_ptr<ExecContext>(ptr);
+
+  return std::make_shared<ExecContext>(ExecContext::ConstructorToken{},
+                                       ExecContext::Type::Default, user, dbname,
+                                       sysLvl, dbLvl, isAdminUser);
 }
 
 bool ExecContext::canUseDatabase(std::string const& db,
@@ -179,3 +174,10 @@ auth::Level ExecContext::collectionAuthLevel(std::string const& dbname,
   }
   return um->collectionAuthLevel(_user, dbname, coll);
 }
+
+ExecContextScope::ExecContextScope(std::shared_ptr<ExecContext const> exe)
+    : _old(std::move(exe)) {
+  std::swap(ExecContext::CURRENT, _old);
+}
+
+ExecContextScope::~ExecContextScope() { std::swap(ExecContext::CURRENT, _old); }

--- a/arangod/VocBase/Methods/Tasks.h
+++ b/arangod/VocBase/Methods/Tasks.h
@@ -87,7 +87,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
  private:
   void toVelocyPack(velocypack::Builder&) const;
-  void work(ExecContext const*);
+  void work();
   bool queue(std::chrono::microseconds offset) ADB_WARN_UNUSED_RESULT;
   std::function<void(bool cancelled)> callbackFunction();
   std::string const& name() const { return _name; }

--- a/lib/Futures/include/Futures/coro-helper.h
+++ b/lib/Futures/include/Futures/coro-helper.h
@@ -58,12 +58,16 @@ namespace std_coro = std;
 namespace arangodb::futures {
 template<typename T>
 class Future;
+
+void logExecContextSwitch(ExecContext const* previous,
+                          ExecContext const* next) noexcept;
+
 template<typename T>
 struct FutureAwaitable {
   [[nodiscard]] auto await_ready() const noexcept -> bool { return false; }
   bool await_suspend(std_coro::coroutine_handle<> coro) noexcept {
     // returning false resumes `coro`
-    _execContext = &ExecContext::current();
+    _execContext = ExecContext::currentAsShared();
     std::move(_future).thenFinal(
         [coro, this](futures::Try<T>&& result) mutable noexcept {
           _result = std::move(result);
@@ -81,7 +85,7 @@ struct FutureAwaitable {
   std::atomic_uint8_t _counter{2};
   Future<T> _future;
   std::optional<futures::Try<T>> _result;
-  ExecContext const* _execContext;
+  std::shared_ptr<ExecContext const> _execContext;
 };
 
 /// See below at (*) for an explanation why we need this operator co_await
@@ -97,7 +101,7 @@ struct FutureTransformAwaitable : F {
   [[nodiscard]] auto await_ready() const noexcept -> bool { return false; }
   bool await_suspend(std_coro::coroutine_handle<> coro) noexcept {
     // returning false resumes `coro`
-    _execContext = &ExecContext::current();
+    _execContext = ExecContext::currentAsShared();
     std::move(_future).thenFinal(
         [coro, this](futures::Try<T>&& result) noexcept {
           _result = F::operator()(std::move(result));
@@ -120,7 +124,7 @@ struct FutureTransformAwaitable : F {
   std::atomic_uint8_t _counter{2};
   Future<T> _future;
   std::optional<ResultType> _result;
-  ExecContext const* _execContext;
+  std::shared_ptr<ExecContext const> _execContext;
 };
 
 template<typename T>

--- a/lib/Futures/include/Futures/coro-helper.h
+++ b/lib/Futures/include/Futures/coro-helper.h
@@ -59,9 +59,6 @@ namespace arangodb::futures {
 template<typename T>
 class Future;
 
-void logExecContextSwitch(ExecContext const* previous,
-                          ExecContext const* next) noexcept;
-
 template<typename T>
 struct FutureAwaitable {
   [[nodiscard]] auto await_ready() const noexcept -> bool { return false; }

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -60,7 +60,7 @@ GeneralRequest::GeneralRequest(ConnectionInfo const& connectionInfo,
                                uint64_t mid)
     : _connectionInfo(connectionInfo),
       _messageId(mid),
-      _requestContext(nullptr),
+      _requestContext(),
       _tokenExpiry(0.0),
       _memoryUsage(0),
       _authenticationMethod(rest::AuthenticationMethod::NONE),
@@ -68,15 +68,7 @@ GeneralRequest::GeneralRequest(ConnectionInfo const& connectionInfo,
       _contentType(ContentType::UNSET),
       _contentTypeResponse(ContentType::UNSET),
       _acceptEncoding(EncodingType::UNSET),
-      _isRequestContextOwner(false),
       _authenticated(false) {}
-
-GeneralRequest::~GeneralRequest() {
-  // only delete if we are the owner of the context
-  if (_requestContext != nullptr && _isRequestContextOwner) {
-    delete _requestContext;
-  }
-}
 
 std::string_view GeneralRequest::translateMethod(RequestType method) {
   switch (method) {
@@ -167,21 +159,11 @@ rest::RequestType GeneralRequest::findRequestType(char const* ptr,
   return RequestType::ILLEGAL;
 }
 
-void GeneralRequest::setRequestContext(RequestContext* requestContext,
-                                       bool isRequestContextOwner) {
+void GeneralRequest::setRequestContext(
+    std::shared_ptr<RequestContext> requestContext) {
   TRI_ASSERT(requestContext != nullptr);
 
-  if (_requestContext) {
-    // if we have a shared context, we should not have got here
-    TRI_ASSERT(isRequestContextOwner);
-
-    // delete any previous context
-    TRI_ASSERT(false);
-    delete _requestContext;
-  }
-
-  _requestContext = requestContext;
-  _isRequestContextOwner = isRequestContextOwner;
+  _requestContext = std::move(requestContext);
 }
 
 void GeneralRequest::setPayload(velocypack::Buffer<uint8_t> buffer) {

--- a/lib/Rest/GeneralRequest.h
+++ b/lib/Rest/GeneralRequest.h
@@ -59,7 +59,7 @@ class GeneralRequest {
 
   explicit GeneralRequest(ConnectionInfo const& connectionInfo, uint64_t mid);
 
-  virtual ~GeneralRequest();
+  virtual ~GeneralRequest() = default;
 
   // translate an RequestType enum value into an "HTTP method string"
   static std::string_view translateMethod(RequestType);
@@ -90,11 +90,12 @@ class GeneralRequest {
   void setUser(std::string user);
 
   /// @brief the request context depends on the application
-  RequestContext* requestContext() const { return _requestContext; }
+  std::shared_ptr<RequestContext> requestContext() const {
+    return _requestContext;
+  }
 
-  /// @brief set request context and whether this requests is allowed
-  ///        to delete it
-  void setRequestContext(RequestContext*, bool);
+  /// @brief set request context
+  void setRequestContext(std::shared_ptr<RequestContext>);
 
   RequestType requestType() const { return _type; }
 
@@ -239,7 +240,7 @@ class GeneralRequest {
   uint64_t const _messageId;
 
   // request context (might contain vocbase)
-  RequestContext* _requestContext;
+  std::shared_ptr<RequestContext> _requestContext;
 
   double _tokenExpiry;
 
@@ -252,7 +253,6 @@ class GeneralRequest {
   ContentType _contentType;  // UNSET, VPACK, JSON
   ContentType _contentTypeResponse;
   EncodingType _acceptEncoding;
-  bool _isRequestContextOwner;
   bool _authenticated;
 };
 }  // namespace arangodb

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -481,7 +481,7 @@ class IResearchAnalyzerFeatureTest
                               // configuration from system database
   }
 
-  std::unique_ptr<arangodb::ExecContext> getLoggedInContext() const {
+  std::shared_ptr<arangodb::ExecContext> getLoggedInContext() const {
     return arangodb::ExecContext::create("testUser", "testVocbase");
   }
 
@@ -508,7 +508,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_no_vocbase_read) {
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::NONE, arangodb::auth::Level::NONE);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   EXPECT_FALSE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RO));
 }
@@ -519,7 +519,7 @@ TEST_F(IResearchAnalyzerFeatureTest,
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::NONE, arangodb::auth::Level::RO);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   EXPECT_FALSE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RO));
 }
@@ -529,7 +529,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_none) {
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::RO, arangodb::auth::Level::NONE);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   // implicit RO access to collection _analyzers collection granted due to RO
   // access to db
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
@@ -543,7 +543,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_ro) {
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::RO, arangodb::auth::Level::RO);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RO));
   EXPECT_FALSE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
@@ -554,7 +554,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_rw) {
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::RO, arangodb::auth::Level::RW);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RO));
   EXPECT_FALSE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
@@ -565,7 +565,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_rw_collection_ro) {
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::RW, arangodb::auth::Level::RO);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RO));
   // implicit access for system analyzers collection granted due to RW access to
@@ -578,7 +578,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_rw_collection_rw) {
   TRI_vocbase_t vocbase(testDBInfo(server.server()));
   userSetAccessLevel(arangodb::auth::Level::RW, arangodb::auth::Level::RW);
   auto ctxt = getLoggedInContext();
-  arangodb::ExecContextScope execContextScope(ctxt.get());
+  arangodb::ExecContextScope execContextScope(ctxt);
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RO));
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -442,11 +442,13 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -855,11 +857,13 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_with_link) {
   {
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -4466,11 +4470,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_links_partial_add) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -6049,11 +6055,13 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -6281,11 +6289,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -6412,11 +6422,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
     arangodb::auth::UserMap userMap;    // empty map, no user -> no permissions
@@ -6526,11 +6538,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -6698,11 +6712,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -6898,11 +6914,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7186,11 +7204,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7317,11 +7337,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
     arangodb::auth::UserMap userMap;    // empty map, no user -> no permissions
@@ -7429,11 +7451,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7609,11 +7633,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7809,11 +7835,13 @@ TEST_F(IResearchViewCoordinatorTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -331,11 +331,13 @@ TEST_F(IResearchViewTest, test_defaults) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
     arangodb::auth::UserMap userMap;    // empty map, no user -> no permissions
@@ -1999,11 +2001,13 @@ TEST_F(IResearchViewTest, test_drop_with_link) {
   {
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7162,11 +7166,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7264,11 +7270,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
     arangodb::auth::UserMap userMap;    // empty map, no user -> no permissions
@@ -7327,11 +7335,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7436,11 +7446,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7559,11 +7571,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7672,11 +7686,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scopedExecContext(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7781,11 +7797,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scopedExecContext(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -7905,11 +7923,13 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scopedExecContext(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -9920,11 +9940,13 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -10022,11 +10044,13 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope scope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
     arangodb::auth::UserMap userMap;    // empty map, no user -> no permissions
@@ -10085,11 +10109,13 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -10194,11 +10220,13 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -10318,11 +10346,13 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 

--- a/tests/IResearch/RestHandlerMock.cpp
+++ b/tests/IResearch/RestHandlerMock.cpp
@@ -29,15 +29,12 @@
 GeneralRequestMock::GeneralRequestMock(TRI_vocbase_t& vocbase)
     : arangodb::GeneralRequest(arangodb::ConnectionInfo{}, 1) {
   _authenticated = false;  // must be set before VocbaseContext::create(...)
-  _isRequestContextOwner =
-      false;  // must be set before VocbaseContext::create(...)
-  _context.reset(arangodb::VocbaseContext::create(*this, vocbase));
+  _context = arangodb::VocbaseContext::create(*this, vocbase);
   _context->vocbase().forceUse();  // must be called or ~VocbaseContext() will
                                    // fail at '_vocbase.release()'
   _requestContext =
-      _context
-          .get();  // do not use setRequestContext(...) since '_requestContext'
-                   // has not been initialized and contains garbage
+      _context;  // do not use setRequestContext(...) since '_requestContext'
+                 // has not been initialized and contains garbage
 }
 GeneralRequestMock::~GeneralRequestMock() = default;
 

--- a/tests/IResearch/RestHandlerMock.h
+++ b/tests/IResearch/RestHandlerMock.h
@@ -38,7 +38,7 @@ class VocbaseContext;
 
 struct GeneralRequestMock : public arangodb::GeneralRequest {
   int64_t _contentLength;
-  std::unique_ptr<arangodb::VocbaseContext>
+  std::shared_ptr<arangodb::VocbaseContext>
       _context;  // VocbaseContext required for use with RestVocbaseBaseHandler
   arangodb::velocypack::Builder _payload;  // request body
 

--- a/tests/RestHandler/RestAnalyzerHandlerTest.cpp
+++ b/tests/RestHandler/RestAnalyzerHandlerTest.cpp
@@ -111,11 +111,13 @@ class RestAnalyzerHandlerTest
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, "", "",
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope;  // (&execContext);
+  };
+  std::shared_ptr<ExecContext> execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope;  // (execContext);
 
   RestAnalyzerHandlerTest()
       : server(),
@@ -126,7 +128,7 @@ class RestAnalyzerHandlerTest
         authFeature(server.getFeature<arangodb::AuthenticationFeature>()),
         userManager(authFeature.userManager()),
         execContext(),
-        execContextScope(&execContext) {
+        execContextScope(execContext) {
     grantOnDb(arangodb::StaticStrings::SystemDatabase,
               arangodb::auth::Level::RW);
 

--- a/tests/RestHandler/RestAnalyzerHandlerTest.cpp
+++ b/tests/RestHandler/RestAnalyzerHandlerTest.cpp
@@ -116,7 +116,7 @@ class RestAnalyzerHandlerTest
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
   };
-  std::shared_ptr<ExecContext> execContext = std::make_shared<ExecContext>();
+  std::shared_ptr<ExecContext> execContext;
   arangodb::ExecContextScope execContextScope;  // (execContext);
 
   RestAnalyzerHandlerTest()
@@ -127,7 +127,7 @@ class RestAnalyzerHandlerTest
         dbFeature(server.getFeature<arangodb::DatabaseFeature>()),
         authFeature(server.getFeature<arangodb::AuthenticationFeature>()),
         userManager(authFeature.userManager()),
-        execContext(),
+        execContext(std::make_shared<ExecContext>()),
         execContextScope(execContext) {
     grantOnDb(arangodb::StaticStrings::SystemDatabase,
               arangodb::auth::Level::RW);

--- a/tests/RestHandler/RestUsersHandlerTest.cpp
+++ b/tests/RestHandler/RestUsersHandlerTest.cpp
@@ -200,12 +200,14 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, userName,
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, userName,
                                 "", arangodb::auth::Level::RW,
                                 arangodb::auth::Level::NONE, true) {
     }  // ExecContext::isAdminUser() == true
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto* authFeature = arangodb::AuthenticationFeature::instance();
   auto* userManager = authFeature->userManager();
   userManager->setGlobalVersion(0);  // required for UserManager::loadFromDB()
@@ -233,7 +235,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = grantHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::NOT_FOUND,
@@ -256,7 +258,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth missing (revoke)
@@ -287,7 +289,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = revokeHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::NOT_FOUND,
@@ -310,7 +312,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(
+         execContext->collectionAuthLevel(
              vocbase->name(), "testDataSource")));  // not modified from above
   }
 
@@ -345,7 +347,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = grantHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::OK, grantResponce.responseCode());
@@ -358,7 +360,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
              slice.get(vocbase->name() + "/testDataSource").copyString()));
     EXPECT_TRUE(
         (arangodb::auth::Level::RW ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth collection (revoke)
@@ -397,7 +399,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = revokeHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::ACCEPTED,
@@ -415,7 +417,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
          false == slice.get(arangodb::StaticStrings::Error).getBoolean()));
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth view (grant)
@@ -449,7 +451,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = grantHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::NOT_FOUND,
@@ -472,7 +474,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth view (revoke)
@@ -511,7 +513,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = revokeHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::NOT_FOUND,
@@ -534,7 +536,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(
+         execContext->collectionAuthLevel(
              vocbase->name(), "testDataSource")));  // not modified from above
   }
 
@@ -569,7 +571,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = grantWildcardHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_EQ(arangodb::rest::ResponseCode::OK,
@@ -583,7 +585,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
              slice.get(vocbase->name() + "/*").copyString()));
     EXPECT_TRUE(
         (arangodb::auth::Level::RW ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth wildcard (revoke)
@@ -622,7 +624,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     auto status = revokeWildcardHandler.execute();
     EXPECT_EQ(arangodb::RestStatus::DONE, status);
     EXPECT_TRUE((arangodb::rest::ResponseCode::ACCEPTED ==
@@ -640,7 +642,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
          false == slice.get(arangodb::StaticStrings::Error).getBoolean()));
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(
+         execContext->collectionAuthLevel(
              vocbase->name(),
              "testDataSource")));  // unchanged since revocation is only for
                                    // exactly matching collection names

--- a/tests/RestHandler/RestViewHandlerTest.cpp
+++ b/tests/RestHandler/RestViewHandlerTest.cpp
@@ -140,11 +140,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -259,11 +261,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -383,11 +387,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -562,11 +568,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -838,11 +846,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -1024,11 +1034,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -1211,11 +1223,13 @@ TEST_F(RestViewHandlerTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -598,11 +598,13 @@ TEST_F(TransactionManagerTest, permission_denied_readonly) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Internal, "dummy",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Internal, "dummy",
                                 "testVocbase", arangodb::auth::Level::RO,
                                 arangodb::auth::Level::RO, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");
@@ -633,11 +635,13 @@ TEST_F(TransactionManagerTest, permission_denied_forbidden) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Internal, "dummy",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Internal, "dummy",
                                 "testVocbase", arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
 
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"read\": [\"42\"]}}");

--- a/tests/Transaction/RestTransactionHandlerTest.cpp
+++ b/tests/Transaction/RestTransactionHandlerTest.cpp
@@ -334,11 +334,13 @@ TEST_F(RestTransactionHandlerTest, permission_denied_read_only) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Internal, "dummy",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Internal, "dummy",
                                 "testVocbase", arangodb::auth::Level::RO,
                                 arangodb::auth::Level::RO, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
 
   request.setRequestType(arangodb::rest::RequestType::POST);
   request.addSuffix("begin");
@@ -376,11 +378,13 @@ TEST_F(RestTransactionHandlerTest, permission_denied_forbidden) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Internal, "dummy",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Internal, "dummy",
                                 "testVocbase", arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
 
   request.setRequestType(arangodb::rest::RequestType::POST);
   request.addSuffix("begin");

--- a/tests/V8Server/V8AnalyzersTest.cpp
+++ b/tests/V8Server/V8AnalyzersTest.cpp
@@ -198,11 +198,13 @@ TEST_F(V8AnalyzerTest, test_instance_accessors) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, "", "",
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto& authFeature = server.getFeature<arangodb::AuthenticationFeature>();
   auto* userManager = authFeature.userManager();
 
@@ -507,11 +509,13 @@ TEST_F(V8AnalyzerTest, test_manager_create) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, "", "",
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto& authFeature = server.getFeature<arangodb::AuthenticationFeature>();
   auto* userManager = authFeature.userManager();
 
@@ -993,11 +997,13 @@ TEST_F(V8AnalyzerTest, test_manager_get) {
                    .ok()));
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, "", "",
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto& authFeature = server.getFeature<arangodb::AuthenticationFeature>();
   auto* userManager = authFeature.userManager();
 
@@ -1427,11 +1433,13 @@ TEST_F(V8AnalyzerTest, test_manager_list) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, "", "",
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto& authFeature = server.getFeature<arangodb::AuthenticationFeature>();
   auto* userManager = authFeature.userManager();
 
@@ -1825,11 +1833,13 @@ TEST_F(V8AnalyzerTest, test_manager_remove) {
   }
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, "", "",
                                 arangodb::auth::Level::NONE,
                                 arangodb::auth::Level::NONE, false) {}
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto& authFeature = server.getFeature<arangodb::AuthenticationFeature>();
   auto* userManager = authFeature.userManager();
 

--- a/tests/V8Server/V8UsersTest.cpp
+++ b/tests/V8Server/V8UsersTest.cpp
@@ -218,12 +218,14 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
   struct ExecContext : public arangodb::ExecContext {
     ExecContext()
-        : arangodb::ExecContext(arangodb::ExecContext::Type::Default, userName,
+        : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                arangodb::ExecContext::Type::Default, userName,
                                 "", arangodb::auth::Level::RW,
                                 arangodb::auth::Level::NONE, true) {
     }  // ExecContext::isAdminUser() == true
-  } execContext;
-  arangodb::ExecContextScope execContextScope(&execContext);
+  };
+  auto execContext = std::make_shared<ExecContext>();
+  arangodb::ExecContextScope execContextScope(execContext);
   auto* authFeature = arangodb::AuthenticationFeature::instance();
   auto* userManager = authFeature->userManager();
   userManager->setGlobalVersion(0);  // required for UserManager::loadFromDB()
@@ -251,7 +253,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result = v8::Function::Cast(*fn_grantCollection)
@@ -270,7 +272,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth missing (revoke)
@@ -301,7 +303,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result = v8::Function::Cast(*fn_revokeCollection)
@@ -320,7 +322,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(
+         execContext->collectionAuthLevel(
              vocbase->name(), "testDataSource")));  // not modified from above
   }
 
@@ -355,7 +357,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result = v8::Function::Cast(*fn_grantCollection)
@@ -367,7 +369,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     EXPECT_FALSE(tryCatch.HasCaught());
     EXPECT_TRUE(
         (arangodb::auth::Level::RW ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth collection (revoke)
@@ -406,7 +408,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result = v8::Function::Cast(*fn_revokeCollection)
@@ -418,7 +420,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     EXPECT_FALSE(tryCatch.HasCaught());
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth view (grant)
@@ -452,7 +454,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result = v8::Function::Cast(*fn_grantCollection)
@@ -471,7 +473,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth view (revoke)
@@ -510,7 +512,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result = v8::Function::Cast(*fn_revokeCollection)
@@ -529,7 +531,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                                    .getNumber<int>()}));
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(
+         execContext->collectionAuthLevel(
              vocbase->name(), "testDataSource")));  // not modified from above
   }
 
@@ -564,7 +566,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::NONE ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result =
@@ -577,7 +579,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     EXPECT_FALSE(tryCatch.HasCaught());
     EXPECT_TRUE(
         (arangodb::auth::Level::RW ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
   }
 
   // test auth wildcard (revoke)
@@ -616,7 +618,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
 
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(vocbase->name(), "testDataSource")));
+         execContext->collectionAuthLevel(vocbase->name(), "testDataSource")));
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
     auto result =
@@ -629,7 +631,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     EXPECT_FALSE(tryCatch.HasCaught());
     EXPECT_TRUE(
         (arangodb::auth::Level::RO ==
-         execContext.collectionAuthLevel(
+         execContext->collectionAuthLevel(
              vocbase->name(),
              "testDataSource")));  // unchanged since revocation is only for
                                    // exactly matching collection names

--- a/tests/V8Server/V8ViewsTest.cpp
+++ b/tests/V8Server/V8ViewsTest.cpp
@@ -229,11 +229,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -369,11 +371,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -509,11 +513,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -645,11 +651,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -840,11 +848,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -1037,11 +1047,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -1200,11 +1212,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
@@ -1362,11 +1376,13 @@ TEST_F(V8ViewsTest, test_auth) {
 
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "", "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "", "",
                                   arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -180,11 +180,13 @@ TEST_F(LogicalViewTest, test_auth) {
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "",
                                   "testVocbase", arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::NONE, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     EXPECT_FALSE(logicalView->canUse(arangodb::auth::Level::RO));
   }
 
@@ -194,11 +196,13 @@ TEST_F(LogicalViewTest, test_auth) {
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "",
                                   "testVocbase", arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::RO, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     EXPECT_TRUE(logicalView->canUse(arangodb::auth::Level::RO));
     EXPECT_FALSE(logicalView->canUse(arangodb::auth::Level::RW));
   }
@@ -210,11 +214,13 @@ TEST_F(LogicalViewTest, test_auth) {
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
-          : arangodb::ExecContext(arangodb::ExecContext::Type::Default, "",
+          : arangodb::ExecContext(arangodb::ExecContext::ConstructorToken{},
+                                  arangodb::ExecContext::Type::Default, "",
                                   "testVocbase", arangodb::auth::Level::NONE,
                                   arangodb::auth::Level::RW, false) {}
-    } execContext;
-    arangodb::ExecContextScope execContextScope(&execContext);
+    };
+    auto execContext = std::make_shared<ExecContext>();
+    arangodb::ExecContextScope execContextScope(execContext);
     EXPECT_TRUE(logicalView->canUse(arangodb::auth::Level::RO));
     EXPECT_TRUE(logicalView->canUse(arangodb::auth::Level::RW));
   }


### PR DESCRIPTION
### Scope & Purpose

The ExecContext's lifetime was tied to the request's lifetime; however, some task run after a request is finished. For example, in Replication 2.0, an appendEntries request can trigger a bunch of different background tasks, like applying entries or acquiring a snapshot. This led to UB, and sporadic test failures. Most often I've seen this in `replication2-replicated-state-document-store.js` and `testFollowerSnapshotTransfer`, but also in others. This can happen (at least in the particular case I've investigated) since the NetworkFeature uses coroutines, which save and restore the old ExecContext.

This PR makes it possible to extend the ExecContext's lifetime, by making it a shared_ptr, which is then copied when a coroutine is suspended.

- [X] :hankey: Bugfix

#### Related Information

- [X] Jira ticket: https://arangodb.atlassian.net/browse/EF-51
