### PR TITLE
Docs: Clarify what at signs do in startup options

### DIFF
--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -129,7 +129,7 @@ arangosh without connecting to a server.)");
       "--server.password",
       "The password to use when connecting. If not specified and "
       "authentication is required, you are prompted for a password.\n"
-      "In startup options, you can wrap the names of an environment variables "
+      "In startup options, you can wrap the names of environment variables "
       "in at signs to use their value, like @ARANGO_PASSWORD@. This helps to "
       "expose the password less, like to the process list. "
       "Literal @ need to be escaped as @@.",

--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -125,11 +125,13 @@ void ClientFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 arangosh without connecting to a server.)");
   }
 
-  options->addOption("--server.password",
-                     "The password to use when connecting. If not specified "
-                     "and authentication is required, the user is prompted for "
-                     "a password",
-                     new StringParameter(&_password));
+  options->addOption(
+      "--server.password",
+      "The password to use when connecting. If not specified and "
+      "authentication is required, you are prompted for a password. "
+      "You can wrap the name of an environment variable in at signs to use its "
+      "value, like @ARANGO_PASSWORD@. Literal @ need to be escaped as @@.",
+      new StringParameter(&_password));
 
   if (isArangosh) {
     // this option is only available in arangosh

--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -128,9 +128,11 @@ arangosh without connecting to a server.)");
   options->addOption(
       "--server.password",
       "The password to use when connecting. If not specified and "
-      "authentication is required, you are prompted for a password. "
-      "You can wrap the name of an environment variable in at signs to use its "
-      "value, like @ARANGO_PASSWORD@. Literal @ need to be escaped as @@.",
+      "authentication is required, you are prompted for a password.\n"
+      "In startup options, you can wrap the names of an environment variables "
+      "in at signs to use their value, like @ARANGO_PASSWORD@. This helps to "
+      "expose the password less, like to the process list. "
+      "Literal @ need to be escaped as @@.",
       new StringParameter(&_password));
 
   if (isArangosh) {


### PR DESCRIPTION
### Scope & Purpose

Use @ENV_VAR@ value, escaping a literal at like @@

### Checklist

- [ ] Backports ?
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
