### PR TITLE
use Result.is() / Result.isNot() where appropriate

### DIFF
--- a/arangod/Aql/QueryResult.h
+++ b/arangod/Aql/QueryResult.h
@@ -75,10 +75,8 @@ struct QueryResult {
   bool ok() const { return result.ok(); }
   bool fail() const { return result.fail(); }
   ErrorCode errorNumber() const { return result.errorNumber(); }
-  bool is(ErrorCode errorNumber) const {
-    return result.errorNumber() == errorNumber;
-  }
-  bool isNot(ErrorCode errorNumber) const { return !is(errorNumber); }
+  bool is(ErrorCode errorNumber) const { return result.is(errorNumber); }
+  bool isNot(ErrorCode errorNumber) const { return result.isNot(errorNumber); }
   std::string_view errorMessage() const { return result.errorMessage(); }
 
   uint64_t memoryUsage() const noexcept {

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -3590,7 +3590,7 @@ arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
       // If we see at least one TRI_ERROR_LOCAL_LOCK_FAILED it is a failure
       // if all errors are TRI_ERROR_LOCK_TIMEOUT, then we report this and
       // this will lead to a retry:
-      if (finalRes.errorNumber() == TRI_ERROR_LOCAL_LOCK_FAILED) {
+      if (finalRes.is(TRI_ERROR_LOCAL_LOCK_FAILED)) {
         c = TRI_ERROR_LOCAL_LOCK_FAILED;
       }
       finalRes =

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -195,7 +195,7 @@ bool CreateCollection::first() {
       // asynchronous creation of shards. In this case, we do not report an
       // error and do not increase the version number of the shard in
       // `setState` below.
-      if (res.errorNumber() == TRI_ERROR_ARANGO_DUPLICATE_NAME) {
+      if (res.is(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {
         LOG_TOPIC("9db9c", DEBUG, Logger::MAINTENANCE)
             << "local collection " << database << "/" << shard
             << " already found, ignoring...";

--- a/arangod/Cluster/CreateDatabase.cpp
+++ b/arangod/Cluster/CreateDatabase.cpp
@@ -90,7 +90,7 @@ bool CreateDatabase::first() {
     res = Databases::create(server, ExecContext::current(),
                             _description.get(DATABASE), users, properties());
     result(res);
-    if (!res.ok() && res.errorNumber() != TRI_ERROR_ARANGO_DUPLICATE_NAME) {
+    if (res.fail() && res.isNot(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {
       LOG_TOPIC("5fb67", ERR, Logger::MAINTENANCE)
           << "CreateDatabase: failed to create database " << database << ": "
           << res;

--- a/arangod/Cluster/DropDatabase.cpp
+++ b/arangod/Cluster/DropDatabase.cpp
@@ -76,7 +76,7 @@ bool DropDatabase::first() {
 
     auto res = Databases::drop(ExecContext::current(), vocbase, database);
     result(res);
-    if (!res.ok() && res.errorNumber() != TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) {
+    if (res.fail() && res.isNot(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND)) {
       LOG_TOPIC("f46b7", ERR, Logger::AGENCY)
           << "DropDatabase: dropping database " << database
           << " failed: " << res.errorMessage();

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -327,7 +327,7 @@ ResultT<std::unique_ptr<Graph>> GraphManager::lookupGraphByName(
   res = trx.finish(result.result);
 
   if (result.fail()) {
-    if (result.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND) {
+    if (result.is(TRI_ERROR_ARANGO_DOCUMENT_NOT_FOUND)) {
       std::string msg = basics::Exception::FillExceptionString(
           TRI_ERROR_GRAPH_NOT_FOUND, name.c_str());
       return Result{TRI_ERROR_GRAPH_NOT_FOUND, std::move(msg)};

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -461,7 +461,7 @@ futures::Future<OperationResult> GraphOperations::eraseOrphanCollection(
   bool collectionExists = true;
   Result res = checkVertexCollectionAvailability(collectionName);
   if (res.fail()) {
-    if (res.errorNumber() == TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST) {
+    if (res.is(TRI_ERROR_GRAPH_VERTEX_COL_DOES_NOT_EXIST)) {
       // in this case, we are allowed just to drop it out of the definition
       collectionExists = false;
     } else {

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -2279,7 +2279,7 @@ Result IResearchAnalyzerFeature::loadAnalyzers(
     };
     auto const res = visitAnalyzers(*vocbase, visitor, operationOrigin);
     if (!res.ok()) {
-      if (res.errorNumber() == TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND) {
+      if (res.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) {
         // collection not found, cleanup any analyzers for 'database'
         if (itr != _lastLoad.end()) {
           cleanupAnalyzers(database);

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -664,7 +664,7 @@ Result Syncer::applyCollectionDumpMarker(transaction::Methods& trx,
       Result res = ::applyCollectionDumpMarkerInternal(
           _state, trx, coll, type, slice, conflictingDocumentKey);
 
-      if (res.errorNumber() != TRI_ERROR_LOCK_TIMEOUT) {
+      if (res.isNot(TRI_ERROR_LOCK_TIMEOUT)) {
         return res;
       }
 

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -476,8 +476,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
                                          conflictingDocumentKey);
     TRI_ASSERT(!r.is(TRI_ERROR_ARANGO_TRY_AGAIN));
 
-    if (r.errorNumber() == TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED &&
-        isSystem) {
+    if (r.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) && isSystem) {
       // ignore unique constraint violations for system collections
       r.reset();
     }
@@ -553,8 +552,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
       continue;
     }
 
-    if (res.errorNumber() == TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED &&
-        isSystem) {
+    if (res.is(TRI_ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED) && isSystem) {
       // ignore unique constraint violations for system collections
       res.reset();
     }

--- a/arangod/Replication2/Storage/WAL/FileIterator.cpp
+++ b/arangod/Replication2/Storage/WAL/FileIterator.cpp
@@ -53,7 +53,7 @@ void FileIterator::moveToFirstEntry(IteratorPosition position) {
 auto FileIterator::next() -> std::optional<PersistedLogEntry> {
   auto res = _reader.readNextLogEntry();
   if (res.fail()) {
-    if (res.errorNumber() == TRI_ERROR_END_OF_FILE) {
+    if (res.is(TRI_ERROR_END_OF_FILE)) {
       return std::nullopt;
     }
     THROW_ARANGO_EXCEPTION(res.result());

--- a/arangod/Replication2/Storage/WAL/LogReader.cpp
+++ b/arangod/Replication2/Storage/WAL/LogReader.cpp
@@ -86,7 +86,7 @@ auto LogReader::seekLogIndexForward(LogIndex index)
   while (true) {
     auto res = _reader->read(header);
     if (res.fail()) {
-      if (res.errorNumber() == TRI_ERROR_END_OF_FILE) {
+      if (res.is(TRI_ERROR_END_OF_FILE)) {
         return ResultT<Record::CompressedHeader>::error(TRI_ERROR_END_OF_FILE,
                                                         "log index not found");
       }
@@ -228,7 +228,7 @@ auto LogReader::readNextLogEntry() -> ResultT<PersistedLogEntry> {
   Record::CompressedHeader compressedHeader;
   auto res = _reader->read(compressedHeader);
   if (res.fail()) {
-    auto error = res.errorNumber() == TRI_ERROR_END_OF_FILE
+    auto error = res.is(TRI_ERROR_END_OF_FILE)
                      ? TRI_ERROR_END_OF_FILE
                      : TRI_ERROR_REPLICATION_REPLICATED_WAL_ERROR;
     return RT::error(

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -336,7 +336,7 @@ void RestVocbaseBaseHandler::generate20x(
 
 void RestVocbaseBaseHandler::generateConflictError(OperationResult const& opres,
                                                    bool precFailed) {
-  TRI_ASSERT(opres.errorNumber() == TRI_ERROR_ARANGO_CONFLICT);
+  TRI_ASSERT(opres.is(TRI_ERROR_ARANGO_CONFLICT));
   auto code =
       precFailed ? ResponseCode::PRECONDITION_FAILED : ResponseCode::CONFLICT;
   resetResponse(code);

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -234,7 +234,7 @@ void UpgradeFeature::start() {
 
       VPackSlice extras = VPackSlice::noneSlice();
       res = um->storeUser(true, "root", init.defaultPassword(), true, extras);
-      if (res.fail() && res.errorNumber() == TRI_ERROR_USER_NOT_FOUND) {
+      if (res.is(TRI_ERROR_USER_NOT_FOUND)) {
         res =
             um->storeUser(false, "root", init.defaultPassword(), true, extras);
       }

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1504,7 +1504,7 @@ void RocksDBEngine::getCollectionInfo(TRI_vocbase_t& vocbase, DataSourceId cid,
                key.string(), &value);
   auto result = rocksutils::convertStatus(res);
 
-  if (result.errorNumber() != TRI_ERROR_NO_ERROR) {
+  if (result.fail()) {
     THROW_ARANGO_EXCEPTION(result);
   }
 
@@ -4024,7 +4024,7 @@ bool RocksDBEngine::checkExistingDB(
   if (!status.ok()) {
     // check if we have found the database directory or not
     Result res = rocksutils::convertStatus(status);
-    if (res.errorNumber() != TRI_ERROR_ARANGO_IO_ERROR) {
+    if (res.isNot(TRI_ERROR_ARANGO_IO_ERROR)) {
       // not an I/O error. so we better report the error and abort here
       LOG_TOPIC("74b7f", FATAL, arangodb::Logger::STARTUP)
           << "unable to initialize RocksDB engine: " << res.errorMessage();

--- a/arangod/RocksDBEngine/RocksDBMultiDimIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBMultiDimIndex.cpp
@@ -720,8 +720,7 @@ Result RocksDBMdiIndex::insert(transaction::Methods& trx,
   {
     auto result = readDocumentKey(doc, _fields);
     if (result.fail()) {
-      if (result.errorNumber() == TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE &&
-          _sparse) {
+      if (result.is(TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE) && _sparse) {
         return {};
       }
       THROW_ARANGO_EXCEPTION(result.result());
@@ -737,7 +736,7 @@ Result RocksDBMdiIndex::insert(transaction::Methods& trx,
     auto result = extractAttributeValues(trx, _prefixFields, doc, !_sparse);
     if (result.fail()) {
       TRI_ASSERT(_sparse);
-      TRI_ASSERT(result.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING);
+      TRI_ASSERT(result.is(TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING));
       return TRI_ERROR_NO_ERROR;
     }
     auto& prefixValues = result.get();
@@ -794,8 +793,7 @@ Result RocksDBMdiIndex::remove(transaction::Methods& trx,
   {
     auto result = readDocumentKey(doc, _fields);
     if (result.fail()) {
-      if (result.errorNumber() == TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE &&
-          _sparse) {
+      if (result.is(TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE) && _sparse) {
         return {};
       }
       THROW_ARANGO_EXCEPTION(result.result());
@@ -811,7 +809,7 @@ Result RocksDBMdiIndex::remove(transaction::Methods& trx,
     auto result = extractAttributeValues(trx, _prefixFields, doc, !_sparse);
     if (result.fail()) {
       TRI_ASSERT(_sparse);
-      TRI_ASSERT(result.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING);
+      TRI_ASSERT(result.is(TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING));
       return TRI_ERROR_NO_ERROR;
     }
     auto& prefixValues = result.get();
@@ -1104,8 +1102,7 @@ Result RocksDBUniqueMdiIndex::insert(transaction::Methods& trx,
   {
     auto result = readDocumentKey(doc, _fields);
     if (result.fail()) {
-      if (result.errorNumber() == TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE &&
-          _sparse) {
+      if (result.is(TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE) && _sparse) {
         return {};
       }
       THROW_ARANGO_EXCEPTION(result.result());
@@ -1120,7 +1117,7 @@ Result RocksDBUniqueMdiIndex::insert(transaction::Methods& trx,
     auto result = extractAttributeValues(trx, _prefixFields, doc, !_sparse);
     if (result.fail()) {
       TRI_ASSERT(_sparse);
-      TRI_ASSERT(result.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING);
+      TRI_ASSERT(result.is(TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING));
       return TRI_ERROR_NO_ERROR;
     }
     auto& prefixValues = result.get();
@@ -1163,8 +1160,7 @@ Result RocksDBUniqueMdiIndex::remove(transaction::Methods& trx,
   {
     auto result = readDocumentKey(doc, _fields);
     if (result.fail()) {
-      if (result.errorNumber() == TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE &&
-          _sparse) {
+      if (result.is(TRI_ERROR_QUERY_INVALID_ARITHMETIC_VALUE) && _sparse) {
         return {};
       }
       THROW_ARANGO_EXCEPTION(result.result());
@@ -1179,7 +1175,7 @@ Result RocksDBUniqueMdiIndex::remove(transaction::Methods& trx,
     auto result = extractAttributeValues(trx, _prefixFields, doc, !_sparse);
     if (result.fail()) {
       TRI_ASSERT(_sparse);
-      TRI_ASSERT(result.errorNumber() == TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING);
+      TRI_ASSERT(result.is(TRI_ERROR_ARANGO_DOCUMENT_KEY_MISSING));
       return TRI_ERROR_NO_ERROR;
     }
     auto& prefixValues = result.get();

--- a/arangod/RocksDBEngine/RocksDBReplicationTailing.cpp
+++ b/arangod/RocksDBEngine/RocksDBReplicationTailing.cpp
@@ -708,7 +708,6 @@ RocksDBReplicationResult rocksutils::tailWal(TRI_vocbase_t* vocbase,
   if (!s.ok()) {
     auto converted = convertStatus(s, rocksutils::StatusHint::wal);
     TRI_ASSERT(s.IsNotFound() || converted.fail());
-    TRI_ASSERT(s.IsNotFound() || converted.errorNumber() != TRI_ERROR_NO_ERROR);
     if (s.IsNotFound()) {
       // specified from-tick not yet available in DB
       return {TRI_ERROR_NO_ERROR, 0};

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -3574,8 +3574,7 @@ Future<Result> Methods::replicateOperations(
           }
 
           bool followerRefused =
-              (r.errorNumber() ==
-               TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
+              r.is(TRI_ERROR_CLUSTER_SHARD_LEADER_REFUSES_REPLICATION);
           didRefuse = didRefuse || followerRefused;
 
           replicationFailureReason =

--- a/arangod/Utils/OperationResult.h
+++ b/arangod/Utils/OperationResult.h
@@ -79,9 +79,11 @@ struct OperationResult final {
   bool fail() const noexcept { return result.fail(); }
   ErrorCode errorNumber() const noexcept { return result.errorNumber(); }
   bool is(ErrorCode errorNumber) const noexcept {
-    return result.errorNumber() == errorNumber;
+    return result.is(errorNumber);
   }
-  bool isNot(ErrorCode errorNumber) const noexcept { return !is(errorNumber); }
+  bool isNot(ErrorCode errorNumber) const noexcept {
+    return result.isNot(errorNumber);
+  }
   std::string_view errorMessage() const { return result.errorMessage(); }
 
   bool hasSlice() const noexcept { return buffer != nullptr; }


### PR DESCRIPTION
### Scope & Purpose

This is a simple refactoring to use the slightly more expressive `Result.is()` / `Result.isNot()` in favor of `Result.errorNumber() == ...` / `Result.errorNumber() != ...`. 
This PR should not change the behavior of existing code.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 