### PR TITLE
Add upgrade task to drop `_pregel_queries` system collections.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Add upgrade task to drop `_pregel_queries` system collections.
+
 * EE-Only bug-fix MDS-1190: When using arangorestore to restore a SmartGraph,
   the restore process may generate new internal collection ids.
   These generated ids were not always updated in the restored SmartGraph schema.

--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -257,6 +257,13 @@ void methods::Upgrade::registerTasks(arangodb::UpgradeFeature& upgradeFeature) {
           /*cluster*/ Flags::CLUSTER_NONE | Flags::CLUSTER_DB_SERVER_LOCAL,
           /*database*/ DATABASE_UPGRADE | DATABASE_EXISTING,
           &UpgradeTasks::renameReplicationApplierStateFiles);
+  addTask(upgradeFeature, "dropPregelQueriesCollection",
+          "drop _pregel_queries collection",
+          /*system*/ Upgrade::Flags::DATABASE_ALL,
+          /*cluster*/ Upgrade::Flags::CLUSTER_COORDINATOR_GLOBAL |
+              Upgrade::Flags::CLUSTER_NONE,
+          /*database*/ DATABASE_UPGRADE | DATABASE_EXISTING,
+          &UpgradeTasks::dropPregelQueriesCollection);
 
   // IResearch related upgrade tasks:
   // NOTE: db-servers do not have a dedicated collection for storing analyzers,
@@ -270,6 +277,7 @@ void methods::Upgrade::registerTasks(arangodb::UpgradeFeature& upgradeFeature) {
               | Upgrade::Flags::DATABASE_UPGRADE,
           &UpgradeTasks::dropLegacyAnalyzersCollection  // action
   );
+
 #ifdef USE_ENTERPRISE
   registerTasksEE(upgradeFeature);
 #endif

--- a/arangod/VocBase/Methods/UpgradeTasks.h
+++ b/arangod/VocBase/Methods/UpgradeTasks.h
@@ -27,23 +27,23 @@
 
 struct TRI_vocbase_t;
 
-namespace arangodb {
-namespace methods {
+namespace arangodb::methods {
 
 /// Code to create and initialize databases
 /// Replaces upgrade-database.js for good
 struct UpgradeTasks {
   static bool createSystemCollectionsAndIndices(TRI_vocbase_t& vocbase,
-                                                velocypack::Slice const& slice);
-  static bool createStatisticsCollectionsAndIndices(
-      TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
+                                                velocypack::Slice slice);
+  static bool createStatisticsCollectionsAndIndices(TRI_vocbase_t& vocbase,
+                                                    velocypack::Slice slice);
   static bool addDefaultUserOther(TRI_vocbase_t& vocbase,
-                                  velocypack::Slice const& slice);
-  static bool renameReplicationApplierStateFiles(
-      TRI_vocbase_t& vocbase, velocypack::Slice const& slice);
+                                  velocypack::Slice slice);
+  static bool renameReplicationApplierStateFiles(TRI_vocbase_t& vocbase,
+                                                 velocypack::Slice slice);
   static bool dropLegacyAnalyzersCollection(TRI_vocbase_t& vocbase,
-                                            velocypack::Slice const& slice);
+                                            velocypack::Slice slice);
+  static bool dropPregelQueriesCollection(TRI_vocbase_t& vocbase,
+                                          velocypack::Slice slice);
 };
 
-}  // namespace methods
-}  // namespace arangodb
+}  // namespace arangodb::methods


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1467

Add upgrade task to drop _pregel_queries system collections.
These collections are unneeded from 3.12.0 onwards, so we can as well delete them.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1467
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 