### PR TITLE
allow larger database ids (larger than UINT32_MAX)

### DIFF
--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -1383,7 +1383,7 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
     for (VPackObjectIterator::ObjectPair options :
          VPackObjectIterator(databases)) {
       try {
-        ids.push_back(std::stoul(options.value.get("id").copyString()));
+        ids.push_back(std::stoull(options.value.get("id").copyString()));
       } catch (std::invalid_argument& e) {
         LOG_TOPIC("a9233", ERR, Logger::CLUSTER)
             << "Number conversion for planned database id for "


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20917
Allow larger database ids (larger than UINT32_MAX) in agency plan handling

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 