### PR TITLE
refactor Query/ClusterQuery

### DIFF
--- a/arangod/Aql/ClusterQuery.cpp
+++ b/arangod/Aql/ClusterQuery.cpp
@@ -48,7 +48,7 @@ using namespace arangodb;
 using namespace arangodb::aql;
 
 // Wait 2s to get the Lock in FastPath, otherwise assume dead-lock.
-const double FAST_PATH_LOCK_TIMEOUT = 2.0;
+constexpr double kFastPathLockTimeout = 2.0;
 
 ClusterQuery::ClusterQuery(QueryId id,
                            std::shared_ptr<transaction::Context> ctx,
@@ -60,12 +60,10 @@ ClusterQuery::ClusterQuery(QueryId id,
             std::move(options),
             /*sharedState*/ ServerState::instance()->isDBServer()
                 ? nullptr
-                : std::make_shared<SharedQueryState>(ctx->vocbase().server())},
-      _planMemoryUsage(0) {}
+                : std::make_shared<SharedQueryState>(ctx->vocbase().server())} {
+}
 
 ClusterQuery::~ClusterQuery() {
-  _resourceMonitor.decreaseMemoryUsage(_planMemoryUsage);
-
   try {
     _traversers.clear();
   } catch (...) {
@@ -95,13 +93,35 @@ std::shared_ptr<ClusterQuery> ClusterQuery::create(
                                            std::move(options));
 }
 
-void ClusterQuery::prepareClusterQuery(
-    VPackSlice querySlice, VPackSlice collections, VPackSlice variables,
-    VPackSlice snippets, VPackSlice traverserSlice, std::string const& user,
-    VPackBuilder& answerBuilder,
+void ClusterQuery::buildTraverserEngines(velocypack::Slice traverserSlice,
+                                         velocypack::Builder& answerBuilder) {
+  TRI_ASSERT(answerBuilder.isOpenObject());
+
+  if (traverserSlice.isArray()) {
+    // used to be RestAqlHandler::registerTraverserEngines
+    answerBuilder.add("traverserEngines", VPackValue(VPackValueType::Array));
+    for (auto te : VPackArrayIterator(traverserSlice)) {
+      auto engine = traverser::BaseEngine::buildEngine(_vocbase, *this, te);
+      answerBuilder.add(VPackValue(engine->engineId()));
+      _traversers.emplace_back(std::move(engine));
+    }
+    answerBuilder.close();  // traverserEngines
+  }
+}
+
+/// @brief prepare a query out of some velocypack data.
+/// only to be used on a DB server.
+/// never call this on a single server or coordinator!
+void ClusterQuery::prepareFromVelocyPack(
+    velocypack::Slice querySlice, velocypack::Slice collections,
+    velocypack::Slice variables, velocypack::Slice snippets,
+    velocypack::Slice traverserSlice, std::string const& user,
+    velocypack::Builder& answerBuilder,
     QueryAnalyzerRevisions const& analyzersRevision, bool fastPathLocking) {
-  LOG_TOPIC("9636f", DEBUG, Logger::QUERIES)
-      << elapsedSince(_startTime) << " ClusterQuery::prepareClusterQuery"
+  TRI_ASSERT(ServerState::instance()->isDBServer());
+
+  LOG_TOPIC("45493", DEBUG, Logger::QUERIES)
+      << elapsedSince(_startTime) << " ClusterQuery::prepareFromVelocyPack"
       << " this: " << (uintptr_t)this;
 
   // track memory usage
@@ -112,14 +132,12 @@ void ClusterQuery::prepareClusterQuery(
 
   _planMemoryUsage += scope.trackedAndSteal();
 
-  init(/*createProfile*/ true);
+  init(/*createProfile*/ false);
 
-  VPackSlice val = querySlice.get("isModificationQuery");
-  if (val.isBool() && val.getBool()) {
+  if (auto val = querySlice.get("isModificationQuery"); val.isTrue()) {
     _ast->setContainsModificationNode();
   }
-  val = querySlice.get("isAsyncQuery");
-  if (val.isBool() && val.getBool()) {
+  if (auto val = querySlice.get("isAsyncQuery"); val.isTrue()) {
     _ast->setContainsParallelNode();
   }
 
@@ -137,9 +155,7 @@ void ClusterQuery::prepareClusterQuery(
   if (_queryOptions.transactionOptions.skipInaccessibleCollections) {
     inaccessibleCollections = _queryOptions.inaccessibleCollections;
   }
-#endif
 
-#ifdef USE_ENTERPRISE
   waitForSatellites();
 #endif
 
@@ -150,14 +166,12 @@ void ClusterQuery::prepareClusterQuery(
   // create the transaction object, but do not start the transaction yet
   _trx->addHint(
       transaction::Hints::Hint::FROM_TOPLEVEL_AQL);  // only used on toplevel
-  if (_trx->state()->isDBServer()) {
-    _trx->state()->acceptAnalyzersRevision(analyzersRevision);
-    _trx->setUsername(user);
-  }
+  _trx->state()->acceptAnalyzersRevision(analyzersRevision);
+  _trx->setUsername(user);
 
   double origLockTimeout = _trx->state()->options().lockTimeout;
   if (fastPathLocking) {
-    _trx->state()->options().lockTimeout = FAST_PATH_LOCK_TIMEOUT;
+    _trx->state()->options().lockTimeout = kFastPathLockTimeout;
   }
 
   Result res = _trx->begin();
@@ -165,6 +179,7 @@ void ClusterQuery::prepareClusterQuery(
     THROW_ARANGO_EXCEPTION(res);
   }
 
+  // restore original lock timeout
   _trx->state()->options().lockTimeout = origLockTimeout;
 
   TRI_IF_FAILURE("Query::setupLockTimeout") {
@@ -174,69 +189,43 @@ void ClusterQuery::prepareClusterQuery(
     }
   }
 
-  if (ServerState::instance()->isDBServer()) {
-    _collections.visit([&](std::string const&,
-                           aql::Collection const& c) -> bool {
-      // this code will only execute on leaders
-      _trx->state()->trackShardRequest(*_trx->resolver(), _vocbase.name(),
-                                       c.name(), user, c.accessType(), "aql");
-      return true;
-    });
-  }
+  _collections.visit([&](std::string const&, aql::Collection const& c) -> bool {
+    // this code will only execute on leaders
+    _trx->state()->trackShardRequest(*_trx->resolver(), _vocbase.name(),
+                                     c.name(), user, c.accessType(), "aql");
+    return true;
+  });
 
   enterState(QueryExecutionState::ValueType::PARSING);
 
   bool const planRegisters = !_queryString.empty();
-  auto instantiateSnippet = [&](VPackSlice snippet) {
+  auto instantiateSnippet = [&](velocypack::Slice snippet) {
     auto plan = ExecutionPlan::instantiateFromVelocyPack(_ast.get(), snippet);
     TRI_ASSERT(plan != nullptr);
-
-    plan->findVarUsage();  // I think this is a no-op
 
     ExecutionEngine::instantiateFromPlan(*this, *plan, planRegisters);
     _plans.push_back(std::move(plan));
   };
 
+  TRI_ASSERT(answerBuilder.isOpenObject());
   answerBuilder.add("snippets", VPackValue(VPackValueType::Object));
   for (auto pair : VPackObjectIterator(snippets, /*sequential*/ true)) {
     instantiateSnippet(pair.value);
 
     TRI_ASSERT(!_snippets.empty());
-    TRI_ASSERT(!_trx->state()->isDBServer() ||
-               _snippets.back()->engineId() != 0);
+    TRI_ASSERT(_snippets.back()->engineId() != 0);
 
-    answerBuilder.add(pair.key);
-    answerBuilder.add(VPackValue(std::to_string(_snippets.back()->engineId())));
+    answerBuilder.add(pair.key.stringView(),
+                      VPackValue(std::to_string(_snippets.back()->engineId())));
   }
   answerBuilder.close();  // snippets
 
   if (!_snippets.empty()) {
-    TRI_ASSERT(_trx->state()->isDBServer() || _snippets[0]->engineId() == 0);
-    // simon: just a hack for AQL_EXECUTEJSON
-    if (_trx->state()->isCoordinator()) {  // register coordinator snippets
-      TRI_ASSERT(_trx->state()->isCoordinator());
-      QueryRegistryFeature::registry()->registerSnippets(_snippets);
-    }
-
     registerQueryInTransactionState();
   }
 
-  if (traverserSlice.isArray()) {
-    // used to be RestAqlHandler::registerTraverserEngines
-    answerBuilder.add("traverserEngines", VPackValue(VPackValueType::Array));
-    for (auto const te : VPackArrayIterator(traverserSlice)) {
-      auto engine = traverser::BaseEngine::BuildEngine(_vocbase, *this, te);
-      answerBuilder.add(VPackValue(engine->engineId()));
+  buildTraverserEngines(traverserSlice, answerBuilder);
 
-      _traversers.emplace_back(std::move(engine));
-    }
-    answerBuilder.close();  // traverserEngines
-  }
-  TRI_ASSERT(_trx != nullptr);
-
-  if (_queryProfile) {  // simon: just a hack for AQL_EXECUTEJSON
-    _queryProfile->registerInQueryList();
-  }
   enterState(QueryExecutionState::ValueType::EXECUTION);
 }
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -605,7 +605,7 @@ void ExecutionPlan::increaseCounter(ExecutionNode const& node) noexcept {
 
 /// @brief process the list of collections in a VelocyPack
 void ExecutionPlan::getCollectionsFromVelocyPack(aql::Collections& colls,
-                                                 VPackSlice const slice) {
+                                                 velocypack::Slice slice) {
   VPackSlice collectionsSlice = slice;
   if (slice.isObject()) {
     collectionsSlice = slice.get("collections");
@@ -617,31 +617,43 @@ void ExecutionPlan::getCollectionsFromVelocyPack(aql::Collections& colls,
         "json node \"collections\" not found or not an array");
   }
 
-  for (VPackSlice const collection : VPackArrayIterator(collectionsSlice)) {
+  for (auto collection : VPackArrayIterator(collectionsSlice)) {
     colls.add(
         basics::VelocyPackHelper::checkAndGetStringValue(collection, "name"),
         AccessMode::fromString(
             arangodb::basics::VelocyPackHelper::checkAndGetStringValue(
-                collection, "type")
-                .c_str()),
+                collection, "type")),
         aql::Collection::Hint::Shard);
   }
 }
 
 /// @brief create an execution plan from VelocyPack
 std::unique_ptr<ExecutionPlan> ExecutionPlan::instantiateFromVelocyPack(
-    Ast* ast, VPackSlice const slice) {
+    Ast* ast, velocypack::Slice slice) {
   TRI_ASSERT(ast != nullptr);
 
-  auto plan = std::make_unique<ExecutionPlan>(ast, true);
+  auto plan = std::make_unique<ExecutionPlan>(ast, /*trackMemoryUsage*/ true);
   plan->_root = plan->fromSlice(slice);
   plan->setVarUsageComputed();
+
+  if (auto rules = slice.get("rules"); rules.isArray()) {
+    for (auto rule : VPackArrayIterator(rules)) {
+      int ruleId = OptimizerRulesFeature::translateRule(rule.stringView());
+      plan->_appliedRules.push_back(ruleId);
+    }
+  }
+
+  if (auto apfn = slice.get("asyncPrefetchNodes"); apfn.isNumber<size_t>()) {
+    plan->_asyncPrefetchNodes = apfn.getNumericValue<size_t>();
+  }
 
   return plan;
 }
 
 /// @brief clone an existing execution plan
 std::unique_ptr<ExecutionPlan> ExecutionPlan::clone(Ast* ast) {
+  TRI_ASSERT(ast != nullptr);
+
   auto plan = std::make_unique<ExecutionPlan>(ast, _trackMemoryUsage);
   plan->_nextId = _nextId;
   plan->_root = _root->clone(plan.get(), true);
@@ -677,9 +689,11 @@ unsigned ExecutionPlan::buildSerializationFlags(
 }
 
 /// @brief export to VelocyPack
-void ExecutionPlan::toVelocyPack(VPackBuilder& builder, Ast* ast,
-                                 unsigned flags) const {
+void ExecutionPlan::toVelocyPack(
+    velocypack::Builder& builder, unsigned flags,
+    std::function<void(velocypack::Builder&)> const& serializeQueryData) const {
   builder.openObject();
+
   builder.add(VPackValue("nodes"));
   _root->allToVelocyPack(builder, flags);
 
@@ -687,28 +701,20 @@ void ExecutionPlan::toVelocyPack(VPackBuilder& builder, Ast* ast,
   TRI_ASSERT(builder.isOpenObject());
   builder.add(VPackValue("rules"));
   builder.openArray();
-  for (auto const& ruleName :
-       OptimizerRulesFeature::translateRules(_appliedRules)) {
-    builder.add(VPackValue(ruleName));
+  for (int rule : _appliedRules) {
+    std::string_view ruleName = OptimizerRulesFeature::translateRule(rule);
+    if (!ruleName.empty()) {
+      builder.add(VPackValue(ruleName));
+    }
   }
   builder.close();
 
-  // set up collections
-  TRI_ASSERT(builder.isOpenObject());
-  builder.add(VPackValue("collections"));
-  ast->query().collections().toVelocyPack(builder);
-
-  // set up variables
-  TRI_ASSERT(builder.isOpenObject());
-  builder.add(VPackValue("variables"));
-  ast->variables()->toVelocyPack(builder);
-
+  // the following attributes are read by the explainer
   CostEstimate estimate = _root->getCost();
-  // simon: who is reading this ?
   builder.add("estimatedCost", VPackValue(estimate.estimatedCost));
   builder.add("estimatedNrItems", VPackValue(estimate.estimatedNrItems));
-  builder.add("isModificationQuery",
-              VPackValue(ast->containsModificationNode()));
+
+  serializeQueryData(builder);
 
   builder.close();
 }
@@ -719,7 +725,7 @@ void ExecutionPlan::addAppliedRule(int level) {
   }
 }
 
-bool ExecutionPlan::hasAppliedRule(int level) const {
+bool ExecutionPlan::hasAppliedRule(int level) const noexcept {
   return std::any_of(_appliedRules.begin(), _appliedRules.end(),
                      [level](int l) { return l == level; });
 }
@@ -728,8 +734,8 @@ void ExecutionPlan::enableRule(int rule) { _disabledRules.erase(rule); }
 
 void ExecutionPlan::disableRule(int rule) { _disabledRules.emplace(rule); }
 
-bool ExecutionPlan::isDisabledRule(int rule) const {
-  return (_disabledRules.find(rule) != _disabledRules.end());
+bool ExecutionPlan::isDisabledRule(int rule) const noexcept {
+  return _disabledRules.contains(rule);
 }
 
 ExecutionNodeId ExecutionPlan::nextId() {
@@ -1150,7 +1156,7 @@ ExecutionNode* ExecutionPlan::registerNode(
   TRI_ASSERT(node != nullptr);
   TRI_ASSERT(node->plan() == this);
   TRI_ASSERT(node->id() > ExecutionNodeId{0});
-  TRI_ASSERT(_ids.find(node->id()) == _ids.end());
+  TRI_ASSERT(!_ids.contains(node->id()));
 
   {
     ResourceUsageScope scope(

--- a/arangod/Aql/ExecutionPlan.h
+++ b/arangod/Aql/ExecutionPlan.h
@@ -35,12 +35,18 @@
 #include "Containers/SmallVector.h"
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string_view>
+#include <unordered_set>
 
 namespace arangodb {
 namespace velocypack {
+class Builder;
 class Slice;
-}
+}  // namespace velocypack
 
 namespace aql {
 class Ast;
@@ -77,17 +83,17 @@ class ExecutionPlan {
       Ast*, bool trackMemoryUsage);
 
   /// @brief process the list of collections in a VelocyPack
-  static void getCollectionsFromVelocyPack(aql::Collections&,
-                                           arangodb::velocypack::Slice const);
+  static void getCollectionsFromVelocyPack(aql::Collections& colls,
+                                           velocypack::Slice slice);
 
   /// @brief create an execution plan from VelocyPack
   static std::unique_ptr<ExecutionPlan> instantiateFromVelocyPack(
-      Ast* ast, arangodb::velocypack::Slice const);
+      Ast* ast, velocypack::Slice slice);
 
   /// @brief whether or not the exclusive flag is set in the write options
   static bool hasExclusiveAccessOption(AstNode const* node);
 
-  std::unique_ptr<ExecutionPlan> clone(Ast*);
+  std::unique_ptr<ExecutionPlan> clone(Ast* ast);
 
   /// @brief clone the plan by recursively cloning starting from the root
   std::unique_ptr<ExecutionPlan> clone();
@@ -97,20 +103,21 @@ class ExecutionPlan {
                                           bool explainRegisters) noexcept;
 
   /// @brief export to VelocyPack
-  void toVelocyPack(arangodb::velocypack::Builder&, Ast* ast,
-                    unsigned flags) const;
+  void toVelocyPack(velocypack::Builder& builder, unsigned flags,
+                    std::function<void(velocypack::Builder&)> const&
+                        serializeQueryData) const;
 
   /// @brief check if the plan is empty
-  bool empty() const { return (_root == nullptr); }
+  bool empty() const noexcept { return (_root == nullptr); }
 
   /// @brief note that an optimizer rule was applied
   void addAppliedRule(int level);
 
   /// @brief check if a specific optimizer rule was applied
-  bool hasAppliedRule(int level) const;
+  bool hasAppliedRule(int level) const noexcept;
 
   /// @brief check if a specific rule is disabled
-  bool isDisabledRule(int rule) const;
+  bool isDisabledRule(int rule) const noexcept;
 
   bool hasForcedIndexHints() const noexcept { return _hasForcedIndexHints; }
 
@@ -137,10 +144,12 @@ class ExecutionPlan {
       const;
 
   /// @brief check if the node is the root node
-  bool isRoot(ExecutionNode const* node) const { return _root == node; }
+  bool isRoot(ExecutionNode const* node) const noexcept {
+    return _root == node;
+  }
 
   /// @brief get the root node
-  ExecutionNode* root() const {
+  ExecutionNode* root() const noexcept {
     TRI_ASSERT(_root != nullptr);
     return _root;
   }
@@ -170,7 +179,7 @@ class ExecutionPlan {
 
   /// @brief this can be called by the optimizer to tell that the
   /// plan is temporarily in an invalid state
-  void setValidity(bool value) { _planValid = value; }
+  void setValidity(bool value) noexcept { _planValid = value; }
 
 /// @brief show an overview over the plan
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
@@ -184,8 +193,7 @@ class ExecutionPlan {
   }
 
   bool shouldExcludeFromScatterGather(ExecutionNode const* node) const {
-    return (_excludeFromScatterGather.find(node) !=
-            _excludeFromScatterGather.end());
+    return _excludeFromScatterGather.contains(node);
   }
 
   /// @brief get the node where variable with id <id> is introduced . . .
@@ -224,10 +232,10 @@ class ExecutionPlan {
   bool varUsageComputed() const;
 
   /// @brief determine if the above are already set
-  void setVarUsageComputed() { _varUsageComputed = true; }
+  void setVarUsageComputed() noexcept { _varUsageComputed = true; }
 
   /// @brief flush var usage calculation
-  void clearVarUsageComputed() { _varUsageComputed = false; }
+  void clearVarUsageComputed() noexcept { _varUsageComputed = false; }
 
   /// @brief static analysis
   void planRegisters(ExplainRegisterPlan = ExplainRegisterPlan::No);
@@ -281,7 +289,7 @@ class ExecutionPlan {
   void insertBefore(ExecutionNode* current, ExecutionNode* newNode);
 
   /// @brief get ast
-  Ast* getAst() const { return _ast; }
+  Ast* getAst() const noexcept { return _ast; }
 
   /// @brief resolves a variable alias, e.g. fn(tmp) -> "a.b" for the following:
   ///  LET tmp = a.b

--- a/arangod/Aql/IResearchViewOptimizerRules.cpp
+++ b/arangod/Aql/IResearchViewOptimizerRules.cpp
@@ -184,8 +184,8 @@ bool optimizeSearchCondition(IResearchViewNode& viewNode,
   if (!addView(*view, query)) {
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_QUERY_PARSE,
-        "failed to process all collections linked with the view '" +
-            view->name() + "'");
+        absl::StrCat("failed to process all collections linked with the view '",
+                     view->name(), "'"));
   }
 
   // build search condition

--- a/arangod/Aql/IndexJoinStrategy.cpp
+++ b/arangod/Aql/IndexJoinStrategy.cpp
@@ -20,23 +20,25 @@
 ///
 /// @author Lars Maier
 ////////////////////////////////////////////////////////////////////////////////
-#include <memory>
-
-#include <velocypack/Slice.h>
-#include "Basics/VelocyPackHelper.h"
 
 #include "IndexJoinStrategy.h"
+
 #include "Aql/IndexJoin/GenericMerge.h"
 #include "Aql/IndexJoin/TwoIndicesMergeJoin.h"
 #include "Aql/IndexJoin/TwoIndicesUniqueMergeJoin.h"
 #include "Aql/QueryOptions.h"
+#include "Basics/VelocyPackHelper.h"
 #include "VocBase/Identifiers/LocalDocumentId.h"
+
+#include <velocypack/Slice.h>
+
+#include <memory>
 
 using namespace arangodb::aql;
 
 namespace {
 struct VPackSliceComparator {
-  auto operator()(VPackSlice left, VPackSlice right) {
+  auto operator()(VPackSlice left, VPackSlice right) const {
     return arangodb::basics::VelocyPackHelper::compare(left, right, true) <=> 0;
   }
 };
@@ -46,7 +48,7 @@ auto IndexJoinStrategyFactory::createStrategy(
     aql::QueryOptions::JoinStrategyType joinStrategy)
     -> std::unique_ptr<AqlIndexJoinStrategy> {
   if (desc.size() == 2 &&
-      joinStrategy != aql::QueryOptions::JoinStrategyType::GENERIC) {
+      joinStrategy != aql::QueryOptions::JoinStrategyType::kGeneric) {
     if (desc[0].isUnique && desc[1].isUnique) {
       // build optimized merge join strategy for two unique indices
       return std::make_unique<TwoIndicesUniqueMergeJoin<

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -30,6 +30,7 @@
 #include "Aql/AqlTransaction.h"
 #include "Aql/Ast.h"
 #include "Aql/Collection.h"
+#include "Aql/ClusterQuery.h"
 #include "Aql/ExecutionBlock.h"
 #include "Aql/ExecutionEngine.h"
 #include "Aql/ExecutionNode/GraphNode.h"
@@ -56,6 +57,7 @@
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
 #include "Network/Utils.h"
+#include "Random/RandomGenerator.h"
 #include "RestServer/AqlFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "StorageEngine/TransactionCollection.h"
@@ -117,6 +119,7 @@ Query::Query(QueryId id, std::shared_ptr<transaction::Context> ctx,
       _startTime(currentSteadyClockValue()),
       _endTime(0.0),
       _resultMemoryUsage(0),
+      _planMemoryUsage(0),
       _queryHash(DontCache),
       _shutdownState(ShutdownState::None),
       _executionPhase(ExecutionPhase::INITIALIZE),
@@ -218,6 +221,9 @@ void Query::destroy() {
 
   _resourceMonitor.decreaseMemoryUsage(_resultMemoryUsage);
   _resultMemoryUsage = 0;
+
+  _resourceMonitor.decreaseMemoryUsage(_planMemoryUsage);
+  _planMemoryUsage = 0;
 
   if (_queryOptions.profile >= ProfileLevel::TraceOne) {
     LOG_TOPIC("36a75", INFO, Logger::QUERIES)
@@ -351,12 +357,27 @@ void Query::prepareQuery() {
         _queryOptions.profile >= ProfileLevel::Blocks &&
         ServerState::isSingleServerOrCoordinator(_trx->state()->serverRole());
     if (keepPlan) {
+      auto serializeQueryData = [this](velocypack::Builder& builder) {
+        // set up collections
+        TRI_ASSERT(builder.isOpenObject());
+        builder.add(VPackValue("collections"));
+        collections().toVelocyPack(builder);
+
+        // set up variables
+        TRI_ASSERT(builder.isOpenObject());
+        builder.add(VPackValue("variables"));
+        _ast->variables()->toVelocyPack(builder);
+
+        builder.add("isModificationQuery",
+                    VPackValue(_ast->containsModificationNode()));
+      };
+
       unsigned flags = ExecutionPlan::buildSerializationFlags(
           /*verbose*/ false, /*includeInternals*/ false,
           /*explainRegisters*/ false);
       _planSliceCopy = std::make_unique<VPackBufferUInt8>();
       VPackBuilder b(*_planSliceCopy);
-      plan->toVelocyPack(b, _ast.get(), flags);
+      plan->toVelocyPack(b, flags, serializeQueryData);
 
       try {
         _resourceMonitor.increaseMemoryUsage(_planSliceCopy->size());
@@ -1079,6 +1100,21 @@ QueryResult Query::explain() {
         _queryOptions.verbosePlans, _queryOptions.explainInternals,
         _queryOptions.explainRegisters == ExplainRegisterPlan::Yes);
 
+    auto serializeQueryData = [this](velocypack::Builder& builder) {
+      // set up collections
+      TRI_ASSERT(builder.isOpenObject());
+      builder.add(VPackValue("collections"));
+      collections().toVelocyPack(builder);
+
+      // set up variables
+      TRI_ASSERT(builder.isOpenObject());
+      builder.add(VPackValue("variables"));
+      _ast->variables()->toVelocyPack(builder);
+
+      builder.add("isModificationQuery",
+                  VPackValue(_ast->containsModificationNode()));
+    };
+
     VPackOptions options;
     options.checkAttributeUniqueness = false;
     options.buildUnindexedArrays = true;
@@ -1093,9 +1129,9 @@ QueryResult Query::explain() {
         TRI_ASSERT(pln != nullptr);
 
         preparePlanForSerialization(pln);
-        pln->toVelocyPack(*result.data, parser.ast(), flags);
+        pln->toVelocyPack(*result.data, flags, serializeQueryData);
       }
-      // cacheability not available here
+      // cachability not available here
       result.cached = false;
     } else {
       std::unique_ptr<ExecutionPlan> bestPlan =
@@ -1103,9 +1139,9 @@ QueryResult Query::explain() {
       TRI_ASSERT(bestPlan != nullptr);
 
       preparePlanForSerialization(bestPlan);
-      bestPlan->toVelocyPack(*result.data, parser.ast(), flags);
+      bestPlan->toVelocyPack(*result.data, flags, serializeQueryData);
 
-      // cacheability
+      // cachability
       result.cached = (!_queryString.empty() && !isModificationQuery() &&
                        _warnings.empty() && _ast->root()->isCacheable());
     }
@@ -1275,6 +1311,10 @@ void Query::runInV8ExecutorContext(
   }
 }
 #endif
+
+/// @brief build traverser engines. only used on DB servers
+void buildTraverserEngines(velocypack::Slice /*traverserSlice*/,
+                           velocypack::Builder& /*answerBuilder*/) {}
 
 /// @brief initializes the query
 void Query::init(bool createProfile) {
@@ -1980,4 +2020,104 @@ void Query::debugKillQuery() {
       << queryList->enabled();
   kill();
 #endif
+}
+
+/// @brief prepare a query out of some velocypack data.
+/// only to be used on single server or coordinator.
+/// never call this on a DB server!
+void Query::prepareFromVelocyPack(
+    velocypack::Slice querySlice, velocypack::Slice collections,
+    velocypack::Slice variables, velocypack::Slice snippets,
+    QueryAnalyzerRevisions const& analyzersRevision) {
+  TRI_ASSERT(!ServerState::instance()->isDBServer());
+
+  LOG_TOPIC("9636f", DEBUG, Logger::QUERIES)
+      << elapsedSince(_startTime) << " Query::prepareFromVelocyPack"
+      << " this: " << (uintptr_t)this;
+
+  // track memory usage
+  ResourceUsageScope scope(_resourceMonitor);
+  scope.increase(querySlice.byteSize() + collections.byteSize() +
+                 variables.byteSize() + snippets.byteSize());
+
+  _planMemoryUsage += scope.trackedAndSteal();
+
+  init(/*createProfile*/ true);
+
+  if (auto val = querySlice.get("isModificationQuery"); val.isTrue()) {
+    _ast->setContainsModificationNode();
+  }
+  if (auto val = querySlice.get("isAsyncQuery"); val.isTrue()) {
+    _ast->setContainsParallelNode();
+  }
+
+  enterState(QueryExecutionState::ValueType::LOADING_COLLECTIONS);
+
+  ExecutionPlan::getCollectionsFromVelocyPack(_collections, collections);
+  _ast->variables()->fromVelocyPack(variables);
+  // creating the plan may have produced some collections
+  // we need to add them to the transaction now (otherwise the query will fail)
+
+  TRI_ASSERT(_trx == nullptr);
+  // needs to be created after the AST collected all collections
+  std::unordered_set<std::string> inaccessibleCollections;
+#ifdef USE_ENTERPRISE
+  if (_queryOptions.transactionOptions.skipInaccessibleCollections) {
+    inaccessibleCollections = _queryOptions.inaccessibleCollections;
+  }
+#endif
+
+  _trx = AqlTransaction::create(_transactionContext, _collections,
+                                _queryOptions.transactionOptions,
+                                std::move(inaccessibleCollections));
+
+  // create the transaction object, but do not start the transaction yet
+  _trx->addHint(
+      transaction::Hints::Hint::FROM_TOPLEVEL_AQL);  // only used on toplevel
+
+  Result res = _trx->begin();
+  if (!res.ok()) {
+    THROW_ARANGO_EXCEPTION(res);
+  }
+
+  TRI_IF_FAILURE("Query::setupLockTimeout") {
+    if (!_trx->state()->isReadOnlyTransaction() &&
+        RandomGenerator::interval(uint32_t(100)) >= 95) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_LOCK_TIMEOUT);
+    }
+  }
+
+  enterState(QueryExecutionState::ValueType::PARSING);
+
+  bool const planRegisters = !_queryString.empty();
+  auto instantiateSnippet = [&](velocypack::Slice snippet) {
+    auto plan = ExecutionPlan::instantiateFromVelocyPack(_ast.get(), snippet);
+    TRI_ASSERT(plan != nullptr);
+
+    ExecutionEngine::instantiateFromPlan(*this, *plan, planRegisters);
+    _plans.push_back(std::move(plan));
+  };
+
+  for (auto pair : VPackObjectIterator(snippets, /*sequential*/ true)) {
+    instantiateSnippet(pair.value);
+
+    TRI_ASSERT(!_snippets.empty());
+    TRI_ASSERT(!_trx->state()->isDBServer() ||
+               _snippets.back()->engineId() != 0);
+  }
+
+  if (!_snippets.empty()) {
+    TRI_ASSERT(_trx->state()->isDBServer() || _snippets[0]->engineId() == 0);
+    // simon: just a hack for AQL_EXECUTEJSON
+    if (_trx->state()->isCoordinator()) {  // register coordinator snippets
+      TRI_ASSERT(_trx->state()->isCoordinator());
+      QueryRegistryFeature::registry()->registerSnippets(_snippets);
+    }
+
+    registerQueryInTransactionState();
+  }
+
+  _queryProfile->registerInQueryList();
+
+  enterState(QueryExecutionState::ValueType::EXECUTION);
 }

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -158,6 +158,15 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// @brief explain an AQL query
   QueryResult explain();
 
+  /// @brief prepare a query out of some velocypack data.
+  /// only to be used on single server or coordinator.
+  /// never call this on a DB server!
+  void prepareFromVelocyPack(velocypack::Slice querySlice,
+                             velocypack::Slice collections,
+                             velocypack::Slice variables,
+                             velocypack::Slice snippets,
+                             QueryAnalyzerRevisions const& analyzersRevision);
+
   /// @brief whether or not a query is a modification query
   bool isModificationQuery() const noexcept final;
 
@@ -356,6 +365,9 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
 
   /// @brief total memory used for building the (partial) result
   size_t _resultMemoryUsage;
+
+  /// @brief total memory used for the velocypack data of an execution plan
+  size_t _planMemoryUsage;
 
   /// @brief hash for this query. will be calculated only once when needed
   mutable uint64_t _queryHash = DontCache;

--- a/arangod/Aql/QueryOptions.h
+++ b/arangod/Aql/QueryOptions.h
@@ -23,15 +23,17 @@
 
 #pragma once
 
-#include <chrono>
-#include <string>
-#include <unordered_set>
-#include <vector>
-
 #include "Aql/ProfileLevel.h"
 #include "Aql/types.h"
 #include "Cluster/Utils/ShardID.h"
 #include "Transaction/Options.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 namespace arangodb {
 namespace velocypack {
@@ -48,7 +50,7 @@ struct QueryOptions {
   QueryOptions(QueryOptions const&) = default;
   TEST_VIRTUAL ~QueryOptions() = default;
 
-  enum JoinStrategyType { DEFAULT, GENERIC };
+  enum JoinStrategyType : uint8_t { kDefault, kGeneric };
 
   void fromVelocyPack(velocypack::Slice slice);
   void toVelocyPack(velocypack::Builder& builder,
@@ -65,9 +67,12 @@ struct QueryOptions {
   size_t spillOverThresholdNumRows;
   size_t spillOverThresholdMemoryUsage;
   size_t maxDNFConditionMembers;
-  double maxRuntime;  // query has to execute within the given time or will be
-                      // killed
+  // query has to execute within the given time or will be killed
+  double maxRuntime;
+
+#ifdef USE_ENTERPRISE
   std::chrono::duration<double> satelliteSyncWait;
+#endif
 
   double ttl;  // time until query cursor expires - avoids coursors to
                // stick around for ever if client does not collect the data
@@ -94,14 +99,15 @@ struct QueryOptions {
   bool count;
   // skips audit logging - used only internally
   bool skipAudit;
+
   ExplainRegisterPlan explainRegisters;
+
+  /// @brief desired join strategy used by the JoinNode (if available)
+  JoinStrategyType desiredJoinStrategy;
 
   /// @brief shard key attribute value used to push a query down
   /// to a single server
   std::string forceOneShardAttributeValue;
-
-  /// @brief desired join strategy used by the JoinNode (if available)
-  JoinStrategyType desiredJoinStrategy = JoinStrategyType::DEFAULT;
 
   /// @brief optimizer rules to turn off/on manually
   std::vector<std::string> optimizerRules;

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -334,10 +334,10 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
     generateError(revisionRes);
     co_return;
   }
-  q->prepareClusterQuery(querySlice, collectionBuilder.slice(), variablesSlice,
-                         snippetsSlice, traverserSlice,
-                         _request->value(StaticStrings::UserString),
-                         answerBuilder, analyzersRevision, fastPath);
+  q->prepareFromVelocyPack(querySlice, collectionBuilder.slice(),
+                           variablesSlice, snippetsSlice, traverserSlice,
+                           _request->value(StaticStrings::UserString),
+                           answerBuilder, analyzersRevision, fastPath);
 
   answerBuilder.close();  // result
   answerBuilder.close();

--- a/arangod/Aql/grammar.cpp
+++ b/arangod/Aql/grammar.cpp
@@ -3202,7 +3202,7 @@ yyreduce:
       }
       auto node = parser->ast()->createNodeTraversal(variablesNode, graphInfoNode);
       parser->ast()->addOperation(node);
-      if(prune->type == NODE_TYPE_ARRAY && prune->getMember(0)->type != NODE_TYPE_NOP) {
+      if (prune->type == NODE_TYPE_ARRAY && prune->getMember(0)->type != NODE_TYPE_NOP) {
         auto pruneLetVariableName = prune->getMember(0);
         parser->ast()->addOperation(pruneLetVariableName);
       }

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -886,7 +886,7 @@ for_statement:
       }
       auto node = parser->ast()->createNodeTraversal(variablesNode, graphInfoNode);
       parser->ast()->addOperation(node);
-      if(prune->type == NODE_TYPE_ARRAY && prune->getMember(0)->type != NODE_TYPE_NOP) {
+      if (prune->type == NODE_TYPE_ARRAY && prune->getMember(0)->type != NODE_TYPE_NOP) {
         auto pruneLetVariableName = prune->getMember(0);
         parser->ast()->addOperation(pruneLetVariableName);
       }

--- a/arangod/Aql/types.h
+++ b/arangod/Aql/types.h
@@ -37,14 +37,12 @@
 #include <unordered_map>
 #include <vector>
 
-namespace boost {
-namespace container {
+namespace boost::container {
 template<class T>
 class new_allocator;
 template<class Key, class Compare, class AllocatorOrContainer>
 class flat_set;
-}  // namespace container
-}  // namespace boost
+}  // namespace boost::container
 
 namespace arangodb {
 
@@ -61,8 +59,8 @@ struct Collection;
 using VariableId = uint32_t;
 
 /// @brief type of a query id
-typedef uint64_t QueryId;
-typedef uint64_t EngineId;
+using QueryId = uint64_t;
+using EngineId = uint64_t;
 
 // Map RemoteID->ServerID->[SnippetId]
 using MapRemoteToSnippet = std::unordered_map<
@@ -107,6 +105,6 @@ class BaseEngine;
 using GraphEngineList = std::vector<std::unique_ptr<BaseEngine>>;
 }  // namespace traverser
 
-enum class ExplainRegisterPlan { No = 0, Yes };
+enum class ExplainRegisterPlan : uint8_t { No = 0, Yes };
 
 }  // namespace arangodb

--- a/arangod/Cluster/ClusterTrxMethods.cpp
+++ b/arangod/Cluster/ClusterTrxMethods.cpp
@@ -55,7 +55,7 @@ using namespace arangodb::futures;
 
 namespace {
 // Wait 2s to get the Lock in FastPath, otherwise assume dead-lock.
-const double FAST_PATH_LOCK_TIMEOUT = 2.0;
+constexpr double kFastPathLockTimeout = 2.0;
 
 void buildTransactionBody(TransactionState& state, ServerID const& server,
                           VPackBuilder& builder) {
@@ -401,7 +401,7 @@ Future<Result> beginTransactionOnLeaders(
       // We first try to do a fast lock, if we cannot get this
       // There is a potential dead lock situation
       // and we revert to a slow locking to be on the safe side.
-      state.options().lockTimeout = FAST_PATH_LOCK_TIMEOUT;
+      state.options().lockTimeout = kFastPathLockTimeout;
     }
     // Run fastPath
     std::vector<Future<network::Response>> requests;

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -53,7 +53,7 @@ static const std::string SHARDS = "shards";
 static const std::string TYPE = "type";
 
 #ifndef USE_ENTERPRISE
-/*static*/ std::unique_ptr<BaseEngine> BaseEngine::BuildEngine(
+/*static*/ std::unique_ptr<BaseEngine> BaseEngine::buildEngine(
     TRI_vocbase_t& vocbase, aql::QueryContext& query, VPackSlice info) {
   VPackSlice type = info.get(std::initializer_list<std::string_view>(
       {StaticStrings::GraphOptions, TYPE}));

--- a/arangod/Cluster/TraverserEngine.h
+++ b/arangod/Cluster/TraverserEngine.h
@@ -64,7 +64,7 @@ class BaseEngine {
  public:
   enum EngineType { TRAVERSER, SHORTESTPATH };
 
-  static std::unique_ptr<BaseEngine> BuildEngine(
+  static std::unique_ptr<BaseEngine> buildEngine(
       TRI_vocbase_t& vocbase, aql::QueryContext& query,
       arangodb::velocypack::Slice info);
 

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -278,13 +278,6 @@ Index::FilterCosts SortedIndexAttributeMatcher::supportsFilterCondition(
     std::vector<std::shared_ptr<arangodb::Index>> const& allIndexes,
     arangodb::Index const* idx, arangodb::aql::AstNode const* node,
     arangodb::aql::Variable const* reference, size_t itemsInIndex) {
-  // mmfiles failure point compat
-  if (idx->type() == Index::TRI_IDX_TYPE_HASH_INDEX) {
-    TRI_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
-    }
-  }
-
   arangodb::containers::FlatHashMap<size_t,
                                     std::vector<arangodb::aql::AstNode const*>>
       found;

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3503,9 +3503,9 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
   std::string vn = _vocbase.name();
   try {
     if (!serverId.empty()) {
-      std::string comment = std::string("SynchronizeShard from ") + serverId +
-                            " for " + col.name() + " access mode " +
-                            AccessMode::typeString(access);
+      std::string comment =
+          absl::StrCat("SynchronizeShard from ", serverId, " for ", col.name(),
+                       " access mode ", AccessMode::typeString(access));
 
       std::function<void(void)> f = [=]() {
         try {
@@ -3569,7 +3569,7 @@ Result RestReplicationHandler::isLockHeld(TransactionId id) const {
   transaction::Status stats = mgr->getManagedTrxStatus(id);
   if (stats == transaction::Status::UNDEFINED) {
     return {TRI_ERROR_HTTP_NOT_FOUND,
-            "no hold read lock job found for id " + std::to_string(id.id())};
+            absl::StrCat("no hold read lock job found for id ", id.id())};
   }
 
   return {};

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -2375,6 +2375,14 @@ Index::FilterCosts RocksDBVPackIndex::supportsFilterCondition(
     std::vector<std::shared_ptr<Index>> const& allIndexes,
     aql::AstNode const* node, aql::Variable const* reference,
     size_t itemsInIndex) const {
+  TRI_IF_FAILURE("SimpleAttributeMatcher::accessFitsIndex") {
+    // mmfiles failure point compat
+    // the hash index is a derived type of the vpack index...
+    if (this->type() == Index::TRI_IDX_TYPE_HASH_INDEX) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+    }
+  }
+
   return SortedIndexAttributeMatcher::supportsFilterCondition(
       allIndexes, this, node, reference, itemsInIndex);
 }

--- a/arangod/StorageEngine/TransactionCollection.cpp
+++ b/arangod/StorageEngine/TransactionCollection.cpp
@@ -29,6 +29,8 @@
 #include "StorageEngine/TransactionState.h"
 #include "VocBase/LogicalCollection.h"
 
+#include <absl/strings/str_cat.h>
+
 using namespace arangodb;
 
 TransactionCollection::~TransactionCollection() {
@@ -64,11 +66,11 @@ Result TransactionCollection::updateUsage(AccessMode::Type accessType) {
       !AccessMode::isWriteOrExclusive(_accessType)) {
     if (_transaction->status() != transaction::Status::CREATED) {
       // trying to write access a collection that is marked read-access
-      return Result(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-                    std::string(TRI_errno_string(
-                        TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION)) +
-                        ": " + collectionName() + " [" +
-                        AccessMode::typeString(accessType) + "]");
+      return {TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
+              absl::StrCat(TRI_errno_string(
+                               TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION),
+                           ": ", collectionName(), " [",
+                           AccessMode::typeString(accessType), "]")};
     }
 
     // upgrade collection type to write-access

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -527,20 +527,20 @@ futures::Future<Result> TransactionState::addCollectionInternal(
       !_options.allowImplicitCollectionsForWrite) {
     // trying to write access a collection that was not declared at start.
     // this is only supported internally for replication transactions.
-    co_return res.reset(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-                        std::string(TRI_errno_string(
-                            TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION)) +
-                            ": " + std::string{cname} + " [" +
-                            AccessMode::typeString(accessType) + "]");
+    co_return res.reset(
+        TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
+        absl::StrCat(
+            TRI_errno_string(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION),
+            ": ", cname, " [", AccessMode::typeString(accessType), "]"));
   }
 
   if (!AccessMode::isWriteOrExclusive(accessType) &&
       (isRunning() && !_options.allowImplicitCollectionsForRead)) {
-    co_return res.reset(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-                        std::string(TRI_errno_string(
-                            TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION)) +
-                            ": " + std::string{cname} + " [" +
-                            AccessMode::typeString(accessType) + "]");
+    co_return res.reset(
+        TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
+        absl::StrCat(
+            TRI_errno_string(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION),
+            ": ", cname, " [", AccessMode::typeString(accessType), "]"));
   }
 
   // now check the permissions
@@ -650,7 +650,7 @@ void TransactionState::acceptAnalyzersRevision(
   LOG_TOPIC_IF("9127a", ERR, Logger::AQL,
                (_analyzersRevision != analyzersRevision &&
                 !_analyzersRevision.isDefault()))
-      << " Changing analyzers revision for transaction from "
+      << "Changing analyzers revision for transaction from "
       << _analyzersRevision << " to " << analyzersRevision;
   TRI_ASSERT(_analyzersRevision == analyzersRevision ||
              _analyzersRevision.isDefault());

--- a/arangod/Utils/SingleCollectionTransaction.cpp
+++ b/arangod/Utils/SingleCollectionTransaction.cpp
@@ -22,7 +22,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "SingleCollectionTransaction.h"
-#include "Basics/StringUtils.h"
 #include "StorageEngine/TransactionCollection.h"
 #include "StorageEngine/TransactionState.h"
 #include "Transaction/Context.h"
@@ -108,11 +107,11 @@ SingleCollectionTransaction::addCollectionAtRuntime(std::string_view name,
   TRI_ASSERT(!name.empty());
   if ((name[0] < '0' || name[0] > '9') &&
       name != resolveTrxCollection()->collectionName()) {
-    auto message = absl::StrCat(
-        TRI_errno_string(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION), ": ",
-        name);
     THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION, message);
+        TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
+        absl::StrCat(
+            TRI_errno_string(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION),
+            ": ", name));
   }
 
   if (AccessMode::isWriteOrExclusive(type) &&
@@ -120,10 +119,9 @@ SingleCollectionTransaction::addCollectionAtRuntime(std::string_view name,
     // trying to write access a collection that is marked read-access
     THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION,
-        std::string(
-            TRI_errno_string(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION)) +
-            ": " + std::string{name} + " [" + AccessMode::typeString(type) +
-            "]");
+        absl::StrCat(
+            TRI_errno_string(TRI_ERROR_TRANSACTION_UNREGISTERED_COLLECTION),
+            ": ", name, " [", AccessMode::typeString(type), "]"));
   }
 
   return _cid;

--- a/arangod/VocBase/AccessMode.h
+++ b/arangod/VocBase/AccessMode.h
@@ -25,7 +25,7 @@
 
 #include "Basics/Exceptions.h"
 
-#include <cstring>
+#include <string_view>
 
 namespace arangodb {
 
@@ -61,21 +61,21 @@ struct AccessMode {
   }
 
   /// @brief get the transaction type from a string
-  static Type fromString(char const* value) {
-    if (strcmp(value, "read") == 0) {
+  static Type fromString(std::string_view value) {
+    if (value == "read") {
       return Type::READ;
     }
-    if (strcmp(value, "write") == 0) {
+    if (value == "write") {
       return Type::WRITE;
     }
-    if (strcmp(value, "exclusive") == 0) {
+    if (value == "exclusive") {
       return Type::EXCLUSIVE;
     }
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid access type");
   }
 
   /// @brief return the type of the transaction as a string
-  static char const* typeString(Type value) {
+  static std::string_view typeString(Type value) {
     switch (value) {
       case Type::NONE:
         return "none";

--- a/js/client/modules/@arangodb/aql-helper.js
+++ b/js/client/modules/@arangodb/aql-helper.js
@@ -26,12 +26,8 @@
 // / @author Copyright 2013, triAGENS GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
-// //////////////////////////////////////////////////////////////////////////////
-// / @brief normalize a single row result
-// //////////////////////////////////////////////////////////////////////////////
-
-let isEqual = require("@arangodb/test-helper-common").isEqual;
-var db = require("@arangodb").db;
+const isEqual = require("@arangodb/test-helper-common").isEqual;
+const db = require("@arangodb").db;
 
 exports.isEqual = isEqual;
 
@@ -78,16 +74,12 @@ function normalizeRow (row, recursive) {
 }
 
 function executeQuery(query, bindVars = null, options = {}) {
-  let stmt = db._createStatement({query, bindVars: bindVars, count: true});
+  let stmt = db._createStatement({query, bindVars, count: true});
   return stmt.execute();
 };
 
 function executeJson (plan, options = {}) {
-  let command = `
-        let data = ${JSON.stringify(plan)};
-        let opts = ${JSON.stringify(options)};
-        return AQL_EXECUTEJSON(data, opts);
-      `;
+  let command = `return AQL_EXECUTEJSON(${JSON.stringify(plan)}, ${JSON.stringify(options)});`;
   return arango.POST("/_admin/execute", command);
 };
 

--- a/tests/js/client/aql/aql-graph-traverser-multiCollectionGraph.js
+++ b/tests/js/client/aql/aql-graph-traverser-multiCollectionGraph.js
@@ -33,13 +33,12 @@ const internal = require('internal');
 const db = require('internal').db;
 const errors = require('@arangodb').errors;
 const gm = require('@arangodb/general-graph');
+const executeAllJson = require("@arangodb/aql-helper").executeAllJson;
+const gh = require('@arangodb/graph/helpers');
+const _ = require('lodash');
+
 const vn = 'UnitTestVertexCollection';
 const en = 'UnitTestEdgeCollection';
-
-const executeAllJson = require("@arangodb/aql-helper").executeAllJson;
-
-const gh = require('@arangodb/graph/helpers');
-var _ = require('lodash');
 
 function multiCollectionGraphSuite() {
   /* *********************************************************************


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1462

Refactor `Query`/`ClusterQuery`
So that a `Query` can be prepared from velocypack input without having to create an artificial/inappropriate `ClusterQuery` instance.

Also clean up a bit of unrelated code in terms of used include directives and naming conventions.

This is a preparation PR to allow queries to be restored from serialized execution plans in the future.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1462
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 