### PR TITLE
Fixed MDS-1229 (bad_function_call with batch materialization)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fixed MDS-1229 (bad_function_call with batch materialization).
+
 * Updated ArangoDB Starter to v0.19.2-preview-3.
 
 * Fixed MDS-1230: added missing variable replacement for inline filters of

--- a/tests/js/client/aql/aql-index-batch-materialize.js
+++ b/tests/js/client/aql/aql-index-batch-materialize.js
@@ -45,13 +45,15 @@ function IndexBatchMaterializeTestSuite() {
     c.ensureIndex({type: "persistent", fields: ["y"]});
     c.ensureIndex({type: "persistent", fields: ["z", "w"]});
     c.ensureIndex({type: "persistent", fields: ["u", "_key"], unique: true});
+    c.ensureIndex({type: "persistent", fields: ["p", "values[*].y"], unique: false});
+
     return c;
   }
 
   function fillCollection(c, n) {
     let docs = [];
     for (let i = 0; i < n; i++) {
-      docs.push({x: i, y: 2 * i, z: 2 * i + 1, w: i % 10, u: i, b: i + 1});
+      docs.push({x: i, y: 2 * i, z: 2 * i + 1, w: i % 10, u: i, b: i + 1, p: i, q: i});
     }
     c.insert(docs);
   }
@@ -119,7 +121,7 @@ function IndexBatchMaterializeTestSuite() {
       const c = makeCollection(collection);
 
       fillCollection(s, 10);
-      fillCollection(c, 1000);
+      fillCollection(c, 5000);
     },
 
     tearDownAll: function () {
@@ -183,11 +185,45 @@ function IndexBatchMaterializeTestSuite() {
       expectOptimization(query);
     },
     
+    testMaterializeIndexScanSkip2: function () {
+      const query = `
+        FOR doc IN ${collection}
+          FILTER doc.p > 5
+          LIMIT 20, 10
+          RETURN doc
+      `;
+
+      expectOptimization(query);
+    },
+    
+    testMaterializeIndexScanSkip3: function () {
+      const query = `
+        FOR doc IN ${collection}
+          FILTER doc.p > 5
+          FILTER NOOPT(doc.q > 0)
+          LIMIT 20, 10
+          RETURN doc
+      `;
+
+      expectOptimization(query);
+    },
+
     testMaterializeIndexScanFullCount: function () {
       const query = `
         FOR doc IN ${collection}
           FILTER doc.x > 5
           SORT doc.x 
+          LIMIT 0, 20
+          RETURN doc
+      `;
+
+      expectOptimization(query, {fullCount: true});
+    },
+    
+    testMaterializeIndexScanFullCount2: function () {
+      const query = `
+        FOR doc IN ${collection}
+          FILTER doc.p > 5
           LIMIT 0, 20
           RETURN doc
       `;
@@ -357,11 +393,33 @@ function IndexBatchMaterializeTestSuite() {
 
       expectOptimization(query);
     },
-
+    
     testMaterializeIndexScanPostFilterNotCovered: function () {
       const query = `
         FOR doc IN ${collection}
           FILTER doc.x > 5 AND doc.c < 7
+          RETURN doc
+      `;
+
+      expectNoOptimization(query);
+    },
+    
+    testMaterializeSkipIndexScanPostFilterCovered: function () {
+      const query = `
+        FOR doc IN ${collection}
+          FILTER doc.x > 5 AND doc.b < 7
+          LIMIT 10, 20
+          RETURN doc
+      `;
+
+      expectOptimization(query);
+    },
+
+    testMaterializeSkipIndexScanPostFilterNotCovered: function () {
+      const query = `
+        FOR doc IN ${collection}
+          FILTER doc.x > 5 AND doc.c < 7
+          LIMIT 10, 20
           RETURN doc
       `;
 


### PR DESCRIPTION
### Scope & Purpose

Fixes https://arangodb.atlassian.net/browse/MDS-1229

Fixes an issue when late document materialization is used in queries together with skipping over documents (`LIMIT x, y` with `x` > 0). Such queries could fail with internal errors and error messages such as "bad_function_call".
This bugfix follows https://arangodb.atlassian.net/browse/OASIS-25823 (https://github.com/arangodb/arangodb/pull/20960), which fixed a similar issue already, but apparently only for queries that used a post-filter on the IndexNode. The case of IndexNodes not using post-filters had been overlooked in the initial bugfix PR.

The bug affects 3.12.0, but not 3.11.x. The reason is that late materialization is used in a lot more cases in 3.12 than in 3.11, so now there are additional cases to consider.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: not needed
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/MDS-1229
- [ ] Design document: 