### PR TITLE
Wait for ClusterInfo to catch up after creating a collection

### DIFF
--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -499,8 +499,15 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
   // for in waitForCurrentToCatchUp
   auto const index = agencyCache.index();
   // wait for cluster info to catch up
-  ci.waitForCurrent(index);
-  ci.waitForPlan(index);
+  auto futCurrent = ci.waitForCurrent(index);
+  auto futPlan = ci.waitForPlan(index);
+  if (auto r = futCurrent.get(); r.fail()) {
+    return r;
+  }
+  if (auto r = futPlan.get(); r.fail()) {
+    return r;
+  }
+  return {};
 }
 
 template<replication::Version ReplicationVersion>

--- a/arangod/Cluster/ClusterCollectionMethods.cpp
+++ b/arangod/Cluster/ClusterCollectionMethods.cpp
@@ -441,9 +441,9 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
   if (buildingTransaction.fail()) {
     return buildingTransaction.result();
   }
+  auto& agencyCache = server.getFeature<ClusterFeature>().agencyCache();
   auto callbackInfos = writer.prepareCurrentWatcher(
-      databaseName, waitForSyncReplication,
-      server.getFeature<ClusterFeature>().agencyCache());
+      databaseName, waitForSyncReplication, agencyCache);
 
   std::vector<std::pair<std::shared_ptr<AgencyCallback>, std::string>>
       callbackList;
@@ -490,8 +490,17 @@ Result impl(ClusterInfo& ci, ArangodServer& server,
     return r;
   }
 
-  return waitForCurrentToCatchUp(server, callbackInfos, callbackList,
-                                 pollInterval);
+  if (auto r = waitForCurrentToCatchUp(server, callbackInfos, callbackList,
+                                       pollInterval);
+      r.fail()) {
+    return r;
+  }
+  // get current raft index; this is at least as high as the one we just waited
+  // for in waitForCurrentToCatchUp
+  auto const index = agencyCache.index();
+  // wait for cluster info to catch up
+  ci.waitForCurrent(index);
+  ci.waitForPlan(index);
 }
 
 template<replication::Version ReplicationVersion>


### PR DESCRIPTION
### Scope & Purpose

Currently, a Coordinator that's creating a Replication 2 collection does not wait for its own ClusterInfo to catch up, which can sometimes lead to "collection not found" errors on that same coordinator after a successful collection creation. This also leads to some spurious test failures.

This PR waits for CI to catch up.

- [X] :hankey: Bugfix