### PR TITLE
ExecuteAsync for RestHandlers

### DIFF
--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -781,3 +781,9 @@ void RestHandler::resetResponse(rest::ResponseCode code) {
   TRI_ASSERT(_response != nullptr);
   _response->reset(code);
 }
+
+futures::Future<futures::Unit> RestHandler::executeAsync() {
+  THROW_ARANGO_EXCEPTION(TRI_ERROR_NOT_IMPLEMENTED);
+}
+
+RestStatus RestHandler::execute() { return waitForFuture(executeAsync()); }

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -127,7 +127,8 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   RequestLane determineRequestLane();
 
   virtual void prepareExecute(bool isContinue);
-  virtual RestStatus execute() = 0;
+  virtual RestStatus execute();
+  virtual futures::Future<futures::Unit> executeAsync();
   virtual RestStatus continueExecute() { return RestStatus::DONE; }
   virtual void shutdownExecute(bool isFinalized) noexcept;
 

--- a/arangod/RestHandler/RestSupervisionStateHandler.cpp
+++ b/arangod/RestHandler/RestSupervisionStateHandler.cpp
@@ -45,58 +45,46 @@ RestSupervisionStateHandler::RestSupervisionStateHandler(
     ArangodServer& server, GeneralRequest* request, GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response) {}
 
-RestStatus RestSupervisionStateHandler::execute() {
+futures::Future<futures::Unit> RestSupervisionStateHandler::executeAsync() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (_request->requestType() != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::NOT_IMPLEMENTED,
                   TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR);
-    return RestStatus::DONE;
+    co_return;
   }
 
-  auto self(shared_from_this());
-
   auto targetPath = arangodb::cluster::paths::root()->arango()->target();
-  return waitForFuture(
-      AsyncAgencyComm()
-          .getValues(targetPath)
-          .thenValue([this, self, targetPath = std::move(targetPath)](
-                         AgencyReadResult&& result) {
-            if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-              VPackBuffer<uint8_t> response;
-              {
-                VPackBuilder bodyBuilder(response);
-                VPackObjectBuilder ob(&bodyBuilder);
-                bodyBuilder.add("ToDo", result.slice().at(0).get(
-                                            targetPath->toDo()->vec()));
-                bodyBuilder.add("Pending", result.slice().at(0).get(
-                                               targetPath->pending()->vec()));
-                bodyBuilder.add("Finished", result.slice().at(0).get(
-                                                targetPath->finished()->vec()));
-                bodyBuilder.add("Failed", result.slice().at(0).get(
-                                              targetPath->failed()->vec()));
-              }
 
-              resetResponse(rest::ResponseCode::OK);
-              _response->setPayload(std::move(response));
-            } else {
-              generateError(result.asResult());
-            }
-          })
-          .thenError<VPackException>([this, self](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this, self](std::exception const&) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR);
-          }));
+  auto result = co_await AsyncAgencyComm().getValues(targetPath);
+
+  if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+    VPackBuffer<uint8_t> response;
+    {
+      VPackBuilder bodyBuilder(response);
+      VPackObjectBuilder ob(&bodyBuilder);
+      bodyBuilder.add("ToDo",
+                      result.slice().at(0).get(targetPath->toDo()->vec()));
+      bodyBuilder.add("Pending",
+                      result.slice().at(0).get(targetPath->pending()->vec()));
+      bodyBuilder.add("Finished",
+                      result.slice().at(0).get(targetPath->finished()->vec()));
+      bodyBuilder.add("Failed",
+                      result.slice().at(0).get(targetPath->failed()->vec()));
+    }
+
+    resetResponse(rest::ResponseCode::OK);
+    _response->setPayload(std::move(response));
+  } else {
+    generateError(result.asResult());
+  }
 }

--- a/arangod/RestHandler/RestSupervisionStateHandler.h
+++ b/arangod/RestHandler/RestSupervisionStateHandler.h
@@ -34,7 +34,7 @@ class RestSupervisionStateHandler : public RestVocbaseBaseHandler {
   ~RestSupervisionStateHandler() = default;
 
  public:
-  RestStatus execute() override;
+  futures::Future<futures::Unit> executeAsync() override;
   char const* name() const override final {
     return "RestSupervisionStateHandler";
   }


### PR DESCRIPTION
### Scope & Purpose
Add the `executeAsync` function to rest handlers. It can be implemented instead of the `execute` function. The future returned is automatically awaited and the rest handlers lifetime will exceed that of the execution of the future.