### PR TITLE
Log info message for requests with queue time >= 30s

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Log an info message if a request was queued in the scheduler queue for 30 s
+  or longer.
+
 * Add upgrade task to drop `_pregel_queries` system collections.
 
 * Fixed an upgrade issue on Agents. When agents are started with

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -145,6 +145,9 @@ void RestHandler::trackTaskStart() noexcept {
 }
 
 void RestHandler::trackTaskEnd() noexcept {
+  // the queueing time in seconds
+  double queueTime = _statistics.ELAPSED_WHILE_QUEUED();
+
   if (_trackedAsOngoingLowPrio) {
     TRI_ASSERT(PriorityRequestLane(determineRequestLane()) ==
                RequestPriority::LOW);
@@ -154,10 +157,18 @@ void RestHandler::trackTaskEnd() noexcept {
 
     // update the time the last low priority item spent waiting in the queue.
 
-    // the queueing time is in ms
-    uint64_t queueTimeMs =
-        static_cast<uint64_t>(_statistics.ELAPSED_WHILE_QUEUED() * 1000.0);
+    // the queueing time in ms
+    uint64_t queueTimeMs = static_cast<uint64_t>(queueTime * 1000.0);
     SchedulerFeature::SCHEDULER->setLastLowPriorityDequeueTime(queueTimeMs);
+  }
+
+  if (queueTime >= 30.0) {
+    // this is an informational message about an exceptionally long queuing
+    // time. it is not per se a bug, but could be a sign of overload of the
+    // instance.
+    LOG_TOPIC("e7b15", INFO, Logger::REQUESTS)
+        << "request to " << _request->fullUrl() << " was queued for "
+        << Logger::FIXED(queueTime) << "s";
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

Log an info message if a request was queued for 30 seconds or longer in the scheduler queue.
This is a sign of severe overload or blockage, so we should make this visible to users.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 