### PR TITLE
BugFix: hotbackup restore analyzers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Fixed the listDatabases API: Directly after adding a new empty DBServer, or
+  after restoring a Hotbackup the listDatabases() would return an empty list of
+  existing databases, which goes back to normal quickly. This bug only effected
+  the APIs exposing the list of database names, all databases in fact still
+  exist and are fully functional.
+
 * FE-447: fix query spotlight search, make it case-insensitive.
 
 * FE-443: Fix inconsistent tooltip padding in Create Index dialog.
@@ -11,15 +17,15 @@ devel
 * Fix connection retry attempts for cluster-internal TLS connections that ran
   into the 15 seconds timeout during the connection establishing attempt.
   In this case, the low-level socket was repurposed, but not reset properly.
-  This could leave the connection in an improper state and lead to callbacks
-  for some requests to not being called as expected.
+  This could leave the connection in an improper state and lead to callbacks for
+  some requests to not being called as expected.
   The connection timeout was also increased from 15 seconds to 60 seconds.
 
 * FE-448: auto-repair collection document JSON on save.
 
 * Improved the time required to create a new Collection in a database with
-  hundreds of collections. This also improves times for indexes and dropping
-  of collections.
+  hundreds of collections. This also improves times for indexes and dropping of
+  collections.
 
 * Added startup option `--cache.max-cache-value-size` to limit the maximum size
   of individual values stored in the in-memory cache used for

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -719,40 +719,16 @@ std::vector<DatabaseID> ClusterInfo::databases() {
     }
   }
 
-  if (!_currentProt.isValid) {
-    Result r = waitForCurrent(1).get();
-    if (r.fail()) {
-      THROW_ARANGO_EXCEPTION(r);
-    }
-  }
-
-  if (!_dbServersProt.isValid) {
-    loadCurrentDBServers();
-  }
-
-  // From now on we know that all data has been valid once, so no need
-  // to check the isValid flags again under the lock.
-
-  size_t expectedSize;
-  {
-    READ_LOCKER(readLocker, _dbServersProt.lock);
-    expectedSize = _dbServers.size();
-  }
-
+  // The _plannedDatabases map contains all Databases that
+  // are planned to exist, and that do not have the "isBuilding"
+  // flag set. Hence those databases have been successfully created
+  // and should be listed.
   std::vector<DatabaseID> result;
   {
     READ_LOCKER(readLockerPlanned, _planProt.lock);
-    READ_LOCKER(readLockerCurrent, _currentProt.lock);
     // _plannedDatabases is a map-type<DatabaseID, VPackSlice>
     for (auto const& it : _plannedDatabases) {
-      // _currentDatabases is:
-      //   a map-type<DatabaseID, a map-type<ServerID, VPackSlice>>
-      if (auto it2 = _currentDatabases.find(it.first);
-          it2 != _currentDatabases.end()) {
-        if (it2->second->size() >= expectedSize) {
-          result.emplace_back(it.first);
-        }
-      }
+      result.emplace_back(it.first);
     }
   }
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -365,6 +365,19 @@ void doQueueLinkDrop(IndexId id, std::string const& collection,
   };
   scheduler->queue(RequestLane::INTERNAL_LOW, dropTask);
 }
+
+inline arangodb::AgencyOperation SetOldEntry(
+    std::string const& key, std::vector<std::string_view> const& path,
+    VPackSlice plan) {
+  VPackSlice newEntry = plan.get(path);
+  if (newEntry.isNone()) {
+    // This is a countermeasure to protect against non-existing paths. If we
+    // get anything else original plan is already broken.
+    newEntry = VPackSlice::emptyObjectSlice();
+  }
+  return {key, AgencyValueOperationType::SET, newEntry};
+}
+
 }  // namespace
 }  // namespace arangodb
 

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3460,7 +3460,11 @@ arangodb::Result hotRestoreCoordinator(ClusterFeature& feature,
   result = (matches.empty()) ? ci.agencyReplan(plan.slice())
                              : ci.agencyReplan(newPlan.slice());
   if (!result.ok()) {
-    result = controlMaintenanceFeature(pool, "proceed", backupId, dbServers);
+    // We ignore the result of the Proceed here.
+    // In case one of the servers does not proceed now, it will automatically
+    // reactivate maintenance after 30s.
+    std::ignore =
+        controlMaintenanceFeature(pool, "proceed", backupId, dbServers);
     events::RestoreHotbackup(backupId, result.errorNumber());
     return result;
   }

--- a/tests/js/client/shell/shell-hotbackup-cluster-nonwindows.js
+++ b/tests/js/client/shell/shell-hotbackup-cluster-nonwindows.js
@@ -1,0 +1,118 @@
+/*jshint globalstrict:false, strict:false */
+/*global arango, assertTrue, assertEqual, assertNotEqual, db*/
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test hotbackup in single server
+///
+/// Copyright 2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// @author Michael Hackstein
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const serverHelper = require('@arangodb/test-helper');
+const {readAgencyValueAt} = require("@arangodb/testutils/replicated-logs-helper");
+const {debugSetFailAt, debugCanUseFailAt, debugClearFailAt, errors} = require('internal');
+
+'use strict';
+
+function HotBackupSuite () {
+
+  return {
+    testRegressionCanRestoreBackupWithMissingAnalyzerEntry: function() {
+      const dbName = "otherDB";
+      const colName = "otherCollection";
+      const colNameTwo = "additionalCollection";
+      const dropExtraCollections = () => {
+        try {
+          db._dropDatabase(dbName);
+        } catch (e) {}
+        db._drop(colName);
+      };
+
+      const assertAdditionalDataDoesNotExist = () => {
+        assertEqual(db._databases().indexOf(dbName), -1, "Setup issue: Database was not dropped before restore");
+        assertEqual(db._collections().map(c => c.name()).indexOf(colName), -1, "Setup issue: Collection was not dropped before restore");
+        assertNotEqual(db._collections().map(c => c.name()).indexOf(colNameTwo), -1, "Collection was not created between backup and restore");
+      };
+      const assertAdditionalDataExists = () => {
+        assertNotEqual(db._databases().indexOf(dbName), -1, "Database was not restored");
+        assertNotEqual(db._collections().map(c => c.name()).indexOf(colName), -1, "Collection was not restored");
+        assertEqual(db._collections().map(c => c.name()).indexOf(colNameTwo), -1, "After Backup Collection was not erased");
+      };
+      try {
+        db._createDatabase(dbName);
+        db._create(colName);
+
+        const backupGood = arango.POST("/_admin/backup/create", {}).result;
+
+        // Now create the regression. In version 3.6 the entry /arango/Plan/Analyzers did not exist.
+
+
+        assertTrue(readAgencyValueAt("Plan/Analyzers") !== undefined, "We should have analyzers in plan by default.");
+        serverHelper.agency.remove("Plan/Analyzers");
+        assertTrue(readAgencyValueAt("Plan/Analyzers") === undefined, "Failed to simulate 3.6 behaviour by removing the analyzers entry");
+
+        const backupRegressed = arango.POST("/_admin/backup/create", {}).result;
+
+        // Drop the Collections, so we see if they get restored from Backup.
+        dropExtraCollections();
+        db._create(colNameTwo);
+        assertAdditionalDataDoesNotExist();
+
+        // Validate we can restore the backup with Analyzers entry, just for good measure.
+        arango.POST("/_admin/backup/restore", {id: backupGood.id});
+        assertAdditionalDataExists();
+
+        dropExtraCollections();
+        db._create(colNameTwo);
+        assertAdditionalDataDoesNotExist();
+
+        arango.POST("/_admin/backup/restore", {id: backupRegressed.id});
+        assertAdditionalDataExists();
+
+        // For good measure make sure we can use the Cluster after restore
+        const c2 = db._create(colNameTwo);
+        assertEqual(c2.name(), colNameTwo);
+      } finally {
+        // Cleanup if anything goes wrong
+        dropExtraCollections();
+        db._drop(colNameTwo);
+      }
+    },
+
+    testRegressionFailedReplanIsReported: function() {
+      if (debugCanUseFailAt()) {
+        const backup = arango.POST("/_admin/backup/create", {}).result;
+        const colName = "additionalCollection";
+        db._create(colName);
+        try {
+          debugSetFailAt("ClusterInfo::failReplanAgency");
+          const response = arango.POST("/_admin/backup/restore", {id: backup.id});
+          assertEqual(response.errorNum, errors.ERROR_DEBUG.code);
+          assertNotEqual(db._collections().map(c => c.name()).indexOf(colName), -1, "Collection was removed on failed restore");
+        } finally {
+          debugClearFailAt();
+          db._drop(colName);
+        }
+
+      }
+
+    }
+  };
+}
+
+jsunity.run(HotBackupSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

*Forward Port of: https://github.com/arangodb/arangodb/pull/20940 and https://github.com/arangodb/arangodb/pull/20947
This fixes two issues:
1) This PR fixes a bug which happens on Hotbackup restore, that only shows up on clusters that started with 3.6 or older. And was upgraded ever since. If such a deployment goes to 3.11.8, and wants to restore a backup this will fail.
2) Listing Database Names after HotRestore or adding a new empty DBServer was for a very short period of time empty, until all DBServers have successfully reported back to the Agency. This situation is now resolved.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
