### PR TITLE
BTS-1775: disable checking of view counts in chaos test

### DIFF
--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -132,28 +132,20 @@ const checkViewConsistency = (cn, isSearchAlias, isMaterialize, viewCounts) => {
   } else {
     expected = runQuery("FOR d IN " + cn + " RETURN d").length;
   }
-  let vn;
-  const checkView = (isMaterialize) => {
+  const checkView = (vn) => {
     let result;
     if (isMaterialize) {
       result = runQuery("FOR d IN " + vn + " OPTIONS {waitForSync: true} RETURN d._key").length;
     } else {
       result = runQuery("FOR d IN " + vn + " OPTIONS {waitForSync: true} COLLECT WITH COUNT INTO length RETURN length")[0];
     }
-    viewCounts.push({viewName:vn, viewCount:result, collectionName:cn, collectionCount:expected, isMaterialize: isMaterialize});
+    viewCounts.push({viewName: vn, viewCount: result, collectionName: cn, collectionCount: expected, isMaterialize});
   };
 
-  vn = viewName(cn + "_view", isSearchAlias);
-  checkView(isMaterialize);
-
-  vn = viewName(cn + "_view_ps", isSearchAlias);
-  checkView(isMaterialize);
-
-  vn = viewName(cn + "_view_sv", isSearchAlias);
-  checkView(isMaterialize);
-
-  vn = viewName(cn + "_view_ps_sv", isSearchAlias);
-  checkView(isMaterialize);
+  checkView(viewName(cn + "_view", isSearchAlias));
+  checkView(viewName(cn + "_view_ps", isSearchAlias));
+  checkView(viewName(cn + "_view_sv", isSearchAlias));
+  checkView(viewName(cn + "_view_ps_sv", isSearchAlias));
 };
 
 function BaseChaosSuite(testOpts) {
@@ -604,6 +596,16 @@ function BaseChaosSuite(testOpts) {
         print(Date() + " checking consistency done.");
         let failedViews = "";
         for (const c of viewCounts) {
+          if (testOpts.withViews && testOpts.withTruncate) {
+            // view counts can differ from collection counts if a DeleteRange
+            // truncate operation was used. this is a known issue, noted in
+            // BTS-1775. until this issue is fixed, we disable checking the
+            // view counts here to avoid spurious errors.
+            // TODO: remove the "continue" here once BTS-1775 is fixed, so that
+            // view counts are again checked!
+            continue;
+          }
+
           if (c.viewCount !== c.collectionCount) {
             print(viewCounts);
             failedViews = " and views count mismatch";


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/BTS-1775

View counts are known to sometimes differ from collection counts when the DeleteRange version of truncate is used. This is noted in BTS-1775. Until there is a proper fix for the view counts when using DeleteRange, we should disable the count check in the chaos test, in order to avoid spurious failed tests for known reasons

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1775
- [ ] Design document: 