### PR TITLE
Async trx commit/abort

### DIFF
--- a/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
+++ b/arangod/Replication2/StateMachines/Document/DocumentLeaderState.cpp
@@ -103,7 +103,7 @@ auto DocumentLeaderState::resign() && noexcept
   for (auto const& trx : activeTransactions) {
     auto tid = trx.first.asLeaderTransactionId();
     if (auto abortRes = basics::catchToResult([&]() {
-          return _transactionManager.abortManagedTrx(tid, gid.database);
+          return _transactionManager.abortManagedTrx(tid, gid.database).get();
         });
         abortRes.fail()) {
       LOG_CTX("1b665", WARN, loggerContext)
@@ -228,8 +228,9 @@ auto DocumentLeaderState::recoverEntries(std::unique_ptr<EntryIterator> ptr)
       // register tombstones in the trx managers for the leader trx id.
       auto tid = trxId.asLeaderTransactionId();
       if (auto abortRes = basics::catchToResult([&]() {
-            return self->_transactionManager.abortManagedTrx(
-                tid, self->gid.database);
+            return self->_transactionManager
+                .abortManagedTrx(tid, self->gid.database)
+                .get();
           });
           abortRes.fail()) {
         LOG_CTX("462a9", DEBUG, self->loggerContext)

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3512,7 +3512,7 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
           // Code does not matter, read only access, so we can roll back.
           transaction::Manager* mgr = transaction::ManagerFeature::manager();
           if (mgr) {
-            mgr->abortManagedTrx(id, vn);
+            mgr->abortManagedTrx(id, vn).get();
           }
         } catch (...) {
           // All errors that show up here can only be
@@ -3544,7 +3544,7 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
 
   if (isTombstoned(id)) {
     try {
-      co_return mgr->abortManagedTrx(id, vn);
+      co_return co_await mgr->abortManagedTrx(id, vn);
     } catch (...) {
       // Maybe thrown in shutdown.
     }
@@ -3583,7 +3583,7 @@ ResultT<bool> RestReplicationHandler::cancelBlockingTransaction(
   if (res.ok()) {
     transaction::Manager* mgr = transaction::ManagerFeature::manager();
     if (mgr) {
-      auto isAborted = mgr->abortManagedTrx(id, _vocbase.name());
+      auto isAborted = mgr->abortManagedTrx(id, _vocbase.name()).get();
       if (isAborted.ok()) {  // lock was held
         return ResultT<bool>::success(true);
       }

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -51,8 +51,8 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
  private:
   void executeGetState();
   [[nodiscard]] futures::Future<futures::Unit> executeBegin();
-  void executeCommit();
-  void executeAbort();
+  [[nodiscard]] futures::Future<futures::Unit> executeCommit();
+  [[nodiscard]] futures::Future<futures::Unit> executeAbort();
   void generateTransactionResult(rest::ResponseCode code, TransactionId tid,
                                  transaction::Status status);
 

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -786,7 +786,7 @@ futures::Future<Result> Manager::ensureManagedTrx(
 
 namespace {
 futures::Future<futures::Unit> sleepUsingSchedulerIfAvailable(
-    const char* reason, std::chrono::milliseconds duration) {
+    std::string_view reason, std::chrono::milliseconds duration) {
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   constexpr bool alwaysHasScheduler = false;
 #else

--- a/arangod/Transaction/Manager.h
+++ b/arangod/Transaction/Manager.h
@@ -67,8 +67,8 @@ struct Options;
 
 struct IManager {
   virtual ~IManager() = default;
-  virtual Result abortManagedTrx(TransactionId,
-                                 std::string const& database) = 0;
+  virtual futures::Future<Result> abortManagedTrx(
+      TransactionId, std::string const& database) = 0;
 };
 
 /// @brief Tracks TransactionState instances
@@ -182,8 +182,10 @@ class Manager final : public IManager {
   /// @brief get the meta transaction state
   transaction::Status getManagedTrxStatus(TransactionId) const;
 
-  Result commitManagedTrx(TransactionId, std::string const& database);
-  Result abortManagedTrx(TransactionId, std::string const& database) override;
+  futures::Future<Result> commitManagedTrx(TransactionId,
+                                           std::string const& database);
+  futures::Future<Result> abortManagedTrx(TransactionId,
+                                          std::string const& database) override;
 
   /// @brief collect forgotten transactions
   bool garbageCollect(bool abortAll);
@@ -265,8 +267,9 @@ class Manager final : public IManager {
   transaction::Hints ensureHints(transaction::Options& options) const;
 
   /// @brief performs a status change on a transaction using a timeout
-  Result statusChangeWithTimeout(TransactionId tid, std::string const& database,
-                                 transaction::Status status);
+  futures::Future<Result> statusChangeWithTimeout(TransactionId tid,
+                                                  std::string const& database,
+                                                  transaction::Status status);
 
   /// @brief hashes the transaction id into a bucket
   inline size_t getBucket(TransactionId tid) const noexcept {

--- a/tests/Replication2/Mocks/DocumentStateMocks.h
+++ b/tests/Replication2/Mocks/DocumentStateMocks.h
@@ -49,7 +49,7 @@ struct MockDocumentStateTransactionHandler;
 struct MockDocumentStateSnapshotHandler;
 
 struct MockTransactionManager : transaction::IManager {
-  MOCK_METHOD(Result, abortManagedTrx,
+  MOCK_METHOD(futures::Future<Result>, abortManagedTrx,
               (TransactionId, std::string const& database), (override));
 };
 

--- a/tests/RocksDBEngine/TransactionManagerTest.cpp
+++ b/tests/RocksDBEngine/TransactionManagerTest.cpp
@@ -80,7 +80,7 @@ TEST(RocksDBTransactionManager, test_overlapping) {
   std::atomic<bool> done;
 
   auto getReadLock = [&]() -> void {
-    tm.commitManagedTrx(trxId, "foo");
+    tm.commitManagedTrx(trxId, "foo").get();
     done = true;
   };
 

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -154,7 +154,7 @@ TEST_F(TransactionManagerTest, transaction_id_reuse) {
             .get();
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_TRANSACTION_INTERNAL);
 
-  res = mgr->abortManagedTrx(tid, vocbase.name());
+  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
   ASSERT_TRUE(res.ok());
 }
 
@@ -209,11 +209,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
   // cannot commit aborted transaction
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name())
+                  .get()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
@@ -254,11 +255,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
   // cannot commit aborted transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
+                  .get()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
@@ -306,11 +308,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
   // cannot commit aborted transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
+                  .get()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
@@ -347,16 +350,17 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
     auto opRes = trx.insert(coll->name(), doc->slice(), opts);
     ASSERT_TRUE(opRes.ok());
     ASSERT_EQ(TRI_ERROR_LOCKED,
-              mgr->commitManagedTrx(tid, vocbase.name()).errorNumber());
+              mgr->commitManagedTrx(tid, vocbase.name()).get().errorNumber());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
   // cannot abort committed transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
+                  .get()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
 }
@@ -400,7 +404,7 @@ TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
     EXPECT_EQ(state3.get(), state2.get());
     ASSERT_TRUE(!responsible);
   }
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
@@ -432,7 +436,7 @@ TEST_F(TransactionManagerTest, lock_conflict) {
     ASSERT_ANY_THROW(
         mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get());
   }
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
@@ -471,7 +475,7 @@ TEST_F(TransactionManagerTest, lock_conflict_side_user) {
     ASSERT_NE(state2.get(), nullptr);
     ASSERT_TRUE(!responsible);
   }
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
@@ -616,7 +620,7 @@ TEST_F(TransactionManagerTest, permission_denied_readonly) {
                             transaction::OperationOriginTestCase{}, false)
           .get();
   EXPECT_TRUE(res.ok());
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
 
   tid = TransactionId::createSingleServer();
   json = arangodb::velocypack::Parser::fromJson(
@@ -679,7 +683,7 @@ TEST_F(TransactionManagerTest, transaction_invalid_mode) {
                arangodb::basics::Exception);
   ;
 
-  res = mgr->abortManagedTrx(tid, vocbase.name());
+  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
   ASSERT_TRUE(res.ok());
 }
 
@@ -711,7 +715,7 @@ TEST_F(TransactionManagerTest, transaction_origin) {
     ASSERT_EQ("some test", origin.description);
   }
 
-  res = mgr->abortManagedTrx(tid, vocbase.name());
+  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
   ASSERT_TRUE(res.ok());
 }
 
@@ -747,10 +751,10 @@ TEST_F(TransactionManagerTest, expired_transaction) {
   ASSERT_EQ(ctx.get(), nullptr);
 
   // aborting it is fine though
-  res = mgr->abortManagedTrx(tid, vocbase.name());
+  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
   ASSERT_TRUE(res.ok());
 
-  res = mgr->commitManagedTrx(tid, vocbase.name());
+  res = mgr->commitManagedTrx(tid, vocbase.name()).get();
   ASSERT_FALSE(res.ok());
   ASSERT_EQ(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION, res.errorNumber());
 }
@@ -797,11 +801,11 @@ TEST_F(TransactionManagerTest, lock_usage_of_expired_transaction) {
   ASSERT_TRUE(res.ok());
 
   // aborting trx1 is still fine, even though it is expired
-  res = mgr->abortManagedTrx(tid, vocbase.name());
+  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
   ASSERT_TRUE(res.ok());
 
   // committing trx2 must be ok
-  res = mgr->commitManagedTrx(tid2, vocbase.name());
+  res = mgr->commitManagedTrx(tid2, vocbase.name()).get();
   ASSERT_TRUE(res.ok());
 }
 #endif


### PR DESCRIPTION
### Scope & Purpose
`commitManagedTrx` and `abortManagedTrx` now return a future. Instead of blocking and spinning in a busy loop, they yield the current thread and wait. However, this waiting is only done, if the transaction is in use by a different request, while also being committed/aborted.