### PR TITLE
remove `_activeTrx` instance variable

### DIFF
--- a/arangod/RestHandler/RestDocumentHandler.h
+++ b/arangod/RestHandler/RestDocumentHandler.h
@@ -25,6 +25,8 @@
 
 #include "RestHandler/RestVocbaseBaseHandler.h"
 
+#include <string_view>
+
 namespace arangodb {
 struct OperationOptions;
 
@@ -75,9 +77,8 @@ class RestDocumentHandler : public RestVocbaseBaseHandler {
 
   void handleFillIndexCachesValue(OperationOptions& options);
 
-  void addTransactionHints(std::string const& collectionName, bool isMultiple,
+  void addTransactionHints(transaction::Methods& trx,
+                           std::string_view collectionName, bool isMultiple,
                            bool isOverwritingInsert);
-
-  std::unique_ptr<transaction::Methods> _activeTrx;
 };
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

the `RestDocumentHandler` had an instance variable `_activeTrx` in which the handler stored the transaction object that was started for the particular operation.
this was previously necessary, because the transaction still needs to be valid in some of the RestDocumentHandler's follow-up async continuations. because we did not pass the unique_ptr with the transaction to these async routines, they needed the instance variable to pick up the transaction later on.

after we changed the `RestDocumentHandler` to use coroutines, we can now remove the `_activeTrx` instance variable entirely, and simply store the transaction in a local variable. once the coroutine execution resumes, it still has access to that same local variable.

the changes should not affect the observable behavior at all.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 