### PR TITLE
reduce the possibility of stampedes

### DIFF
--- a/arangod/Transaction/CountCache.cpp
+++ b/arangod/Transaction/CountCache.cpp
@@ -29,16 +29,16 @@
 using namespace arangodb;
 using namespace arangodb::transaction;
 
-CountCache::CountCache(double ttl)
+CountCache::CountCache(double ttl) noexcept
     : count(CountCache::NotPopulated), expireStamp(0.0), ttl(ttl) {}
 
-uint64_t CountCache::get() const {
+uint64_t CountCache::get() const noexcept {
   return count.load(std::memory_order_relaxed);
 }
 
-double CountCache::getTime() const { return TRI_microtime(); }
+double CountCache::getTime() const noexcept { return TRI_microtime(); }
 
-uint64_t CountCache::getWithTtl() const {
+uint64_t CountCache::getWithTtl() const noexcept {
   // (1) - this acquire-load synchronizes with the release-store (2)
   double ts = expireStamp.load(std::memory_order_acquire);
   if (ts >= getTime()) {
@@ -48,9 +48,36 @@ uint64_t CountCache::getWithTtl() const {
   return CountCache::NotPopulated;
 }
 
-void CountCache::store(uint64_t value) {
+bool CountCache::bumpExpiry() noexcept {
+  double now = getTime();
+  double ts = expireStamp.load(std::memory_order_acquire);
+  if (ts < now) {
+    // expired
+    double newTs = now + ttl;
+    if (expireStamp.compare_exchange_strong(ts, newTs,
+                                            std::memory_order_release)) {
+      // we were able to update the expiry time ourselves
+      return true;
+    }
+    // fallthrough to returning false
+  }
+  return false;
+}
+
+void CountCache::store(uint64_t value) noexcept {
   TRI_ASSERT(value != CountCache::NotPopulated);
   count.store(value, std::memory_order_relaxed);
   // (2) - this release-store synchronizes with the acquire-load (1)
   expireStamp.store(getTime() + ttl, std::memory_order_release);
 }
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+void CountCache::storeWithoutTtlBump(uint64_t value) noexcept {
+  count.store(value, std::memory_order_relaxed);
+}
+
+bool CountCache::isExpired() const noexcept {
+  return expireStamp.load(std::memory_order_acquire) < getTime();
+}
+
+#endif

--- a/tests/Transaction/CountCacheTest.cpp
+++ b/tests/Transaction/CountCacheTest.cpp
@@ -35,9 +35,9 @@ struct SpeedyCountCache : public transaction::CountCache {
   explicit SpeedyCountCache(double ttl)
       : CountCache(ttl), _time(TRI_microtime()) {}
 
-  double getTime() const override { return _time; }
+  double getTime() const noexcept override { return _time; }
 
-  void advanceTime(double value) { _time += value; }
+  void advanceTime(double value) noexcept { _time += value; }
 
   double _time;
 };
@@ -161,4 +161,59 @@ TEST(TransactionCountCacheTest, testExpireLong) {
   cache.advanceTime(5.01);
   EXPECT_EQ(888, cache.get());
   EXPECT_EQ(transaction::CountCache::NotPopulated, cache.getWithTtl());
+}
+
+TEST(TransactionCountCacheTest, testBumpExpiry) {
+  SpeedyCountCache cache(10.0);
+
+  EXPECT_EQ(transaction::CountCache::NotPopulated, cache.get());
+  EXPECT_EQ(transaction::CountCache::NotPopulated, cache.getWithTtl());
+
+  cache.store(0);
+  EXPECT_EQ(0, cache.get());
+  EXPECT_EQ(0, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.storeWithoutTtlBump(1);
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(1, cache.get());
+  EXPECT_EQ(1, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(9.9);
+  cache.storeWithoutTtlBump(2);
+
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(2, cache.get());
+  EXPECT_EQ(2, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(0.101);
+  EXPECT_EQ(2, cache.get());
+  EXPECT_EQ(transaction::CountCache::NotPopulated, cache.getWithTtl());
+  EXPECT_TRUE(cache.isExpired());
+
+  EXPECT_TRUE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(2, cache.get());
+  EXPECT_EQ(2, cache.getWithTtl());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(5.0);
+  cache.storeWithoutTtlBump(3);
+
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_EQ(3, cache.get());
+  EXPECT_EQ(3, cache.getWithTtl());
+
+  cache.advanceTime(5.0);
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.isExpired());
+
+  cache.advanceTime(0.0001);
+  EXPECT_TRUE(cache.isExpired());
+  EXPECT_TRUE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.bumpExpiry());
+  EXPECT_FALSE(cache.isExpired());
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20990

Reduce the possibility of stampedes during collection count cache refilling.
This is not a perfect solution, but it should greatly reduce the opportunity for request stampedes to happen when updating the cached value for collection counts.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 