### PR TITLE
Removed incorrect assertion in bindCollectionIncremental

### DIFF
--- a/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationContext.cpp
@@ -309,10 +309,8 @@ RocksDBReplicationContext::bindCollectionIncremental(TRI_vocbase_t& vocbase,
         << logical->guid();
   }
 
-  // we should have a valid iterator if there are documents in here
-  TRI_ASSERT(numberDocuments == 0 || cIter->hasMore())
-      << "numDocs: " << numberDocuments << ", hasMore: " << cIter->hasMore()
-      << ", shard: " << logical->name();
+  // Please Note: numberDocuments can be different to the amount
+  // of entries actually returned by cIter.
   return std::make_tuple(Result{}, cid, numberDocuments);
 }
 


### PR DESCRIPTION
### Scope & Purpose

*NO Production change, therefore no CHANGELOG entry made. This PR removes an assertion for the createKeys() replication API. The amount of _keys and the asynchronously stored count can be different. In the Method of the assertion there are Code-Paths where we get the Count and the _snapshot without holding required locks, so it is expected to be different. The assertion only triggered on the 0 vs some case, therefore it was seldom. We validated that the returned count is only used if we get the `documentCountAdjustmentTicket`, which is only set on the code-path where count and real number of docs should be synchronous. => We use the returned value to adjust the count of necessary.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
