### PR TITLE
fix BTS-1840

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
-* BTS-1840: active failover: connection/tcp leak in active failover mode in
-  case no leader change happened for a long time.
+* BTS-1840: active failover: connection/tcp leak in active failover mode in case
+  no leader change happened for a long time.
 
 * Fix potential deadlocks in "fast lock round" when starting transactions in
   cluster. The "fast lock round" is used to send out transaction begin requests

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* BTS-1840: active failover: connection/tcp leak in active failover mode in
+  case no leader change happened for a long time.
+
 * Fix potential deadlocks in "fast lock round" when starting transactions in
   cluster. The "fast lock round" is used to send out transaction begin requests
   to multiple leaders concurrently, without caring about the order in which


### PR DESCRIPTION
### Scope & Purpose

Fixes https://arangodb.atlassian.net/browse/BTS-1840.

In active failover mode, there is a potential connection leak for connections made to the agency on the leader, when there is a longer period with no leader changes.
In this case, the code that closes stale connections to the agency isn't executed, so the number of connections can keep increasing.
Other deployment modes (single server, cluster) are not affected by this issue.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1840
- [ ] Design document: 