### PR TITLE
obsolete now-unused startup option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Obsolete startup option `--server.max-number-detached-threads`.
+  This option is now obsolete because coroutines are used instead of blocking
+  function calls.
+
 * Log an info message if a request was queued in the scheduler queue for 30 s
   or longer.
 

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -85,11 +85,6 @@ bool Scheduler::start() {
   return _cronThread->start();
 }
 
-Result Scheduler::detachThread(uint64_t* detachedThreads,
-                               uint64_t* maximumDetachedThreads) {
-  return {};
-}
-
 void Scheduler::schedulerJobMemoryAccounting(std::int64_t x) noexcept {
   if (SchedulerFeature::SCHEDULER) {
     SchedulerFeature::SCHEDULER->trackQueueItemSize(x);

--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -63,9 +63,6 @@ class Scheduler {
   // ---------------------------------------------------------------------------
   // Scheduling and Task Queuing - the relevant stuff
   // ---------------------------------------------------------------------------
-  virtual Result detachThread(uint64_t* detachedThreads,
-                              uint64_t* maximumDetachedThreads);
-
   class DelayedWorkItem;
   typedef std::chrono::steady_clock clock;
   typedef std::shared_ptr<DelayedWorkItem> WorkHandle;

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -244,19 +244,12 @@ return HTTP 503 instead of HTTP 200 when their availability API is probed.)");
       new UInt64Parameter(&_fifo1Size),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
 
-  options
-      ->addOption("--server.max-number-detached-threads",
-                  "The maximum number of detached scheduler threads.",
-                  new UInt64Parameter(&_nrMaximalDetachedThreads),
-                  arangodb::options::makeDefaultFlags(
-                      arangodb::options::Flags::Default,
-                      arangodb::options::Flags::Uncommon))
-      .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(If a scheduler thread performs a potentially long running operation like waiting for a lock, it can detach itself from the scheduler. This allows a new scheduler thread to be started and avoids blocking all threads with long-running operations, thereby avoiding deadlock situations. The default should normally be OK.)");
-
   // obsolete options
   options->addObsoleteOption("--server.threads", "number of threads", true);
+
+  options->addObsoleteOption(
+      "--server.max-number-detached-threads",
+      "The maximum number of detached scheduler threads.", true);
 
   // renamed options
   options->addOldOption("scheduler.threads", "server.maximal-threads");
@@ -337,8 +330,7 @@ void SchedulerFeature::prepare() {
   auto sched = std::make_unique<SupervisedScheduler>(
       server(), _nrMinimalThreads, _nrMaximalThreads, _queueSize, _fifo1Size,
       _fifo2Size, _fifo3Size, ongoingLowPriorityLimit,
-      _unavailabilityQueueFillGrade, _nrMaximalDetachedThreads,
-      _metricsFeature);
+      _unavailabilityQueueFillGrade, _metricsFeature);
 
   SCHEDULER = sched.get();
 

--- a/arangod/Scheduler/SchedulerFeature.h
+++ b/arangod/Scheduler/SchedulerFeature.h
@@ -61,7 +61,6 @@ class SchedulerFeature final : public ArangodFeature {
 
   uint64_t _nrMinimalThreads = 4;
   uint64_t _nrMaximalThreads = 0;
-  uint64_t _nrMaximalDetachedThreads = 1000;
   uint64_t _queueSize = 4096;
   uint64_t _fifo1Size = 4096;
   uint64_t _fifo2Size = 4096;

--- a/arangod/Scheduler/SupervisedScheduler.h
+++ b/arangod/Scheduler/SupervisedScheduler.h
@@ -48,22 +48,11 @@ class SupervisedScheduler final : public Scheduler {
                       uint64_t fifo1Size, uint64_t fifo2Size,
                       uint64_t fifo3Size, uint64_t ongoingLowPriorityLimit,
                       double unavailabilityQueueFillGrade,
-                      uint64_t maxNumberDetachedThreads,
                       metrics::MetricsFeature& metrics);
   ~SupervisedScheduler() final;
 
   bool start() override;
   void shutdown() override;
-
-  /// @brief Take current thread out of the Scheduler (to finish some
-  /// potentially long running task and allow a new thread to be started).
-  /// This should be called from a scheduler thread. If an error is returned
-  /// this operation has not worked. The thread can then consider to error
-  /// out instead of starting its long running task. Note that his also
-  /// happens if a configurable total number of detached threads has been
-  /// reached.
-  Result detachThread(uint64_t* detachedThreads,
-                      uint64_t* maximumDetachedThreads) override;
 
   void toVelocyPack(velocypack::Builder&) const override;
   Scheduler::QueueStatistics queueStatistics() const override;
@@ -198,7 +187,6 @@ class SupervisedScheduler final : public Scheduler {
   size_t const _maxNumWorkers;
   uint64_t const _maxFifoSizes[NumberOfQueues];
   uint64_t const _ongoingLowPriorityLimit;
-  uint64_t const _maxNumberDetachedThreads;
 
   /// @brief fill grade of the scheduler's queue (in %) from which onwards
   /// the server is considered unavailable (because of overload)

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -894,13 +894,6 @@ futures::Future<std::shared_ptr<transaction::Context>> Manager::leaseManagedTrx(
     LOG_TOPIC("abd72", TRACE, Logger::TRANSACTIONS)
         << "transaction " << tid << " is already in use (RO)";
 
-    // simon: Two allowed scenarios:
-    // 1. User sends concurrent write (CRUD) requests, (which was never intended
-    // to be possible)
-    //    but now we do have to kind of support it otherwise shitty apps break
-    // 2. one does a bulk write within a el-cheapo / V8 transaction into
-    // multiple shards
-    //    on the same DBServer (still bad design).
     TRI_ASSERT(endTime.time_since_epoch().count() == 0 ||
                !ServerState::instance()->isDBServer());
 

--- a/tests/Cluster/RebootTrackerTest.cpp
+++ b/tests/Cluster/RebootTrackerTest.cpp
@@ -136,23 +136,13 @@ class RebootTrackerTest
     : public ::testing::Test,
       public LogSuppressor<Logger::CLUSTER, LogLevel::WARN> {
  protected:
-// MSVC new/malloc only guarantees 8 byte alignment, but SupervisedScheduler
-// needs 64. Disable warning:
-#if (_MSC_VER >= 1)
-#pragma warning(push)
-#pragma warning(disable : 4316)  // Object allocated on the heap may not be
-                                 // aligned for this type
-#endif
   RebootTrackerTest()
       : mockApplicationServer(),
         scheduler(std::make_unique<SupervisedScheduler>(
             mockApplicationServer.server(), 2, 64, 128, 1024 * 1024, 4096, 4096,
-            128, 0.0, 42,
+            128, 0.0,
             mockApplicationServer.server()
                 .template getFeature<arangodb::metrics::MetricsFeature>())) {}
-#if (_MSC_VER >= 1)
-#pragma warning(pop)
-#endif
 
   MockRestServer mockApplicationServer;
   std::unique_ptr<SupervisedScheduler> scheduler;


### PR DESCRIPTION
### Scope & Purpose

Remove unused startup option for detaching threads.
The option became meaningless after commit https://github.com/arangodb/arangodb/commit/b0b9f026c2af1952c3218105f082c408e5c957d2.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 