### PR TITLE
retry query shutdown in case no connection can be established

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1708,7 +1708,7 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
 
   network::RequestOptions options;
   options.database = query.vocbase().name();
-  options.timeout = network::Timeout(60.0);  // Picked arbitrarily
+  options.timeout = network::Timeout(120.0);  // Picked arbitrarily
   options.continuationLane = RequestLane::CLUSTER_INTERNAL;
   // Most coordinator AQL code might be executed on the MEDIUM prio lane,
   // since it comes from a continuation. Therefore, to avoid deadlock, we
@@ -1733,9 +1733,9 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
     TRI_ASSERT(!server.starts_with("server:"));
 
     auto f =
-        network::sendRequest(pool, "server:" + server, fuerte::RestVerb::Delete,
-                             absl::StrCat("/_api/aql/finish/", queryId), body,
-                             options)
+        network::sendRequestRetry(
+            pool, "server:" + server, fuerte::RestVerb::Delete,
+            absl::StrCat("/_api/aql/finish/", queryId), body, options)
             .thenValue([ss, &query](network::Response&& res) mutable -> Result {
               // simon: checked until 3.5, shutdown result is always ignored
               if (res.fail()) {


### PR DESCRIPTION
### Scope & Purpose

Retry query shutdown in case no connection can be established.
Also double the request timeout for query shutdown.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20912
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 