### PR TITLE
try to fix shutdown errors

### DIFF
--- a/3rdParty/fuerte/include/fuerte/loop.h
+++ b/3rdParty/fuerte/include/fuerte/loop.h
@@ -40,8 +40,7 @@ namespace arangodb { namespace fuerte { inline namespace v1 {
 
 // need partial rewrite so it can be better integrated in client applications
 
-typedef asio_ns::executor_work_guard<asio_ns::io_context::executor_type>
-    asio_work_guard;
+using asio_work_guard = asio_ns::executor_work_guard<asio_ns::io_context::executor_type>;
 
 /// @brief EventLoopService implements single-threaded event loops
 /// Idea is to shard connections across io context's to avoid
@@ -61,10 +60,7 @@ class EventLoopService {
   EventLoopService& operator=(EventLoopService const& other) = delete;
 
   // io_service returns a reference to the boost io_service.
-  std::shared_ptr<asio_ns::io_context>& nextIOContext() {
-    return _ioContexts[_lastUsed.fetch_add(1, std::memory_order_relaxed) %
-                       _ioContexts.size()];
-  }
+  std::shared_ptr<asio_ns::io_context>& nextIOContext();
 
   asio_ns::ssl::context& sslContext();
 

--- a/arangod/Network/ConnectionPool.cpp
+++ b/arangod/Network/ConnectionPool.cpp
@@ -111,6 +111,7 @@ struct ConnectionPool::Impl {
     TRI_ASSERT(_totalConnectionsInPool.load() == n);
     _totalConnectionsInPool -= n;
     _connections.clear();
+    _loop.stop();
   }
 
   /// @brief shutdown all connections

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -32,7 +32,6 @@ namespace fuerte {
 inline namespace v1 {
 class Connection;
 class ConnectionBuilder;
-class EventLoopService;
 }  // namespace v1
 }  // namespace fuerte
 class ClusterInfo;


### PR DESCRIPTION
### Scope & Purpose

it seems that under some unknown circumstances the Boost asio io_contexts can still execute actions after the destructors of the NetworkFeature ran. this PR is an attempt to improve the situation, by stopping and clearing all available io_context objects when shutting down one of the ConnectionPool objects.
it is unclear yet if this will fix the issue or not.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 