### PR TITLE
fix protocol confusion

### DIFF
--- a/arangod/GeneralServer/H2CommTask.h
+++ b/arangod/GeneralServer/H2CommTask.h
@@ -26,23 +26,22 @@
 #include "GeneralServer/AsioSocket.h"
 #include "GeneralServer/GeneralCommTask.h"
 
+#include <boost/lockfree/queue.hpp>
+#include <nghttp2/nghttp2.h>
+#include <velocypack/Buffer.h>
+
 #include <atomic>
 #include <memory>
 #include <map>
 
-#include <boost/lockfree/queue.hpp>
-#include <velocypack/Buffer.h>
-
-#include <nghttp2/nghttp2.h>
-
 namespace arangodb {
 class HttpRequest;
+class HttpResponse;
 
 /// @brief maximum number of concurrent streams
 static constexpr uint32_t H2MaxConcurrentStreams = 32;
 
 namespace rest {
-
 struct H2Response;
 
 template<SocketType T>
@@ -95,7 +94,7 @@ class H2CommTask final : public GeneralCommTask<T> {
     std::string origin;
 
     std::unique_ptr<HttpRequest> request;
-    std::unique_ptr<H2Response> response;  // hold response memory
+    std::unique_ptr<HttpResponse> response;  // hold response memory
     bool mustSendAuthHeader = true;
 
     size_t headerBuffSize = 0;  // total header size
@@ -128,7 +127,7 @@ class H2CommTask final : public GeneralCommTask<T> {
 
   velocypack::Buffer<uint8_t> _outbuffer;
 
-  boost::lockfree::queue<H2Response*,
+  boost::lockfree::queue<HttpResponse*,
                          boost::lockfree::capacity<H2MaxConcurrentStreams>>
       _responses;
 

--- a/tests/js/client/shell/api-job-different-protocols.js
+++ b/tests/js/client/shell/api-job-different-protocols.js
@@ -1,0 +1,86 @@
+/*jshint globalstrict:false, strict:false */
+/*global arango, assertEqual, assertNotEqual, assertTrue, assertFalse, assertUndefined, assertNull, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const internal = require('internal');
+const db = arangodb.db;
+
+const originalEndpoint = arango.getEndpoint();
+const createConnection = (protocol) => {
+  let endpoint = protocol + originalEndpoint.replace(/^[a-z0-9]+:/, ':');
+  arango.reconnect(endpoint, db._name(), "root", "");
+};
+
+function JobsApiWithDifferentProtocols() {
+  'use strict';
+  
+  return {
+    tearDown: function () {
+      arango.reconnect(originalEndpoint, db._name(), "root", "");
+    },
+
+    testStartJobWithHttp1AndFetchWithHttp2: function () {
+      createConnection("http");
+      let res = arango.POST_RAW("/_api/cursor", {query: "RETURN 'foobar'"}, {"x-arango-async": "store"});
+      const id = res.headers["x-arango-async-id"];
+
+      createConnection("h2");
+      let tries = 60;
+      while (--tries > 0) {
+        res = arango.PUT_RAW("/_api/job/" + id, {});
+        if (res.code === 201) {
+          assertEqual(["foobar"], res.parsedBody.result);
+          break;
+        }
+        internal.sleep(0.5);
+      }
+      assertTrue(tries > 0, "timed out");
+    },
+    
+    testStartJobWithHttp2AndFetchWithHttp1: function () {
+      createConnection("h2");
+      let res = arango.POST_RAW("/_api/cursor", {query: "RETURN 'foobar'"}, {"x-arango-async": "store"});
+      const id = res.headers["x-arango-async-id"];
+
+      createConnection("http");
+      let tries = 60;
+      while (--tries > 0) {
+        res = arango.PUT_RAW("/_api/job/" + id, {});
+        if (res.code === 201) {
+          assertEqual(["foobar"], res.parsedBody.result);
+          break;
+        }
+        internal.sleep(0.5);
+      }
+      assertTrue(tries > 0, "timed out");
+    },
+
+  };
+}
+
+jsunity.run(JobsApiWithDifferentProtocols);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fix protocol confusion.
When an async job was created via the jobs API via HTTP/1.1, the job result was stored as an `HttpResponse`. 
When the job result was retrieved via HTTP/2, the server code expected the response to be an `H2Response` (a struct that is derived from `HttpResponse`). This could lead to the wrong response class to be used, and thus potential UB. 
The situation in which this happens is rare though, because it requires usage of the jobs API and a protocol change.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 