### PR TITLE
ENTRIES for AQL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Added ENTRIES function, that takes an object and produces a list of key-value
+  pairs.
+
 * Prevent spurious rclone errors in S3.
 
 * Use posix_spawn instead of fork/exec for subprocesses. This solves a

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@ devel
 -----
 
 * Added ENTRIES function, that takes an object and produces a list of key-value
-  pairs.
+  pairs. The order of pairs is unspecified.
 
 * Prevent spurious rclone errors in S3.
 

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -396,6 +396,7 @@ void AqlFunctionFeature::addDocumentFunctions() {
   add({"KEEP_RECURSIVE", ".,.|+", flags, &functions::KeepRecursive});
   add({"TRANSLATE", ".,.|.", flags, &functions::Translate});
   add({"ZIP", ".,.", flags, &functions::Zip});
+  add({"ENTRIES", ".", flags, &functions::Entries});
   add({"JSON_STRINGIFY", ".", flags, &functions::JsonStringify});
   add({"JSON_PARSE", ".", flags, &functions::JsonParse});
 

--- a/arangod/Aql/Function/ObjectFunctions.cpp
+++ b/arangod/Aql/Function/ObjectFunctions.cpp
@@ -798,7 +798,7 @@ AqlValue functions::Entries(ExpressionContext* expressionContext,
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
 
-  for (auto [key, value] : VPackObjectIterator(objectSlice)) {
+  for (auto [key, value] : VPackObjectIterator(objectSlice, true)) {
     VPackArrayBuilder pair(builder.get(), true);
     builder->add(key);
     builder->add(value);

--- a/arangod/Aql/Function/ObjectFunctions.cpp
+++ b/arangod/Aql/Function/ObjectFunctions.cpp
@@ -774,4 +774,39 @@ AqlValue functions::Zip(ExpressionContext* expressionContext, AstNode const&,
   return AqlValue(builder->slice(), builder->size());
 }
 
+AqlValue functions::Entries(ExpressionContext* expressionContext,
+                            AstNode const&,
+                            VPackFunctionParametersView parameters) {
+  // cppcheck-suppress variableScope
+  static char const* AFN = "ENTRIES";
+
+  AqlValue const& object =
+      aql::functions::extractFunctionParameterValue(parameters, 0);
+
+  if (!object.isObject()) {
+    registerWarning(expressionContext, AFN,
+                    TRI_ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH);
+    return AqlValue(AqlValueHintNull());
+  }
+
+  transaction::Methods* trx = &expressionContext->trx();
+  auto* vopts = &trx->vpackOptions();
+
+  AqlValueMaterializer objectMaterializer(vopts);
+  VPackSlice objectSlice = objectMaterializer.slice(object);
+
+  transaction::BuilderLeaser builder(trx);
+  builder->openArray();
+
+  for (auto [key, value] : VPackObjectIterator (objectSlice)) {
+    VPackArrayBuilder pair(builder.get(), true);
+    builder->add(key);
+    builder->add(value);
+  }
+
+  builder->close();
+
+  return AqlValue(builder->slice(), builder->size());
+}
+
 }  // namespace arangodb::aql

--- a/arangod/Aql/Function/ObjectFunctions.cpp
+++ b/arangod/Aql/Function/ObjectFunctions.cpp
@@ -798,7 +798,7 @@ AqlValue functions::Entries(ExpressionContext* expressionContext,
   transaction::BuilderLeaser builder(trx);
   builder->openArray();
 
-  for (auto [key, value] : VPackObjectIterator (objectSlice)) {
+  for (auto [key, value] : VPackObjectIterator(objectSlice)) {
     VPackArrayBuilder pair(builder.get(), true);
     builder->add(key);
     builder->add(value);

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -399,6 +399,8 @@ AqlValue Flatten(arangodb::aql::ExpressionContext*, AstNode const&,
                  VPackFunctionParametersView);
 AqlValue Zip(arangodb::aql::ExpressionContext*, AstNode const&,
              VPackFunctionParametersView);
+AqlValue Entries(arangodb::aql::ExpressionContext*, AstNode const&,
+             VPackFunctionParametersView);
 AqlValue JsonStringify(arangodb::aql::ExpressionContext*, AstNode const&,
                        VPackFunctionParametersView);
 AqlValue JsonParse(arangodb::aql::ExpressionContext*, AstNode const&,

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -400,7 +400,7 @@ AqlValue Flatten(arangodb::aql::ExpressionContext*, AstNode const&,
 AqlValue Zip(arangodb::aql::ExpressionContext*, AstNode const&,
              VPackFunctionParametersView);
 AqlValue Entries(arangodb::aql::ExpressionContext*, AstNode const&,
-             VPackFunctionParametersView);
+                 VPackFunctionParametersView);
 AqlValue JsonStringify(arangodb::aql::ExpressionContext*, AstNode const&,
                        VPackFunctionParametersView);
 AqlValue JsonParse(arangodb::aql::ExpressionContext*, AstNode const&,

--- a/tests/js/client/aql/aql-functions.js
+++ b/tests/js/client/aql/aql-functions.js
@@ -2558,6 +2558,37 @@ function ahuacatlFunctionsTestSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test entries
+////////////////////////////////////////////////////////////////////////////////
+
+    testEntries: function () {
+      const values = [
+        {a:1},
+        {a:2, b:3},
+        {a:2, b:"foo"},
+        {b:"foo"},
+      ];
+
+      values.forEach(function (value) {
+        const actual = getQueryResults("RETURN ENTRIES(" + JSON.stringify(value[1]) + ")");
+        assertEqual(Object.entries(value), actual[0], value);
+      });
+    },
+
+    testEntriesInvalid : function () {
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ZIP()");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ZIP({}, 1)");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ZIP({}, 1, 2)");
+
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP([ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(null)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(0)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(\"\")");
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test matches
 ////////////////////////////////////////////////////////////////////////////////
     

--- a/tests/js/client/aql/aql-functions.js
+++ b/tests/js/client/aql/aql-functions.js
@@ -2570,22 +2570,22 @@ function ahuacatlFunctionsTestSuite () {
       ];
 
       values.forEach(function (value) {
-        const actual = getQueryResults("RETURN ENTRIES(" + JSON.stringify(value[1]) + ")");
+        const actual = getQueryResults("RETURN ENTRIES(" + JSON.stringify(value) + ")");
         assertEqual(Object.entries(value), actual[0], value);
       });
     },
 
     testEntriesInvalid : function () {
-      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ZIP()");
-      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ZIP({}, 1)");
-      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ZIP({}, 1, 2)");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ENTRIES()");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ENTRIES({}, 1)");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ENTRIES({}, 1, 2)");
 
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP([ ])");
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(null)");
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(true)");
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(0)");
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(1)");
-      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ZIP(\"\")");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ENTRIES([ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ENTRIES(null)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ENTRIES(true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ENTRIES(0)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ENTRIES(1)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN ENTRIES(\"\")");
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose
`ENTRIES` takes a single object argument and returns a list of key-value pairs, similar to JS `Object.entries()`.
This PR is part of a bigger effort to make iteration over objects in aql more memory efficient and performant.

Currently the only way of iteration over objects is
```
LET keys = ATTRIBUTES(object)
FOR key IN keys
    LET value = object[key]
```

This requires `object` to be copied past the `FOR` loop. Secondly, we have to build the `ATTRIBUTES` array and then do a binary search in the object to look up the value.

This PR alone does not improve the situation by much, however, it allows to write
```
FOR pair in ENTRIES(object)
   let key = pair[0]
   let value = pair[1]
```
Which already eliminates the copy of `object` if it is not used after the `FOR` loop.

A follow up PR will introduce a optimizer rule and a new executor, that takes in an object and produces two registers, containing the keys and values.
