### PR TITLE
Transactions reaching max size

### DIFF
--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -167,11 +167,10 @@ Result RocksDBTrxBaseMethods::addOperation(
 
   if (_memoryTracker.memoryUsage() > _state->options().maxTransactionSize) {
     // we hit the transaction size limit
-    return {
-        TRI_ERROR_RESOURCE_LIMIT,
-        absl::StrCat(
-            "aborting transaction because maximal transaction size limit of ",
-            _state->options().maxTransactionSize, " bytes is reached")};
+    return {TRI_ERROR_RESOURCE_LIMIT,
+            absl::StrCat("Maximal transaction size limit of ",
+                         _state->options().maxTransactionSize,
+                         " bytes is reached")};
   }
 
   switch (operationType) {

--- a/tests/js/client/server_parameters/test-streaming-max-transaction-size.js
+++ b/tests/js/client/server_parameters/test-streaming-max-transaction-size.js
@@ -128,7 +128,7 @@ function testSuite() {
         }
         ++docCount;
       }
-      assertTrue(docCount > 0, "We didn't insert anything, better check maxTransactionSize!")
+      assertTrue(docCount > 0, "We didn't insert anything, better check maxTransactionSize!");
       assertTrue(docCount < maxDocs, "We actually inserted everything, better check maxTransactionSize!");
       trx.commit();
       c = db._collection(cn);


### PR DESCRIPTION
### Scope & Purpose

The `maxTransactionSize` option is there to limit the memory usage of a given transaction. Upon reaching this limitation, any subsequent operations are being rejected, but the transaction can be continued and even committed. However, the error message is misleading, as it states the the transaction is being *aborted*, which is not the case.

This PR modifies the error message and adds a clear test, showcasing the expected behavior.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification