### PR TITLE
do not copy log message

### DIFF
--- a/lib/Logger/LoggerStream.cpp
+++ b/lib/Logger/LoggerStream.cpp
@@ -61,7 +61,7 @@ LoggerStreamBase& LoggerStreamBase::operator<<(
   try {
     std::ostringstream tmp;
     tmp << std::setprecision(value._precision) << std::fixed << value._value;
-    _out << tmp.str();
+    _out << tmp.view();
   } catch (...) {
     // ignore any errors here. logging should not have side effects
   }
@@ -109,14 +109,13 @@ LoggerStream::~LoggerStream() {
 #endif
 
   try {
-    // TODO: with c++20, we can get a view on the stream's underlying buffer,
-    // without copying it
-    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.str());
+    // get a view on the stream's underlying buffer, without copying it
+    Logger::log(_logid, _function, _file, _line, _level, _topicId, _out.view());
   } catch (...) {
     try {
       // logging the error may fail as well, and we should never throw in the
       // dtor
-      std::cerr << "failed to log: " << _out.str() << std::endl;
+      std::cerr << "failed to log: " << _out.view() << std::endl;
     } catch (...) {
     }
   }


### PR DESCRIPTION
### Scope & Purpose

Do not copy log message.

Since c++20 there is a `view()` method to access an ostream's contents without copying it.
This PR is attempt to figure out if we can use this operator in all environments that we need to support.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 