### PR TITLE
reduce the possibility of stampedes

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -83,6 +83,7 @@
 #include "Sharding/ShardingInfo.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
+#include "Transaction/CountCache.h"
 #include "Utils/Events.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
@@ -756,12 +757,16 @@ ClusterInfo::CollectionWithHash ClusterInfo::buildCollection(
     TRI_vocbase_t& vocbase, uint64_t planVersion, bool cleanupLinks) const {
   std::shared_ptr<LogicalCollection> collection;
   uint64_t hash = 0;
+  uint64_t countCache = transaction::CountCache::NotPopulated;
 
   if (!isBuilding && existingCollections != _plannedCollections.end()) {
     // check if we already know this collection from a previous run...
     if (auto existing = existingCollections->second->find(collectionId);
         existing != existingCollections->second->end()) {
       CollectionWithHash const& previous = existing->second;
+      // note the cached count result of the previous collection
+      countCache = previous.collection->countCache().get();
+
       // compare the hash values of what is in the cache with the hash of the
       // collection a hash value of 0 means that the collection must not be read
       // from the cache, potentially because it contains a link to a view (which
@@ -793,6 +798,13 @@ ClusterInfo::CollectionWithHash ClusterInfo::buildCollection(
     // changed
     collection = vocbase.createCollectionObject(data, /*isAStub*/ true);
     TRI_ASSERT(collection != nullptr);
+
+    if (countCache != transaction::CountCache::NotPopulated) {
+      // carry forward the count cache value from the previous collection, if
+      // set. this way we avoid that the count value will be refetched via
+      // HTTP requests instantly after the collection object is used next.
+      collection->countCache().store(countCache);
+    }
     if (!isBuilding) {
       auto indexes = collection->getPhysical()->getAllIndexes();
       // if the collection has a link to a view, there are dependencies between

--- a/arangod/Transaction/CountCache.cpp
+++ b/arangod/Transaction/CountCache.cpp
@@ -29,16 +29,16 @@
 using namespace arangodb;
 using namespace arangodb::transaction;
 
-CountCache::CountCache(double ttl)
+CountCache::CountCache(double ttl) noexcept
     : count(CountCache::NotPopulated), expireStamp(0.0), ttl(ttl) {}
 
-uint64_t CountCache::get() const {
+uint64_t CountCache::get() const noexcept {
   return count.load(std::memory_order_relaxed);
 }
 
-double CountCache::getTime() const { return TRI_microtime(); }
+double CountCache::getTime() const noexcept { return TRI_microtime(); }
 
-uint64_t CountCache::getWithTtl() const {
+uint64_t CountCache::getWithTtl() const noexcept {
   // (1) - this acquire-load synchronizes with the release-store (2)
   double ts = expireStamp.load(std::memory_order_acquire);
   if (ts >= getTime()) {
@@ -48,9 +48,36 @@ uint64_t CountCache::getWithTtl() const {
   return CountCache::NotPopulated;
 }
 
-void CountCache::store(uint64_t value) {
+bool CountCache::bumpExpiry() noexcept {
+  double now = getTime();
+  double ts = expireStamp.load(std::memory_order_acquire);
+  if (ts < now) {
+    // expired
+    double newTs = now + ttl;
+    if (expireStamp.compare_exchange_strong(ts, newTs,
+                                            std::memory_order_release)) {
+      // we were able to update the expiry time ourselves
+      return true;
+    }
+    // fallthrough to returning false
+  }
+  return false;
+}
+
+void CountCache::store(uint64_t value) noexcept {
   TRI_ASSERT(value != CountCache::NotPopulated);
   count.store(value, std::memory_order_relaxed);
   // (2) - this release-store synchronizes with the acquire-load (1)
   expireStamp.store(getTime() + ttl, std::memory_order_release);
 }
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+void CountCache::storeWithoutTtlBump(uint64_t value) noexcept {
+  count.store(value, std::memory_order_relaxed);
+}
+
+bool CountCache::isExpired() const noexcept {
+  return expireStamp.load(std::memory_order_acquire) < getTime();
+}
+
+#endif

--- a/arangod/Transaction/CountCache.h
+++ b/arangod/Transaction/CountCache.h
@@ -24,10 +24,10 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <limits>
 
-namespace arangodb {
-namespace transaction {
+namespace arangodb::transaction {
 
 enum class CountType {
   // actual and accurate result. always returns the collection's actual count
@@ -50,7 +50,7 @@ struct CountCache {
   static constexpr uint64_t NotPopulated = std::numeric_limits<uint64_t>::max();
 
   /// @brief construct a cache with the specified TTL value
-  explicit CountCache(double ttl);
+  explicit CountCache(double ttl) noexcept;
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
   virtual ~CountCache() = default;
@@ -59,17 +59,30 @@ struct CountCache {
   /// @brief get current value from cache, regardless if expired or not.
   /// will return whatever has been stored. if nothing was stored yet, will
   /// return NotPopulated.
-  uint64_t get() const;
+  uint64_t get() const noexcept;
 
-  /// @brief get current value from cache if not yet expired
-  /// if expired or never populated, returns NotPopulated
-  uint64_t getWithTtl() const;
+  /// @brief get current value from cache if not yet expired.
+  /// if expired or never populated, returns NotPopulated.
+  uint64_t getWithTtl() const noexcept;
 
   /// @brief stores value in the cache and bumps the TTL into the future
-  void store(uint64_t value);
+  void store(uint64_t value) noexcept;
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  void storeWithoutTtlBump(uint64_t value) noexcept;
+
+  bool isExpired() const noexcept;
+#endif
+
+  /// @brief bump expiry timestamp if necessary. returns true if timestamp
+  /// was changed. return false otherwise.
+  /// this method is useful so that multiple concurrent threads can call it
+  /// and at most one of gets the "true" value back and update the cache's
+  /// value.
+  bool bumpExpiry() noexcept;
 
  protected:
-  TEST_VIRTUAL double getTime() const;
+  TEST_VIRTUAL double getTime() const noexcept;
 
  private:
   std::atomic<uint64_t> count;
@@ -77,5 +90,4 @@ struct CountCache {
   double const ttl;
 };
 
-}  // namespace transaction
-}  // namespace arangodb
+}  // namespace arangodb::transaction

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -3013,11 +3013,32 @@ futures::Future<OperationResult> transaction::Methods::countCoordinatorHelper(
     // always return from the cache, regardless what's in it
     documents = cache.get();
   } else if (type == transaction::CountType::TryCache) {
-    documents = cache.getWithTtl();
+    // fetch current cache value
+    documents = cache.get();
+    // bump the cache expiry value if required. this will only
+    // modify the cache's expiry timestamp if the cache value is
+    // already expired. when called concurrently, only one thread
+    // will succeed and return true from bumpExpiry.
+    bool bumped = cache.bumpExpiry();
+    if (bumped) {
+      // our thread bumped the expiry date. now set the count
+      // value to unknown so that we refresh the cache value from
+      // this thread.
+      documents = CountCache::NotPopulated;
+    }
+    // if bumped is false here, it means that either the cache value
+    // was not expired, or that is was expired, but another concurrent
+    // thread updated the expiry value concurrently. in this case we
+    // will return the stale cache value if the cache value was ever
+    // populated. otherwise we need to update the cache ourselves.
   }
 
   if (documents == CountCache::NotPopulated) {
-    // no cache hit, or detailed results requested
+    // no cache hit, a cache refresh operation, or detailed results requested.
+    // note that it is still possible for multiple concurrent threads to
+    // fetch the count values from DB servers even for the same collection.
+    // this is possible if detailed requests are requested
+    // (CountType::Detailed), or the cache value has never been populated.
     return arangodb::countOnCoordinator(*this, collectionName, options, api)
         .thenValue(
             [&cache, type, options](OperationResult&& res) -> OperationResult {

--- a/tests/Transaction/CountCacheTest.cpp
+++ b/tests/Transaction/CountCacheTest.cpp
@@ -35,9 +35,9 @@ struct SpeedyCountCache : public transaction::CountCache {
   explicit SpeedyCountCache(double ttl)
       : CountCache(ttl), _time(TRI_microtime()) {}
 
-  double getTime() const override { return _time; }
+  double getTime() const noexcept override { return _time; }
 
-  void advanceTime(double value) { _time += value; }
+  void advanceTime(double value) noexcept { _time += value; }
 
   double _time;
 };
@@ -161,4 +161,59 @@ TEST(TransactionCountCacheTest, testExpireLong) {
   cache.advanceTime(5.01);
   EXPECT_EQ(888, cache.get());
   EXPECT_EQ(transaction::CountCache::NotPopulated, cache.getWithTtl());
+}
+
+TEST(TransactionCountCacheTest, testBumpExpiry) {
+  SpeedyCountCache cache(10.0);
+
+  EXPECT_EQ(transaction::CountCache::NotPopulated, cache.get());
+  EXPECT_EQ(transaction::CountCache::NotPopulated, cache.getWithTtl());
+
+  cache.store(0);
+  EXPECT_EQ(0, cache.get());
+  EXPECT_EQ(0, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.storeWithoutTtlBump(1);
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(1, cache.get());
+  EXPECT_EQ(1, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(9.9);
+  cache.storeWithoutTtlBump(2);
+
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(2, cache.get());
+  EXPECT_EQ(2, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(0.101);
+  EXPECT_EQ(2, cache.get());
+  EXPECT_EQ(transaction::CountCache::NotPopulated, cache.getWithTtl());
+  EXPECT_TRUE(cache.isExpired());
+
+  EXPECT_TRUE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(2, cache.get());
+  EXPECT_EQ(2, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(5.0);
+  cache.storeWithoutTtlBump(3);
+
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(3, cache.get());
+  EXPECT_EQ(3, cache.getWithTtl());
+
+  cache.advanceTime(5.0);
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(0.0001);
+  EXPECT_TRUE(cache.isExpired());
+  EXPECT_TRUE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.isExpired());
 }


### PR DESCRIPTION
### Scope & Purpose

Reduce the possibility of stampedes during collection count cache refilling.
This is not a perfect solution, but it should greatly reduce the opportunity for request stampedes to happen when updating the cached value for collection counts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20991
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
