### PR TITLE
add debug information for spuriously failing test

### DIFF
--- a/tests/js/client/shell/shell-index.js
+++ b/tests/js/client/shell/shell-index.js
@@ -72,9 +72,12 @@ function IndexSuite() {
                                 {"x-arango-async": "store"}).headers["x-arango-async-id"];
       let count = 0;
       let progress = 0.0;
+      let idxs = [];
       while (true) {
         // Wait until the index is there (with withHidden):
-        let idxs = arango.GET(`/_api/index?collection=${cn}&withHidden=true`).indexes;
+        idxs = arango.GET(`/_api/index?collection=${cn}&withHidden=true`);
+        assertTrue(idxs.hasOwnProperty("indexes"), idxs);
+        idxs = idxs.indexes;
         if (idxs.length > 1) {
           assertEqual(idxs[1].name, "progress", idxs);
           break;
@@ -84,11 +87,16 @@ function IndexSuite() {
           assertFalse(true, "Did not see hidden index in time!");
         }
       }
+      assertEqual(2, idxs.length, idxs);
 
       let seenProgress = false;
       count = 0;
       while (true) {
-        let idx = arango.GET(`/_api/index?collection=${cn}&withHidden=true`).indexes[1];
+        idxs = arango.GET(`/_api/index?collection=${cn}&withHidden=true`);
+        assertTrue(idxs.hasOwnProperty("indexes"), idxs);
+        idxs = idxs.indexes;
+        assertEqual(2, idxs.length, idxs);
+        let idx = idxs[1];
         assertEqual(idx.name, "progress", idx); // Check we have the right one!
         if (idx.hasOwnProperty("progress")) {
           assertTrue(idx.progress >= progress, {idx, progress});


### PR DESCRIPTION
### Scope & Purpose

Add debug information for a spuriously failing test:
```
=== shell_client_3 ===
* Test "shell_client_3"
    [FAILED]  tests\js\client\shell\shell-index.js

      "testIndexProgressIsReported" failed: TypeError: Cannot read property 'name' of undefined
    at Object.testIndexProgressIsReported (tests\js\client\shell\shell-index.js:92:25)
    at tests\js\client\shell\shell-index.js:159:11
    at tests\js\client\shell\shell-index.js:163:3
    at Object.shellClient [as shell_client] (c:\gce-win-6jakv0\oskar\work\ArangoDB\js\client\modules\@arangodb\testsuites\aql.js:226:79)
 - test failed
```

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 