### PR TITLE
use FlatHashMap for bind parameters

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2175,7 +2175,7 @@ AstNode* Ast::replaceValueBindParameter(AstNode* node,
                                         BindParameters& parameters) {
   TRI_ASSERT(node->type == NODE_TYPE_PARAMETER);
 
-  std::string const param = node->getString();
+  std::string_view param = node->getStringView();
   TRI_ASSERT(!param.empty());
 
   auto [value, cachedNode] = parameters.get(param);

--- a/arangod/Aql/BindParameters.cpp
+++ b/arangod/Aql/BindParameters.cpp
@@ -96,7 +96,7 @@ void BindParameters::validateAllUsed() const {
 /// does not exist. the returned AstNode is a nullptr in case no AstNode was yet
 /// registered for this bind parameter. This is not an error.
 std::pair<VPackSlice, AstNode*> BindParameters::get(
-    std::string const& name) const noexcept {
+    std::string_view name) const noexcept {
   TRI_ASSERT(_processed);
 
   auto it = _parameters.find(name);
@@ -109,8 +109,9 @@ std::pair<VPackSlice, AstNode*> BindParameters::get(
   return (*it).second;
 }
 
-/// @brief register an AstNode for the bind parameter
-void BindParameters::registerNode(std::string const& name, AstNode* node) {
+/// @brief register an AstNode for the bind parameter.
+/// note: the AstNode is not owned by the bind parameters class.
+void BindParameters::registerNode(std::string_view name, AstNode* node) {
   TRI_ASSERT(_processed);
 
   auto it = _parameters.find(name);

--- a/arangod/Aql/BindParameters.h
+++ b/arangod/Aql/BindParameters.h
@@ -23,13 +23,15 @@
 
 #pragma once
 
+#include "Containers/FlatHashMap.h"
+
 #include <velocypack/Slice.h>
 
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
-#include <unordered_map>
+#include <string_view>
 #include <utility>
 
 namespace arangodb {
@@ -42,8 +44,8 @@ namespace aql {
 struct AstNode;
 
 using BindParametersType =
-    std::unordered_map<std::string,
-                       std::pair<arangodb::velocypack::Slice, AstNode*>>;
+    containers::FlatHashMap<std::string,
+                            std::pair<arangodb::velocypack::Slice, AstNode*>>;
 
 class BindParameters {
  public:
@@ -70,10 +72,11 @@ class BindParameters {
   /// does not exist. the returned AstNode is a nullptr in case no AstNode was
   /// yet registered for this bind parameter. This is not an error.
   std::pair<arangodb::velocypack::Slice, AstNode*> get(
-      std::string const& name) const noexcept;
+      std::string_view name) const noexcept;
 
-  /// @brief register an AstNode for the bind parameter
-  void registerNode(std::string const& name, AstNode* node);
+  /// @brief register an AstNode for the bind parameter.
+  /// note: the AstNode is not owned by the bind parameters class.
+  void registerNode(std::string_view name, AstNode* node);
 
   /// @brief run a visitor function on all bind parameters
   void visit(std::function<void(std::string const& key,


### PR DESCRIPTION
### Scope & Purpose

use FlatHashMap for bind parameters

this allows us to do heterogeneous lookups in the map of bind parameter names using std::string_view keys, and thus saves us from converting any lookup value into an std::string first.

potential changes in iterator invalidation behavior when moving from std::unordered_map to FlatHashMap have been considered and are not relevant. the map in question is only used internally in the BindParameters class and all usages are safe.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 