### PR TITLE
make optimizer rule `async-prefetch` unavailable in 3.11.

### DIFF
--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -796,21 +796,6 @@ return a few results at a time.
 This optimization is performed on all subqueries and is applied after all other
 optimizations.)");
 
-  // allow nodes to asynchronously prefetch the next batch while processing the
-  // current batch. this effectively allows parts of the query to run in
-  // parallel, but as some internal details are currently not guaranteed to be
-  // thread safe (e.g., TransactionState), this is currently disabled, and
-  // should only be activated for experimental usage at one's own risk.
-  registerRule("async-prefetch", asyncPrefetchRule,
-               OptimizerRule::asyncPrefetch,
-               OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled,
-                                        OptimizerRule::Flags::DisabledByDefault,
-                                        OptimizerRule::Flags::Hidden),
-               R"(Allow query execution nodes to asynchronously prefetch the
-next batch while processing the current batch, allowing parts of the query to
-run in parallel. This is an experimental option as not all operations are
-thread-safe.)");
-
   // finally sort all rules by their level
   std::sort(_rules.begin(), _rules.end(),
             [](OptimizerRule const& lhs, OptimizerRule const& rhs) noexcept {


### PR DESCRIPTION
### Scope & Purpose

make the optimizer rule `async-prefetch` fully unavailable in 3.11, so that enabling it by accident does not cause any queries to execute the rule.
the motivation for this change is that although the `async-prefetch` optimizer rule already existed in 3.11, it was disabled by default and can lead to errors in query execution when enabled. thus it is better to fully disable the optimizer rule in 3.11 and only bring it back with version 3.12.0, where the rule's code has been rewritten and fixed.

no forward port to 3.12 is needed, as the optimizer rule has a different implementation there, and should be enabled by default.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: not needed
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 