### PR TITLE
Repair dump/restore tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -569,17 +569,6 @@ devel
 
 * Fix propagation of collection `writeConcern` changes to DB servers.
 
-* Make arangodump exclude the following cluster collection properties when
-  writing collection parameters files in a single server dump:
-  - replicationFactor
-  - writeConcern
-  - numberOfShards
-  - minReplicationFactor
-  - shardKeys
-  - shards
-  It is not really useful to write these attributes out when taking single
-  server dumps, because they don't have useful values.
-
 * Change default value of arangodump startup option `--use-parallel-dump` from
   `false` to `true`.
   This enables the more parallel dump procedure by default, which allows dumps

--- a/arangod/Sharding/ShardingFeature.cpp
+++ b/arangod/Sharding/ShardingFeature.cpp
@@ -24,7 +24,7 @@
 #include "ShardingFeature.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Cluster/ServerState.h"
+#include "Basics/StaticStrings.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"

--- a/arangod/Sharding/ShardingInfo.cpp
+++ b/arangod/Sharding/ShardingInfo.cpp
@@ -28,6 +28,7 @@
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Containers/SmallVector.h"
 #include "Logger/LogMacros.h"

--- a/arangod/Sharding/ShardingStrategy.h
+++ b/arangod/Sharding/ShardingStrategy.h
@@ -23,11 +23,12 @@
 
 #pragma once
 
-#include "Cluster/ClusterInfo.h"
+#include "Cluster/Utils/ShardID.h"
 
 #include <functional>
 #include <string>
 #include <string_view>
+#include <memory>
 
 namespace arangodb {
 class ShardingInfo;

--- a/arangod/Sharding/ShardingStrategyDefault.cpp
+++ b/arangod/Sharding/ShardingStrategyDefault.cpp
@@ -28,6 +28,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/hashes.h"
 #include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Sharding/ShardingInfo.h"
 #include "VocBase/LogicalCollection.h"

--- a/arangod/Sharding/ShardingStrategyDefault.h
+++ b/arangod/Sharding/ShardingStrategyDefault.h
@@ -25,12 +25,14 @@
 
 #include "Sharding/ShardingStrategy.h"
 
-#include <velocypack/Slice.h>
-
+#include <atomic>
 #include <span>
 #include <mutex>
 
 namespace arangodb {
+namespace velocypack {
+class Slice;
+}
 class ShardingInfo;
 
 /// @brief a sharding implementation that will always fail when asking

--- a/arangod/VocBase/Properties/CreateCollectionBody.cpp
+++ b/arangod/VocBase/Properties/CreateCollectionBody.cpp
@@ -27,12 +27,7 @@
 #include "Inspection/VPack.h"
 #include "Logger/LogMacros.h"
 #include "Basics/VelocyPackHelper.h"
-#include "Sharding/ShardingStrategyDefault.h"
 #include "VocBase/Properties/DatabaseConfiguration.h"
-
-#ifdef USE_ENTERPRISE
-#include "Enterprise/Sharding/ShardingStrategyEE.h"
-#endif
 
 #include <velocypack/Collection.h>
 #include <velocypack/Slice.h>
@@ -812,22 +807,20 @@ ResultT<CreateCollectionBody> CreateCollectionBody::fromRestoreAPIBody(
                 false;
 #endif
             if (!isSmart) {
-              col.shardingStrategy = ShardingStrategyHash::NAME;
+              col.shardingStrategy = "hash";
             } else {
               if (col.getType() == TRI_COL_TYPE_DOCUMENT) {
                 if (col.smartGraphAttribute.has_value()) {
                   // SmartGraphs need  to have shardingStrategy "hash"
-                  col.shardingStrategy = ShardingStrategyHash::NAME;
+                  col.shardingStrategy = "hash";
                 } else {
                   // EnterpriseGraphs need  to have shardingStrategy
                   // "enterprise-hex-smart-vertex"
-                  col.shardingStrategy =
-                      ShardingStrategyEnterpriseHexSmartVertex::NAME;
+                  col.shardingStrategy = "enterprise-hex-smart-vertex";
                 }
               } else {
                 // Smart Edge Collections always have hash-smart-edge sharding
-                col.shardingStrategy =
-                    ShardingStrategyEnterpriseHashSmartEdge::NAME;
+                col.shardingStrategy = "enterprise-hash-smart-edge";
               }
             }
           }

--- a/arangod/VocBase/Properties/CreateCollectionBody.cpp
+++ b/arangod/VocBase/Properties/CreateCollectionBody.cpp
@@ -777,7 +777,7 @@ ResultT<CreateCollectionBody> CreateCollectionBody::fromRestoreAPIBody(
         if (!col.shardingStrategy.has_value() &&
             !col.distributeShardsLike.has_value() &&
             config.defaultDistributeShardsLike.empty()) {
-          col.shardingStrategy = ShardingStrategyHash::NAME;
+          col.shardingStrategy = "hash";
         }
       });
   if (res.fail()) {

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -657,22 +657,6 @@ Result DumpFeature::DumpCollectionJob::run(
         VPackObjectBuilder subObject(&excludes, "parameters");
         subObject->add(StaticStrings::ShadowCollections,
                        VPackSlice::nullSlice());
-
-        if (!options.clusterMode) {
-          // single server.
-          // remove replicationFactor, writeConcern and others that are
-          // only relevant in cluster
-          subObject->add(StaticStrings::MinReplicationFactor,
-                         VPackSlice::nullSlice());
-          subObject->add(StaticStrings::NumberOfShards,
-                         VPackSlice::nullSlice());
-          subObject->add(StaticStrings::ReplicationFactor,
-                         VPackSlice::nullSlice());
-          subObject->add(StaticStrings::WriteConcern, VPackSlice::nullSlice());
-          // note: we cannot exclude shardKeys and sharding, because they
-          // can be used even in single-server SmartGraphs.
-          subObject->add("shards", VPackSlice::nullSlice());
-        }
       }
     }
 

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -116,7 +116,7 @@ std::string escapedCollectionName(std::string const& name,
 
 /// @brief return the target replication factor for the specified collection
 uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
-                              arangodb::velocypack::Slice slice,
+                              arangodb::velocypack::Slice const& slice,
                               bool& isSatellite) {
   uint64_t result = options.defaultReplicationFactor;
   isSatellite = false;
@@ -125,9 +125,10 @@ uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
       slice.get(arangodb::StaticStrings::ReplicationFactor);
   if (s.isInteger()) {
     result = s.getNumericValue<uint64_t>();
-  } else if (s.isString() &&
-             s.stringView() == arangodb::StaticStrings::Satellite) {
-    isSatellite = true;
+  } else if (s.isString()) {
+    if (s.copyString() == arangodb::StaticStrings::Satellite) {
+      isSatellite = true;
+    }
   }
 
   s = slice.get("name");
@@ -136,29 +137,33 @@ uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
     return result;
   }
 
-  for (auto const& it : options.replicationFactor) {
-    auto parts = arangodb::basics::StringUtils::split(it, '=');
-    if (parts.size() == 1) {
-      // this is the default value, e.g. `--replicationFactor 2`
-      if (parts[0] == arangodb::StaticStrings::Satellite) {
+  if (!options.replicationFactor.empty()) {
+    std::string const name = s.copyString();
+
+    for (auto const& it : options.replicationFactor) {
+      auto parts = arangodb::basics::StringUtils::split(it, '=');
+      if (parts.size() == 1) {
+        // this is the default value, e.g. `--replicationFactor 2`
+        if (parts[0] == arangodb::StaticStrings::Satellite) {
+          isSatellite = true;
+        } else {
+          result = arangodb::basics::StringUtils::uint64(parts[0]);
+        }
+      }
+
+      // look if we have a more specific value, e.g. `--replicationFactor
+      // myCollection=3`
+      if (parts.size() != 2 || parts[0] != name) {
+        // somehow invalid or different collection
+        continue;
+      }
+      if (parts[1] == arangodb::StaticStrings::Satellite) {
         isSatellite = true;
       } else {
-        result = arangodb::basics::StringUtils::uint64(parts[0]);
+        result = arangodb::basics::StringUtils::uint64(parts[1]);
       }
+      break;
     }
-
-    // look if we have a more specific value, e.g. `--replicationFactor
-    // myCollection=3`
-    if (parts.size() != 2 || parts[0] != s.stringView()) {
-      // somehow invalid or different collection
-      continue;
-    }
-    if (parts[1] == arangodb::StaticStrings::Satellite) {
-      isSatellite = true;
-    } else {
-      result = arangodb::basics::StringUtils::uint64(parts[1]);
-    }
-    break;
   }
 
   return result;
@@ -203,7 +208,7 @@ uint64_t getWriteConcern(arangodb::RestoreFeature::Options const& options,
 
 /// @brief return the target number of shards for the specified collection
 uint64_t getNumberOfShards(arangodb::RestoreFeature::Options const& options,
-                           arangodb::velocypack::Slice slice) {
+                           arangodb::velocypack::Slice const& slice) {
   uint64_t result = options.defaultNumberOfShards;
 
   arangodb::velocypack::Slice s = slice.get("numberOfShards");
@@ -217,21 +222,25 @@ uint64_t getNumberOfShards(arangodb::RestoreFeature::Options const& options,
     return result;
   }
 
-  for (auto const& it : options.numberOfShards) {
-    auto parts = arangodb::basics::StringUtils::split(it, '=');
-    if (parts.size() == 1) {
-      // this is the default value, e.g. `--numberOfShards 2`
-      result = arangodb::basics::StringUtils::uint64(parts[0]);
-    }
+  if (!options.numberOfShards.empty()) {
+    std::string const name = s.copyString();
 
-    // look if we have a more specific value, e.g. `--numberOfShards
-    // myCollection=3`
-    if (parts.size() != 2 || parts[0] != s.stringView()) {
-      // somehow invalid or different collection
-      continue;
+    for (auto const& it : options.numberOfShards) {
+      auto parts = arangodb::basics::StringUtils::split(it, '=');
+      if (parts.size() == 1) {
+        // this is the default value, e.g. `--numberOfShards 2`
+        result = arangodb::basics::StringUtils::uint64(parts[0]);
+      }
+
+      // look if we have a more specific value, e.g. `--numberOfShards
+      // myCollection=3`
+      if (parts.size() != 2 || parts[0] != name) {
+        // somehow invalid or different collection
+        continue;
+      }
+      result = arangodb::basics::StringUtils::uint64(parts[1]);
+      break;
     }
-    result = arangodb::basics::StringUtils::uint64(parts[1]);
-    break;
   }
 
   return result;
@@ -312,13 +321,13 @@ arangodb::Result tryCreateDatabase(
     ObjectBuilder object(&builder);
     object->add(arangodb::StaticStrings::DatabaseName, VPackValue(name));
 
-    // add replication factor, write concern, sharding, if set
+    // add replication factor write concern etc
     if (properties.isObject()) {
       ObjectBuilder guard(&builder, "options");
-      for (auto const& key : std::array<std::string_view, 3>{
-               arangodb::StaticStrings::ReplicationFactor,
-               arangodb::StaticStrings::Sharding,
-               arangodb::StaticStrings::WriteConcern}) {
+      for (auto const& key :
+           std::vector<std::string>{arangodb::StaticStrings::ReplicationFactor,
+                                    arangodb::StaticStrings::Sharding,
+                                    arangodb::StaticStrings::WriteConcern}) {
         VPackSlice slice = properties.get(key);
         if (key == arangodb::StaticStrings::ReplicationFactor) {
           // overwrite replicationFactor if set
@@ -384,10 +393,6 @@ void getDBProperties(arangodb::ManagedDirectory& directory,
   VPackSlice slice = VPackSlice::emptyObjectSlice();
   try {
     fileContentBuilder = directory.vpackFromJsonFile("dump.json");
-  } catch (std::exception const& ex) {
-    LOG_TOPIC("5ad64", WARN, arangodb::Logger::RESTORE)
-        << "could not read dump.json file: " << ex.what();
-    builder.add(slice);
   } catch (...) {
     LOG_TOPIC("3a5a4", WARN, arangodb::Logger::RESTORE)
         << "could not read dump.json file: "

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -116,7 +116,7 @@ std::string escapedCollectionName(std::string const& name,
 
 /// @brief return the target replication factor for the specified collection
 uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
-                              arangodb::velocypack::Slice const& slice,
+                              arangodb::velocypack::Slice slice,
                               bool& isSatellite) {
   uint64_t result = options.defaultReplicationFactor;
   isSatellite = false;
@@ -125,10 +125,9 @@ uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
       slice.get(arangodb::StaticStrings::ReplicationFactor);
   if (s.isInteger()) {
     result = s.getNumericValue<uint64_t>();
-  } else if (s.isString()) {
-    if (s.copyString() == arangodb::StaticStrings::Satellite) {
-      isSatellite = true;
-    }
+  } else if (s.isString() &&
+             s.stringView() == arangodb::StaticStrings::Satellite) {
+    isSatellite = true;
   }
 
   s = slice.get("name");
@@ -137,33 +136,29 @@ uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
     return result;
   }
 
-  if (!options.replicationFactor.empty()) {
-    std::string const name = s.copyString();
-
-    for (auto const& it : options.replicationFactor) {
-      auto parts = arangodb::basics::StringUtils::split(it, '=');
-      if (parts.size() == 1) {
-        // this is the default value, e.g. `--replicationFactor 2`
-        if (parts[0] == arangodb::StaticStrings::Satellite) {
-          isSatellite = true;
-        } else {
-          result = arangodb::basics::StringUtils::uint64(parts[0]);
-        }
-      }
-
-      // look if we have a more specific value, e.g. `--replicationFactor
-      // myCollection=3`
-      if (parts.size() != 2 || parts[0] != name) {
-        // somehow invalid or different collection
-        continue;
-      }
-      if (parts[1] == arangodb::StaticStrings::Satellite) {
+  for (auto const& it : options.replicationFactor) {
+    auto parts = arangodb::basics::StringUtils::split(it, '=');
+    if (parts.size() == 1) {
+      // this is the default value, e.g. `--replicationFactor 2`
+      if (parts[0] == arangodb::StaticStrings::Satellite) {
         isSatellite = true;
       } else {
-        result = arangodb::basics::StringUtils::uint64(parts[1]);
+        result = arangodb::basics::StringUtils::uint64(parts[0]);
       }
-      break;
     }
+
+    // look if we have a more specific value, e.g. `--replicationFactor
+    // myCollection=3`
+    if (parts.size() != 2 || parts[0] != s.stringView()) {
+      // somehow invalid or different collection
+      continue;
+    }
+    if (parts[1] == arangodb::StaticStrings::Satellite) {
+      isSatellite = true;
+    } else {
+      result = arangodb::basics::StringUtils::uint64(parts[1]);
+    }
+    break;
   }
 
   return result;
@@ -171,7 +166,7 @@ uint64_t getReplicationFactor(arangodb::RestoreFeature::Options const& options,
 
 /// @brief return the target replication factor for the specified collection
 uint64_t getWriteConcern(arangodb::RestoreFeature::Options const& options,
-                         arangodb::velocypack::Slice const& slice) {
+                         arangodb::velocypack::Slice slice) {
   uint64_t result = 1;
 
   arangodb::velocypack::Slice s =
@@ -208,7 +203,7 @@ uint64_t getWriteConcern(arangodb::RestoreFeature::Options const& options,
 
 /// @brief return the target number of shards for the specified collection
 uint64_t getNumberOfShards(arangodb::RestoreFeature::Options const& options,
-                           arangodb::velocypack::Slice const& slice) {
+                           arangodb::velocypack::Slice slice) {
   uint64_t result = options.defaultNumberOfShards;
 
   arangodb::velocypack::Slice s = slice.get("numberOfShards");
@@ -321,13 +316,13 @@ arangodb::Result tryCreateDatabase(
     ObjectBuilder object(&builder);
     object->add(arangodb::StaticStrings::DatabaseName, VPackValue(name));
 
-    // add replication factor write concern etc
+    // add replication factor, write concern, sharding, if set
     if (properties.isObject()) {
       ObjectBuilder guard(&builder, "options");
-      for (auto const& key :
-           std::vector<std::string>{arangodb::StaticStrings::ReplicationFactor,
-                                    arangodb::StaticStrings::Sharding,
-                                    arangodb::StaticStrings::WriteConcern}) {
+      for (auto const& key : std::array<std::string_view, 3>{
+               arangodb::StaticStrings::ReplicationFactor,
+               arangodb::StaticStrings::Sharding,
+               arangodb::StaticStrings::WriteConcern}) {
         VPackSlice slice = properties.get(key);
         if (key == arangodb::StaticStrings::ReplicationFactor) {
           // overwrite replicationFactor if set
@@ -393,6 +388,10 @@ void getDBProperties(arangodb::ManagedDirectory& directory,
   VPackSlice slice = VPackSlice::emptyObjectSlice();
   try {
     fileContentBuilder = directory.vpackFromJsonFile("dump.json");
+  } catch (std::exception const& ex) {
+    LOG_TOPIC("5ad64", WARN, arangodb::Logger::RESTORE)
+        << "could not read dump.json file: " << ex.what();
+    builder.add(slice);
   } catch (...) {
     LOG_TOPIC("3a5a4", WARN, arangodb::Logger::RESTORE)
         << "could not read dump.json file: "
@@ -459,7 +458,7 @@ arangodb::Result checkDumpDatabase(arangodb::ArangoRestoreServer& server,
 /// @brief Send the command to recreate a collection
 arangodb::Result sendRestoreCollection(
     arangodb::httpclient::SimpleHttpClient& httpClient,
-    arangodb::RestoreFeature::Options const& options, VPackSlice const& slice,
+    arangodb::RestoreFeature::Options const& options, VPackSlice slice,
     std::string const& name) {
   using arangodb::Logger;
   using arangodb::httpclient::SimpleHttpResult;
@@ -566,7 +565,7 @@ arangodb::Result recreateCollection(
 /// @brief Restore the data for a given view
 arangodb::Result restoreView(arangodb::httpclient::SimpleHttpClient& httpClient,
                              arangodb::RestoreFeature::Options const& options,
-                             VPackSlice const& viewDefinition) {
+                             VPackSlice viewDefinition) {
   using arangodb::httpclient::SimpleHttpResult;
 
   std::string url = absl::StrCat("/_api/replication/restore-view?overwrite=",

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -181,21 +181,17 @@ uint64_t getWriteConcern(arangodb::RestoreFeature::Options const& options,
     return result;
   }
 
-  if (!options.writeConcern.empty()) {
-    std::string const name = s.copyString();
-
-    for (auto const& it : options.writeConcern) {
-      auto parts = arangodb::basics::StringUtils::split(it, '=');
-      if (parts.size() == 1) {
-        result = arangodb::basics::StringUtils::uint64(parts[0]);
-      }
-      if (parts.size() != 2 || parts[0] != name) {
-        // somehow invalid or different collection
-        continue;
-      }
-      result = arangodb::basics::StringUtils::uint64(parts[1]);
-      break;
+  for (auto const& it : options.writeConcern) {
+    auto parts = arangodb::basics::StringUtils::split(it, '=');
+    if (parts.size() == 1) {
+      result = arangodb::basics::StringUtils::uint64(parts[0]);
     }
+    if (parts.size() != 2 || parts[0] != s.stringView()) {
+      // somehow invalid or different collection
+      continue;
+    }
+    result = arangodb::basics::StringUtils::uint64(parts[1]);
+    break;
   }
 
   return result;

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -956,6 +956,7 @@ function dumpWithCrashes (options) {
 function dumpWithCrashesNonParallel (options) {
   let dumpOptions = {
     dbServers: 3,
+    allDatabases: true,
     deactivateCompression: true,
     activateFailurePoint: true,
     threads: 1,

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -719,7 +719,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
       this.results.RtaCheckdata = {
         status: true
       };
-      return false;
+      return true;
     }
   }
 };

--- a/js/client/modules/@arangodb/testsuites/dump.js
+++ b/js/client/modules/@arangodb/testsuites/dump.js
@@ -489,7 +489,7 @@ class DumpRestoreHelper extends tu.runInArangoshRunner {
     this.print('Foxx Apps with full restore to ' + database);
     this.restoreConfig.setDatabase(database);
     this.restoreConfig.setIncludeSystem(true);
-    this.restoreConfig.setInputDirectory('dump', true);
+    this.restoreConfig.setInputDirectory('UnitTestsDumpSrc', true);
     this.results.restoreFoxxComplete = this.arangorestore();
     return this.validate(this.results.restoreFoxxComplete);
   }

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -48,6 +48,7 @@
 #include "Basics/files.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
 #include "FeaturePhases/BasicFeaturePhaseServer.h"
 #include "FeaturePhases/ClusterFeaturePhase.h"
 #include "FeaturePhases/DatabaseFeaturePhase.h"

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -42,6 +42,7 @@
 #include "Cluster/ActionDescription.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
 #include "Cluster/CreateCollection.h"
 #include "Cluster/CreateDatabase.h"
 #include "Cluster/DropDatabase.h"

--- a/tests/js/client/dump/dump-multiple.js
+++ b/tests/js/client/dump/dump-multiple.js
@@ -61,7 +61,7 @@ jsunity.run(function dump_single_testsuite() {
       indexesCount: 9,
       // testKeygenAutoInc
       keygenAutoInc: 42049,
-      autoIncDocCount: 1000, // this one is special
+      autoIncDocCount: 1001,
       // testKeygenPadded
       paddedDocCount: 1001,
       // testKeygenUuid

--- a/tests/js/client/dump/dump-teardown-cluster.js
+++ b/tests/js/client/dump/dump-teardown-cluster.js
@@ -30,7 +30,6 @@
 
   db._dropDatabase("UnitTestsDumpProperties1");
   db._dropDatabase("UnitTestsDumpProperties2");
-  //   db._dropDatabase("UnitTestsDumpSrc");
   db._dropDatabase("UnitTestsDumpDst");
 })();
 

--- a/tests/js/client/dump/dump-teardown-cluster.js
+++ b/tests/js/client/dump/dump-teardown-cluster.js
@@ -30,7 +30,7 @@
 
   db._dropDatabase("UnitTestsDumpProperties1");
   db._dropDatabase("UnitTestsDumpProperties2");
-  db._dropDatabase("UnitTestsDumpSrc");
+  //   db._dropDatabase("UnitTestsDumpSrc");
   db._dropDatabase("UnitTestsDumpDst");
 })();
 

--- a/tests/js/client/dump/dump-teardown-multiple.js
+++ b/tests/js/client/dump/dump-teardown-multiple.js
@@ -1,0 +1,35 @@
+/*jshint globalstrict:false, strict:false */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+(function () {
+  'use strict';
+  var db = require("@arangodb").db;
+
+  db._dropDatabase("UnitTestsDumpSrc");
+  db._dropDatabase("UnitTestsDumpDst");
+})();
+
+return {
+  status: true
+};
+

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -37,7 +37,17 @@
   const arangosh = require('@arangodb/arangosh');
   const isCluster = internal.isCluster();
   const isEnterprise = internal.isEnterprise();
+  const instanceInfo = JSON.parse(require('internal').env.INSTANCEINFO);
   var db = internal.db;
+
+  const getDumpDir = () => {
+    let dumpDir = instanceInfo.rootDir;
+    if (fs.exists(fs.join(dumpDir, "UnitTestsDumpSrc"))) {
+      // when dumping multiple database the database name is one layer added:
+      dumpDir = fs.join(dumpDir, "UnitTestsDumpSrc");
+    }
+    return dumpDir;
+  };
 
   function getCollection(name) {
     var c = db._collection(name);
@@ -125,7 +135,6 @@
     const satelliteEdgeCollection2Name = "UnitTestDumpSatelliteEdgeCollection2";
     const gm = (isEnterprise) ? require("@arangodb/smart-graph") : {};
     const satgm = (isEnterprise) ? require("@arangodb/satellite-graph") : {};
-    const instanceInfo = JSON.parse(require('internal').env.INSTANCEINFO);
     const {map, zipObject} = require('lodash');
     const isServer = require("@arangodb").isServer;
     const request = require("@arangodb/request");
@@ -1163,11 +1172,7 @@
       },
 
       testHiddenCollectionsOmitted: function () {
-        let dumpDir = fs.join(instanceInfo.rootDir, 'dump');
-        if (fs.exists(fs.join(dumpDir, "UnitTestsDumpSrc"))) {
-          // when dumping multiple database the database name is one layer added:
-          dumpDir = fs.join(dumpDir, "UnitTestsDumpSrc");
-        }
+        const dumpDir = getDumpDir();
         const smartEdgeCollectionPath = fs.join(dumpDir, `${edges}.structure.json`);
         const localEdgeCollectionPath = fs.join(dumpDir, `_local_${edges}.structure.json`);
         const fromEdgeCollectionPath = fs.join(dumpDir, `_from_${edges}.structure.json`);
@@ -1180,7 +1185,8 @@
       },
 
       testShadowCollectionsOmitted: function () {
-        const encryption = fs.read(fs.join(instanceInfo.rootDir, 'dump', 'ENCRYPTION'));
+        const dumpDir = getDumpDir();
+        const encryption = fs.read(fs.join(dumpDir, 'ENCRYPTION'));
         if (encryption === '' || encryption === 'none') {
           let dumpDir = fs.join(instanceInfo.rootDir, 'dump');
           if (fs.exists(fs.join(dumpDir, "UnitTestsDumpSrc"))) {

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -1188,10 +1188,6 @@
         const dumpDir = getDumpDir();
         const encryption = fs.read(fs.join(dumpDir, 'ENCRYPTION'));
         if (encryption === '' || encryption === 'none') {
-          if (fs.exists(fs.join(dumpDir, "UnitTestsDumpSrc"))) {
-            // when dumping multiple database the database name is one layer added:
-            dumpDir = fs.join(dumpDir, "UnitTestsDumpSrc");
-          }
           const collStructure = JSON.parse(
             fs.read(fs.join(dumpDir, `${edges}.structure.json`))
           );

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -52,7 +52,7 @@
   function getCollection(name) {
     var c = db._collection(name);
     if (c === null) {
-      let allCols = db._collections();
+      let allCols = db._collections().map(c => c.name());
       assertNotEqual(c, null, `${name} not found, ${JSON.stringify(allCols)} are here`);
     }
     return c;

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -1188,7 +1188,6 @@
         const dumpDir = getDumpDir();
         const encryption = fs.read(fs.join(dumpDir, 'ENCRYPTION'));
         if (encryption === '' || encryption === 'none') {
-          let dumpDir = fs.join(instanceInfo.rootDir, 'dump');
           if (fs.exists(fs.join(dumpDir, "UnitTestsDumpSrc"))) {
             // when dumping multiple database the database name is one layer added:
             dumpDir = fs.join(dumpDir, "UnitTestsDumpSrc");

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -45,6 +45,9 @@
     if (fs.exists(fs.join(dumpDir, "UnitTestsDumpSrc"))) {
       // when dumping multiple database the database name is one layer added:
       dumpDir = fs.join(dumpDir, "UnitTestsDumpSrc");
+    } else {
+      // single database always ends up in "dump"
+      dumpDir = fs.join(dumpDir, "dump");
     }
     return dumpDir;
   };

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -286,7 +286,7 @@
         assertEqual(properties.numberOfShards, 1);
         assertEqual(properties.replicationFactor, 'satellite');
         if (isCluster) {
-          assertEqual(properties.shardingStrategy, 'enterprise-compat');
+          assertEqual(properties.shardingStrategy, 'hash');
         }
       }
 
@@ -298,7 +298,7 @@
       assertEqual(properties.numberOfShards, 1);
       assertEqual(properties.replicationFactor, 'satellite');
       if (isCluster) {
-        assertEqual(properties.shardingStrategy, 'enterprise-compat');
+        assertEqual(properties.shardingStrategy, 'hash');
       }
     }
 
@@ -1859,7 +1859,7 @@
           assertEqual(properties.numberOfShards, 1);
           assertEqual(properties.replicationFactor, 'satellite');
           if (isCluster) {
-            assertEqual(properties.shardingStrategy, 'enterprise-compat');
+            assertEqual(properties.shardingStrategy, 'hash');
           }
         }
 
@@ -1871,7 +1871,7 @@
         assertEqual(properties.numberOfShards, 1);
         assertEqual(properties.replicationFactor, 'satellite');
         if (isCluster) {
-          assertEqual(properties.shardingStrategy, 'enterprise-compat');
+          assertEqual(properties.shardingStrategy, 'hash');
         }
 
         // test data
@@ -1964,7 +1964,7 @@
         assertEqual(verticesSatProps.smartGraphAttribute, undefined);
         assertEqual(verticesSatProps.replicationFactor, 'satellite');
         if (isCluster) {
-          assertEqual(verticesSatCol.properties().shardingStrategy, 'enterprise-compat', `Failed for collection: "${verticesSatCol.name()}".`);
+          assertEqual(verticesSatCol.properties().shardingStrategy, 'hash', `Failed for collection: "${verticesSatCol.name()}".`);
         }
 
         // check properties of edge collections

--- a/tests/js/client/shell/api/api-replication.js
+++ b/tests/js/client/shell/api/api-replication.js
@@ -134,8 +134,7 @@ const getDefaultProps = () => {
       "replicationFactor": 2,
       "minReplicationFactor": 1,
       "writeConcern": 1,
-      /* Is this a reasonable default?, We have a new collection */
-      "shardingStrategy": isEnterprise ? "enterprise-compat" : "community-compat",
+      "shardingStrategy": "hash",
       "cacheEnabled": false,
       "computedValues": null,
       "syncByRevision": true,


### PR DESCRIPTION
### Scope & Purpose

We would return false while the rta-checkdata test result is true. This would skip further tests. It was introduced in #19718, and since then those tests haven't been run.

Necessary changes to fix the by-now failing tests are also part of this PR. The most notable changes are the following:

- Change the default of shardingStrategy from `enterprise-compat`/`community-compat` to `hash` in the restore API, and adjust the tests accordingly. This is now consistent with the collection API, and the more sensible default. An inconsistent default would lead to test failures.
- Revert https://github.com/arangodb/arangodb/pull/20096: there are a bunch of tests that check that restoring a cluster-dump to a single server preserves the cluster-specific attributes that were removed in that PR. Other improvements from that PR are preserved. (only applies to devel and 3.12.0)

In addition, the tests got the following fixes:

- Restoring foxx apps used the wrong dump-path to restore
- Two more tests calculated the wrong input path (testHiddenCollectionsOmitted and testShadowCollectionsOmitted)
- `testKeygenAutoInc` got the wrong expected document count in `dump-multiple.js`
- One of the teardown files threw an exception when trying to remove a non-existent database, making the teardown fail
- Another teardown file was missing completely

- [x] :hankey: Bugfix
