### PR TITLE
prevent parallel index creation thread from hanging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* Fix potentially hanging threads during index creation if starting one of the
+  parallel index creation threads returned an error.
+
 * Fix connection retry attempts for cluster-internal TLS connections that ran 
   into the 15 seconds timeout during the connection establishing attempt.
   In this case, the low-level socket was repurposed, but not reset properly.


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20924
Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1481

prevent parallel index creation thread from hanging indefinitely, in case the thread objects were created successfully but starting a thread returned an error.
in this case, the threads that were unable to start would never call the completion function on the shared env, so that the main index creation thread would wait forever for all threads to complete. now, if a thread cannot be started successfully, we immediately count down the number of threads to wait for in the shared env.

The actual fix is in https://github.com/arangodb/enterprise/pull/1481

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1481
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 