### PR TITLE
Fix shard rebalancer [BTS-1814]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* Repair shard rebalancer if some server has no leaders of a collection
+  but followers. Previously, this server was then not always considered
+  for leader movements.
+
 * Updated ArangoDB Starter to v0.18.4 and arangosync to v2.19.7.
 
 * BTS-1808: fix arangodump format for ZKD indexes. Previously the structural

--- a/arangod/Cluster/AutoRebalance.cpp
+++ b/arangod/Cluster/AutoRebalance.cpp
@@ -73,6 +73,9 @@ void AutoRebalanceProblem::createCluster(uint32_t nrDBServer, bool withZones) {
         .zone = withZones ? i : 0,
     });
   }
+  for (auto const& db : dbServers) {
+    serversHealthInfo.insert(db.id);
+  }
 }
 #endif
 
@@ -230,29 +233,36 @@ ShardImbalance AutoRebalanceProblem::computeShardImbalance() const {
 
 std::vector<double> AutoRebalanceProblem::piCoefficients(
     Collection const& c) const {
-  std::vector<double> tmp;
-  tmp.resize(dbServers.size(), 0);
+  std::vector<double> leaders;
+  leaders.resize(dbServers.size(), 0);
+  std::vector<bool> haveShards;
   if (c.shards.size() == 1) {
-    return tmp;  // No contribution for 1 shard collections
+    return leaders;  // No contribution for 1 shard collections
   }
+  haveShards.resize(dbServers.size(), false);
+  uint32_t dbServersAffected = 0;
   double sum = 0;
   for (auto const sindex : c.shards) {
-    tmp[shards[sindex].leader] += 1.0;
+    leaders[shards[sindex].leader] += 1.0;
     sum += 1.0;
-  }
-  uint32_t dbServersAffected = 0;
-  for (auto& t : tmp) {
-    if (t > 0.1) {
+    if (!haveShards[shards[sindex].leader]) {
+      haveShards[shards[sindex].leader] = true;
       ++dbServersAffected;
+    }
+    for (auto const f : shards[sindex].followers) {
+      if (!haveShards[f]) {
+        haveShards[f] = true;
+        ++dbServersAffected;
+      }
     }
   }
   double avg = sum / dbServersAffected;
   for (size_t i = 0; i < dbServers.size(); ++i) {
-    if (tmp[i] > 0.1) {  // only if affected
-      tmp[i] = pow(tmp[i] - avg, 2.0) * _piFactor;
+    if (haveShards[i]) {  // only if affected
+      leaders[i] = pow(leaders[i] - avg, 2.0) * _piFactor;
     }
   }
-  return tmp;
+  return leaders;
 }
 
 LeaderImbalance AutoRebalanceProblem::computeLeaderImbalance() const {

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -2591,11 +2591,11 @@ RestStatus RestAdminClusterHandler::handleRebalancePlan() {
 
   auto p = collectRebalanceInformation(options->databasesExcluded,
                                        options->excludeSystemCollections);
+  p.setPiFactor(options->piFactor);
   auto const imbalanceLeaderBefore = p.computeLeaderImbalance();
   auto const imbalanceShardsBefore = p.computeShardImbalance();
 
   moves.reserve(options->maximumNumberOfMoves);
-  p.setPiFactor(options->piFactor);
   p.optimize(options->leaderChanges, options->moveFollowers,
              options->moveLeaders, options->maximumNumberOfMoves, moves);
 

--- a/tests/Cluster/ShardAutoRebalancerTest.cpp
+++ b/tests/Cluster/ShardAutoRebalancerTest.cpp
@@ -30,5 +30,36 @@ TEST(AutoShardRebalancer, simple_randomized_test) {
   int res = p.optimize(true, true, true, atMostJobs, moves);
   ASSERT_EQ(res, 0) << "Internal error, should not have happened: " << res
                     << " !";
+  EXPECT_GT(moves.size(), 0);
   EXPECT_LE(moves.size(), atMostJobs);
+}
+
+TEST(AutoShardRebalancer, regression_leaderless_server_ignored) {
+  const auto nrDBServers = 3;
+
+  AutoRebalanceProblem p;
+  p.createCluster(nrDBServers, true);
+  p.createDatabase("d", 1);
+  auto collId = p.createCollection("c", "d", 32, 4, 1.0);
+  auto& coll = p.collections[collId];
+  auto& shardIds = coll.shards;
+  // Distribute leaders across servers 0 and 1, but not 2:
+  uint32_t cur = 0;
+  for (auto shardId : shardIds) {
+    auto& shard = p.shards[shardId];
+    shard.leader = cur;
+    shard.followers.clear();
+    for (uint32_t i = 0; i < 3; ++i) {
+      if (i != cur) {
+        shard.followers.push_back(i);
+      }
+    }
+    cur = 1 - cur;
+  }
+
+  std::vector<MoveShardJob> moves;
+  int res = p.optimize(true, false, false, 10, moves);
+  ASSERT_EQ(res, 0) << "Internal error, should not have happened: " << res
+                    << " !";
+  ASSERT_NE(moves.size(), 0);
 }


### PR DESCRIPTION
This is a backport from devel: https://github.com/arangodb/arangodb/pull/20719

This fixes a problem in shard rebalancing. Here is a description of the
problem:

  https://arangodb.atlassian.net/browse/BTS-1814

If for some collection a server is not the leader for any of its
shards, but has some follower shards. Then the leader imbalance score
does not take into account this server. Therefore, the system does not
consider leader moves to this server, since they often do not
improve the score. Therefore the rebalancer often only rebalances
leaders between servers which already have leader shards.

Furthermore, there is another small problem that some parameter of the
algorithm is only set from the user's input after the computation of the
imbalance score "before" has already happened. This is also fixed in
this PR.

- Set pifactors before computing starting imbalances.
- Repair piCoefficients computation.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1814

