### PR TITLE
fix upgrade of agents to 3.12.0 if `--cluster.force-one-shard` is set

### DIFF
--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1678,7 +1678,15 @@ void TRI_SanitizeObject(VPackSlice slice, VPackBuilder& builder) {
 
   config.defaultWriteConcern = writeConcern();
 
-  config.isOneShardDB = cl.forceOneShard() || isOneShard();
+  if (ServerState::instance()->isSingleServer() ||
+      ServerState::instance()->isAgent()) {
+    // on single servers and agents, the value of `--cluster.force-one-shard`
+    // is intentionally ignored. all databases and collections are local.
+    config.isOneShardDB = false;
+  } else {
+    config.isOneShardDB = cl.forceOneShard() || isOneShard();
+  }
+
   if (config.isOneShardDB) {
     config.defaultDistributeShardsLike = shardingPrototypeName();
   } else {

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -362,7 +362,9 @@ class instance {
       'temp.intermediate-results-path': fs.join(this.rootDir, 'temp-rocksdb-dir'),
       'log.file': this.logFile
     });
-
+    if (options.singleShardCluster) {
+      this.args['cluster.force-one-shard'] = true;
+    }
     if (require("@arangodb/test-helper").isEnterprise()) {
       this.args['arangosearch.columns-cache-limit'] = '100000';
     }

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -362,7 +362,7 @@ class instance {
       'temp.intermediate-results-path': fs.join(this.rootDir, 'temp-rocksdb-dir'),
       'log.file': this.logFile
     });
-    if (options.forceOneShard) {
+    if (this.options.forceOneShard) {
       this.args['cluster.force-one-shard'] = true;
     }
     if (require("@arangodb/test-helper").isEnterprise()) {

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -362,7 +362,7 @@ class instance {
       'temp.intermediate-results-path': fs.join(this.rootDir, 'temp-rocksdb-dir'),
       'log.file': this.logFile
     });
-    if (options.singleShardCluster) {
+    if (options.forceOneShard) {
       this.args['cluster.force-one-shard'] = true;
     }
     if (require("@arangodb/test-helper").isEnterprise()) {

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -573,6 +573,9 @@ function rtaMakedata(options, instanceManager, writeReadClean, msg, logFile, mor
   if (options.rtaNegFilter !== '') {
     argv = argv.concat(['--skip', options.rtaNegFilter]);
   }
+  if (options.extraArgs.hasOwnProperty('cluster.force-one-shard')) {
+    argv = argv.concat(['--singleShard', 'true']);
+  }
   if (options.hasOwnProperty('makedata_args')) {
     argv = argv.concat(toArgv(options['makedata_args']));
   }

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -573,7 +573,7 @@ function rtaMakedata(options, instanceManager, writeReadClean, msg, logFile, mor
   if (options.rtaNegFilter !== '') {
     argv = argv.concat(['--skip', options.rtaNegFilter]);
   }
-  if (options.singleShardCluster) {
+  if (options.forceOneShard) {
     argv = argv.concat(['--singleShard', 'true']);
   }
   if (options.hasOwnProperty('makedata_args')) {

--- a/js/client/modules/@arangodb/testutils/process-utils.js
+++ b/js/client/modules/@arangodb/testutils/process-utils.js
@@ -573,7 +573,7 @@ function rtaMakedata(options, instanceManager, writeReadClean, msg, logFile, mor
   if (options.rtaNegFilter !== '') {
     argv = argv.concat(['--skip', options.rtaNegFilter]);
   }
-  if (options.extraArgs.hasOwnProperty('cluster.force-one-shard')) {
+  if (options.singleShardCluster) {
     argv = argv.concat(['--singleShard', 'true']);
   }
   if (options.hasOwnProperty('makedata_args')) {

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -84,8 +84,8 @@ let optionsDocumentation = [
   '   - `server`: server_url (e.g. tcp://127.0.0.1:8529) for external server',
   '   - `serverRoot`: directory where data/ points into the db server. Use in',
   '                   conjunction with `server`.',
-  '   - `cluster`: if set to true the tests are run with the coordinator',
-  '     of a small local cluster',
+  '   - `cluster`: if set to true the tests are run with a cluster',
+  '   - `singleShardCluster`: if set to true the tests are run with a singleshard cluster',
   '   - `replicationVersion`: if set, define the default replication version. (Currently we have "1" and "2")',
   '   - `arangosearch`: if set to true enable the ArangoSearch-related tests',
   '   - `minPort`: minimum port number to use',
@@ -184,6 +184,7 @@ const optionsDefaults = {
   'buildType': '',
   'cleanup': true,
   'cluster': false,
+  'singleShardCluster': false,
   'concurrency': 3,
   'configDir': 'etc/testing',
   'coordinators': 1,
@@ -605,6 +606,9 @@ function unitTest (cases, options) {
 
   // testsuites may register more defaults...
   _.defaults(options, optionsDefaults);
+  if (options.singleShardCluster) {
+    options.cluster = true;
+  }
   if (options.memprof) {
     process.env['MALLOC_CONF'] = 'prof:true';
   }

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -607,7 +607,9 @@ function unitTest (cases, options) {
   // testsuites may register more defaults...
   _.defaults(options, optionsDefaults);
   if (options.forceOneShard) {
-    options.cluster = true;
+    if (!options.cluster) {
+      throw new Error("need cluster enabled");
+    }
   }
   if (options.memprof) {
     process.env['MALLOC_CONF'] = 'prof:true';

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -85,7 +85,7 @@ let optionsDocumentation = [
   '   - `serverRoot`: directory where data/ points into the db server. Use in',
   '                   conjunction with `server`.',
   '   - `cluster`: if set to true the tests are run with a cluster',
-  '   - `singleShardCluster`: if set to true the tests are run with a singleshard cluster',
+  '   - `forceOneShard`: if set to true the tests are run with a OneShard (EE only) cluster, requires cluster option to be set to true',
   '   - `replicationVersion`: if set, define the default replication version. (Currently we have "1" and "2")',
   '   - `arangosearch`: if set to true enable the ArangoSearch-related tests',
   '   - `minPort`: minimum port number to use',
@@ -184,7 +184,7 @@ const optionsDefaults = {
   'buildType': '',
   'cleanup': true,
   'cluster': false,
-  'singleShardCluster': false,
+  'forceOneShard': false,
   'concurrency': 3,
   'configDir': 'etc/testing',
   'coordinators': 1,
@@ -606,7 +606,7 @@ function unitTest (cases, options) {
 
   // testsuites may register more defaults...
   _.defaults(options, optionsDefaults);
-  if (options.singleShardCluster) {
+  if (options.forceOneShard) {
     options.cluster = true;
   }
   if (options.memprof) {

--- a/tests/js/client/shell/api/api-replication.js
+++ b/tests/js/client/shell/api/api-replication.js
@@ -1593,7 +1593,9 @@ function RestoreOverwriteErrorSuite() {
 
 jsunity.run(RestoreCollectionsSuite);
 jsunity.run(IgnoreIllegalTypesSuite);
-jsunity.run(RestoreInOneShardSuite);
+if (isCluster) {
+  jsunity.run(RestoreInOneShardSuite);
+}
 jsunity.run(RestoreOverwriteErrorSuite);
 
 return jsunity.done();

--- a/tests/js/client/shell/shell-collection-api.js
+++ b/tests/js/client/shell/shell-collection-api.js
@@ -1632,6 +1632,8 @@ function CreateCollectionsInOneShardSuite() {
 
 jsunity.run(CreateCollectionsSuite);
 jsunity.run(IgnoreIllegalTypesSuite);
-jsunity.run(CreateCollectionsInOneShardSuite);
+if (isCluster) {
+  jsunity.run(CreateCollectionsInOneShardSuite);
+}
 
 return jsunity.done();

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -96,7 +96,7 @@ shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5
 shell_client_replication2_recovery priority=500 size=medium cluster -- --dumpAgencyOnError true
 
 rta_makedata sniff cluster 
-rta_makedata sniff cluster --  --singleShardCluster true
+rta_makedata sniff enterprise cluster --  --forceOneShard true
 # Common Tests
 
 importing,export name=import_export parallelity=5 size=small cluster -- --dumpAgencyOnError true

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -96,7 +96,7 @@ shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5
 shell_client_replication2_recovery priority=500 size=medium cluster -- --dumpAgencyOnError true
 
 rta_makedata sniff cluster 
-rta_makedata sniff enterprise cluster --  --forceOneShard true
+rta_makedata sniff enterprise cluster name=rta_makedata_force_oneshard --  --forceOneShard true
 # Common Tests
 
 importing,export name=import_export parallelity=5 size=small cluster -- --dumpAgencyOnError true

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -96,7 +96,7 @@ shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5
 shell_client_replication2_recovery priority=500 size=medium cluster -- --dumpAgencyOnError true
 
 rta_makedata sniff cluster 
-
+rta_makedata sniff cluster --  --extraArgs:cluster.force-one-shard true
 # Common Tests
 
 importing,export name=import_export parallelity=5 size=small cluster -- --dumpAgencyOnError true

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -96,7 +96,7 @@ shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5
 shell_client_replication2_recovery priority=500 size=medium cluster -- --dumpAgencyOnError true
 
 rta_makedata sniff cluster 
-rta_makedata sniff cluster --  --extraArgs:cluster.force-one-shard true
+rta_makedata sniff cluster --  --singleShardCluster true
 # Common Tests
 
 importing,export name=import_export parallelity=5 size=small cluster -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

Fix upgrade of agents to 3.12.0 if `--cluster.force-one-shard` is set.

Note that this PR now disables certain collection API tests for OneShard databases on single servers.
Previously there were tests that set up a OneShard database on single servers and then tested the behavior of the collection API when trying to create collections with various cluster attributes inside that OneShard database.
The tests mainly asserted that certain error log messages occurred.

This PR now turns off the OneShard tests on single server, as I think we should ignore the usage of OneShard on single servers entirely, same for all cluster collection attributes. This may not be the majority opinion, but IMHO it does not make sense to support any of these attributes on single servers.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 