### PR TITLE
remove obsolete check for new versions from web interface

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/frontend/js/routers/versionCheck.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/routers/versionCheck.js
@@ -1,33 +1,6 @@
 (function () {
   'use strict';
 
-  var showInterface = function (currentVersion, json) {
-    var buttons = [];
-
-    buttons.push(window.modalView.createSuccessButton('Download Page', function () {
-      window.open('https://www.arangodb.com/download', '_blank');
-      window.modalView.hide();
-    }));
-
-    var infos = [];
-    var cEntry = window.modalView.createReadOnlyEntry.bind(window.modalView);
-    infos.push(cEntry('current', 'Current', currentVersion.toString()));
-
-    if (json.major) {
-      infos.push(cEntry('major', 'Major', json.major.version));
-    }
-    if (json.minor) {
-      infos.push(cEntry('minor', 'Minor', json.minor.version));
-    }
-    if (json.bugfix) {
-      infos.push(cEntry('bugfix', 'Bugfix', json.bugfix.version));
-    }
-
-    window.modalView.show(
-      'modalTable.ejs', 'New Version Available', buttons, infos
-    );
-  };
-
   window.checkVersion = function () {
     // this checks for version updates
     $.ajax({
@@ -44,43 +17,7 @@
         $('.navbar #currentVersion').html(
           data.version + '<i class="fa fa-exclamation-circle"></i>'
         );
-
-        window.parseVersions = function (json) {
-          if (_.isEmpty(json)) {
-            $('#currentVersion').removeClass('out-of-date');
-            return; // no new version.
-          }
-          $('#currentVersion').addClass('out-of-date');
-          $('#currentVersion').click(function () {
-            showInterface(currentVersion, json);
-          });
-        };
-
-        $.ajax({
-          type: 'GET',
-          async: true,
-          crossDomain: true,
-          timeout: 3000,
-          dataType: 'jsonp',
-          url: 'https://www.arangodb.com/versions.php' +
-            '?jsonp=parseVersions'
-            + '&version=' + encodeURIComponent(data.version)
-            + '&platform=' + encodeURIComponent(data.platform)
-            + '&engine=' + encodeURIComponent(data.engine)
-            + '&license=' + encodeURIComponent(data.license)
-            + '&source=ui'
-            + '&hash=' + encodeURIComponent(data.hash),
-          error: function (e) {
-            if (e.status === 200) {
-              window.activeInternetConnection = true;
-            } else {
-              window.activeInternetConnection = false;
-            }
-          },
-          success: function (e) {
-            window.activeInternetConnection = true;
-          }
-        });
+        $('#currentVersion').removeClass('out-of-date');
       }
     });
   };


### PR DESCRIPTION
### Scope & Purpose

Remove an obsolete check for new server versions from the web interface.
The called API does not return the list of new server versions anymore, so making the AJAX call to it is pointless.
Apart from that, the call is likely blocked anyway by browsers because it is a cross-domain request.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 