### PR TITLE
Bug fix 3.11/hotbackup restore analyzers

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6921,6 +6921,9 @@ Result ClusterInfo::agencyPlan(std::shared_ptr<VPackBuilder> const& body) {
 }
 
 arangodb::Result ClusterInfo::agencyReplan(VPackSlice plan) {
+  TRI_IF_FAILURE("ClusterInfo::failReplanAgency") {
+    return TRI_ERROR_DEBUG;
+  }
   // Apply only Collections and DBServers
   AgencyWriteTransaction transaction(std::vector<AgencyOperation>{
       {"Current/Collections", AgencyValueOperationType::SET,

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6921,9 +6921,7 @@ Result ClusterInfo::agencyPlan(std::shared_ptr<VPackBuilder> const& body) {
 }
 
 arangodb::Result ClusterInfo::agencyReplan(VPackSlice plan) {
-  TRI_IF_FAILURE("ClusterInfo::failReplanAgency") {
-    return TRI_ERROR_DEBUG;
-  }
+  TRI_IF_FAILURE("ClusterInfo::failReplanAgency") { return TRI_ERROR_DEBUG; }
   // Apply only Collections and DBServers
   AgencyWriteTransaction transaction(std::vector<AgencyOperation>{
       {"Current/Collections", AgencyValueOperationType::SET,

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -273,6 +273,18 @@ inline arangodb::AgencyOperation CreateCollectionSuccess(
                                    info};
 }
 
+inline arangodb::AgencyOperation SetOldEntry(
+    std::string const& key, std::vector<std::string_view> const& path,
+    VPackSlice plan) {
+  VPackSlice newEntry = plan.get(path);
+  if (newEntry.isNone()) {
+    // This is a countermeasure to protect against non-existing paths. If we
+    // get anything else original plan is already broken.
+    newEntry = VPackSlice::emptyObjectSlice();
+  }
+  return {key, AgencyValueOperationType::SET, newEntry};
+}
+
 // make sure a collection is still in Plan
 // we are only going from *assuming* that it is present
 // to it being changed to not present.
@@ -6908,23 +6920,19 @@ Result ClusterInfo::agencyPlan(std::shared_ptr<VPackBuilder> const& body) {
   return Result();
 }
 
-arangodb::Result ClusterInfo::agencyReplan(VPackSlice const plan) {
+arangodb::Result ClusterInfo::agencyReplan(VPackSlice plan) {
   // Apply only Collections and DBServers
   AgencyWriteTransaction transaction(std::vector<AgencyOperation>{
       {"Current/Collections", AgencyValueOperationType::SET,
        VPackSlice::emptyObjectSlice()},
-      {"Plan/Collections", AgencyValueOperationType::SET,
-       plan.get({"arango", "Plan", "Collections"})},
+      SetOldEntry("Plan/Collections", {"arango", "Plan", "Collections"}, plan),
       {"Current/Databases", AgencyValueOperationType::SET,
        VPackSlice::emptyObjectSlice()},
-      {"Plan/Databases", AgencyValueOperationType::SET,
-       plan.get({"arango", "Plan", "Databases"})},
+      SetOldEntry("Plan/Databases", {"arango", "Plan", "Databases"}, plan),
       {"Current/Views", AgencyValueOperationType::SET,
        VPackSlice::emptyObjectSlice()},
-      {"Plan/Analyzers", AgencyValueOperationType::SET,
-       plan.get({"arango", "Plan", "Analyzers"})},
-      {"Plan/Views", AgencyValueOperationType::SET,
-       plan.get({"arango", "Plan", "Views"})},
+      SetOldEntry("Plan/Analyzers", {"arango", "Plan", "Analyzers"}, plan),
+      SetOldEntry("Plan/Views", {"arango", "Plan", "Views"}, plan),
       {"Current/Version", AgencySimpleOperationType::INCREMENT_OP},
       {"Plan/Version", AgencySimpleOperationType::INCREMENT_OP},
       {"Sync/UserVersion", AgencySimpleOperationType::INCREMENT_OP},
@@ -6948,7 +6956,14 @@ arangodb::Result ClusterInfo::agencyReplan(VPackSlice const plan) {
   Result rr;
   if (VPackSlice resultsSlice = r.slice().get("results");
       resultsSlice.length() > 0) {
-    rr = waitForPlan(resultsSlice[0].getNumber<uint64_t>()).get();
+    auto raftIndex = resultsSlice[0].getNumber<uint64_t>();
+    if (raftIndex == 0) {
+      // This means the above request was actually illegal
+      return {TRI_ERROR_HOT_BACKUP_INTERNAL,
+              "Failed to restore agency plan from Hotbackup. Please contact "
+              "ArangoDB support immediately."};
+    }
+    rr = waitForPlan(raftIndex).get();
   }
 
   return rr;

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3730,7 +3730,11 @@ arangodb::Result hotRestoreCoordinator(ClusterFeature& feature,
   result = (matches.empty()) ? ci.agencyReplan(plan.slice())
                              : ci.agencyReplan(newPlan.slice());
   if (!result.ok()) {
-    result = controlMaintenanceFeature(pool, "proceed", backupId, dbServers);
+    // We ignore the result of the Proceed here.
+    // In case one of the servers does not proceed now, it will automatically
+    // reactivate maintenance after 30s.
+    std::ignore =
+        controlMaintenanceFeature(pool, "proceed", backupId, dbServers);
     events::RestoreHotbackup(backupId, result.errorNumber());
     return result;
   }

--- a/tests/js/client/shell/shell-hotbackup-cluster-nonwindows.js
+++ b/tests/js/client/shell/shell-hotbackup-cluster-nonwindows.js
@@ -1,0 +1,118 @@
+/*jshint globalstrict:false, strict:false */
+/*global arango, assertTrue, assertEqual, assertNotEqual, db*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test hotbackup in single server
+///
+/// Copyright 2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const serverHelper = require('@arangodb/test-helper');
+const {readAgencyValueAt} = require("@arangodb/testutils/replicated-logs-helper");
+const {debugSetFailAt, debugCanUseFailAt, debugClearFailAt, errors} = require('internal');
+
+'use strict';
+
+function HotBackupSuite () {
+
+  return {
+    testRegressionCanRestoreBackupWithMissingAnalyzerEntry: function() {
+      const dbName = "otherDB";
+      const colName = "otherCollection";
+      const colNameTwo = "additionalCollection";
+      const dropExtraCollections = () => {
+        try {
+          db._dropDatabase(dbName);
+        } catch (e) {}
+        db._drop(colName);
+      };
+
+      const assertAdditionalDataDoesNotExist = () => {
+        assertEqual(db._databases().indexOf(dbName), -1, "Setup issue: Database was not dropped before restore");
+        assertEqual(db._collections().map(c => c.name()).indexOf(colName), -1, "Setup issue: Collection was not dropped before restore");
+        assertNotEqual(db._collections().map(c => c.name()).indexOf(colNameTwo), -1, "Collection was not created between backup and restore");
+      };
+      const assertAdditionalDataExists = () => {
+        assertNotEqual(db._databases().indexOf(dbName), -1, "Database was not restored");
+        assertNotEqual(db._collections().map(c => c.name()).indexOf(colName), -1, "Collection was not restored");
+        assertEqual(db._collections().map(c => c.name()).indexOf(colNameTwo), -1, "After Backup Collection was not erased");
+      };
+      try {
+        db._createDatabase(dbName);
+        db._create(colName);
+
+        const backupGood = arango.POST("/_admin/backup/create", {}).result;
+
+        // Now create the regression. In version 3.6 the entry /arango/Plan/Analyzers did not exist.
+
+
+        assertTrue(readAgencyValueAt("Plan/Analyzers") !== undefined, "We should have analyzers in plan by default.");
+        serverHelper.agency.remove("Plan/Analyzers");
+        assertTrue(readAgencyValueAt("Plan/Analyzers") === undefined, "Failed to simulate 3.6 behaviour by removing the analyzers entry");
+
+        const backupRegressed = arango.POST("/_admin/backup/create", {}).result;
+
+        // Drop the Collections, so we see if they get restored from Backup.
+        dropExtraCollections();
+        db._create(colNameTwo);
+        assertAdditionalDataDoesNotExist();
+
+        // Validate we can restore the backup with Analyzers entry, just for good measure.
+        arango.POST("/_admin/backup/restore", {id: backupGood.id});
+        assertAdditionalDataExists();
+
+        dropExtraCollections();
+        db._create(colNameTwo);
+        assertAdditionalDataDoesNotExist();
+
+        arango.POST("/_admin/backup/restore", {id: backupRegressed.id});
+        assertAdditionalDataExists();
+
+        // For good measure make sure we can use the Cluster after restore
+        const c2 = db._create(colNameTwo);
+        assertEqual(c2.name(), colNameTwo);
+      } finally {
+        // Cleanup if anything goes wrong
+        dropExtraCollections();
+        db._drop(colNameTwo);
+      }
+    },
+
+    testRegressionFailedReplanIsReported: function() {
+      if (debugCanUseFailAt()) {
+        const backup = arango.POST("/_admin/backup/create", {}).result;
+        const colName = "additionalCollection";
+        db._create(colName);
+        try {
+          debugSetFailAt("ClusterInfo::failReplanAgency");
+          const response = arango.POST("/_admin/backup/restore", {id: backup.id});
+          assertEqual(response.errorNum, errors.ERROR_DEBUG.code);
+          assertNotEqual(db._collections().map(c => c.name()).indexOf(colName), -1, "Collection was removed on failed restore");
+        } finally {
+          debugClearFailAt();
+          db._drop(colName);
+        }
+
+      }
+
+    }
+  };
+}
+
+jsunity.run(HotBackupSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

*This PR fixes a bug which happens on Hotbackup restore, that only shows up on **clusters that started with 3.6 or older**. And was upgraded ever since. If such a deployment goes to 3.11.8, and wants to restore a backup this will fail.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
