### PR TITLE
fix an invalid assertion during replication

### DIFF
--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -328,9 +328,14 @@ RocksDBReplicationContext::bindCollectionIncremental(TRI_vocbase_t& vocbase,
         << logical->guid();
   }
 
-  // we should have a valid iterator if there are documents in here
-  TRI_ASSERT(numberDocuments == 0 || cIter->hasMore())
+  // we should have a valid iterator if there are documents in here.
+  // note that we can only assume this if we took the number of documents and
+  // the snapshot under the exclusive lock. otherwise the number of documents
+  // and the actual number of documents in the snapshot may differ.
+  TRI_ASSERT(documentCountAdjustmentTicket == 0 || numberDocuments == 0 ||
+             cIter->hasMore())
       << "numDocs: " << numberDocuments << ", hasMore: " << cIter->hasMore()
+      << ", ticket: " << documentCountAdjustmentTicket
       << ", shard: " << logical->name();
   co_return std::make_tuple(Result{}, cid, numberDocuments);
 }


### PR DESCRIPTION
### Scope & Purpose

Fix an invalid assertion in replication code.
The assumptions made in the assertion are correct for the case when a snapshot is taken under an exclusive lock. In this case, the number of documents in the collection and the snapshot are taken together under the lock.
However, if the number of documents is determined independent of the snapshot, there is no guarantee that the number of documents determined and the actual number of documents in the snapshot are identical.
This PR adjusts an assertion accordingly.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 