### PR TITLE
[3.12.0] BTS-1820: Flush ClusterInfo in Heartbeat again

### DIFF
--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1014,6 +1014,8 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
 
   _hasRunOnce.store(true, std::memory_order_release);
 
+  // invalidate our local cache
+  _clusterFeature.clusterInfo().flush();
   return true;
 }
 


### PR DESCRIPTION
### Scope & Purpose

*This PR introduces a flush in the Heartbeat thread again which has been removed in 3.12 but has side-effects. This introduced a regression to 3.11..
As we still want to remove the flush here, we created a ticket: https://arangodb.atlassian.net/browse/EF-61 to handle a more targeted replacement.
*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1820
- [ ] Design document: 
