### PR TITLE
move resolution of replication callback to high prio lane

### DIFF
--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -644,7 +644,7 @@ struct ReplicatedProcessorBase : GenericProcessor<Derived> {
         _replicationType, _followers);
 
     if (res.fail()) {
-      THROW_ARANGO_EXCEPTION_MESSAGE(res.errorNumber(), res.errorMessage());
+      THROW_ARANGO_EXCEPTION(res);
     }
 
     _excludeAllFromReplication =
@@ -3389,16 +3389,24 @@ Future<Result> Methods::replicateOperations(
 
   network::RequestOptions reqOpts;
   reqOpts.database = vocbase().name();
-  reqOpts.param(StaticStrings::IsRestoreString, "true");
+  // use a HIGH priority lane to execute the callback when the
+  // response arrives. we must not skip the scheduler entirely here
+  // because the callback may execute an intermediate commit in
+  // RocksDB or carry out agency communication in case a follower
+  // needs to be dropped. the HIGH priority is justified here
+  // because the callback must make progress: the callback can
+  // unblock other block threads on the leader that synchronously
+  // wait for this future to be resolved.
+  reqOpts.continuationLane = RequestLane::CLUSTER_INTERNAL;
 
+  reqOpts.param(StaticStrings::IsRestoreString, "true");
   reqOpts.param(StaticStrings::RefillIndexCachesString,
                 refill ? "true" : "false");
 
   network::addUserParameter(reqOpts, username());
 
   std::string url = absl::StrCat(
-      "/_api/document/",
-      arangodb::basics::StringUtils::urlEncode(collection->name()));
+      "/_api/document/", basics::StringUtils::urlEncode(collection->name()));
 
   std::string_view opName = "unknown";
   arangodb::fuerte::RestVerb requestType = arangodb::fuerte::RestVerb::Illegal;


### PR DESCRIPTION
### Scope & Purpose

Move resolution of replication callback to high prio lane

  // use a HIGH priority lane to execute the callback when the
  // response arrives. we must not skip the scheduler entirely here
  // because the callback may execute an intermediate commit in
  // RocksDB or carry out agency communication in case a follower
  // needs to be dropped. the HIGH priority is justified here
  // because the callback must make progress: the callback can
  // unblock other block threads on the leader that synchronously
  // wait for this future to be resolved.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/20997
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 