### PR TITLE
retry query shutdown in case no connection can be established

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* Retry cluster query shutdown in case no connection can be made to the
+  DB-Servers for the shutdown request.
+
 * Improved the time required to create a new Collection in a database with
   hundreds of collections. This also improves times for indexes and dropping
   of collections.

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1592,7 +1592,7 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
 
   network::RequestOptions options;
   options.database = query.vocbase().name();
-  options.timeout = network::Timeout(60.0);  // Picked arbitrarily
+  options.timeout = network::Timeout(120.0);  // Picked arbitrarily
   options.continuationLane = RequestLane::CLUSTER_INTERNAL;
   // Most coordinator AQL code might be executed on the MEDIUM prio lane,
   // since it comes from a continuation. Therefore, to avoid deadlock, we
@@ -1617,9 +1617,9 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
     TRI_ASSERT(!server.starts_with("server:"));
 
     auto f =
-        network::sendRequest(pool, "server:" + server, fuerte::RestVerb::Delete,
-                             "/_api/aql/finish/" + std::to_string(queryId),
-                             body, options)
+        network::sendRequestRetry(
+            pool, "server:" + server, fuerte::RestVerb::Delete,
+            "/_api/aql/finish/" + std::to_string(queryId), body, options)
             .thenValue([ss, &query](network::Response&& res) mutable -> Result {
               // simon: checked until 3.5, shutdown result is always
               // ignored


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20911

Retry query shutdown in case no connection can be established.
Also double the request timeout for query shutdown.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 