### PR TITLE
fix leaks on shutdown

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -911,7 +911,6 @@ void RocksDBEngine::verifySstFiles(rocksdb::Options const& options) const {
       << "' completed successfully";
   Logger::flush();
   // exit with status code = 0, without leaking
-  exit(EXIT_SUCCESS);
   int exitCode = static_cast<int>(TRI_ERROR_NO_ERROR);
   TRI_EXIT_FUNCTION(exitCode, nullptr);
   exit(exitCode);


### PR DESCRIPTION
### Scope & Purpose

Fix memleaks on shutdown when `--rocksdb.verify-sst` is used.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
