### PR TITLE
Update default log format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@ devel
   but followers. Previously, this server was then not always considered
   for leader movements.
 
+* Change the default log format. The option log.thread is now by default true.
+  The option log.time-format is now by default `utc-datestring-micros`.
+
 * Guarantee conditional-only evaluation of the operands of the AQL ternary
   operator.
 

--- a/lib/Logger/LogTimeFormat.cpp
+++ b/lib/Logger/LogTimeFormat.cpp
@@ -89,7 +89,7 @@ bool isStringFormat(TimeFormat format) {
 }
 
 /// @brief return the name of the default log time format
-std::string defaultFormatName() { return "utc-datestring"; }
+std::string defaultFormatName() { return "utc-datestring-micros"; }
 
 /// @brief return the names of all log time formats
 std::unordered_set<std::string> getAvailableFormatNames() {

--- a/lib/Logger/LoggerFeature.h
+++ b/lib/Logger/LoggerFeature.h
@@ -90,7 +90,7 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   bool _lineNumber = false;
   bool _shortenFilenames = true;
   bool _processId = true;
-  bool _threadId = false;
+  bool _threadId = true;
   bool _threadName = false;
   bool _performance = false;
   bool _keepLogRotate = false;


### PR DESCRIPTION
### Scope & Purpose
Update default log format. Include thread id and utc mirco seconds timestamp.