### PR TITLE
Remove the detach thread code from transaction manager.

### DIFF
--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -90,6 +90,11 @@ RestStatus RestCursorHandler::continueExecute() {
     return RestStatus::DONE;
   }
 
+  if (!_response->isResponseEmpty()) {
+    // an exception occurred in one of the suspension points
+    return RestStatus::DONE;
+  }
+
   // extract the sub-request type
   rest::RequestType const type = _request->requestType();
 
@@ -115,7 +120,8 @@ RestStatus RestCursorHandler::continueExecute() {
   }
 
   // Other parts of the query cannot be paused
-  TRI_ASSERT(false);
+  TRI_ASSERT(false) << requestToString(type) << " " << _request->fullUrl()
+                    << " " << _request->parameters();
   return RestStatus::DONE;
 }
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2465,7 +2465,7 @@ RestReplicationHandler::handleCommandAddFollower() {
 
   // referenceChecksum is the stringified number of documents in the collection
   ResultT<std::string> referenceChecksum =
-      computeCollectionChecksum(readLockId, col.get());
+      co_await computeCollectionChecksum(readLockId, col.get());
   if (!referenceChecksum.ok()) {
     generateError(std::move(referenceChecksum).result());
     co_return;
@@ -2476,7 +2476,7 @@ RestReplicationHandler::handleCommandAddFollower() {
     transaction::Manager* mgr = transaction::ManagerFeature::manager();
     TRI_ASSERT(mgr != nullptr);
     auto trxCtxtLease =
-        mgr->leaseManagedTrx(readLockId, AccessMode::Type::READ, true);
+        mgr->leaseManagedTrx(readLockId, AccessMode::Type::READ, true).get();
     if (trxCtxtLease) {
       transaction::Methods trx{trxCtxtLease};
       if (!trx.isLocked(col.get(), AccessMode::Type::EXCLUSIVE)) {
@@ -3523,8 +3523,8 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
       auto rGuard =
           std::make_unique<RebootCookie>(ci.rebootTracker().callMeOnChange(
               {serverId, rebootId}, std::move(f), std::move(comment)));
-      auto ctx = mgr->leaseManagedTrx(id, AccessMode::Type::WRITE,
-                                      /*isSideUser*/ false);
+      auto ctx = co_await mgr->leaseManagedTrx(id, AccessMode::Type::WRITE,
+                                               /*isSideUser*/ false);
 
       if (!ctx) {
         // Trx does not exist. So we assume it got cancelled.
@@ -3595,32 +3595,33 @@ ResultT<bool> RestReplicationHandler::cancelBlockingTransaction(
   return res;
 }
 
-ResultT<std::string> RestReplicationHandler::computeCollectionChecksum(
+futures::Future<ResultT<std::string>>
+RestReplicationHandler::computeCollectionChecksum(
     TransactionId id, LogicalCollection* col) const {
   transaction::Manager* mgr = transaction::ManagerFeature::manager();
   if (!mgr) {
-    return ResultT<std::string>::error(TRI_ERROR_SHUTTING_DOWN);
+    co_return ResultT<std::string>::error(TRI_ERROR_SHUTTING_DOWN);
   }
 
   try {
-    auto ctx =
-        mgr->leaseManagedTrx(id, AccessMode::Type::READ, /*isSideUser*/ false);
+    auto ctx = co_await mgr->leaseManagedTrx(id, AccessMode::Type::READ,
+                                             /*isSideUser*/ false);
     if (!ctx) {
       // Trx does not exist. So we assume it got cancelled.
-      return ResultT<std::string>::error(TRI_ERROR_TRANSACTION_INTERNAL,
-                                         "read transaction was cancelled");
+      co_return ResultT<std::string>::error(TRI_ERROR_TRANSACTION_INTERNAL,
+                                            "read transaction was cancelled");
     }
 
     transaction::Methods trx(ctx);
     TRI_ASSERT(trx.status() == transaction::Status::RUNNING);
 
     uint64_t num = col->getPhysical()->numberDocuments(&trx);
-    return ResultT<std::string>::success(std::to_string(num));
+    co_return ResultT<std::string>::success(std::to_string(num));
   } catch (...) {
     // Query exists, but is in use.
     // So in Locking phase
-    return ResultT<std::string>::error(TRI_ERROR_TRANSACTION_INTERNAL,
-                                       "Read lock not yet acquired!");
+    co_return ResultT<std::string>::error(TRI_ERROR_TRANSACTION_INTERNAL,
+                                          "Read lock not yet acquired!");
   }
 }
 

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -544,8 +544,8 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   ///        Will return error if the lock has expired.
   //////////////////////////////////////////////////////////////////////////////
 
-  ResultT<std::string> computeCollectionChecksum(TransactionId readLockId,
-                                                 LogicalCollection* col) const;
+  futures::Future<ResultT<std::string>> computeCollectionChecksum(
+      TransactionId readLockId, LogicalCollection* col) const;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Cacnel the lock with the given id

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -647,7 +647,7 @@ RestVocbaseBaseHandler::createTransaction(
                      !_request->header(StaticStrings::AqlDocumentCall).empty());
 
   std::shared_ptr<transaction::Context> ctx =
-      mgr->leaseManagedTrx(tid, type, isSideUser);
+      co_await mgr->leaseManagedTrx(tid, type, isSideUser);
 
   if (!ctx) {
     LOG_TOPIC("e94ea", DEBUG, Logger::TRANSACTIONS)
@@ -743,7 +743,7 @@ RestVocbaseBaseHandler::createTransactionContext(
     }
   }
 
-  auto ctx = mgr->leaseManagedTrx(tid, mode, /*isSideUser*/ false);
+  auto ctx = co_await mgr->leaseManagedTrx(tid, mode, /*isSideUser*/ false);
   if (!ctx) {
     LOG_TOPIC("2cfed", DEBUG, Logger::TRANSACTIONS)
         << "Transaction with id '" << tid << "' not found";

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -780,15 +780,15 @@ futures::Future<Result> Manager::ensureManagedTrx(
 }
 
 /// @brief lease the transaction, increases nesting
-std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
+futures::Future<std::shared_ptr<transaction::Context>> Manager::leaseManagedTrx(
     TransactionId tid, AccessMode::Type mode, bool isSideUser) {
   TRI_ASSERT(mode != AccessMode::Type::NONE);
 
   if (_disallowInserts.load(std::memory_order_acquire)) {
-    return nullptr;
+    co_return nullptr;
   }
 
-  TRI_IF_FAILURE("leaseManagedTrxFail") { return nullptr; }
+  TRI_IF_FAILURE("leaseManagedTrxFail") { co_return nullptr; }
 
   auto role = ServerState::instance()->getRole();
   std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
@@ -797,11 +797,6 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
     endTime =
         now + std::chrono::milliseconds(int64_t(1000 * _streamingLockTimeout));
   }
-  std::chrono::steady_clock::time_point detachTime;
-  if (_streamingLockTimeout >= 1.0) {
-    detachTime = now + std::chrono::milliseconds(1000);
-  }
-  bool alreadyDetached = false;
   // always serialize access on coordinator,
   // TransactionState::_knownServers is modified even for READ
   if (ServerState::isCoordinator(role)) {
@@ -817,7 +812,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
 
     auto it = _transactions[bucket]._managed.find(tid);
     if (it == _transactions[bucket]._managed.end()) {
-      return nullptr;
+      co_return nullptr;
     }
 
     ManagedTrx& mtrx = it->second;
@@ -828,11 +823,11 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
             absl::StrCat("transaction ", tid.id(),
                          " has already been aborted"));
       }
-      return nullptr;
+      co_return nullptr;
     }
 
     if (mtrx.expired() || !isAuthorized(mtrx)) {
-      return nullptr;  // no need to return anything
+      co_return nullptr;  // no need to return anything
     }
 
     if (AccessMode::isWriteOrExclusive(mode)) {
@@ -846,7 +841,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
         if (mtrx.state->isReadOnlyTransaction()) {
           managedContext->setReadOnly();
         }
-        return managedContext;
+        co_return managedContext;
       }
       // continue the loop after a small pause
     } else {
@@ -857,7 +852,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
         if (mtrx.state->isReadOnlyTransaction()) {
           managedContext->setReadOnly();
         }
-        return managedContext;
+        co_return managedContext;
       }
       if (isSideUser) {
         // number of side users is atomically increased under the bucket's read
@@ -876,7 +871,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
           if (mtrx.state->isReadOnlyTransaction()) {
             managedContext->setReadOnly();
           }
-          return managedContext;
+          co_return managedContext;
         } catch (...) {
           // roll back our increase of the number of side users
           auto previous =
@@ -910,25 +905,6 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
                !ServerState::instance()->isDBServer());
 
     auto now = std::chrono::steady_clock::now();
-    if (!alreadyDetached && detachTime.time_since_epoch().count() != 0 &&
-        now > detachTime) {
-      alreadyDetached = true;
-      LOG_TOPIC("dd234", INFO, Logger::THREADS)
-          << "Did not get lock within 1 seconds, detaching scheduler thread.";
-      uint64_t currentNumberDetached = 0;
-      uint64_t maximumNumberDetached = 0;
-      auto res = SchedulerFeature::SCHEDULER->detachThread(
-          &currentNumberDetached, &maximumNumberDetached);
-      if (res.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
-        LOG_TOPIC("dd233", WARN, Logger::THREADS)
-            << "Could not detach scheduler thread (currently detached threads: "
-            << currentNumberDetached
-            << ", maximal number of detached threads: " << maximumNumberDetached
-            << "), will continue to acquire "
-               "lock in scheduler thread, this can potentially lead to "
-               "blockages!";
-      }
-    }
     if (!ServerState::isDBServer(role) && now > endTime) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_LOCKED, absl::StrCat("cannot write-lock, transaction ",
@@ -938,11 +914,23 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
           << "waiting on trx write-lock " << tid;
       i = 0;
       if (_feature.server().isStopping()) {
-        return nullptr;  // shutting down
+        co_return nullptr;  // shutting down
       }
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+    constexpr bool alwaysHasScheduler = false;
+#else
+    constexpr bool alwaysHashScheduler = true;
+#endif
+
+    if (alwaysHasScheduler || SchedulerFeature::SCHEDULER) {
+      TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
+      co_await SchedulerFeature::SCHEDULER->delay(
+          "managed-trx-lock-wait", std::chrono::milliseconds(10));
+    } else {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
   } while (true);
 }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -921,7 +921,7 @@ futures::Future<std::shared_ptr<transaction::Context>> Manager::leaseManagedTrx(
 #ifdef ARANGODB_USE_GOOGLE_TESTS
     constexpr bool alwaysHasScheduler = false;
 #else
-    constexpr bool alwaysHashScheduler = true;
+    constexpr bool alwaysHasScheduler = true;
 #endif
 
     if (alwaysHasScheduler || SchedulerFeature::SCHEDULER) {

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -175,9 +175,8 @@ class Manager final : public IManager {
       transaction::Hints hints, std::shared_ptr<TransactionState>& state);
 
   /// @brief lease the transaction, increases nesting
-  std::shared_ptr<transaction::Context> leaseManagedTrx(TransactionId tid,
-                                                        AccessMode::Type mode,
-                                                        bool isSideUser);
+  futures::Future<std::shared_ptr<transaction::Context>> leaseManagedTrx(
+      TransactionId tid, AccessMode::Type mode, bool isSideUser);
   void returnManagedTrx(TransactionId, bool isSideUser) noexcept;
 
   /// @brief get the meta transaction state

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -177,7 +177,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
 
   auto doc = arangodb::velocypack::Parser::fromJson("{ \"_key\": \"1\"}");
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
     auto origin = ctx->operationOrigin();
     ASSERT_EQ(transaction::OperationOrigin::Type::kInternal, origin.type);
@@ -196,7 +196,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
   {  // lease again
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(ctx, "testCollection",
@@ -237,7 +237,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -289,7 +289,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -334,7 +334,7 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -382,19 +382,19 @@ TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
 
-    auto ctx2 = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false);
+    auto ctx2 = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get();
     ASSERT_NE(ctx2.get(), nullptr);
     auto state2 = ctx2->acquireState(opts, responsible);
     EXPECT_EQ(state1.get(), state2.get());
     ASSERT_TRUE(!responsible);
 
-    auto ctx3 = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false);
+    auto ctx3 = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get();
     ASSERT_NE(ctx3.get(), nullptr);
     auto state3 = ctx3->acquireState(opts, responsible);
     EXPECT_EQ(state3.get(), state2.get());
@@ -424,12 +424,13 @@ TEST_F(TransactionManagerTest, lock_conflict) {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
-    ASSERT_ANY_THROW(mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false));
+    ASSERT_ANY_THROW(
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get());
   }
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
@@ -455,14 +456,16 @@ TEST_F(TransactionManagerTest, lock_conflict_side_user) {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
-    ASSERT_ANY_THROW(mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false));
+    ASSERT_ANY_THROW(
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get());
 
-    auto ctxSide = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, true);
+    auto ctxSide =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, true).get();
     ASSERT_NE(ctxSide.get(), nullptr);
     auto state2 = ctxSide->acquireState(opts, responsible);
     ASSERT_NE(state2.get(), nullptr);
@@ -492,7 +495,7 @@ TEST_F(TransactionManagerTest, garbage_collection_shutdown) {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
@@ -562,7 +565,7 @@ TEST_F(TransactionManagerTest, abort_transactions_with_matcher) {
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -668,7 +671,7 @@ TEST_F(TransactionManagerTest, transaction_invalid_mode) {
                    .get();
   ASSERT_TRUE(res.ok());
 
-  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
   ASSERT_NE(ctx.get(), nullptr);
 
   ASSERT_THROW(SingleCollectionTransaction(std::move(ctx), "testCollection",
@@ -696,7 +699,7 @@ TEST_F(TransactionManagerTest, transaction_origin) {
                    .get();
   ASSERT_TRUE(res.ok());
 
-  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
   ASSERT_NE(ctx.get(), nullptr);
 
   {
@@ -740,7 +743,7 @@ TEST_F(TransactionManagerTest, expired_transaction) {
   std::this_thread::sleep_for(std::chrono::milliseconds(150));
 
   // we cannot use the transaction anymore
-  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
+  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
   ASSERT_EQ(ctx.get(), nullptr);
 
   // aborting it is fine though


### PR DESCRIPTION
### Scope & Purpose

Remove the detach thread thingy from the `leaderManagedTrx` function. Instead use a delayed future to make the current execution fiber sleep for some time. Previously we would block the thread and then eventually detach it.