### PR TITLE
skip fuerte timeout tests on Windows

### DIFF
--- a/tests/Fuerte/ConnectionTimeoutsTest.cpp
+++ b/tests/Fuerte/ConnectionTimeoutsTest.cpp
@@ -130,8 +130,26 @@ void performRequests(fu::ProtocolType pt) {
 
 }  // namespace
 
-TEST(RequestTimeout, VelocyStream) { ::performRequests(fu::ProtocolType::Vst); }
+TEST(RequestTimeout, VelocyStream) {
+#ifdef _WIN32
+  GTEST_SKIP() << "test disabled on Windows";
+#else
+  ::performRequests(fu::ProtocolType::Vst);
+#endif
+}
 
-TEST(RequestTimeout, HTTP) { ::performRequests(fu::ProtocolType::Http); }
+TEST(RequestTimeout, HTTP) {
+#ifdef _WIN32
+  GTEST_SKIP() << "test disabled on Windows";
+#else
+  ::performRequests(fu::ProtocolType::Http);
+#endif
+}
 
-TEST(RequestTimeout, HTTP2) { ::performRequests(fu::ProtocolType::Http2); }
+TEST(RequestTimeout, HTTP2) {
+#ifdef _WIN32
+  GTEST_SKIP() << "test disabled on Windows";
+#else
+  ::performRequests(fu::ProtocolType::Http2);
+#endif
+}


### PR DESCRIPTION
### Scope & Purpose

the fuerte timeout tests are unreliable and often fail with "Request timeout" messages on Windows. disable them on Windows only.

this fixes spurious test failures such as
```
=== fuerte_http ===
* Test "fuerte"
    [FAILED]  fuerte

      "test" failed: exit code of 'Thu May 16 2024 02:16:04 GMT+0200 (Central European Summer Time) executeAndWait: cmd =build\bin\RelWithDebInfo\fuertetest.exe args =["--gtest_output=json:c:\\gce-win-0v8vdp\\oskar\\work\\tmp\\ArangoDB\\46\\arangosh_a25384\\fuertetest\\testResults.json","--log.line-number","false","--endpoint=tcp://127.0.0.1:12124","--authentication=basic:root:"]' was 1

    [FAILED]  RequestTimeout

      "test" failed: C:\gce-win-0v8vdp\oskar\work\ArangoDB\tests\Fuerte\ConnectionTimeoutsTest.cpp:110
Expected equality of these values:
  e
    Which is: 2-byte object <EB-03>
  fu::Error::NoError
    Which is: 2-byte object <00-00>
C:\gce-win-0v8vdp\oskar\work\ArangoDB\tests\Fuerte\ConnectionTimeoutsTest.cpp:110
Expected equality of these values:
  e
    Which is: 2-byte object <EB-03>
  fu::Error::NoError
    Which is: 2-byte object <00-00>
```

there is intentionally no forward port of these changes to devel, as in devel all Windows-related code has been removed previously.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 