### PR TITLE
improve error message for failed `posix_spawn` calls

### DIFF
--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -323,12 +323,14 @@ static void StartExternalProcessPosixSpawn(
       external->_status = TRI_EXT_TERMINATED;
       external->_exitStatus = 1;
       LOG_TOPIC("e3a2c", ERR, arangodb::Logger::FIXME)
-          << "spawn failed: executable not found";
+          << "spawn failed: executable '" << external->_executable
+          << "' not found";
     } else {
       external->_status = TRI_EXT_FORK_FAILED;
 
       LOG_TOPIC("e3a2b", ERR, arangodb::Logger::FIXME)
-          << "spawn failed: " << strerror(errnoCopy);
+          << "spawning of executable '" << external->_executable
+          << "' failed: " << strerror(errnoCopy);
     }
     if (usePipes) {
       close(pipe_server_to_child[0]);
@@ -341,7 +343,8 @@ static void StartExternalProcessPosixSpawn(
   }
 
   LOG_TOPIC("ac58b", DEBUG, arangodb::Logger::FIXME)
-      << "spawn succeeded, child pid: " << external->_pid;
+      << "spawning executable '" << external->_executable
+      << "' succeeded, child pid: " << external->_pid;
 
   if (usePipes) {
     close(pipe_server_to_child[0]);


### PR DESCRIPTION
### Scope & Purpose

improve error message for failed `posix_spawn` calls, by including the name of the executable that we tried to spawn.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 