### PR TITLE
Make beginTransaction async

### DIFF
--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -169,7 +169,8 @@ Future<Result> beginTransactionOnSomeLeaders(TransactionState& state,
       }
     }
   }
-  return ClusterTrxMethods::beginTransactionOnLeaders(state, servers, api);
+  return ClusterTrxMethods::beginTransactionOnLeaders(state.shared_from_this(),
+                                                      std::move(servers), api);
 }
 
 // begin transaction on shard leaders
@@ -197,8 +198,8 @@ Future<Result> beginTransactionOnAllLeaders(transaction::Methods& trx,
       }
     }
   }
-  return ClusterTrxMethods::beginTransactionOnLeaders(*trx.state(), servers,
-                                                      api);
+  return ClusterTrxMethods::beginTransactionOnLeaders(stateShrdPtr(),
+                                                      std::move(servers), api);
 }
 
 /// @brief add the correct header for the shard

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -198,7 +198,7 @@ Future<Result> beginTransactionOnAllLeaders(transaction::Methods& trx,
       }
     }
   }
-  return ClusterTrxMethods::beginTransactionOnLeaders(stateShrdPtr(),
+  return ClusterTrxMethods::beginTransactionOnLeaders(trx.stateShrdPtr(),
                                                       std::move(servers), api);
 }
 

--- a/arangod/Cluster/ClusterTrxMethods.h
+++ b/arangod/Cluster/ClusterTrxMethods.h
@@ -51,8 +51,8 @@ using SortedServersSet = std::set<ServerID, IsServerIdLessThan>;
 
 /// @brief begin a transaction on all followers
 Future<Result> beginTransactionOnLeaders(
-    TransactionState&, ClusterTrxMethods::SortedServersSet const& leaders,
-    transaction::MethodsApi api);
+    std::shared_ptr<TransactionState>,
+    ClusterTrxMethods::SortedServersSet leaders, transaction::MethodsApi api);
 
 /// @brief commit a transaction on a subordinate
 Future<arangodb::Result> commitTransaction(transaction::Methods& trx,

--- a/arangod/ClusterEngine/ClusterTransactionState.cpp
+++ b/arangod/ClusterEngine/ClusterTransactionState.cpp
@@ -130,9 +130,9 @@ futures::Future<Result> ClusterTransactionState::beginTransaction(
     // if there is only one server we may defer the lazy locking
     // until the first actual operation (should save one request)
     if (leaders.size() > 1) {
-      res = ClusterTrxMethods::beginTransactionOnLeaders(
-                *this, leaders, transaction::MethodsApi::Synchronous)
-                .get();
+      res = co_await ClusterTrxMethods::beginTransactionOnLeaders(
+          shared_from_this(), std::move(leaders),
+          transaction::MethodsApi::Asynchronous);
       if (res.fail()) {  // something is wrong
         co_return res;
       }


### PR DESCRIPTION
### Scope & Purpose

Make beginTransaction on a Coordinator asynchronous (i.e., don't block a thread when waiting for network responses).

- [X] :pizza: New feature