### PR TITLE
try to fix more shutdown errors

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -989,7 +989,7 @@ void ClusterFeature::stop() {
     shutdown();
 
     // We try to actively cancel all open requests that may still be in the
-    // Agency We cannot react to them anymore.
+    // Agency. We cannot react to them anymore.
     _asyncAgencyCommPool->shutdownConnections();
   }
 }
@@ -997,6 +997,9 @@ void ClusterFeature::stop() {
 void ClusterFeature::unprepare() {
   if (_enableCluster) {
     _clusterInfo->unprepare();
+    if (_asyncAgencyCommPool) {
+      _asyncAgencyCommPool->drainConnections();
+    }
   }
 }
 
@@ -1027,6 +1030,10 @@ void ClusterFeature::shutdown() try {
   // must make sure that the HeartbeatThread is fully stopped before
   // we destroy the AgencyCallbackRegistry.
   _heartbeatThread.reset();
+
+  if (_asyncAgencyCommPool) {
+    _asyncAgencyCommPool->drainConnections();
+  }
 } catch (...) {
   // this is called from the dtor. not much we can do here except logging
   LOG_TOPIC("9f538", WARN, Logger::CLUSTER)

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -327,7 +327,10 @@ struct ConnectionPool::Impl {
 ConnectionPool::ConnectionPool(ConnectionPool::Config const& config)
     : _impl(std::make_unique<Impl>(config, *this)) {}
 
-ConnectionPool::~ConnectionPool() { shutdownConnections(); }
+ConnectionPool::~ConnectionPool() {
+  shutdownConnections();
+  drainConnections();
+}
 
 /// @brief request a connection for a specific endpoint
 /// note: it is the callers responsibility to ensure the endpoint

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -142,7 +142,12 @@ NetworkFeature::NetworkFeature(Server& server, metrics::MetricsFeature& metrics,
   startsAfter<EngineSelectorFeature>();
 }
 
-NetworkFeature::~NetworkFeature() { cancelRetryRequests(); }
+NetworkFeature::~NetworkFeature() {
+  cancelRetryRequests();
+  if (_pool) {
+    _pool->drainConnections();
+  }
+}
 
 void NetworkFeature::collectOptions(
     std::shared_ptr<options::ProgramOptions> options) {
@@ -363,10 +368,12 @@ void NetworkFeature::stop() {
   cancelRetryRequests();
   if (_pool) {
     _pool->shutdownConnections();
+    _pool->drainConnections();
   }
 }
 
 void NetworkFeature::unprepare() {
+  cancelRetryRequests();
   if (_pool) {
     _pool->drainConnections();
   }


### PR DESCRIPTION
### Scope & Purpose

Try to fix more shutdown errors:
AsyncAgencyComm requests may still be in flight when the server is shutting down. Try to fix this.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 