### PR TITLE
ConnectionPool without MetricsFeature

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -655,13 +655,17 @@ void ClusterFeature::prepare() {
 
   reportRole(_requestedRole);
 
-  network::ConnectionPool::Config config(_metrics);
+  network::ConnectionPool::Config config;
   config.numIOThreads = 2u;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10000;
   config.verifyHosts = false;
   config.clusterInfo = &clusterInfo();
   config.name = "AgencyComm";
+
+  auto& metricsFeature = server().getFeature<metrics::MetricsFeature>();
+  config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+      metricsFeature, config.name);
 
   _asyncAgencyCommPool = std::make_unique<network::ConnectionPool>(config);
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -663,9 +663,8 @@ void ClusterFeature::prepare() {
   config.clusterInfo = &clusterInfo();
   config.name = "AgencyComm";
 
-  auto& metricsFeature = server().getFeature<metrics::MetricsFeature>();
   config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
-      metricsFeature, config.name);
+      _metrics, config.name);
 
   _asyncAgencyCommPool = std::make_unique<network::ConnectionPool>(config);
 

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -42,23 +42,6 @@
 #include <fuerte/connection.h>
 #include <memory>
 
-DECLARE_GAUGE(arangodb_connection_pool_connections_current, uint64_t,
-              "Current number of connections in pool");
-DECLARE_COUNTER(arangodb_connection_pool_leases_successful_total,
-                "Total number of successful connection leases");
-DECLARE_COUNTER(arangodb_connection_pool_leases_failed_total,
-                "Total number of failed connection leases");
-DECLARE_COUNTER(arangodb_connection_pool_connections_created_total,
-                "Total number of connections created");
-
-struct LeaseTimeScale {
-  static arangodb::metrics::LogScale<float> scale() {
-    return {2.f, 0.f, 1000.f, 10};
-  }
-};
-DECLARE_HISTOGRAM(arangodb_connection_pool_lease_time_hist, LeaseTimeScale,
-                  "Time to lease a connection from pool [ms]");
-
 namespace arangodb {
 namespace network {
 
@@ -84,21 +67,11 @@ struct ConnectionPool::Impl {
       : _config(config),
         _pool(pool),
         _loop(config.numIOThreads, config.name),
-        _totalConnectionsInPool(_config.metricsFeature.add(
-            arangodb_connection_pool_connections_current{}.withLabel(
-                "pool", _config.name))),
-        _successSelect(_config.metricsFeature.add(
-            arangodb_connection_pool_leases_successful_total{}.withLabel(
-                "pool", config.name))),
-        _noSuccessSelect(_config.metricsFeature.add(
-            arangodb_connection_pool_leases_failed_total{}.withLabel(
-                "pool", config.name))),
-        _connectionsCreated(_config.metricsFeature.add(
-            arangodb_connection_pool_connections_created_total{}.withLabel(
-                "pool", config.name))),
-        _leaseHistMSec(_config.metricsFeature.add(
-            arangodb_connection_pool_lease_time_hist{}.withLabel(
-                "pool", config.name))) {
+        _totalConnectionsInPool(*_config.metrics.totalConnectionsInPool),
+        _successSelect(*_config.metrics.successSelect),
+        _noSuccessSelect(*_config.metrics.noSuccessSelect),
+        _connectionsCreated(*_config.metrics.connectionsCreated),
+        _leaseHistMSec(*_config.metrics.leaseHistMSec) {
     TRI_ASSERT(config.numIOThreads > 0);
   }
 
@@ -419,6 +392,41 @@ fuerte::Connection* ConnectionPtr::operator->() const {
 
 fuerte::Connection* ConnectionPtr::get() const {
   return _context->fuerte.get();
+}
+
+DECLARE_GAUGE(arangodb_connection_pool_connections_current, uint64_t,
+              "Current number of connections in pool");
+DECLARE_COUNTER(arangodb_connection_pool_leases_successful_total,
+                "Total number of successful connection leases");
+DECLARE_COUNTER(arangodb_connection_pool_leases_failed_total,
+                "Total number of failed connection leases");
+DECLARE_COUNTER(arangodb_connection_pool_connections_created_total,
+                "Total number of connections created");
+
+struct LeaseTimeScale {
+  static arangodb::metrics::LogScale<float> scale() {
+    return {2.f, 0.f, 1000.f, 10};
+  }
+};
+DECLARE_HISTOGRAM(arangodb_connection_pool_lease_time_hist, LeaseTimeScale,
+                  "Time to lease a connection from pool [ms]");
+
+ConnectionPool::Metrics ConnectionPool::Metrics::fromMetricsFeature(
+    metrics::MetricsFeature& metricsFeature, std::string_view name) {
+  Metrics m;
+  m.totalConnectionsInPool = &metricsFeature.add(
+      arangodb_connection_pool_connections_current{}.withLabel("pool", name));
+  m.successSelect = &metricsFeature.add(
+      arangodb_connection_pool_leases_successful_total{}.withLabel("pool",
+                                                                   name));
+  m.noSuccessSelect = &metricsFeature.add(
+      arangodb_connection_pool_leases_failed_total{}.withLabel("pool", name));
+  m.connectionsCreated = &metricsFeature.add(
+      arangodb_connection_pool_connections_created_total{}.withLabel("pool",
+                                                                     name));
+  m.leaseHistMSec = &metricsFeature.add(
+      arangodb_connection_pool_lease_time_hist{}.withLabel("pool", name));
+  return m;
 }
 
 }  // namespace network

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -60,7 +60,8 @@ class ConnectionPool final {
 
     metrics::Histogram<metrics::LogScale<float>>* leaseHistMSec;
 
-    static Metrics fromMetricsFeature(metrics::MetricsFeature& feature, std::string_view name);
+    static Metrics fromMetricsFeature(metrics::MetricsFeature& feature,
+                                      std::string_view name);
     static Metrics createStub(std::string_view name);
   };
 

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -52,8 +52,20 @@ class ConnectionPool final {
   friend class ConnectionPtr;
 
  public:
+  struct Metrics {
+    metrics::Gauge<uint64_t>* totalConnectionsInPool;
+    metrics::Counter* successSelect;
+    metrics::Counter* noSuccessSelect;
+    metrics::Counter* connectionsCreated;
+
+    metrics::Histogram<metrics::LogScale<float>>* leaseHistMSec;
+
+    static Metrics fromMetricsFeature(metrics::MetricsFeature& feature, std::string_view name);
+    static Metrics createStub(std::string_view name);
+  };
+
   struct Config {
-    metrics::MetricsFeature& metricsFeature;
+    Metrics metrics;
     // note: clusterInfo can remain a nullptr in unit tests
     ClusterInfo* clusterInfo = nullptr;
     uint64_t maxOpenConnections = 1024;     /// max number of connections
@@ -63,9 +75,6 @@ class ConnectionPool final {
     fuerte::ProtocolType protocol = fuerte::ProtocolType::Http;
     // name must remain valid for the lifetime of the Config object.
     char const* name = "";
-
-    Config(metrics::MetricsFeature& metricsFeature)
-        : metricsFeature(metricsFeature) {}
   };
 
  public:

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -281,14 +281,15 @@ void NetworkFeature::prepare() {
     ci = &server().getFeature<ClusterFeature>().clusterInfo();
   }
 
-  network::ConnectionPool::Config config(
-      server().getFeature<metrics::MetricsFeature>());
+  auto& metricsFeature = server().getFeature<metrics::MetricsFeature>();
+  network::ConnectionPool::Config config;
   config.numIOThreads = static_cast<unsigned>(_numIOThreads);
   config.maxOpenConnections = _maxOpenConnections;
   config.idleConnectionMilli = _idleTtlMilli;
   config.verifyHosts = _verifyHosts;
   config.clusterInfo = ci;
   config.name = "ClusterComm";
+  config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(metricsFeature);
 
   // using an internal network protocol other than HTTP/1 is
   // not supported since 3.9. the protocol is always hard-coded

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -132,7 +132,8 @@ NetworkFeature::NetworkFeature(Server& server, metrics::MetricsFeature& metrics,
       // we should set the compression type "auto" for future releases though
       // to save some traffic.
       _compressionType(CompressionType::kNone),
-      _compressionTypeLabel("none") {
+      _compressionTypeLabel("none"),
+      _metrics(metrics) {
   setOptional(true);
   startsAfter<ClusterFeature>();
   startsAfter<SchedulerFeature>();
@@ -281,7 +282,6 @@ void NetworkFeature::prepare() {
     ci = &server().getFeature<ClusterFeature>().clusterInfo();
   }
 
-  auto& metricsFeature = server().getFeature<metrics::MetricsFeature>();
   network::ConnectionPool::Config config;
   config.numIOThreads = static_cast<unsigned>(_numIOThreads);
   config.maxOpenConnections = _maxOpenConnections;
@@ -290,7 +290,7 @@ void NetworkFeature::prepare() {
   config.clusterInfo = ci;
   config.name = "ClusterComm";
   config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
-      metricsFeature, config.name);
+      _metrics, config.name);
 
   // using an internal network protocol other than HTTP/1 is
   // not supported since 3.9. the protocol is always hard-coded

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -289,7 +289,8 @@ void NetworkFeature::prepare() {
   config.verifyHosts = _verifyHosts;
   config.clusterInfo = ci;
   config.name = "ClusterComm";
-  config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(metricsFeature);
+  config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+      metricsFeature, config.name);
 
   // using an internal network protocol other than HTTP/1 is
   // not supported since 3.9. the protocol is always hard-coded

--- a/arangod/Network/NetworkFeature.h
+++ b/arangod/Network/NetworkFeature.h
@@ -147,6 +147,7 @@ class NetworkFeature final : public ArangodFeature {
   enum class CompressionType { kNone, kDeflate, kGzip, kLz4, kAuto };
   CompressionType _compressionType;
   std::string _compressionTypeLabel;
+  metrics::MetricsFeature& _metrics;
 };
 
 }  // namespace arangodb

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -88,7 +88,8 @@ futures::Future<ErrorCode> resolveDestination(ClusterInfo& ci,
     if (maybeServer.fail()) {
       LOG_TOPIC("60ee8", ERR, Logger::CLUSTER)
           << "cannot find responsible server for shard '" << spec.shardId
-          << "'";
+          << "': " << maybeServer.errorMessage() << " ("
+          << maybeServer.errorNumber() << ")";
       co_return TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE;
     }
 

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -118,7 +118,7 @@ static int runServer(int argc, char** argv, ArangoGlobalContext& context) {
           auto& metrics =
               server.template getFeature<arangodb::metrics::MetricsFeature>();
           return std::make_unique<NetworkFeature>(
-              server, metrics, network::ConnectionPool::Config{metrics});
+              server, metrics, network::ConnectionPool::Config{});
         },
         [](auto& server, TypeTag<QueryRegistryFeature>) {
           return std::make_unique<QueryRegistryFeature>(

--- a/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
+++ b/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
@@ -188,8 +188,9 @@ struct AsyncAgencyCommTest
   }
 
   network::ConnectionPool::Config config() {
-    network::ConnectionPool::Config config(
-        server.getFeature<metrics::MetricsFeature>());
+    network::ConnectionPool::Config config;
+    config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+        server.getFeature<metrics::MetricsFeature>(), "agency-comm");
     config.clusterInfo = &server.getFeature<ClusterFeature>().clusterInfo();
     config.numIOThreads = 1;
     config.maxOpenConnections = 3;

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -2535,7 +2535,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
   arangodb::network::ConnectionPool::Config poolConfig;
   poolConfig.metrics =
       arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
-          server.getFeature<arangodb::metrics::MetricsFeature>(), "mock");
+          server.getFeature<arangodb::metrics::MetricsFeature>(), "mock-foo");
   poolConfig.clusterInfo =
       &server.getFeature<arangodb::ClusterFeature>().clusterInfo();
   poolConfig.numIOThreads = 1;

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -2532,8 +2532,10 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
       .agencyCache()
       .applyTestTransaction(bogus.slice());
 
-  arangodb::network::ConnectionPool::Config poolConfig(
-      server.server().getFeature<arangodb::metrics::MetricsFeature>());
+  arangodb::network::ConnectionPool::Config poolConfig;
+  poolConfig.metrics =
+      arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
+          server.getFeature<arangodb::metrics::MetricsFeature>(), "mock");
   poolConfig.clusterInfo =
       &server.getFeature<arangodb::ClusterFeature>().clusterInfo();
   poolConfig.numIOThreads = 1;
@@ -2647,8 +2649,11 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
     auto& cluster = newServer.addFeature<arangodb::ClusterFeature>();
     auto& networkFeature = newServer.addFeature<arangodb::NetworkFeature>(
         newServer.getFeature<arangodb::metrics::MetricsFeature>(),
-        arangodb::network::ConnectionPool::Config(
-            newServer.getFeature<arangodb::metrics::MetricsFeature>()));
+        arangodb::network::ConnectionPool::Config{
+            .metrics =
+                arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
+                    newServer.getFeature<arangodb::metrics::MetricsFeature>(),
+                    "mock")});
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
     auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     StorageEngineMock engine(newServer);
@@ -2738,8 +2743,11 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
     auto& cluster = newServer.addFeature<arangodb::ClusterFeature>();
     auto& networkFeature = newServer.addFeature<arangodb::NetworkFeature>(
         newServer.getFeature<arangodb::metrics::MetricsFeature>(),
-        arangodb::network::ConnectionPool::Config(
-            newServer.getFeature<arangodb::metrics::MetricsFeature>()));
+        arangodb::network::ConnectionPool::Config{
+            .metrics =
+                arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
+                    newServer.getFeature<arangodb::metrics::MetricsFeature>(),
+                    "mock")});
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
     auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     StorageEngineMock engine(newServer);

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -532,7 +532,7 @@ MockClusterServer::MockClusterServer(bool useAgencyMockPool,
 
   network::ConnectionPool::Config config;
   config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
-      _server.getFeature<metrics::MetricsFeature>(), "mock");
+      _server.getFeature<metrics::MetricsFeature>(), "network-mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 8;
   config.verifyHosts = false;

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -393,8 +393,9 @@ MockV8Server::MockV8Server(bool start) : MockServer() {
   SetupV8Phase(*this);
   addFeature<NetworkFeature>(
       false, _server.getFeature<metrics::MetricsFeature>(),
-      network::ConnectionPool::Config(
-          _server.getFeature<metrics::MetricsFeature>()));
+      network::ConnectionPool::Config{
+          .metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+              _server.getFeature<metrics::MetricsFeature>(), "mock")});
 
   if (start) {
     MockV8Server::startFeatures();
@@ -470,8 +471,9 @@ MockRestServer::MockRestServer(bool start) : MockServer() {
       false, getFeature<arangodb::metrics::MetricsFeature>());
   addFeature<NetworkFeature>(
       false, _server.getFeature<metrics::MetricsFeature>(),
-      network::ConnectionPool::Config(
-          _server.getFeature<metrics::MetricsFeature>()));
+      network::ConnectionPool::Config{
+          .metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+              _server.getFeature<metrics::MetricsFeature>(), "mock")});
   if (start) {
     MockRestServer::startFeatures();
   }
@@ -528,8 +530,9 @@ MockClusterServer::MockClusterServer(bool useAgencyMockPool,
   addFeature<replication2::replicated_state::ReplicatedStateAppFeature>(false);
   addFeature<ReplicatedLogFeature>(false);
 
-  network::ConnectionPool::Config config(
-      _server.getFeature<metrics::MetricsFeature>());
+  network::ConnectionPool::Config config;
+  config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+      _server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 8;
   config.verifyHosts = false;
@@ -544,12 +547,13 @@ MockClusterServer::~MockClusterServer() {
 void MockClusterServer::startFeatures() {
   MockServer::startFeatures();
 
-  network::ConnectionPool::Config poolConfig(
-      _server.getFeature<metrics::MetricsFeature>());
+  network::ConnectionPool::Config poolConfig;
   poolConfig.clusterInfo = &getFeature<ClusterFeature>().clusterInfo();
   poolConfig.numIOThreads = 1;
   poolConfig.maxOpenConnections = 3;
   poolConfig.verifyHosts = false;
+  poolConfig.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+      _server.getFeature<metrics::MetricsFeature>(), "mock");
 
   if (_useAgencyMockPool) {
     _pool = std::make_unique<AsyncAgencyStorePoolMock>(_server, poolConfig);
@@ -1003,7 +1007,8 @@ MockRestAqlServer::MockRestAqlServer() {
   SetupAqlPhase(*this);
   addFeature<NetworkFeature>(
       false, _server.getFeature<metrics::MetricsFeature>(),
-      network::ConnectionPool::Config(
-          _server.getFeature<metrics::MetricsFeature>()));
+      network::ConnectionPool::Config{
+          .metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+              _server.getFeature<metrics::MetricsFeature>(), "mock")});
   MockRestAqlServer::startFeatures();
 }

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -70,7 +70,7 @@ struct NetworkConnectionPoolTest : public ::testing::Test {
 TEST_F(NetworkConnectionPoolTest, prune_while_in_flight) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 5;  // extra small for testing
@@ -135,7 +135,7 @@ TEST_F(NetworkConnectionPoolTest, prune_while_in_flight) {
 TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -157,7 +157,7 @@ TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
 TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -189,7 +189,7 @@ TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 5;  // extra small for testing
@@ -234,7 +234,7 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -346,7 +346,7 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
 TEST_F(NetworkConnectionPoolTest, force_drain) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -382,7 +382,7 @@ TEST_F(NetworkConnectionPoolTest, force_drain) {
 TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
   ConnectionPool::Config config;
   config.metrics =
-      ConnectionPool::Metrics::fromMetricsFeature(metrics(), "mock");
+      ConnectionPool::Metrics::fromMetricsFeature(metrics(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -494,7 +494,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
 TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -578,7 +578,7 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
 TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -731,7 +731,7 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -771,7 +771,7 @@ TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_some) {
   std::string endpointB = "tcp://example.org:800";
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
-      server.getFeature<metrics::MetricsFeature>(), "mock");
+      server.getFeature<metrics::MetricsFeature>(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -381,8 +381,7 @@ TEST_F(NetworkConnectionPoolTest, force_drain) {
 
 TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
   ConnectionPool::Config config;
-  config.metrics =
-      ConnectionPool::Metrics::fromMetricsFeature(metrics(), "");
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(metrics(), "");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -68,7 +68,9 @@ struct NetworkConnectionPoolTest : public ::testing::Test {
 };
 
 TEST_F(NetworkConnectionPoolTest, prune_while_in_flight) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 5;  // extra small for testing
@@ -131,7 +133,9 @@ TEST_F(NetworkConnectionPoolTest, prune_while_in_flight) {
 }
 
 TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
-  ConnectionPool::Config config(metrics());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -151,7 +155,9 @@ TEST_F(NetworkConnectionPoolTest, acquire_endpoint) {
 }
 
 TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
-  ConnectionPool::Config config(metrics());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -181,7 +187,9 @@ TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
 }
 
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 5;  // extra small for testing
@@ -224,7 +232,9 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
 }
 
 TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
-  ConnectionPool::Config config(metrics());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -334,7 +344,9 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
 }
 
 TEST_F(NetworkConnectionPoolTest, force_drain) {
-  ConnectionPool::Config config(metrics());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 3;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -368,7 +380,9 @@ TEST_F(NetworkConnectionPoolTest, force_drain) {
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
-  ConnectionPool::Config config(metrics());
+  ConnectionPool::Config config;
+  config.metrics =
+      ConnectionPool::Metrics::fromMetricsFeature(metrics(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -478,7 +492,9 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_expiration) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -560,7 +576,9 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
 }
 
 TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -711,7 +729,9 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 }
 
 TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing
@@ -749,7 +769,9 @@ TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
 TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_some) {
   std::string endpointA = "tcp://example.org:80";
   std::string endpointB = "tcp://example.org:800";
-  ConnectionPool::Config config(server.getFeature<metrics::MetricsFeature>());
+  ConnectionPool::Config config;
+  config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
+      server.getFeature<metrics::MetricsFeature>(), "mock");
   config.numIOThreads = 1;
   config.maxOpenConnections = 2;
   config.idleConnectionMilli = 10;  // extra small for testing

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -174,8 +174,9 @@ struct NetworkMethodsTest
 
  private:
   network::ConnectionPool::Config config() {
-    network::ConnectionPool::Config config(
-        server.getFeature<metrics::MetricsFeature>());
+    network::ConnectionPool::Config config;
+    config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
+        server.getFeature<metrics::MetricsFeature>(), "mock");
     config.clusterInfo = &server.getFeature<ClusterFeature>().clusterInfo();
     config.numIOThreads = 1;
     config.maxOpenConnections = 3;

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -176,7 +176,7 @@ struct NetworkMethodsTest
   network::ConnectionPool::Config config() {
     network::ConnectionPool::Config config;
     config.metrics = network::ConnectionPool::Metrics::fromMetricsFeature(
-        server.getFeature<metrics::MetricsFeature>(), "mock");
+        server.getFeature<metrics::MetricsFeature>(), "mock-network");
     config.clusterInfo = &server.getFeature<ClusterFeature>().clusterInfo();
     config.numIOThreads = 1;
     config.maxOpenConnections = 3;


### PR DESCRIPTION
### Scope & Purpose
Remove the direct dependency of the ConnectionPool from the MetricsFeature.