### PR TITLE
[BTS-1034]: Make ArangoLanguageFeature unit test independent from system locale

### DIFF
--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -39,13 +39,14 @@
 #include "Basics/files.h"
 #include "Basics/icu-helper.h"
 #include "IResearch/common.h"
+#include <locale.h>
 
 // -----------------------------------------------------------------------------
 // --SECTION--                                                 setup / tear-down
 // -----------------------------------------------------------------------------
 
 namespace {
-void checkCollatorSettings(const std::string& language,
+void checkCollatorSettings(std::string_view language,
                            bool isDefaultLanguage) {
   // Create collator with expected language
   UErrorCode status = U_ZERO_ERROR;
@@ -54,7 +55,7 @@ void checkCollatorSettings(const std::string& language,
     // get default collator for empty language
     expectedColl = icu::Collator::createInstance(status);
   } else {
-    icu::Locale locale(language.c_str());
+    icu::Locale locale(language.data());
     expectedColl = icu::Collator::createInstance(locale, status);
   }
 
@@ -92,7 +93,7 @@ void checkCollatorSettings(const std::string& language,
 }
 
 void checkLanguageFile(const arangodb::ArangodServer& server,
-                       const std::string expectedLang,
+                       std::string_view expectedLang,
                        const std::string& expectedParameter,
                        bool shouldBeEqual) {
   std::string key = expectedParameter;
@@ -130,6 +131,24 @@ void checkLanguageFile(const arangodb::ArangodServer& server,
     ASSERT_TRUE(false);
   }
 }
+
+constexpr std::string_view kGerman = "de";
+constexpr std::string_view kRussian = "ru";
+
+std::string_view getNonSysLang() {
+  setlocale(LC_ALL, "");
+  const std::string_view currSysLang =
+      std::string_view(setlocale(LC_ALL, NULL)).substr(0,2);
+  if (currSysLang == "de") {
+    return kRussian;
+  } else {
+    return kGerman;
+  }
+}
+
+constexpr std::string_view defaultParameter = "default-language";
+constexpr std::string_view icuParameter = "icu-language";
+
 }  // namespace
 
 using namespace arangodb::options;
@@ -310,9 +329,7 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
   server.addFeatureUntracked<arangodb::LanguageCheckFeature>();
 
   constexpr std::string_view firstLang = "sv";
-  constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
+  constexpr std::string_view secondLang = "de";;
 
   // Enable force check for languages
   server.server()
@@ -336,10 +353,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -357,10 +374,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -377,7 +394,7 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -421,10 +438,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 }
@@ -439,8 +456,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
 
   constexpr std::string_view firstLang = "sv";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Disable force check for languages
   server.server()
@@ -464,10 +479,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -485,10 +500,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -505,7 +520,7 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
     langCheckFeature.start();
@@ -549,10 +564,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 }
@@ -567,10 +582,8 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
 
   // firstLang in this case will be initialized after langFeature.prepare()
   // because collator will be ready after prepare()
-  std::string firstLang = {};
-  constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
+  std::string_view firstLang = {};
+  std::string_view secondLang = getNonSysLang();
 
   // Enable force check for languages
   server.server()
@@ -599,10 +612,10 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
     firstLang = langFeature.getCollatorLanguage();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang, isDefaultLanguage);
   }
 
@@ -620,10 +633,10 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang, defaultParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang, isDefaultLanguage);
   }
 
@@ -640,7 +653,7 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -684,10 +697,10 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang, defaultParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang, isDefaultLanguage);
   }
 }
@@ -702,10 +715,8 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
 
   // firstLang in this case will be initialized after langFeature.prepare()
   // because collator will be ready after prepare()
-  std::string firstLang = {};
-  constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
+  std::string_view firstLang = {};
+  std::string_view secondLang = getNonSysLang();
 
   // Disable force check for languages
   server.server()
@@ -734,10 +745,10 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
     firstLang = langFeature.getCollatorLanguage();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang, isDefaultLanguage);
   }
 
@@ -755,10 +766,10 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang, defaultParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang, isDefaultLanguage);
   }
 
@@ -775,7 +786,7 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
     langCheckFeature.start();
@@ -819,10 +830,10 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang, defaultParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(firstLang, isDefaultLanguage);
   }
 }
@@ -837,8 +848,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
 
   constexpr std::string_view firstLang = "sv";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -862,10 +871,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -883,10 +892,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -903,7 +912,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -947,10 +956,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 }
@@ -965,8 +974,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
 
   constexpr std::string_view firstLang = "sv";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Disable force check for languages
   server.server()
@@ -990,10 +997,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -1011,10 +1018,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -1031,7 +1038,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     langCheckFeature.start();
@@ -1075,10 +1082,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 }
@@ -1093,8 +1100,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
   constexpr std::string_view inputFirstLang = "de@PhOneBoOk";
   constexpr std::string_view actualFirstLang = "de__PHONEBOOK";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
   // Enable force check for languages
   server.server()
       .options()
@@ -1114,10 +1119,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
     // Simulate server launch
     langFeature.prepare();
     langCheckFeature.start();
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
   // Assume that server is stoped
@@ -1131,10 +1136,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
     // Simulate server launch
     langFeature.prepare();
     langCheckFeature.start();
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
   // Assume that server is stoped
@@ -1148,7 +1153,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
     langFeature.validateOptions(server.server().options());
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -1185,10 +1190,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
     // Simulate server launch
     langFeature.prepare();
     langCheckFeature.start();
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }
@@ -1203,8 +1208,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
 
   constexpr std::string_view firstLang = "de@collation=phonebook";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -1228,10 +1231,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -1249,10 +1252,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -1269,7 +1272,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -1313,10 +1316,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 }
@@ -1332,8 +1335,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
   constexpr std::string_view inputFirstLang = "en_US@collation=phonebook";
   constexpr std::string_view actualFirstLang = "en_US";
   constexpr std::string_view secondLang = "en";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -1357,10 +1358,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1378,10 +1379,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1398,7 +1399,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -1442,10 +1443,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }
@@ -1461,8 +1462,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
   constexpr std::string_view inputFirstLang = "de_DE@collation=phonebook";
   constexpr std::string_view actualFirstLang = "de@collation=phonebook";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -1486,10 +1485,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1507,10 +1506,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1527,7 +1526,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -1571,10 +1570,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }
@@ -1589,8 +1588,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
 
   constexpr std::string_view firstLang = "de_AT@collation=phonebook";
   constexpr std::string_view secondLang = "de_AT";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -1614,10 +1611,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -1635,10 +1632,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 
@@ -1655,7 +1652,7 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
 
     // Simulate server launch
     langFeature.prepare();
-    bool shouldBeLangEqual = false;
+    constexpr bool shouldBeLangEqual = false;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
     EXPECT_DEATH(langCheckFeature.start(), "");
@@ -1699,10 +1696,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), firstLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(firstLang.data(), isDefaultLanguage);
   }
 }
@@ -1718,8 +1715,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
   constexpr std::string_view inputFirstLang = "de_DE@collation=phonebook";
   constexpr std::string_view actualFirstLang = "de";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -1747,10 +1742,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1772,10 +1767,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1798,10 +1793,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(secondLang.data(), isDefaultLanguage);
   }
 
@@ -1843,10 +1838,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }
@@ -1863,8 +1858,6 @@ TEST_F(ArangoLanguageFeatureTest,
   constexpr std::string_view inputFirstLang = "en_US@collation=phonebook";
   constexpr std::string_view actualFirstLang = "en_US";
   constexpr std::string_view secondLang = "en_US";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -1892,10 +1885,10 @@ TEST_F(ArangoLanguageFeatureTest,
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1917,10 +1910,10 @@ TEST_F(ArangoLanguageFeatureTest,
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -1943,10 +1936,10 @@ TEST_F(ArangoLanguageFeatureTest,
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(secondLang.data(), isDefaultLanguage);
   }
 
@@ -1988,10 +1981,10 @@ TEST_F(ArangoLanguageFeatureTest,
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }
@@ -2007,8 +2000,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
   constexpr std::string_view inputFirstLang = "de@collation=AbCxYz";
   constexpr std::string_view actualFirstLang = "de";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -2036,10 +2027,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -2061,10 +2052,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -2087,10 +2078,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), secondLang.data(), icuParameter.data(),
                       shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(secondLang.data(), isDefaultLanguage);
   }
 
@@ -2132,10 +2123,10 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       icuParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = false;
+    constexpr bool isDefaultLanguage = false;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }
@@ -2151,8 +2142,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
   constexpr std::string_view inputFirstLang = "de@collation=AbCxYz";
   constexpr std::string_view actualFirstLang = "de";
   constexpr std::string_view secondLang = "de";
-  constexpr std::string_view defaultParameter = "default-language";
-  constexpr std::string_view icuParameter = "icu-language";
 
   // Enable force check for languages
   server.server()
@@ -2180,10 +2169,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -2205,10 +2194,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 
@@ -2231,10 +2220,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(secondLang.data(), isDefaultLanguage);
   }
 
@@ -2257,10 +2246,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), secondLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(secondLang.data(), isDefaultLanguage);
   }
 
@@ -2282,10 +2271,10 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
     langFeature.prepare();
     langCheckFeature.start();
 
-    bool shouldBeLangEqual = true;
+    constexpr bool shouldBeLangEqual = true;
     checkLanguageFile(server.server(), actualFirstLang.data(),
                       defaultParameter.data(), shouldBeLangEqual);
-    bool isDefaultLanguage = true;
+    constexpr bool isDefaultLanguage = true;
     checkCollatorSettings(actualFirstLang.data(), isDefaultLanguage);
   }
 }


### PR DESCRIPTION
### Scope & Purpose

This PR fixes bug for ArangoLanguageFeature test when current system locale is "DE".
 

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1034
- [ ] Design document: 
