### PR TITLE
FE-448: auto-repair collection JSON on save

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* FE-448: auto-repair collection document JSON on save.
+
 * Improved the time required to create a new Collection in a database with
   hundreds of collections. This also improves times for indexes and dropping
   of collections.

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
@@ -409,6 +409,7 @@
     },
 
     saveDocument: function () {
+      this.editor.repair();
       if ($('#saveDocumentButton').attr('disabled') === undefined) {
         if (this.collection.first().attributes._id.substr(0, 1) === '_') {
           var buttons = []; var tableContent = [];


### PR DESCRIPTION
### Scope & Purpose

This restores a behaviour which existed pre-3.11 jsoneditor upgrade. Previously, jsoneditor would auto-repair the doucments on format; not we have to call the `repair()` function on our own. 

ref: https://github.com/josdejong/jsoneditor/issues/1107#issuecomment-693509237

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested
- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] Backport for 3.11:  https://github.com/arangodb/arangodb/pull/20895

#### Related Information

- [ ] GitHub issue / Jira ticket:  https://arangodb.atlassian.net/browse/FE-448

