### PR TITLE
try to fix restart test

### DIFF
--- a/arangod/VocBase/Methods/Upgrade.cpp
+++ b/arangod/VocBase/Methods/Upgrade.cpp
@@ -359,7 +359,7 @@ UpgradeResult methods::Upgrade::runTasks(TRI_vocbase_t& vocbase,
                          ") failed: ", res.errorMessage());
         LOG_TOPIC("0a886", ERR, Logger::STARTUP)
             << msg << " aborting upgrade procedure.";
-        return UpgradeResult(TRI_ERROR_INTERNAL, std::move(msg), vinfo.status);
+        return UpgradeResult(res.errorNumber(), std::move(msg), vinfo.status);
       }
     } catch (std::exception const& e) {
       LOG_TOPIC("022fe", ERR, Logger::STARTUP)


### PR DESCRIPTION
### Scope & Purpose

Try to fix restart test, attempt 2.
The previous implementation that executed upgrade tasks always swallowed the original error, and unconditionally turned it into a `TRI_ERROR_INTERNAL` error. Thus checking for a specific error code did not work.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
