### PR TITLE
Remove server dependency of Logger and Thread

### DIFF
--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -202,7 +202,7 @@ std::string Supervision::_agencyPrefix = "/arango";
 
 Supervision::Supervision(ArangodServer& server,
                          metrics::MetricsFeature& metrics)
-    : arangodb::Thread(server, "Supervision"),
+    : arangodb::ServerThread<ArangodServer>(server, "Supervision"),
       _agent(nullptr),
       _snapshot(nullptr),
       _transient(Node::create()),

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -77,7 +77,7 @@ void cleanupHotbackupTransferJobsFunctional(
 void failBrokenHotbackupTransferJobsFunctional(
     Node const& snapshot, std::shared_ptr<VPackBuilder> envelope);
 
-class Supervision : public arangodb::Thread {
+class Supervision : public ServerThread<ArangodServer> {
  public:
   typedef std::chrono::system_clock::time_point TimePoint;
   typedef std::string ServerID;

--- a/arangod/GeneralServer/IoContext.cpp
+++ b/arangod/GeneralServer/IoContext.cpp
@@ -38,7 +38,7 @@ IoContext::IoThread::IoThread(application_features::ApplicationServer& server,
     : Thread(server, "Io"), _iocontext(iocontext) {}
 
 IoContext::IoThread::IoThread(IoThread const& other)
-    : Thread(other._server, "Io"), _iocontext(other._iocontext) {}
+    : Thread("Io"), _iocontext(other._iocontext) {}
 
 IoContext::IoThread::~IoThread() { shutdown(); }
 

--- a/lib/Basics/Thread.cpp
+++ b/lib/Basics/Thread.cpp
@@ -181,11 +181,13 @@ std::string Thread::stringify(ThreadState state) {
 }
 
 /// @brief constructs a thread
-Thread::Thread(application_features::ApplicationServer& server,
+Thread::Thread(application_features::ApplicationServer&,
                std::string const& name, bool deleteOnExit,
                std::uint32_t terminationTimeout)
-    : _server(server),
-      _threadStructInitialized(false),
+    : Thread(name, deleteOnExit, terminationTimeout) {}
+Thread::Thread(std::string const& name, bool deleteOnExit,
+               std::uint32_t terminationTimeout)
+    : _threadStructInitialized(false),
       _refs(0),
       _name(name),
       _thread(),
@@ -265,14 +267,6 @@ bool Thread::isStopping() const noexcept {
 
 /// @brief starts the thread
 bool Thread::start(ConditionVariable* finishedCondition) {
-  if (!isSystem() && !_server.isPrepared()) {
-    LOG_TOPIC("6ba8a", FATAL, arangodb::Logger::FIXME)
-        << "trying to start a thread '" << _name
-        << "' before prepare has finished, current state: "
-        << (int)_server.state();
-    FATAL_ERROR_ABORT();
-  }
-
   _finishedCondition = finishedCondition;
   ThreadState state = _state.load();
 

--- a/lib/Basics/Thread.h
+++ b/lib/Basics/Thread.h
@@ -94,8 +94,10 @@ class Thread {
   static TRI_tid_t currentThreadId();
 
  public:
-  Thread(application_features::ApplicationServer& server,
-         std::string const& name, bool deleteOnExit = false,
+  [[deprecated("server argument is no longer needed")]] Thread(
+      application_features::ApplicationServer&, std::string const& name,
+      bool deleteOnExit = false, std::uint32_t terminationTimeout = INFINITE);
+  Thread(std::string const& name, bool deleteOnExit = false,
          std::uint32_t terminationTimeout = INFINITE);
   virtual ~Thread();
 
@@ -104,9 +106,6 @@ class Thread {
 
   /// @brief whether or not the thread is chatty on shutdown
   virtual bool isSilent() const { return false; }
-
-  /// @brief the underlying application server
-  application_features::ApplicationServer& server() noexcept { return _server; }
 
   /// @brief flags the thread as stopping
   /// Classes that override this function must ensure that they
@@ -172,9 +171,6 @@ class Thread {
   void runMe();
   void releaseRef() noexcept;
 
- protected:
-  application_features::ApplicationServer& _server;
-
  private:
   std::atomic<bool> _threadStructInitialized;
   std::atomic<int> _refs;
@@ -207,11 +203,13 @@ class ServerThread : public Thread {
   ServerThread(Server& server, std::string const& name,
                bool deleteOnExit = false,
                std::uint32_t terminationTimeout = INFINITE)
-      : Thread{server, name, deleteOnExit, terminationTimeout} {}
+      : Thread{server, name, deleteOnExit, terminationTimeout},
+        _server(server) {}
 
-  Server& server() noexcept {
-    return basics::downCast<Server>(Thread::server());
-  }
+  Server& server() noexcept { return _server; }
+
+ protected:
+  Server& _server;
 };
 
 }  // namespace arangodb

--- a/lib/Logger/LogThread.cpp
+++ b/lib/Logger/LogThread.cpp
@@ -29,9 +29,8 @@
 
 using namespace arangodb;
 
-LogThread::LogThread(application_features::ApplicationServer& server,
-                     std::string const& name, uint32_t maxQueuedLogMessages)
-    : Thread(server, name),
+LogThread::LogThread(std::string const& name, uint32_t maxQueuedLogMessages)
+    : Thread(name),
       _messages(64),
       _maxQueuedLogMessages(maxQueuedLogMessages) {}
 

--- a/lib/Logger/LogThread.h
+++ b/lib/Logger/LogThread.h
@@ -49,8 +49,7 @@ class LogThread final : public Thread {
   };
 
  public:
-  explicit LogThread(application_features::ApplicationServer& server,
-                     std::string const& name, uint32_t maxQueuedLogMessages);
+  explicit LogThread(std::string const& name, uint32_t maxQueuedLogMessages);
   ~LogThread();
 
   bool isSystem() const override { return true; }

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -883,8 +883,7 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage> msg,
 /// @brief initializes the logging component
 ////////////////////////////////////////////////////////////////////////////////
 
-void Logger::initialize(application_features::ApplicationServer& server,
-                        bool threaded, uint32_t maxQueuedLogMessages) {
+void Logger::initialize(bool threaded, uint32_t maxQueuedLogMessages) {
   if (_active.exchange(true, std::memory_order_acquire)) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "Logger already initialized");
@@ -892,8 +891,8 @@ void Logger::initialize(application_features::ApplicationServer& server,
 
   // logging is now active
   if (threaded) {
-    auto loggingThread = std::make_unique<LogThread>(
-        server, std::string(logThreadName), maxQueuedLogMessages);
+    auto loggingThread = std::make_unique<LogThread>(std::string(logThreadName),
+                                                     maxQueuedLogMessages);
     if (!loggingThread->start()) {
       LOG_TOPIC("28bd9", FATAL, arangodb::Logger::FIXME)
           << "could not start logging thread";

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -305,8 +305,7 @@ class Logger {
                                    : topic.level());
   }
 
-  static void initialize(application_features::ApplicationServer&, bool,
-                         uint32_t maxQueuedLogMessages);
+  static void initialize(bool, uint32_t maxQueuedLogMessages);
   static void shutdown();
   static void flush() noexcept;
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -720,9 +720,9 @@ void LoggerFeature::prepare() {
   }
 
   if (_forceDirect || _supervisor) {
-    Logger::initialize(server(), false, _maxQueuedLogMessages);
+    Logger::initialize(false, _maxQueuedLogMessages);
   } else {
-    Logger::initialize(server(), _threaded, _maxQueuedLogMessages);
+    Logger::initialize(_threaded, _maxQueuedLogMessages);
   }
 }
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -123,7 +123,7 @@ int main(int argc, char* argv[]) {
   arangodb::ShellColorsFeature sc(server);
 
   arangodb::Logger::setShowLineNumber(logLineNumbers);
-  arangodb::Logger::initialize(server, false, 10000);
+  arangodb::Logger::initialize(false, 10000);
   arangodb::LogAppender::addAppender(arangodb::Logger::defaultLogGroup(), "-");
 
   sc.prepare();


### PR DESCRIPTION
### Scope & Purpose

Remove dependency on the Server of Logger and Thread; this makes it easier to instantiate them in tests.

This removes a check whether a thread may be started depending on the server's state (in `Thread::start`).