### PR TITLE
obsolete 3.11 feature flag

### DIFF
--- a/arangod/RestServer/QueryRegistryFeature.cpp
+++ b/arangod/RestServer/QueryRegistryFeature.cpp
@@ -249,6 +249,10 @@ void QueryRegistryFeature::collectOptions(
                         "query.cache-entries");
   options->addOldOption("database.disable-query-tracking", "query.tracking");
 
+  // option obsoleted since 3.12.1, because the APIs are turned on by default.
+  options->addObsoleteOption("query.enable-debug-apis",
+                             "Whether to enable query debug APIs.", false);
+
   options
       ->addOption("--query.global-memory-limit",
                   "The memory threshold for all AQL queries combined "


### PR DESCRIPTION
### Scope & Purpose

This PR adds the option `--query.enable-debug-apis` as an obsolete option in devel.
The option was introduced in 3.11.9 via https://github.com/arangodb/arangodb/pull/20770 as actual feature flag for some debugging APIs. These APIs are always available in devel, and cannot be turned off.
So while setting this option has no effect in devel, the existence of the options allows users to upgrade from ArangoDB 3.11.9 with having the startup option explicitly set.
If devel would not recognize the startup option as a valid option, it would otherwise bail out with an error on startup, thus preventing a successful upgrade.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 