### PR TITLE
remove artificial limit of 8 for the number of ClusterComm IO threads

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -672,12 +672,12 @@ void ClusterFeature::prepare() {
   AsyncAgencyCommManager::INSTANCE->setSkipScheduler(true);
   AsyncAgencyCommManager::INSTANCE->pool(_asyncAgencyCommPool.get());
 
-  for (const auto& _agencyEndpoint : _agencyEndpoints) {
-    std::string const unified = Endpoint::unifiedForm(_agencyEndpoint);
+  for (auto const& agencyEndpoint : _agencyEndpoints) {
+    std::string unified = Endpoint::unifiedForm(agencyEndpoint);
 
     if (unified.empty()) {
       LOG_TOPIC("1b759", FATAL, arangodb::Logger::CLUSTER)
-          << "invalid endpoint '" << _agencyEndpoint
+          << "invalid endpoint '" << agencyEndpoint
           << "' specified for --cluster.agency-endpoint";
       FATAL_ERROR_EXIT();
     }

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -34,7 +34,6 @@
 #include "Agency/RestAgencyPrivHandler.h"
 #include "ApplicationFeatures/HttpEndpointProvider.h"
 #include "Aql/RestAqlHandler.h"
-#include "Basics/NumberOfCores.h"
 #include "Basics/StringUtils.h"
 #include "Basics/application-exit.h"
 #include "Basics/debugging.h"
@@ -53,6 +52,7 @@
 #include "Metrics/CounterBuilder.h"
 #include "Metrics/HistogramBuilder.h"
 #include "Metrics/MetricsFeature.h"
+#include "Network/NetworkFeature.h"
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "ProgramOptions/Section.h"
@@ -145,8 +145,6 @@ using namespace arangodb::options;
 
 namespace arangodb {
 
-constexpr uint64_t const maxIoThreads = 64;
-
 struct RequestBodySizeScale {
   static metrics::LogScale<uint64_t> scale() { return {2, 64, 65536, 10}; }
 };
@@ -185,7 +183,7 @@ GeneralServerFeature::GeneralServerFeature(Server& server,
       _redirectRootTo("/_admin/aardvark/index.html"),
       _supportInfoApiPolicy("admin"),
       _optionsApiPolicy("jwt"),
-      _numIoThreads(0),
+      _numIoThreads(NetworkFeature::defaultIOThreads()),
       _requestBodySizeHttp1(metrics.add(arangodb_request_body_size_http1{})),
       _requestBodySizeHttp2(metrics.add(arangodb_request_body_size_http2{})),
       _http1Connections(metrics.add(arangodb_http1_connections_total{})),
@@ -200,13 +198,6 @@ GeneralServerFeature::GeneralServerFeature(Server& server,
   startsAfter<SslServerFeature>();
   startsAfter<SchedulerFeature>();
   startsAfter<UpgradeFeature>();
-
-  _numIoThreads =
-      (std::max)(static_cast<uint64_t>(1),
-                 static_cast<uint64_t>(NumberOfCores::getValue() / 4));
-  if (_numIoThreads > maxIoThreads) {
-    _numIoThreads = maxIoThreads;
-  }
 }
 
 void GeneralServerFeature::collectOptions(
@@ -255,7 +246,7 @@ batch processing.)");
 
   options->addOption(
       "--server.io-threads", "The number of threads used to handle I/O.",
-      new UInt64Parameter(&_numIoThreads),
+      new UInt64Parameter(&_numIoThreads, /*base*/ 1, /*minValue*/ 1),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Dynamic));
 
   options
@@ -417,16 +408,6 @@ void GeneralServerFeature::validateOptions(std::shared_ptr<ProgramOptions>) {
                          return basics::StringUtils::trim(value).empty();
                        }),
         _accessControlAllowOrigins.end());
-  }
-
-  // we need at least one io thread and context
-  if (_numIoThreads == 0) {
-    LOG_TOPIC("1ade3", WARN, Logger::FIXME) << "Need at least one io-context";
-    _numIoThreads = 1;
-  } else if (_numIoThreads > maxIoThreads) {
-    LOG_TOPIC("80dcf", WARN, Logger::FIXME)
-        << "io-contexts are limited to " << maxIoThreads;
-    _numIoThreads = maxIoThreads;
   }
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -80,6 +80,9 @@ struct ConnectionPool::Bucket {
 };
 
 struct ConnectionPool::Impl {
+  Impl(Impl const& other) = delete;
+  Impl& operator=(Impl const& other) = delete;
+
   explicit Impl(ConnectionPool::Config const& config, ConnectionPool& pool)
       : _config(config),
         _pool(pool),
@@ -386,10 +389,6 @@ std::shared_ptr<fuerte::Connection> ConnectionPool::createConnection(
 
 ConnectionPool::Config const& ConnectionPool::config() const {
   return _impl->_config;
-}
-
-fuerte::EventLoopService& ConnectionPool::eventLoopService() {
-  return _impl->_loop;
 }
 
 ConnectionPool::Context::Context(std::shared_ptr<fuerte::Connection> c,

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -68,7 +68,9 @@ class ConnectionPool final {
         : metricsFeature(metricsFeature) {}
   };
 
- public:
+  ConnectionPool(ConnectionPool const& other) = delete;
+  ConnectionPool& operator=(ConnectionPool const& other) = delete;
+
   explicit ConnectionPool(ConnectionPool::Config const& config);
   TEST_VIRTUAL ~ConnectionPool();
 
@@ -76,10 +78,6 @@ class ConnectionPool final {
   /// note: it is the callers responsibility to ensure the endpoint
   /// is always the same, we do not do any post-processing
   ConnectionPtr leaseConnection(std::string const& endpoint, bool& isFromPool);
-
-  /// @brief event loop service to create a connection seperately
-  /// user is responsible for correctly shutting it down
-  fuerte::EventLoopService& eventLoopService();
 
   /// @brief shutdown all connections
   void drainConnections();

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -144,14 +144,16 @@ void NetworkFeature::collectOptions(
     std::shared_ptr<options::ProgramOptions> options) {
   options->addSection("network", "cluster-internal networking");
 
-  options->addOption("--network.io-threads",
-                     "The number of network I/O threads for cluster-internal "
-                     "communication.",
-                     new UInt32Parameter(&_numIOThreads));
-  options->addOption("--network.max-open-connections",
-                     "The maximum number of open TCP connections for "
-                     "cluster-internal communication per endpoint",
-                     new UInt64Parameter(&_maxOpenConnections));
+  options->addOption(
+      "--network.io-threads",
+      "The number of network I/O threads for cluster-internal "
+      "communication.",
+      new UInt32Parameter(&_numIOThreads, /*base*/ 1, /*minValue*/ 1));
+  options->addOption(
+      "--network.max-open-connections",
+      "The maximum number of open TCP connections for "
+      "cluster-internal communication per endpoint",
+      new UInt64Parameter(&_maxOpenConnections, /*base*/ 1, /*minValue*/ 8));
   options->addOption("--network.idle-connection-ttl",
                      "The default time-to-live of idle connections for "
                      "cluster-internal communication (in milliseconds).",
@@ -233,10 +235,6 @@ then no compression will be performed.)");
 
 void NetworkFeature::validateOptions(
     std::shared_ptr<options::ProgramOptions> opts) {
-  _numIOThreads = std::max<unsigned>(1, std::min<unsigned>(_numIOThreads, 8));
-  if (_maxOpenConnections < 8) {
-    _maxOpenConnections = 8;
-  }
   if (!opts->processingResult().touched("--network.idle-connection-ttl")) {
     auto& gs = server().getFeature<GeneralServerFeature>();
     _idleTtlMilli = uint64_t(gs.keepAliveTimeout() * 1000 / 2);

--- a/arangod/Network/NetworkFeature.h
+++ b/arangod/Network/NetworkFeature.h
@@ -91,6 +91,8 @@ class NetworkFeature final : public ArangodFeature {
   void retryRequest(std::shared_ptr<network::RetryableRequest>, RequestLane,
                     std::chrono::steady_clock::duration);
 
+  static uint64_t defaultIOThreads();
+
  protected:
   void prepareRequest(network::ConnectionPool const& pool,
                       std::unique_ptr<fuerte::Request>& req);


### PR DESCRIPTION
### Scope & Purpose

* remove artificial limit of 8 for the number of ClusterComm IO threads (`--network.io-threads`)
* remove artificial limit of 16 for the number of GeneralServer IO threads (`--server.io-threads`)
* unify default value generation for the above two config variables as `max(1, # cores / 4)`

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 