### PR TITLE
fix ASan errors in test

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -888,8 +888,10 @@ void RocksDBEngine::verifySstFiles(rocksdb::Options const& options) const {
       << "verification of RocksDB .sst files in path '" << _path
       << "' completed successfully";
   Logger::flush();
-
-  exit(EXIT_SUCCESS);
+  // exit with status code = 0, without leaking
+  int exitCode = static_cast<int>(TRI_ERROR_NO_ERROR);
+  TRI_EXIT_FUNCTION(exitCode, nullptr);
+  exit(exitCode);
 }
 
 namespace {

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -267,7 +267,16 @@ SupervisedScheduler::SupervisedScheduler(
   TRI_ASSERT(fifo3Size > 0);
 }
 
-SupervisedScheduler::~SupervisedScheduler() = default;
+SupervisedScheduler::~SupervisedScheduler() {
+  // make sure we are freeing all items from all queues here if we
+  // are in an uncontrolled shutdown
+  for (size_t i = 0; i < NumberOfQueues; ++i) {
+    WorkItemBase* res = nullptr;
+    while (_queues[i].queue.pop(res)) {
+      delete res;
+    }
+  }
+}
 
 void SupervisedScheduler::trackQueueItemSize(std::int64_t x) noexcept {
   _schedulerQueueMemory += x;

--- a/arangod/Transaction/ManagerFeature.cpp
+++ b/arangod/Transaction/ManagerFeature.cpp
@@ -70,7 +70,9 @@ ManagerFeature::ManagerFeature(Server& server)
       return;
     }
 
-    MANAGER->garbageCollect(/*abortAll*/ false);
+    if (MANAGER != nullptr) {
+      MANAGER->garbageCollect(/*abortAll*/ false);
+    }
 
     if (!this->server().isStopping()) {
       queueGarbageCollection();
@@ -78,7 +80,10 @@ ManagerFeature::ManagerFeature(Server& server)
   };
 }
 
-ManagerFeature::~ManagerFeature() = default;
+ManagerFeature::~ManagerFeature() {
+  std::lock_guard<std::mutex> guard(_workItemMutex);
+  _workItem.reset();
+}
 
 void ManagerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("transaction", "transactions");

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -37,6 +37,12 @@ LogThread::LogThread(application_features::ApplicationServer& server,
 LogThread::~LogThread() {
   Logger::_active = false;
 
+  // make sure there are no memory leaks on uncontrolled shutdown
+  MessageEnvelope env{nullptr, nullptr};
+  while (_messages.pop(env)) {
+    delete env.msg;
+  }
+
   shutdown();
 }
 


### PR DESCRIPTION
### Scope & Purpose

Fix ASan errors in test.
Should fix the following test error with sanitizers enabled:

```
[FAILED]  tests/js/client/shell/shell-verify-sst-noncluster.js

  "testVerify" failed: Error: at assertion #6: {
  "pid" : 896,
  "status" : "TERMINATED",
  "exit" : 1
}: (1) is not equal to (0)
(Error
    at verifySsts (tests/js/client/shell/shell-verify-sst-noncluster.js:106:9)
    at tests/js/client/shell/shell-verify-sst-noncluster.js:116:11
    at Object.testVerify (tests/js/client/shell/shell-verify-sst-noncluster.js:111:12)
....    at Object.shellClient [as shell_client] (/root/project/js/client/modules/@arangodb/testsuites/aql.js:209:79)
 - test failed
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 