### PR TITLE
Use std::source_location, and make paths relative to the content root

### DIFF
--- a/arangod/Replication2/Methods.cpp
+++ b/arangod/Replication2/Methods.cpp
@@ -1052,7 +1052,7 @@ struct ReplicatedLogMethodsCoordinator final
     auto leader = clusterInfo.getReplicatedLogLeader(id);
     if (leader.fail()) {
       if (leader.is(TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED)) {
-        throw ParticipantResignedException(leader.result(), ADB_HERE);
+        throw ParticipantResignedException(leader.result());
       } else {
         THROW_ARANGO_EXCEPTION(leader.result());
       }

--- a/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/AppendEntriesManager.cpp
@@ -54,7 +54,7 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
   Guarded<GuardedData>::mutex_guard_type guard = guarded.getLockedGuard();
   if (guard->resigned) {
     throw ParticipantResignedException(
-        TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE);
+        TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
   }
   auto requestGuard = guard->requestInFlight.acquire();
   if (not requestGuard) {
@@ -111,7 +111,7 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
       guard = self->guarded.getLockedGuard();
       if (guard->resigned) {
         throw ParticipantResignedException(
-            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE);
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
       }
       if (result.fail()) {
         LOG_CTX("0982a", ERR, lctx) << "failed to persist: " << result;
@@ -135,7 +135,7 @@ auto AppendEntriesManager::appendEntries(AppendEntriesRequest request)
       guard = self->guarded.getLockedGuard();
       if (guard->resigned) {
         throw ParticipantResignedException(
-            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE);
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED);
       }
       if (result.fail()) {
         LOG_CTX("7cb3d", ERR, lctx)

--- a/arangod/Replication2/ReplicatedLog/Components/CompactionManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/CompactionManager.cpp
@@ -141,7 +141,7 @@ void CompactionManager::triggerAsyncCompaction(
 
         guard.unlock();
         auto ex = std::make_exception_ptr(
-            basics::Exception(std::move(storeRes).result(), ADB_HERE));
+            basics::Exception(std::move(storeRes).result()));
         promises.resolveAll(futures::Try<CompactResult>{std::move(ex)});
         break;
       }

--- a/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/FollowerCommitManager.cpp
@@ -102,7 +102,7 @@ auto FollowerCommitManager::waitFor(LogIndex index) noexcept
   if (guard->isResigned) {
     auto promise = ResolvePromise{};
     promise.setException(ParticipantResignedException(
-        TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE));
+        TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED));
     return promise.getFuture();
   }
 
@@ -135,7 +135,7 @@ void FollowerCommitManager::resign() noexcept {
   guard->isResigned = true;
   for (auto& [idx, promise] : guard->waitQueue) {
     promise.setException(ParticipantResignedException(
-        TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE));
+        TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED));
   }
   guard->waitQueue.clear();
 }

--- a/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/InMemoryLogManager.cpp
@@ -96,7 +96,7 @@ auto InMemoryLogManager::appendLogEntry(
   return _guardedData.doUnderLock([&](auto& data) -> LogIndex {
     if (data._resigned) {
       throw ParticipantResignedException(
-          TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED, ADB_HERE);
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED);
     }
 
     auto const index = data._inMemoryLog.getNextIndex();

--- a/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
+++ b/arangod/Replication2/ReplicatedState/FollowerStateManager.tpp
@@ -201,7 +201,7 @@ auto FollowerStateManager<S>::GuardedData::maybeScheduleApplyEntries(
                 });
       } else {
         promise.setException(replicated_log::ParticipantResignedException(
-            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE));
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED));
       }
     });
 
@@ -387,7 +387,7 @@ auto FollowerStateManager<S>::resign() && noexcept
 
   auto tryResult = futures::Try<LogIndex>(
       std::make_exception_ptr(replicated_log::ParticipantResignedException(
-          TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE)));
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED)));
   _guardedData.getLockedGuard()->_waitQueue.resolveAllWith(
       std::move(tryResult), [&scheduler = *_scheduler]<typename F>(F&& f) {
         static_assert(noexcept(std::decay_t<decltype(f)>(std::forward<F>(f))));

--- a/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
+++ b/arangod/Replication2/ReplicatedState/ReplicatedState.tpp
@@ -69,7 +69,7 @@ auto IReplicatedFollowerState<S>::waitForApplied(LogIndex index)
   } else {
     WaitForAppliedFuture future(
         std::make_exception_ptr(replicated_log::ParticipantResignedException(
-            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE)));
+            TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED)));
     return future;
   }
 }

--- a/arangod/Replication2/ReplicatedState/StreamProxy.tpp
+++ b/arangod/Replication2/ReplicatedState/StreamProxy.tpp
@@ -123,7 +123,7 @@ void StreamProxy<S, Interface, ILogMethodsT>::throwResignedException() {
   // the stream with resigning (see
   // https://github.com/arangodb/arangodb/pull/17850).
   // It relies on the stream throwing an exception in that case.
-  throw replicated_log::ParticipantResignedException(errorCode, ADB_HERE);
+  throw replicated_log::ParticipantResignedException(errorCode);
 }
 
 template<typename S>

--- a/arangod/VocBase/VocBaseLogManager.cpp
+++ b/arangod/VocBase/VocBaseLogManager.cpp
@@ -417,7 +417,7 @@ auto VocBaseLogManager::GuardedData::buildReplicatedStateWithMethods(
 
   auto maybeMetadata = storage->readMetadata();
   if (!maybeMetadata) {
-    throw basics::Exception(std::move(maybeMetadata).result(), ADB_HERE);
+    throw basics::Exception(std::move(maybeMetadata).result());
   }
 
   auto sched = std::make_shared<MyScheduler>();

--- a/lib/Basics/Exceptions.cpp
+++ b/lib/Basics/Exceptions.cpp
@@ -61,23 +61,6 @@ Exception::Exception(ErrorCode code, const char* errorMessage,
                      SourceLocation location)
     : Exception(code, std::string{errorMessage}, location) {}
 
-Exception::Exception(ErrorCode code, char const* file, int line)
-    : Exception(code, SourceLocation(file, line)) {}
-Exception::Exception(arangodb::Result const& result, char const* file, int line)
-    : Exception(result, SourceLocation(file, line)) {}
-Exception::Exception(arangodb::Result&& result, char const* file,
-                     int line) noexcept
-    : Exception(std::move(result), SourceLocation(file, line)) {}
-Exception::Exception(ErrorCode code, std::string_view errorMessage,
-                     char const* file, int line)
-    : Exception(code, errorMessage, SourceLocation(file, line)) {}
-Exception::Exception(ErrorCode code, std::string&& errorMessage,
-                     char const* file, int line) noexcept
-    : Exception(code, std::move(errorMessage), SourceLocation(file, line)) {}
-Exception::Exception(ErrorCode code, char const* errorMessage, char const* file,
-                     int line)
-    : Exception(code, errorMessage, SourceLocation(file, line)) {}
-
 /// @brief returns the error message
 std::string const& Exception::message() const noexcept { return _errorMessage; }
 

--- a/lib/Basics/Exceptions.h
+++ b/lib/Basics/Exceptions.h
@@ -72,27 +72,18 @@ class Exception : public virtual std::exception {
  public:
   // primary constructor
   Exception(ErrorCode code, std::string&& errorMessage,
-            SourceLocation location) noexcept;
+            SourceLocation location = SourceLocation::current()) noexcept;
 
   // convenience constructors
-  Exception(ErrorCode code, SourceLocation location);
-  Exception(Result const&, SourceLocation location);
-  Exception(Result&&, SourceLocation location) noexcept;
+  Exception(ErrorCode code,
+            SourceLocation location = SourceLocation::current());
+  Exception(Result const&, SourceLocation location = SourceLocation::current());
+  Exception(Result&&,
+            SourceLocation location = SourceLocation::current()) noexcept;
   Exception(ErrorCode code, std::string_view errorMessage,
-            SourceLocation location);
-  Exception(ErrorCode code, char const* errorMessage, SourceLocation location);
-
-  // I think we should get rid of the following (char*,int) versions as opposed
-  // to the SourceLocation ones, to keep it a little clearer.
-  Exception(ErrorCode code, char const* file, int line);
-  Exception(Result const&, char const* file, int line);
-  Exception(Result&&, char const* file, int line) noexcept;
-  Exception(ErrorCode code, std::string_view errorMessage, char const* file,
-            int line);
-  Exception(ErrorCode code, std::string&& errorMessage, char const* file,
-            int line) noexcept;
-  Exception(ErrorCode code, char const* errorMessage, char const* file,
-            int line);
+            SourceLocation location = SourceLocation::current());
+  Exception(ErrorCode code, char const* errorMessage,
+            SourceLocation location = SourceLocation::current());
 
   ~Exception() override = default;
   Exception(Exception const&) = default;

--- a/lib/Basics/FutureSharedLock.h
+++ b/lib/Basics/FutureSharedLock.h
@@ -253,8 +253,7 @@ struct FutureSharedLock {
                   lock.unlock();
                   nodePtr->promise.setException(::arangodb::basics::Exception(
                       cancelled ? TRI_ERROR_REQUEST_CANCELED
-                                : TRI_ERROR_LOCK_TIMEOUT,
-                      ADB_HERE));
+                                : TRI_ERROR_LOCK_TIMEOUT));
                 }
               }
             }

--- a/lib/Basics/SourceLocation.cpp
+++ b/lib/Basics/SourceLocation.cpp
@@ -29,6 +29,11 @@ namespace arangodb::basics {
 
 auto operator<<(std::ostream& ostream, SourceLocation const& sourceLocation)
     -> std::ostream& {
-  return ostream << sourceLocation.file_name() << ":" << sourceLocation.line();
+  return ostream << sourceLocation.file_name() << ":"
+                 << sourceLocation.line()
+                 // I guess the column usually isn't useful.
+                 // << sourceLocation.column() << ":"
+                 << "[" << sourceLocation.function_name() << "]";
 }
+
 }  // namespace arangodb::basics

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -24,33 +24,82 @@
 #pragma once
 
 #include <iosfwd>
+#include <source_location>
+#include <string_view>
 
 namespace arangodb::basics {
+consteval auto stripPrefix(const char* pathStr) -> const char*;
 
-// Poor-man's replacement for std::source_location, until we get C++20.
+// This is mostly a custom type around std::source_location with the same
+// interface; However, it changes the filename's path, so it's relative to the
+// git root directory.
 struct SourceLocation {
  private:
-  char const* _fileName;
-  int _line;
+  char const* _fileName{};
+  char const* _functionName{};
+  std::uint_least32_t _line{};
+  std::uint_least32_t _column{};
 
  public:
+  consteval static auto current(
+      std::source_location loc = std::source_location::current())
+      -> SourceLocation {
+    return SourceLocation{loc};
+  }
+
+  // We can allow this if we need to, but this way it prevents accidental usage
+  // of uninitialized SourceLocations.
   SourceLocation() = delete;
-  // cppcheck-suppress unknownMacro
-  constexpr SourceLocation(decltype(_fileName) file,
-                           decltype(_line) line) noexcept
-      : _fileName(file), _line(line) {}
+
+  consteval explicit SourceLocation(
+      std::source_location const location) noexcept
+      : _fileName(stripPrefix(location.file_name())),
+        _functionName(location.function_name()),
+        _line(location.line()) {}
 
   [[nodiscard]] constexpr auto file_name() const noexcept
       -> decltype(_fileName) {
     return _fileName;
   }
+
   [[nodiscard]] constexpr auto line() const noexcept -> decltype(_line) {
     return _line;
+  }
+
+  [[nodiscard]] constexpr auto function_name() const noexcept
+      -> decltype(_functionName) {
+    return _functionName;
+  }
+
+  [[nodiscard]] constexpr auto column() const noexcept -> decltype(_column) {
+    return _column;
   }
 };
 
 auto operator<<(std::ostream&, SourceLocation const&) -> std::ostream&;
 
+// if pathStr is `/path/to/arangodb/lib/Basics/SourceLocation.h`,
+// then this will return `lib/Basics/SourceLocation.h`
+consteval auto stripPrefix(const char* pathStr) -> const char* {
+  // `/path/to/arangodb/lib/Basics/SourceLocation.h`
+  constexpr auto thisFile = std::string_view(__FILE__);
+  // `/path/to/arangodb/lib/Basics`
+  constexpr auto thisDir = thisFile.substr(0, thisFile.rfind('/'));
+  // `/path/to/arangodb/lib`
+  constexpr auto libDir = thisDir.substr(0, thisDir.rfind('/'));
+  // `/path/to/arangodb`
+  constexpr auto srcDir = libDir.substr(0, libDir.rfind('/'));
+  auto path = std::string_view{pathStr};
+  if (path.starts_with(srcDir)) {
+    // + 1 removes the slash
+    path.remove_prefix(srcDir.size() + 1);
+  }
+  return path.data();
+}
+
+static_assert(std::string_view{"lib/Basics/SourceLocation.h"}.compare(
+                  stripPrefix(__FILE__)) == 0);
+
 }  // namespace arangodb::basics
 
-#define ADB_HERE (::arangodb::basics::SourceLocation(__FILE__, __LINE__))
+#define ADB_HERE (::arangodb::basics::SourceLocation::current())

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -51,8 +51,7 @@ struct SourceLocation {
   // of uninitialized SourceLocations.
   SourceLocation() = delete;
 
-  consteval explicit SourceLocation(
-      std::source_location location) noexcept
+  consteval explicit SourceLocation(std::source_location location) noexcept
       : _fileName(_stripPrefix(location.file_name())),
         _functionName(location.function_name()),
         _line(location.line()) {}

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iosfwd>
 #include <source_location>
 #include <string_view>

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -52,7 +52,7 @@ struct SourceLocation {
   SourceLocation() = delete;
 
   consteval explicit SourceLocation(
-      std::source_location const location) noexcept
+      std::source_location location) noexcept
       : _fileName(stripPrefix(location.file_name())),
         _functionName(location.function_name()),
         _line(location.line()) {}

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -53,7 +53,7 @@ struct SourceLocation {
 
   consteval explicit SourceLocation(
       std::source_location location) noexcept
-      : _fileName(stripPrefix(location.file_name())),
+      : _fileName(_stripPrefix(location.file_name())),
         _functionName(location.function_name()),
         _line(location.line()) {}
 

--- a/lib/Basics/SourceLocation.h
+++ b/lib/Basics/SourceLocation.h
@@ -29,7 +29,6 @@
 #include <string_view>
 
 namespace arangodb::basics {
-consteval auto stripPrefix(const char* pathStr) -> const char*;
 
 // This is mostly a custom type around std::source_location with the same
 // interface; However, it changes the filename's path, so it's relative to the
@@ -75,13 +74,18 @@ struct SourceLocation {
   [[nodiscard]] constexpr auto column() const noexcept -> decltype(_column) {
     return _column;
   }
+
+  // if pathStr is `/path/to/arangodb/lib/Basics/SourceLocation.h`,
+  // then this will return `lib/Basics/SourceLocation.h`
+  consteval static auto _stripPrefix(const char* pathStr) -> const char*;
 };
 
 auto operator<<(std::ostream&, SourceLocation const&) -> std::ostream&;
 
 // if pathStr is `/path/to/arangodb/lib/Basics/SourceLocation.h`,
 // then this will return `lib/Basics/SourceLocation.h`
-consteval auto stripPrefix(const char* pathStr) -> const char* {
+consteval auto SourceLocation::_stripPrefix(const char* pathStr) -> const
+    char* {
   // `/path/to/arangodb/lib/Basics/SourceLocation.h`
   constexpr auto thisFile = std::string_view(__FILE__);
   // `/path/to/arangodb/lib/Basics`
@@ -99,7 +103,7 @@ consteval auto stripPrefix(const char* pathStr) -> const char* {
 }
 
 static_assert(std::string_view{"lib/Basics/SourceLocation.h"}.compare(
-                  stripPrefix(__FILE__)) == 0);
+                  SourceLocation::_stripPrefix(__FILE__)) == 0);
 
 }  // namespace arangodb::basics
 

--- a/tests/Basics/CMakeLists.txt
+++ b/tests/Basics/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(arangodbtests
   InputProcessorsTest.cpp
   OverloadTest.cpp
   SizeLimitedStringTest.cpp
+  SourceLocationTest.cpp
   StringBufferTest.cpp
   StringBufferInternalTest.cpp
   StringTest.cpp

--- a/tests/Basics/SourceLocationTest.cpp
+++ b/tests/Basics/SourceLocationTest.cpp
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Tobias Gödderz
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/SourceLocation.h"
+
+#include <filesystem>
+#include <ranges>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock-matchers.h>
+
+using namespace arangodb::basics;
+
+TEST(SourceLocationTest, filename_prefix) {
+  using namespace std::ranges::views;
+  using namespace testing;
+  namespace fs = std::filesystem;
+
+  // This path should end in .../tests/Basics/SourceLocationTest.cpp
+  auto const path = fs::path(__FILE__);
+
+  auto pathFromContentRoot = std::vector<std::string>{};
+  std::ranges::copy(path | reverse | take(3) | reverse,
+                    std::back_inserter(pathFromContentRoot));
+
+  // Just checking that the test is in its expected environment.
+  ASSERT_THAT(pathFromContentRoot,
+              ElementsAre("tests", "Basics", "SourceLocationTest.cpp"));
+
+  {
+    // now compare that with SourceLocation
+    auto loc = SourceLocation::current();
+    auto fn = loc.file_name();
+    auto expected = fs::path("tests") / fs::path("Basics") / fs::path("SourceLocationTest.cpp");
+    ASSERT_STREQ(fn, expected.c_str());
+  }
+}
+
+TEST(SourceLocationTest, line) {
+  ASSERT_EQ(SourceLocation::current().line(), __LINE__);
+}

--- a/tests/Basics/SourceLocationTest.cpp
+++ b/tests/Basics/SourceLocationTest.cpp
@@ -50,7 +50,8 @@ TEST(SourceLocationTest, filename_prefix) {
     // now compare that with SourceLocation
     auto loc = SourceLocation::current();
     auto fn = loc.file_name();
-    auto expected = fs::path("tests") / fs::path("Basics") / fs::path("SourceLocationTest.cpp");
+    auto expected = fs::path("tests") / fs::path("Basics") /
+                    fs::path("SourceLocationTest.cpp");
     ASSERT_STREQ(fn, expected.c_str());
   }
 }

--- a/tests/Replication2/Mocks/FakeFollower.cpp
+++ b/tests/Replication2/Mocks/FakeFollower.cpp
@@ -117,7 +117,7 @@ void FakeFollower::updateCommitIndex(LogIndex index) {
 void FakeFollower::resign() & {
   auto const exPtr =
       std::make_exception_ptr(replicated_log::ParticipantResignedException(
-          TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED, ADB_HERE));
+          TRI_ERROR_REPLICATION_REPLICATED_LOG_FOLLOWER_RESIGNED));
   waitForQueue.resolveAll(futures::Try<replicated_log::WaitForResult>(exPtr));
   waitForLeaderAckedQueue.resolveAll(
       futures::Try<replicated_log::WaitForResult>(exPtr));


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1470

1) Make use of std::source_location in SourceLocation, instead of __FILE__ and __LINE__, to make it more usable
2) Strip the prefix of the content root from the file name.

A little explanation for 2): SourceLocation is generally used to show where an exception originated from. There's usually no use to have the absolute path of that file on the machine that built the binary. So SourceLocation now makes the path relative to the content root; e.g., instead of `/root/project/arangodb/lib/Basics/SourceLocation.h`, the file_name will contain `lib/Basics/SourceLocation.h`.

- [X] :pizza: New feature

### Checklist

- [X] Tests
  - [X] C++ **Unit tests**