### PR TITLE
Adding parenthesis around error message

### DIFF
--- a/arangod/VocBase/Properties/CreateCollectionBody.cpp
+++ b/arangod/VocBase/Properties/CreateCollectionBody.cpp
@@ -60,10 +60,11 @@ auto rewriteStatusErrorMessage(inspection::Status const& status) -> Result {
     return Result{TRI_ERROR_VALIDATION_BAD_PARAMETER, status.error()};
   }
 
-  return Result{
-      TRI_ERROR_BAD_PARAMETER,
-      status.error() +
-          (status.path().empty() ? "" : " on attribute " + status.path())};
+  return Result{TRI_ERROR_BAD_PARAMETER,
+                status.error() +
+                    (status.path().empty()
+                         ? ""
+                         : fmt::format(" (on attribute {})", status.path()))};
 }
 
 auto rewriteStatusErrorMessageForRestore(inspection::Status const& status)
@@ -96,10 +97,11 @@ auto rewriteStatusErrorMessageForRestore(inspection::Status const& status)
     return Result{TRI_ERROR_VALIDATION_BAD_PARAMETER, status.error()};
   }
 
-  return Result{
-      TRI_ERROR_BAD_PARAMETER,
-      status.error() +
-          (status.path().empty() ? "" : " on attribute " + status.path())};
+  return Result{TRI_ERROR_BAD_PARAMETER,
+                status.error() +
+                    (status.path().empty()
+                         ? ""
+                         : fmt::format(" (on attribute {})", status.path()))};
 }
 
 auto handleShards(std::string_view, VPackSlice value, VPackSlice fullBody,

--- a/arangod/VocBase/Properties/CreateCollectionBody.cpp
+++ b/arangod/VocBase/Properties/CreateCollectionBody.cpp
@@ -61,10 +61,10 @@ auto rewriteStatusErrorMessage(inspection::Status const& status) -> Result {
   }
 
   return Result{TRI_ERROR_BAD_PARAMETER,
-                status.error() +
-                    (status.path().empty()
-                         ? ""
-                         : fmt::format(" (on attribute {})", status.path()))};
+                status.error() + (status.path().empty()
+                                      ? ""
+                                      : fmt::format(" (on attribute \"{}\")",
+                                                    status.path()))};
 }
 
 auto rewriteStatusErrorMessageForRestore(inspection::Status const& status)
@@ -98,10 +98,10 @@ auto rewriteStatusErrorMessageForRestore(inspection::Status const& status)
   }
 
   return Result{TRI_ERROR_BAD_PARAMETER,
-                status.error() +
-                    (status.path().empty()
-                         ? ""
-                         : fmt::format(" (on attribute {})", status.path()))};
+                status.error() + (status.path().empty()
+                                      ? ""
+                                      : fmt::format(" (on attribute \"{}\")",
+                                                    status.path()))};
 }
 
 auto handleShards(std::string_view, VPackSlice value, VPackSlice fullBody,


### PR DESCRIPTION
### Scope & Purpose

While working on the Python driver, I noticed that an error message looks rather strange: `Value cannot be empty. on attribute distributeShardsLike`. It's nothing bad really, but due to the way the string gets formatted in some cases we get a dot before the on _attribute..._, which looks as if the sentence is incomplete.
This PR simply adds some parenthesis around that, to make it look more like an additional explanation of the previous sentence: `Value cannot be empty. (on attribute "distributeShardsLike")`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
