### PR TITLE
honor `maxProjections` options for MaterializeNode projections

### DIFF
--- a/arangod/Aql/ExecutionNode/DocumentProducingNode.cpp
+++ b/arangod/Aql/ExecutionNode/DocumentProducingNode.cpp
@@ -60,7 +60,8 @@ DocumentProducingNode::DocumentProducingNode(ExecutionPlan* plan,
           plan->getAst()->query().resourceMonitor())),
       _count(false),
       _useCache(true),
-      _maxProjections(kMaxProjections) {
+      _maxProjections(basics::VelocyPackHelper::getNumericValue(
+          slice.get(StaticStrings::MaxProjections), kMaxProjections)) {
   TRI_ASSERT(_outVariable != nullptr);
 
   VPackSlice p = slice.get(StaticStrings::Filter);

--- a/arangod/Aql/ExecutionNode/GraphNode.cpp
+++ b/arangod/Aql/ExecutionNode/GraphNode.cpp
@@ -361,8 +361,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
   }
 }
 
-GraphNode::GraphNode(ExecutionPlan* plan,
-                     arangodb::velocypack::Slice const& base)
+GraphNode::GraphNode(ExecutionPlan* plan, arangodb::velocypack::Slice base)
     : ExecutionNode(plan, base),
       _vocbase(&(plan->getAst()->query().vocbase())),
       _vertexOutVariable(nullptr),

--- a/arangod/Aql/ExecutionNode/GraphNode.h
+++ b/arangod/Aql/ExecutionNode/GraphNode.h
@@ -84,7 +84,7 @@ class GraphNode : public ExecutionNode {
             AstNode const* direction, AstNode const* graph,
             std::unique_ptr<graph::BaseOptions> options);
 
-  GraphNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& base);
+  GraphNode(ExecutionPlan* plan, arangodb::velocypack::Slice base);
 
   /// @brief Internal constructor to clone the node.
   GraphNode(ExecutionPlan* plan, ExecutionNodeId id, TRI_vocbase_t* vocbase,

--- a/arangod/Aql/ExecutionNode/MaterializeRocksDBNode.h
+++ b/arangod/Aql/ExecutionNode/MaterializeRocksDBNode.h
@@ -70,6 +70,9 @@ class MaterializeRocksDBNode : public MaterializeNode,
 
   std::vector<Variable const*> getVariablesSetHere() const override final;
 
+  void setMaxProjections(size_t value) noexcept { _maxProjections = value; }
+  size_t maxProjections() const noexcept { return _maxProjections; }
+
   void projections(Projections proj) noexcept {
     _projections = std::move(proj);
   }
@@ -82,6 +85,8 @@ class MaterializeRocksDBNode : public MaterializeNode,
                       unsigned flags) const override final;
 
   Projections _projections;
+
+  size_t _maxProjections;
 };
 
 }  // namespace materialize

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -72,7 +72,7 @@ TraversalNode::TraversalEdgeConditionBuilder::TraversalEdgeConditionBuilder(
       _tn(tn) {}
 
 TraversalNode::TraversalEdgeConditionBuilder::TraversalEdgeConditionBuilder(
-    TraversalNode const* tn, arangodb::velocypack::Slice const& condition)
+    TraversalNode const* tn, arangodb::velocypack::Slice condition)
     : EdgeConditionBuilder(tn->_plan->getAst()->createNode(condition),
                            tn->_plan->getAst()->query().resourceMonitor()),
       _tn(tn) {}
@@ -186,7 +186,7 @@ TraversalNode::TraversalNode(
 }
 
 TraversalNode::TraversalNode(ExecutionPlan* plan,
-                             arangodb::velocypack::Slice const& base)
+                             arangodb::velocypack::Slice base)
     : GraphNode(plan, base),
       _pathOutVariable(nullptr),
       _inVariable(nullptr),

--- a/arangod/Aql/ExecutionNode/TraversalNode.h
+++ b/arangod/Aql/ExecutionNode/TraversalNode.h
@@ -69,15 +69,15 @@ class TraversalNode : public virtual GraphNode {
    public:
     explicit TraversalEdgeConditionBuilder(TraversalNode const*);
 
-    TraversalEdgeConditionBuilder(TraversalNode const*,
-                                  arangodb::velocypack::Slice const&);
+    TraversalEdgeConditionBuilder(TraversalNode const* tn,
+                                  arangodb::velocypack::Slice condition);
 
-    TraversalEdgeConditionBuilder(TraversalNode const*,
-                                  TraversalEdgeConditionBuilder const*);
+    TraversalEdgeConditionBuilder(TraversalNode const* tn,
+                                  TraversalEdgeConditionBuilder const* other);
 
     ~TraversalEdgeConditionBuilder() = default;
 
-    void toVelocyPack(arangodb::velocypack::Builder&, bool);
+    void toVelocyPack(arangodb::velocypack::Builder& builder, bool verbose);
   };
 
   friend class ExecutionBlock;
@@ -90,7 +90,7 @@ class TraversalNode : public virtual GraphNode {
                 std::unique_ptr<Expression> pruneExpression,
                 std::unique_ptr<graph::BaseOptions> options);
 
-  TraversalNode(ExecutionPlan* plan, arangodb::velocypack::Slice const& base);
+  TraversalNode(ExecutionPlan* plan, arangodb::velocypack::Slice base);
 
   ~TraversalNode();
 

--- a/arangod/Aql/ExecutionNode/WindowNode.cpp
+++ b/arangod/Aql/ExecutionNode/WindowNode.cpp
@@ -330,8 +330,7 @@ WindowNode::WindowNode(ExecutionPlan* plan, ExecutionNodeId id,
       _rangeVariable(rangeVariable),
       _aggregateVariables(aggregateVariables) {}
 
-WindowNode::WindowNode(ExecutionPlan* plan,
-                       arangodb::velocypack::Slice const& base,
+WindowNode::WindowNode(ExecutionPlan* plan, arangodb::velocypack::Slice base,
                        WindowBounds&& b, Variable const* rangeVariable,
                        std::vector<AggregateVarInfo> const& aggregateVariables)
     : ExecutionNode(plan, base),

--- a/arangod/Aql/ExecutionNode/WindowNode.h
+++ b/arangod/Aql/ExecutionNode/WindowNode.h
@@ -101,8 +101,8 @@ class WindowNode : public ExecutionNode {
              Variable const* rangeVariable,
              std::vector<AggregateVarInfo> const& aggregateVariables);
 
-  WindowNode(ExecutionPlan*, arangodb::velocypack::Slice const& base,
-             WindowBounds&& b, Variable const* rangeVariable,
+  WindowNode(ExecutionPlan*, arangodb::velocypack::Slice base, WindowBounds&& b,
+             Variable const* rangeVariable,
              std::vector<AggregateVarInfo> const& aggregateVariables);
 
   ~WindowNode() override;

--- a/arangod/Aql/OptimizerRuleBatchMaterializeDocuments.cpp
+++ b/arangod/Aql/OptimizerRuleBatchMaterializeDocuments.cpp
@@ -136,6 +136,7 @@ void arangodb::aql::batchMaterializeDocumentsRule(
 
     plan->insertAfter(indexNode, materialized);
 
+    materialized->setMaxProjections(indexNode->maxProjections());
     if (!indexNode->projections().empty()) {
       TRI_ASSERT(!indexNode->projections().usesCoveringIndex());
       TRI_ASSERT(!indexNode->projections().hasOutputRegisters());

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -9032,7 +9032,7 @@ void arangodb::aql::optimizeProjections(Optimizer* opt,
                                  /*expectedAttribute*/ "",
                                  /*excludeStartNodeFilterCondition*/ true,
                                  attributes)) {
-        if (attributes.size() <= DocumentProducingNode::kMaxProjections) {
+        if (attributes.size() <= matNode->maxProjections()) {
           matNode->projections() = Projections(std::move(attributes));
         }
       }


### PR DESCRIPTION
### Scope & Purpose

Honor `maxProjections` option in IndexNodes when the IndexNode data is later materialized using a MaterializeNode.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 