### PR TITLE
reduce dependencies on system-functions.h

### DIFF
--- a/arangod/Agency/Constituent.cpp
+++ b/arangod/Agency/Constituent.cpp
@@ -23,17 +23,14 @@
 
 #include "Constituent.h"
 
-#include <chrono>
-#include <iomanip>
-#include <thread>
-
-#include <velocypack/Iterator.h>
-
 #include "Agency/Agent.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Query.h"
 #include "Basics/application-exit.h"
+#include "Basics/system-functions.h"
 #include "Logger/LogMacros.h"
+#include "Metrics/GaugeBuilder.h"
+#include "Metrics/MetricsFeature.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
 #include "Random/RandomGenerator.h"
@@ -45,8 +42,11 @@
 #include "VocBase/ticks.h"
 #include "VocBase/vocbase.h"
 
-#include "Metrics/GaugeBuilder.h"
-#include "Metrics/MetricsFeature.h"
+#include <velocypack/Iterator.h>
+
+#include <chrono>
+#include <iomanip>
+#include <thread>
 
 using namespace arangodb::consensus;
 using namespace arangodb::rest;

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -37,7 +37,6 @@
 #include "Aql/QueryString.h"
 #include "Basics/Common.h"
 #include "Basics/ResourceUsage.h"
-#include "Basics/system-functions.h"
 #include "Scheduler/SchedulerFeature.h"
 #ifdef USE_V8
 #include "V8Server/V8Executor.h"

--- a/arangod/Aql/QueryCursor.h
+++ b/arangod/Aql/QueryCursor.h
@@ -30,13 +30,16 @@
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 #include "Utils/Cursor.h"
+#include "Utils/DatabaseGuard.h"
 #include "VocBase/vocbase.h"
+
+#include <velocypack/Iterator.h>
 
 #include <cstdint>
 #include <deque>
+#include <memory>
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
 
 class AqlItemBlock;
 enum class ExecutionState;
@@ -160,5 +163,4 @@ class QueryStreamCursor final : public arangodb::Cursor {
                           // gone.
 };
 
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql

--- a/arangod/Auth/TokenCache.h
+++ b/arangod/Auth/TokenCache.h
@@ -27,21 +27,22 @@
 #include "Basics/LruCache.h"
 #include "Basics/ReadWriteLock.h"
 #include "Basics/Result.h"
-#include "Basics/debugging.h"
-#include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
 #include "Rest/CommonDefines.h"
 
-#include <velocypack/Builder.h>
-#include <velocypack/Slice.h>
-
 #include <atomic>
+#include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <vector>
 
-namespace arangodb {
-namespace auth {
+namespace arangodb::velocypack {
+class Builder;
+}
+
+namespace arangodb::auth {
 class UserManager;
 
 /// @brief Caches the basic and JWT authentication tokens
@@ -53,7 +54,6 @@ class TokenCache {
   explicit TokenCache(auth::UserManager* um, double timeout);
   ~TokenCache();
 
- public:
   struct Entry {
     friend class auth::TokenCache;
 
@@ -69,9 +69,7 @@ class TokenCache {
     void authenticated(bool value) noexcept { _authenticated = value; }
     void setExpiry(double expiry) noexcept { _expiry = expiry; }
     double expiry() const noexcept { return _expiry; }
-    bool expired() const noexcept {
-      return _expiry != 0 && _expiry < TRI_microtime();
-    }
+    bool expired() const noexcept;
     std::vector<std::string> const& allowedPaths() const {
       return _allowedPaths;
     }
@@ -104,10 +102,7 @@ class TokenCache {
 #endif
 
   /// Get the jwt token, which should be used for communication
-  std::string const& jwtToken() const noexcept {
-    TRI_ASSERT(!_jwtSuperToken.empty());
-    return _jwtSuperToken;
-  }
+  std::string const& jwtToken() const noexcept;
 
   std::string jwtSecret() const;
 
@@ -149,5 +144,5 @@ class TokenCache {
   /// Timeout in seconds
   double const _authTimeout;
 };
-}  // namespace auth
-}  // namespace arangodb
+
+}  // namespace arangodb::auth

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -29,6 +29,7 @@
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/application-exit.h"
 #include "Basics/files.h"
+#include "Basics/system-functions.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/AgencyCallbackRegistry.h"
 #include "Cluster/ClusterInfo.h"

--- a/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBBackgroundThread.cpp
@@ -24,6 +24,7 @@
 #include "RocksDBBackgroundThread.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/system-functions.h"
 #include "Logger/LogMacros.h"
 #include "Metrics/GaugeBuilder.h"
 #include "Metrics/MetricsFeature.h"

--- a/arangod/Statistics/StatisticsFeature.cpp
+++ b/arangod/Statistics/StatisticsFeature.cpp
@@ -32,6 +32,7 @@
 #include "Basics/StringUtils.h"
 #include "Basics/application-exit.h"
 #include "Basics/process-utils.h"
+#include "Basics/system-functions.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
@@ -667,6 +668,8 @@ StatisticsFeature::StatisticsFeature(Server& server)
   }
 #endif
 }
+
+/*static*/ double StatisticsFeature::time() { return TRI_microtime(); }
 
 void StatisticsFeature::collectOptions(
     std::shared_ptr<ProgramOptions> options) {

--- a/arangod/Statistics/StatisticsFeature.h
+++ b/arangod/Statistics/StatisticsFeature.h
@@ -33,6 +33,7 @@
 
 #include <array>
 #include <initializer_list>
+#include <memory>
 #include <string>
 #include <string_view>
 
@@ -87,12 +88,11 @@ extern RequestFigures UserRequestFigures;
 
 class StatisticsFeature final : public ArangodFeature {
  public:
-  static double time() { return TRI_microtime(); }
-
- public:
   static constexpr std::string_view name() noexcept { return "Statistics"; }
 
   explicit StatisticsFeature(Server& server);
+
+  static double time();
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;

--- a/arangod/Utils/CMakeLists.txt
+++ b/arangod/Utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arango_utils STATIC
+  Cursor.cpp
   ExecContext.cpp
   OperationOptions.cpp
   SupportInfoBuilder.cpp

--- a/arangod/Utils/Cursor.cpp
+++ b/arangod/Utils/Cursor.cpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Utils/Cursor.h"
+
+#include "Assertions/Assert.h"
+#include "Basics/system-functions.h"
+
+#include <velocypack/Builder.h>
+
+namespace arangodb {
+
+Cursor::Cursor(CursorId id, size_t batchSize, double ttl, bool hasCount,
+               bool isRetriable)
+    : _id(id),
+      _batchSize(batchSize == 0 ? 1 : batchSize),
+      _currentBatchId(0),
+      _lastAvailableBatchId(1),
+      _ttl(ttl),
+      _expires(TRI_microtime() + _ttl),
+      _hasCount(hasCount),
+      _isRetriable(isRetriable),
+      _isDeleted(false),
+      _isUsed(false) {}
+
+Cursor::~Cursor() = default;
+
+double Cursor::expires() const noexcept {
+  return _expires.load(std::memory_order_relaxed);
+}
+
+bool Cursor::isUsed() const noexcept {
+  // (1) - this release-store synchronizes-with the acquire-load (2)
+  return _isUsed.load(std::memory_order_acquire);
+}
+
+bool Cursor::isDeleted() const noexcept { return _isDeleted; }
+
+void Cursor::setDeleted() noexcept { _isDeleted = true; }
+
+bool Cursor::isCurrentBatchId(uint64_t id) const noexcept {
+  return id == _currentBatchResult.first;
+}
+
+bool Cursor::isNextBatchId(uint64_t id) const {
+  return id == _currentBatchResult.first + 1 && id == _lastAvailableBatchId;
+}
+
+void Cursor::setLastQueryBatchObject(
+    std::shared_ptr<velocypack::Buffer<uint8_t>> buffer) noexcept {
+  _currentBatchResult.second = std::move(buffer);
+}
+
+std::shared_ptr<velocypack::Buffer<uint8_t>> Cursor::getLastBatch() const {
+  return _currentBatchResult.second;
+}
+
+uint64_t Cursor::storedBatchId() const { return _currentBatchResult.first; }
+
+void Cursor::handleNextBatchIdValue(velocypack::Builder& builder,
+                                    bool hasMore) {
+  _currentBatchResult.first = ++_currentBatchId;
+  if (hasMore) {
+    builder.add("nextBatchId", std::to_string(_currentBatchId + 1));
+    _lastAvailableBatchId = _currentBatchId + 1;
+  }
+}
+
+void Cursor::use() noexcept {
+  TRI_ASSERT(!_isDeleted);
+  TRI_ASSERT(!_isUsed);
+
+  _isUsed.store(true, std::memory_order_relaxed);
+}
+
+void Cursor::release() noexcept {
+  TRI_ASSERT(_isUsed);
+  _expires.store(TRI_microtime() + _ttl, std::memory_order_relaxed);
+  // (2) - this release-store synchronizes-with the acquire-load (1)
+  _isUsed.store(false, std::memory_order_release);
+}
+
+}  // namespace arangodb

--- a/arangod/Utils/Cursor.h
+++ b/arangod/Utils/Cursor.h
@@ -24,21 +24,17 @@
 #pragma once
 
 #include "Aql/ExecutionState.h"
-#include "Assertions/Assert.h"
 #include "Basics/Common.h"
 #include "Basics/Result.h"
-#include "Basics/system-functions.h"
-#include "Utils/DatabaseGuard.h"
 #include "VocBase/voc-types.h"
 
-#include <velocypack/Buffer.h>
-#include <velocypack/Iterator.h>
-#include <velocypack/Builder.h>
-
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace arangodb {
 
@@ -47,11 +43,13 @@ class Context;
 }
 
 namespace velocypack {
+template<typename T>
+class Buffer;
 class Builder;
 class Slice;
 }  // namespace velocypack
 
-typedef TRI_voc_tick_t CursorId;
+using CursorId = TRI_voc_tick_t;
 
 class Cursor {
  public:
@@ -59,19 +57,9 @@ class Cursor {
   Cursor& operator=(Cursor const&) = delete;
 
   Cursor(CursorId id, size_t batchSize, double ttl, bool hasCount,
-         bool isRetriable)
-      : _id(id),
-        _batchSize(batchSize == 0 ? 1 : batchSize),
-        _currentBatchId(0),
-        _lastAvailableBatchId(1),
-        _ttl(ttl),
-        _expires(TRI_microtime() + _ttl),
-        _hasCount(hasCount),
-        _isRetriable(isRetriable),
-        _isDeleted(false),
-        _isUsed(false) {}
+         bool isRetriable);
 
-  virtual ~Cursor() = default;
+  virtual ~Cursor();
 
  public:
   CursorId id() const noexcept { return _id; }
@@ -84,59 +72,30 @@ class Cursor {
 
   double ttl() const noexcept { return _ttl; }
 
-  double expires() const noexcept {
-    return _expires.load(std::memory_order_relaxed);
-  }
+  double expires() const noexcept;
 
-  bool isUsed() const noexcept {
-    // (1) - this release-store synchronizes-with the acquire-load (2)
-    return _isUsed.load(std::memory_order_acquire);
-  }
+  bool isUsed() const noexcept;
 
-  bool isDeleted() const noexcept { return _isDeleted; }
+  bool isDeleted() const noexcept;
 
-  void setDeleted() noexcept { _isDeleted = true; }
+  void setDeleted() noexcept;
 
-  bool isCurrentBatchId(uint64_t id) const noexcept {
-    return id == _currentBatchResult.first;
-  }
+  bool isCurrentBatchId(uint64_t id) const noexcept;
 
-  bool isNextBatchId(uint64_t id) const {
-    return id == _currentBatchResult.first + 1 && id == _lastAvailableBatchId;
-  }
+  bool isNextBatchId(uint64_t id) const;
 
   void setLastQueryBatchObject(
-      std::shared_ptr<velocypack::Buffer<uint8_t>> buffer) noexcept {
-    _currentBatchResult.second = std::move(buffer);
-  }
+      std::shared_ptr<velocypack::Buffer<uint8_t>> buffer) noexcept;
 
-  std::shared_ptr<velocypack::Buffer<uint8_t>> getLastBatch() const {
-    return _currentBatchResult.second;
-  }
+  std::shared_ptr<velocypack::Buffer<uint8_t>> getLastBatch() const;
 
-  uint64_t storedBatchId() const { return _currentBatchResult.first; }
+  uint64_t storedBatchId() const;
 
-  void handleNextBatchIdValue(VPackBuilder& builder, bool hasMore) {
-    _currentBatchResult.first = ++_currentBatchId;
-    if (hasMore) {
-      builder.add("nextBatchId", std::to_string(_currentBatchId + 1));
-      _lastAvailableBatchId = _currentBatchId + 1;
-    }
-  }
+  void handleNextBatchIdValue(velocypack::Builder& builder, bool hasMore);
 
-  void use() noexcept {
-    TRI_ASSERT(!_isDeleted);
-    TRI_ASSERT(!_isUsed);
+  void use() noexcept;
 
-    _isUsed.store(true, std::memory_order_relaxed);
-  }
-
-  void release() noexcept {
-    TRI_ASSERT(_isUsed);
-    _expires.store(TRI_microtime() + _ttl, std::memory_order_relaxed);
-    // (2) - this release-store synchronizes-with the acquire-load (1)
-    _isUsed.store(false, std::memory_order_release);
-  }
+  void release() noexcept;
 
   virtual void kill() {}
 

--- a/arangod/Utils/CursorRepository.cpp
+++ b/arangod/Utils/CursorRepository.cpp
@@ -28,6 +28,7 @@
 #include "Aql/QueryCursor.h"
 #include "Aql/QueryResult.h"
 #include "Basics/ScopeGuard.h"
+#include "Basics/system-functions.h"
 #include "Cluster/ServerState.h"
 #include "Containers/SmallVector.h"
 #include "Logger/LogMacros.h"


### PR DESCRIPTION
### Scope & Purpose

Reduce dependencies on `system-functions.h` header file.

The header file `system-functions.h` was previous included by 4 header files, of which 2 were very essential.
So any change to `system-functions.h` would trigger a rebuild of the majority of files.
This PR removes the include directives for `system-functions.h` from the header files and moves them into the appropriate .cpp files. A few other unused directives in header files have also been removed and have been replaced with forward declarations.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 