### PR TITLE
Use posix_spawn instead of fork+exec

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 v3.11.7.5 (xxxx-xx-xx)
 ----------------------
 
+* Fix file counting in hotbackup upload in case of errors in remote-to-remote
+  copies. Also prevent spurious rclone errors in S3.
+
 * Use posix_spawn instead of fork/exec for subprocesses. This solves a
   performance issue during hotbackup upload.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+v3.11.7.5 (xxxx-xx-xx)
+----------------------
+
+* Use posix_spawn instead of fork/exec for subprocesses. This solves a
+  performance issue during hotbackup upload.
+
+
 v3.11.7.4 (2024-05-10)
 ----------------------
 

--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <signal.h>
 #include <algorithm>
 #include <chrono>
 #include <memory>
@@ -37,6 +38,7 @@
 
 #include "process-utils.h"
 #include "signals.h"
+#include "Basics/ScopeGuard.h"
 #include "Basics/system-functions.h"
 
 #if defined(TRI_HAVE_MACOS_MEM_STATS)
@@ -93,6 +95,13 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+
+#ifdef __APPLE__
+// The following hack is required to get access to the environment variables
+// in the same way as on Linux:
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
+#endif
 
 using namespace arangodb;
 
@@ -271,6 +280,8 @@ static bool CreatePipes(int* pipe_server_to_child, int* pipe_child_to_server) {
 /// @brief starts external process
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <spawn.h>
+
 static void StartExternalProcess(ExternalProcess* external, bool usePipes,
                                  std::vector<std::string> const& additionalEnv,
                                  std::string const& fileForStdErr) {
@@ -286,76 +297,104 @@ static void StartExternalProcess(ExternalProcess* external, bool usePipes,
     }
   }
 
-  int processPid = fork();
+  int err = 0;  // accumulate any errors we might get
+  posix_spawn_file_actions_t file_actions;
+  err |= posix_spawn_file_actions_init(&file_actions);
+  // file actions are performed in order they were added.
 
-  // child process
-  if (processPid == 0) {
-    // set stdin and stdout of child process
-    if (usePipes) {
-      dup2(pipe_server_to_child[0], 0);
-      dup2(pipe_child_to_server[1], 1);
+  if (usePipes) {
+    err |= posix_spawn_file_actions_adddup2(&file_actions,
+                                            pipe_server_to_child[0], 0);
+    err |= posix_spawn_file_actions_adddup2(&file_actions,
+                                            pipe_child_to_server[1], 1);
 
-      fcntl(0, F_SETFD, 0);
-      fcntl(1, F_SETFD, 0);
-      fcntl(2, F_SETFD, 0);
-
-      // close pipes
-      close(pipe_server_to_child[0]);
-      close(pipe_server_to_child[1]);
-      close(pipe_child_to_server[0]);
-      close(pipe_child_to_server[1]);
-    } else {
-      {  // "close" stdin, but avoid fd 0 being reused!
-        int fd = open("/dev/null", O_RDONLY);
-        if (fd >= 0) {
-          dup2(fd, 0);
-          close(fd);
-        }
-      }
-      fcntl(1, F_SETFD, 0);
-      fcntl(2, F_SETFD, 0);
-    }
-    if (!fileForStdErr.empty()) {
-      // Redirect stderr:
-      int fd = open(fileForStdErr.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
-      if (fd >= 0) {
-        dup2(fd, 2);  // note that 2 was open before, so fd is not equal to 2,
-                      // and the previous 2 is now silently being closed!
-                      // Furthermore, if this fails, we stay on the other one.
-        close(fd);    // need to get rid of the second file descriptor.
-      }
-    }
-
-    // add environment variables
-    for (auto const& it : additionalEnv) {
-      putenv(TRI_DuplicateString(it.c_str(), it.size()));
-    }
-
-    arangodb::signals::unmaskAllSignals();
-
-    // execute worker
-    execvp(external->_executable.c_str(), external->_arguments);
-
-    _exit(1);
+    err |= posix_spawn_file_actions_addclose(&file_actions,
+                                             pipe_server_to_child[0]);
+    err |= posix_spawn_file_actions_addclose(&file_actions,
+                                             pipe_server_to_child[1]);
+    err |= posix_spawn_file_actions_addclose(&file_actions,
+                                             pipe_child_to_server[0]);
+    err |= posix_spawn_file_actions_addclose(&file_actions,
+                                             pipe_child_to_server[1]);
+  } else {
+    err |= posix_spawn_file_actions_addopen(&file_actions, 0, "/dev/null",
+                                            O_RDONLY, 0);
   }
 
-  // parent
-  if (processPid == -1) {
-    LOG_TOPIC("e3a2a", ERR, arangodb::Logger::FIXME) << "fork failed";
+  if (!fileForStdErr.empty()) {
+    err |= posix_spawn_file_actions_addopen(&file_actions, 2,
+                                            fileForStdErr.c_str(),
+                                            O_CREAT | O_WRONLY | O_TRUNC, 0644);
+  }
 
+  posix_spawnattr_t spawn_attrs;
+  err |= posix_spawnattr_init(&spawn_attrs);
+  err |= posix_spawnattr_setflags(
+      &spawn_attrs, POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK);
+  sigset_t all;
+  sigfillset(&all);
+  err |= posix_spawnattr_setsigdefault(&spawn_attrs, &all);
+  sigset_t none;
+  sigemptyset(&none);
+  err |= posix_spawnattr_setsigmask(&spawn_attrs, &none);
+
+  ScopeGuard cleanup([&]() noexcept {
+    posix_spawnattr_destroy(&spawn_attrs);
+    posix_spawn_file_actions_destroy(&file_actions);
+  });
+
+  if (err != 0) {
+    external->_status = TRI_EXT_PIPE_FAILED;
     if (usePipes) {
       close(pipe_server_to_child[0]);
       close(pipe_server_to_child[1]);
       close(pipe_child_to_server[0]);
       close(pipe_child_to_server[1]);
     }
-
-    external->_status = TRI_EXT_FORK_FAILED;
     return;
   }
 
-  LOG_TOPIC("ac58a", DEBUG, arangodb::Logger::FIXME)
-      << "fork succeeded, child pid: " << processPid;
+  std::vector<char*> envs;
+  for (char** e = environ; *e != nullptr; ++e) {
+    envs.push_back(*e);
+  }
+
+  envs.reserve(envs.size() + additionalEnv.size() + 1);
+  std::transform(
+      additionalEnv.begin(), additionalEnv.end(), std::back_inserter(envs),
+      [](auto& str) -> char* { return const_cast<char*>(str.data()); });
+  envs.emplace_back(nullptr);
+
+  int result = posix_spawnp(&external->_pid, external->_executable.c_str(),
+                            &file_actions, &spawn_attrs, external->_arguments,
+                            envs.data());
+
+  if (result != 0) {
+    int errnoCopy = errno;
+    if (errnoCopy == ENOENT) {
+      // We fake the old legacy behaviour here from the fork/exec times:
+      external->_status = TRI_EXT_TERMINATED;
+      external->_exitStatus = 1;
+      LOG_TOPIC("e3a2a", ERR, arangodb::Logger::FIXME)
+          << "spawn failed: executable not found";
+    } else {
+      external->_status = TRI_EXT_FORK_FAILED;
+
+      LOG_TOPIC("e3a2b", ERR, arangodb::Logger::FIXME)
+          << "spawn failed: " << strerror(errnoCopy);
+    }
+    if (usePipes) {
+      close(pipe_server_to_child[0]);
+      close(pipe_server_to_child[1]);
+      close(pipe_child_to_server[0]);
+      close(pipe_child_to_server[1]);
+    }
+
+    return;
+  }
+
+  LOG_TOPIC("ac58b", DEBUG, arangodb::Logger::FIXME)
+      << "spawn succeeded, child pid: " << external->_pid;
 
   if (usePipes) {
     close(pipe_server_to_child[0]);
@@ -368,9 +407,9 @@ static void StartExternalProcess(ExternalProcess* external, bool usePipes,
     external->_readPipe = -1;
   }
 
-  external->_pid = processPid;
   external->_status = TRI_EXT_RUNNING;
 }
+
 #else
 static bool createPipes(HANDLE* hChildStdinRd, HANDLE* hChildStdinWr,
                         HANDLE* hChildStdoutRd, HANDLE* hChildStdoutWr) {
@@ -984,7 +1023,8 @@ void TRI_CreateExternalProcess(char const* executable,
 
   StartExternalProcess(external.get(), usePipes, additionalEnv, fileForStdErr);
 
-  if (external->_status != TRI_EXT_RUNNING) {
+  if (external->_status != TRI_EXT_RUNNING &&
+      external->_status != TRI_EXT_TERMINATED) {
     pid->_pid = TRI_INVALID_PROCESS_ID;
     return;
   }


### PR DESCRIPTION
# Scope & Purpose

Use `posix_spawn` instead of fork + exec calls.

This solves a problem in hotbackup upload via rclone.

devel PR: https://github.com/arangodb/arangodb/pull/20961

This is the 3.11.7.5 backport.

