### PR TITLE
avoid dropping of followers in some case

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Avoid dropping of followers in case a leader resigns and then comes back.
+
 * Updated ArangoDB Starter to v0.19.2-preview-3.
 
 * Fixed MDS-1230: added missing variable replacement for inline filters of

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -26,9 +26,10 @@
 
 #include "Agency/AgencyComm.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/ReadLocker.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
-#include "Basics/StringUtils.h"
+#include "Basics/WriteLocker.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/MaintenanceStrings.h"
 #include "Cluster/ServerState.h"
@@ -42,8 +43,9 @@
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/VocbaseMetrics.h"
 
+#include <absl/strings/str_cat.h>
+
 using namespace arangodb;
-namespace StringUtils = arangodb::basics::StringUtils;
 
 namespace {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
@@ -94,8 +96,8 @@ char const* reportName(bool isRemove) {
 std::string currentShardPath(arangodb::LogicalCollection const& col) {
   // Agency path is
   //   Current/Collections/<dbName>/<collectionID>/<shardID>
-  return "Current/Collections/" + col.vocbase().name() + "/" +
-         std::to_string(col.planId().id()) + "/" + col.name();
+  return absl::StrCat("Current/Collections/", col.vocbase().name(), "/",
+                      col.planId().id(), "/", col.name());
 }
 
 VPackSlice currentShardEntry(arangodb::LogicalCollection const& col,
@@ -106,8 +108,8 @@ VPackSlice currentShardEntry(arangodb::LogicalCollection const& col,
 }
 
 std::string planShardPath(arangodb::LogicalCollection const& col) {
-  return "Plan/Collections/" + col.vocbase().name() + "/" +
-         std::to_string(col.planId().id()) + "/shards/" + col.name();
+  return absl::StrCat("Plan/Collections/", col.vocbase().name(), "/",
+                      col.planId().id(), "/shards/", col.name());
 }
 
 VPackSlice planShardEntry(arangodb::LogicalCollection const& col,
@@ -119,7 +121,7 @@ VPackSlice planShardEntry(arangodb::LogicalCollection const& col,
 
 }  // namespace
 
-FollowerInfo::FollowerInfo(arangodb::LogicalCollection* d)
+FollowerInfo::FollowerInfo(LogicalCollection* d)
     : _followers(std::make_shared<std::vector<ServerID>>()),
       _failoverCandidates(std::make_shared<std::vector<ServerID>>()),
       _docColl(d),
@@ -134,12 +136,29 @@ FollowerInfo::FollowerInfo(arangodb::LogicalCollection* d)
   // This should also disable satellite tracking.
 }
 
-////////////////////////////////////////////////////////////////////////////////
+/// @brief get information about current followers of a shard.
+std::shared_ptr<std::vector<ServerID> const> FollowerInfo::get() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _followers;
+}
+
+/// @brief get a copy of the information about current followers of a shard.
+std::vector<ServerID> FollowerInfo::getCopy() const {
+  READ_LOCKER(readLocker, _dataLock);
+  TRI_ASSERT(_followers != nullptr);
+  return *_followers;
+}
+
+/// @brief get information about current followers of a shard.
+std::shared_ptr<std::vector<ServerID> const>
+FollowerInfo::getFailoverCandidates() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _failoverCandidates;
+}
+
 /// @brief add a follower to a shard, this is only done by the server side
 /// of the "get-in-sync" capabilities. This reports to the agency under
 /// `/Current` but in asynchronous "fire-and-forget" way.
-////////////////////////////////////////////////////////////////////////////////
-
 Result FollowerInfo::add(ServerID const& sid) {
   TRI_IF_FAILURE("FollowerInfo::add") {
     return {TRI_ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED,
@@ -186,15 +205,56 @@ Result FollowerInfo::add(ServerID const& sid) {
   if (!agencyRes.is(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) &&
       !agencyRes.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) {
     // "Real error", report and log
-    auto errorMessage = StringUtils::concatT(
-        "unable to add follower in agency, timeout in agency CAS operation for "
-        "key ",
-        _docColl->vocbase().name(), "/", _docColl->planId().id(), ": ",
-        TRI_errno_string(agencyRes.errorNumber()));
-    LOG_TOPIC("6295b", ERR, Logger::CLUSTER) << errorMessage;
-    agencyRes.reset(agencyRes.errorNumber(), std::move(errorMessage));
+    agencyRes.reset(
+        agencyRes.errorNumber(),
+        absl::StrCat("unable to add follower in agency, timeout in agency CAS "
+                     "operation for "
+                     "key ",
+                     _docColl->vocbase().name(), "/", _docColl->planId().id(),
+                     ": ", TRI_errno_string(agencyRes.errorNumber())));
+    LOG_TOPIC("6295b", ERR, Logger::CLUSTER) << agencyRes.errorMessage();
   }
   return agencyRes;
+}
+
+/// @brief set leadership
+void FollowerInfo::setTheLeader(std::string const& who) {
+  // Empty leader => we are now new leader.
+  // This needs to be handled with takeOverLeadership
+  TRI_ASSERT(!who.empty());
+  WRITE_LOCKER(writeLocker, _dataLock);
+  _theLeader = who;
+  _theLeaderTouched = true;
+  _writeConcernReached = true;
+}
+
+// conditionally change the leader, in case the current leader is still the
+// same as expected. in this case, return true and change the leader to
+// actual. otherwise, don't change anything and return false
+bool FollowerInfo::setTheLeaderConditional(std::string const& expected,
+                                           std::string const& actual) {
+  TRI_ASSERT(!actual.empty());
+  WRITE_LOCKER(writeLocker, _dataLock);
+  if (_theLeader != expected) {
+    // leader has already changed compared to what was expected.
+    // do not modify anything and abort.
+    return false;
+  }
+  // old leader was as expected. now change it and return success.
+  _theLeader = actual;
+  _theLeaderTouched = true;
+  _writeConcernReached = true;
+  return true;
+}
+
+std::string FollowerInfo::getLeader() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _theLeader;
+}
+
+bool FollowerInfo::getLeaderTouched() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _theLeaderTouched;
 }
 
 FollowerInfo::WriteState FollowerInfo::allowedToWrite() {
@@ -240,8 +300,7 @@ FollowerInfo::WriteState FollowerInfo::allowedToWrite() {
           << "Shard " << _docColl->name()
           << " is temporarily in read-only mode, since we have less than "
              "writeConcern ("
-          << basics::StringUtils::itoa(_docColl->writeConcern())
-          << ") replicas in sync.";
+          << _docColl->writeConcern() << ") replicas in sync.";
       return WriteState::FORBIDDEN;
     }
   }
@@ -338,7 +397,7 @@ Result FollowerInfo::remove(ServerID const& sid) {
     // we are finished
     ++_docColl->vocbase()
           .server()
-          .getFeature<arangodb::ClusterFeature>()
+          .getFeature<ClusterFeature>()
           .followersDroppedCounter();
     LOG_TOPIC("be0cb", DEBUG, Logger::CLUSTER)
         << "Removing follower " << sid << " from " << _docColl->name()
@@ -353,7 +412,7 @@ Result FollowerInfo::remove(ServerID const& sid) {
   // rollback:
   _followers = oldFollowers;
   _failoverCandidates = oldFailovers;
-  auto errorMessage = StringUtils::concatT(
+  auto errorMessage = absl::StrCat(
       "unable to remove follower from agency, timeout in agency CAS operation "
       "for key ",
       _docColl->vocbase().name(), "/", _docColl->planId().id(), ": ",
@@ -375,22 +434,16 @@ void FollowerInfo::clear() {
   _writeConcernReached = _followers->size() + 1 >= _docColl->writeConcern();
 }
 
-//////////////////////////////////////////////////////////////////////////////
 /// @brief check whether the given server is a follower
-//////////////////////////////////////////////////////////////////////////////
-
 bool FollowerInfo::contains(ServerID const& sid) const {
   READ_LOCKER(readLocker, _dataLock);
   auto const& f = *_followers;
   return std::find(f.begin(), f.end(), sid) != f.end();
 }
 
-////////////////////////////////////////////////////////////////////////////////
 /// @brief Take over leadership for this shard.
 ///        Also inject information of a insync followers that we knew about
 ///        before a failover to this server has happened
-////////////////////////////////////////////////////////////////////////////////
-
 void FollowerInfo::takeOverLeadership(
     std::vector<ServerID> const& previousInsyncFollowers,
     std::shared_ptr<std::vector<ServerID>> realInsyncFollowers) {
@@ -406,7 +459,7 @@ void FollowerInfo::takeOverLeadership(
   // all modifications to the internal state are guaranteed to be
   // atomic
   if (previousInsyncFollowers.size() > 1) {
-    auto ourselves = arangodb::ServerState::instance()->getId();
+    auto ourselves = ServerState::instance()->getId();
     auto failoverCandidates =
         std::make_shared<std::vector<ServerID>>(previousInsyncFollowers);
     auto myEntry = std::find(failoverCandidates->begin(),
@@ -468,11 +521,9 @@ void FollowerInfo::takeOverLeadership(
   _theLeaderTouched = true;
 }
 
-////////////////////////////////////////////////////////////////////////////////
 /// @brief Update the current information in the Agency. We update the failover-
 ///        list with the newest values, after this the guarantee is that
 ///        _followers == _failoverCandidates
-////////////////////////////////////////////////////////////////////////////////
 bool FollowerInfo::updateFailoverCandidates() {
   std::lock_guard agencyLocker{_agencyMutex};
   // Acquire _canWriteLock first
@@ -515,9 +566,7 @@ bool FollowerInfo::updateFailoverCandidates() {
   return _canWrite;
 }
 
-////////////////////////////////////////////////////////////////////////////////
 /// @brief Persist information in Current
-////////////////////////////////////////////////////////////////////////////////
 Result FollowerInfo::persistInAgency(bool isRemove) const {
   // Now tell the agency
   TRI_ASSERT(_docColl != nullptr);
@@ -607,12 +656,19 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
   return TRI_ERROR_SHUTTING_DOWN;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief inject the information about "servers" and "failoverCandidates"
-////////////////////////////////////////////////////////////////////////////////
+/// @brief Inject the information about followers into the builder.
+///        Builder needs to be an open object and is not allowed to contain
+///        the keys "servers" and "failoverCandidates".
+std::pair<size_t, size_t> FollowerInfo::injectFollowerInfo(
+    velocypack::Builder& builder) const {
+  READ_LOCKER(readLockerData, _dataLock);
+  injectFollowerInfoInternal(builder);
+  return std::make_pair(_followers->size(), _failoverCandidates->size());
+}
 
+/// @brief inject the information about "servers" and "failoverCandidates"
 void FollowerInfo::injectFollowerInfoInternal(VPackBuilder& builder) const {
-  auto ourselves = arangodb::ServerState::instance()->getId();
+  auto ourselves = ServerState::instance()->getId();
   TRI_ASSERT(builder.isOpenObject());
   builder.add(VPackValue(maintenance::SERVERS));
   {
@@ -696,14 +752,4 @@ uint64_t FollowerInfo::getFollowingTermId(ServerID const& s) const noexcept {
     return 1;
   }
   return it->second;
-}
-
-void FollowerInfo::setTheLeader(const std::string& who) {
-  // Empty leader => we are now new leader.
-  // This needs to be handled with takeOverLeadership
-  TRI_ASSERT(!who.empty());
-  WRITE_LOCKER(writeLocker, _dataLock);
-  _theLeader = who;
-  _theLeaderTouched = true;
-  _writeConcernReached = true;
 }

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -24,13 +24,16 @@
 
 #pragma once
 
-#include <mutex>
-
-#include "Basics/ReadLocker.h"
 #include "Basics/ReadWriteLock.h"
-#include "Basics/WriteLocker.h"
 #include "Cluster/ClusterTypes.h"
 #include "Metrics/InstrumentedBool.h"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace arangodb {
 
@@ -75,10 +78,10 @@ class FollowerInfo {
   // 2.) _canWriteLock
   // 3.) _dataLock
   mutable std::mutex _agencyMutex;
-  mutable arangodb::basics::ReadWriteLock _canWriteLock;
-  mutable arangodb::basics::ReadWriteLock _dataLock;
+  mutable basics::ReadWriteLock _canWriteLock;
+  mutable basics::ReadWriteLock _dataLock;
 
-  arangodb::LogicalCollection* _docColl;
+  LogicalCollection* _docColl;
   // if the latter is empty, then we are leading
   std::string _theLeader;
   bool _theLeaderTouched;
@@ -87,155 +90,98 @@ class FollowerInfo {
   metrics::InstrumentedBool _writeConcernReached;
 
  public:
-  explicit FollowerInfo(arangodb::LogicalCollection* d);
+  explicit FollowerInfo(LogicalCollection* d);
 
   enum class WriteState { ALLOWED = 0, FORBIDDEN, STARTUP, UNAVAILABLE };
 
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get information about current followers of a shard.
-  ////////////////////////////////////////////////////////////////////////////////
+  std::shared_ptr<std::vector<ServerID> const> get() const;
 
-  std::shared_ptr<std::vector<ServerID> const> get() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _followers;
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get a copy of the information about current followers of a shard.
-  ////////////////////////////////////////////////////////////////////////////////
-  std::vector<ServerID> getCopy() const {
-    READ_LOCKER(readLocker, _dataLock);
-    TRI_ASSERT(_followers != nullptr);
-    return *_followers;
-  }
+  std::vector<ServerID> getCopy() const;
 
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get information about current followers of a shard.
-  ////////////////////////////////////////////////////////////////////////////////
+  std::shared_ptr<std::vector<ServerID> const> getFailoverCandidates() const;
 
-  std::shared_ptr<std::vector<ServerID> const> getFailoverCandidates() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _failoverCandidates;
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief Take over leadership for this shard.
   ///        Also inject information of a insync followers that we knew about
   ///        before a failover to this server has happened
   ///        The second parameter may be nullptr. It is an additional list
   ///        of declared to be insync followers. If it is nullptr the follower
   ///        list is initialized empty.
-  ////////////////////////////////////////////////////////////////////////////////
-
   void takeOverLeadership(
       std::vector<ServerID> const& previousInsyncFollowers,
       std::shared_ptr<std::vector<ServerID>> realInsyncFollowers);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief add a follower to a shard, this is only done by the server side
   /// of the "get-in-sync" capabilities. This reports to the agency under
   /// `/Current` but in asynchronous "fire-and-forget" way. The method
   /// fails silently, if the follower information has since been dropped
   /// (see `dropFollowerInfo` below).
-  //////////////////////////////////////////////////////////////////////////////
-
   Result add(ServerID const& s);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief remove a follower from a shard, this is only done by the
   /// server if a synchronous replication request fails. This reports to
   /// the agency under `/Current` but in an asynchronous "fire-and-forget"
   /// way.
-  //////////////////////////////////////////////////////////////////////////////
-
   Result remove(ServerID const& s);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief explicitly set the following term id for a follower.
   /// this should only be used for special cases during upgrading or testing.
-  //////////////////////////////////////////////////////////////////////////////
   void setFollowingTermId(ServerID const& s, uint64_t value);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief for each run of the "get-in-sync" protocol we generate a
   /// random number to identify this "following term". This is created
   /// when the follower fetches the exclusive lock to finally get in sync
   /// and is stored in _followingTermId, so that it can be forwarded with
   /// each synchronous replication request. The follower can then decline
   /// the replication in case it is not "in the same term".
-  //////////////////////////////////////////////////////////////////////////////
-
   uint64_t newFollowingTermId(ServerID const& s) noexcept;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief for each run of the "get-in-sync" protocol we generate a
   /// random number to identify this "following term". This is created
   /// when the follower fetches the exclusive lock to finally get in sync
   /// and is stored in _followingTermId, so that it can be forwarded with
   /// each synchronous replication request. The follower can then decline
   /// the replication in case it is not "in the same term".
-  //////////////////////////////////////////////////////////////////////////////
-
   uint64_t getFollowingTermId(ServerID const& s) const noexcept;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief clear follower list, no changes in agency necesary
-  //////////////////////////////////////////////////////////////////////////////
-
   void clear();
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief check whether the given server is a follower
-  //////////////////////////////////////////////////////////////////////////////
-
   bool contains(ServerID const& s) const;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief set leadership
-  //////////////////////////////////////////////////////////////////////////////
-
   void setTheLeader(std::string const& who);
 
-  //////////////////////////////////////////////////////////////////////////////
+  // conditionally change the leader, in case the current leader is still the
+  // same as expected. in this case, return true and change the leader to
+  // actual. otherwise, don't change anything and return false
+  bool setTheLeaderConditional(std::string const& expected,
+                               std::string const& actual);
+
   /// @brief get the leader
-  //////////////////////////////////////////////////////////////////////////////
+  std::string getLeader() const;
 
-  std::string getLeader() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _theLeader;
-  }
-
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief see if leader was explicitly set
-  //////////////////////////////////////////////////////////////////////////////
-
-  bool getLeaderTouched() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _theLeaderTouched;
-  }
+  bool getLeaderTouched() const;
 
   WriteState allowedToWrite();
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief Inject the information about followers into the builder.
   ///        Builder needs to be an open object and is not allowed to contain
   ///        the keys "servers" and "failoverCandidates".
-  //////////////////////////////////////////////////////////////////////////////
   std::pair<size_t, size_t> injectFollowerInfo(
-      arangodb::velocypack::Builder& builder) const {
-    READ_LOCKER(readLockerData, _dataLock);
-    injectFollowerInfoInternal(builder);
-    return std::make_pair(_followers->size(), _failoverCandidates->size());
-  }
+      velocypack::Builder& builder) const;
 
  private:
-  void injectFollowerInfoInternal(arangodb::velocypack::Builder& builder) const;
+  void injectFollowerInfoInternal(velocypack::Builder& builder) const;
 
   bool updateFailoverCandidates();
 
   Result persistInAgency(bool isRemove) const;
 
-  arangodb::velocypack::Builder newShardEntry(
-      arangodb::velocypack::Slice oldValue) const;
+  velocypack::Builder newShardEntry(velocypack::Slice oldValue) const;
 };
 }  // end namespace arangodb

--- a/tests/js/client/shell/shell-leader-resign-cluster-noinstr-nonwindows.js
+++ b/tests/js/client/shell/shell-leader-resign-cluster-noinstr-nonwindows.js
@@ -1,0 +1,97 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertEqual, assertNotEqual, assertFalse, assertTrue */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Apache License, Version 2.0 (the "License")
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     http://www.apache.org/licenses/LICENSE-2.0
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is triAGENS GmbH, Cologne, Germany
+// /
+// / @author Jan Steemann
+// //////////////////////////////////////////////////////////////////////////////
+
+let jsunity = require('jsunity');
+let arangodb = require('@arangodb');
+let internal = require('internal');
+let _ = require('lodash');
+let db = arangodb.db;
+let { agency, getMetric, getEndpointById } = require('@arangodb/test-helper');
+  
+const cn = 'UnitTestsCollection';
+  
+function LeaderResignSuite() {
+  'use strict';
+
+  return {
+    setUp: function () {
+      let c = db._create(cn, {numberOfShards: 1, replicationFactor: 3});
+      let docs = [];
+      for (let i = 0; i < 100; ++i) {
+        docs.push({value: i});
+      }
+      c.insert(docs);
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+    
+    testResignLeaderWhileWriteQueryRuns: function () {
+      const c = db._collection(cn);
+      const shards = db._collection(cn).shards(true);
+      const shardId = Object.keys(shards)[0];
+
+      const expectedShards = shards[shardId];
+      const leader = getEndpointById(expectedShards[0]);
+
+//      curl http://localhost:4001/_api/agency/write -d '[[{"/arango/Plan/Collections/_system/10043/shards/s10044":["_PRMR-434a57f2-199d-4289-be95-3ee6a2ec1ea2","PRMR-549e4fee-775f-4d8e-940c-afc3b4e5a7a9","PRMR-faa38bf9-5a6d-4e07-81be-ad59f8523ed9"], "/arango/Plan/Version":{"op":"increment"}}]]'; echo
+      const planKey = `/arango/Plan/Collections/_system/${c._id}/shards/${shardId}`;
+      let planValue = agency.call("read", [[planKey]])[0].arango.Plan.Collections._system[c._id].shards[shardId];
+      assertEqual(expectedShards, planValue);
+      
+      let droppedFollowersBefore = getMetric(leader, "arangodb_dropped_followers_total");
+      
+      // make leader resign
+      let body = {"/arango/Plan/Version":{op:"increment"}};
+      let shardsWithResignedLeader = _.clone(expectedShards);
+      // prepend underscore to server name
+      shardsWithResignedLeader[0] = "_" + shardsWithResignedLeader[0];
+      body[planKey] = {"op":"set", "new": shardsWithResignedLeader};
+      agency.call("write", [[body]]);
+  
+      // wait for servers to pick up the changes
+      internal.sleep(5);
+      
+      // reactivate leader
+      body[planKey] = {"op":"set", "new": expectedShards};
+      agency.call("write", [[body]]);
+      
+      // wait for servers to pick up the changes
+      internal.sleep(5);
+
+      // insert a single document. this must not drop the follower
+      c.insert({});
+      
+      // no followers must have been dropped by the insert
+      let droppedFollowersAfter = getMetric(leader, "arangodb_dropped_followers_total");
+      assertEqual(droppedFollowersBefore, droppedFollowersAfter);
+    },
+      
+  };
+}
+
+jsunity.run(LeaderResignSuite);
+return jsunity.done();

--- a/tests/js/client/shell/shell-leader-resign-cluster-noinstr.js
+++ b/tests/js/client/shell/shell-leader-resign-cluster-noinstr.js
@@ -4,13 +4,14 @@
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
 // /
-// / Copyright 2018 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 // /
-// / Licensed under the Apache License, Version 2.0 (the "License")
+// / Licensed under the Business Source License 1.1 (the "License");
 // / you may not use this file except in compliance with the License.
 // / You may obtain a copy of the License at
 // /
-// /     http://www.apache.org/licenses/LICENSE-2.0
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
 // /
 // / Unless required by applicable law or agreed to in writing, software
 // / distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,9 +19,7 @@
 // / See the License for the specific language governing permissions and
 // / limitations under the License.
 // /
-// / Copyright holder is triAGENS GmbH, Cologne, Germany
-// /
-// / @author Jan Steemann
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
 let jsunity = require('jsunity');


### PR DESCRIPTION
### Scope & Purpose

Avoid dropping of followers in the following scenario:
- leader has in-sync follower(s) for a given shard
- resignLeadership is called for current leader
- resignLeadership is reverted, so that old leader is now again the leader
- write to the shard

Previously this led to dropping the followers when the write operation was executed, because the leader's session id changed when taking over shard leadership again. The new session id was propagated to all followers, but it wasn't picked up because the leader server id did not change.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21004
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 