### PR TITLE
[3.11]: Make ArangoLanguageFeature unit test independent from system locale

### DIFF
--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -136,9 +136,8 @@ std::string_view getNonSysLang() {
   const std::string_view currSysLang =
       std::string_view(setlocale(LC_ALL, NULL)).substr(0, 2);
 
-  auto sg = arangodb::scopeGuard([&]() noexcept {
-    setlocale(LC_ALL, before.c_str());
-  });
+  auto sg = arangodb::scopeGuard(
+      [&]() noexcept { setlocale(LC_ALL, before.c_str()); });
 
   if (currSysLang == "de") {
     return kRussian;

--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -131,13 +131,13 @@ constexpr std::string_view kGerman = "de";
 constexpr std::string_view kRussian = "ru";
 
 std::string_view getNonSysLang() {
-  auto before = std::string_view(setlocale(LC_ALL, NULL)).substr(0, 2);
+  auto before = std::string(setlocale(LC_ALL, NULL));
   setlocale(LC_ALL, "");
   const std::string_view currSysLang =
       std::string_view(setlocale(LC_ALL, NULL)).substr(0, 2);
 
   auto sg = arangodb::scopeGuard([&]() noexcept {
-    setlocale(LC_ALL, before.data());
+    setlocale(LC_ALL, before.c_str());
   });
 
   if (currSysLang == "de") {

--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -131,9 +131,15 @@ constexpr std::string_view kGerman = "de";
 constexpr std::string_view kRussian = "ru";
 
 std::string_view getNonSysLang() {
+  auto before = std::string_view(setlocale(LC_ALL, NULL)).substr(0, 2);
   setlocale(LC_ALL, "");
   const std::string_view currSysLang =
       std::string_view(setlocale(LC_ALL, NULL)).substr(0, 2);
+
+  auto sg = arangodb::scopeGuard([&]() noexcept {
+    setlocale(LC_ALL, before.data());
+  });
+
   if (currSysLang == "de") {
     return kRussian;
   } else {
@@ -325,7 +331,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
 
   constexpr std::string_view firstLang = "sv";
   constexpr std::string_view secondLang = "de";
-  ;
 
   // Enable force check for languages
   server.server()


### PR DESCRIPTION
Make ArangoLanguageFeature unit test independent from system locale (#20777)

* Initial commit

* test debug

* wip

* wip

* fix clang-format

* clear debug output

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
