### PR TITLE
Change request lane priorities

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,25 @@ devel
   transactions and AQL queries can block other operations from starting, so
   these should be completed first.
 
+  The following request priorities have changed:
+  - cluster-internal requests for continuing already started AQL queries have
+    changed their priority from low to medium. This excludes requests that
+    setup AQL queries on DB servers, which still run with low priority.
+  - requests that include the transaction id header are now elevated to run
+    with medium priority if they originally ran with low priority. This
+    excludes requests that begin new transactions or AQL queries.
+  - requests to commit or abort an already running streaming transaction will
+    be elevated from low to medium priority.
+  - requests to HTTP GET `/_api/collection/<collection>/shards` and GET
+    `/_api/collection/<collection>/reponsibleShard` are now running with high
+    priority instead of low. Such requests are only used for inspection and
+    have no dependencies.
+  - requests to push further an existing query cursor via the `/_api/cursor`
+    are now running with medium priority instead of low priority. Requests
+    to start new queries still run with low priority.
+  - follower requests that acquire the lock on the leader while the follower
+    tries to get in sync are now running with low instead of medium priority.
+
 * Fixed an upgrade issue on Agents. When agents are started with
   `--database.auto-upgrade true` and `--cluster.force-one-shard true`. The
   upgrade procedure got into an incorrect state. Please note `--cluster.force-one-shard`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Prioritize requests for commiting or aborting streaming transactions
+  on leaders and followers, because they can unblock other operations.
+
 * FE-316: Edge collection import example now correctly reflects the required
   `from` and `to` attributes.
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -839,6 +839,8 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
 }
 
 RequestLane RestAqlHandler::lane() const {
+  TRI_ASSERT(!ServerState::instance()->isSingleServer());
+
   if (ServerState::instance()->isCoordinator()) {
     // continuation requests on coordinators will get medium priority,
     // so that they don't block query parts elsewhere
@@ -860,11 +862,15 @@ RequestLane RestAqlHandler::lane() const {
                     "invalid request lane priority");
       return RequestLane::CLUSTER_AQL_SHUTDOWN;
     }
+
+    if (suffixes.size() == 1 && suffixes[0] == "setup") {
+      return RequestLane::INTERNAL_LOW;
+    }
   }
 
-  // everything else will run with low priority
+  // everything else will run with med priority
   static_assert(
-      PriorityRequestLane(RequestLane::CLUSTER_AQL) == RequestPriority::LOW,
+      PriorityRequestLane(RequestLane::CLUSTER_AQL) == RequestPriority::MED,
       "invalid request lane priority");
   return RequestLane::CLUSTER_AQL;
 }

--- a/arangod/GeneralServer/RequestLane.h
+++ b/arangod/GeneralServer/RequestLane.h
@@ -152,7 +152,7 @@ constexpr inline RequestPriority PriorityRequestLane(RequestLane lane) {
     case RequestLane::CLUSTER_INTERNAL:
       return RequestPriority::HIGH;
     case RequestLane::CLUSTER_AQL:
-      return RequestPriority::LOW;
+      return RequestPriority::MED;
     case RequestLane::CLUSTER_AQL_INTERNAL_COORDINATOR:
       return RequestPriority::MED;
     case RequestLane::CLUSTER_AQL_SHUTDOWN:

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -43,6 +43,7 @@
 #include "Scheduler/SchedulerFeature.h"
 #include "Statistics/RequestStatistics.h"
 #include "Utils/ExecContext.h"
+#include "VocBase/Identifiers/TransactionId.h"
 #include "VocBase/ticks.h"
 
 #include <absl/strings/str_cat.h>
@@ -120,6 +121,34 @@ RequestLane RestHandler::determineRequestLane() {
       _lane = RequestLane::CLIENT_UI;
     } else {
       _lane = lane();
+
+      if (PriorityRequestLane(_lane) == RequestPriority::LOW) {
+        // if this is a low-priority request, check if it contains
+        // a transaction id, but is not the start of an AQL query
+        // or streaming transaction.
+        // if we find out that the request is part of an already
+        // ongoing transaction, we can now increase its priority,
+        // so that ongoing transactions can proceed. however, we
+        // don't want to prioritize the start of new transactions
+        // here.
+        std::string const& value =
+            _request->header(StaticStrings::TransactionId, found);
+
+        if (found) {
+          TransactionId tid = TransactionId::none();
+          std::size_t pos = 0;
+          try {
+            tid = TransactionId{std::stoull(value, &pos, 10)};
+          } catch (...) {
+          }
+          if (!tid.empty() &&
+              !(value.compare(pos, std::string::npos, " aql") == 0 ||
+                value.compare(pos, std::string::npos, " begin") == 0)) {
+            // increase request priority from previously LOW to now MED.
+            _lane = RequestLane::CONTINUATION;
+          }
+        }
+      }
     }
   }
   TRI_ASSERT(_lane != RequestLane::UNDEFINED);

--- a/arangod/RestHandler/RestCollectionHandler.h
+++ b/arangod/RestHandler/RestCollectionHandler.h
@@ -35,11 +35,10 @@ class RestCollectionHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   RestCollectionHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
- public:
   char const* name() const override final { return "RestCollectionHandler"; }
-  RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
-  RestStatus execute() override final;
+  RequestLane lane() const override final;
 
+  RestStatus execute() override final;
   void shutdownExecute(bool isFinalized) noexcept override final;
 
  protected:
@@ -70,13 +69,11 @@ class RestCollectionHandler : public arangodb::RestVocbaseBaseHandler {
   RestStatus standardResponse();
   futures::Future<futures::Unit> initializeTransaction(LogicalCollection&);
 
- private:
   futures::Future<RestStatus> handleCommandGet();
   void handleCommandPost();
   futures::Future<RestStatus> handleCommandPut();
   void handleCommandDelete();
 
- private:
   VPackBuilder _builder;
   std::unique_ptr<transaction::Methods> _activeTrx;
   std::unique_ptr<methods::Collections::Context> _ctxt;

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -60,6 +60,18 @@ RestCursorHandler::RestCursorHandler(
 
 RestCursorHandler::~RestCursorHandler() { releaseCursor(); }
 
+RequestLane RestCursorHandler::lane() const {
+  if (_request->requestType() != rest::RequestType::POST ||
+      !_request->suffixes().empty()) {
+    // continuing an existing query or cleaning up its resources
+    // gets higher priority than starting new queries
+    return RequestLane::CONTINUATION;
+  }
+
+  // low priority for starting new queries
+  return RequestLane::CLIENT_AQL;
+}
+
 RestStatus RestCursorHandler::execute() {
   // extract the sub-request type
   rest::RequestType const type = _request->requestType();

--- a/arangod/RestHandler/RestCursorHandler.h
+++ b/arangod/RestHandler/RestCursorHandler.h
@@ -57,10 +57,10 @@ class RestCursorHandler : public RestVocbaseBaseHandler {
   ~RestCursorHandler();
 
  public:
-  virtual RestStatus execute() override;
   char const* name() const override { return "RestCursorHandler"; }
-  RequestLane lane() const override final { return RequestLane::CLIENT_AQL; }
+  RequestLane lane() const override final;
 
+  virtual RestStatus execute() override;
   virtual RestStatus continueExecute() override;
   void shutdownExecute(bool isFinalized) noexcept override;
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3712,14 +3712,15 @@ RequestLane RestReplicationHandler::lane() const {
         // In case of a hard-lock this shard is actually blocking
         // other operations. So let's hurry up with this.
         return RequestLane::CLUSTER_INTERNAL;
-      } else {
-        // This process will determine the start of a replication.
-        // It can be delayed a bit and can be queued after other write
-        // operations The follower is not in sync and requires to catch up
-        // anyways.
-        return RequestLane::SERVER_REPLICATION_CATCHUP;
       }
+
+      // This process will determine the start of a replication.
+      // It can be delayed a bit and can be queued after other write
+      // operations The follower is not in sync and requires to catch up
+      // anyways.
+      return RequestLane::SERVER_REPLICATION;
     }
+
     if (command == RemoveFollower || command == LoggerFollow ||
         command == Batch || command == Inventory || command == Revisions ||
         command == Dump) {

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -61,6 +61,44 @@ RestTransactionHandler::RestTransactionHandler(ArangodServer& server,
                                                GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response), _v8Context(nullptr) {}
 
+RequestLane RestTransactionHandler::lane() const {
+  bool isCommit = _request->requestType() == rest::RequestType::PUT;
+  bool isAbort = _request->requestType() == rest::RequestType::DELETE_REQ;
+
+  if ((isCommit || isAbort) &&
+      ServerState::instance()->isSingleServerOrCoordinator()) {
+    // give commits and aborts a higer priority than normal document
+    // operations on coordinators and single servers, because these
+    // operations can unblock other operations.
+    // strictly speaking, the request lane should not be "continuation"
+    // here, as it is no continuation. but we don't have a better
+    // other request lane with medium priority. the only important
+    // thing here is that the request lane priority is set to medium.
+    return RequestLane::CONTINUATION;
+  }
+
+  if (ServerState::instance()->isDBServer()) {
+    bool isSyncReplication = false;
+    // We do not care for the real value, enough if it is there.
+    std::ignore = _request->value(StaticStrings::IsSynchronousReplicationString,
+                                  isSyncReplication);
+    if (isSyncReplication) {
+      return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
+      // This leads to the high queue, we want replication requests (for
+      // commit or abort in the El Cheapo case) to be executed with a
+      // higher prio than leader requests, even if they are done from
+      // AQL.
+    }
+    if (isCommit || isAbort) {
+      // commit or abort on leader gets a medium priority, because it
+      // can unblock other operations
+      return RequestLane::CONTINUATION;
+    }
+  }
+
+  return RequestLane::CLIENT_V8;
+}
+
 RestStatus RestTransactionHandler::execute() {
   switch (_request->requestType()) {
     case rest::RequestType::POST:

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -39,24 +39,9 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   RestTransactionHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
- public:
   char const* name() const override final { return "RestTransactionHandler"; }
-  RequestLane lane() const override final {
-    if (ServerState::instance()->isDBServer()) {
-      bool isSyncReplication = false;
-      // We do not care for the real value, enough if it is there.
-      std::ignore = _request->value(
-          StaticStrings::IsSynchronousReplicationString, isSyncReplication);
-      if (isSyncReplication) {
-        return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
-        // This leads to the high queue, we want replication requests (for
-        // commit or abort in the El Cheapo case) to be executed with a
-        // higher prio than leader requests, even if they are done from
-        // AQL.
-      }
-    }
-    return RequestLane::CLIENT_V8;
-  }
+  RequestLane lane() const override final;
+
   RestStatus execute() override;
   void cancel() override final;
 

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -643,6 +643,41 @@ void TransactionState::setExclusiveAccessType() {
   _type = AccessMode::Type::EXCLUSIVE;
 }
 
+/// @brief whether or not a transaction is read-only
+bool TransactionState::isReadOnlyTransaction() const noexcept {
+  return _type == AccessMode::Type::READ;
+}
+
+/// @brief whether or not a transaction is a follower transaction
+bool TransactionState::isFollowerTransaction() const noexcept {
+  return hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
+}
+
+/// @brief servers already contacted
+containers::FlatHashSet<ServerID> const& TransactionState::knownServers()
+    const noexcept {
+  return _knownServers;
+}
+
+bool TransactionState::knowsServer(std::string_view uuid) const noexcept {
+  TRI_ASSERT(!uuid.empty());
+  return _knownServers.contains(uuid);
+}
+
+/// @brief add a server to the known set
+void TransactionState::addKnownServer(std::string_view uuid) {
+  TRI_ASSERT(!uuid.empty());
+  _knownServers.emplace(uuid);
+}
+
+/// @brief remove a server from the known set
+void TransactionState::removeKnownServer(std::string_view uuid) {
+  TRI_ASSERT(!uuid.empty());
+  _knownServers.erase(uuid);
+}
+
+void TransactionState::clearKnownServers() { _knownServers.clear(); }
+
 void TransactionState::acceptAnalyzersRevision(
     QueryAnalyzerRevisions const& analyzersRevision) noexcept {
   // only init from default allowed! Or we have problem -> different

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -297,32 +297,24 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
   void setExclusiveAccessType();
 
   /// @brief whether or not a transaction is read-only
-  [[nodiscard]] bool isReadOnlyTransaction() const noexcept {
-    return _type == AccessMode::Type::READ;
-  }
+  [[nodiscard]] bool isReadOnlyTransaction() const noexcept;
 
   /// @brief whether or not a transaction is a follower transaction
-  [[nodiscard]] bool isFollowerTransaction() const noexcept {
-    return hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX);
-  }
+  [[nodiscard]] bool isFollowerTransaction() const noexcept;
 
   /// @brief servers already contacted
   [[nodiscard]] containers::FlatHashSet<ServerID> const& knownServers()
-      const noexcept {
-    return _knownServers;
-  }
+      const noexcept;
 
-  [[nodiscard]] bool knowsServer(std::string_view uuid) const noexcept {
-    return _knownServers.contains(uuid);
-  }
+  [[nodiscard]] bool knowsServer(std::string_view uuid) const noexcept;
 
   /// @brief add a server to the known set
-  void addKnownServer(std::string_view uuid) { _knownServers.emplace(uuid); }
+  void addKnownServer(std::string_view uuid);
 
   /// @brief remove a server from the known set
-  void removeKnownServer(std::string_view uuid) { _knownServers.erase(uuid); }
+  void removeKnownServer(std::string_view uuid);
 
-  void clearKnownServers() { _knownServers.clear(); }
+  void clearKnownServers();
 
   void chooseReplicas(containers::FlatHashSet<ShardID> const& shards);
 

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -481,8 +481,8 @@ exports.runParallelArangoshTests = function (tests, duration, cn) {
 
       const logfile = client.file + '.log';
       if (client.failed) {
-        if (fs.exists(logfile)) {
-          debug("test client with pid " + client.pid + " has failed and wrote logfile: " + fs.readFileSync(logfile).toString());
+        if (fs.exists(logfile) && fs.readFileSync(logfile).toString() !== '') {
+          debug("test client with pid " + client.pid + " has failed and wrote logfile '" + logfile + ": " + fs.readFileSync(logfile).toString());
         } else {
           debug("test client with pid " + client.pid + " has failed and did not write a logfile");
         }

--- a/tests/js/client/shell/shell-transaction-commit-abort-overwhelm-cluster.js
+++ b/tests/js/client/shell/shell-transaction-commit-abort-overwhelm-cluster.js
@@ -1,0 +1,149 @@
+/* jshint globalstrict:true, strict:true, maxlen: 5000 */
+/* global assertTrue, assertFalse, assertEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+
+const jsunity = require("jsunity");
+const db = require("internal").db;
+const url = require('url');
+const _ = require("lodash");
+const { getDBServers } = require('@arangodb/test-helper');
+
+const cn = "UnitTestsQueries";
+
+function TransactionCommitAbortOverwhelmSuite () {
+  'use strict';
+    
+  let testFunc = (cb) => {
+    // create exclusive transaction
+    let trx = db._createTransaction({
+      collections: { write: "d" }
+    });
+
+    try {
+      // write 5 documents
+      trx.collection('d').insert([{}, {}, {}, {}, {}]);
+
+      const [shard, servers] = Object.entries(db.c.shards(true))[0];
+
+      // trigger move shard
+      let body = {database: cn, collection: "c", shard, fromServer: servers[0], toServer: servers[1]};
+      let result = arango.POST("/_admin/cluster/moveShard", body);
+
+      assertFalse(result.error);
+      assertEqual(202, result.code);
+
+      while (true) {
+        const job = arango.GET(`/_admin/cluster/queryAgencyJob?id=${result.id}`);
+        if (job.error === false && job.status === "Pending") {
+          break;
+        }
+        require('internal').wait(0.5);
+      }
+
+      // create many small write to e f and f
+      const header = {"X-Arango-Async": "store"};
+      for (let i = 0; i < 1000; i++) {
+        arango.POST(`/_api/document/e`, {}, header);
+        arango.POST(`/_api/document/f`, {}, header);
+        arango.POST(`/_api/document/g`, {}, header);
+      }
+
+      // commit transaction
+      // should have priority over the inserts
+      result = cb(trx); 
+      trx = null;
+    } finally {
+      if (trx !== null) {
+        trx.abort();
+      }
+    }
+  };
+  
+  return {
+    setUp: function () {
+      db._createDatabase(cn);
+      db._useDatabase(cn);
+  
+      db._create("c", {numberOfShards: 5, replicationFactor: 2});
+      db._create("d", {distributeShardsLike: "c"});
+      db._create("e", {distributeShardsLike: "c"});
+      db._create("f", {distributeShardsLike: "c"});
+      db._create("g", {distributeShardsLike: "c"});
+    },
+    
+    tearDown: function () {
+      db._useDatabase('_system');
+      db._dropDatabase(cn);
+    },
+
+    testCommitNotAffectedByOverwhelm : function () {
+      testFunc((trx) => {
+        let result = trx.commit();
+        assertEqual("committed", result.status);
+        return result;
+      });
+    },
+    
+    testAbortNotAffectedByOverwhelm : function () {
+      testFunc((trx) => {
+        let result = trx.abort();
+        assertEqual("aborted", result.status);
+        return result;
+      });
+    },
+    
+    testInsertInRunningTrxNotAffectedByOverwhelm : function () {
+      testFunc((trx) => {
+        let col = trx.collection("d");
+        let result = col.insert({_key: "testi"});
+        assertEqual("testi", result._key);
+        
+        result = trx.commit();
+        assertEqual("committed", result.status);
+        return result;
+      });
+    },
+    
+    testRemoveInRunningTrxNotAffectedByOverwhelm : function () {
+      testFunc((trx) => {
+        let col = trx.collection("d");
+        let result = col.insert({_key: "testi"});
+        assertEqual("testi", result._key);
+        result = col.remove("testi");
+        assertEqual("testi", result._key);
+
+        result = trx.commit();
+        assertEqual("committed", result.status);
+        return result;
+      });
+    },
+    
+  };
+}
+
+jsunity.run(TransactionCommitAbortOverwhelmSuite);
+return jsunity.done();

--- a/tests/js/client/shell/shell-transaction-commit-abort-overwhelm-cluster.js
+++ b/tests/js/client/shell/shell-transaction-commit-abort-overwhelm-cluster.js
@@ -64,7 +64,7 @@ function TransactionCommitAbortOverwhelmSuite () {
         require('internal').wait(0.5);
       }
 
-      // create many small write to e f and f
+      // create many small writes to e f and g
       const header = {"X-Arango-Async": "store"};
       for (let i = 0; i < 1000; i++) {
         arango.POST(`/_api/document/e`, {}, header);
@@ -72,8 +72,6 @@ function TransactionCommitAbortOverwhelmSuite () {
         arango.POST(`/_api/document/g`, {}, header);
       }
 
-      // commit transaction
-      // should have priority over the inserts
       result = cb(trx); 
       trx = null;
     } finally {
@@ -116,26 +114,10 @@ function TransactionCommitAbortOverwhelmSuite () {
       });
     },
     
-    testInsertInRunningTrxNotAffectedByOverwhelm : function () {
+    testAqlNotAffectedByOverwhelm : function () {
       testFunc((trx) => {
-        let col = trx.collection("d");
-        let result = col.insert({_key: "testi"});
-        assertEqual("testi", result._key);
-        
-        result = trx.commit();
-        assertEqual("committed", result.status);
-        return result;
-      });
-    },
-    
-    testRemoveInRunningTrxNotAffectedByOverwhelm : function () {
-      testFunc((trx) => {
-        let col = trx.collection("d");
-        let result = col.insert({_key: "testi"});
-        assertEqual("testi", result._key);
-        result = col.remove("testi");
-        assertEqual("testi", result._key);
-
+        let result = trx.query("FOR i IN 1..1000 INSERT {} INTO d RETURN 1").toArray();
+        assertEqual(1000, result.length);
         result = trx.commit();
         assertEqual("committed", result.status);
         return result;


### PR DESCRIPTION
### Scope & Purpose

* Prioritize requests for commiting or aborting streaming transactions on
  leaders and followers, because they can unblock other operations. Also
  prioritize requests in already started streaming transactions and AQL queries
  over new requests because it is assumed that already started streaming
  transactions and AQL queries can block other operations from starting, so
  these should be completed first.

  The following request priorities have changed:
  - cluster-internal requests for continuing already started AQL queries have
    changed their priority from low to medium. This excludes requests that
    setup AQL queries on DB servers, which still run with low priority.
  - requests that include the transaction id header are now elevated to run
    with medium priority if they originally ran with low priority. This
    excludes requests that begin new transactions or AQL queries.
  - requests to commit or abort an already running streaming transaction will
    be elevated from low to medium priority.
  - requests to HTTP GET `/_api/collection/<collection>/shards` and GET
    `/_api/collection/<collection>/reponsibleShard` are now running with high
    priority instead of low. Such requests are only used for inspection and
    have no dependencies.
  - requests to push further an existing query cursor via the `/_api/cursor`
    are now running with medium priority instead of low priority. Requests
    to start new queries still run with low priority.
  - follower requests that acquire the lock on the leader while the follower
    tries to get in sync are now running with low instead of medium priority.
    **Note**: this can potentially delay the getting-in-sync of followers!

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 