### PR TITLE
log state of lock in case we cant acquire it

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1714,6 +1714,10 @@ ErrorCode RocksDBMetaCollection::doLock(double timeout, AccessMode::Type mode) {
   return TRI_ERROR_LOCK_TIMEOUT;
 }
 
+std::string RocksDBMetaCollection::stringifyLockState() const {
+  return _exclusiveLock.stringifyLockState();
+}
+
 bool RocksDBMetaCollection::haveBufferedOperations(
     std::unique_lock<std::mutex> const& lock) const {
   TRI_ASSERT(lock.owns_lock());

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -142,6 +142,8 @@ class RocksDBMetaCollection : public PhysicalCollection {
   void corruptRevisionTree(std::uint64_t count, std::uint64_t hash);
 #endif
 
+  std::string stringifyLockState() const;
+
  private:
   /// @brief sends the collection's revision tree to hibernation
   void hibernateRevisionTree(std::unique_lock<std::mutex> const& lock);

--- a/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionCollection.cpp
@@ -369,11 +369,11 @@ Result RocksDBTransactionCollection::doLock(AccessMode::Type type) {
   } else if (res.is(TRI_ERROR_LOCK_TIMEOUT) && timeout >= 0.1) {
     char const* actor = _transaction->actorName();
     TRI_ASSERT(actor != nullptr);
-    std::string message = "timed out after " + std::to_string(timeout) +
-                          " s waiting for " + AccessMode::typeString(type) +
-                          "-lock on collection " +
-                          _transaction->vocbase().name() + "/" +
-                          _collection->name() + " on " + actor;
+    std::string message =
+        "timed out after " + std::to_string(timeout) + " s waiting for " +
+        AccessMode::typeString(type) + "-lock on collection " +
+        _transaction->vocbase().name() + "/" + _collection->name() + " on " +
+        actor + ", lock state: " + physical->stringifyLockState();
     LOG_TOPIC("4512c", WARN, Logger::QUERIES) << message;
     res.reset(TRI_ERROR_LOCK_TIMEOUT, std::move(message));
 

--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -221,3 +221,25 @@ bool ReadWriteLock::isLockedRead() const noexcept {
 bool ReadWriteLock::isLockedWrite() const noexcept {
   return _state.load(std::memory_order_relaxed) & WRITE_LOCK;
 }
+
+std::string ReadWriteLock::stringifyLockState() const {
+  std::string result;
+
+  auto append = [&result](std::string msg) {
+    if (!result.empty()) {
+      result.append(", ");
+    }
+    result.append(msg);
+  };
+
+  auto state = _state.load(std::memory_order_relaxed);
+  auto readers = (state & READER_MASK) >> 16;
+  auto writers = state & QUEUED_WRITER_MASK;
+  append(std::to_string(readers).append(" active reader(s)"));
+  append(std::to_string(writers).append(" queued writer(s)"));
+  if (state & WRITE_LOCK) {
+    append("write-locked");
+  }
+
+  return result;
+}

--- a/lib/Basics/ReadWriteLock.h
+++ b/lib/Basics/ReadWriteLock.h
@@ -29,6 +29,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <string>
 
 namespace arangodb::basics {
 
@@ -84,6 +85,8 @@ class ReadWriteLock {
   [[nodiscard]] bool isLocked() const noexcept;
   [[nodiscard]] bool isLockedRead() const noexcept;
   [[nodiscard]] bool isLockedWrite() const noexcept;
+
+  std::string stringifyLockState() const;
 
  private:
   /// @brief mutex for _readers_bell cv


### PR DESCRIPTION
### Scope & Purpose

Dump state of lock in case we cannot acquire the lock in time. The lock state can be used to reason about pending readers/writers and thus can be used for internal debugging.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 