### PR TITLE
OASIS-25823

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed OASIS-25823: when late materialization was used together with skipping
+  over documents or the `fullCount` operation, it was possible for AQL queries
+  to fail with errors such as `bad_function_call`.
+
 * Fixed the listDatabases API: Directly after adding a new empty DBServer, or
   after restoring a Hotbackup the listDatabases() would return an empty list of
   existing databases, which goes back to normal quickly. This bug only effected


### PR DESCRIPTION
### Scope & Purpose

Fixes https://arangodb.atlassian.net/issues/OASIS-25823

* Fixed OASIS-25823: when late materialization was used together with skipping over documents or the `fullCount` operation, it was possible for AQL queries to fail with errors such as `bad_function_call`.

The issue occurred when an index was used together with late document materialization, and either `fullCount` was used or a `LIMIT x, y` with `x > 0`.

3.11 is not affected by this issue.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/issues/OASIS-25823
- [ ] Design document: 
