### PR TITLE
Bug fix 3.11.7.4/detach get responsible server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
-v3.11.7.4 (2024-05-10)
+3.11.7.5 (2024-05-27)
+----------------------
+
+* Detach threads in getResponsibleServers if they wait for more than 1s.
+
+3.11.7.4 (2024-05-10)
 ----------------------
 
 * Retry cluster query shutdown in case no connection can be made to the

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,9 @@
-3.11.7.5 (2024-05-27)
+v3.11.7.5 (2024-05-27)
 ----------------------
 
 * Detach threads in getResponsibleServers if they wait for more than 1s.
 
-3.11.7.4 (2024-05-10)
+v3.11.7.4 (2024-05-10)
 ----------------------
 
 * Retry cluster query shutdown in case no connection can be made to the

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6286,7 +6286,7 @@ ClusterInfo::getResponsibleServerReplication1(std::string_view shardID) {
           &currentNumberDetached, &maximumNumberDetached);
       LOG_DEVEL_IF(r.ok()) << "DETACHED THREAD (" << currentNumberDetached << ")";
       if (r.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
-        LOG_TOPIC("dd232", WARN, Logger::THREADS)
+        LOG_TOPIC("dd235", WARN, Logger::THREADS)
             << "Could not detach scheduler thread (currently detached threads: "
             << currentNumberDetached
             << ", maximal number of detached threads: " << maximumNumberDetached
@@ -6482,7 +6482,7 @@ void ClusterInfo::getResponsibleServersReplication1(
           &currentNumberDetached, &maximumNumberDetached);
       LOG_DEVEL_IF(r.ok()) << "DETACHED THREAD";
       if (r.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
-        LOG_TOPIC("dd232", WARN, Logger::THREADS)
+        LOG_TOPIC("dd238", WARN, Logger::THREADS)
             << "Could not detach scheduler thread (currently detached threads: "
             << currentNumberDetached
             << ", maximal number of detached threads: " << maximumNumberDetached

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6284,7 +6284,6 @@ ClusterInfo::getResponsibleServerReplication1(std::string_view shardID) {
       uint64_t maximumNumberDetached = 0;
       Result r = arangodb::SchedulerFeature::SCHEDULER->detachThread(
           &currentNumberDetached, &maximumNumberDetached);
-      LOG_DEVEL_IF(r.ok()) << "DETACHED THREAD (" << currentNumberDetached << ")";
       if (r.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
         LOG_TOPIC("dd235", WARN, Logger::THREADS)
             << "Could not detach scheduler thread (currently detached threads: "
@@ -6480,7 +6479,6 @@ void ClusterInfo::getResponsibleServersReplication1(
       uint64_t maximumNumberDetached = 0;
       Result r = arangodb::SchedulerFeature::SCHEDULER->detachThread(
           &currentNumberDetached, &maximumNumberDetached);
-      LOG_DEVEL_IF(r.ok()) << "DETACHED THREAD";
       if (r.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
         LOG_TOPIC("dd238", WARN, Logger::THREADS)
             << "Could not detach scheduler thread (currently detached threads: "


### PR DESCRIPTION
### Scope & Purpose

* Detach get responsible server if waiting longer than one second. Back porterd from 3.11.8.2*

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
