### PR TITLE
Fix potential race in collectRebalanceInformation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix a potential race in collectRebalanceInformation.
+
 * FE-447: fix query spotlight search, make it case-insensitive.
 
 * FE-443: Fix inconsistent tooltip padding in Create Index dialog.

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -2863,7 +2863,8 @@ RestAdminClusterHandler::collectRebalanceInformation(
         collectionRef.weight = 1.0;
         distributeShardsLikeCounter[collectionRef.name].index = index;
 
-        for (auto const& shard : *collection->shardIds()) {
+        auto shardIds = collection->shardIds();
+        for (auto const& shard : *shardIds) {
           auto shardIndex =
               static_cast<decltype(collectionRef.shards)::value_type>(
                   p.shards.size());


### PR DESCRIPTION
### Scope & Purpose

shardIds returns a shared_ptr copy which must stay alive long enough. However, if we dereference the shared_ptr as part of the range expression, then we only keep the reference to the ShardMap, but the temporary is immediately destroyed and does not guarantee that the map stays around.

- [x] :hankey: Bugfix

### Checklist

- [x] :book: CHANGELOG entry made
- [x] Backports
  - [x] Backport for 3.11: #20953 
