### PR TITLE
[3.12] Correctly return the Sharding Prototype of Agents

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+3.12.0.1 (XXXX-XX-XX)
+-----
+
+* Fixed an upgrade issue on Agents. When agents are started with
+  `--database.auto-upgrade true` and `--cluster.force-one-shard true`. The
+  upgrade procedure got into an incorrect state. Please note `--cluster.force-one-shard`
+  is not required on the Agent instances.
+
 3.12.0 (2024-03-21)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,11 @@
 3.12.0.1 (XXXX-XX-XX)
------
+---------------------
 
 * Fixed an upgrade issue on Agents. When agents are started with
   `--database.auto-upgrade true` and `--cluster.force-one-shard true`. The
-  upgrade procedure got into an incorrect state. Please note `--cluster.force-one-shard`
-  is not required on the Agent instances.
+  upgrade procedure got into an incorrect state. Please note
+  `--cluster.force-one-shard` is not required on the Agent instances.
+
 
 3.12.0 (2024-03-21)
 -------------------

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1465,7 +1465,7 @@ std::string const& TRI_vocbase_t::shardingPrototypeName() const {
         // All others should follow _graphs
         return StaticStrings::GraphCollection;
       }
-    }
+  }
 }
 
 std::vector<std::shared_ptr<LogicalView>> TRI_vocbase_t::views() const {

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1450,9 +1450,22 @@ ShardingPrototype TRI_vocbase_t::shardingPrototype() const {
 }
 
 std::string const& TRI_vocbase_t::shardingPrototypeName() const {
-  return _info.shardingPrototype() == ShardingPrototype::Users
-             ? StaticStrings::UsersCollection
-             : StaticStrings::GraphCollection;
+  switch (_info.shardingPrototype()) {
+    case ShardingPrototype::Users:
+      // Specifically set defaults should win
+      return StaticStrings::UsersCollection;
+    case ShardingPrototype::Graphs:
+      // Specifically set defaults should win
+      return StaticStrings::GraphCollection;
+    case ShardingPrototype::Undefined:
+      if (isSystem()) {
+        // The sharding Prototype for system databases is always the users
+        return StaticStrings::UsersCollection;
+      } else {
+        // All others should follow _graphs
+        return StaticStrings::GraphCollection;
+      }
+    }
 }
 
 std::vector<std::shared_ptr<LogicalView>> TRI_vocbase_t::views() const {

--- a/tests/js/client/shell/agency-oneshard-regression-nocluster.js
+++ b/tests/js/client/shell/agency-oneshard-regression-nocluster.js
@@ -1,0 +1,81 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertFalse, assertTrue, arango, print */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Michael Hackstein
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const pu = require('@arangodb/testutils/process-utils');
+const fs = require("fs");
+const {executeExternalAndWait} = require("internal");
+
+function UpgradeForceOneShardRegressionSuite() {
+  'use strict';
+
+  return {
+    testCanStartAgencyWithAutoUpgradeAndForceOneShard: function () {
+
+      /*
+      * This tests a regression on Agent servers, that could not be restarted
+      * with force-one-shard and auto-upgrade.
+      * As we need to get controll over return code we start the agent as
+      * an external process and wait for it to complete the upgrade routine
+      * If it exits with anything other than ExitCode 0 it should print log
+      * to std out for investigation.
+      * The options we use here are the bare minimum to identify a server as
+      * agent.
+      */
+      const arangod = pu.ARANGOD_BIN;
+      assertTrue(fs.isFile(arangod), "arangod not found!");
+
+      let addConnectionArgs = function (args) {
+        const path = fs.getTempFile();
+        args.push('--server.endpoint');
+        args.push("none");
+        args.push('--agency.activate');
+        args.push('true');
+        args.push('--agency.size');
+        args.push('1');
+        args.push('--agency.supervision');
+        args.push('true');
+        args.push('--cluster.force-one-shard');
+        args.push('true');
+        args.push('--database.auto-upgrade');
+        args.push('true');
+        args.push(path);
+      };
+      const args = [];
+      addConnectionArgs(args);
+      require("console").warn(`Start arangod agency with args: ${JSON.stringify(args)}`);
+      const actualRc = executeExternalAndWait(arangod, args);
+      assertEqual(actualRc.exit, 0, `Instead process exited with ${JSON.stringify(actualRc)}`);
+    }
+  };
+}
+
+//////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+//////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(UpgradeForceOneShardRegressionSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of: https://github.com/arangodb/arangodb/pull/20788

*Fixed a sharding prototype mismatch on Agents, when they are started with force-one-shard and auto-upgrade at the same time.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
