### PR TITLE
fix a false positive report of Merkle tree differences

### DIFF
--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -60,6 +60,11 @@ const fetchRevisionTree = (serverUrl, shardId) => {
   return JSON.parse(result.body);
 };
 
+const compareTree = function (left, right) {
+  const attributes = ["version", "maxDepth", "count", "hash", "initialRangeMin"];
+  return _.every(attributes, (attr) => left[attr] === right[attr]);
+};
+
 const checkCollectionConsistency = (cn) => {
   const c = db._collection(cn);
   const servers = getDBServers();
@@ -91,7 +96,7 @@ const checkCollectionConsistency = (cn) => {
           failed = true;
         }
 
-        if (!_.isEqual(leaderTree, followerTree)) {
+        if (!compareTree(leaderTree.computed, followerTree.computed)) {
           console.error(`Leader and follower have different trees for shard ${shard}`);
           console.error("Leader: ", leaderTree);
           console.error("Follower: ", followerTree);


### PR DESCRIPTION
### Scope & Purpose

Fix a false positive report of Merkle tree differences.
This is a late 3.11 backport of https://github.com/arangodb/arangodb/pull/19502

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 