### PR TITLE
pass database name in callback guard

### DIFF
--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -293,9 +293,9 @@ arangodb::cluster::CallbackGuard Manager::buildCallbackGuard(
       auto& clusterInfo = clusterFeature.clusterInfo();
       rGuard = clusterInfo.rebootTracker().callMeOnChange(
           origin,
-          [this, tid = state.id(), vocbase = state.vocbase().name()]() {
+          [this, tid = state.id(), databaseName = state.vocbase().name()]() {
             // abort the transaction once the coordinator goes away
-            abortManagedTrx(tid, vocbase).get();
+            abortManagedTrx(tid, databaseName).get();
           },
           "Transaction aborted since coordinator rebooted or failed.");
     }

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -293,9 +293,9 @@ arangodb::cluster::CallbackGuard Manager::buildCallbackGuard(
       auto& clusterInfo = clusterFeature.clusterInfo();
       rGuard = clusterInfo.rebootTracker().callMeOnChange(
           origin,
-          [this, tid = state.id()]() {
+          [this, tid = state.id(), vocbase = state.vocbase().name()]() {
             // abort the transaction once the coordinator goes away
-            abortManagedTrx(tid, std::string()).get();
+            abortManagedTrx(tid, vocbase).get();
           },
           "Transaction aborted since coordinator rebooted or failed.");
     }
@@ -1118,7 +1118,6 @@ Result Manager::updateTransaction(TransactionId tid, transaction::Status status,
     auto& buck = _transactions[bucket];
     auto it = buck._managed.find(tid);
     if (it == buck._managed.end()) {
-      ADB_PROD_ASSERT(database != "");
       // insert a tombstone for an aborted transaction that we never saw before
       auto inserted = buck._managed.try_emplace(
           tid, _feature, MetaType::Tombstone,


### PR DESCRIPTION
### Scope & Purpose

Pass correct database name when registering a CallbackGuard that is supposed to shut down the transaction should the coordinator die or reboot.
Not passing the database name will lead to an assertion failure should the callback fire.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
