### PR TITLE
try to improve non-deterministic test

### DIFF
--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -1708,10 +1708,19 @@ TEST_F(IResearchLinkTest, test_maintenance_disabled_at_creation) {
     ASSERT_TRUE(created);
     ASSERT_NE(nullptr, link);
 
+    // 1st - tasks active(), 2nd - tasks pending(), 3rd - threads()
     ASSERT_EQ(std::make_tuple(size_t(1), size_t(0), size_t(1)),
               feature.stats(ThreadGroup::_0));
-    ASSERT_EQ(std::make_tuple(size_t(1), size_t(0), size_t(1)),
-              feature.stats(ThreadGroup::_1));
+
+    std::tuple<size_t, size_t, size_t> stats;
+    do {
+      stats = feature.stats(ThreadGroup::_1);
+      if (std::get<0>(stats) == 1) {
+        break;
+      }
+      // spin
+    } while (true);
+    ASSERT_EQ(std::make_tuple(size_t(1), size_t(0), size_t(1)), stats);
   }
 
   ASSERT_TRUE(link->drop().ok());


### PR DESCRIPTION
### Scope & Purpose

Try to improve an unstable iresearch test.
The following test failure was often seen:

    [FAILED]  IResearchLinkTest

      "test" failed: /root/project/tests/IResearch/IResearchLinkTest.cpp:1714
Expected equality of these values:
  std::make_tuple(size_t(1), size_t(0), size_t(1))
    Which is: (1, 0, 1)
  feature.stats(ThreadGroup::_1)
    Which is: (0, 1, 1)

The failure is due to a race between the iresearch thread pool picking up and starting a task and the test checking for the task to be started.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 