### PR TITLE
enable TCP_NODELAY on fuerte tcp connections

### DIFF
--- a/arangod/Agency/AsyncAgencyComm.h
+++ b/arangod/Agency/AsyncAgencyComm.h
@@ -23,15 +23,6 @@
 
 #pragma once
 
-#include <fuerte/message.h>
-
-#include <deque>
-#include <memory>
-#include <mutex>
-
-#include <velocypack/Builder.h>
-#include <velocypack/Slice.h>
-
 #include "Agency/AgencyComm.h"
 #include "Agency/AgencyCommon.h"
 #include "Agency/PathComponent.h"
@@ -40,6 +31,15 @@
 #include "Futures/Future.h"
 #include "Network/Methods.h"
 #include "Network/Utils.h"
+
+#include <fuerte/message.h>
+#include <fuerte/types.h>
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+
+#include <deque>
+#include <memory>
+#include <mutex>
 
 namespace arangodb {
 

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -40,7 +40,7 @@
 #include "Basics/Exceptions.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
-#include "debugging.h"
+#include "Basics/debugging.h"
 #include "Containers/FlatHashSet.h"
 #include "Containers/SmallVector.h"
 #include "Indexes/Index.h"

--- a/arangod/Aql/Executor/RemoteExecutor.cpp
+++ b/arangod/Aql/Executor/RemoteExecutor.cpp
@@ -49,6 +49,7 @@
 #include "Transaction/Methods.h"
 
 #include <fuerte/connection.h>
+#include <fuerte/message.h>
 #include <fuerte/requests.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
@@ -84,6 +85,8 @@ ExecutionBlockImpl<RemoteExecutor>::ExecutionBlockImpl(
              (!arangodb::ServerState::instance()->isCoordinator() &&
               !distributeId.empty()));
 }
+
+ExecutionBlockImpl<RemoteExecutor>::~ExecutionBlockImpl() = default;
 
 std::pair<ExecutionState, Result> ExecutionBlockImpl<
     RemoteExecutor>::initializeCursor(InputAqlItemRow const& input) {

--- a/arangod/Aql/Executor/RemoteExecutor.h
+++ b/arangod/Aql/Executor/RemoteExecutor.h
@@ -29,8 +29,6 @@
 #include "Aql/RegisterInfos.h"
 #include "Basics/Result.h"
 
-#include <fuerte/message.h>
-
 #include <memory>
 #include <mutex>
 #include <string>
@@ -38,8 +36,9 @@
 
 namespace arangodb::fuerte {
 inline namespace v1 {
+class Response;
 enum class RestVerb;
-}
+}  // namespace v1
 }  // namespace arangodb::fuerte
 
 namespace arangodb::aql {
@@ -64,7 +63,7 @@ class ExecutionBlockImpl<RemoteExecutor> : public ExecutionBlock {
                      std::string const& distributeId,
                      std::string const& queryId);
 
-  ~ExecutionBlockImpl() override = default;
+  ~ExecutionBlockImpl() override;
 
   std::pair<ExecutionState, Result> initializeCursor(
       InputAqlItemRow const& input) override;

--- a/arangod/Network/ClusterUtils.h
+++ b/arangod/Network/ClusterUtils.h
@@ -30,8 +30,7 @@
 #include <velocypack/Buffer.h>
 #include <velocypack/Slice.h>
 
-namespace arangodb {
-namespace network {
+namespace arangodb::network {
 
 /// @brief Create Cluster Communication result for insert
 OperationResult clusterResultInsert(
@@ -51,5 +50,4 @@ OperationResult clusterResultRemove(
     std::shared_ptr<VPackBuffer<uint8_t>> body, OperationOptions options,
     std::unordered_map<ErrorCode, size_t> errorCounter);
 
-}  // namespace network
-}  // namespace arangodb
+}  // namespace arangodb::network

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -55,6 +55,7 @@ using namespace arangodb::basics;
 using namespace arangodb::options;
 
 // Please leave this code in for the next time we have to debug fuerte.
+// change to `#if 1` in order to make fuerte logging work.
 #if 0
 void LogHackWriter(std::string_view msg) { LOG_DEVEL << msg; }
 #endif


### PR DESCRIPTION
### Scope & Purpose

Enable TCP_NODELAY on fuerte tcp connections.
The TCP_NODELAY option wasn't previously set for fuerte TCP connections that did not use SSL/TLS.
Now it is being set explicitly.
I could not measure a significant performance difference between setting and not setting the option on the socket, but this change at least unifies the socket options between the TCP (non-SSL/TLS) and the SSL/TLS socket implementations. The SSL/TLS socket implementation did already set the TCP_NODELAY flag on the socket before, but the TCP (non-SSL/TLS) implementation did not.

This PR also slightly cleans up the fuerte logging code and reduces dependencies on fuerte include files in some ArangoDB header files.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 