### PR TITLE
micro-optimize AqlCallList

### DIFF
--- a/arangod/Aql/AqlCallList.h
+++ b/arangod/Aql/AqlCallList.h
@@ -26,7 +26,6 @@
 #include "Aql/AqlCall.h"
 
 #include <optional>
-#include <vector>
 
 namespace arangodb::velocypack {
 class Builder;
@@ -50,7 +49,7 @@ class AqlCallList {
   friend bool operator==(AqlCallList const& left, AqlCallList const& right);
 
   friend auto operator<<(std::ostream& out,
-                         const arangodb::aql::AqlCallList& list)
+                         arangodb::aql::AqlCallList const& list)
       -> std::ostream&;
 
   /**
@@ -143,12 +142,10 @@ class AqlCallList {
 
  private:
   /**
-   * @brief A list of specific calls for subqueries.
-   *        Right now we have only implemented variants where there is
-   *        at most one call in this list. But the code is actually ready for
-   *        any number of calls here.
+   * @brief An optional specific call for subqueries.
    */
-  std::vector<AqlCall> _specificCalls{};
+  std::optional<AqlCall> _specificCall{};
+
   std::optional<AqlCall> _defaultCall{std::nullopt};
 };
 

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -37,8 +37,11 @@ using namespace arangodb::aql;
 
 AqlCallStack::AqlCallStack(AqlCallStack::Empty) {}
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+// only used in tests
 AqlCallStack::AqlCallStack(AqlCallList call) : _operations{{std::move(call)}} {}
 
+// only used in tests
 AqlCallStack::AqlCallStack(AqlCallStack const& other, AqlCallList call)
     : _operations{other._operations} {
   // We can only use this constructor on relevant levels
@@ -48,6 +51,7 @@ AqlCallStack::AqlCallStack(AqlCallStack const& other, AqlCallList call)
   validateNoCallHasSkippedRows();
 #endif
 }
+#endif
 
 AqlCallStack::AqlCallStack(std::vector<AqlCallList>&& operations) noexcept
     : _operations(std::move(operations)) {
@@ -210,7 +214,7 @@ auto AqlCallStack::getCallAtDepth(size_t depth) const -> AqlCall const& {
   // depth 0 is back of vector
   TRI_ASSERT(_operations.size() > depth);
   // Take the depth-most from top of the vector.
-  auto& callList = _operations.at(_operations.size() - 1 - depth);
+  auto const& callList = _operations.at(_operations.size() - 1 - depth);
   return callList.peekNextCall();
 }
 

--- a/arangod/Aql/AqlCallStack.cpp
+++ b/arangod/Aql/AqlCallStack.cpp
@@ -37,11 +37,11 @@ using namespace arangodb::aql;
 
 AqlCallStack::AqlCallStack(AqlCallStack::Empty) {}
 
-#ifdef ARANGODB_USE_GOOGLE_TESTS
-// only used in tests
 AqlCallStack::AqlCallStack(AqlCallList call) : _operations{{std::move(call)}} {}
 
 // only used in tests
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
 AqlCallStack::AqlCallStack(AqlCallStack const& other, AqlCallList call)
     : _operations{other._operations} {
   // We can only use this constructor on relevant levels

--- a/arangod/Aql/AqlCallStack.h
+++ b/arangod/Aql/AqlCallStack.h
@@ -55,6 +55,8 @@ class AqlCallStack {
   // Initial
   explicit AqlCallStack(Empty);
 
+  explicit AqlCallStack(AqlCallList call);
+
   // Used to pass between blocks
   AqlCallStack(AqlCallStack const& other) = default;
   AqlCallStack(AqlCallStack&& other) noexcept = default;
@@ -62,7 +64,6 @@ class AqlCallStack {
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   // For tests
   explicit AqlCallStack(std::initializer_list<AqlCallList> calls);
-  explicit AqlCallStack(AqlCallList call);
   // Used in subquery
   AqlCallStack(AqlCallStack const& other, AqlCallList call);
 #endif

--- a/arangod/Aql/AqlCallStack.h
+++ b/arangod/Aql/AqlCallStack.h
@@ -54,9 +54,7 @@ class AqlCallStack {
 
   // Initial
   explicit AqlCallStack(Empty);
-  explicit AqlCallStack(AqlCallList call);
-  // Used in subquery
-  AqlCallStack(AqlCallStack const& other, AqlCallList call);
+
   // Used to pass between blocks
   AqlCallStack(AqlCallStack const& other) = default;
   AqlCallStack(AqlCallStack&& other) noexcept = default;
@@ -64,6 +62,9 @@ class AqlCallStack {
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   // For tests
   explicit AqlCallStack(std::initializer_list<AqlCallList> calls);
+  explicit AqlCallStack(AqlCallList call);
+  // Used in subquery
+  AqlCallStack(AqlCallStack const& other, AqlCallList call);
 #endif
 
   AqlCallStack& operator=(AqlCallStack const& other) = default;


### PR DESCRIPTION
### Scope & Purpose

The `AqlCallList` class previously contained an `std::vector<AqlCall>` member, which was allowed to have at most one entry. to save to heap memory allocation associated with pushing something into the vector, this PR replaces the vector with an `std::optional<AqlCall>`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 