### PR TITLE
Fix a small issue in a bash-if that causes a confusing warnings

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -339,12 +339,12 @@ jobs:
           no_output_timeout: 20m
           command: |
             mkdir work
-            if [ << pipeline.parameters.sanitizer >> = "alubsan" ]; then
+            if [ "<< pipeline.parameters.sanitizer >>" = "alubsan" ]; then
               export ASAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:handle_ioctl=true:check_initialization_order=true:detect_container_overflow=true:detect_stack_use_after_return=false:detect_odr_violation=1:strict_init_order=true"
               export LSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:suppressions=lsan_arangodb_suppressions.txt:print_suppressions=0"
               export UBSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:print_stacktrace=1:suppressions=ubsan_arangodb_suppressions.txt:print_suppressions=0"
               export SAN_MODE=alubsan
-            elif [ << pipeline.parameters.sanitizer >> = "tsan" ]; then
+            elif [ "<< pipeline.parameters.sanitizer >>" = "tsan" ]; then
               export TSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/tsan.log:detect_deadlocks=true:second_deadlock_stack=1:suppressions=tsan_arangodb_suppressions.txt:print_suppressions=0"
               export SAN_MODE=tsan
             fi


### PR DESCRIPTION
### Scope & Purpose

Without this fix the CircleCI output contains these errors/warnings:
```
/bin/bash: line 2: [: =: unary operator expected
/bin/bash: line 7: [: =: unary operator expected
```