### PR TITLE
do not move uncorrelated subqueries down

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2456,14 +2456,20 @@ ExecutionNode* ExecutionPlan::fromNode(AstNode const* node) {
     TRI_ASSERT(en != nullptr);
 
     if (en == nullptr) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "type not handled");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          absl::StrCat("type not handled: ", member->getTypeString()));
     }
 
     if (_ids.size() > maxPlanNodes) {
       // maximum number of execution nodes reached
       // we have to limit this to prevent super-long runtimes for query
       // optimization and execution
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_TOO_MUCH_NESTING);
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_QUERY_TOO_MUCH_NESTING,
+          absl::StrCat("total number of generated execution nodes for query "
+                       "execution plans reached the maximum possible value (",
+                       maxPlanNodes, ")"));
     }
   }
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1811,7 +1811,8 @@ void arangodb::aql::moveCalculationsDownRule(
         continue;
       }
       variable = nn->outVariable();
-    } else if (n->getType() == EN::SUBQUERY) {
+    } else {
+      TRI_ASSERT(n->getType() == EN::SUBQUERY);
       auto nn = ExecutionNode::castTo<SubqueryNode*>(n);
       if (!nn->isDeterministic() || nn->isModificationNode()) {
         // we will only move subqueries down that are deterministic and are not
@@ -1819,8 +1820,6 @@ void arangodb::aql::moveCalculationsDownRule(
         continue;
       }
       variable = nn->outVariable();
-    } else {
-      TRI_ASSERT(false);
     }
 
     stack.clear();

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1819,6 +1819,8 @@ void arangodb::aql::moveCalculationsDownRule(
         continue;
       }
       variable = nn->outVariable();
+    } else {
+      TRI_ASSERT(false);
     }
 
     stack.clear();
@@ -1831,61 +1833,62 @@ void arangodb::aql::moveCalculationsDownRule(
       stack.pop_back();
 
       auto const currentType = current->getType();
-      bool tryToPushIntoSubquery = false;
 
-      if (currentType == EN::SUBQUERY && !current->isVarUsedLater(variable)) {
+      usedHere.clear();
+      current->getVariablesUsedHere(usedHere);
+
+      bool varUsedHere = std::find(usedHere.begin(), usedHere.end(),
+                                   variable) != usedHere.end();
+
+      if (n->getType() == EN::CALCULATION && currentType == EN::SUBQUERY &&
+          varUsedHere && !current->isVarUsedLater(variable)) {
+        // move calculations into subqueries if they are required by the
+        // subquery and not used later
         current = ExecutionNode::castTo<SubqueryNode*>(current)->getSubquery();
         while (current->hasDependency()) {
           current = current->getFirstDependency();
         }
-        tryToPushIntoSubquery = true;
+        lastNode = current;
       } else {
-        usedHere.clear();
-        current->getVariablesUsedHere(usedHere);
-
-        bool const done = std::find(usedHere.begin(), usedHere.end(),
-                                    variable) != usedHere.end();
-
-        if (done) {
+        if (varUsedHere) {
           // the node we're looking at needs the variable we're setting.
           // can't push further!
           break;
         }
-      }
 
-      if (tryToPushIntoSubquery) {
-        lastNode = current;
-      } else if (currentType == EN::FILTER || currentType == EN::SORT ||
-                 currentType == EN::LIMIT || currentType == EN::SUBQUERY ||
-                 currentType == EN::SINGLETON) {
-        // we found something interesting that justifies moving our node down
-        if (currentType == EN::LIMIT &&
-            arangodb::ServerState::instance()->isCoordinator()) {
-          // in a cluster, we do not want to move the calculations as far down
-          // as possible, because this will mean we may need to transfer a lot
-          // more data between DB servers and the coordinator
+        if (currentType == EN::FILTER || currentType == EN::SORT ||
+            currentType == EN::LIMIT || currentType == EN::SINGLETON ||
+            // do not move a subquery past another unrelated subquery
+            (currentType == EN::SUBQUERY && n->getType() != EN::SUBQUERY)) {
+          // we found something interesting that justifies moving our node down
+          if (currentType == EN::LIMIT &&
+              arangodb::ServerState::instance()->isCoordinator()) {
+            // in a cluster, we do not want to move the calculations as far down
+            // as possible, because this will mean we may need to transfer a lot
+            // more data between DB servers and the coordinator
 
-          // assume first that we want to move the node past the LIMIT
+            // assume first that we want to move the node past the LIMIT
 
-          // however, if our calculation uses any data from a
-          // collection/index/view, it probably makes sense to not move it,
-          // because the result set may be huge
-          if (::accessesCollectionVariable(plan.get(), n, vars)) {
-            break;
+            // however, if our calculation uses any data from a
+            // collection/index/view, it probably makes sense to not move it,
+            // because the result set may be huge
+            if (::accessesCollectionVariable(plan.get(), n, vars)) {
+              break;
+            }
           }
-        }
 
-        lastNode = current;
-      } else if (currentType == EN::INDEX ||
-                 currentType == EN::ENUMERATE_COLLECTION ||
-                 currentType == EN::ENUMERATE_IRESEARCH_VIEW ||
-                 currentType == EN::ENUMERATE_LIST ||
-                 currentType == EN::TRAVERSAL ||
-                 currentType == EN::SHORTEST_PATH ||
-                 currentType == EN::ENUMERATE_PATHS ||
-                 currentType == EN::COLLECT || currentType == EN::NORESULTS) {
-        // we will not push further down than such nodes
-        break;
+          lastNode = current;
+        } else if (currentType == EN::INDEX ||
+                   currentType == EN::ENUMERATE_COLLECTION ||
+                   currentType == EN::ENUMERATE_IRESEARCH_VIEW ||
+                   currentType == EN::ENUMERATE_LIST ||
+                   currentType == EN::TRAVERSAL ||
+                   currentType == EN::SHORTEST_PATH ||
+                   currentType == EN::ENUMERATE_PATHS ||
+                   currentType == EN::COLLECT || currentType == EN::NORESULTS) {
+          // we will not push further down than such nodes
+          break;
+        }
       }
 
       if (!current->hasParent()) {

--- a/arangod/Aql/RegisterId.cpp
+++ b/arangod/Aql/RegisterId.cpp
@@ -24,6 +24,8 @@
 #include "Aql/types.h"
 #include "Basics/Exceptions.h"
 
+#include <absl/strings/str_cat.h>
+
 namespace arangodb::aql {
 RegisterId RegisterId::fromUInt32(uint32_t value) {
   auto v = static_cast<value_t>(value);
@@ -33,7 +35,7 @@ RegisterId RegisterId::fromUInt32(uint32_t value) {
   if (!result.isValid()) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_INTERNAL,
-        "Cannot parse RegisterId from value " + std::to_string(value));
+        absl::StrCat("Cannot parse RegisterId from value ", value));
   }
   return result;
 }

--- a/arangod/Aql/RegisterPlan.h
+++ b/arangod/Aql/RegisterPlan.h
@@ -30,6 +30,7 @@
 #include "Aql/types.h"
 
 #include <iosfwd>
+#include <map>
 #include <memory>
 #include <stack>
 #include <vector>


### PR DESCRIPTION
### Scope & Purpose

Do not move uncorrelated subqueries down via optimizer rule `move-calculations-down`.
Doing so can cause performance degradations during query plan optimization for no good reason.

For example, if there is the following query
```
FOR doc IN ...
  LET result1 = (...)
  LET result2 = (...)
  ...
```
and `result1` and `result2` are uncorrelated, then there is no benefit in moving `result1` down past `result2`. 
Doing so anyway will trigger a recalculation of which variables are valid in the plan at any step, which is expensive and thus we want to avoid doing this unnecessarily.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 