### PR TITLE
work around log output limits in circleci?

### DIFF
--- a/js/client/modules/@arangodb/testsuites/fuerte.js
+++ b/js/client/modules/@arangodb/testsuites/fuerte.js
@@ -85,7 +85,7 @@ function gtestRunner(options) {
 
   let instanceManager = new im.instanceManager('tcp', options, {
     "http.keep-alive-timeout": "10",
-    "log.level": "requests=TRACE"
+    "log.level": "requests=INFO"
   }, 'fuerte');
   instanceManager.prepareInstance();
   instanceManager.launchTcpDump("");

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -425,7 +425,7 @@ class instance {
         'agency.my-address': this.protocol + '://127.0.0.1:' + this.port,
         // Sometimes for unknown reason the agency startup is too slow.
         // With this log level we might have a chance to see what is going on.
-        'log.level': "agency=debug",
+        'log.level': "agency=info",
       });
       if (!this.args.hasOwnProperty("agency.supervision-grace-period")) {
         this.args['agency.supervision-grace-period'] = '10.0';


### PR DESCRIPTION
### Scope & Purpose

Try to reduce log output for CircleCI runs. We suspect that runs with a too large log output now automatically fail in CircleCI. This is a test PR to validate this hypothesis.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 