### PR TITLE
fix a race between collection deletion and revision tree persistence

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -478,7 +478,7 @@ Result RocksDBMetaCollection::takeCareOfRevisionTreePersistence(
     rocksdb::SequenceNumber wantedMaxCommitSeq, bool force,
     std::string const& context, std::string& scratch,
     rocksdb::SequenceNumber& appliedSeq) {
-  TRI_ASSERT(coll.useSyncByRevision());
+  TRI_ASSERT(coll.useSyncByRevision() || coll.deleted());
 
   // might lower `appliedSeq`!
 
@@ -750,6 +750,10 @@ rocksdb::SequenceNumber RocksDBMetaCollection::serializeRevisionTree(
     std::string& output, rocksdb::SequenceNumber commitSeq, bool force,
     std::unique_lock<std::mutex> const& lock) {
   TRI_ASSERT(lock.owns_lock());
+  if (_logicalCollection.deleted()) {
+    return commitSeq;
+  }
+
   TRI_ASSERT(_logicalCollection.useSyncByRevision());
 
   if (!_revisionTree && !haveBufferedOperations(lock)) {  // empty collection


### PR DESCRIPTION
### Scope & Purpose

fix a race between collection deletion and revision tree persistence

if a collection is marked as deleted, by deleting its underlying database, then there is a small window of time in which revision tree persistence is running while the collection is being deleted. during deletion, the collection's syncByRevision attribute can be flipped from true to false. this can clash with the revision tree persistence functionality, which asserts that the collection's syncByRevision attribute is always true.

this could cause spurios failures such as
```
caught unexpected signal 6 (SIGABRT) in state "in wait": assertion failed in arangod/RocksDBEngine/RocksDBMetaCollection.cpp:753 [rocksdb::SequenceNumber arangodb::RocksDBMetaCollection::serializeRevisionTree(std::string &, rocksdb::SequenceNumber, bool, const std::unique_lock<std::mutex> &)]: _logicalCollection.useSyncByRevision()
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 