### PR TITLE
disable non-v8 build in the CI

### DIFF
--- a/.circleci/generate_config.py
+++ b/.circleci/generate_config.py
@@ -482,17 +482,6 @@ def add_x64_enterprise_workflow(workflows, tests, args):
                 "build-tests": False,
             },
         )
-        add_build_job(
-            workflow,
-            build_config,
-            {
-                "name": "build-ee-no-v8-x64",
-                "preset": "enterprise-pr-no-v8",
-                "publish-artifacts": False,
-                "build-tests": False,
-                "build-v8": False,
-            },
-        )
 
 
 def add_aarch64_community_workflow(workflows, tests, args):


### PR DESCRIPTION
### Scope & Purpose

Disable building with `-DUSE_V8=Off` in every CI run. This is an attempt to reduce (cumulated) build times/container usage times and thus CI costs.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 