### PR TITLE
fix logical error in test assertion

### DIFF
--- a/tests/Fuerte/ConnectionFailuresTest.cpp
+++ b/tests/Fuerte/ConnectionFailuresTest.cpp
@@ -156,7 +156,7 @@ TEST(ConnectionFailureTest, LowTimeouts) {
   int n = 100;
   auto [callbacksCalled, failureCallbacksCalled] = runTimeoutTest(cbuilder, n);
   ASSERT_EQ(n, callbacksCalled);
-  ASSERT_LE(n, failureCallbacksCalled);
+  ASSERT_LE(failureCallbacksCalled, n);
 }
 
 TEST(ConnectionFailureTest, LowTimeoutsActualBackend) {


### PR DESCRIPTION
### Scope & Purpose

Fix logical error in test assertion.
This fixes spurious
```
    [FAILED]  fuerte

      "test" failed: exit code of 'Mon May 13 2024 08:23:29 GMT+0000 (GMT) executeAndWait: cmd =build/bin/fuertetest args =["--gtest_output=json:/tmp/ArangoDB/0/arangosh_a9IRiY/fuertetest/testResults.json","--log.line-number","false","--endpoint=ssl://127.0.0.1:7044","--authentication=basic:root:"]' was 1

    [FAILED]  ConnectionFailureTest

      "test" failed: /root/project/tests/Fuerte/ConnectionFailuresTest.cpp:159
Expected: (n) <= (failureCallbacksCalled), actual: 100 vs 99
```
test errors.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 