### PR TITLE
[3.11] Fix move assignments in boost asio

### DIFF
--- a/3rdParty/boost/1.78.0/boost/asio/ssl/detail/engine.hpp
+++ b/3rdParty/boost/1.78.0/boost/asio/ssl/detail/engine.hpp
@@ -122,6 +122,8 @@ private:
   engine(const engine&);
   engine& operator=(const engine&);
 
+  BOOST_ASIO_DECL void clear();
+
   // Callback used when the SSL implementation wants to verify a certificate.
   BOOST_ASIO_DECL static int verify_callback_function(
       int preverified, X509_STORE_CTX* ctx);

--- a/3rdParty/boost/1.78.0/boost/asio/ssl/detail/impl/engine.ipp
+++ b/3rdParty/boost/1.78.0/boost/asio/ssl/detail/impl/engine.ipp
@@ -68,6 +68,26 @@ engine::engine(engine&& other) BOOST_ASIO_NOEXCEPT
 
 engine::~engine()
 {
+  clear();
+}
+
+#if defined(BOOST_ASIO_HAS_MOVE)
+engine& engine::operator=(engine&& other) BOOST_ASIO_NOEXCEPT
+{
+  if (this != &other)
+  {
+    clear();
+    ssl_ = other.ssl_;
+    ext_bio_ = other.ext_bio_;
+    other.ssl_ = 0;
+    other.ext_bio_ = 0;
+  }
+  return *this;
+}
+#endif // defined(BOOST_ASIO_HAS_MOVE)
+
+void engine::clear()
+{
   if (ssl_ && SSL_get_app_data(ssl_))
   {
     delete static_cast<verify_callback_base*>(SSL_get_app_data(ssl_));
@@ -80,20 +100,6 @@ engine::~engine()
   if (ssl_)
     ::SSL_free(ssl_);
 }
-
-#if defined(BOOST_ASIO_HAS_MOVE)
-engine& engine::operator=(engine&& other) BOOST_ASIO_NOEXCEPT
-{
-  if (this != &other)
-  {
-    ssl_ = other.ssl_;
-    ext_bio_ = other.ext_bio_;
-    other.ssl_ = 0;
-    other.ext_bio_ = 0;
-  }
-  return *this;
-}
-#endif // defined(BOOST_ASIO_HAS_MOVE)
 
 SSL* engine::native_handle()
 {

--- a/3rdParty/boost/1.78.0/boost/asio/ssl/detail/stream_core.hpp
+++ b/3rdParty/boost/1.78.0/boost/asio/ssl/detail/stream_core.hpp
@@ -118,6 +118,7 @@ struct stream_core
       input_buffer_space_ =
         BOOST_ASIO_MOVE_CAST(std::vector<unsigned char>)(
           other.input_buffer_space_);
+      input_buffer_ = other.input_buffer_;
       input_ = other.input_;
       other.output_buffer_ = boost::asio::mutable_buffer(0, 0);
       other.input_buffer_ = boost::asio::mutable_buffer(0, 0);


### PR DESCRIPTION
### Scope & Purpose

Fixes two move assignments in boost asio. One that causes an invalid pointer and heap-use-after-free, and one leaking resources.

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

