### PR TITLE
Improved the time required to create a new collection into a large database

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ v3.11.9 (XXXX-XX-XX)
 --------------------
 
 * Improved the time required to create a new Collection in a database with
-  hundreds of collections. This also imrpoves times for indexes and dropping
+  hundreds of collections. This also improves times for indexes and dropping
   of collections.
 
 * Prioritize requests for commiting or aborting streaming transactions on

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* Improved the time required to create a new Collection in a database with
+  hundreds of collections. This also imrpoves times for indexes and dropping
+  of collections.
+
 * Prioritize requests for commiting or aborting streaming transactions on
   leaders and followers, because they can unblock other operations.
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -844,12 +844,12 @@ arangodb::Result arangodb::maintenance::diffPlanLocal(
           std::vector<std::string>{AgencyCommHelper::path(), PLAN, COLLECTIONS,
                                    ldbname});
       if (ldbslice.isObject()) {
+        auto const shardMap = getShardMap(plan);  // plan shards -> servers
         // Note that if `plan` is not an object, then `getShardMap` will simply
         // return an empty object, which is fine for `handleLocalShard`, so we
         // do not have to check anything else here.
         for (auto const& lcol : VPackObjectIterator(ldbslice)) {
           auto const& colname = lcol.key.copyString();
-          auto const shardMap = getShardMap(plan);  // plan shards -> servers
           auto rv = replicationVersion.find(dbname);
           TRI_ASSERT(rv != replicationVersion.end());
 


### PR DESCRIPTION
### Scope & Purpose

*There was a quadratic increase in runtime of collection creation within the same database. @maierlars found the blocking line, and we could trivially move it outside of one loop. This drastically improves creation/deletion time for collections and indexes on databases with hundreds of Collections.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
