### PR TITLE
Accept legcy LANGUAGE detections for C locale [BTS-1824]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 3.12.0 (XXXX-XX-XX)
 -------------------
 
+* Accept language settings found in the LANGUAGE file which previous versions
+  have detected for the "C" locale. This is to allow upgrades from 3.11
+  if the database directory was created with the "C" locale.
 
 
 3.12.0-rc.1 (2024-03-12)


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/browse/BTS-1824

This is the backport for 3.12.0.

Original PR: https://github.com/arangodb/arangodb/pull/20748

The problem is that the ICU library was updated for 3.12. The new
version detects the language settings differently for the case that the
locale is set to "C". The new version then uses "en_US_POSIX", whereas
the old version sometimes takes "" (empty string) and sometimes uses
"en_US" (depending on the charset settings). This is a problem in
upgrades, which use the LanguageFeatureCheck feature to FATAL exit,
if the detected language setting is different from the one found during
database directory creation.

This PR "fixes" this problem by being more tolerant in the check, thus
allowing seamless upgrades. Furthermore, new databases in 3.12 would
then be generated with the newer, more correct detection.

See https://unicode-org.github.io/icu/userguide/locale/

- CHANGELOG.
- Accept legacy LANGUAGE settings for "C" locale.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.12.0: This is it.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1824

