### PR TITLE
try to reduce memory usage of subquery chaos test

### DIFF
--- a/js/common/modules/@arangodb/test-generators/subquery-chaos-test.js
+++ b/js/common/modules/@arangodb/test-generators/subquery-chaos-test.js
@@ -27,6 +27,8 @@ const db = require("@arangodb").db;
 const _ = require("lodash");
 const {md5} = require("@arangodb/crypto");
 
+const batchSize = 10;
+
 // This is a seedable RandomNumberGenerator
 // it is not operfect for Random numbers,
 // but good enough for what we are doing here
@@ -295,7 +297,7 @@ function runQuery(query, queryOptions, testOptions) {
   }
 
   /* Run query */
-  const result = db._createStatement({query: query.queryString, options: queryOptions}).execute();
+  const result = db._createStatement({query: query.queryString, batchSize, options: queryOptions}).execute();
  
   /* Create a simple hash value from the query results, so that we don't have to
    * load the entire result set into memory and work with it */
@@ -320,12 +322,12 @@ function testQuery(query, testOptions) {
   }
 
   /* Run query with all optimizations */
-  const result1 = runQuery(query, {}, testOptions);
+  const result1 = runQuery(query, {batchSize}, testOptions);
 
   /* Run query with full count */
   const result2 = runQuery(
     query,
-    { fullCount: true }, 
+    {fullCount: true, batchSize}, 
     testOptions
   );
 

--- a/js/common/modules/@arangodb/test-generators/subquery-chaos-test.js
+++ b/js/common/modules/@arangodb/test-generators/subquery-chaos-test.js
@@ -25,6 +25,7 @@
 // //////////////////////////////////////////////////////////////////////////////
 const db = require("@arangodb").db;
 const _ = require("lodash");
+const {md5} = require("@arangodb/crypto");
 
 // This is a seedable RandomNumberGenerator
 // it is not operfect for Random numbers,
@@ -88,7 +89,7 @@ function popRandomElement(generator, list) {
 
 function randomFilter(generator, indent, bias, variables = []) {
   if (variables.length > 0 && coinToss(generator, bias)) {
-    var variable = Math.trunc(randomInt(generator, 0, variables.length));
+    let variable = Math.trunc(randomInt(generator, 0, variables.length));
     return (
       indent +
       " FILTER " +
@@ -130,7 +131,7 @@ function randomUpsert(generator, indent, bias, variables, collectionName) {
 }
 
 function* idGeneratorGenerator() {
-  var counter = 0;
+  let counter = 0;
   while (true) {
     yield counter;
     counter = counter + 1;
@@ -138,7 +139,7 @@ function* idGeneratorGenerator() {
 }
 
 function createChaosQuery(seed, numberSubqueries) {
-  var subqueryTotal = numberSubqueries;
+  let subqueryTotal = numberSubqueries;
   const idGenerator = idGeneratorGenerator();
   const randomGenerator = randomNumberGeneratorGenerator(seed);
   const collectionSize = 20;
@@ -146,7 +147,7 @@ function createChaosQuery(seed, numberSubqueries) {
   const query = function (indent, outerVariables) {
     // We have access to all variables in the enclosing scope
     // but we don't want them to leak outside, so we take a copy
-    var variables = {
+    let variables = {
       forVariables: [...outerVariables.forVariables],
       subqueryVariables: [...outerVariables.subqueryVariables],
     };
@@ -154,34 +155,32 @@ function createChaosQuery(seed, numberSubqueries) {
     const for_variable = "fv" + idGenerator.next().value;
     variables.forVariables.push(for_variable);
 
-    var my_query = "FOR " + for_variable + " IN 1.." + collectionSize + "\n";
+    let my_query = "FOR " + for_variable + " IN 1.." + collectionSize + "\n";
 
     my_query = my_query + randomFilter(randomGenerator, indent, 0.2, variables);
 
-    var nqueries = randomInt(randomGenerator, 0, Math.min(subqueryTotal, 3));
-    subqueryTotal = subqueryTotal - nqueries;
-    for (var i = 0; i < nqueries; i++) {
-      var sqv = "sq" + idGenerator.next().value;
-      var sq = query(indent + "  ", variables);
+    let nqueries = randomInt(randomGenerator, 0, Math.min(subqueryTotal, 3));
+    subqueryTotal -= nqueries;
+    for (let i = 0; i < nqueries; i++) {
+      let sqv = "sq" + idGenerator.next().value;
+      let sq = query(indent + "  ", variables);
       variables.subqueryVariables.push(sqv);
 
-      my_query = my_query + indent + " LET " + sqv + " = (" + sq + ")\n";
-      my_query =
-        my_query + randomFilter(randomGenerator, 0.4, variables.forVariables);
+      my_query += indent + " LET " + sqv + " = (" + sq + ")\n";
+      my_query += randomFilter(randomGenerator, 0.4, variables.forVariables);
     }
 
-    my_query = my_query + randomLimit(randomGenerator, indent, 0.7);
+    my_query += randomLimit(randomGenerator, indent, 0.7);
 
-    var collect = randomCollectWithCount(randomGenerator, indent, 0.1);
+    let collect = randomCollectWithCount(randomGenerator, indent, 0.1);
     if (collect !== "") {
-      my_query = my_query + collect;
+      my_query += collect;
       variables = { forVariables: [], subqueryVariables: ["counter"] };
     } else {
       variables.forVariables = [for_variable];
     }
 
-    my_query =
-      my_query +
+    my_query +=
       indent +
       " RETURN {" +
       [...variables.forVariables, ...variables.subqueryVariables].join(", ") +
@@ -196,22 +195,22 @@ function createChaosQuery(seed, numberSubqueries) {
 }
 
 function createModifyingChaosQuery(seed, numberSubqueries) {
-  var subqueryTotal = numberSubqueries;
+  let subqueryTotal = numberSubqueries;
   const idGenerator = idGeneratorGenerator();
   const randomGenerator = randomNumberGeneratorGenerator(seed);
   const collectionSize = 20;
 
   const collectionIdGenerator = (function* () {
-    var counter = 0;
+    let counter = 0;
     while (true) {
-      var cn = "SubqueryChaosCollection" + counter;
+      let cn = "SubqueryChaosCollection" + counter;
       counter = counter + 1;
       yield cn;
     }
   })();
 
   const query = function (indent, outerVariables) {
-    var variables = {
+    let variables = {
       forVariables: [...outerVariables.forVariables],
       subqueryVariables: [...outerVariables.subqueryVariables],
       collectionNames: [...outerVariables.collectionNames],
@@ -222,30 +221,26 @@ function createModifyingChaosQuery(seed, numberSubqueries) {
 
     const collection = collectionIdGenerator.next().value;
     variables.collectionNames.push(collection);
-    var my_query = "FOR " + for_variable + " IN " + collection + " \n";
+    let my_query = "FOR " + for_variable + " IN " + collection + " \n";
 
-    my_query = my_query + randomFilter(randomGenerator, indent, 0.2, variables);
+    my_query += randomFilter(randomGenerator, indent, 0.2, variables);
 
-    var nqueries = randomInt(randomGenerator, 0, Math.min(subqueryTotal, 3));
-    subqueryTotal = subqueryTotal - nqueries;
-    for (var i = 0; i < nqueries; i++) {
-      var sqv = "sq" + idGenerator.next().value;
-      var sq = query(indent + "  ", variables);
+    let nqueries = randomInt(randomGenerator, 0, Math.min(subqueryTotal, 3));
+    subqueryTotal -= nqueries;
+    for (let i = 0; i < nqueries; i++) {
+      let sqv = "sq" + idGenerator.next().value;
+      let sq = query(indent + "  ", variables);
       variables.subqueryVariables.push(sqv);
       variables.collectionNames = sq.collectionNames;
 
-      my_query =
-        my_query + indent + " LET " + sqv + " = (" + sq.queryString + ")\n";
-      my_query =
-        my_query +
-        randomFilter(randomGenerator, indent, 0.4, variables.forVariables);
+      my_query += indent + " LET " + sqv + " = (" + sq.queryString + ")\n";
+      my_query += randomFilter(randomGenerator, indent, 0.4, variables.forVariables);
     }
 
     // at the moment we only modify the current collection, as we otherwise
     // run into problems with generating queries that try to access data after
     // modification
-    my_query =
-      my_query +
+    my_query +=
       randomUpsert(
         randomGenerator,
         indent,
@@ -254,11 +249,11 @@ function createModifyingChaosQuery(seed, numberSubqueries) {
         collection
       );
 
-    my_query = my_query + randomLimit(randomGenerator, indent, 0.7);
+    my_query += randomLimit(randomGenerator, indent, 0.7);
 
-    var collect = randomCollectWithCount(randomGenerator, indent, 0.1);
+    let collect = randomCollectWithCount(randomGenerator, indent, 0.1);
     if (collect !== "") {
-      my_query = my_query + collect;
+      my_query += collect;
       variables = {
         forVariables: [],
         collectionNames: variables.collectionNames,
@@ -272,7 +267,7 @@ function createModifyingChaosQuery(seed, numberSubqueries) {
       .map((x) => x + ": UNSET_RECURSIVE(" + x + ',"_rev", "_id", "_key")')
       .join(", ");
 
-    my_query = my_query + indent + " RETURN {" + returns + "}";
+    my_query += indent + " RETURN {" + returns + "}";
 
     return {
       collectionNames: variables.collectionNames,
@@ -299,15 +294,23 @@ function runQuery(query, queryOptions, testOptions) {
     db._explain(query.queryString, {}, queryOptions);
   }
 
-  /* Run query with all optimizations */
-  const result = db._query(query.queryString, {}, queryOptions).toArray();
+  /* Run query */
+  const result = db._createStatement({query: query.queryString, options: queryOptions}).execute();
+ 
+  /* Create a simple hash value from the query results, so that we don't have to
+   * load the entire result set into memory and work with it */
+  let hash = "";
+  while (result.hasNext()) {
+    let row = JSON.stringify(result.next());
+    hash = md5(hash + row); 
+  }
 
+  /* Cleanup */
   for (const cn of query.collectionNames) {
     db._drop(cn);
   }
 
-  /* Cleanup */
-  return result;
+  return hash;
 }
 
 function testQuery(query, testOptions) {
@@ -317,21 +320,21 @@ function testQuery(query, testOptions) {
   }
 
   /* Run query with all optimizations */
-  const result1 = runQuery(query, { }, testOptions);
+  const result1 = runQuery(query, {}, testOptions);
 
-  /* Run query without subquery splicing */
+  /* Run query with full count */
   const result2 = runQuery(
     query,
-    { fullCount: true, optimizer: { rules: ["-splice-subqueries"] } },
+    { fullCount: true }, 
     testOptions
   );
 
   if (!_.isEqual(result1, result2)) {
     const msg = `Results of query
 	${query.queryString}
-        with subquery splicing:
+        hash without fullcount:
 	${JSON.stringify(result1)}
-        without subquery splicing:
+        hash with fullcount:
         ${JSON.stringify(result2)}
 	do not match!`;
 

--- a/tests/js/client/aql/aql-subquery-chaos-nightly.js
+++ b/tests/js/client/aql/aql-subquery-chaos-nightly.js
@@ -64,10 +64,6 @@ const randomModificationDepth = () => {
   return 3;
 };
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite for cross-collection queries
-////////////////////////////////////////////////////////////////////////////////
-
 function ahuacatlSubqueryChaos() {
   /// Some queries that caused errors before. We don't have the seeds
   /// to create them, unfortunately, so we test them in here verbatim.
@@ -143,16 +139,6 @@ function ahuacatlSubqueryChaos() {
     },
   };
   return {
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief set up
-    ////////////////////////////////////////////////////////////////////////////////
-    setUp: function () {},
-
-    ////////////////////////////////////////////////////////////////////////////////
-    /// @brief tear down
-    ////////////////////////////////////////////////////////////////////////////////
-    tearDown: function () {},
-
     testSpecificQueries: function () {
       for (const [key, value] of Object.entries(specificQueries)) {
         ct.testQuery(value, {});
@@ -160,7 +146,7 @@ function ahuacatlSubqueryChaos() {
     },
 
     testSomeSubqueryChaos: function () {
-      for (var i = 0; i < numberOfQueriesGenerated; i++) {
+      for (let i = 0; i < numberOfQueriesGenerated; i++) {
         ct.testQueryWithSeed({
           numberSubqueries: randomDepth(),
           seed: Math.trunc(Math.random() * 10000),
@@ -171,7 +157,7 @@ function ahuacatlSubqueryChaos() {
     },
 
     testSomeSubqueryModificationChaos: function () {
-      for (var i = 0; i < numberOfQueriesGenerated; i++) {
+      for (let i = 0; i < numberOfQueriesGenerated; i++) {
         ct.testModifyingQueryWithSeed({
           numberSubqueries: randomModificationDepth(),
           seed: Math.trunc(Math.random() * 10000),
@@ -182,10 +168,6 @@ function ahuacatlSubqueryChaos() {
     },
   };
 }
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suite
-////////////////////////////////////////////////////////////////////////////////
 
 jsunity.run(ahuacatlSubqueryChaos);
 


### PR DESCRIPTION
### Scope & Purpose

Try to reduce memory usage in subquery chaos test.
The subquery chaos test previously always built up full results in memory in order to compare the results of two identical queries that were run with different options. The result sets of the produced queries could grow arbitrarily large.
Instead of loading the entire query result into memory at once, we are now querying the result set using a batch size of 10, so that we only need to buffer up to 10 result rows in memory. Instead of memoizing all of them, we keep a rolling hash of the rows we have seen, so that the test only produces a single md5 value instead of a large result array.

The failure we are trying to fix looks as follows in the CI:
https://app.circleci.com/pipelines/github/arangodb/arangodb/22966/workflows/bfa6ff18-5c99-48c3-ae03-8b7c7976816e/jobs/1849063
```
2024-04-29T00:39:12.613Z [ RUN        ] testSomeSubqueryChaos
2024-04-29T00:39:58.427472Z [78-1] WARNING [95f66] {v8} reached heap-size limit of context #0 interrupting V8 execution (heap size limit 1073741824, used 872227480) during V8 internal collection
2024-04-29T00:39:58.448126Z [78-1] ERROR [532c3] {general} encountered out-of-memory error in context #0
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 