### PR TITLE
simplify shard synchronization code

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Remove "read lock" acquisition calls from shard synchronization because they
+  are now unnecessary. This slightly simplifies the shard synchronization
+  protocol.
+
 * Repair shard rebalancer if some server has no leaders of a collection
   but followers. Previously, this server was then not always considered
   for leader movements.

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -60,6 +60,8 @@ class SynchronizeShard : public ActionBase, public ShardDefinition {
 
   std::string const& clientInfoString() const;
 
+  std::string shardNameForLogging() const;
+
  private:
   arangodb::Result collectionCountOnLeader(std::string const& endpoint,
                                            uint64_t& c);

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -66,19 +66,19 @@ class SynchronizeShard : public ActionBase, public ShardDefinition {
   arangodb::Result collectionCountOnLeader(std::string const& endpoint,
                                            uint64_t& c);
 
-  arangodb::Result getReadLock(network::ConnectionPool* pool,
-                               std::string const& endpoint,
-                               std::string const& collection,
-                               std::string const& clientId, uint64_t rlid,
-                               bool soft, double timeout);
+  arangodb::Result requestExclusiveLockOnLeader(network::ConnectionPool* pool,
+                                                std::string const& endpoint,
+                                                std::string const& collection,
+                                                std::string const& clientId,
+                                                uint64_t rlid, double timeout);
 
-  arangodb::Result startReadLockOnLeader(std::string const& endpoint,
-                                         std::string const& collection,
-                                         std::string const& clientId,
-                                         uint64_t& rlid, bool soft,
-                                         double timeout = 300.0);
+  arangodb::Result establishExclusiveLockOnLeader(std::string const& endpoint,
+                                                  std::string const& collection,
+                                                  std::string const& clientId,
+                                                  uint64_t& rlid,
+                                                  double timeout = 300.0);
 
-  arangodb::ResultT<TRI_voc_tick_t> catchupWithReadLock(
+  arangodb::ResultT<TRI_voc_tick_t> catchupWithoutLock(
       std::string const& ep, LogicalCollection const& collection,
       std::string const& clientId, std::string const& leader,
       TRI_voc_tick_t lastLogTick,

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2798,6 +2798,10 @@ RestReplicationHandler::handleCommandHoldReadLockCollection() {
   Result res = co_await createBlockingTransaction(id, *col, ttl, lockType,
                                                   rebootId, serverId);
   if (!res.ok()) {
+    LOG_TOPIC("5f00f", DEBUG, Logger::REPLICATION)
+        << "Lock " << id << " for shard " << _vocbase.name() << "/"
+        << col->name() << " of type: " << (doSoftLock ? "soft" : "hard")
+        << " could not be created because of: " << res.errorMessage();
     generateError(res);
     co_return;
   }
@@ -2811,7 +2815,8 @@ RestReplicationHandler::handleCommandHoldReadLockCollection() {
     if (!res.ok()) {
       // this is potentially bad!
       LOG_TOPIC("957fa", WARN, Logger::REPLICATION)
-          << "Lock " << id
+          << "Lock " << id << " for shard " << _vocbase.name() << "/"
+          << col->name() << " of type: " << (doSoftLock ? "soft" : "hard")
           << " could not be canceled because of: " << res.errorMessage();
     }
     // indicate that we are not the leader

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2776,6 +2776,8 @@ RestReplicationHandler::handleCommandHoldReadLockCollection() {
   // potentially faster soft-lock synchronization with a smaller hard-lock
   // phase.
 
+  // TODO: the follower will always send "doSoftLockOnly=false" from 3.12.1
+  // onwards. we can remove the entire parameter in the future.
   bool doSoftLock = VelocyPackHelper::getBooleanValue(
       body, StaticStrings::ReplicationSoftLockOnly, false);
   AccessMode::Type lockType = AccessMode::Type::READ;

--- a/arangod/Sharding/ShardDistributionReporter.cpp
+++ b/arangod/Sharding/ShardDistributionReporter.cpp
@@ -445,7 +445,7 @@ void ShardDistributionReporter::helperDistributionForDatabase(
               auto responses = futures::collectAll(futures).get();
               for (futures::Try<network::Response> const& response :
                    responses) {
-                if (!response.hasValue() || response.get().fail()) {
+                if (!response.hasValue()) {
                   // We do not care for errors of any kind.
                   // We can continue here because all other requests will be
                   // handled by the accumulated timeout
@@ -453,10 +453,22 @@ void ShardDistributionReporter::helperDistributionForDatabase(
                 }
 
                 auto const& res = response.get();
+                if (Result r = res.combinedResult(); r.fail()) {
+                  if (r.isNot(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND) &&
+                      r.isNot(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) &&
+                      r.isNot(TRI_ERROR_SHUTTING_DOWN)) {
+                    // we got an error that we didnt expect
+                    LOG_TOPIC("bed1e", INFO, arangodb::Logger::CLUSTER)
+                        << "Received invalid response for shard count: "
+                        << r.errorMessage();
+                  }
+                  // ignore this response
+                  continue;
+                }
                 VPackSlice slice = res.slice();
                 if (!slice.isObject()) {
                   LOG_TOPIC("fcbb3", WARN, arangodb::Logger::CLUSTER)
-                      << "Received invalid response for count. Shard "
+                      << "Received invalid response for shard count. Shard "
                       << "distribution inaccurate: " << slice.toJson();
                   continue;
                 }
@@ -464,7 +476,7 @@ void ShardDistributionReporter::helperDistributionForDatabase(
                 VPackSlice answer = slice.get("count");
                 if (!answer.isNumber()) {
                   LOG_TOPIC("8d7b0", WARN, arangodb::Logger::CLUSTER)
-                      << "Received invalid response for count. Shard "
+                      << "Received invalid response for shard count. Shard "
                       << "distribution inaccurate: " << slice.toJson();
                   continue;
                 }


### PR DESCRIPTION
### Scope & Purpose

* Improve debug logging for shard synchronization by adding database name/shard name to most debug messages.
* Remove "read" lock acquisition on leader when trying to get shard follower in sync. The exclusive lock phase remains unchanged. Acquiring a read lock on the leader is not necessary, as under RocksDB this does nothing.
* The leader-side code that can handle "read" lock acquisitions still remains unchanged, because followers running older ArangoDB versions may still call it.
* Reduce timeout for acquiring the exclusive lock on the leader from 300s to 240s. The network request timeout still stays at 300s, but the leader-side lock acquisition timeout is now 240s. This is not perfect, but it prevents many cases in which the follower declares the request failed (because of network request timeout) while the lock acquisition request is still ongoing on the leader.
* Rename methods in SynchronizeShard.cpp so that the method names better reflect what the methods are actually doing.
* Slightly improve error handling in ShardDistributionReporter.cpp, because it previously logged errors in case it could not find shards. This is however expected when followers are planned but the DB servers haven't yet created the shards.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 