### PR TITLE
add method to stringify RW lock state

### DIFF
--- a/lib/Basics/ReadWriteLock.cpp
+++ b/lib/Basics/ReadWriteLock.cpp
@@ -221,3 +221,25 @@ bool ReadWriteLock::isLockedRead() const noexcept {
 bool ReadWriteLock::isLockedWrite() const noexcept {
   return _state.load(std::memory_order_relaxed) & WRITE_LOCK;
 }
+
+std::string ReadWriteLock::stringifyLockState() const {
+  std::string result;
+
+  auto append = [&result](std::string msg) {
+    if (!result.empty()) {
+      result.append(", ");
+    }
+    result.append(msg);
+  };
+
+  auto state = _state.load(std::memory_order_relaxed);
+  auto readers = (state & READER_MASK) >> 32;
+  auto writers = (state & QUEUED_WRITER_MASK) >> 1;
+  append(std::to_string(readers).append(" active reader(s)"));
+  append(std::to_string(writers).append(" queued writer(s)"));
+  if (state & WRITE_LOCK) {
+    append("write-locked");
+  }
+
+  return result;
+}

--- a/lib/Basics/ReadWriteLock.h
+++ b/lib/Basics/ReadWriteLock.h
@@ -29,6 +29,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <mutex>
+#include <string>
 
 namespace arangodb::basics {
 
@@ -84,6 +85,8 @@ class ReadWriteLock {
   [[nodiscard]] bool isLocked() const noexcept;
   [[nodiscard]] bool isLockedRead() const noexcept;
   [[nodiscard]] bool isLockedWrite() const noexcept;
+
+  std::string stringifyLockState() const;
 
  private:
   /// @brief mutex for _readers_bell cv


### PR DESCRIPTION
### Scope & Purpose

Add helper function to stringify the internal state of an RW lock.
The function is currently not used, but it can be used everywhere for debugging/development purposes.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 