### PR TITLE
add debug APIs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Added internal APIs to dump the contents of the AQL query registry from
+  DB-Servers plus the contents of the transaction manager on coordinators and
+  DB-Servers.
+
 * Log an info message if a request was queued in the scheduler queue for 30 s
   or longer.
 

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -159,6 +159,18 @@ std::vector<bool> EngineInfoContainerDBServerServerBased::buildEngineInfo(
                   VPackValue(_query.isModificationQuery()));
   infoBuilder.add("isAsyncQuery", VPackValue(_query.isAsyncQuery()));
 
+  // include query string for informational/debugging purposes.
+  // this allows us to link DB server query snippets to actual queries
+  // as written by the end user.
+  QueryContext* qc = &_query;
+  Query* q = dynamic_cast<Query*>(qc);
+  if (q != nullptr) {
+    // only send up to 1K of query strings to save network traffic and
+    // memory on the DB server later
+    infoBuilder.add("qs",
+                    VPackValue(q->queryString().extract(/*maxLength*/ 1024)));
+  }
+
   infoBuilder.add(StaticStrings::AttrCoordinatorRebootId,
                   VPackValue(ServerState::instance()->getRebootId().value()));
   infoBuilder.add(StaticStrings::AttrCoordinatorId,

--- a/arangod/Aql/QueryString.h
+++ b/arangod/Aql/QueryString.h
@@ -28,8 +28,7 @@
 #include <string>
 #include <string_view>
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
 
 /// View on a query string
 class QueryString {
@@ -52,7 +51,6 @@ class QueryString {
 
   ~QueryString() = default;
 
- public:
   std::string const& string() const noexcept { return _queryString; }
   char const* data() const noexcept { return _queryString.data(); }
   size_t size() const noexcept { return _queryString.size(); }
@@ -73,5 +71,4 @@ class QueryString {
 };
 
 std::ostream& operator<<(std::ostream&, QueryString const&);
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql

--- a/arangod/RestHandler/RestQueryHandler.h
+++ b/arangod/RestHandler/RestQueryHandler.h
@@ -68,6 +68,9 @@ class RestQueryHandler : public RestVocbaseBaseHandler {
   /// @brief parses a query
   void parseQuery();
 
+  /// @brief dump contents of query registry
+  void dumpQueryRegistry();
+
   /// @brief returns the available optimizer rules
   void handleAvailableOptimizerRules();
 };

--- a/arangod/RestHandler/RestTransactionHandler.cpp
+++ b/arangod/RestHandler/RestTransactionHandler.cpp
@@ -61,6 +61,30 @@ RestTransactionHandler::RestTransactionHandler(ArangodServer& server,
                                                GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response), _v8Context(nullptr) {}
 
+RequestLane RestTransactionHandler::lane() const {
+  if (_request->requestType() == RequestType::GET) {
+    // a GET request only returns the list of ongoing transactions.
+    // this is used only for debugging and should not be blocked
+    // by if most scheduler threads are busy.
+    return RequestLane::CLUSTER_ADMIN;
+  }
+
+  if (ServerState::instance()->isDBServer()) {
+    bool isSyncReplication = false;
+    // We do not care for the real value, enough if it is there.
+    std::ignore = _request->value(StaticStrings::IsSynchronousReplicationString,
+                                  isSyncReplication);
+    if (isSyncReplication) {
+      return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
+      // This leads to the high queue, we want replication requests (for
+      // commit or abort in the El Cheapo case) to be executed with a
+      // higher prio than leader requests, even if they are done from
+      // AQL.
+    }
+  }
+  return RequestLane::CLIENT_V8;
+}
+
 RestStatus RestTransactionHandler::execute() {
   switch (_request->requestType()) {
     case rest::RequestType::POST:
@@ -108,7 +132,11 @@ void RestTransactionHandler::executeGetState() {
 
     bool fanout = ServerState::instance()->isCoordinator() &&
                   !_request->parsedValue("local", false);
-    mgr->toVelocyPack(builder, _vocbase.name(), exec.user(), fanout);
+    // note: "details" parameter is not documented and not part of the public
+    // API, so the output format of toVelocyPack(details=true) may change
+    // without notice
+    bool details = _request->parsedValue("details", false);
+    mgr->toVelocyPack(builder, _vocbase.name(), exec.user(), fanout, details);
 
     builder.close();  // array
     builder.close();  // object
@@ -195,7 +223,6 @@ futures::Future<futures::Unit> RestTransactionHandler::executeBegin() {
     }
     TRI_ASSERT(tid.isSet());
     TRI_ASSERT(!tid.isLegacyTransactionId());
-    TRI_ASSERT(tid.isSet());
 
     Result res =
         co_await mgr->ensureManagedTrx(_vocbase, tid, slice, origin, false);

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -39,24 +39,9 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   RestTransactionHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
- public:
   char const* name() const override final { return "RestTransactionHandler"; }
-  RequestLane lane() const override final {
-    if (ServerState::instance()->isDBServer()) {
-      bool isSyncReplication = false;
-      // We do not care for the real value, enough if it is there.
-      std::ignore = _request->value(
-          StaticStrings::IsSynchronousReplicationString, isSyncReplication);
-      if (isSyncReplication) {
-        return RequestLane::SERVER_SYNCHRONOUS_REPLICATION;
-        // This leads to the high queue, we want replication requests (for
-        // commit or abort in the El Cheapo case) to be executed with a
-        // higher prio than leader requests, even if they are done from
-        // AQL.
-      }
-    }
-    return RequestLane::CLIENT_V8;
-  }
+  RequestLane lane() const override final;
+
   RestStatus execute() override;
   void cancel() override final;
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -849,7 +849,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
     }
     if (!isAuthorized(mtrx)) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_FORBIDDEN,
+          TRI_ERROR_TRANSACTION_NOT_FOUND,
           absl::StrCat("not authorized to access transaction ", tid.id()));
     }
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -1537,7 +1537,7 @@ void Manager::toVelocyPack(VPackBuilder& builder, std::string const& database,
             idType = "legacy id";
           }
           builder.add("idType", VPackValue(idType));
-          if (tid.isChildTransactionId()) {
+          if (!ServerState::instance()->isSingleServer()) {
             builder.add("coordinatorId",
                         VPackValue(tid.asCoordinatorTransactionId().id()));
           }

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -45,6 +45,7 @@
 #include "RestServer/DatabaseFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
+#include "StorageEngine/TransactionCollection.h"
 #include "StorageEngine/TransactionState.h"
 #include "Transaction/Helpers.h"
 #include "VocBase/vocbase.h"
@@ -67,9 +68,12 @@
 #include <fuerte/jwt.h>
 #include <velocypack/Iterator.h>
 
+#include <algorithm>
 #include <optional>
 #include <string_view>
 #include <thread>
+
+using namespace arangodb;
 
 namespace {
 bool authorized(std::string const& user) {
@@ -81,133 +85,6 @@ bool authorized(std::string const& user) {
 }
 
 std::string currentUser() { return arangodb::ExecContext::current().user(); }
-
-}  // namespace
-
-namespace arangodb::transaction {
-
-namespace {
-struct MGMethods final : arangodb::transaction::Methods {
-  MGMethods(std::shared_ptr<arangodb::transaction::Context> ctx,
-            arangodb::transaction::Options const& opts)
-      : Methods(std::move(ctx)) {}
-};
-}  // namespace
-
-Manager::Manager(ManagerFeature& feature)
-    : _feature(feature),
-      _nrRunning(0),
-      _disallowInserts(false),
-      _hotbackupCommitLockHeld(false),
-      _streamingLockTimeout(feature.streamingLockTimeout()),
-      _softShutdownOngoing(false) {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-  _history = std::make_unique<transaction::History>(/*maxSize*/ 256);
-#endif
-}
-
-Manager::~Manager() = default;
-
-void Manager::releaseTransactions() noexcept {
-  std::unique_lock<std::mutex> guard(_hotbackupMutex);
-  if (_hotbackupCommitLockHeld) {
-    LOG_TOPIC("eeddd", TRACE, Logger::TRANSACTIONS)
-        << "Releasing write lock to hold transactions.";
-    _hotbackupCommitLock.unlockWrite();
-    _hotbackupCommitLockHeld = false;
-  }
-}
-
-std::shared_ptr<CounterGuard> Manager::registerTransaction(
-    TransactionId transactionId, bool isReadOnlyTransaction,
-    bool isFollowerTransaction) {
-  // If isFollowerTransaction is set then either the transactionId should be
-  // an isFollowerTransactionId or it should be a legacy transactionId:
-  TRI_ASSERT(!isFollowerTransaction ||
-             transactionId.isFollowerTransactionId() ||
-             transactionId.isLegacyTransactionId());
-
-  return std::make_shared<CounterGuard>(*this);
-}
-
-uint64_t Manager::getActiveTransactionCount() {
-  return _nrRunning.load(std::memory_order_relaxed);
-}
-
-/*static*/ double Manager::ttlForType(ManagerFeature const& feature,
-                                      Manager::MetaType type) {
-  TRI_IF_FAILURE("transaction::Manager::shortTTL") { return 0.1; }
-
-  if (type == Manager::MetaType::Tombstone) {
-    return tombstoneTTL;
-  }
-
-  auto role = ServerState::instance()->getRole();
-  if ((ServerState::isSingleServer(role) || ServerState::isCoordinator(role))) {
-    TRI_IF_FAILURE("lowStreamingIdleTimeout") { return 5.0; }
-
-    return feature.streamingIdleTimeout();
-  }
-  return idleTTLDBServer;
-}
-
-Manager::ManagedTrx::ManagedTrx(ManagerFeature const& feature, MetaType t,
-                                double ttl,
-                                std::shared_ptr<TransactionState> st,
-                                arangodb::cluster::CallbackGuard rGuard)
-    : type(t),
-      intermediateCommits(false),
-      wasExpired(false),
-      sideUsers(0),
-      finalStatus(Status::UNDEFINED),
-      timeToLive(ttl),
-      expiryTime(TRI_microtime() + Manager::ttlForType(feature, t)),
-      state(std::move(st)),
-      rGuard(std::move(rGuard)),
-      user(::currentUser()),
-      db(state ? state->vocbase().name() : ""),
-      rwlock() {}
-
-bool Manager::ManagedTrx::hasPerformedIntermediateCommits() const noexcept {
-  return this->intermediateCommits;
-}
-
-bool Manager::ManagedTrx::expired() const noexcept {
-  return this->expiryTime < TRI_microtime();
-}
-
-void Manager::ManagedTrx::updateExpiry() noexcept {
-  this->expiryTime = TRI_microtime() + this->timeToLive;
-}
-
-Manager::ManagedTrx::~ManagedTrx() {
-  if (type == MetaType::StandaloneAQL || state == nullptr) {
-    return;  // not managed by us
-  }
-  if (!state->isRunning()) {
-    return;
-  }
-
-  try {
-    transaction::Options opts;
-    transaction::ManagedContext ctx(TransactionId{2}, state,
-                                    /*responsibleForCommit*/ true,
-                                    /*cloned*/ false);
-    MGMethods trx(std::shared_ptr<transaction::Context>(
-                      std::shared_ptr<transaction::Context>(), &ctx),
-                  opts);  // own state now
-    TRI_ASSERT(trx.state()->status() == transaction::Status::RUNNING);
-    TRI_ASSERT(trx.isMainTransaction());
-    std::ignore = trx.abort();
-  } catch (...) {
-    // obviously it is not good to consume all exceptions here,
-    // but we are in a destructor and must never throw from here
-  }
-}
-
-using namespace arangodb;
-
-namespace {
 
 bool extractCollections(VPackSlice collections, std::vector<std::string>& reads,
                         std::vector<std::string>& writes,
@@ -268,6 +145,140 @@ Result buildOptions(VPackSlice trxOpts, transaction::Options& options,
 }
 
 }  // namespace
+
+namespace arangodb::transaction {
+
+namespace {
+struct MGMethods final : arangodb::transaction::Methods {
+  MGMethods(std::shared_ptr<arangodb::transaction::Context> ctx,
+            arangodb::transaction::Options const& opts)
+      : Methods(std::move(ctx)) {}
+};
+}  // namespace
+
+Manager::Manager(ManagerFeature& feature)
+    : _feature(feature),
+      _nrRunning(0),
+      _disallowInserts(false),
+      _hotbackupCommitLockHeld(false),
+      _streamingLockTimeout(feature.streamingLockTimeout()),
+      _softShutdownOngoing(false) {
+#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
+  _history = std::make_unique<transaction::History>(/*maxSize*/ 256);
+#endif
+}
+
+Manager::~Manager() = default;
+
+void Manager::releaseTransactions() noexcept {
+  std::unique_lock<std::mutex> guard(_hotbackupMutex);
+  if (_hotbackupCommitLockHeld) {
+    LOG_TOPIC("eeddd", TRACE, Logger::TRANSACTIONS)
+        << "Releasing write lock to hold transactions.";
+    _hotbackupCommitLock.unlockWrite();
+    _hotbackupCommitLockHeld = false;
+  }
+}
+
+std::string_view Manager::typeName(MetaType type) {
+  switch (type) {
+    case MetaType::Managed:
+      return "managed";
+    case MetaType::StandaloneAQL:
+      return "standalone-aql";
+    case MetaType::Tombstone:
+      return "tombstone";
+  }
+  return "unknown";
+}
+
+std::shared_ptr<CounterGuard> Manager::registerTransaction(
+    TransactionId transactionId, bool isReadOnlyTransaction,
+    bool isFollowerTransaction) {
+  // If isFollowerTransaction is set then either the transactionId should be
+  // an isFollowerTransactionId or it should be a legacy transactionId:
+  TRI_ASSERT(!isFollowerTransaction ||
+             transactionId.isFollowerTransactionId() ||
+             transactionId.isLegacyTransactionId());
+
+  return std::make_shared<CounterGuard>(*this);
+}
+
+uint64_t Manager::getActiveTransactionCount() const noexcept {
+  return _nrRunning.load(std::memory_order_relaxed);
+}
+
+/*static*/ double Manager::ttlForType(ManagerFeature const& feature,
+                                      Manager::MetaType type) {
+  TRI_IF_FAILURE("transaction::Manager::shortTTL") { return 0.1; }
+
+  if (type == Manager::MetaType::Tombstone) {
+    return tombstoneTTL;
+  }
+
+  auto role = ServerState::instance()->getRole();
+  if ((ServerState::isSingleServer(role) || ServerState::isCoordinator(role))) {
+    TRI_IF_FAILURE("lowStreamingIdleTimeout") { return 5.0; }
+
+    return feature.streamingIdleTimeout();
+  }
+  return idleTTLDBServer;
+}
+
+Manager::ManagedTrx::ManagedTrx(ManagerFeature const& feature, MetaType t,
+                                double ttl,
+                                std::shared_ptr<TransactionState> st,
+                                arangodb::cluster::CallbackGuard rGuard)
+    : type(t),
+      intermediateCommits(false),
+      wasExpired(false),
+      sideUsers(0),
+      finalStatus(Status::UNDEFINED),
+      timeToLive(ttl),
+      expiryTime(TRI_microtime() + Manager::ttlForType(feature, t)),
+      state(std::move(st)),
+      rGuard(std::move(rGuard)),
+      user(::currentUser()),
+      db(state ? state->vocbase().name() : ""),
+      context(state ? buildContextFromState(*state, t) : ""),
+      rwlock() {}
+
+Manager::ManagedTrx::~ManagedTrx() {
+  if (type == MetaType::StandaloneAQL || state == nullptr) {
+    return;  // not managed by us
+  }
+  if (!state->isRunning()) {
+    return;
+  }
+
+  try {
+    transaction::Options opts;
+    transaction::ManagedContext ctx(TransactionId{2}, state,
+                                    /*responsibleForCommit*/ true,
+                                    /*cloned*/ false);
+    MGMethods trx(std::shared_ptr<transaction::Context>(
+                      std::shared_ptr<transaction::Context>(), &ctx),
+                  opts);  // own state now
+    TRI_ASSERT(trx.state()->status() == transaction::Status::RUNNING);
+    TRI_ASSERT(trx.isMainTransaction());
+    std::ignore = trx.abort();
+  } catch (...) {
+    // obviously it is not good to consume all exceptions here,
+    // but we are in a destructor and must never throw from here
+  }
+}
+
+bool Manager::ManagedTrx::hasPerformedIntermediateCommits() const noexcept {
+  return intermediateCommits;
+}
+
+bool Manager::ManagedTrx::expired() const noexcept {
+  return expiryTime < TRI_microtime();
+}
+
+void Manager::ManagedTrx::updateExpiry() noexcept {
+  expiryTime = TRI_microtime() + timeToLive;
+}
 
 arangodb::cluster::CallbackGuard Manager::buildCallbackGuard(
     TransactionState const& state) {
@@ -435,18 +446,12 @@ Result Manager::prepareOptions(transaction::Options& options) {
   }
   // enforce size limit per DBServer
   if (isFollowerTransactionOnDBServer(options)) {
-    // if we are a follower, we reuse the leader's max transaction size and
-    // slightly increase it. this is to ensure that the follower can process at
-    // least as many data as the leader, even if the data representation is
-    // slightly varied for network transport etc.
-    if (options.maxTransactionSize != UINT64_MAX) {
-      uint64_t adjust = options.maxTransactionSize / 10;
-      if (adjust < UINT64_MAX - options.maxTransactionSize) {
-        // now the transaction on the follower should be able to grow to at
-        // least the size of the transaction on the leader.
-        options.maxTransactionSize += adjust;
-      }
-    }
+    // if we are a follower, we allow transactions of arbitrary size.
+    // this is because the max transaction size should be enforced already
+    // when writing to the leader. the follower should simply accept
+    // everything that the leader was able to apply successfully.
+    options.maxTransactionSize = UINT64_MAX;
+
     // it is also important that we set this option, so that it is ok for two
     // different leaders to add "their" shards to the same follower transaction.
     // for example, if we have 3 database servers and 2 shards, so that
@@ -487,7 +492,7 @@ Result Manager::prepareOptions(transaction::Options& options) {
   return res;
 }
 
-futures::Future<Result> Manager::lockCollections(
+futures::Future<Result> Manager::addCollections(
     TRI_vocbase_t& vocbase, std::shared_ptr<TransactionState> state,
     std::vector<std::string> const& exclusiveCollections,
     std::vector<std::string> const& writeCollections,
@@ -495,8 +500,8 @@ futures::Future<Result> Manager::lockCollections(
   Result res;
   CollectionNameResolver resolver(vocbase);
 
-  auto lockCols = [&](std::vector<std::string> const& cols,
-                      AccessMode::Type mode) -> futures::Future<bool> {
+  auto addCols = [&](std::vector<std::string> const& cols,
+                     AccessMode::Type mode) -> futures::Future<bool> {
     for (auto const& cname : cols) {
       DataSourceId cid = DataSourceId::none();
       if (state->isCoordinator()) {
@@ -508,9 +513,9 @@ futures::Future<Result> Manager::lockCollections(
       if (cid.empty()) {
         // not found
         res.reset(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                  std::string(TRI_errno_string(
-                      TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) +
-                      ": " + cname);
+                  absl::StrCat(
+                      TRI_errno_string(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND),
+                      ": ", cname));
       } else {
 #ifdef USE_ENTERPRISE
         if (state->isCoordinator()) {
@@ -564,9 +569,9 @@ futures::Future<Result> Manager::lockCollections(
     co_return true;
   };
 
-  if (!co_await lockCols(exclusiveCollections, AccessMode::Type::EXCLUSIVE) ||
-      !co_await lockCols(writeCollections, AccessMode::Type::WRITE) ||
-      !co_await lockCols(readCollections, AccessMode::Type::READ)) {
+  if (!co_await addCols(exclusiveCollections, AccessMode::Type::EXCLUSIVE) ||
+      !co_await addCols(writeCollections, AccessMode::Type::WRITE) ||
+      !co_await addCols(readCollections, AccessMode::Type::READ)) {
     if (res.fail()) {
       // error already set by callback function
       co_return res;
@@ -638,9 +643,9 @@ futures::Future<ResultT<TransactionId>> Manager::createManagedTrx(
     state->chooseReplicas(shards);
   }
 
-  // lock collections
-  res = co_await lockCollections(vocbase, state, exclusiveCollections,
-                                 writeCollections, readCollections);
+  // add collections
+  res = co_await addCollections(vocbase, state, exclusiveCollections,
+                                writeCollections, readCollections);
   if (res.fail()) {
     co_return res;
   }
@@ -743,9 +748,9 @@ futures::Future<Result> Manager::ensureManagedTrx(
   TRI_ASSERT(state != nullptr);
   TRI_ASSERT(state->id() == tid);
 
-  // lock collections
-  res = co_await lockCollections(vocbase, state, exclusiveCollections,
-                                 writeCollections, readCollections);
+  // add collections
+  res = co_await addCollections(vocbase, state, exclusiveCollections,
+                                writeCollections, readCollections);
   if (res.fail()) {
     co_return res;
   }
@@ -817,6 +822,7 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
 
     auto it = _transactions[bucket]._managed.find(tid);
     if (it == _transactions[bucket]._managed.end()) {
+      // transaction actually not found
       return nullptr;
     }
 
@@ -828,11 +834,23 @@ std::shared_ptr<transaction::Context> Manager::leaseManagedTrx(
             absl::StrCat("transaction ", tid.id(),
                          " has already been aborted"));
       }
-      return nullptr;
+
+      TRI_ASSERT(mtrx.finalStatus == transaction::Status::COMMITTED);
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION,
+          absl::StrCat("transaction ", tid.id(),
+                       " has already been committed"));
     }
 
-    if (mtrx.expired() || !isAuthorized(mtrx)) {
-      return nullptr;  // no need to return anything
+    if (mtrx.expired()) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_TRANSACTION_NOT_FOUND,
+          absl::StrCat("transaction ", tid.id(), " has already expired"));
+    }
+    if (!isAuthorized(mtrx)) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_FORBIDDEN,
+          absl::StrCat("not authorized to access transaction ", tid.id()));
     }
 
     if (AccessMode::isWriteOrExclusive(mode)) {
@@ -954,10 +972,16 @@ void Manager::returnManagedTrx(TransactionId tid, bool isSideUser) noexcept {
     WRITE_LOCKER(writeLocker, _transactions[bucket]._lock);
 
     auto it = _transactions[bucket]._managed.find(tid);
-    if (it == _transactions[bucket]._managed.end() ||
-        !isAuthorized(it->second)) {
+    if (it == _transactions[bucket]._managed.end()) {
       LOG_TOPIC("1d5b0", WARN, Logger::TRANSACTIONS)
-          << "managed transaction " << tid << " not found or inaccessible";
+          << "managed transaction " << tid << " not found";
+      TRI_ASSERT(false);
+      return;
+    }
+
+    if (!isAuthorized(it->second)) {
+      LOG_TOPIC("93894", WARN, Logger::TRANSACTIONS)
+          << "not authorized to access managed transaction " << tid;
       TRI_ASSERT(false);
       return;
     }
@@ -1182,9 +1206,14 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
     // type is changed under the transaction's write lock and the bucket's write
     // lock
     mtrx.type = MetaType::Tombstone;
+    // clear context information of commit/aborted/expired transactions so that
+    // we can save memory. there will be many tombstones on busy instances.
+    mtrx.context = std::string{};
     if (state->numCommits() > 0) {
-      // note that we have performed a commit or an intermediate commit.
-      // this is necessary for follower transactions
+      // track the fact that we have performed a commit or an intermediate
+      // commit. this is necessary for follower transactions, because we cannot
+      // abort a transaction for which there have been intermediate commits
+      // already.
       mtrx.intermediateCommits = true;
     }
     mtrx.wasExpired = wasExpired;
@@ -1254,16 +1283,21 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
 
 /// @brief calls the callback function for each managed transaction
 void Manager::iterateManagedTrx(
-    std::function<void(TransactionId, ManagedTrx const&)> const& callback)
-    const {
+    std::function<void(TransactionId, ManagedTrx const&)> const& callback,
+    bool details) const {
   // iterate over all active transactions
   for (size_t bucket = 0; bucket < numBuckets; ++bucket) {
+    // acquiring just the bucket lock in read mode is enough here,
+    // as modifications to the transaction state lock
+    // the transaction's bucket in write mode.
     READ_LOCKER(locker, _transactions[bucket]._lock);
 
     auto& buck = _transactions[bucket];
     for (auto const& it : buck._managed) {
-      if (it.second.type == MetaType::Managed) {
-        // we only care about managed transactions here
+      // by default, we only care about managed transactions here, unless we
+      // want to see details
+      if (it.second.type == MetaType::Managed ||
+          (details && it.second.type == MetaType::StandaloneAQL)) {
         callback(it.first, it.second);
       }
     }
@@ -1411,7 +1445,8 @@ bool Manager::abortManagedTrx(
 }
 
 void Manager::toVelocyPack(VPackBuilder& builder, std::string const& database,
-                           std::string const& username, bool fanout) const {
+                           std::string const& username, bool fanout,
+                           bool details) const {
   TRI_ASSERT(!builder.isClosed());
 
   if (fanout) {
@@ -1431,11 +1466,20 @@ void Manager::toVelocyPack(VPackBuilder& builder, std::string const& database,
     options.database = database;
     options.timeout = network::Timeout(30.0);
     options.param("local", "true");
+    if (details) {
+      options.param("details", "true");
+    }
 
     VPackBuffer<uint8_t> body;
 
-    for (auto const& coordinator : ci.getCurrentCoordinators()) {
-      if (coordinator == ServerState::instance()->getId()) {
+    auto servers = ci.getCurrentCoordinators();
+    if (details) {
+      auto dbs = ci.getCurrentDBServers();
+      std::move(dbs.begin(), dbs.end(), std::back_inserter(servers));
+    }
+
+    for (auto const& server : servers) {
+      if (server == ServerState::instance()->getId()) {
         // ourselves!
         continue;
       }
@@ -1454,8 +1498,8 @@ void Manager::toVelocyPack(VPackBuilder& builder, std::string const& database,
       }
 
       auto f = network::sendRequestRetry(
-          pool, "server:" + coordinator, fuerte::RestVerb::Get,
-          "/_api/transaction", body, options, std::move(headers));
+          pool, "server:" + server, fuerte::RestVerb::Get, "/_api/transaction",
+          body, options, std::move(headers));
       futures.emplace_back(std::move(f));
     }
 
@@ -1480,16 +1524,70 @@ void Manager::toVelocyPack(VPackBuilder& builder, std::string const& database,
   }
 
   // merge with local transactions
-  iterateManagedTrx([this, &builder, &database](TransactionId tid,
-                                                ManagedTrx const& trx) {
-    if (isAuthorized(trx, database)) {
-      builder.openObject(true);
-      builder.add("id", VPackValue(std::to_string(tid.id())));
-      builder.add("state",
-                  VPackValue(transaction::statusString(trx.state->status())));
-      builder.close();
-    }
-  });
+  iterateManagedTrx(
+      [this, &builder, &database, details](TransactionId tid,
+                                           ManagedTrx const& trx) {
+        bool authorized = isAuthorized(trx, database);
+        if (details && arangodb::ExecContext::current().isSuperuser()) {
+          authorized = true;
+        }
+        if (!authorized) {
+          return;
+        }
+
+        builder.openObject(true);
+        builder.add("id", VPackValue(std::to_string(tid.id())));
+        if (trx.state == nullptr) {
+          builder.add("state", VPackValue("none"));
+        } else {
+          builder.add(
+              "state",
+              VPackValue(transaction::statusString(trx.state->status())));
+        }
+        if (details) {
+          std::string_view idType = "unknown";
+          if (tid.isCoordinatorTransactionId()) {
+            idType = "coordinator id";
+          } else if (tid.isFollowerTransactionId()) {
+            idType = "follower id";
+          } else if (tid.isLeaderTransactionId()) {
+            idType = "leader id";
+          } else if (tid.isLegacyTransactionId()) {
+            idType = "legacy id";
+          }
+          builder.add("idType", VPackValue(idType));
+          if (tid.isChildTransactionId()) {
+            builder.add("coordinatorId",
+                        VPackValue(tid.asCoordinatorTransactionId().id()));
+          }
+          builder.add("context", VPackValue(trx.context));
+          builder.add("type", VPackValue(typeName(trx.type)));
+          if (trx.type != MetaType::Tombstone) {
+            builder.add("expired", VPackValue(trx.expired()));
+          }
+          builder.add("hasPerformedIntermediateCommits",
+                      VPackValue(trx.hasPerformedIntermediateCommits()));
+          builder.add(
+              "sideUsers",
+              VPackValue(trx.sideUsers.load(std::memory_order_relaxed)));
+          builder.add("finalStatus",
+                      VPackValue(transaction::statusString(trx.finalStatus)));
+          builder.add("timeToLive", VPackValue(trx.timeToLive));
+          // note: expiry timestamp is a system clock value that indicates
+          // number of seconds since the OS was started.
+          builder.add("expiryTime",
+                      VPackValue(static_cast<uint64_t>(trx.expiryTime)));
+          if (!ServerState::instance()->isDBServer()) {
+            // proper user information is only present on single servers
+            // and coordinators
+            builder.add("user", VPackValue(trx.user));
+          }
+          builder.add("database", VPackValue(trx.db));
+          builder.add("server", VPackValue(ServerState::instance()->getId()));
+        }
+        builder.close();
+      },
+      details);
 }
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
@@ -1576,7 +1674,7 @@ Result Manager::abortAllManagedWriteTrx(std::string const& username,
   return res;
 }
 
-bool Manager::transactionIdExists(TransactionId const& tid) const {
+bool Manager::transactionIdExists(TransactionId tid) const {
   size_t bucket = getBucket(tid);
   // quick check whether ID exists
   READ_LOCKER(readLocker, _transactions[bucket]._lock);
@@ -1587,7 +1685,7 @@ bool Manager::transactionIdExists(TransactionId const& tid) const {
 }
 
 bool Manager::storeManagedState(
-    TransactionId const& tid, std::shared_ptr<arangodb::TransactionState> state,
+    TransactionId tid, std::shared_ptr<arangodb::TransactionState> state,
     double ttl) {
   if (ttl <= 0) {
     ttl = Manager::ttlForType(_feature, MetaType::Managed);
@@ -1641,6 +1739,50 @@ std::shared_ptr<ManagedContext> Manager::buildManagedContextUnderLock(
     mtrx.rwlock.unlock();
     throw;
   }
+}
+
+std::string Manager::buildContextFromState(TransactionState& state,
+                                           MetaType t) {
+  std::string result =
+      absl::StrCat("trx type: ", typeName(t),
+                   state.isSingleOperation() ? ", single op" : ", multi op",
+                   state.isReadOnlyTransaction() ? ", read only" : "",
+                   state.isFollowerTransaction() ? ", follower" : "",
+                   ", lock timeout: ", state.lockTimeout());
+
+  if (state.hasHint(transaction::Hints::Hint::INTERMEDIATE_COMMITS)) {
+    absl::StrAppend(&result, ", intermediate commits");
+  }
+  if (state.hasHint(transaction::Hints::Hint::ALLOW_RANGE_DELETE)) {
+    absl::StrAppend(&result, ", allow range delete");
+  }
+  if (state.hasHint(transaction::Hints::Hint::FROM_TOPLEVEL_AQL)) {
+    absl::StrAppend(&result, ", from toplevel aql");
+  }
+  if (state.hasHint(transaction::Hints::Hint::GLOBAL_MANAGED)) {
+    absl::StrAppend(&result, ", global managed");
+  }
+  if (state.hasHint(transaction::Hints::Hint::INDEX_CREATION)) {
+    absl::StrAppend(&result, ", index creation");
+  }
+
+  if (state.numCollections() > 0) {
+    absl::StrAppend(&result, ", collections: [");
+    bool first = true;
+    state.allCollections([&result, &first](auto const& c) -> bool {
+      if (first) {
+        first = false;
+      } else {
+        absl::StrAppend(&result, ", ");
+      }
+      absl::StrAppend(
+          &result, "{id: ", c.id().id(), ", name: ", c.collectionName(),
+          ", access: ", AccessMode::typeString(c.accessType()), "}");
+      return true;
+    });
+    absl::StrAppend(&result, "]");
+  }
+  return result;
 }
 
 Manager::TransactionCommitGuard Manager::getTransactionCommitGuard() {

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -84,6 +84,8 @@ class Manager final : public IManager {
     Tombstone = 3  /// used to ensure we can acknowledge double commits / aborts
   };
 
+  static std::string_view typeName(MetaType type);
+
   struct ManagedTrx {
     ManagedTrx(ManagerFeature const& feature, MetaType type, double ttl,
                std::shared_ptr<TransactionState> state,
@@ -101,7 +103,6 @@ class Manager final : public IManager {
     bool intermediateCommits;
     /// @brief whether or not the transaction did expire at least once
     bool wasExpired;
-
     /// @brief number of (reading) side users of the transaction. this number
     /// is currently only increased on DB servers when they handle incoming
     /// requests by the AQL document function. while this number is > 0, there
@@ -112,12 +113,24 @@ class Manager final : public IManager {
     /// necessary to avoid getting error on a 'diamond' commit or accidentally
     /// repeated commit / abort messages
     transaction::Status finalStatus;
+    /// time-to-live extension for the transaction. will be added
+    /// every time the transaction is touched
     double const timeToLive;
-    double expiryTime;                        // time this expires
-    std::shared_ptr<TransactionState> state;  /// Transaction, may be nullptr
+    // timestamp when this transaction expires
+    double expiryTime;
+    /// Transaction, may be nullptr
+    std::shared_ptr<TransactionState> state;
+    /// callback guard, to abort the transaction once the
+    /// coordinator dies/restarts
     arangodb::cluster::CallbackGuard rGuard;
-    std::string const user;  /// user owning the transaction
-    std::string db;          /// database in which the transaction operates
+    /// user owning the transaction
+    std::string const user;
+    /// database in which the transaction operates
+    std::string db;
+    /// informational string about the original transaction.
+    /// will be cleared once the transaction gets turned into
+    /// a tombstone
+    std::string context;
     /// cheap usage lock for _state
     mutable basics::ReadWriteSpinLock rwlock;
   };
@@ -136,7 +149,7 @@ class Manager final : public IManager {
                                                     bool isReadOnlyTransaction,
                                                     bool isFollowerTransaction);
 
-  uint64_t getActiveTransactionCount();
+  uint64_t getActiveTransactionCount() const noexcept;
 
   void disallowInserts() noexcept {
     _disallowInserts.store(true, std::memory_order_release);
@@ -202,7 +215,7 @@ class Manager final : public IManager {
   /// coordinators in a cluster
   void toVelocyPack(arangodb::velocypack::Builder& builder,
                     std::string const& database, std::string const& username,
-                    bool fanout) const;
+                    bool fanout, bool details) const;
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// @brief a history of currently ongoing and recently finished
@@ -243,7 +256,7 @@ class Manager final : public IManager {
 
   TransactionCommitGuard getTransactionCommitGuard();
 
-  void initiateSoftShutdown() {
+  void initiateSoftShutdown() noexcept {
     _softShutdownOngoing.store(true, std::memory_order_relaxed);
   }
 
@@ -256,13 +269,16 @@ class Manager final : public IManager {
       OperationOrigin operationOrigin);
 
   Result prepareOptions(transaction::Options& options);
+
   bool isFollowerTransactionOnDBServer(
       transaction::Options const& options) const;
-  futures::Future<Result> lockCollections(
+
+  futures::Future<Result> addCollections(
       TRI_vocbase_t& vocbase, std::shared_ptr<TransactionState> state,
       std::vector<std::string> const& exclusiveCollections,
       std::vector<std::string> const& writeCollections,
       std::vector<std::string> const& readCollections);
+
   transaction::Hints ensureHints(transaction::Options& options) const;
 
   /// @brief performs a status change on a transaction using a timeout
@@ -285,18 +301,23 @@ class Manager final : public IManager {
 
   /// @brief calls the callback function for each managed transaction
   void iterateManagedTrx(
-      std::function<void(TransactionId, ManagedTrx const&)> const&) const;
+      std::function<void(TransactionId, ManagedTrx const&)> const& callback,
+      bool details) const;
 
-  static double ttlForType(ManagerFeature const& feature, Manager::MetaType);
+  static double ttlForType(ManagerFeature const& feature,
+                           Manager::MetaType type);
 
-  bool transactionIdExists(TransactionId const& tid) const;
+  bool transactionIdExists(TransactionId tid) const;
 
-  bool storeManagedState(TransactionId const& tid,
+  bool storeManagedState(TransactionId tid,
                          std::shared_ptr<arangodb::TransactionState> state,
                          double ttl);
 
   bool isAuthorized(ManagedTrx const& trx) const;
   bool isAuthorized(ManagedTrx const& trx, std::string_view database) const;
+
+  static std::string buildContextFromState(TransactionState& state,
+                                           MetaType type);
 
  private:
   ManagerFeature& _feature;

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -193,7 +193,7 @@ static void JS_Transactions(v8::FunctionCallbackInfo<v8::Value> const& args) {
   if (arangodb::ExecContext::isAuthEnabled()) {
     user = ExecContext::current().user();
   }
-  mgr->toVelocyPack(builder, vocbase.name(), user, fanout);
+  mgr->toVelocyPack(builder, vocbase.name(), user, fanout, /*details*/ false);
 
   builder.close();
 

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -740,8 +740,7 @@ TEST_F(TransactionManagerTest, expired_transaction) {
   std::this_thread::sleep_for(std::chrono::milliseconds(150));
 
   // we cannot use the transaction anymore
-  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false);
-  ASSERT_EQ(ctx.get(), nullptr);
+  ASSERT_ANY_THROW(mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false));
 
   // aborting it is fine though
   res = mgr->abortManagedTrx(tid, vocbase.name());

--- a/tests/js/client/server_parameters/test-query-registry-contents-cluster.js
+++ b/tests/js/client/server_parameters/test-query-registry-contents-cluster.js
@@ -1,0 +1,125 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global getOptions, fail, arango, assertEqual, assertFalse, assertTrue, assertMatch */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+const jsunity = require('jsunity');
+const arangodb = require('@arangodb');
+const db = arangodb.db;
+const crypto = require('@arangodb/crypto');
+const request = require("@arangodb/request");
+
+const jwtSecret = 'haxxmann';
+
+if (getOptions === true) {
+  return {
+    'server.authentication': 'true',
+    'server.jwt-secret': jwtSecret,
+  };
+}
+
+const jwt = crypto.jwtEncode(jwtSecret, {
+  "server_id": "ABCD",
+  "iss": "arangodb", "exp": Math.floor(Date.now() / 1000) + 3600
+}, 'HS256');
+
+function RegistrySuite() { 
+  const cn = "UnitTests";
+  
+  const baseUrl = function () {
+    return arango.getEndpoint().replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+  };
+
+  return {
+    setUpAll: function () {
+      let c = db._create(cn, {numberOfShards: 1, replicationFactor: 1});
+      let docs = [];
+      for (let i = 0; i < 5000; ++i) {
+        docs.push({});
+      }
+      c.insert(docs);
+    },
+
+    tearDownAll: function () {
+      db._drop(cn);
+    },
+    
+    testRegistryContents: function () {
+      const qs = `FOR doc IN ${cn} RETURN doc`;
+
+      // note: async-prefetch disabled here so that we know that no engines
+      // are opened when we read from the query registry
+      let query = db._createStatement({ query: qs, options: { stream: true, optimizer: { rules: ["-async-prefetch"] } } }).execute();
+
+      try {
+        let result = request.get({
+          url: baseUrl() + "/_api/query/registry",
+          auth: {
+            bearer: jwt,
+          }
+        }).json.queries;
+         
+        assertTrue(Array.isArray(result));
+
+        let q = result.filter((q) => q.queryString === qs);
+        assertEqual(1, q.length);
+
+        assertEqual("number", typeof q[0].id, q);
+        assertEqual(600, q[0].timeToLive);
+        assertTrue(q[0].expires * 1000 >= Date.now(), q);
+        assertEqual(1, q[0].numEngines);
+        assertEqual(0, q[0].numOpen);
+        assertEqual(0, q[0].errorCode);
+        assertFalse(q[0].isTombstone);
+        assertFalse(q[0].finished);
+        assertEqual(qs, q[0].queryString);
+        assertEqual(db._name(), q[0].database);
+        assertFalse(q[0].killed, q);
+        assertTrue(q[0].startTime > 0, q);
+        assertMatch(/^PRMR-/, q[0].serverId);
+
+        // collections
+        const shards = db[cn].shards();
+
+        assertTrue(Array.isArray(q[0].collections, q));
+        assertEqual(1, q[0].collections.length);
+        assertEqual(shards[0], q[0].collections[0].name, q);
+        assertEqual("read", q[0].collections[0].access, q);
+
+        // engines
+        assertTrue(Array.isArray(q[0].engines, q));
+        assertEqual(1, q[0].engines.length);
+        assertFalse(q[0].engines[0].isOpen, q);
+        assertEqual("execution", q[0].engines[0].type, q);
+      } finally {
+        query.dispose();
+      }
+    },
+
+  };
+}
+
+jsunity.run(RegistrySuite);
+return jsunity.done();

--- a/tests/js/client/shell/test-trx-registry-contents-cluster.js
+++ b/tests/js/client/shell/test-trx-registry-contents-cluster.js
@@ -1,0 +1,301 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, arango, BigInt, assertEqual, assertFalse, assertTrue, assertMatch */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+const jsunity = require('jsunity');
+const arangodb = require('@arangodb');
+const db = arangodb.db;
+
+function RegistrySuite() { 
+  const cn = "UnitTests";
+
+  const incrementId = (id, value = 1) => {
+    assertEqual("string", typeof id, id);
+    assertTrue(id.length > 0, id);
+    return (BigInt(id) + BigInt(value)).toString();
+  };
+
+  const runInTrx = (options, cb) => {
+    let trx = db._createTransaction(options);
+    try {
+      cb(trx);
+    } finally {
+      trx.abort();
+    }
+  };
+
+  const validateCoordinatorPart = (id, tx) => {
+    assertEqual(id, tx.id);
+    assertEqual("running", tx.state);
+    assertFalse(tx.expired);
+    assertEqual("managed", tx.type);
+    assertEqual("coordinator id", tx.idType);
+    assertFalse(tx.hasPerformedIntermediateCommits);
+    assertEqual(0, tx.sideUsers);
+    assertEqual("undefined", tx.finalStatus);
+    assertEqual(60, tx.timeToLive);
+    assertTrue(tx.expiryTime * 1000 > Date.now());
+    assertEqual("root", tx.user);
+    assertEqual(db._name(), tx.database);
+    assertMatch(/^CRDN-/, tx.server);
+    assertMatch(/trx type: managed/, tx.context);
+    assertMatch(/multi op/, tx.context);
+  };
+
+  const validateDBServerPart = (id, tx) => {
+    const isFollower = BigInt(id) % BigInt(4) === BigInt(2);
+
+    assertEqual(id, tx.id);
+    assertEqual("running", tx.state);
+    assertFalse(tx.expired);
+    assertEqual("managed", tx.type);
+    assertEqual(isFollower ? "follower id" : "leader id", tx.idType);
+    // round down to coordinator id
+    assertEqual(BigInt(id) / BigInt(4) * BigInt(4), tx.coordinatorId);
+    assertFalse(tx.hasPerformedIntermediateCommits);
+    assertEqual(0, tx.sideUsers);
+    assertEqual("undefined", tx.finalStatus);
+    assertEqual(300, tx.timeToLive);
+    assertTrue(tx.expiryTime * 1000 > Date.now());
+    assertEqual(db._name(), tx.database);
+    assertMatch(/^PRMR-/, tx.server);
+  };
+
+  return {
+    setUpAll: function () {
+      db._create(cn, {numberOfShards: 10, replicationFactor: 2});
+    },
+
+    tearDownAll: function () {
+      db._drop(cn);
+    },
+    
+    testTrxRegistryNoDetails: function () {
+      runInTrx({ collections: { write: cn } }, (trx) => {
+        let result = arango.GET("/_api/transaction").transactions;
+        assertTrue(Array.isArray(result));
+
+        let tx = result.filter((t) => t.id === trx.id());
+        assertEqual(1, tx.length);
+        assertEqual(trx.id(), tx[0].id);
+        assertEqual("running", tx[0].state);
+      });
+    },
+    
+    testTrxRegistryWithDetailsOnlyLeader: function () {
+      runInTrx({ collections: { write: cn } }, (trx) => {
+        let result = arango.GET("/_api/transaction?details=true").transactions;
+        assertTrue(Array.isArray(result));
+
+        // coordinator part
+        {
+          const id = trx.id();
+          let tx = result.filter((t) => t.id === id);
+          assertEqual(1, tx.length);
+
+          validateCoordinatorPart(id, tx[0]);
+          assertMatch(/collections: \[.*name: UnitTests, access: write.*\]/, tx[0].context);
+        }
+        
+        // leader part(s)
+        {
+          const id = incrementId(trx.id());
+          let tx = result.filter((t) => t.id === id);
+          assertTrue(tx.length > 0, tx);
+
+          tx.forEach((tx) => {
+            validateDBServerPart(id, tx);
+          });
+        }
+        
+        // follower part(s)
+        {
+          const id = incrementId(trx.id(), 2);
+          let tx = result.filter((t) => t.id === id);
+          assertEqual(0, tx.length, tx);
+        }
+      });
+    },
+    
+    testTrxRegistryWithDetailsLeaderAndFollower: function () {
+      runInTrx({ collections: { write: cn } }, (trx) => {
+        // write documents into collection. this also starts the transaction
+        // on the follower(s)
+        let docs = [];
+        for (let i = 0; i < 5000; ++i) {
+          docs.push({});
+        }
+        trx.collection(cn).insert(docs);
+
+        let result = arango.GET("/_api/transaction?details=true").transactions;
+        assertTrue(Array.isArray(result));
+
+        // leader part(s)
+        {
+          const id = incrementId(trx.id());
+          let tx = result.filter((t) => t.id === id);
+          assertTrue(tx.length > 0, tx);
+
+          tx.forEach((tx) => {
+            validateDBServerPart(id, tx);
+          });
+        }
+        
+        // follower part(s)
+        {
+          const id = incrementId(trx.id(), 2);
+          let tx = result.filter((t) => t.id === id);
+          assertTrue(tx.length > 0, tx);
+
+          tx.forEach((tx) => {
+            validateDBServerPart(id, tx);
+          });
+        }
+      });
+    },
+    
+    testTrxRegistryWithDetailsLeaderAndFollowerOtherDB: function () {
+      db._createDatabase(cn);
+
+      try {
+        db._useDatabase(cn);
+      
+        db._create(cn, {numberOfShards: 10, replicationFactor: 2});
+
+        runInTrx({ collections: { write: cn } }, (trx) => {
+          // write documents into collection. this also starts the transaction
+          // on the follower(s)
+          let docs = [];
+          for (let i = 0; i < 5000; ++i) {
+            docs.push({});
+          }
+          trx.collection(cn).insert(docs);
+
+          let result = arango.GET("/_api/transaction?details=true").transactions;
+          assertTrue(Array.isArray(result));
+          
+          // coordinator part
+          {
+            const id = trx.id();
+            let tx = result.filter((t) => t.id === id);
+            assertEqual(1, tx.length);
+
+            validateCoordinatorPart(id, tx[0]);
+            assertMatch(/collections: \[.*name: UnitTests, access: write.*\]/, tx[0].context);
+          }
+
+          // leader part(s)
+          {
+            const id = incrementId(trx.id());
+            let tx = result.filter((t) => t.id === id);
+            assertTrue(tx.length > 0, tx);
+
+            tx.forEach((tx) => {
+              validateDBServerPart(id, tx);
+            });
+          }
+          
+          // follower part(s)
+          {
+            const id = incrementId(trx.id(), 2);
+            let tx = result.filter((t) => t.id === id);
+            assertTrue(tx.length > 0, tx);
+
+            tx.forEach((tx) => {
+              validateDBServerPart(id, tx);
+            });
+          }
+        });
+      } finally {
+        db._useDatabase("_system");
+        db._dropDatabase(cn);
+      }
+    },
+    
+    testTrxRegistryWithExclusiveTrx: function () {
+      db._createDatabase(cn);
+
+      try {
+        db._useDatabase(cn);
+      
+        db._create(cn, {numberOfShards: 1, replicationFactor: 1});
+
+        runInTrx({ collections: { exclusive: cn } }, (trx) => {
+          // write documents into collection
+          let docs = [];
+          for (let i = 0; i < 10; ++i) {
+            docs.push({});
+          }
+          trx.collection(cn).insert(docs);
+
+          let result = arango.GET("/_api/transaction?details=true").transactions;
+          assertTrue(Array.isArray(result));
+          
+          // coordinator part
+          {
+            const id = trx.id();
+            let tx = result.filter((t) => t.id === id);
+            assertEqual(1, tx.length);
+
+            validateCoordinatorPart(id, tx[0]);
+            assertMatch(/collections: \[.*name: UnitTests, access: exclusive.*\]/, tx[0].context);
+          }
+              
+          const shards = db._collection(cn).shards();
+          assertEqual(1, shards.length, shards);
+
+          // leader part(s)
+          {
+            const id = incrementId(trx.id());
+            let tx = result.filter((t) => t.id === id);
+            assertEqual(1, tx.length, tx);
+
+            tx.forEach((tx) => {
+              validateDBServerPart(id, tx);
+              assertMatch(/collections: \[.*, access: exclusive.*\]/, tx.context);
+
+              assertMatch(new RegExp(shards[0]), tx.context);
+            });
+          }
+          
+          // follower part(s) - we don't have followers because of replicationFactor 1
+          {
+            const id = incrementId(trx.id(), 2);
+            let tx = result.filter((t) => t.id === id);
+            assertEqual(0, tx.length, tx);
+          }
+        });
+      } finally {
+        db._useDatabase("_system");
+        db._dropDatabase(cn);
+      }
+    },
+
+  };
+}
+
+jsunity.run(RegistrySuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This PR adds internal APIs to dump the contents of the AQL query registry from DB-Servers plus the contents of the transaction manager on coordinators and DB-Servers.
The APIs are for internal use only, so they should not be considered part of the officially supported API, and thus do not need to be mentioned in our official documentation. The output of this API can change at any point without further notice.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 