### PR TITLE
reduce amount of data in test

### DIFF
--- a/tests/js/client/aql/aql-arangosearch-constrained-sort-optimization.inc
+++ b/tests/js/client/aql/aql-arangosearch-constrained-sort-optimization.inc
@@ -108,7 +108,7 @@
         let cats = "cat";
         let j = 0;
         let sort = 0;
-        for (let i = 0; i < 5000; ++i) {
+        for (let i = 0; i < 2500; ++i) {
           data.push({field1:i, field2: "A" + i % 1000, field3: "B" + i % 100, strval: cats, idx:i, storedVal: longValue + i,
           compound: {val:sort},
           obj: {ps:sort, a: {a1: 30}, b: {b1: 31}, c: i, d: {d1: 33}, e: {e1: 34}, f: j, g: 36, h: 37, j: 38}});
@@ -211,8 +211,8 @@
           let res = result.toArray();
           assertEqual(1, res.length);
           assertEqual(300, res[0]);
-          assertEqual(6216, result.getExtra().stats.fullCount);
-          assertEqual(6216, result.getExtra().stats.scannedIndex);
+          assertEqual(2885, result.getExtra().stats.fullCount);
+          assertEqual(2885, result.getExtra().stats.scannedIndex);
       },
       testApplyWithNoFullCount() {
           let query = "FOR d IN " + vn + " SEARCH d.field2 >= 'A3' SORT BM25(d) " +
@@ -223,7 +223,7 @@
           let res = result.toArray();
           assertEqual(1, res.length);
           assertEqual(300, res[0]);
-          assertEqual(6216, result.getExtra().stats.scannedIndex);
+          assertEqual(2885, result.getExtra().stats.scannedIndex);
       },
       testApplyWithFullCountDocs() {
           let query = "FOR d IN " + vn + " SEARCH d.field2 >= 'A3' SORT BM25(d) " +
@@ -232,8 +232,8 @@
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
           let result = db._query(query, {}, {fullCount:true});
           assertEqual(300, result.toArray().length);
-          assertEqual(6216, result.getExtra().stats.fullCount);
-          assertEqual(6216, result.getExtra().stats.scannedIndex);
+          assertEqual(2885, result.getExtra().stats.fullCount);
+          assertEqual(2885, result.getExtra().stats.scannedIndex);
       },
       testApplyWithNoFullCountDocs() {
           let query = "FOR d IN " + vn + " SEARCH d.field2 >= 'A3' SORT BM25(d) " +
@@ -242,7 +242,7 @@
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
           let result = db._query(query, {}, {fullCount:false});
           assertEqual(300, result.toArray().length);
-          assertEqual(6216, result.getExtra().stats.scannedIndex);
+          assertEqual(2885, result.getExtra().stats.scannedIndex);
       },
       testApplyWithFullCountDocsNoOffset() {
           let query = "FOR d IN " + vn + " SEARCH d.field2 >= 'A3' SORT BM25(d) " +
@@ -251,8 +251,8 @@
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
           let result = db._query(query, {}, {fullCount:true});
           assertEqual(1500, result.toArray().length);
-          assertEqual(6216, result.getExtra().stats.fullCount);
-          assertEqual(6216, result.getExtra().stats.scannedIndex);
+          assertEqual(2885, result.getExtra().stats.fullCount);
+          assertEqual(2885, result.getExtra().stats.scannedIndex);
       },
       testApplyWithNoFullCountDocsNoOffset() {
           let query = "FOR d IN " + vn + " SEARCH d.field2 >= 'A3' SORT BM25(d) " +
@@ -261,7 +261,7 @@
           assertNotEqual(-1, plan.rules.indexOf(ruleName));
           let result = db._query(query, {}, {fullCount:false});
           assertEqual(1500, result.toArray().length);
-          assertEqual(6216, result.getExtra().stats.scannedIndex);
+          assertEqual(2885, result.getExtra().stats.scannedIndex);
       },
       testAppliedWithNonDetermAfter() {
         let query = "FOR d IN " + vn + " SEARCH d.field2 >= 'A3' SORT BM25(d) LIMIT 10 LET a = NOOPT(d.b.b1) RETURN {dD:d, aA:a}";
@@ -269,8 +269,8 @@
         assertNotEqual(-1, plan.rules.indexOf(ruleName));
         let result = db._query(query, {}, {fullCount:true});
         assertEqual(10, result.toArray().length);
-        assertEqual(6216, result.getExtra().stats.scannedIndex);
-        assertEqual(6216, result.getExtra().stats.fullCount);
+        assertEqual(2885, result.getExtra().stats.scannedIndex);
+        assertEqual(2885, result.getExtra().stats.fullCount);
       },
       testAppliedDeterministicUsedBetweenSort() {
         let query = "FOR d IN " + vn + " SEARCH d.field2 < 'A3' SORT BM25(d) LET a = UPPER(d.b.b1) LIMIT 10 RETURN {dD:d, aA:a}";
@@ -278,8 +278,8 @@
         assertNotEqual(-1, plan.rules.indexOf(ruleName), {}, {optimizer:{rules:['-move-calculations-down']}});
         let result = db._query(query, {}, {fullCount:true, optimizer:{rules:['-move-calculations-down']}});
         assertEqual(10, result.toArray().length);
-        assertEqual(3784, result.getExtra().stats.scannedIndex);
-        assertEqual(3784, result.getExtra().stats.fullCount);
+        assertEqual(2115, result.getExtra().stats.scannedIndex);
+        assertEqual(2115, result.getExtra().stats.fullCount);
       },
       testAppliedDeterministicUsedBeforeSort() {
         let query = "FOR d IN " + vn + " SEARCH d.field2 < 'A3' LET a = UPPER(d.b.b1) SORT BM25(d) LIMIT 10 RETURN {dD:d, aA:a}";
@@ -287,8 +287,8 @@
         assertNotEqual(-1, plan.rules.indexOf(ruleName), {}, {optimizer:{rules:['-move-calculations-down']}});
         let result = db._query(query, {}, {fullCount:true, optimizer:{rules:['-move-calculations-down']}});
         assertEqual(10, result.toArray().length);
-        assertEqual(3784, result.getExtra().stats.scannedIndex);
-        assertEqual(3784, result.getExtra().stats.fullCount);
+        assertEqual(2115, result.getExtra().stats.scannedIndex);
+        assertEqual(2115, result.getExtra().stats.fullCount);
       },
       testAppliedDeterministicUsedBeforeSortTwoSorts() {
         let query = "FOR d IN " + vn + " SEARCH d.field2 < 'A3' LET a = UPPER(d.b.b1) SORT BM25(d) ASC "
@@ -297,8 +297,8 @@
         assertNotEqual(-1, plan.rules.indexOf(ruleName), {}, {optimizer:{rules:['-move-calculations-down']}});
         let result = db._query(query, {}, {fullCount:true, optimizer:{rules:['-move-calculations-down']}});
         assertEqual(10, result.toArray().length);
-        assertEqual(3784, result.getExtra().stats.scannedIndex);
-        assertEqual(3784, result.getExtra().stats.fullCount);
+        assertEqual(2115, result.getExtra().stats.scannedIndex);
+        assertEqual(2115, result.getExtra().stats.fullCount);
       },
       testAppliedMultiSorts() {
         let query = "FOR d IN " + vn + " SEARCH d.field2 < 'A3' LET a = TFIDF(d) LET b = BM25(d) LET t = a + b SORT b ASC, a DESC "
@@ -307,8 +307,8 @@
         assertNotEqual(-1, plan.rules.indexOf(ruleName), {}, {optimizer:{rules:['-move-calculations-down']}});
         let result = db._query(query, {}, {fullCount:true, optimizer:{rules:['-move-calculations-down']}});
         assertEqual(10, result.toArray().length);
-        assertEqual(3784, result.getExtra().stats.scannedIndex);
-        assertEqual(3784, result.getExtra().stats.fullCount);
+        assertEqual(2115, result.getExtra().stats.scannedIndex);
+        assertEqual(2115, result.getExtra().stats.fullCount);
       },
       testAppliedSort() {
         let query = "FOR d IN " + vn + " SEARCH ANALYZER(d.strval == 'cat', 'text_en') SORT TFIDF(d) DESC LIMIT 10, 10 "
@@ -318,7 +318,7 @@
         let result = db._query(query);
         let res = result.toArray();
         assertEqual(10, res.length);
-        let expectedIdx = 4994;
+        let expectedIdx = 2494;
         for (let i = 0; i < 10; ++i) {
           assertEqual(res[i].idx, expectedIdx);
           if (i % 2 === 1) {
@@ -462,7 +462,7 @@
         let result = db._query(query);
         let res = result.toArray();
         assertEqual(10, res.length);
-        let expectedIdx = 9989;
+        let expectedIdx = 4989;
         for (let i = 0; i < 10; ++i) {
           assertEqual(res[i].dv, expectedIdx);
           expectedIdx = expectedIdx - 1;
@@ -476,7 +476,7 @@
         let result = db._query(query);
         let res = result.toArray();
         assertEqual(10, res.length);
-        let expectedIdx = 9989;
+        let expectedIdx = 4989;
         for (let i = 0; i < 10; ++i) {
           assertEqual(res[i].stored, expectedIdx);
           expectedIdx = expectedIdx - 1;


### PR DESCRIPTION
### Scope & Purpose

Reduce the amount of data in a test that takes multiple minutes without this modification.
Test-only bugfix.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
