### PR TITLE
remove retry logic for fuerte connections

### DIFF
--- a/3rdParty/boost/1.78.0/boost/asio/ssl/detail/engine.hpp
+++ b/3rdParty/boost/1.78.0/boost/asio/ssl/detail/engine.hpp
@@ -122,6 +122,8 @@ private:
   engine(const engine&);
   engine& operator=(const engine&);
 
+  BOOST_ASIO_DECL void clear();
+
   // Callback used when the SSL implementation wants to verify a certificate.
   BOOST_ASIO_DECL static int verify_callback_function(
       int preverified, X509_STORE_CTX* ctx);

--- a/3rdParty/boost/1.78.0/boost/asio/ssl/detail/impl/engine.ipp
+++ b/3rdParty/boost/1.78.0/boost/asio/ssl/detail/impl/engine.ipp
@@ -68,6 +68,26 @@ engine::engine(engine&& other) BOOST_ASIO_NOEXCEPT
 
 engine::~engine()
 {
+  clear();
+}
+
+#if defined(BOOST_ASIO_HAS_MOVE)
+engine& engine::operator=(engine&& other) BOOST_ASIO_NOEXCEPT
+{
+  if (this != &other)
+  {
+    clear();
+    ssl_ = other.ssl_;
+    ext_bio_ = other.ext_bio_;
+    other.ssl_ = 0;
+    other.ext_bio_ = 0;
+  }
+  return *this;
+}
+#endif // defined(BOOST_ASIO_HAS_MOVE)
+
+void engine::clear()
+{
   if (ssl_ && SSL_get_app_data(ssl_))
   {
     delete static_cast<verify_callback_base*>(SSL_get_app_data(ssl_));
@@ -80,20 +100,6 @@ engine::~engine()
   if (ssl_)
     ::SSL_free(ssl_);
 }
-
-#if defined(BOOST_ASIO_HAS_MOVE)
-engine& engine::operator=(engine&& other) BOOST_ASIO_NOEXCEPT
-{
-  if (this != &other)
-  {
-    ssl_ = other.ssl_;
-    ext_bio_ = other.ext_bio_;
-    other.ssl_ = 0;
-    other.ext_bio_ = 0;
-  }
-  return *this;
-}
-#endif // defined(BOOST_ASIO_HAS_MOVE)
 
 SSL* engine::native_handle()
 {

--- a/3rdParty/boost/1.78.0/boost/asio/ssl/detail/stream_core.hpp
+++ b/3rdParty/boost/1.78.0/boost/asio/ssl/detail/stream_core.hpp
@@ -118,6 +118,7 @@ struct stream_core
       input_buffer_space_ =
         BOOST_ASIO_MOVE_CAST(std::vector<unsigned char>)(
           other.input_buffer_space_);
+      input_buffer_ = other.input_buffer_;
       input_ = other.input_;
       other.output_buffer_ = boost::asio::mutable_buffer(0, 0);
       other.input_buffer_ = boost::asio::mutable_buffer(0, 0);

--- a/3rdParty/fuerte/include/fuerte/FuerteLogger.h
+++ b/3rdParty/fuerte/include/fuerte/FuerteLogger.h
@@ -26,14 +26,15 @@
 #if 0
 #include <iostream>
 #include <sstream>
+#include <string_view>
 
-extern void LogHackWriter(char const* p);
+extern void LogHackWriter(std::string_view p);
 
 class LogHack {
   std::stringstream _s;
  public:
   LogHack() {};
-  ~LogHack() { LogHackWriter(_s.str().c_str()); };
+  ~LogHack() { LogHackWriter(_s.str()); };
   template<typename T> LogHack& operator<<(T const& o) { _s << o; return *this; }
   typedef std::basic_ostream<char, std::char_traits<char> > CoutType;
   typedef CoutType& (*StandardEndLine)(CoutType&);
@@ -90,13 +91,6 @@ class LogHack {
 #define FUERTE_LOG_HTTPTRACE std::cout << "[http] "
 #else
 #define FUERTE_LOG_HTTPTRACE \
-  if (0) std::cout
-#endif
-
-#if ENABLE_FUERTE_LOG_NODE > 0
-#define FUERTE_LOG_NODE std::cout
-#else
-#define FUERTE_LOG_NODE \
   if (0) std::cout
 #endif
 

--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -157,24 +157,6 @@ class ConnectionBuilder {
     return *this;
   }
 
-  /// @brief connect retry pause (1s default)
-  std::chrono::milliseconds connectRetryPause() const {
-    return _conf._connectRetryPause;
-  }
-  /// @brief set the connect retry pause (1s default)
-  ConnectionBuilder& connectRetryPause(std::chrono::milliseconds p) {
-    _conf._connectRetryPause = p;
-    return *this;
-  }
-
-  /// @brief connect retries (3 default)
-  unsigned maxConnectRetries() const { return _conf._maxConnectRetries; }
-  /// @brief set the max connect retries (3 default)
-  ConnectionBuilder& maxConnectRetries(unsigned r) {
-    _conf._maxConnectRetries = r;
-    return *this;
-  }
-
   // Set the authentication type of the connection
   AuthenticationType authenticationType() const {
     return _conf._authenticationType;

--- a/3rdParty/fuerte/include/fuerte/loop.h
+++ b/3rdParty/fuerte/include/fuerte/loop.h
@@ -27,9 +27,11 @@
 
 #include <fuerte/asio_ns.h>
 
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <utility>
+#include <vector>
 
 // run / runWithWork / poll for Loop mapping to ioservice
 // free function run with threads / with thread group barrier and work

--- a/3rdParty/fuerte/include/fuerte/types.h
+++ b/3rdParty/fuerte/include/fuerte/types.h
@@ -204,10 +204,8 @@ struct ConnectionConfiguration {
         _host("localhost"),
         _port("8529"),
         _verifyHost(false),
-        _connectTimeout(15000),
+        _connectTimeout(60000),
         _idleTimeout(300000),
-        _connectRetryPause(1000),
-        _maxConnectRetries(3),
         _useIdleTimeout(true),
         _authenticationType(AuthenticationType::None),
         _user(""),
@@ -225,8 +223,6 @@ struct ConnectionConfiguration {
 
   std::chrono::milliseconds _connectTimeout;
   std::chrono::milliseconds _idleTimeout;
-  std::chrono::milliseconds _connectRetryPause;
-  unsigned _maxConnectRetries;
   bool _useIdleTimeout;
 
   AuthenticationType _authenticationType;

--- a/3rdParty/fuerte/src/AsioSockets.h
+++ b/3rdParty/fuerte/src/AsioSockets.h
@@ -112,6 +112,10 @@ struct Socket<SocketType::Tcp> {
       return canceled;
     });
   }
+  
+  bool isOpen() const {
+    return socket.is_open();
+  }
 
   void cancel() {
     canceled = true;
@@ -219,6 +223,10 @@ struct Socket<fuerte::SocketType::Ssl> {
         });
   }
   
+  bool isOpen() const {
+    return socket.lowest_layer().is_open();
+  }
+  
   void cancel() {
     canceled = true;
     try {
@@ -310,6 +318,10 @@ struct Socket<fuerte::SocketType::Unix> {
 
     asio_ns::local::stream_protocol::endpoint ep(config._host);
     socket.async_connect(ep, std::forward<F>(done));
+  }
+  
+  bool isOpen() const {
+    return socket.is_open();
   }
   
   void cancel() {

--- a/3rdParty/fuerte/src/AsioSockets.h
+++ b/3rdParty/fuerte/src/AsioSockets.h
@@ -30,12 +30,19 @@
 namespace arangodb { namespace fuerte { inline namespace v1 {
 
 namespace {
-template <typename SocketT, typename F>
+template <typename SocketT, typename F, typename IsAbortedCb>
 void resolveConnect(detail::ConnectionConfiguration const& config,
                     asio_ns::ip::tcp::resolver& resolver, SocketT& socket,
-                    F&& done) {
-  auto cb = [&socket, done(std::forward<F>(done))](auto ec, auto it) mutable {
+                    F&& done, IsAbortedCb&& isAborted) {
+  auto cb = [&socket, 
+             done = std::forward<F>(done),
+             isAborted = std::forward<IsAbortedCb>(isAborted)](auto ec, auto it) mutable {
+    if (isAborted()) {
+      ec = asio_ns::error::operation_aborted;
+    }
+
     if (ec) {  // error in address resolver
+      FUERTE_LOG_DEBUG << "received error during address resolving: " << ec.message() << "\n";
       done(ec);
       return;
     }
@@ -44,7 +51,12 @@ void resolveConnect(detail::ConnectionConfiguration const& config,
       // A successful resolve operation is guaranteed to pass a
       // non-empty range to the handler.
       asio_ns::async_connect(socket, it,
-                             [done(std::move(done))](auto ec, auto it) mutable {
+                             [done](auto ec, auto it) mutable {
+                               if (ec) {
+                                 FUERTE_LOG_DEBUG << "executing async connect callback, error: " << ec.message() << "\n";
+                               } else {
+                                 FUERTE_LOG_DEBUG << "executing async connect callback, no error\n";
+                               }
                                std::forward<F>(done)(ec);
                              });
     } catch (std::bad_alloc const&) {
@@ -63,7 +75,8 @@ void resolveConnect(detail::ConnectionConfiguration const& config,
   auto it = resolver.resolve(config._host, config._port, ec);
   cb(ec, it);
 #else
-  // Resolve the host asynchronous into a series of endpoints
+  // Resolve the host asynchronously into a series of endpoints
+  FUERTE_LOG_DEBUG << "scheduled callback to resolve host " << config._host << ":" << config._port << "\n";
   resolver.async_resolve(config._host, config._port, std::move(cb));
 #endif
 }
@@ -77,14 +90,31 @@ struct Socket<SocketType::Tcp> {
   Socket(EventLoopService&, asio_ns::io_context& ctx)
       : resolver(ctx), socket(ctx), timer(ctx) {}
 
-  ~Socket() { this->cancel(); }
+  ~Socket() { 
+    try {
+      this->cancel(); 
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during tcp socket shutdown: " << ex.what() << "\n";
+    }
+  }
 
   template <typename F>
   void connect(detail::ConnectionConfiguration const& config, F&& done) {
-    resolveConnect(config, resolver, socket, std::forward<F>(done));
+    resolveConnect(config, resolver, socket, [this, done = std::forward<F>(done)](asio_ns::error_code ec) mutable {
+      FUERTE_LOG_DEBUG << "executing tcp connect callback, ec: " << ec.message() << ", canceled: " << this->canceled << "\n";
+      if (canceled) {
+        // cancel() was already called on this socket
+        FUERTE_ASSERT(socket.is_open() == false);
+        ec = asio_ns::error::operation_aborted;
+      }
+      done(ec);
+    }, [this]() {
+      return canceled;
+    });
   }
 
   void cancel() {
+    canceled = true;
     try {
       timer.cancel();
       resolver.cancel();
@@ -92,7 +122,8 @@ struct Socket<SocketType::Tcp> {
         asio_ns::error_code ec;
         socket.close(ec);
       }
-    } catch (...) {
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during tcp socket cancelation: " << ex.what() << "\n";
     }
   }
 
@@ -108,7 +139,10 @@ struct Socket<SocketType::Tcp> {
         ec.clear();
         socket.close(ec);
       }
-    } catch (...) {
+    } catch (std::exception const& ex) {
+      // an exception is unlikely to occur here, as we are using the error-code
+      // variants of cancel/shutdown/close above 
+      FUERTE_LOG_ERROR << "caught exception during tcp socket shutdown: " << ex.what() << "\n";
     }
     std::forward<F>(cb)(ec);
   }
@@ -116,6 +150,7 @@ struct Socket<SocketType::Tcp> {
   asio_ns::ip::tcp::resolver resolver;
   asio_ns::ip::tcp::socket socket;
   asio_ns::steady_timer timer;
+  bool canceled = false;
 };
 
 template <>
@@ -123,14 +158,26 @@ struct Socket<fuerte::SocketType::Ssl> {
   Socket(EventLoopService& loop, asio_ns::io_context& ctx)
     : resolver(ctx), socket(ctx, loop.sslContext()), timer(ctx), cleanupDone(false) {}
 
-  ~Socket() { this->cancel(); }
+  ~Socket() { 
+    try {
+      this->cancel(); 
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during ssl socket shutdown: " << ex.what() << "\n";
+    }
+  }
 
   template <typename F>
   void connect(detail::ConnectionConfiguration const& config, F&& done) {
     bool verify = config._verifyHost;
     resolveConnect(
         config, resolver, socket.next_layer(),
-        [=, this, done(std::forward<F>(done))](auto const& ec) mutable {
+        [=, this](asio_ns::error_code ec) mutable {
+          FUERTE_LOG_DEBUG << "executing ssl connect callback, ec: " << ec.message() << ", canceled: " << this->canceled << "\n";
+          if (canceled) {
+            // cancel() was already called on this socket
+            FUERTE_ASSERT(socket.lowest_layer().is_open() == false);
+            ec = asio_ns::error::operation_aborted;
+          }
           if (ec) {
             done(ec);
             return;
@@ -167,10 +214,13 @@ struct Socket<fuerte::SocketType::Ssl> {
           }
           socket.async_handshake(asio_ns::ssl::stream_base::client,
                                  std::move(done));
+        }, [this]() { 
+          return canceled; 
         });
   }
-
+  
   void cancel() {
+    canceled = true;
     try {
       timer.cancel();
       resolver.cancel();
@@ -180,7 +230,8 @@ struct Socket<fuerte::SocketType::Ssl> {
         ec.clear();
         socket.lowest_layer().close(ec);
       }
-    } catch (...) {
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during ssl socket cancelation: " << ex.what() << "\n";
     }
   }
 
@@ -201,21 +252,10 @@ struct Socket<fuerte::SocketType::Ssl> {
       return;
     }
     cleanupDone = false;
-    timer.expires_from_now(std::chrono::seconds(3));
-    timer.async_wait([cb, this](asio_ns::error_code ec) {
-      // Copy in callback such that the connection object is kept alive long
-      // enough, please do not delete, although it is not used here!
-      if (!cleanupDone && !ec) {
-        socket.lowest_layer().shutdown(asio_ns::ip::tcp::socket::shutdown_both, ec);
-        ec.clear();
-        socket.lowest_layer().close(ec);
-        cleanupDone = true;
-      }
-    });
-    socket.async_shutdown([cb(std::forward<F>(cb)), this](auto const& ec) {
+    socket.async_shutdown([cb, this](auto const& ec) {
       timer.cancel();
 #ifndef _WIN32
-      if (!cleanupDone && (!ec || ec == asio_ns::error::basic_errors::not_connected)) {
+      if ((!ec || ec == asio_ns::error::basic_errors::not_connected) && !cleanupDone) {
         asio_ns::error_code ec2;
         socket.lowest_layer().shutdown(asio_ns::ip::tcp::socket::shutdown_both, ec2);
         ec2.clear();
@@ -225,12 +265,24 @@ struct Socket<fuerte::SocketType::Ssl> {
 #endif
       cb(ec);
     });
+    timer.expires_from_now(std::chrono::seconds(3));
+    timer.async_wait([cb(std::forward<F>(cb)), this](asio_ns::error_code ec) {
+      // Copy in callback such that the connection object is kept alive long
+      // enough, please do not delete, although it is not used here!
+      if (!ec && !cleanupDone) {
+        socket.lowest_layer().shutdown(asio_ns::ip::tcp::socket::shutdown_both, ec);
+        ec.clear();
+        socket.lowest_layer().close(ec);
+        cleanupDone = true;
+      }
+    });
   }
 
   asio_ns::ip::tcp::resolver resolver;
   asio_ns::ssl::stream<asio_ns::ip::tcp::socket> socket;
   asio_ns::steady_timer timer;
   std::atomic<bool> cleanupDone;
+  bool canceled = false;
 };
 
 #ifdef ASIO_HAS_LOCAL_SOCKETS
@@ -238,19 +290,38 @@ template <>
 struct Socket<fuerte::SocketType::Unix> {
   Socket(EventLoopService&, asio_ns::io_context& ctx)
       : socket(ctx), timer(ctx) {}
-  ~Socket() { this->cancel(); }
+
+  ~Socket() { 
+    canceled = true;
+    try {
+      this->cancel(); 
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during unix socket shutdown: " << ex.what() << "\n";
+    }
+  }
 
   template <typename F>
   void connect(detail::ConnectionConfiguration const& config, F&& done) {
+    if (canceled) {
+      // cancel() was already called on this socket
+      done(asio_ns::error::operation_aborted);
+      return;
+    }
+
     asio_ns::local::stream_protocol::endpoint ep(config._host);
     socket.async_connect(ep, std::forward<F>(done));
   }
-
+  
   void cancel() {
-    timer.cancel();
-    if (socket.is_open()) {  // non-graceful shutdown
-      asio_ns::error_code ec;
-      socket.close(ec);
+    canceled = true;
+    try {
+      timer.cancel();
+      if (socket.is_open()) {  // non-graceful shutdown
+        asio_ns::error_code ec;
+        socket.close(ec);
+      }
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during unix socket cancelation: " << ex.what() << "\n";
     }
   }
 
@@ -268,6 +339,7 @@ struct Socket<fuerte::SocketType::Unix> {
 
   asio_ns::local::stream_protocol::socket socket;
   asio_ns::steady_timer timer;
+  bool canceled = false;
 };
 #endif  // ASIO_HAS_LOCAL_SOCKETS
 

--- a/3rdParty/fuerte/src/AsioSockets.h
+++ b/3rdParty/fuerte/src/AsioSockets.h
@@ -252,6 +252,7 @@ struct Socket<fuerte::SocketType::Ssl> {
       return;
     }
     cleanupDone = false;
+    timer.expires_from_now(std::chrono::seconds(3));
     socket.async_shutdown([cb, this](auto const& ec) {
       timer.cancel();
 #ifndef _WIN32
@@ -265,7 +266,6 @@ struct Socket<fuerte::SocketType::Ssl> {
 #endif
       cb(ec);
     });
-    timer.expires_from_now(std::chrono::seconds(3));
     timer.async_wait([cb(std::forward<F>(cb)), this](asio_ns::error_code ec) {
       // Copy in callback such that the connection object is kept alive long
       // enough, please do not delete, although it is not used here!

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -71,6 +71,10 @@
 #include "AsioSockets.h"
 #include "debugging.h"
 
+#include <atomic>
+#include <chrono>
+#include <map>
+
 namespace arangodb { namespace fuerte {
 
 using Clock = std::chrono::steady_clock;
@@ -164,13 +168,11 @@ class GeneralConnection : public fuerte::Connection {
     Connection::State exp = Connection::State::Created;
     if (_state.compare_exchange_strong(exp, Connection::State::Connecting)) {
       FUERTE_LOG_DEBUG << "startConnection: this=" << this << "\n";
-      FUERTE_ASSERT(_config._maxConnectRetries > 0);
-      tryConnect(_config._maxConnectRetries, Clock::now(),
-                 asio_ns::error_code());
+      tryConnect();
     } else {
       FUERTE_LOG_DEBUG << "startConnection: this=" << this
                        << " found unexpected state " << static_cast<int>(exp)
-                       << " not equal to 'Created'";
+                       << " not equal to 'Created'\n";
       FUERTE_ASSERT(false);
     }
   }
@@ -193,9 +195,10 @@ class GeneralConnection : public fuerte::Connection {
 
     abortRequests(err, /*now*/ Clock::time_point::max());
 
-    _proto.shutdown([=, this, self(shared_from_this())](auto const& ec) {
-      terminateActivity(err);
-      onFailure(err, msg);
+    _proto.shutdown([=, self = shared_from_this()](asio_ns::error_code ec) {
+      auto& me = static_cast<GeneralConnection<ST, RT>&>(*self);
+      me.terminateActivity(err);
+      me.onFailure(err, msg);
     });  // Close socket
   }
 
@@ -259,7 +262,7 @@ class GeneralConnection : public fuerte::Connection {
   /// The following is called when the connection is permanently failed. It is
   /// used to shut down any activity in the derived classes in a way that avoids
   /// sleeping barbers
-  void terminateActivity(const fuerte::Error err) {
+  void terminateActivity(fuerte::Error err) {
     // Usually, we are `active == true` when we get here, except for the
     // following case: If we are inactive but the connection is still open and
     // then the idle timeout goes off, then we shutdownConnection and in the TLS
@@ -275,6 +278,14 @@ class GeneralConnection : public fuerte::Connection {
         return;
       }
       this->_active.store(true);
+    }
+  }
+
+  void cancelTimer() noexcept {
+    try {
+      this->_proto.timer.cancel();
+    } catch (std::exception const& ex) {
+      FUERTE_LOG_ERROR << "caught exception during timer cancelation: " << ex.what() << "\n";
     }
   }
 
@@ -296,58 +307,46 @@ class GeneralConnection : public fuerte::Connection {
                                             RequestCallback&& cb) = 0;
 
  private:
-  // Connect with a given number of retries
-  void tryConnect(unsigned retries, Clock::time_point start,
-                  asio_ns::error_code const& ec) {
+  // Try to connect
+  void tryConnect() {
     if (_state.load() != Connection::State::Connecting) {
       return;
     }
 
-    if (retries == 0) {
-      std::string msg("connecting failed: '");
-      msg.append((ec != asio_ns::error::operation_aborted) ? ec.message()
-                                                           : "timeout");
-      msg.push_back('\'');
-      shutdownConnection(Error::CouldNotConnect, msg);
-      return;
-    }
-
-    FUERTE_LOG_DEBUG << "tryConnect (" << retries << ") this=" << this << "\n";
+    FUERTE_LOG_DEBUG << "tryConnect this=" << this << "\n";
     auto self = Connection::shared_from_this();
 
-    _proto.timer.expires_at(start + _config._connectTimeout);
-    _proto.timer.async_wait([self](asio_ns::error_code const& ec) {
-      if (!ec && self->state() == Connection::State::Connecting) {
-        // the connect handler below gets 'operation_aborted' error
-        static_cast<GeneralConnection<ST, RT>&>(*self)._proto.cancel();
-      }
-    });
-
-    _proto.connect(_config, [self, start, retries](auto const& ec) mutable {
+    _proto.connect(_config, [self](asio_ns::error_code ec) mutable {
       auto& me = static_cast<GeneralConnection<ST, RT>&>(*self);
-      me._proto.timer.cancel();
+      me.cancelTimer();
       // Note that is is possible that the alarm has already gone off, in which
       // case its closure might already be queued right after ourselves!
       // However, we now quickly set the state to `Connected` in which case the
       // closure will no longer shut down the socket and ruin our success.
       if (!ec) {
+        FUERTE_LOG_DEBUG << "tryConnect established connection this=" << self.get() << "\n";
         me.finishConnect();
         return;
       }
-      FUERTE_LOG_DEBUG << "connecting failed: " << ec.message() << "\n";
-      if (retries > 0 && ec != asio_ns::error::operation_aborted) {
-        auto end = std::min(Clock::now() + me._config._connectRetryPause,
-                            start + me._config._connectTimeout);
-        me._proto.timer.expires_at(end);
-        me._proto.timer.async_wait(
-            [self(std::move(self)), start, retries](auto ec) mutable {
-              auto& me = static_cast<GeneralConnection<ST, RT>&>(*self);
-              me.tryConnect(!ec ? retries - 1 : 0, start, ec);
-            });
-      } else {
-        me.tryConnect(0, start, ec);  // <- handles errors
+        
+      std::string msg("connecting failed: ");
+      msg.append((ec != asio_ns::error::operation_aborted) ? ec.message()
+                                                             : "timeout");
+      FUERTE_LOG_DEBUG << "tryConnect, calling shutdownConnection: " << msg << " this=" << self.get() << "\n";
+      me.shutdownConnection(Error::CouldNotConnect, msg);
+    });
+    
+    _proto.timer.expires_after(_config._connectTimeout);
+    _proto.timer.async_wait([self = std::move(self)](asio_ns::error_code ec) {
+      if (!ec && self->state() == Connection::State::Connecting) {
+        // note: if the timer fires successfully, ec is empty here.
+        // the connect handler below gets 'operation_aborted' error
+        auto& me = static_cast<GeneralConnection<ST, RT>&>(*self);
+        me._proto.cancel();
+        FUERTE_LOG_DEBUG << "tryConnect, connect timeout this=" << self.get() << "\n";
       }
     });
+
   }
 
  protected:
@@ -422,8 +421,7 @@ struct MultiConnection : public GeneralConnection<ST, RT> {
   void setTimeout(bool setIOBegin) {
     const bool wasIdle = _streams.empty();
     if (wasIdle && !this->_config._useIdleTimeout) {
-      asio_ns::error_code ec;
-      this->_proto.timer.cancel(ec);
+      this->cancelTimer();
       return;
     }
 

--- a/3rdParty/fuerte/src/GeneralConnection.h
+++ b/3rdParty/fuerte/src/GeneralConnection.h
@@ -315,6 +315,8 @@ class GeneralConnection : public fuerte::Connection {
 
     FUERTE_LOG_DEBUG << "tryConnect this=" << this << "\n";
     auto self = Connection::shared_from_this();
+    
+    _proto.timer.expires_after(_config._connectTimeout);
 
     _proto.connect(_config, [self](asio_ns::error_code ec) mutable {
       auto& me = static_cast<GeneralConnection<ST, RT>&>(*self);
@@ -336,7 +338,6 @@ class GeneralConnection : public fuerte::Connection {
       me.shutdownConnection(Error::CouldNotConnect, msg);
     });
     
-    _proto.timer.expires_after(_config._connectTimeout);
     _proto.timer.async_wait([self = std::move(self)](asio_ns::error_code ec) {
       if (!ec && self->state() == Connection::State::Connecting) {
         // note: if the timer fires successfully, ec is empty here.

--- a/3rdParty/fuerte/src/H1Connection.cpp
+++ b/3rdParty/fuerte/src/H1Connection.cpp
@@ -365,7 +365,7 @@ void H1Connection<ST>::asyncWriteCallback(asio_ns::error_code const& ec,
   FUERTE_ASSERT(this->_state == Connection::State::Connected ||
                 this->_state == Connection::State::Closed);
   this->_writing = false;  // indicate that no async write is ongoing any more
-  this->_proto.timer.cancel();  // cancel alarm for timeout
+  this->cancelTimer();  // cancel alarm for timeout
 
   auto const now = Clock::now();
   if (ec || _item == nullptr || _item->expires < now) {
@@ -405,7 +405,7 @@ template <SocketType ST>
 void H1Connection<ST>::asyncReadCallback(asio_ns::error_code const& ec) {
   // Do not cancel timeout now, because we might be going on to read!
   if (_item == nullptr) {  // could happen on aborts
-    this->_proto.timer.cancel();
+    this->cancelTimer();
     this->shutdownConnection(Error::CloseRequested);
     return;
   }
@@ -445,7 +445,8 @@ void H1Connection<ST>::asyncReadCallback(asio_ns::error_code const& ec) {
     FUERTE_ASSERT(_response != nullptr);
     _messageComplete = false;  // prevent entering branch on EOF
 
-    this->_proto.timer.cancel();  // got response in time
+    this->cancelTimer();  // got response in time
+
     if (!_responseBuffer.empty()) {
       _response->setPayload(std::move(_responseBuffer), 0);
     }
@@ -504,8 +505,7 @@ template <SocketType ST>
 void H1Connection<ST>::setIOTimeout() {
   const bool isIdle = _item == nullptr;
   if (isIdle && !this->_config._useIdleTimeout) {
-    asio_ns::error_code ec;
-    this->_proto.timer.cancel(ec);
+    this->cancelTimer();
     return;
   }
 

--- a/3rdParty/fuerte/src/H2Connection.cpp
+++ b/3rdParty/fuerte/src/H2Connection.cpp
@@ -353,7 +353,7 @@ void H2Connection<SocketType::Tcp>::readSwitchingProtocolsResponse() {
       this->_proto.socket, this->_receiveBuffer, "\r\n\r\n",
       [self](asio_ns::error_code const& ec, size_t nread) {
         auto& me = static_cast<H2Connection<SocketType::Tcp>&>(*self);
-        me._proto.timer.cancel();
+        me.cancelTimer();
         if (ec) {
           me.shutdownConnection(Error::ReadError,
                                 "error reading upgrade response");

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 devel
 -----
 
+* Fix connection retry attempts for cluster-internal TLS connections that ran 
+  into the 15 seconds timeout during the connection establishing attempt.
+  In this case, the low-level socket was repurposed, but not reset properly.
+  This could leave the connection in an improper state and lead to callbacks
+  for some requests to not being called as expected.
+  The fix is to remove the retry logic, and instead prolong the connection
+  timeout to a multiple of the previous timeout value.
+
 * Improved the time required to create a new Collection in a database with
   hundreds of collections. This also improves times for indexes and dropping
   of collections.

--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -106,8 +106,6 @@ V8ClientConnection::V8ClientConnection(ArangoshServer& server,
   _vpackOptions.buildUnindexedObjects = true;
   _vpackOptions.buildUnindexedArrays = true;
 
-  _builder.maxConnectRetries(3);
-  _builder.connectRetryPause(std::chrono::milliseconds(100));
   _builder.connectTimeout(std::chrono::milliseconds(
       static_cast<int64_t>(1000.0 * _client.connectionTimeout())));
   _builder.onFailure([this](fu::Error err, std::string const& msg) {

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -56,9 +56,7 @@ using namespace arangodb::options;
 
 // Please leave this code in for the next time we have to debug fuerte.
 #if 0
-void LogHackWriter(char const* p) {
-  LOG_DEVEL << p;
-}
+void LogHackWriter(std::string_view msg) { LOG_DEVEL << msg; }
 #endif
 
 namespace arangodb {

--- a/tests/Fuerte/ConnectionFailuresTest.cpp
+++ b/tests/Fuerte/ConnectionFailuresTest.cpp
@@ -27,21 +27,37 @@
 
 #include "gtest/gtest.h"
 
+#include <string_view>
+
 namespace f = ::arangodb::fuerte;
+
+// for testing connection failures, we need a free port that is not used by
+// another service. because we can't be sure about high port numbers, we are
+// using some from the very range. according to
+// https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?&page=2
+// port 60 is unassigned and thus likely not taken by any service on the test
+// host. previously we used port 8629 for testing connection failures, but this
+// was flawed because it was possible that some service was running on port
+// 8629, which then made the connection failure tests fail.
+constexpr std::string_view urls[] = {
+    "http://localhost:60",
+    "h2://localhost:60",
+    "ssl://localhost:60",
+    "h2s://localhost:60",
+};
 
 // tryToConnectExpectFailure tries to make a connection to a host with given
 // url. This is expected to fail.
 static void tryToConnectExpectFailure(f::EventLoopService& eventLoopService,
-                                      const std::string& url) {
+                                      std::string_view url) {
   f::WaitGroup wg;
 
   wg.add();
   f::ConnectionBuilder cbuilder;
   cbuilder.connectTimeout(std::chrono::milliseconds(250));
-  cbuilder.connectRetryPause(std::chrono::milliseconds(100));
-  cbuilder.endpoint(url);
+  cbuilder.endpoint(std::string{url});
 
-  cbuilder.onFailure([&](f::Error errorCode, const std::string& errorMessage) {
+  cbuilder.onFailure([&](f::Error errorCode, std::string const& errorMessage) {
     ASSERT_EQ(errorCode, f::Error::CouldNotConnect);
     wg.done();
   });
@@ -66,12 +82,9 @@ TEST(ConnectionFailureTest, CannotResolveHttp) {
 
 // CannotConnect tests try to make a connection to a host with a valid name
 // but a wrong port.
-TEST(ConnectionFailureTest, CannotConnectHttp) {
-  f::EventLoopService loop;
-  tryToConnectExpectFailure(loop, "http://localhost:8629");
-}
-
-TEST(ConnectionFailureTest, CannotConnectHttp2) {
-  f::EventLoopService loop;
-  tryToConnectExpectFailure(loop, "h2://localhost:8629");
+TEST(ConnectionFailureTest, CannotConnect) {
+  for (auto const& url : urls) {
+    f::EventLoopService loop;
+    tryToConnectExpectFailure(loop, url);
+  }
 }


### PR DESCRIPTION
### Scope & Purpose

* Fix connection retry attempts for cluster-internal TLS connections that ran
  into the 15 seconds timeout during the connection establishing attempt.
  In this case, the low-level socket was repurposed, but not reset properly.
  This could leave the connection in an improper state and lead to callbacks
  for some requests to not being called as expected.
  The fix is to remove the retry logic, and instead prolong the connection
  timeout to a multiple of the previous timeout value.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20906
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 