### PR TITLE
BTS-1489: Race condition in AsioSocket shutdown when using SSL.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* Fixed BTS-1489: Race condition in AsioSocket shutdown when using SSL.
+
 * Rebuilt included rclone v1.62.2 with go1.21.8.
 
 * Repair shard rebalancer if some server has no leaders of a collection

--- a/arangod/GeneralServer/Acceptor.h
+++ b/arangod/GeneralServer/Acceptor.h
@@ -29,8 +29,7 @@
 #include "GeneralServer/GeneralServerFeature.h"
 #include "GeneralServer/IoContext.h"
 
-namespace arangodb {
-namespace rest {
+namespace arangodb::rest {
 
 /// Abstract class handling the socket acceptor
 class Acceptor {
@@ -62,5 +61,4 @@ class Acceptor {
   bool _open;
   size_t _acceptFailures;
 };
-}  // namespace rest
-}  // namespace arangodb
+}  // namespace arangodb::rest

--- a/arangod/GeneralServer/AcceptorTcp.cpp
+++ b/arangod/GeneralServer/AcceptorTcp.cpp
@@ -145,7 +145,7 @@ void AcceptorTcp<SocketType::Tcp>::asyncAccept() {
   TRI_ASSERT(_endpoint->encryption() == Endpoint::EncryptionType::NONE);
 
   auto asioSocket =
-      std::make_unique<AsioSocket<SocketType::Tcp>>(_server.selectIoContext());
+      std::make_shared<AsioSocket<SocketType::Tcp>>(_server.selectIoContext());
   auto& socket = asioSocket->socket;
   auto& peer = asioSocket->peer;
   auto handler = [this, asioSocket = std::move(asioSocket)](
@@ -182,7 +182,7 @@ void AcceptorTcp<SocketType::Tcp>::asyncAccept() {
 
 template<>
 void AcceptorTcp<SocketType::Tcp>::performHandshake(
-    std::unique_ptr<AsioSocket<SocketType::Tcp>> proto) {
+    std::shared_ptr<AsioSocket<SocketType::Tcp>> proto) {
   TRI_ASSERT(false);  // MSVC requires the implementation to exist
 }
 
@@ -205,7 +205,7 @@ bool tls_h2_negotiated(SSL* ssl) {
 
 template<>
 void AcceptorTcp<SocketType::Ssl>::performHandshake(
-    std::unique_ptr<AsioSocket<SocketType::Ssl>> proto) {
+    std::shared_ptr<AsioSocket<SocketType::Ssl>> proto) {
   // io_context is single-threaded, no sync needed
   auto* ptr = proto.get();
   proto->timer.expires_from_now(std::chrono::seconds(60));
@@ -259,7 +259,7 @@ void AcceptorTcp<SocketType::Ssl>::asyncAccept() {
   auto& ctx = _server.selectIoContext();
 
   auto asioSocket =
-      std::make_unique<AsioSocket<SocketType::Ssl>>(ctx, _server.sslContexts());
+      std::make_shared<AsioSocket<SocketType::Ssl>>(ctx, _server.sslContexts());
   auto& socket = asioSocket->socket.lowest_layer();
   auto& peer = asioSocket->peer;
   auto handler = [this, asioSocket = std::move(asioSocket)](

--- a/arangod/GeneralServer/AcceptorTcp.h
+++ b/arangod/GeneralServer/AcceptorTcp.h
@@ -26,10 +26,7 @@
 #include "GeneralServer/Acceptor.h"
 #include "GeneralServer/AsioSocket.h"
 
-#include <mutex>
-
-namespace arangodb {
-namespace rest {
+namespace arangodb::rest {
 
 template<SocketType T>
 class AcceptorTcp final : public Acceptor {
@@ -45,10 +42,9 @@ class AcceptorTcp final : public Acceptor {
   void asyncAccept() override;
 
  private:
-  void performHandshake(std::unique_ptr<AsioSocket<T>>);
+  void performHandshake(std::shared_ptr<AsioSocket<T>>);
 
  private:
   asio_ns::ip::tcp::acceptor _acceptor;
 };
-}  // namespace rest
-}  // namespace arangodb
+}  // namespace arangodb::rest

--- a/arangod/GeneralServer/AcceptorUnixDomain.cpp
+++ b/arangod/GeneralServer/AcceptorUnixDomain.cpp
@@ -67,7 +67,7 @@ void AcceptorUnixDomain::open() {
 void AcceptorUnixDomain::asyncAccept() {
   IoContext& context = _server.selectIoContext();
 
-  auto asioSocket = std::make_unique<AsioSocket<SocketType::Unix>>(context);
+  auto asioSocket = std::make_shared<AsioSocket<SocketType::Unix>>(context);
   auto& socket = asioSocket->socket;
   auto& peer = asioSocket->peer;
   auto handler = [this, asioSocket = std::move(asioSocket)](

--- a/arangod/GeneralServer/AcceptorUnixDomain.h
+++ b/arangod/GeneralServer/AcceptorUnixDomain.h
@@ -26,8 +26,10 @@
 #include "GeneralServer/Acceptor.h"
 #include "GeneralServer/AsioSocket.h"
 
-namespace arangodb {
-namespace rest {
+#include <memory>
+#include <mutex>
+
+namespace arangodb::rest {
 
 class AcceptorUnixDomain final : public Acceptor {
  public:
@@ -45,7 +47,6 @@ class AcceptorUnixDomain final : public Acceptor {
   asio_ns::local::stream_protocol::acceptor _acceptor;
   /// @brief protects the _asioSocket
   std::mutex _mutex;
-  std::unique_ptr<AsioSocket<SocketType::Unix>> _asioSocket;
+  std::shared_ptr<AsioSocket<SocketType::Unix>> _asioSocket;
 };
-}  // namespace rest
-}  // namespace arangodb
+}  // namespace arangodb::rest

--- a/arangod/GeneralServer/GeneralCommTask.cpp
+++ b/arangod/GeneralServer/GeneralCommTask.cpp
@@ -37,7 +37,7 @@ using namespace arangodb::rest;
 
 template<SocketType T>
 GeneralCommTask<T>::GeneralCommTask(GeneralServer& server, ConnectionInfo info,
-                                    std::unique_ptr<AsioSocket<T>> socket)
+                                    std::shared_ptr<AsioSocket<T>> socket)
     : CommTask(server, std::move(info)),
       _protocol(std::move(socket)),
       _generalServerFeature(server.server().getFeature<GeneralServerFeature>()),

--- a/arangod/GeneralServer/GeneralCommTask.h
+++ b/arangod/GeneralServer/GeneralCommTask.h
@@ -38,7 +38,7 @@ class GeneralCommTask : public CommTask {
 
  public:
   GeneralCommTask(GeneralServer& server, ConnectionInfo,
-                  std::unique_ptr<AsioSocket<T>>);
+                  std::shared_ptr<AsioSocket<T>>);
 
   virtual ~GeneralCommTask() = default;
 
@@ -62,7 +62,7 @@ class GeneralCommTask : public CommTask {
   static constexpr size_t ReadBlockSize = 1024 * 32;
   static constexpr double WriteTimeout = 300.0;
 
-  std::unique_ptr<AsioSocket<T>> _protocol;
+  std::shared_ptr<AsioSocket<T>> _protocol;
 
   GeneralServerFeature& _generalServerFeature;
 

--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -262,7 +262,7 @@ template<SocketType T>
 
 template<SocketType T>
 H2CommTask<T>::H2CommTask(GeneralServer& server, ConnectionInfo info,
-                          std::unique_ptr<AsioSocket<T>> so)
+                          std::shared_ptr<AsioSocket<T>> so)
     : GeneralCommTask<T>(server, std::move(info), std::move(so)) {
   this->_connectionStatistics.SET_HTTP();
   this->_generalServerFeature.countHttp2Connection();

--- a/arangod/GeneralServer/H2CommTask.h
+++ b/arangod/GeneralServer/H2CommTask.h
@@ -57,7 +57,7 @@ template<SocketType T>
 class H2CommTask final : public GeneralCommTask<T> {
  public:
   H2CommTask(GeneralServer& server, ConnectionInfo,
-             std::unique_ptr<AsioSocket<T>> so);
+             std::shared_ptr<AsioSocket<T>> so);
   ~H2CommTask() noexcept;
 
   void start() override;

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -259,7 +259,7 @@ int HttpCommTask<T>::on_message_complete(llhttp_t* p) try {
 
 template<SocketType T>
 HttpCommTask<T>::HttpCommTask(GeneralServer& server, ConnectionInfo info,
-                              std::unique_ptr<AsioSocket<T>> so)
+                              std::shared_ptr<AsioSocket<T>> so)
     : GeneralCommTask<T>(server, std::move(info), std::move(so)),
       _lastHeaderWasValue(false),
       _shouldKeepAlive(false),

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -41,7 +41,7 @@ template<SocketType T>
 class HttpCommTask final : public GeneralCommTask<T> {
  public:
   HttpCommTask(GeneralServer& server, ConnectionInfo,
-               std::unique_ptr<AsioSocket<T>> so);
+               std::shared_ptr<AsioSocket<T>> so);
   ~HttpCommTask() noexcept;
 
   void start() override;

--- a/arangod/GeneralServer/VstCommTask.cpp
+++ b/arangod/GeneralServer/VstCommTask.cpp
@@ -58,7 +58,7 @@ using namespace arangodb::rest;
 
 template<SocketType T>
 VstCommTask<T>::VstCommTask(GeneralServer& server, ConnectionInfo info,
-                            std::unique_ptr<AsioSocket<T>> so,
+                            std::shared_ptr<AsioSocket<T>> so,
                             fuerte::vst::VSTVersion v)
     : GeneralCommTask<T>(server, std::move(info), std::move(so)),
       _writeLoopActive(false),

--- a/arangod/GeneralServer/VstCommTask.h
+++ b/arangod/GeneralServer/VstCommTask.h
@@ -40,7 +40,7 @@ template<SocketType T>
 class VstCommTask final : public GeneralCommTask<T> {
  public:
   VstCommTask(GeneralServer& server, ConnectionInfo,
-              std::unique_ptr<AsioSocket<T>> socket, fuerte::vst::VSTVersion v);
+              std::shared_ptr<AsioSocket<T>> socket, fuerte::vst::VSTVersion v);
   ~VstCommTask();
 
  protected:


### PR DESCRIPTION
### Scope & Purpose

Late backport of https://github.com/arangodb/arangodb/pull/19727

Fix BTS-1489: https://arangodb.atlassian.net/browse/BTS-1489

All AsioSocket instances are now created via `std::make_shared()`. This allows us to pass a shared_ptr to an AsioSocket into a lambda, so the lambda can still safely refer to the AsioSocket without any lifetime issues.
With the fix it is possible that the AsioSocket posts a lambda with a this pointer (to the AsioSocket), and the lambda being executed after the AsioSocket is destroyed.

This fix is already included in 3.12.0 and devel.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1489
- [ ] Design document: 