### PR TITLE
Added metric `arangodb_logger_messages_dropped_total`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Changed default value of `--log.max-queued-entries` from 10000 to 16384.
+
 * Added metric `arangodb_logger_messages_dropped_total` to count the number
   of log messages that were discarded by the logger if its log queue was full.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added metric `arangodb_logger_messages_dropped_total` to count the number
+  of log messages that were discarded by the logger if its log queue was full.
+
 * Added option `skipFastLockRound` for transactions.
   The option can be set in a streaming write transaction's options (i.e. 
   `{"skipFastLockRound":true}`) to disable the fast lock round inside the

--- a/Documentation/Metrics/arangodb_logger_messages_dropped_total.yaml
+++ b/Documentation/Metrics/arangodb_logger_messages_dropped_total.yaml
@@ -1,0 +1,39 @@
+name: arangodb_logger_messages_dropped_total
+introducedIn: "3.12.1"
+help: |
+  Total number of dropped log messages.
+unit: number
+type: counter
+category: Statistics
+complexity: simple
+exposedBy:
+  - agent
+  - coordinator
+  - dbserver
+  - single
+description: |
+  Total number of log messages that were dropped by the logger.
+
+  Log messages that are produced by worker threads are pushed into a log
+  queue that is owned by a dedicated logger thread. This dedicated log
+  thread is then responsible for writing the log messages out to disk or
+  stdout asynchronously.
+  As there can be many threads that produce log messages, but only one
+  thread that consumes and logs messages from the log queue, it is possible
+  that the log queue grows too large, potentially consuming a lot of
+  memory to buffer all non-consumed log messages in RAM.
+  In order to prevent the log queue from using too much memory, its size
+  is bounded. The startup option `--log.max-queued-entries` controls the
+  maximum size of the log queue.
+  Whenever the log queue has reached its capacity limit and a log producer
+  thread tries to push a log message to the log queue, the log message
+  will be dropped. For every dropped log message this metric will be 
+  increased by one, so it becomes visible that log messages were dropped.
+troubleshoot: |
+  In case this metric is greater than one, there is too much logging
+  going on for the log thread to keep up with incoming log messages. There
+  are two ways to counteract this. 
+  Either the log levels needed to be lowered (e.g. from "trace" to "debug"
+  or from "debug" to "info"), or the maximum capacity of the log queue
+  needs to be increased. This can be achieved by adjusting the value of
+  the startup option `--log.max-queued-entries` to a higher value.

--- a/arangod/RestServer/LogBufferFeature.h
+++ b/arangod/RestServer/LogBufferFeature.h
@@ -70,6 +70,7 @@ class LogBufferFeature final : public ArangodFeature {
 
  private:
   std::shared_ptr<LogAppender> _inMemoryAppender;
+  std::shared_ptr<LogAppender> _metricsCounter;
   std::string _minInMemoryLogLevel;
   bool _useInMemoryAppender;
 };

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -79,7 +79,8 @@ bool LogThread::log(LogGroup& group, std::unique_ptr<LogMessage>& message) {
 
   if (!_messages.push({&group, message.get()})) {
     // unable to push message onto the queue.
-    // this will execute the rollback.
+    // this will also execute the rollback.
+    return false;
   }
 
   rollback.cancel();

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -58,6 +58,9 @@ bool LogThread::log(LogGroup& group, std::unique_ptr<LogMessage>& message) {
       !_messages.push({&group, message.get()})) {
     /* roll back the update */
     _pendingMessages.fetch_sub(1, std::memory_order_relaxed);
+
+    // inform logger that we dropped a message
+    Logger::onDroppedMessage();
     return false;
   }
 

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "LogThread.h"
+#include "Basics/ScopeGuard.h"
 #include "Basics/debugging.h"
 #include "Logger/LogAppender.h"
 #include "Logger/Logger.h"
@@ -48,21 +49,34 @@ bool LogThread::log(LogGroup& group, std::unique_ptr<LogMessage>& message) {
     return true;
   }
 
-  bool const isDirectLogLevel =
+  bool isDirectLogLevel =
       (message->_level == LogLevel::FATAL || message->_level == LogLevel::ERR ||
        message->_level == LogLevel::WARN);
 
   auto numMessages =
       _pendingMessages.fetch_add(1, std::memory_order_relaxed) + 1;
-  if (numMessages >= _maxQueuedLogMessages ||
-      !_messages.push({&group, message.get()})) {
-    /* roll back the update */
+
+  auto rollback = scopeGuard([&]() noexcept {
+    // roll back the counter update
     _pendingMessages.fetch_sub(1, std::memory_order_relaxed);
 
-    // inform logger that we dropped a message
+    // and inform logger that we dropped a message
+    // the callback function is noexcept, too.
     Logger::onDroppedMessage();
+  });
+
+  if (numMessages >= _maxQueuedLogMessages && !isDirectLogLevel) {
+    // log queue is full, and the message is not important enough
+    // to push it anyway. this will execute the rollback.
     return false;
   }
+
+  if (!_messages.push({&group, message.get()})) {
+    // unable to push message onto the queue.
+    // this will execute the rollback.
+  }
+
+  rollback.cancel();
 
   // only release message if adding to the queue succeeded
   // otherwise we would leak here

--- a/lib/Logger/LogThread.h
+++ b/lib/Logger/LogThread.h
@@ -28,6 +28,9 @@
 
 #include <boost/lockfree/queue.hpp>
 
+#include <atomic>
+#include <cstdint>
+
 namespace arangodb {
 class LogGroup;
 namespace application_features {
@@ -50,7 +53,6 @@ class LogThread final : public Thread {
                      std::string const& name, uint32_t maxQueuedLogMessages);
   ~LogThread();
 
- public:
   bool isSystem() const override { return true; }
   bool isSilent() const override { return true; }
   void run() override;
@@ -69,7 +71,7 @@ class LogThread final : public Thread {
   bool processPendingMessages();
 
  private:
-  arangodb::basics::ConditionVariable _condition;
+  basics::ConditionVariable _condition;
   boost::lockfree::queue<MessageEnvelope> _messages;
   std::atomic<size_t> _pendingMessages{0};
   uint32_t _maxQueuedLogMessages{10000};

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -56,6 +56,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -309,6 +310,9 @@ class Logger {
   static void shutdown();
   static void flush() noexcept;
 
+  static void setOnDroppedMessage(std::function<void()> cb);
+  static void onDroppedMessage() noexcept;
+
  private:
   // these variables might be changed asynchronously
   static std::atomic<bool> _active;
@@ -343,9 +347,9 @@ class Logger {
     ThreadRef();
     ~ThreadRef();
 
-    ThreadRef(const ThreadRef&) = delete;
+    ThreadRef(ThreadRef const&) = delete;
     ThreadRef(ThreadRef&&) = delete;
-    ThreadRef& operator=(const ThreadRef&) = delete;
+    ThreadRef& operator=(ThreadRef const&) = delete;
     ThreadRef& operator=(ThreadRef&&) = delete;
 
     LogThread* operator->() const noexcept { return _thread; }
@@ -357,8 +361,10 @@ class Logger {
 
   // logger thread. only populated when threaded logging is selected.
   // the pointer must only be used with atomic accessors after the ref counter
-  // has been increased. Best to usethe ThreadRef class for this!
+  // has been increased. Best to use the ThreadRef class for this!
   static std::atomic<std::size_t> _loggingThreadRefs;
   static std::atomic<LogThread*> _loggingThread;
+
+  static std::function<void()> _onDroppedMessage;
 };
 }  // namespace arangodb

--- a/lib/Logger/LoggerFeature.h
+++ b/lib/Logger/LoggerFeature.h
@@ -62,11 +62,11 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   void prepare() override final;
   void unprepare() override final;
 
-  void disableThreaded() { _threaded = false; }
-  void setSupervisor(bool supervisor) { _supervisor = supervisor; }
+  void disableThreaded() noexcept { _threaded = false; }
+  void setSupervisor(bool supervisor) noexcept { _supervisor = supervisor; }
 
-  bool isAPIEnabled() const { return _apiEnabled; }
-  bool onlySuperUser() const { return _apiSwitch == "jwt"; }
+  bool isAPIEnabled() const noexcept { return _apiEnabled; }
+  bool onlySuperUser() const noexcept { return _apiSwitch == "jwt"; }
 
  private:
   LoggerFeature(application_features::ApplicationServer& server,
@@ -80,8 +80,10 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   std::string _fileMode;
   std::string _fileGroup;
   std::string _timeFormatString;
+  std::string _apiSwitch = "true";
   std::vector<std::string> _structuredLogParams;
   uint32_t _maxEntryLength = 128U * 1048576U;
+  uint32_t _maxQueuedLogMessages = 16384;
   bool _useJson = false;
   bool _useLocalTime = false;
   bool _useColor = true;
@@ -96,14 +98,12 @@ class LoggerFeature final : public application_features::ApplicationFeature {
   bool _keepLogRotate = false;
   bool _foregroundTty = false;
   bool _forceDirect = false;
-  uint32_t _maxQueuedLogMessages = 10000;
   bool _useMicrotime = false;
   bool _showIds = true;
   bool _showRole = false;
   bool _logRequestParameters = true;
   bool _supervisor = false;
   bool _threaded = false;
-  std::string _apiSwitch = "true";
   bool _apiEnabled = true;
 };
 

--- a/tests/js/client/server_parameters/log-dropped-messages-noncluster.js
+++ b/tests/js/client/server_parameters/log-dropped-messages-noncluster.js
@@ -1,0 +1,58 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertTrue, assertFalse, arango, assertEqual */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'log.max-queued-entries': '0',
+    'javascript.allow-admin-execute': 'true',
+    'log.force-direct': 'false',
+    'log.foreground-tty': 'false',
+  };
+}
+
+const jsunity = require('jsunity');
+const getMetric = require('@arangodb/test-helper').getMetricSingle;
+
+function LoggerSuite() {
+  'use strict';
+
+  return {
+    testDroppedMessages: function () {
+      const oldValue = getMetric("arangodb_logger_messages_dropped_total");
+
+      let res = arango.POST_RAW("/_admin/execute", "for (let i = 0; i < 100; ++i) { require('console').error('abc'); }");
+      assertEqual(200, res.code, res);
+
+      const newValue = getMetric("arangodb_logger_messages_dropped_total");
+      assertTrue(newValue >= oldValue + 100, {oldValue, newValue});
+    },
+
+  };
+}
+
+jsunity.run(LoggerSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

* Added metric `arangodb_logger_messages_dropped_total` to count the number of log messages that were discarded by the logger if its log queue was full.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
