### PR TITLE
Remove artificial upper bounds for IO threads configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.11.9 (XXXX-XX-XX)
 --------------------
 
+* Remove artificial upper bounds for the command-line options regarding the
+  number of IO threads: `--server.io-threads` and `--network.io-threads` were
+  previously limited to 64 and 16, resp. Now there is no upper bound for these
+  options anymore. The default values remain unchanged.
+
 * Fix potentially hanging threads during index creation if starting one of the
   parallel index creation threads returned an error.
 

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -150,16 +150,18 @@ void NetworkFeature::collectOptions(
   options->addSection("network", "cluster-internal networking");
 
   options
-      ->addOption("--network.io-threads",
-                  "The number of network I/O threads for cluster-internal "
-                  "communication.",
-                  new UInt32Parameter(&_numIOThreads))
+      ->addOption(
+          "--network.io-threads",
+          "The number of network I/O threads for cluster-internal "
+          "communication.",
+          new UInt32Parameter(&_numIOThreads, /*base*/ 1, /*minValue*/ 1))
       .setIntroducedIn(30600);
   options
-      ->addOption("--network.max-open-connections",
-                  "The maximum number of open TCP connections for "
-                  "cluster-internal communication per endpoint",
-                  new UInt64Parameter(&_maxOpenConnections))
+      ->addOption(
+          "--network.max-open-connections",
+          "The maximum number of open TCP connections for "
+          "cluster-internal communication per endpoint",
+          new UInt64Parameter(&_maxOpenConnections, /*base*/ 1, /*minValue*/ 1))
       .setIntroducedIn(30600);
   options
       ->addOption("--network.idle-connection-ttl",
@@ -198,10 +200,6 @@ void NetworkFeature::collectOptions(
 
 void NetworkFeature::validateOptions(
     std::shared_ptr<options::ProgramOptions> opts) {
-  _numIOThreads = std::max<unsigned>(1, std::min<unsigned>(_numIOThreads, 8));
-  if (_maxOpenConnections < 8) {
-    _maxOpenConnections = 8;
-  }
   if (!opts->processingResult().touched("--network.idle-connection-ttl")) {
     auto& gs = server().getFeature<GeneralServerFeature>();
     _idleTtlMilli = uint64_t(gs.keepAliveTimeout() * 1000 / 2);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20922

* remove artificial limit of 8 for the number of ClusterComm IO threads (`--network.io-threads`)
* remove artificial limit of 64 for the number of GeneralServer IO threads (`--server.io-threads`)

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 