### PR TITLE
allow larger database ids (larger than UINT32_MAX)

### DIFF
--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -934,7 +934,7 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
   containers::FlatHashSet<TRI_voc_tick_t> ids;
   for (auto options : VPackObjectIterator(databases)) {
     try {
-      ids.emplace(std::stoul(options.value.get("id").copyString()));
+      ids.emplace(std::stoull(options.value.get("id").copyString()));
     } catch (std::exception const& e) {
       LOG_TOPIC("a9235", ERR, Logger::CLUSTER)
           << "Failed to read planned databases " << options.key.stringView()


### PR DESCRIPTION
### Scope & Purpose

allow larger database ids (larger than UINT32_MAX) in agency plan handling

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 