### PR TITLE
skip scheduler for query shutdown

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1594,11 +1594,12 @@ futures::Future<Result> finishDBServerParts(Query& query, ErrorCode errorCode) {
   options.database = query.vocbase().name();
   options.timeout = network::Timeout(120.0);  // Picked arbitrarily
   options.continuationLane = RequestLane::CLUSTER_INTERNAL;
-  // Most coordinator AQL code might be executed on the MEDIUM prio lane,
-  // since it comes from a continuation. Therefore, to avoid deadlock, we
-  // must use a lane which has priority HIGH. We do not want to skip the
-  // scheduler, since the cleanup code acquires locks and does some
-  // non-trivial work.
+  // We definitely want to skip the scheduler here, because normally
+  // the thread that orders the query shutdown is blocked and waits
+  // synchronously until the shutdown requests have been responded to.
+  // we thus must guarantee progress here, even in case all
+  // scheduler threads are otherwise blocked.
+  options.skipScheduler = true;
 
   VPackBuffer<uint8_t> body;
   VPackBuilder builder(body);


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/20993

Skip scheduler for query shutdown.
During query shutdown, we definitely want to skip the scheduler, because normally the thread that orders the query shutdown is blocked and waits synchronously until the shutdown requests have been responded to. we thus must guarantee progress here, even in case all scheduler threads are otherwise blocked.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [x] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 