### PR TITLE
Fixed MDS-1230

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed MDS-1230: added missing variable replacement for inline filters of
+  EnumerateListNodes.
+
 * Fixed BTS-1813: Fixed an AQL error that could lead to range-check exceptions
   in certain queries with subqueries.
 

--- a/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
@@ -142,6 +142,9 @@ size_t EnumerateListNode::getMemoryUsedBytes() const { return sizeof(*this); }
 void EnumerateListNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   _inVariable = Variable::replace(_inVariable, replacements);
+  if (hasFilter()) {
+    filter()->replaceVariables(replacements);
+  }
 }
 
 void EnumerateListNode::replaceAttributeAccess(


### PR DESCRIPTION
### Scope & Purpose

Fixes https://arangodb.atlassian.net/browse/MDS-1230

* Fixed MDS-1230: added missing variable replacement for inline filters of EnumerateListNodes.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: not necessary
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/MDS-1230
- [ ] Design document: 