### PR TITLE
Rename Future::get to ::waitAndGet (and getTry to waitAndGetTry)

### DIFF
--- a/arangod/Agency/AgencyComm.cpp
+++ b/arangod/Agency/AgencyComm.cpp
@@ -1232,7 +1232,7 @@ AgencyCommResult AgencyComm::sendWithFailover(
       result = comm.withSkipScheduler(true)
                    .sendWriteTransaction(std::chrono::duration<double>(timeout),
                                          std::move(buffer))
-                   .get();
+                   .waitAndGet();
     } else {
       LOG_TOPIC("4e44f", TRACE, Logger::AGENCYCOMM)
           << "sendWithFailover: "
@@ -1243,7 +1243,7 @@ AgencyCommResult AgencyComm::sendWithFailover(
                                      std::chrono::duration<double>(timeout),
                                      AsyncAgencyComm::RequestType::READ,
                                      std::move(buffer))
-                   .get();
+                   .waitAndGet();
     }
   } else if (method == arangodb::rest::RequestType::GET) {
     LOG_TOPIC("4e448", TRACE, Logger::AGENCYCOMM)
@@ -1255,7 +1255,7 @@ AgencyCommResult AgencyComm::sendWithFailover(
                                    std::chrono::duration<double>(timeout),
                                    AsyncAgencyComm::RequestType::CUSTOM,
                                    std::move(buffer))
-                 .get();
+                 .waitAndGet();
   } else {
     return AgencyCommResult{rest::ResponseCode::METHOD_NOT_ALLOWED,
                             "method not supported"};

--- a/arangod/Agency/Inception.cpp
+++ b/arangod/Agency/Inception.cpp
@@ -331,7 +331,7 @@ bool Inception::restartingActiveAgent() {
 
       auto comres = network::sendRequest(cp, p, fuerte::RestVerb::Post, path,
                                          greetBuffer, reqOpts)
-                        .get();
+                        .waitAndGet();
 
       if (comres.ok() && comres.statusCode() == fuerte::StatusOK) {
         VPackSlice const theirConfig = comres.slice();
@@ -365,7 +365,7 @@ bool Inception::restartingActiveAgent() {
 
         auto comres = network::sendRequest(cp, p.second, fuerte::RestVerb::Post,
                                            path, greetBuffer, reqOpts)
-                          .get();
+                          .waitAndGet();
 
         if (comres.combinedResult().ok()) {
           try {
@@ -399,7 +399,7 @@ bool Inception::restartingActiveAgent() {
                 comres = network::sendRequest(cp, theirLeaderEp,
                                               fuerte::RestVerb::Post, path,
                                               greetBuffer, reqOpts)
-                             .get();
+                             .waitAndGet();
 
                 // Failed to contact leader move on until we do. This way at
                 // least we inform everybody individually of the news.

--- a/arangod/Aql/Function/DocumentFunctions.cpp
+++ b/arangod/Aql/Function/DocumentFunctions.cpp
@@ -116,7 +116,7 @@ void getDocumentByIdentifier(transaction::Methods* trx,
   try {
     res = trx->documentFastPath(collectionName, searchBuilder->slice(), options,
                                 result)
-              .get();
+              .waitAndGet();
   } catch (basics::Exception const& ex) {
     res.reset(ex.code());
   }

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1107,7 +1107,7 @@ Collection* addCollectionToQuery(QueryContext& query, std::string const& cname,
       TRI_ASSERT(coll != nullptr);
       query.trxForOptimization()
           .addCollectionAtRuntime(cname, AccessMode::Type::READ)
-          .get();
+          .waitAndGet();
     }
   }
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1842,8 +1842,8 @@ ExecutionState Query::cleanupTrxAndEngines(ErrorCode errorCode) {
       _shutdownState.store(ShutdownState::None, std::memory_order_relaxed);
     });
     futures::Future<Result> commitResult = _trx->commitAsync();
-    if (commitResult.get().fail()) {
-      THROW_ARANGO_EXCEPTION(std::move(commitResult).get());
+    if (commitResult.waitAndGet().fail()) {
+      THROW_ARANGO_EXCEPTION(std::move(commitResult).waitAndGet());
     }
     TRI_IF_FAILURE("Query::finalize_before_done") {
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -636,7 +636,7 @@ Result RestAqlHandler::findEngine(std::string const& idString) {
 
       auto fut = _queryRegistry->finishQuery(queryId, errorCode);
       TRI_ASSERT(fut.isReady());
-      auto query = fut.get();
+      auto query = fut.waitAndGet();
       if (query != nullptr) {
         auto f = query->finalizeClusterQuery(errorCode);
         // Wait for query to be fully finalized, as a finish call would do.

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -194,7 +194,7 @@ ExecutionState SimpleModifier<ModifierCompletion, Enable>::transact(
   result.wait();
 
   if (result.isReady()) {
-    _results = std::move(result.get());
+    _results = std::move(result.waitAndGet());
     return ExecutionState::DONE;
   }
 

--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -390,7 +390,7 @@ void AgencyCache::run() {
 
       if (server().getFeature<NetworkFeature>().prepared()) {
         try {
-          auto rb = sendTransaction().get();
+          auto rb = sendTransaction().waitAndGet();
           if (!rb.ok() || rb.statusCode() != arangodb::fuerte::StatusOK) {
             // Error response, this includes client timeout
             increaseWaitTime();

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -754,7 +754,7 @@ void ClusterFeature::start() {
   // empty agency. There are also other measures that guard against such a
   // outcome. But there is also no point continuing with a first agency poll.
   if (role != ServerState::ROLE_AGENT && role != ServerState::ROLE_UNDEFINED) {
-    _agencyCache->waitFor(1).get();
+    _agencyCache->waitFor(1).waitAndGet();
     LOG_TOPIC("13eab", DEBUG, Logger::CLUSTER)
         << "Agency cache is ready. Starting cluster cache syncers";
   }
@@ -1285,7 +1285,7 @@ void ClusterFeature::runConnectivityCheck() {
     if (this->server().isStopping()) {
       break;
     }
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
     TRI_ASSERT(r.destination.starts_with("server:"));
 
     if (r.ok()) {

--- a/arangod/Cluster/ClusterIndexMethods.cpp
+++ b/arangod/Cluster/ClusterIndexMethods.cpp
@@ -504,8 +504,8 @@ Result dropIndexCoordinatorReplication2Inner(LogicalCollection const& col,
   }
   if (VPackSlice resultSlice = result.slice().get("results");
       resultSlice.length() > 0) {
-    Result r =
-        clusterInfo.waitForPlan(resultSlice[0].getNumber<uint64_t>()).get();
+    Result r = clusterInfo.waitForPlan(resultSlice[0].getNumber<uint64_t>())
+                   .waitAndGet();
     if (r.fail()) {
       return r;
     }
@@ -729,8 +729,8 @@ Result dropIndexCoordinatorInner(LogicalCollection const& col, IndexId iid,
   }
   if (VPackSlice resultSlice = result.slice().get("results");
       resultSlice.length() > 0) {
-    Result r =
-        clusterInfo.waitForPlan(resultSlice[0].getNumber<uint64_t>()).get();
+    Result r = clusterInfo.waitForPlan(resultSlice[0].getNumber<uint64_t>())
+                   .waitAndGet();
     if (r.fail()) {
       return r;
     }
@@ -932,7 +932,7 @@ auto ensureIndexCoordinatorReplication2Inner(
               }
               return Result{};
             });
-    auto res = waitOnSuccess.get();
+    auto res = waitOnSuccess.waitAndGet();
     if (res.fail()) {
       // Try our best to drop the index again
       std::ignore =
@@ -1146,8 +1146,8 @@ Result ensureIndexCoordinatorInner(LogicalCollection const& collection,
   if (result.successful()) {
     if (VPackSlice resultsSlice = result.slice().get("results");
         resultsSlice.length() > 0) {
-      Result r =
-          clusterInfo.waitForPlan(resultsSlice[0].getNumber<uint64_t>()).get();
+      Result r = clusterInfo.waitForPlan(resultsSlice[0].getNumber<uint64_t>())
+                     .waitAndGet();
       if (r.fail()) {
         return r;
       }
@@ -1262,7 +1262,7 @@ Result ensureIndexCoordinatorInner(LogicalCollection const& collection,
               resultsSlice.length() > 0) {
             Result r =
                 clusterInfo.waitForPlan(resultsSlice[0].getNumber<uint64_t>())
-                    .get();
+                    .waitAndGet();
             if (r.fail()) {
               return r;
             }
@@ -1312,7 +1312,7 @@ Result ensureIndexCoordinatorInner(LogicalCollection const& collection,
                 updateSlice.length() > 0) {
               Result r =
                   clusterInfo.waitForPlan(updateSlice[0].getNumber<uint64_t>())
-                      .get();
+                      .waitAndGet();
               if (r.fail()) {
                 return r;
               }

--- a/arangod/Cluster/ClusterMethods.cpp
+++ b/arangod/Cluster/ClusterMethods.cpp
@@ -1194,7 +1194,7 @@ futures::Future<OperationResult> countOnCoordinator(
   if (isManaged) {
     Result res = ::beginTransactionOnAllLeaders(
                      trx, *shardIds, transaction::MethodsApi::Synchronous)
-                     .get();
+                     .waitAndGet();
     if (res.fail()) {
       return futures::makeFuture(OperationResult(res, options));
     }
@@ -1412,7 +1412,7 @@ Result selectivityEstimatesOnCoordinator(ClusterFeature& feature,
 
   containers::FlatHashMap<std::string, std::vector<double>> indexEstimates;
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     auto res = r.combinedResult();
     if (res.fail()) {
@@ -1877,7 +1877,7 @@ futures::Future<OperationResult> truncateCollectionOnCoordinator(
   if (trx.state()->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED)) {
     res = ::beginTransactionOnAllLeaders(trx, *shardIds,
                                          transaction::MethodsApi::Synchronous)
-              .get();
+              .waitAndGet();
     if (res.fail()) {
       return futures::makeFuture(OperationResult(res, options));
     }
@@ -2088,7 +2088,7 @@ Future<OperationResult> getDocumentOnCoordinator(
   if (isManaged) {  // lazily begin the transaction
     Result res = ::beginTransactionOnAllLeaders(
                      trx, *shardIds, transaction::MethodsApi::Synchronous)
-                     .get();
+                     .waitAndGet();
     if (res.fail()) {
       return makeFuture(OperationResult(res, options));
     }
@@ -2216,7 +2216,7 @@ Result fetchEdgesFromEngines(
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     auto res = r.combinedResult();
     if (res.fail()) {
@@ -2313,7 +2313,7 @@ Result fetchEdgesFromEngines(transaction::Methods& trx,
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     auto res = r.combinedResult();
     if (res.fail()) {
@@ -2408,7 +2408,7 @@ void fetchVerticesFromEngines(
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     auto res = r.combinedResult();
     if (res.fail()) {
@@ -2739,7 +2739,7 @@ Result flushWalOnAllDBServers(ClusterFeature& feature, bool waitForSync,
   }
 
   for (Future<network::Response>& f : futures) {
-    Result res = f.get().combinedResult();
+    Result res = f.waitAndGet().combinedResult();
     if (res.fail()) {
       return res;
     }
@@ -2790,7 +2790,7 @@ Result recalculateCountsOnAllDBServers(ClusterFeature& feature,
     }
   }
 
-  auto responses = futures::collectAll(futures).get();
+  auto responses = futures::collectAll(futures).waitAndGet();
   for (auto const& r : responses) {
     Result res = r.get().combinedResult();
     if (res.fail()) {
@@ -2830,7 +2830,7 @@ Result compactOnAllDBServers(ClusterFeature& feature, bool changeLevel,
   }
 
   for (Future<network::Response>& f : futures) {
-    Result res = f.get().combinedResult();
+    Result res = f.waitAndGet().combinedResult();
     if (res.fail()) {
       return res;
     }
@@ -2877,7 +2877,7 @@ Result compactOnAllDBServers(ClusterFeature& feature, std::string const& dbname,
   }
 
   for (Future<network::Response>& f : futures) {
-    Result res = f.get().combinedResult();
+    Result res = f.waitAndGet().combinedResult();
     if (res.fail()) {
       return res;
     }
@@ -2921,7 +2921,7 @@ arangodb::Result hotBackupList(
 
   size_t nrGood = 0;
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
     if (!r.ok()) {
       continue;
     }
@@ -2944,7 +2944,7 @@ arangodb::Result hotBackupList(
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
     if (!r.ok()) {
       continue;
     }
@@ -3163,7 +3163,7 @@ arangodb::Result controlMaintenanceFeature(
 
   // Now listen to the results:
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return arangodb::Result(
@@ -3229,7 +3229,7 @@ arangodb::Result restoreOnDBServers(network::ConnectionPool* pool,
 
   // Now listen to the results:
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       // oh-oh cluster is in a bad state
@@ -3598,7 +3598,7 @@ arangodb::Result lockServersTrxCommit(network::ConnectionPool* pool,
     }
   };
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       reportError(
@@ -3707,7 +3707,7 @@ arangodb::Result unlockServersTrxCommit(
         pool, "server:" + server, fuerte::RestVerb::Post, url, body, reqOpts));
   }
 
-  auto responses = futures::collectAll(std::move(futures)).get();
+  auto responses = futures::collectAll(std::move(futures)).waitAndGet();
 
   Result res;
   for (auto const& tryRes : responses) {
@@ -3769,7 +3769,7 @@ arangodb::Result hotBackupDBServers(network::ConnectionPool* pool,
   std::string version;
   bool sizeValid = true;
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return arangodb::Result(
@@ -3887,7 +3887,7 @@ arangodb::Result removeLocalBackups(network::ConnectionPool* pool,
 
   // Now listen to the results:
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return arangodb::Result(
@@ -3981,7 +3981,7 @@ arangodb::Result hotbackupAsyncLockCoordinatorsTransactions(
 
   // Perform the requests
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return arangodb::Result(
@@ -4036,7 +4036,7 @@ arangodb::Result hotbackupWaitForLockCoordinatorsTransactions(
 
   // Perform the requests
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return arangodb::Result(
@@ -4635,7 +4635,7 @@ arangodb::Result getEngineStatsFromDBServers(ClusterFeature& feature,
         VPackBuffer<uint8_t>(), reqOpts));
   }
 
-  auto responses = futures::collectAll(std::move(futures)).get();
+  auto responses = futures::collectAll(std::move(futures)).waitAndGet();
 
   report.openObject();
   for (auto const& tryRes : responses) {

--- a/arangod/Cluster/ClusterTtlMethods.cpp
+++ b/arangod/Cluster/ClusterTtlMethods.cpp
@@ -65,7 +65,7 @@ Result getTtlStatisticsFromAllDBServers(ClusterFeature& feature,
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return network::fuerteToArangoErrorCode(r);
@@ -100,7 +100,7 @@ Result getTtlPropertiesFromAllDBServers(ClusterFeature& feature,
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return network::fuerteToArangoErrorCode(r);
@@ -139,7 +139,7 @@ Result setTtlPropertiesOnAllDBServers(ClusterFeature& feature,
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return network::fuerteToArangoErrorCode(r);

--- a/arangod/Cluster/ClusterUpgradeFeature.cpp
+++ b/arangod/Cluster/ClusterUpgradeFeature.cpp
@@ -182,7 +182,8 @@ void ClusterUpgradeFeature::tryClusterUpgrade() {
   AgencyCommResult result = agency.sendTransactionWithFailover(transaction);
   if (result.successful()) {
     auto& cache = server().getFeature<ClusterFeature>().agencyCache();
-    cache.waitFor(result.slice().get("results")[0].getNumber<uint64_t>()).get();
+    cache.waitFor(result.slice().get("results")[0].getNumber<uint64_t>())
+        .waitAndGet();
 
     // we are responsible for the upgrade!
     LOG_TOPIC("15ac4", INFO, arangodb::Logger::CLUSTER)

--- a/arangod/Cluster/CreateCollection.cpp
+++ b/arangod/Cluster/CreateCollection.cpp
@@ -309,7 +309,7 @@ Result CreateCollection::createCollectionReplication2(
             // created.
             return leaderState
                 ->createShard(shard, collectionType, std::move(properties))
-                .get();
+                .waitAndGet();
           }));
     } else {
       res.reset(

--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -429,7 +429,7 @@ DBServerAgencySyncResult DBServerAgencySync::execute() {
               auto waitIndex = resultsSlice[0].getNumber<uint64_t>();
               LOG_TOPIC("cdc71", TRACE, Logger::MAINTENANCE)
                   << "waiting for local current version to update";
-              std::ignore = clusterInfo.waitForCurrent(waitIndex).get();
+              std::ignore = clusterInfo.waitForCurrent(waitIndex).waitAndGet();
               LOG_TOPIC("3f185", TRACE, Logger::MAINTENANCE)
                   << "current version updated";
             }

--- a/arangod/Cluster/DropCollection.cpp
+++ b/arangod/Cluster/DropCollection.cpp
@@ -162,7 +162,7 @@ Result DropCollection::dropCollectionReplication2(
 
   auto res = basics::catchToResult([&]() {
     auto leader = coll->getDocumentStateLeader();
-    return leader->dropShard(shard).get();
+    return leader->dropShard(shard).waitAndGet();
   });
 
   if (res.is(TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_THE_LEADER) ||

--- a/arangod/Cluster/DropIndex.cpp
+++ b/arangod/Cluster/DropIndex.cpp
@@ -115,7 +115,7 @@ bool DropIndex::first() {
       if (vocbase->replicationVersion() == replication::Version::TWO) {
         return dropIndexReplication2(col, id);
       }
-      return Indexes::drop(*col, index.slice()).get();
+      return Indexes::drop(*col, index.slice()).waitAndGet();
     });
     result(res);
 
@@ -155,7 +155,9 @@ auto DropIndex::dropIndexReplication2(std::shared_ptr<LogicalCollection>& coll,
       return res.result();
     }
     auto indexId = IndexId{res.get()};
-    return coll->getDocumentStateLeader()->dropIndex(shardId, indexId).get();
+    return coll->getDocumentStateLeader()
+        ->dropIndex(shardId, indexId)
+        .waitAndGet();
   });
 
   if (res.is(TRI_ERROR_REPLICATION_REPLICATED_LOG_NOT_THE_LEADER) ||

--- a/arangod/Cluster/EnsureIndex.cpp
+++ b/arangod/Cluster/EnsureIndex.cpp
@@ -177,7 +177,7 @@ bool EnsureIndex::first() {
       auto index = VPackBuilder();
       auto res = methods::Indexes::ensureIndex(*col, body.slice(), true, index,
                                                std::move(lambda))
-                     .get();
+                     .waitAndGet();
       if (res.ok()) {
         indexCreationLogging(index.slice());
         setProgress(100.);
@@ -267,6 +267,6 @@ auto EnsureIndex::ensureIndexReplication2(
                                 progress = std::move(progress)]() mutable {
     return coll->getDocumentStateLeader()
         ->createIndex(shard, indexInfo, std::move(progress))
-        .get();
+        .waitAndGet();
   });
 }

--- a/arangod/Cluster/TakeoverShardLeadership.cpp
+++ b/arangod/Cluster/TakeoverShardLeadership.cpp
@@ -151,7 +151,7 @@ static void sendLeaderChangeRequests(
     futures.emplace_back(std::move(f));
   }
 
-  auto responses = futures::collectAll(futures).get();
+  auto responses = futures::collectAll(futures).waitAndGet();
 
   // This code intentionally ignores all errors
   realInsyncFollowers = std::make_shared<std::vector<ServerID>>();
@@ -209,7 +209,7 @@ static void handleLeadership(uint64_t planIndex, LogicalCollection& collection,
     }
     LOG_TOPIC("fe222", DEBUG, Logger::MAINTENANCE)
         << "Waiting until ClusterInfo has version " << currVersion;
-    ci.waitForCurrentVersion(currVersion).get();
+    ci.waitForCurrentVersion(currVersion).waitAndGet();
 
     auto currentInfo = ci.getCollectionCurrent(
         databaseName, std::to_string(collection.planId().id()));

--- a/arangod/Cluster/TraverserEngine.cpp
+++ b/arangod/Cluster/TraverserEngine.cpp
@@ -207,8 +207,8 @@ void BaseEngine::getVertexData(VPackSlice vertex, VPackBuilder& builder,
       return true;
     };
     for (auto const& shard : shards->second) {
-      Result res =
-          _trx->documentFastPathLocal(std::string{shard}, vertex, cb).get();
+      Result res = _trx->documentFastPathLocal(std::string{shard}, vertex, cb)
+                       .waitAndGet();
       if (res.ok()) {
         break;
       }

--- a/arangod/Cluster/UpdateCollection.cpp
+++ b/arangod/Cluster/UpdateCollection.cpp
@@ -133,7 +133,8 @@ bool UpdateCollection::first() {
         }
 
         OperationOptions options(ExecContext::current());
-        return Collections::updateProperties(*coll, props, options).get();
+        return Collections::updateProperties(*coll, props, options)
+            .waitAndGet();
       }));
       result(res);
 
@@ -193,6 +194,6 @@ auto UpdateCollection::updateCollectionReplication2(
                                 &shard]() mutable {
     return coll->getDocumentStateLeader()
         ->modifyShard(shard, collection, std::move(props))
-        .get();
+        .waitAndGet();
   });
 }

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -1644,7 +1644,7 @@ static void JS_PropagateSelfHeal(
     Result res;
 
     if (!futures.empty()) {
-      auto responses = futures::collectAll(futures).get();
+      auto responses = futures::collectAll(futures).waitAndGet();
       for (auto const& it : responses) {
         auto& resp = it.get();
         res.reset(resp.combinedResult());

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -473,8 +473,8 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
     return;
   }
 
-  if (res.hasValue() && res.get().fail()) {
-    auto& r = res.get();
+  if (res.hasValue() && res.waitAndGet().fail()) {
+    auto& r = res.waitAndGet();
     sendErrorResponse(GeneralResponse::responseCode(r.errorNumber()), respType,
                       messageId, r.errorNumber(), r.errorMessage());
     return;

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -752,7 +752,7 @@ RestStatus RestHandler::waitForFuture(futures::Future<futures::Unit>&& f) {
 RestStatus RestHandler::waitForFuture(futures::Future<RestStatus>&& f) {
   if (f.isReady()) {             // fast-path out
     f.result().throwIfFailed();  // just throw the error upwards
-    return f.get();
+    return f.waitAndGet();
   }
   TRI_ASSERT(_executionCounter == 0);
   _executionCounter = 2;

--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -261,7 +261,7 @@ bool RefactoredTraverserCache::appendVertex(
                   shardId,
                   id.substr(collectionNameResult.get().second + 1).stringView(),
                   cb)
-              .get();
+              .waitAndGet();
       if (res.ok()) {
         return true;
       }

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
@@ -118,7 +118,7 @@ auto OneSidedEnumerator<Configuration>::computeNeighbourhoodOfNextVertex()
         _provider.fetchVertices(looseEnds);
 
     // Will throw all network errors here
-    std::vector<Step*> preparedEnds = std::move(futureEnds.get());
+    std::vector<Step*> preparedEnds = std::move(futureEnds.waitAndGet());
     TRI_ASSERT(preparedEnds.size() != 0);
     TRI_ASSERT(_queue.firstIsVertexFetched());
   }
@@ -331,7 +331,7 @@ auto OneSidedEnumerator<Configuration>::fetchResults() -> void {
         // Will throw all network errors here
         futures::Future<std::vector<Step*>> futureEnds =
             _provider.fetchVertices(looseEnds);
-        futureEnds.get();
+        futureEnds.waitAndGet();
         // Notes for the future:
         // Vertices are now fetched. Think about other less-blocking and
         // batch-wise fetching (e.g. re-fetch at some later point).

--- a/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/TwoSidedEnumerator.cpp
@@ -181,7 +181,7 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType,
   if (!looseEnds.empty()) {
     // Will throw all network errors here
     futures::Future<std::vector<Step*>> futureEnds = _provider.fetch(looseEnds);
-    futureEnds.get();
+    futureEnds.waitAndGet();
     // Notes for the future:
     // Vertices are now fetched. Thnink about other less-blocking and batch-wise
     // fetching (e.g. re-fetch at some later point).
@@ -205,7 +205,7 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
     futures::Future<std::vector<Step*>> futureEnds = _provider.fetch(looseEnds);
 
     // Will throw all network errors here
-    auto&& preparedEnds = futureEnds.get();
+    auto&& preparedEnds = futureEnds.waitAndGet();
 
     TRI_ASSERT(preparedEnds.size() != 0);
     TRI_ASSERT(_queue.hasProcessableElement());
@@ -223,7 +223,7 @@ auto TwoSidedEnumerator<QueueType, PathStoreType, ProviderType, PathValidator>::
       // needs to be addressed.
       if (!n.isProcessable()) {
         auto futureEnds = _provider.fetch({&n});
-        futureEnds.get();
+        futureEnds.waitAndGet();
       }
     }
     auto valid = _validator.validatePath(n);

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
@@ -186,7 +186,7 @@ auto WeightedTwoSidedEnumerator<
   if (!looseEnds.empty()) {
     // Will throw all network errors here
     futures::Future<std::vector<Step*>> futureEnds = _provider.fetch(looseEnds);
-    futureEnds.get();
+    futureEnds.waitAndGet();
   }
 }
 
@@ -207,7 +207,7 @@ auto WeightedTwoSidedEnumerator<
   if (!looseEnds.empty()) {
     // Will throw all network errors here
     futures::Future<std::vector<Step*>> futureEnds = _provider.fetch(looseEnds);
-    futureEnds.get();
+    futureEnds.waitAndGet();
   }
 }
 
@@ -234,7 +234,7 @@ auto WeightedTwoSidedEnumerator<
     futures::Future<std::vector<Step*>> futureEnds = _provider.fetch(looseEnds);
 
     // Will throw all network errors here
-    auto&& preparedEnds = futureEnds.get();
+    auto&& preparedEnds = futureEnds.waitAndGet();
 
     TRI_ASSERT(preparedEnds.size() != 0);
   }

--- a/arangod/Graph/Providers/ClusterProvider.cpp
+++ b/arangod/Graph/Providers/ClusterProvider.cpp
@@ -197,7 +197,7 @@ void ClusterProvider<StepImpl>::fetchVerticesFromEngines(
   }
 
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       THROW_ARANGO_EXCEPTION(network::fuerteToArangoErrorCode(r));
@@ -284,7 +284,7 @@ void ClusterProvider<StepImpl>::destroyEngines() {
                    "/_internal/traverser/" +
                        arangodb::basics::StringUtils::itoa(engine.second),
                    VPackBuffer<uint8_t>(), options)
-                   .get();
+                   .waitAndGet();
 
     if (res.error != fuerte::Error::NoError) {
       // Note If there was an error on server side we do not have
@@ -353,7 +353,7 @@ Result ClusterProvider<StepImpl>::fetchEdgesFromEngines(Step* step) {
 
   std::vector<std::pair<EdgeType, VertexType>> connectedEdges;
   for (Future<network::Response>& f : futures) {
-    network::Response const& r = f.get();
+    network::Response const& r = f.waitAndGet();
 
     if (r.fail()) {
       return network::fuerteToArangoErrorCode(r);

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -581,7 +581,7 @@ Result visitAnalyzers(TRI_vocbase_t& vocbase,
           pool, "server:" + coord, fuerte::RestVerb::Post,
           RestVocbaseBaseHandler::CURSOR_PATH, buffer, reqOpts);
 
-      auto& response = f.get();
+      auto& response = f.waitAndGet();
 
       if (response.error == fuerte::Error::RequestTimeout) {
         // timeout, try another coordinator
@@ -1508,8 +1508,8 @@ Result IResearchAnalyzerFeature::removeAllAnalyzers(
 
     OperationOptions options;
     trx.truncateAsync(arangodb::StaticStrings::AnalyzersCollection, options)
-        .get();
-    res = trx.commitAsync().get();
+        .waitAndGet();
+    res = trx.commitAsync().waitAndGet();
     if (res.ok()) {
       invalidate(vocbase, operationOrigin);
     }
@@ -1540,7 +1540,7 @@ Result IResearchAnalyzerFeature::removeAllAnalyzers(
       if (queryResult.fail()) {
         return queryResult.result;
       }
-      res = trx.commitAsync().get();
+      res = trx.commitAsync().waitAndGet();
       if (!res.ok()) {
         return res;
       }
@@ -1564,8 +1564,8 @@ Result IResearchAnalyzerFeature::removeAllAnalyzers(
         truncateTrx
             .truncateAsync(arangodb::StaticStrings::AnalyzersCollection,
                            options)
-            .get();
-        res = truncateTrx.commitAsync().get();
+            .waitAndGet();
+        res = truncateTrx.commitAsync().waitAndGet();
       }
       if (res.fail()) {
         // failed cleanup is not critical problem. just log it

--- a/arangod/IResearch/IResearchLinkHelper.cpp
+++ b/arangod/IResearch/IResearchLinkHelper.cpp
@@ -129,7 +129,7 @@ Result createLink(LogicalCollection& collection, LogicalView const& view,
                   velocypack::Slice definition) {
   try {
     bool isNew = false;
-    auto link = collection.createIndex(definition, isNew).get();
+    auto link = collection.createIndex(definition, isNew).waitAndGet();
 
     if (!(link && isNew)) {
       return {TRI_ERROR_INTERNAL,
@@ -197,7 +197,7 @@ Result createLink(LogicalCollection& collection,
 
   velocypack::Builder tmp;
   return methods::Indexes::ensureIndex(collection, builder.slice(), true, tmp)
-      .get();
+      .waitAndGet();
 }
 
 template<typename ViewType>
@@ -232,7 +232,7 @@ Result dropLink<IResearchViewCoordinator>(LogicalCollection& collection,
               velocypack::Value(link.index().id().id()));
   builder.close();
 
-  return methods::Indexes::drop(collection, builder.slice()).get();
+  return methods::Indexes::drop(collection, builder.slice()).waitAndGet();
 }
 
 struct State {

--- a/arangod/Metrics/ClusterMetricsFeature.cpp
+++ b/arangod/Metrics/ClusterMetricsFeature.cpp
@@ -132,7 +132,7 @@ std::optional<std::string> ClusterMetricsFeature::update(
                                             .getNumber<uint64_t>()
                                       : 0;
       }();
-      writeData(version, metricsOnLeader(nf, cf).getTry());
+      writeData(version, metricsOnLeader(nf, cf).waitAndGetTry());
     }
   } catch (...) {
   }

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -160,7 +160,7 @@ Result removeRevisions(transaction::Methods& trx, LogicalCollection& collection,
       auto fut =
           trx.state()->performIntermediateCommitIfRequired(collection.id());
       TRI_ASSERT(fut.isReady());
-      res = fut.get();
+      res = fut.waitAndGet();
     }
 
     stats.waitedForRemovals += TRI_microtime() - t;
@@ -329,7 +329,7 @@ Result fetchRevisions(NetworkFeature& netFeature, transaction::Methods& trx,
       TRI_ASSERT(futures.size() == shoppingLists.size());
       auto& f = futures.front();
       double tWait = TRI_microtime();
-      auto& val = f.get();
+      auto& val = f.waitAndGet();
       stats.waitedForDocs += TRI_microtime() - tWait;
       Result res = val.combinedResult();
       if (res.fail()) {
@@ -495,7 +495,7 @@ Result fetchRevisions(NetworkFeature& netFeature, transaction::Methods& trx,
       auto fut =
           trx.state()->performIntermediateCommitIfRequired(collection.id());
       TRI_ASSERT(fut.isReady());
-      res = fut.get();
+      res = fut.waitAndGet();
 
       if (res.fail()) {
         return res;

--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -918,7 +918,7 @@ void Syncer::createIndexInternal(velocypack::Slice idxDef,
 
   if (idx == nullptr) {
     bool created = false;
-    idx = physical->createIndex(idxDef, /*restore*/ true, created).get();
+    idx = physical->createIndex(idxDef, /*restore*/ true, created).waitAndGet();
   }
   TRI_ASSERT(idx != nullptr);
 }

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -470,7 +470,7 @@ Result TailingSyncer::processDocument(TRI_replication_operation_e type,
 
     trx->addCollectionAtRuntime(coll->id(), coll->name(),
                                 AccessMode::Type::EXCLUSIVE)
-        .get();
+        .waitAndGet();
     std::string conflictingDocumentKey;
     Result r = applyCollectionDumpMarker(*trx, coll.get(), type, applySlice,
                                          conflictingDocumentKey);

--- a/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
+++ b/arangod/Replication2/ReplicatedLog/Components/LogFollower.cpp
@@ -293,7 +293,7 @@ auto LogFollowerImpl::getInternalLogIterator(
 
 auto LogFollowerImpl::compact() -> ResultT<CompactionResult> {
   // TODO clean up CompacionResult vs ICompactionManager::CompactResult
-  auto result = guarded.getLockedGuard()->compaction->compact().get();
+  auto result = guarded.getLockedGuard()->compaction->compact().waitAndGet();
   if (result.error) {
     return Result{result.error->errorNumber(), result.error->errorMessage()};
   }

--- a/arangod/Replication2/ReplicatedLog/LogLeader.cpp
+++ b/arangod/Replication2/ReplicatedLog/LogLeader.cpp
@@ -1240,7 +1240,7 @@ void replicated_log::LogLeader::updateReleaseIndex(LogIndex doneWithIdx) {
 }
 
 auto replicated_log::LogLeader::compact() -> ResultT<CompactionResult> {
-  auto result = _compactionManager->compact().get();
+  auto result = _compactionManager->compact().waitAndGet();
   if (result.error) {
     return Result{result.error->errorNumber(), result.error->errorMessage()};
   }
@@ -1645,7 +1645,7 @@ auto replicated_log::LogLeader::LocalFollower::release(LogIndex stop) const
   LOG_CTX("23745", DEBUG, _logContext)
       << "local follower releasing with stop at " << stop;
   auto trx = _storageManager->transaction();
-  auto res = trx->removeFront(stop).get();
+  auto res = trx->removeFront(stop).waitAndGet();
   LOG_CTX_IF("2aba1", WARN, _logContext, res.fail())
       << "local follower failed to release log entries: " << res.errorMessage();
   return res;

--- a/arangod/Replication2/StateMachines/Document/CollectionReader.cpp
+++ b/arangod/Replication2/StateMachines/Document/CollectionReader.cpp
@@ -47,7 +47,7 @@ auto SnapshotTransaction::options() -> transaction::Options {
 void SnapshotTransaction::addCollection(LogicalCollection const& collection) {
   transaction::Methods::addCollectionAtRuntime(
       collection.id(), collection.name(), AccessMode::Type::READ)
-      .get();
+      .waitAndGet();
 }
 
 DatabaseSnapshot::DatabaseSnapshot(TRI_vocbase_t& vocbase)
@@ -90,7 +90,7 @@ CollectionReader::CollectionReader(
   OperationResult countResult =
       trx.countAsync(_logicalCollection->name(), transaction::CountType::Normal,
                      countOptions)
-          .get();
+          .waitAndGet();
   if (countResult.ok()) {
     _totalDocs = countResult.slice().getNumber<uint64_t>();
   } else {

--- a/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.cpp
+++ b/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.cpp
@@ -85,7 +85,7 @@ auto MaintenanceActionExecutor::executeModifyCollection(
         OperationOptions options(ExecContext::current());
         return methods::Collections::updateProperties(*col, properties.slice(),
                                                       options)
-            .get();
+            .waitAndGet();
       });
 
   if (res.fail()) {
@@ -116,7 +116,7 @@ auto MaintenanceActionExecutor::executeCreateIndex(
     return methods::Indexes::ensureIndex(*col, properties.slice(), true, output,
                                          std::move(progress),
                                          std::move(callback))
-        .get();
+        .waitAndGet();
   });
 
   if (res.ok()) {
@@ -135,8 +135,9 @@ auto MaintenanceActionExecutor::executeCreateIndex(
 auto MaintenanceActionExecutor::executeDropIndex(
     std::shared_ptr<LogicalCollection> col, IndexId indexId) noexcept
     -> Result {
-  auto res = basics::catchToResult(
-      [&] { return methods::Indexes::dropDBServer(*col, indexId).get(); });
+  auto res = basics::catchToResult([&] {
+    return methods::Indexes::dropDBServer(*col, indexId).waitAndGet();
+  });
 
   LOG_CTX("e155f", DEBUG, _loggerContext)
       << "Dropping local index " << indexId << " of " << _vocbase.name() << "/"

--- a/arangod/RestHandler/RestCollectionHandler.cpp
+++ b/arangod/RestHandler/RestCollectionHandler.cpp
@@ -618,7 +618,7 @@ futures::Future<RestStatus> RestCollectionHandler::handleCommandPut() {
 
     OperationOptions options(_context);
     res = methods::Collections::updateProperties(*coll, props.slice(), options)
-              .get();
+              .waitAndGet();
     if (res.fail()) {
       generateError(res);
       co_return RestStatus::DONE;
@@ -743,7 +743,7 @@ void RestCollectionHandler::collectionRepresentation(
     FiguresType showFigures, CountType showCount) {
   if (showProperties || showCount != CountType::None) {
     // Here we need a transaction
-    initializeTransaction(*coll).get();
+    initializeTransaction(*coll).waitAndGet();
     methods::Collections::Context ctxt(coll, _activeTrx.get());
 
     collectionRepresentation(ctxt, showProperties, showFigures, showCount);
@@ -759,7 +759,7 @@ void RestCollectionHandler::collectionRepresentation(
     methods::Collections::Context& ctxt, bool showProperties,
     FiguresType showFigures, CountType showCount) {
   collectionRepresentationAsync(ctxt, showProperties, showFigures, showCount)
-      .get();
+      .waitAndGet();
 }
 
 futures::Future<futures::Unit>

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -106,7 +106,7 @@ RestStatus RestLogHandler::handlePostRequest(
     namespace paths = ::arangodb::cluster::paths;
     auto& agencyCache =
         _vocbase.server().getFeature<ClusterFeature>().agencyCache();
-    if (auto result = agencyCache.waitForLatestCommitIndex().get();
+    if (auto result = agencyCache.waitForLatestCommitIndex().waitAndGet();
         result.fail()) {
       THROW_ARANGO_EXCEPTION(result);
     }

--- a/arangod/RestHandler/RestQueryHandler.cpp
+++ b/arangod/RestHandler/RestQueryHandler.cpp
@@ -156,7 +156,7 @@ void RestQueryHandler::dumpQueryRegistry() {
     }
 
     if (!futures.empty()) {
-      auto responses = futures::collectAll(futures).get();
+      auto responses = futures::collectAll(futures).waitAndGet();
       for (auto const& it : responses) {
         if (!it.hasValue()) {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_CLUSTER_BACKEND_UNAVAILABLE);

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1877,7 +1877,8 @@ Result RestReplicationHandler::processRestoreIndexes(
       std::shared_ptr<arangodb::Index> idx;
       try {
         bool created = false;
-        idx = physical->createIndex(idxDef, /*restore*/ true, created).get();
+        idx = physical->createIndex(idxDef, /*restore*/ true, created)
+                  .waitAndGet();
       } catch (basics::Exception const& e) {
         if (e.code() == TRI_ERROR_NOT_IMPLEMENTED) {
           continue;
@@ -2479,7 +2480,8 @@ RestReplicationHandler::handleCommandAddFollower() {
     transaction::Manager* mgr = transaction::ManagerFeature::manager();
     TRI_ASSERT(mgr != nullptr);
     auto trxCtxtLease =
-        mgr->leaseManagedTrx(readLockId, AccessMode::Type::READ, true).get();
+        mgr->leaseManagedTrx(readLockId, AccessMode::Type::READ, true)
+            .waitAndGet();
     if (trxCtxtLease) {
       transaction::Methods trx{trxCtxtLease};
       if (!trx.isLocked(col.get(), AccessMode::Type::EXCLUSIVE)) {
@@ -3507,7 +3509,7 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
   // make sure if it is aborted if something goes wrong.
   auto transactionAborter = scopeGuard([mgr, id, vn]() noexcept {
     try {
-      mgr->abortManagedTrx(id, vn).get();
+      mgr->abortManagedTrx(id, vn).waitAndGet();
     } catch (...) {
     }
   });
@@ -3523,7 +3525,7 @@ futures::Future<Result> RestReplicationHandler::createBlockingTransaction(
           // Code does not matter, read only access, so we can roll back.
           transaction::Manager* mgr = transaction::ManagerFeature::manager();
           if (mgr) {
-            mgr->abortManagedTrx(id, vn).get();
+            mgr->abortManagedTrx(id, vn).waitAndGet();
           }
         } catch (...) {
           // All errors that show up here can only be
@@ -3595,7 +3597,7 @@ ResultT<bool> RestReplicationHandler::cancelBlockingTransaction(
   if (res.ok()) {
     transaction::Manager* mgr = transaction::ManagerFeature::manager();
     if (mgr) {
-      auto isAborted = mgr->abortManagedTrx(id, _vocbase.name()).get();
+      auto isAborted = mgr->abortManagedTrx(id, _vocbase.name()).waitAndGet();
       if (isAborted.ok()) {  // lock was held
         return ResultT<bool>::success(true);
       }

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -635,7 +635,7 @@ void DatabaseFeature::recoveryDone() {
   // TODO(MBkkt) use single wait with early termination
   // when it would be available
   for (auto& future : futures) {
-    auto result = std::move(future).get();
+    auto result = std::move(future).waitAndGet();
     if (!result.ok()) {
       LOG_TOPIC("772a7", ERR, Logger::FIXME)
           << "recovery failure due to error from callback, error '"

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -490,7 +490,7 @@ class TtlThread final : public ServerThread<ArangodServer> {
               auto f = network::sendRequestRetry(
                   pool, "server:" + coordinator, fuerte::RestVerb::Delete, url,
                   std::move(*queryResult.data->steal()), reqOptions);
-              auto& val = f.get();
+              auto& val = f.waitAndGet();
               Result res = val.combinedResult();
 
               if (res.fail()) {

--- a/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/ReplicatedRocksDBTransactionState.cpp
@@ -96,7 +96,7 @@ futures::Future<Result> ReplicatedRocksDBTransactionState::doCommit() {
   // in replicateOperation futures, even if we return early
   ScopeGuard guard{[&]() noexcept {
     try {
-      futures::collectAll(commits).get();
+      futures::collectAll(commits).waitAndGet();
     } catch (std::exception const&) {
     }
   }};
@@ -272,7 +272,7 @@ Result ReplicatedRocksDBTransactionState::doAbort() {
         }
         continue;
       }
-      auto res = leader->replicateOperation(operation, options).get();
+      auto res = leader->replicateOperation(operation, options).waitAndGet();
       bool resigned = false;
       if (res.fail()) {
         if (res.is(TRI_ERROR_REPLICATION_REPLICATED_LOG_LEADER_RESIGNED)) {

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1867,7 +1867,7 @@ void RocksDBEngine::processTreeRebuilds() {
               Result res =
                   static_cast<RocksDBCollection*>(collection->getPhysical())
                       ->rebuildRevisionTree()
-                      .get();
+                      .waitAndGet();
               if (res.ok()) {
                 ++_metricsTreeRebuildsSuccess;
                 LOG_TOPIC("2f997", INFO, Logger::ENGINES)
@@ -2069,7 +2069,7 @@ Result RocksDBEngine::dropCollection(TRI_vocbase_t& vocbase,
   bool const prefixSameAsStart = true;
   bool const useRangeDelete = rcoll->meta().numberDocuments() >= 32 * 1024;
 
-  auto resLock = rcoll->lockWrite().get();  // technically not necessary
+  auto resLock = rcoll->lockWrite().waitAndGet();  // technically not necessary
   if (resLock != TRI_ERROR_NO_ERROR) {
     return resLock;
   }

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -158,7 +158,7 @@ static void JS_RecalculateCounts(
   auto* physical = toRocksDBCollection(*collection);
 
   v8::Handle<v8::Value> result = v8::Number::New(
-      isolate, static_cast<double>(physical->recalculateCounts().get()));
+      isolate, static_cast<double>(physical->recalculateCounts().waitAndGet()));
 
   TRI_V8_RETURN(result);
   TRI_V8_TRY_CATCH_END
@@ -343,7 +343,7 @@ static void JS_CollectionRevisionTreeRebuild(
   }
 
   auto* physical = toRocksDBCollection(*collection);
-  Result result = physical->rebuildRevisionTree().get();
+  Result result = physical->rebuildRevisionTree().waitAndGet();
 
   if (result.fail()) {
     TRI_V8_THROW_EXCEPTION_FULL(result.errorNumber(), result.errorMessage());
@@ -371,7 +371,7 @@ static void JS_CollectionRevisionTreeSummary(
 
   auto* physical = toRocksDBCollection(*collection);
   VPackBuilder builder;
-  physical->revisionTreeSummary(builder, fromCollection).get();
+  physical->revisionTreeSummary(builder, fromCollection).waitAndGet();
 
   v8::Handle<v8::Value> result = TRI_VPackToV8(isolate, builder.slice());
   TRI_V8_RETURN(result);

--- a/arangod/Sharding/ShardDistributionReporter.cpp
+++ b/arangod/Sharding/ShardDistributionReporter.cpp
@@ -403,7 +403,7 @@ void ShardDistributionReporter::helperDistributionForDatabase(
             // Wait for responses
             // First wait for Leader
             {
-              auto const& res = leaderF.get();
+              auto const& res = leaderF.waitAndGet();
               if (res.fail()) {
                 // We did not even get count for leader, use defaults
                 continue;
@@ -442,7 +442,7 @@ void ShardDistributionReporter::helperDistributionForDatabase(
               uint64_t followerResponses = followersInSync;
               uint64_t followerTotal = followersInSync * entry.total;
 
-              auto responses = futures::collectAll(futures).get();
+              auto responses = futures::collectAll(futures).waitAndGet();
               for (futures::Try<network::Response> const& response :
                    responses) {
                 if (!response.hasValue()) {

--- a/arangod/Utils/SupportInfoBuilder.cpp
+++ b/arangod/Utils/SupportInfoBuilder.cpp
@@ -352,7 +352,7 @@ void SupportInfoBuilder::buildInfoMessage(VPackBuilder& result,
       VPackBuilder dbInfoBuilder;
       if (!futures.empty()) {
         dbInfoBuilder.openObject();
-        auto responses = futures::collectAll(futures).get();
+        auto responses = futures::collectAll(futures).waitAndGet();
         for (auto const& it : responses) {
           auto& resp = it.get();
           auto res = resp.combinedResult();

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -1492,7 +1492,7 @@ static ErrorCode clusterSendToAllServers(
   }
 
   for (auto& f : futures) {
-    network::Response const& res = f.get();  // throws exceptions upwards
+    network::Response const& res = f.waitAndGet();  // throws exceptions upwards
     auto commError = network::fuerteToArangoErrorCode(res);
     if (commError != TRI_ERROR_NO_ERROR) {
       return commError;

--- a/arangod/V8Server/v8-collection.cpp
+++ b/arangod/V8Server/v8-collection.cpp
@@ -1096,7 +1096,7 @@ static void JS_FiguresVocbaseCol(
   }
 
   OperationOptions options(ExecContext::current());
-  auto opRes = collection->figures(details, options).get();
+  auto opRes = collection->figures(details, options).waitAndGet();
 
   if (trx.finish(opRes.result).ok()) {
     TRI_V8_RETURN(TRI_VPackToV8(isolate, opRes.slice()));
@@ -1275,7 +1275,7 @@ static void JS_PropertiesVocbaseCol(
 
       auto res = methods::Collections::updateProperties(
                      *consoleColl, builder.slice(), options)
-                     .get();
+                     .waitAndGet();
       if (res.fail() && ServerState::instance()->isCoordinator()) {
         TRI_V8_THROW_EXCEPTION(res);
       }
@@ -1292,7 +1292,7 @@ static void JS_PropertiesVocbaseCol(
   if (coll) {
     VPackObjectBuilder object(&builder, true);
     methods::Collections::Context ctxt(coll);
-    Result res = methods::Collections::properties(ctxt, builder).get();
+    Result res = methods::Collections::properties(ctxt, builder).waitAndGet();
 
     if (res.fail()) {
       TRI_V8_THROW_EXCEPTION(res);
@@ -1728,7 +1728,7 @@ static void JS_RevisionVocbaseCol(
   std::shared_ptr<LogicalCollection> coll(collection, NonDeleter());
   methods::Collections::Context ctxt(coll);
   OperationOptions options(ExecContext::current());
-  auto res = methods::Collections::revisionId(ctxt, options).get();
+  auto res = methods::Collections::revisionId(ctxt, options).waitAndGet();
 
   if (res.fail()) {
     TRI_V8_THROW_EXCEPTION(res.result);
@@ -2509,7 +2509,7 @@ static void JS_WarmupVocbaseCol(
 
   auto res =
       arangodb::methods::Collections::warmup(collection->vocbase(), *collection)
-          .get();
+          .waitAndGet();
 
   if (res.fail()) {
     TRI_V8_THROW_EXCEPTION(res);

--- a/arangod/V8Server/v8-general-graph.cpp
+++ b/arangod/V8Server/v8-general-graph.cpp
@@ -311,7 +311,7 @@ static void JS_AddEdgeDefinitions(
   GraphOperations gops{*graph.get(), vocbase, origin, ctx};
   OperationResult r =
       gops.addEdgeDefinition(edgeDefinition.slice(), options.slice(), false)
-          .get();
+          .waitAndGet();
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
@@ -380,7 +380,7 @@ static void JS_EditEdgeDefinitions(
       gops.editEdgeDefinition(
               edgeDefinition.slice(), options.slice(), false,
               edgeDefinition.slice().get("collection").copyString())
-          .get();
+          .waitAndGet();
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
@@ -448,7 +448,8 @@ static void JS_RemoveVertexCollection(
   auto ctx = transaction::V8Context::create(vocbase, origin, true);
   GraphOperations gops{*graph.get(), vocbase, origin, ctx};
   OperationResult r =
-      gops.eraseOrphanCollection(false, vertexName, dropCollection).get();
+      gops.eraseOrphanCollection(false, vertexName, dropCollection)
+          .waitAndGet();
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
@@ -526,7 +527,8 @@ static void JS_AddVertexCollection(
   builder.close();
 
   OperationResult r =
-      gops.addOrphanCollection(builder.slice(), false, createCollection).get();
+      gops.addOrphanCollection(builder.slice(), false, createCollection)
+          .waitAndGet();
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());
@@ -592,7 +594,7 @@ static void JS_DropEdgeDefinition(
   GraphOperations gops{*graph.get(), vocbase, origin, ctx};
   OperationResult r =
       gops.eraseEdgeDefinition(false, edgeDefinitionName, dropCollections)
-          .get();
+          .waitAndGet();
 
   if (r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(r.errorNumber(), r.errorMessage());

--- a/arangod/V8Server/v8-query.cpp
+++ b/arangod/V8Server/v8-query.cpp
@@ -320,7 +320,7 @@ static void JS_AnyQuery(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
 
   OperationOptions options(ExecContext::current());
-  OperationResult cursor = trx.any(collectionName, options).get();
+  OperationResult cursor = trx.any(collectionName, options).waitAndGet();
 
   res = trx.finish(cursor.result);
 
@@ -375,7 +375,7 @@ static void JS_ChecksumCollection(
 
   Result r = methods::Collections::checksum(*col, withRevisions, withData,
                                             checksum, revId)
-                 .get();
+                 .waitAndGet();
 
   if (!r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);

--- a/arangod/V8Server/v8-vocindex.cpp
+++ b/arangod/V8Server/v8-vocindex.cpp
@@ -92,7 +92,7 @@ static void EnsureIndex(v8::FunctionCallbackInfo<v8::Value> const& args,
   VPackBuilder output;
   auto res = methods::Indexes::ensureIndex(*collection, builder.slice(), create,
                                            output)
-                 .get();
+                 .waitAndGet();
 
   if (res.fail()) {
     TRI_V8_THROW_EXCEPTION(res);
@@ -149,7 +149,7 @@ static void JS_DropIndexVocbaseCol(
   VPackBuilder builder;
   TRI_V8ToVPack(isolate, builder, args[0], false, false);
 
-  auto res = methods::Indexes::drop(*collection, builder.slice()).get();
+  auto res = methods::Indexes::drop(*collection, builder.slice()).waitAndGet();
 
   if (res.fail()) {
     TRI_V8_THROW_EXCEPTION(res);
@@ -183,8 +183,8 @@ static void JS_GetIndexesVocbaseCol(
   }
 
   VPackBuilder output;
-  auto res =
-      methods::Indexes::getAll(*collection, flags, withHidden, output).get();
+  auto res = methods::Indexes::getAll(*collection, flags, withHidden, output)
+                 .waitAndGet();
 
   if (res.fail()) {
     TRI_V8_THROW_EXCEPTION(res);

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -1375,7 +1375,7 @@ futures::Future<Result> Collections::checksum(LogicalCollection& collection,
     OperationOptions options(ExecContext::current());
     auto res = checksumOnCoordinator(feature, collection.vocbase().name(), cid,
                                      options, withRevisions, withData)
-                   .get();
+                   .waitAndGet();
     if (res.ok()) {
       revId = RevisionId::fromSlice(res.slice().get("revision"));
       checksum = res.slice().get("checksum").getUInt();

--- a/arangod/VocBase/Methods/Queries.cpp
+++ b/arangod/VocBase/Methods/Queries.cpp
@@ -156,7 +156,7 @@ arangodb::Result getQueries(TRI_vocbase_t& vocbase, velocypack::Builder& out,
     }
 
     if (!futures.empty()) {
-      auto responses = futures::collectAll(futures).get();
+      auto responses = futures::collectAll(futures).waitAndGet();
       for (auto const& it : responses) {
         auto& resp = it.get();
         res.reset(resp.combinedResult());
@@ -257,7 +257,7 @@ Result Queries::clearSlow(TRI_vocbase_t& vocbase, bool allDatabases,
     }
 
     if (!futures.empty()) {
-      auto responses = futures::collectAll(futures).get();
+      auto responses = futures::collectAll(futures).waitAndGet();
       for (auto const& it : responses) {
         auto& resp = it.get();
         res.reset(resp.combinedResult());

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -91,7 +91,7 @@ arangodb::Result recreateGeoIndex(TRI_vocbase_t& vocbase,
   bool created = false;
   auto newIndex = collection.getPhysical()
                       ->createIndex(newDesc.slice(), /*restore*/ true, created)
-                      .get();
+                      .waitAndGet();
 
   if (!created) {
     res.reset(TRI_ERROR_INTERNAL);
@@ -358,7 +358,7 @@ Result createIndex(
   }
   return methods::Indexes::createIndex(*(*colIt), type, fields, unique, sparse,
                                        false /*estimates*/)
-      .get();
+      .waitAndGet();
 }
 
 Result createSystemStatisticsIndices(

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -239,24 +239,24 @@ class [[nodiscard]] Future {
 
   // template <bool x = std::is_copy_constructible<T>::value,
   //          std::enable_if_t<x,int> = 0>
-  T& get() & {
+  T& waitAndGet() & {
     wait();
     return result().get();
   }
 
   /// waits and moves the result out
-  T get() && {
+  T waitAndGet() && {
     wait();
     return Future<T>(std::move(*this)).result().get();
   }
 
   /// Blocks until the future is fulfilled. Returns the Try of the result
-  Try<T>& getTry() & {
+  Try<T>& waitAndGetTry() & {
     wait();
     return getStateTryChecked();
   }
 
-  Try<T>&& getTry() && {
+  Try<T>&& waitAndGetTry() && {
     wait();
     return std::move(getStateTryChecked());
   }

--- a/tests/Aql/ExecutionNode/IndexNodeTest.cpp
+++ b/tests/Aql/ExecutionNode/IndexNodeTest.cpp
@@ -102,7 +102,8 @@ TEST_F(IndexNodeTest, objectQuery) {
   auto indexJson = arangodb::velocypack::Parser::fromJson(
       "{\"type\": \"hash\", \"fields\": [\"obj.a\", \"obj.b\", \"obj.c\"]}");
   auto createdIndex = false;
-  auto index = collection->createIndex(indexJson->slice(), createdIndex).get();
+  auto index =
+      collection->createIndex(indexJson->slice(), createdIndex).waitAndGet();
   ASSERT_TRUE(createdIndex);
   ASSERT_FALSE(!index);
 
@@ -183,7 +184,8 @@ TEST_F(IndexNodeTest, expansionQuery) {
       "{\"type\": \"hash\", \"fields\": [\"tags.hop[*].foo.fo\", "
       "\"tags.hop[*].bar.br\", \"tags.hop[*].baz.bz\"]}");
   auto createdIndex = false;
-  auto index = collection->createIndex(indexJson->slice(), createdIndex).get();
+  auto index =
+      collection->createIndex(indexJson->slice(), createdIndex).waitAndGet();
   ASSERT_TRUE(createdIndex);
   ASSERT_FALSE(!index);
 
@@ -237,7 +239,8 @@ TEST_F(IndexNodeTest, expansionIndexAndNotExpansionDocumentQuery) {
       "{\"type\": \"hash\", \"fields\": [\"tags.hop[*].foo.fo\", "
       "\"tags.hop[*].bar.br\", \"tags.hop[*].baz.bz\"]}");
   auto createdIndex = false;
-  auto index = collection->createIndex(indexJson->slice(), createdIndex).get();
+  auto index =
+      collection->createIndex(indexJson->slice(), createdIndex).waitAndGet();
   ASSERT_TRUE(createdIndex);
   ASSERT_FALSE(!index);
 
@@ -279,7 +282,8 @@ TEST_F(IndexNodeTest, lastExpansionQuery) {
   auto indexJson = arangodb::velocypack::Parser::fromJson(
       "{\"type\": \"hash\", \"fields\": [\"tags[*]\"]}");
   auto createdIndex = false;
-  auto index = collection->createIndex(indexJson->slice(), createdIndex).get();
+  auto index =
+      collection->createIndex(indexJson->slice(), createdIndex).waitAndGet();
   ASSERT_TRUE(createdIndex);
   ASSERT_FALSE(!index);
 
@@ -341,7 +345,8 @@ TEST_F(IndexNodeTest, constructIndexNode) {
       "{\"type\": \"hash\", \"id\": 2086177, \"fields\": [\"obj.a\", "
       "\"obj.b\", \"obj.c\"]}");
   auto createdIndex = false;
-  auto index = collection->createIndex(indexJson->slice(), createdIndex).get();
+  auto index =
+      collection->createIndex(indexJson->slice(), createdIndex).waitAndGet();
   ASSERT_TRUE(createdIndex);
   ASSERT_FALSE(!index);
   // auto jsonDocument = arangodb::velocypack::Parser::fromJson("{\"obj\":
@@ -601,7 +606,8 @@ TEST_F(IndexNodeTest, invalidLateMaterializedJSON) {
       "{\"type\": \"hash\", \"id\": 2086177, \"fields\": [\"obj.a\", "
       "\"obj.b\", \"obj.c\"]}");
   auto createdIndex = false;
-  auto index = collection->createIndex(indexJson->slice(), createdIndex).get();
+  auto index =
+      collection->createIndex(indexJson->slice(), createdIndex).waitAndGet();
   ASSERT_TRUE(createdIndex);
   ASSERT_FALSE(!index);
 

--- a/tests/Aql/ProjectionsTest.cpp
+++ b/tests/Aql/ProjectionsTest.cpp
@@ -574,7 +574,7 @@ TEST(ProjectionsTest, toVelocyPackFromIndexSimple) {
   auto indexJson = velocypack::Parser::fromJson(
       "{\"type\":\"hash\", \"fields\":[\"a\", \"b\"]}");
   auto index =
-      logicalCollection->createIndex(indexJson->slice(), created).get();
+      logicalCollection->createIndex(indexJson->slice(), created).waitAndGet();
 
   std::vector<arangodb::aql::AttributeNamePath> attributes = {
       createAttributeNamePath({"a"}, resMonitor),
@@ -625,7 +625,7 @@ TEST(ProjectionsTest, toVelocyPackFromIndexComplex1) {
   auto indexJson = velocypack::Parser::fromJson(
       "{\"type\":\"hash\", \"fields\":[\"sub.a\", \"sub.b\", \"c\"]}");
   auto index =
-      logicalCollection->createIndex(indexJson->slice(), created).get();
+      logicalCollection->createIndex(indexJson->slice(), created).waitAndGet();
 
   std::vector<arangodb::aql::AttributeNamePath> attributes = {
       createAttributeNamePath({"sub", "a"}, resMonitor),
@@ -671,7 +671,7 @@ TEST(ProjectionsTest, toVelocyPackFromIndexComplex2) {
   auto indexJson = velocypack::Parser::fromJson(
       "{\"type\":\"hash\", \"fields\":[\"sub\", \"c\"]}");
   auto index =
-      logicalCollection->createIndex(indexJson->slice(), created).get();
+      logicalCollection->createIndex(indexJson->slice(), created).waitAndGet();
 
   std::vector<arangodb::aql::AttributeNamePath> attributes = {
       createAttributeNamePath({"sub", "a"}, resMonitor),

--- a/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
+++ b/tests/AsyncAgencyComm/AsyncAgencyCommTest.cpp
@@ -224,7 +224,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.slice().at(0).get("a").getNumber<int>(), 12);
 
@@ -252,7 +252,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_failover) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.slice().at(0).get("a").getNumber<int>(), 12);
 
@@ -283,7 +283,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_timeout_redirect) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.slice().at(0).get("a").getNumber<int>(), 12);
 
@@ -311,7 +311,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_redirect) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.slice().at(0).get("a").getNumber<int>(), 12);
 
@@ -339,7 +339,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_redirect_new_endpoint) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.slice().at(0).get("a").getNumber<int>(), 12);
 
@@ -364,7 +364,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_not_found) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusNotFound);
 
@@ -390,7 +390,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_prec_failed) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusPreconditionFailed);
 
@@ -425,7 +425,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_inquire_timeout_not_found) {
   auto result =
       AsyncAgencyComm(manager)
           .sendWriteTransaction(10s, R"=([[{"a":12}, {}, "cid-1"]])="_vpack)
-          .get();
+          .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusOK);
   ASSERT_EQ(result.slice().get("results").at(0).getNumber<int>(), 15);
@@ -465,7 +465,7 @@ TEST_F(AsyncAgencyCommTest,
   auto result =
       AsyncAgencyComm(manager)
           .sendWriteTransaction(10s, R"=([[{"a":12}, {}, "cid-1"]])="_vpack)
-          .get();
+          .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusOK);
   ASSERT_EQ(result.slice().get("results").at(0).getNumber<int>(), 15);
@@ -498,7 +498,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_inquire_timeout_found) {
   auto result =
       AsyncAgencyComm(manager)
           .sendWriteTransaction(10s, R"=([[{"a":12}, {}, "cid-1"]])="_vpack)
-          .get();
+          .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusOK);
   ASSERT_EQ(result.slice().get("results").at(0).getNumber<int>(), 32);
@@ -538,7 +538,7 @@ TEST_F(AsyncAgencyCommTest,
   auto result =
       AsyncAgencyComm(manager)
           .sendWriteTransaction(10s, R"=([[{"a":12}, {}, "cid-1"]])="_vpack)
-          .get();
+          .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusOK);
   ASSERT_EQ(result.slice().get("results").at(0).getNumber<int>(), 15);
@@ -578,7 +578,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_inquire_service_unavailable) {
   auto result =
       AsyncAgencyComm(manager)
           .sendWriteTransaction(10s, R"=([[{"a":12}, {}, "cid-1"]])="_vpack)
-          .get();
+          .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusOK);
   ASSERT_EQ(result.slice().get("results").at(0).getNumber<int>(), 15);
@@ -611,7 +611,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_read_only_timeout_not_found) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendReadTransaction(10s, R"=([["a"]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusNotFound);
 
@@ -636,7 +636,7 @@ TEST_F(AsyncAgencyCommTest, send_with_failover_write_no_cids_timeout) {
 
   auto result = AsyncAgencyComm(manager)
                     .sendWriteTransaction(10s, R"=([[{"a":12}, {}]])="_vpack)
-                    .get();
+                    .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::RequestTimeout);
 
   compareEndpoints(manager.endpoints(),
@@ -661,7 +661,7 @@ TEST_F(AsyncAgencyCommTest, get_values) {
   auto result =
       AsyncAgencyComm(manager)
           .getValues(arangodb::cluster::paths::root()->arango()->plan())
-          .get();
+          .waitAndGet();
   ASSERT_EQ(result.error, fuerte::Error::NoError);
   ASSERT_EQ(result.statusCode(), fuerte::StatusOK);
   ASSERT_EQ(result.value().getNumber<int>(), 12);

--- a/tests/Futures/PromiseTest.cpp
+++ b/tests/Futures/PromiseTest.cpp
@@ -242,7 +242,7 @@ TEST(PromiseTest, setValue) {
   Promise<int> fund;
   auto ffund = fund.getFuture();
   fund.setValue(42);
-  ASSERT_TRUE(42 == ffund.get());
+  ASSERT_TRUE(42 == ffund.waitAndGet());
 
   struct Foo {
     std::string name;
@@ -253,21 +253,21 @@ TEST(PromiseTest, setValue) {
   auto fpod = pod.getFuture();
   Foo f = {"the answer", 42};
   pod.setValue(f);
-  Foo f2 = fpod.get();
+  Foo f2 = fpod.waitAndGet();
   ASSERT_TRUE(f.name == f2.name);
   ASSERT_TRUE(f.value == f2.value);
 
   pod = Promise<Foo>();
   fpod = pod.getFuture();
   pod.setValue(std::move(f2));
-  Foo f3 = fpod.get();
+  Foo f3 = fpod.waitAndGet();
   ASSERT_TRUE(f.name == f3.name);
   ASSERT_TRUE(f.value == f3.value);
 
   Promise<std::unique_ptr<int>> mov;
   auto fmov = mov.getFuture();
   mov.setValue(std::make_unique<int>(42));
-  std::unique_ptr<int> ptr = std::move(fmov).get();
+  std::unique_ptr<int> ptr = std::move(fmov).waitAndGet();
   ASSERT_TRUE(42 == *ptr);
 
   Promise<Unit> v;
@@ -281,13 +281,13 @@ TEST(PromiseTest, setException) {
     Promise<int> p;
     auto f = p.getFuture();
     p.setException(eggs);
-    EXPECT_THROW(f.get(), eggs_t);
+    EXPECT_THROW(f.waitAndGet(), eggs_t);
   }
   {
     Promise<int> p;
     auto f = p.getFuture();
     p.setException(std::make_exception_ptr(eggs));
-    EXPECT_THROW(f.get(), eggs_t);
+    EXPECT_THROW(f.waitAndGet(), eggs_t);
   }
 }
 
@@ -296,13 +296,13 @@ TEST(PromiseTest, setWith) {
     Promise<int> p;
     auto f = p.getFuture();
     p.setWith([] { return 42; });
-    ASSERT_TRUE(42 == f.get());
+    ASSERT_TRUE(42 == f.waitAndGet());
   }
   {
     Promise<int> p;
     auto f = p.getFuture();
     p.setWith([]() -> int { throw eggs; });
-    EXPECT_THROW(f.get(), eggs_t);
+    EXPECT_THROW(f.waitAndGet(), eggs_t);
   }
 }
 
@@ -333,7 +333,7 @@ TEST(PromiseTest, brokenOnDelete) {
 
   ASSERT_TRUE(f.isReady());
 
-  auto t = f.getTry();
+  auto t = f.waitAndGetTry();
 
   ASSERT_TRUE(t.hasException());
   EXPECT_THROW(t.throwIfFailed(), FutureException);

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -270,7 +270,7 @@ TYPED_TEST(GraphProviderTest, no_results_if_graph_is_empty) {
     std::vector<decltype(start)*> looseEnds{};
     looseEnds.emplace_back(&start);
     auto futures = testee.fetch(looseEnds);
-    auto steps = futures.get();
+    auto steps = futures.waitAndGet();
   }
 
   std::vector<typename decltype(testee)::Step> result{};
@@ -314,7 +314,7 @@ TYPED_TEST(GraphProviderTest, should_enumerate_a_single_edge) {
     std::vector<decltype(start)*> looseEnds{};
     looseEnds.emplace_back(&start);
     auto futures = testee.fetch(looseEnds);
-    auto steps = futures.get();
+    auto steps = futures.waitAndGet();
   }
 
   std::vector<typename decltype(testee)::Step> result{};
@@ -382,7 +382,7 @@ TYPED_TEST(GraphProviderTest, should_enumerate_all_edges) {
     std::vector<decltype(start)*> looseEnds{};
     looseEnds.emplace_back(&start);
     auto futures = testee.fetch(looseEnds);
-    auto steps = futures.get();
+    auto steps = futures.waitAndGet();
   }
 
   std::vector<typename decltype(testee)::Step> result{};

--- a/tests/Graph/GraphTestTools.h
+++ b/tests/Graph/GraphTestTools.h
@@ -193,7 +193,7 @@ struct MockGraphDatabase {
 
     auto indexJson = velocypack::Parser::fromJson("{ \"type\": \"edge\" }");
     bool created = false;
-    auto index = edges->createIndex(indexJson->slice(), created).get();
+    auto index = edges->createIndex(indexJson->slice(), created).waitAndGet();
     TRI_ASSERT(index);
     TRI_ASSERT(created);
     return edges;

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -1613,7 +1613,7 @@ TEST_F(IResearchAnalyzerFeatureCoordinatorTest, test_ensure_index_add_factory) {
     builder.close();
     res = arangodb::methods::Indexes::ensureIndex(*logicalCollection,
                                                   builder.slice(), true, tmp)
-              .get();
+              .waitAndGet();
     EXPECT_TRUE(res.ok());
   }
 }
@@ -2306,7 +2306,8 @@ TEST_F(IResearchAnalyzerFeatureTest,
         arangodb::AccessMode::Type::WRITE);
     EXPECT_TRUE((trx.begin().ok()));
     auto queryResult =
-        trx.all(arangodb::tests::AnalyzerCollectionName, 0, 2, options).get();
+        trx.all(arangodb::tests::AnalyzerCollectionName, 0, 2, options)
+            .waitAndGet();
     EXPECT_TRUE((true == queryResult.ok()));
     auto slice = arangodb::velocypack::Slice(queryResult.buffer->data());
     EXPECT_TRUE(slice.isArray());

--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -1861,7 +1861,8 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1_no_directory) {
   // logicalView0->guid();
   ASSERT_NE(logicalView0, nullptr);
   bool created = false;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE(created);
   ASSERT_NE(index, nullptr);
   auto link0 =
@@ -1967,7 +1968,8 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1_with_directory) {
   auto logicalView0 = vocbase.createView(viewJson->slice(), false);
   ASSERT_FALSE(!logicalView0);
   bool created;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE(created);
   ASSERT_FALSE(!index);
   auto link0 =
@@ -2496,7 +2498,7 @@ TEST_F(IResearchFeatureTestCoordinator, test_upgrade0_1) {
 
   ASSERT_TRUE((arangodb::methods::Indexes::ensureIndex(
                    *logicalCollection, linkJson->slice(), true, tmp)
-                   .get()
+                   .waitAndGet()
                    .ok()));
   logicalCollection = ci.getCollection(vocbase->name(), collectionId);
   ASSERT_FALSE(!logicalCollection);
@@ -2686,7 +2688,8 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_no_directory) {
       dynamic_cast<arangodb::iresearch::IResearchView*>(logicalView.get());
   ASSERT_FALSE(!view);
   bool created = false;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE(created);
   ASSERT_FALSE(!index);
   auto link =
@@ -2784,7 +2787,8 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_with_directory) {
       dynamic_cast<arangodb::iresearch::IResearchView*>(logicalView.get());
   ASSERT_FALSE(!view);
   bool created;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE(created);
   ASSERT_FALSE(!index);
   auto link =
@@ -2895,7 +2899,8 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade1_link_collectionName) {
   auto* view =
       dynamic_cast<arangodb::iresearch::IResearchView*>(logicalView.get());
   bool created;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE(created);
   ASSERT_FALSE(!index);
   auto link =

--- a/tests/IResearch/IResearchIndexTest.cpp
+++ b/tests/IResearch/IResearchIndexTest.cpp
@@ -301,8 +301,8 @@ TEST_F(IResearchIndexTest, test_analyzer) {
     bool createdIndex;
 
 #ifdef USE_ENTERPRISE
-    auto index =
-        collection0->createIndex(nestedIndex->slice(), createdIndex).get();
+    auto index = collection0->createIndex(nestedIndex->slice(), createdIndex)
+                     .waitAndGet();
     //    collection->createIndex(nestedIndex->slice(), result);
     //    ASSERT_TRUE(createdIndex);
 
@@ -1083,7 +1083,8 @@ TEST_F(IResearchIndexTest, test_pkCachedInverted) {
       "fields":  ["X", "Y"]})");
 
     bool created{false};
-    ASSERT_TRUE(collection0->createIndex(updateJson->slice(), created).get());
+    ASSERT_TRUE(
+        collection0->createIndex(updateJson->slice(), created).waitAndGet());
     ASSERT_TRUE(created);
   }
   // running query to force sync
@@ -1277,7 +1278,8 @@ TEST_F(IResearchIndexTest, test_sortCachedInverted) {
       "fields":  ["X", "Y"]})");
 
     bool created{false};
-    ASSERT_TRUE(collection0->createIndex(updateJson->slice(), created).get());
+    ASSERT_TRUE(
+        collection0->createIndex(updateJson->slice(), created).waitAndGet());
     ASSERT_TRUE(created);
   }
   // running query to force sync
@@ -1475,7 +1477,8 @@ TEST_F(IResearchIndexTest, test_geoCachedInverted) {
       "fields": ["X", {"name":"geofield", "cache":true, "analyzer":"geojson"}]})");
 
     bool created{false};
-    ASSERT_TRUE(collection0->createIndex(updateJson->slice(), created).get());
+    ASSERT_TRUE(
+        collection0->createIndex(updateJson->slice(), created).waitAndGet());
     ASSERT_TRUE(created);
   }
   // running query to force sync
@@ -1545,7 +1548,8 @@ TEST_F(IResearchCacheOnlyFollowersTest, test_PkInverted) {
       "fields":  ["X", "Y"]})");
 
     bool created{false};
-    ASSERT_TRUE(collection0->createIndex(updateJson->slice(), created).get());
+    ASSERT_TRUE(
+        collection0->createIndex(updateJson->slice(), created).waitAndGet());
     ASSERT_TRUE(created);
   }
   // running query to force sync
@@ -1621,7 +1625,8 @@ TEST_F(IResearchCacheOnlyFollowersTest, test_PkInverted_InitialLeader) {
       "fields":  ["X", "Y"]})");
 
     bool created{false};
-    ASSERT_TRUE(collection0->createIndex(updateJson->slice(), created).get());
+    ASSERT_TRUE(
+        collection0->createIndex(updateJson->slice(), created).waitAndGet());
     ASSERT_TRUE(created);
   }
   // running query to force sync

--- a/tests/IResearch/IResearchIndexTest.cpp
+++ b/tests/IResearch/IResearchIndexTest.cpp
@@ -310,9 +310,9 @@ TEST_F(IResearchIndexTest, test_analyzer) {
     //    ASSERT_TRUE(arangodb::methods::Indexes::ensureIndex(collection,
     //    nestedIndex->slice(), createdIndex, outputDefinition).ok());
 #else
-    ASSERT_THROW(
-        collection0->createIndex(nestedIndex->slice(), createdIndex).get(),
-        arangodb::basics::Exception);
+    ASSERT_THROW(collection0->createIndex(nestedIndex->slice(), createdIndex)
+                     .waitAndGet(),
+                 arangodb::basics::Exception);
 #endif
   }
 

--- a/tests/IResearch/IResearchInvertedIndexConditionTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexConditionTest.cpp
@@ -94,7 +94,8 @@ class IResearchInvertedIndexConditionTest
     auto builder = getInvertedIndexPropertiesSlice(id, fields, &storedFields,
                                                    nullptr, "unique_name2");
     bool created = false;
-    auto inverted = _collection->createIndex(builder.slice(), created).get();
+    auto inverted =
+        _collection->createIndex(builder.slice(), created).waitAndGet();
     ASSERT_TRUE(created);
     ASSERT_TRUE(inverted);
     auto* index = dynamic_cast<arangodb::iresearch::IResearchInvertedIndex*>(
@@ -127,7 +128,8 @@ class IResearchInvertedIndexConditionTest
     auto builder = getInvertedIndexPropertiesSlice(id, fields, nullptr, nullptr,
                                                    "unique_name3");
     bool created = false;
-    auto inverted = _collection->createIndex(builder.slice(), created).get();
+    auto inverted =
+        _collection->createIndex(builder.slice(), created).waitAndGet();
     ASSERT_TRUE(created);
     ASSERT_TRUE(inverted);
     auto* index = dynamic_cast<arangodb::iresearch::IResearchInvertedIndex*>(
@@ -207,7 +209,8 @@ class IResearchInvertedIndexConditionTest
     auto builder = getInvertedIndexPropertiesSlice(id, indexFields, nullptr,
                                                    &fields, "unique_name3");
     bool created = false;
-    auto inverted = _collection->createIndex(builder.slice(), created).get();
+    auto inverted =
+        _collection->createIndex(builder.slice(), created).waitAndGet();
     ASSERT_TRUE(created);
     ASSERT_TRUE(inverted);
     auto* index = dynamic_cast<arangodb::iresearch::IResearchInvertedIndex*>(

--- a/tests/IResearch/IResearchInvertedIndexIteratorTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexIteratorTest.cpp
@@ -135,7 +135,7 @@ class IResearchInvertedIndexIteratorTestBase
                                                    &storedFields, &sortedFields,
                                                    "unique_name");
     bool created = false;
-    _inverted = _collection->createIndex(builder.slice(), created).get();
+    _inverted = _collection->createIndex(builder.slice(), created).waitAndGet();
     EXPECT_TRUE(created);
     EXPECT_TRUE(_inverted);
     _index = dynamic_cast<arangodb::iresearch::IResearchInvertedIndex*>(
@@ -163,7 +163,7 @@ class IResearchInvertedIndexIteratorTestBase
         EXPECT_TRUE(res);
         ++doc;
       }
-      EXPECT_TRUE(trx.commitAsync().get().ok());
+      EXPECT_TRUE(trx.commitAsync().waitAndGet().ok());
       EXPECT_TRUE(_index->commit(true).ok());
     }
     // second transaction to have more than one segment in the index
@@ -184,7 +184,7 @@ class IResearchInvertedIndexIteratorTestBase
       EXPECT_TRUE(res);
       ++doc;
     }
-    EXPECT_TRUE(trx.commitAsync().get().ok());
+    EXPECT_TRUE(trx.commitAsync().waitAndGet().ok());
     EXPECT_TRUE(_index->commit(true).ok());
   }
 

--- a/tests/IResearch/IResearchLinkCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchLinkCoordinatorTest.cpp
@@ -184,7 +184,7 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
     EXPECT_TRUE(arangodb::methods::Indexes::ensureIndex(*logicalCollection,
                                                         linkJson->slice(), true,
                                                         outputDefinition)
-                    .get()
+                    .waitAndGet()
                     .ok());
 
     // get new version from plan
@@ -263,7 +263,7 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
         arangodb::velocypack::Parser::fromJson("{\"id\": \"42\"}");
     EXPECT_TRUE(
         arangodb::methods::Indexes::drop(*logicalCollection, indexArg->slice())
-            .get()
+            .waitAndGet()
             .ok());
 
     // get new version from plan
@@ -345,7 +345,7 @@ TEST_F(IResearchLinkCoordinatorTest, test_create_drop) {
     EXPECT_TRUE(arangodb::methods::Indexes::ensureIndex(*logicalCollection,
                                                         linkJson->slice(), true,
                                                         outputDefinition)
-                    .get()
+                    .waitAndGet()
                     .ok());
 
     // get new version from plan

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -195,7 +195,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
 
     bool created;
     auto link =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_TRUE(nullptr != link && created);
     EXPECT_TRUE(link->canBeDropped());
     EXPECT_EQ(logicalCollection.get(), &(link->collection()));
@@ -273,7 +273,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
 
     bool created;
     auto link =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_TRUE(nullptr != link && created);
     EXPECT_TRUE(link->canBeDropped());
     EXPECT_EQ(logicalCollection.get(), &(link->collection()));
@@ -351,7 +351,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
 
     bool created;
     auto link =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_TRUE(nullptr != link && created);
     EXPECT_TRUE(link->canBeDropped());
     EXPECT_EQ(logicalCollection.get(), &(link->collection()));
@@ -875,7 +875,8 @@ TEST_F(IResearchLinkTest, test_write_index_creation_version_0) {
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -941,7 +942,8 @@ TEST_F(IResearchLinkTest, test_write_index_creation_version_1) {
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1009,7 +1011,8 @@ TEST_F(IResearchLinkTest, test_write) {
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1123,7 +1126,8 @@ TEST_F(IResearchLinkTest, test_write_with_custom_compression_nondefault_sole) {
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1232,7 +1236,8 @@ TEST_F(IResearchLinkTest,
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1347,7 +1352,8 @@ TEST_F(IResearchLinkTest, test_write_with_custom_compression_nondefault_mixed) {
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1460,7 +1466,8 @@ TEST_F(IResearchLinkTest,
                  .string();
   irs::FSDirectory directory(dataPath);
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1589,7 +1596,8 @@ TEST_F(
           std::make_unique<irs::mock::test_encryption>(kEncBlockSize)});
 
   bool created;
-  auto link = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto link =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_TRUE((false == !link && created));
   auto reader = irs::DirectoryReader(directory);
   EXPECT_EQ(0, reader.Reopen().live_docs_count());
@@ -1704,7 +1712,8 @@ TEST_F(IResearchLinkTest, test_maintenance_disabled_at_creation) {
     ASSERT_TRUE(feature.queue(ThreadGroup::_1, 0ms, blockQueue));
 
     bool created;
-    link = logicalCollection->createIndex(linkJson->slice(), created).get();
+    link =
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
     ASSERT_NE(nullptr, link);
 
@@ -1815,7 +1824,7 @@ TEST_F(IResearchLinkTest, test_maintenance_consolidation) {
 
     bool created;
     auto link =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
     ASSERT_NE(nullptr, link);
     auto linkImpl = std::dynamic_pointer_cast<IResearchLink>(link);
@@ -2046,7 +2055,7 @@ TEST_F(IResearchLinkTest, test_maintenance_commit) {
 
     bool created;
     auto link =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
     ASSERT_NE(nullptr, link);
     auto linkImpl = std::dynamic_pointer_cast<IResearchLink>(link);
@@ -2294,7 +2303,8 @@ class IResearchLinkMetricsTest : public IResearchLinkTest {
       "view": "42",
       "includeAllFields": true
     })");
-    _link = _logicalCollection->createIndex(linkJson->slice(), created).get();
+    _link = _logicalCollection->createIndex(linkJson->slice(), created)
+                .waitAndGet();
     EXPECT_TRUE(created);
     EXPECT_NE(_link, nullptr);
     auto label = getLinkMetricLabel();

--- a/tests/IResearch/IResearchQueryCommon.cpp
+++ b/tests/IResearch/IResearchQueryCommon.cpp
@@ -307,7 +307,7 @@ void QueryTest::createIndexes(std::string_view definition1,
         version(), definition1));
     auto collection = _vocbase.lookupCollection("testCollection0");
     ASSERT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
   }
   // testIndex1
@@ -321,7 +321,7 @@ void QueryTest::createIndexes(std::string_view definition1,
         version(), definition2));
     auto collection = _vocbase.lookupCollection("testCollection1");
     ASSERT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     EXPECT_TRUE(created);
   }
 }

--- a/tests/IResearch/IResearchQueryGeoContainsTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoContainsTest.cpp
@@ -745,7 +745,7 @@ class QueryGeoContainsSearch : public QueryGeoContains {
         version(), analyzer));
     auto collection = _vocbase.lookupCollection("testCollection0");
     EXPECT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
   }
 

--- a/tests/IResearch/IResearchQueryGeoDistanceTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoDistanceTest.cpp
@@ -565,7 +565,7 @@ class QueryGeoDistanceSearch : public QueryGeoDistance {
         version(), analyzer));
     auto collection = _vocbase.lookupCollection("testCollection0");
     EXPECT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
   }
 

--- a/tests/IResearch/IResearchQueryGeoInRangeTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoInRangeTest.cpp
@@ -1062,7 +1062,7 @@ class QueryGeoInRangeSearch : public QueryGeoInRange {
         version(), fields));
     auto collection = _vocbase.lookupCollection("testCollection0");
     EXPECT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
   }
 

--- a/tests/IResearch/IResearchQueryGeoIntersectsTest.cpp
+++ b/tests/IResearch/IResearchQueryGeoIntersectsTest.cpp
@@ -362,7 +362,7 @@ class QueryGeoIntersectsSearch : public QueryGeoIntersects {
         version()));
     auto collection = _vocbase.lookupCollection("testCollection0");
     EXPECT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
   }
 

--- a/tests/IResearch/IResearchQueryJoinTest.cpp
+++ b/tests/IResearch/IResearchQueryJoinTest.cpp
@@ -1774,7 +1774,7 @@ class QueryJoinSearch : public QueryJoin {
           version(), name));
       auto collection = _vocbase.lookupCollection(name);
       EXPECT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     auto createSearchName = [&](std::string_view name) {

--- a/tests/IResearch/IResearchQueryLateMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryLateMaterializationTest.cpp
@@ -421,7 +421,7 @@ class QueryLateMaterializationSearch : public QueryLateMaterialization {
       auto collection =
           vocbase().lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1, false);

--- a/tests/IResearch/IResearchQueryLevenshteinMatchTest.cpp
+++ b/tests/IResearch/IResearchQueryLevenshteinMatchTest.cpp
@@ -992,7 +992,7 @@ class QueryLevenhsteinMatchSearch : public QueryLevenhsteinMatch {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("testCollection$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryNGramMatchTest.cpp
+++ b/tests/IResearch/IResearchQueryNGramMatchTest.cpp
@@ -1241,7 +1241,7 @@ class QueryNGramMatchSearch : public QueryNGramMatch {
         version(), toString(analyzer)));
     auto collection = vocbase.lookupCollection("testCollection0");
     ASSERT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
 
     // add view

--- a/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
@@ -284,10 +284,12 @@ class QueryNoMaterialization : public QueryTestMulti {
                "version": $1, $2
                "includeAllFields": true })",
           index, version(), addition));
-      logicalCollection1->createIndex(createJson->slice(), created).get();
+      logicalCollection1->createIndex(createJson->slice(), created)
+          .waitAndGet();
       ASSERT_TRUE(created);
       created = false;
-      logicalCollection2->createIndex(createJson->slice(), created).get();
+      logicalCollection2->createIndex(createJson->slice(), created)
+          .waitAndGet();
       ASSERT_TRUE(created);
     };
 

--- a/tests/IResearch/IResearchQueryNumericTermTest.cpp
+++ b/tests/IResearch/IResearchQueryNumericTermTest.cpp
@@ -3192,7 +3192,7 @@ class QueryNumericTermSearch : public QueryNumericTerm {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryOptimizationTest.cpp
+++ b/tests/IResearch/IResearchQueryOptimizationTest.cpp
@@ -322,7 +322,8 @@ class QueryOptimization : public QueryTestMulti {
                "version": $0,
                "includeAllFields": true })",
           version()));
-      logicalCollection1->createIndex(createJson->slice(), created).get();
+      logicalCollection1->createIndex(createJson->slice(), created)
+          .waitAndGet();
       ASSERT_TRUE(created);
       auto const viewDefinition = absl::Substitute(R"({ "indexes": [
         { "collection": "collection_1", "index": "index_1"}

--- a/tests/IResearch/IResearchQueryOptionsTest.cpp
+++ b/tests/IResearch/IResearchQueryOptionsTest.cpp
@@ -1200,7 +1200,7 @@ class QueryOptionsSearch : public QueryOptions {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryOrTest.cpp
+++ b/tests/IResearch/IResearchQueryOrTest.cpp
@@ -673,7 +673,7 @@ class QueryOrSearch : public QueryOr {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryPhraseTest.cpp
+++ b/tests/IResearch/IResearchQueryPhraseTest.cpp
@@ -6499,7 +6499,7 @@ class QueryPhraseSearch : public QueryPhrase {
       auto collection =
           vocbase.lookupCollection(absl::Substitute("testCollection$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(0);

--- a/tests/IResearch/IResearchQueryScorerTest.cpp
+++ b/tests/IResearch/IResearchQueryScorerTest.cpp
@@ -1966,7 +1966,7 @@ class QueryScorerSearch : public QueryScorer {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQuerySelectAllTest.cpp
+++ b/tests/IResearch/IResearchQuerySelectAllTest.cpp
@@ -543,7 +543,7 @@ class QuerySelectAllSearch : public QuerySelectAll {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryStartsWithTest.cpp
+++ b/tests/IResearch/IResearchQueryStartsWithTest.cpp
@@ -1531,7 +1531,7 @@ class QueryStartsWithSearch : public QueryStartsWith {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryStringTermTest.cpp
+++ b/tests/IResearch/IResearchQueryStringTermTest.cpp
@@ -2872,7 +2872,7 @@ class QueryStringTermSearch : public QueryStringTerm {
       auto collection =
           _vocbase.lookupCollection(absl::Substitute("collection_$0", name));
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     };
     createIndex(1);

--- a/tests/IResearch/IResearchQueryTraversalTest.cpp
+++ b/tests/IResearch/IResearchQueryTraversalTest.cpp
@@ -132,8 +132,8 @@ class QueryTraversal : public QueryTest {
       auto createIndexJson =
           arangodb::velocypack::Parser::fromJson("{ \"type\": \"edge\" }");
       bool created = false;
-      auto index =
-          collection->createIndex(createIndexJson->slice(), created).get();
+      auto index = collection->createIndex(createIndexJson->slice(), created)
+                       .waitAndGet();
       EXPECT_TRUE(index);
       EXPECT_TRUE(created);
 
@@ -366,7 +366,7 @@ TEST_P(QueryTraversalSearch, Test) {
         version()));
     auto collection = _vocbase.lookupCollection("edges");
     ASSERT_TRUE(collection);
-    collection->createIndex(createJson->slice(), created).get();
+    collection->createIndex(createJson->slice(), created).waitAndGet();
     ASSERT_TRUE(created);
   }
   // create view on edge collection

--- a/tests/IResearch/IResearchQueryWildcardTest.cpp
+++ b/tests/IResearch/IResearchQueryWildcardTest.cpp
@@ -626,7 +626,7 @@ class QueryWildcardSearch : public QueryWildcard {
           version()));
       auto collection = _vocbase.lookupCollection("testCollection1");
       ASSERT_TRUE(collection);
-      collection->createIndex(createJson->slice(), created).get();
+      collection->createIndex(createJson->slice(), created).waitAndGet();
       ASSERT_TRUE(created);
     }
     // create view

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -5942,7 +5942,7 @@ TEST_F(IResearchViewCoordinatorTest, test_drop_link) {
                      *logicalCollection, arangodb::velocypack::Parser::fromJson(
                                              std::to_string(linkId.id()))
                                              ->slice())
-                     .get()
+                     .waitAndGet()
                      .ok()));
     EXPECT_TRUE(planVersion < arangodb::tests::getCurrentPlanVersion(
                                   server.server()));  // plan version changed

--- a/tests/IResearch/IResearchViewDBServerTest.cpp
+++ b/tests/IResearch/IResearchViewDBServerTest.cpp
@@ -146,7 +146,7 @@ TEST_F(IResearchViewDBServerTest, test_drop) {
     // ensure we have shard view in vocbase
     bool created;
     auto index =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_FALSE(!index);
     auto link =
         std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(
@@ -190,7 +190,7 @@ TEST_F(IResearchViewDBServerTest, test_drop) {
     // ensure we have shard view in vocbase
     bool created;
     auto index =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_FALSE(!index);
     auto link =
         std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(
@@ -239,7 +239,8 @@ TEST_F(IResearchViewDBServerTest, test_drop_cid) {
 
   // ensure we have shard view in vocbase
   bool created;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_FALSE(!index);
   auto link =
       std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(index);
@@ -320,7 +321,8 @@ TEST_F(IResearchViewDBServerTest, test_ensure) {
   EXPECT_NE(nullptr, impl);
 
   bool created;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_FALSE(!index);
   auto link =
       std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(index);
@@ -462,7 +464,7 @@ TEST_F(IResearchViewDBServerTest, test_query) {
 
     bool created;
     auto index =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_FALSE(!index);
     auto link =
         std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(
@@ -510,7 +512,7 @@ TEST_F(IResearchViewDBServerTest, test_query) {
 
     bool created;
     auto index =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_FALSE(!index);
     auto link =
         std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(
@@ -1044,7 +1046,8 @@ TEST_F(IResearchViewDBServerTest, test_transaction_snapshot) {
   ASSERT_NE(nullptr, viewImpl);
 
   bool created;
-  auto index = logicalCollection->createIndex(linkJson->slice(), created).get();
+  auto index =
+      logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
   ASSERT_FALSE(!index);
   auto link =
       std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(index);
@@ -1488,7 +1491,7 @@ TEST_F(IResearchViewDBServerTest, test_updateProperties) {
 
     bool created;
     auto index =
-        logicalCollection->createIndex(linkJson->slice(), created).get();
+        logicalCollection->createIndex(linkJson->slice(), created).waitAndGet();
     ASSERT_FALSE(!index);
     auto link =
         std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(
@@ -1643,8 +1646,8 @@ TEST_F(IResearchViewDBServerTest, test_updateProperties) {
     EXPECT_NE(nullptr, impl);
 
     bool created;
-    auto index =
-        logicalCollection1->createIndex(linkJson->slice(), created).get();
+    auto index = logicalCollection1->createIndex(linkJson->slice(), created)
+                     .waitAndGet();
     ASSERT_FALSE(!index);
     auto link =
         std::dynamic_pointer_cast<arangodb::iresearch::IResearchLinkMock>(

--- a/tests/Mocks/ClusterInfoMock.cpp
+++ b/tests/Mocks/ClusterInfoMock.cpp
@@ -704,7 +704,7 @@ Result ClusterInfo::createCollectionsCoordinator(
           if (VPackSlice resultsSlice = res.slice().get("results");
               resultsSlice.length() > 0) {
             [[maybe_unused]] Result r =
-                waitForPlan(resultsSlice[0].getNumber<uint64_t>()).get();
+                waitForPlan(resultsSlice[0].getNumber<uint64_t>()).waitAndGet();
           }
           return;
         } else if (res.httpCode() == rest::ResponseCode::PRECONDITION_FAILED) {
@@ -796,7 +796,8 @@ Result ClusterInfo::createCollectionsCoordinator(
 
       if (VPackSlice resultsSlice = res.slice().get("results");
           resultsSlice.length() > 0) {
-        Result r = waitForPlan(resultsSlice[0].getNumber<uint64_t>()).get();
+        Result r =
+            waitForPlan(resultsSlice[0].getNumber<uint64_t>()).waitAndGet();
         if (r.fail()) {
           return r;
         }
@@ -845,7 +846,7 @@ Result ClusterInfo::createCollectionsCoordinator(
         (replicationVersion == replication::Version::ONE ||
          replicatedStatesWait.isReady())) {
       if (replicationVersion == replication::Version::TWO) {
-        auto result = replicatedStatesWait.get();
+        auto result = replicatedStatesWait.waitAndGet();
         if (result.fail()) {
           LOG_TOPIC("ce2be", WARN, Logger::CLUSTER)
               << "Failed createCollectionsCoordinator for " << infos.size()
@@ -899,7 +900,8 @@ Result ClusterInfo::createCollectionsCoordinator(
         deleteCollectionGuard.cancel();
         if (VPackSlice resultsSlice = res.slice().get("results");
             resultsSlice.length() > 0) {
-          Result r = waitForPlan(resultsSlice[0].getNumber<uint64_t>()).get();
+          Result r =
+              waitForPlan(resultsSlice[0].getNumber<uint64_t>()).waitAndGet();
           if (r.fail()) {
             return r;
           }

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -943,7 +943,7 @@ void MockDBServer::createShard(std::string const& dbName,
       bool created = false;
       auto const idx = velocypack::Parser::fromJson(
           R"({"id":"1","type":"edge","name":"edge_from","fields":["_from"],"unique":false,"sparse":false})");
-      col->createIndex(idx->slice(), created).get();
+      col->createIndex(idx->slice(), created).waitAndGet();
       TRI_ASSERT(created);
     }
 
@@ -951,7 +951,7 @@ void MockDBServer::createShard(std::string const& dbName,
       bool created = false;
       auto const idx = velocypack::Parser::fromJson(
           R"({"id":"2","type":"edge","name":"edge_to","fields":["_to"],"unique":false,"sparse":false})");
-      col->createIndex(idx->slice(), created).get();
+      col->createIndex(idx->slice(), created).waitAndGet();
       TRI_ASSERT(created);
     }
   }

--- a/tests/Network/MethodsTest.cpp
+++ b/tests/Network/MethodsTest.cpp
@@ -164,7 +164,7 @@ struct NetworkMethodsTest
         network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                   fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-    network::Response res = std::move(f).get();
+    network::Response res = std::move(f).waitAndGet();
     assertIsPositiveResponse(res);
 
     // Now the connection is in the pool and is good
@@ -209,7 +209,7 @@ TEST_F(NetworkMethodsTest, simple_request) {
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -226,7 +226,7 @@ TEST_F(NetworkMethodsTest, request_failure) {
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::ConnectionClosed);
   ASSERT_FALSE(res.hasResponse());
@@ -246,7 +246,7 @@ TEST_F(NetworkMethodsTest, request_failure_on_status_not_acceptable) {
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -263,7 +263,7 @@ TEST_F(NetworkMethodsTest, request_failure_on_timeout) {
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::RequestTimeout);
   ASSERT_FALSE(res.hasResponse());
@@ -281,7 +281,7 @@ TEST_F(NetworkMethodsTest, request_failure_on_shutdown) {
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -302,7 +302,7 @@ TEST_F(NetworkMethodsTest, request_failure_on_connection_closed) {
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::ConnectionClosed);
   ASSERT_FALSE(res.hasResponse());
@@ -324,7 +324,7 @@ TEST_F(NetworkMethodsTest,
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  auto res = std::move(f).get();
+  auto res = std::move(f).waitAndGet();
   assertIsPositiveResponse(res);
 }
 
@@ -343,7 +343,7 @@ TEST_F(NetworkMethodsTest, request_automatic_retry_write_error_when_from_pool) {
   auto f = network::sendRequest(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  auto res = std::move(f).get();
+  auto res = std::move(f).waitAndGet();
   assertIsPositiveResponse(res);
 }
 
@@ -376,7 +376,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_error) {
   auto resBuffer = b->steal();
   pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -408,7 +408,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_and_networkfeature_failure1) {
 
   // Step 2: Now respond with no error
   ASSERT_TRUE(f.isReady());
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::ConnectionCanceled);
   ASSERT_FALSE(res.hasResponse());
@@ -445,7 +445,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_421) {
   auto resBuffer = b->steal();
   pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -481,7 +481,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_conn_canceled) {
   pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
   pool->_conn->_err = fuerte::Error::NoError;
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -525,7 +525,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_after_not_found_error) {
   resBuffer = b->steal();
   pool->_conn->_response->setPayload(std::move(*resBuffer), 0);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -543,7 +543,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_failure) {
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::ConnectionClosed);
   ASSERT_FALSE(res.hasResponse());
@@ -565,7 +565,7 @@ TEST_F(NetworkMethodsTest,
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::NoError);
   ASSERT_TRUE(res.hasResponse());
@@ -583,7 +583,7 @@ TEST_F(NetworkMethodsTest, request_with_retry_failure_on_timeout) {
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  network::Response res = std::move(f).get();
+  network::Response res = std::move(f).waitAndGet();
   ASSERT_EQ(res.destination, "tcp://example.org:80");
   ASSERT_EQ(res.error, fuerte::Error::RequestTimeout);
   ASSERT_FALSE(res.hasResponse());
@@ -606,7 +606,7 @@ TEST_F(NetworkMethodsTest,
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  auto res = std::move(f).get();
+  auto res = std::move(f).waitAndGet();
   assertIsPositiveResponse(res);
 }
 
@@ -627,6 +627,6 @@ TEST_F(NetworkMethodsTest,
       network::sendRequestRetry(pool.get(), "tcp://example.org:80",
                                 fuerte::RestVerb::Get, "/", buffer, reqOpts);
 
-  auto res = std::move(f).get();
+  auto res = std::move(f).waitAndGet();
   assertIsPositiveResponse(res);
 }

--- a/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/CompactionManagerTest.cpp
@@ -209,7 +209,7 @@ TEST_F(CompactionManagerTest, manual_compaction_call_nothing_to_compact_ok) {
 
   auto cf = compactionManager->compact();
   ASSERT_TRUE(cf.isReady());
-  auto result = cf.get();
+  auto result = cf.waitAndGet();
   EXPECT_EQ(result.error, std::nullopt);
   EXPECT_TRUE(result.compactedRange.empty());
 }
@@ -270,7 +270,7 @@ TEST_F(CompactionManagerTest, manual_compaction_call_ok) {
   removeFrontPromise->setValue(Result{});
 
   ASSERT_TRUE(cf.isReady());
-  auto result = cf.get();
+  auto result = cf.waitAndGet();
   EXPECT_EQ(result.error, std::nullopt);
   EXPECT_EQ(result.compactedRange, (LogRange{LogIndex{20}, LogIndex{40}}));
 }

--- a/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/FollowerCommitManagerTest.cpp
@@ -86,7 +86,7 @@ TEST_F(FollowerCommitManagerTest, wait_for_update_commit_index) {
   EXPECT_EQ(resolveIndex, LogIndex{12});
 
   ASSERT_TRUE(f.isReady());
-  auto index = f.get().currentCommitIndex;
+  auto index = f.waitAndGet().currentCommitIndex;
   EXPECT_EQ(index, LogIndex{12});
 }
 
@@ -110,7 +110,7 @@ TEST_F(FollowerCommitManagerTest, wait_for_iterator_update_commit_index) {
   EXPECT_EQ(resolveIndex, LogIndex{25});
 
   ASSERT_TRUE(f.isReady());
-  auto iter = std::move(f).get();
+  auto iter = std::move(f).waitAndGet();
   EXPECT_EQ(iter->range(),
             (LogRange{LogIndex{12},
                       LogIndex{26}}));  // contains the interval [12, 25]
@@ -153,7 +153,7 @@ TEST_F(FollowerCommitManagerTest,
   action.fire();
   EXPECT_EQ(resolveIndex, LogIndex{44});
   ASSERT_TRUE(f.isReady());
-  auto iter = std::move(f).get();
+  auto iter = std::move(f).waitAndGet();
   EXPECT_EQ(iter->range(),
             (LogRange{LogIndex{12},
                       LogIndex{45}}));  // contains the interval [12, 45]
@@ -170,7 +170,7 @@ TEST_F(FollowerCommitManagerTest, wait_for_already_resolved) {
   auto f = commit->waitFor(LogIndex{12});
 
   ASSERT_TRUE(f.isReady());
-  EXPECT_EQ(f.get().currentCommitIndex,
+  EXPECT_EQ(f.waitAndGet().currentCommitIndex,
             LogIndex{30});  // contains the interval [12, 45]
 }
 
@@ -192,7 +192,7 @@ TEST_F(FollowerCommitManagerTest, wait_for_iterator_already_resolved) {
   auto f = commit->waitForIterator(LogIndex{12});
 
   ASSERT_TRUE(f.isReady());
-  auto iter = std::move(f).get();
+  auto iter = std::move(f).waitAndGet();
   EXPECT_EQ(iter->range(),
             (LogRange{LogIndex{12},
                       LogIndex{31}}));  // contains the interval [12, 30]

--- a/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Components/StorageManagerTest.cpp
@@ -342,11 +342,11 @@ TEST_F(StorageManagerGMockTest, multiple_actions_with_error) {
 
   // first one failed with original error
   ASSERT_TRUE(f1.isReady());
-  EXPECT_EQ(f1.get().errorNumber(), TRI_ERROR_DEBUG);
+  EXPECT_EQ(f1.waitAndGet().errorNumber(), TRI_ERROR_DEBUG);
 
   // others are aborted due to conflict
   ASSERT_TRUE(f2.isReady());
-  EXPECT_EQ(f2.get().errorNumber(),
+  EXPECT_EQ(f2.waitAndGet().errorNumber(),
             TRI_ERROR_REPLICATION_REPLICATED_LOG_SUBSEQUENT_FAULT);
 }
 

--- a/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
+++ b/tests/Replication2/ReplicatedLog/Integration/StorageEngineMethodsTest.cpp
@@ -297,7 +297,7 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries) {
 
   {
     auto iter = storage::rocksdb::test::make_iterator(entries);
-    auto res = this->methods->insert(std::move(iter), {}).get();
+    auto res = this->methods->insert(std::move(iter), {}).waitAndGet();
     EXPECT_TRUE(res.ok());
   }
 
@@ -322,16 +322,16 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_remove_front_back) {
 
   {
     auto iter = storage::rocksdb::test::make_iterator(entries);
-    auto res = this->methods->insert(std::move(iter), {}).get();
+    auto res = this->methods->insert(std::move(iter), {}).waitAndGet();
     EXPECT_TRUE(res.ok());
   }
 
   {
-    auto result = this->methods->removeFront(LogIndex{2}, {}).get();
+    auto result = this->methods->removeFront(LogIndex{2}, {}).waitAndGet();
     ASSERT_TRUE(result.ok());
   }
   {
-    auto result = this->methods->removeBack(LogIndex{3}, {}).get();
+    auto result = this->methods->removeBack(LogIndex{3}, {}).waitAndGet();
     ASSERT_TRUE(result.ok());
   }
 
@@ -357,7 +357,7 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_iter_after_remove) {
 
   {
     auto iter = storage::rocksdb::test::make_iterator(entries);
-    auto res = this->methods->insert(std::move(iter), {}).get();
+    auto res = this->methods->insert(std::move(iter), {}).waitAndGet();
     EXPECT_TRUE(res.ok());
   }
 
@@ -367,7 +367,7 @@ TYPED_TEST(StorageEngineMethodsTest, write_log_entries_iter_after_remove) {
 
   {
     // remove log entries
-    auto result = this->methods->removeFront(LogIndex{1}, {}).get();
+    auto result = this->methods->removeFront(LogIndex{1}, {}).waitAndGet();
     ASSERT_TRUE(result.ok());
   }
 

--- a/tests/Replication2/ReplicatedLog/MultiTermTest.cpp
+++ b/tests/Replication2/ReplicatedLog/MultiTermTest.cpp
@@ -56,7 +56,7 @@ TEST_F(MultiTermTest, add_follower_test) {
     leaderLogContainer->runAll();
     {
       ASSERT_TRUE(f.isReady());
-      auto const& result = f.get();
+      auto const& result = f.waitAndGet();
       EXPECT_THAT(result.quorum->quorum,
                   testing::ElementsAre(leaderLogContainer->serverId()));
     }
@@ -128,7 +128,7 @@ TEST_F(MultiTermTest, resign_leader_wait_for) {
     config = addUpdatedTerm({});
     config->installConfig(false);
     ASSERT_TRUE(f.isReady());
-    EXPECT_ANY_THROW({ std::ignore = f.get(); });
+    EXPECT_ANY_THROW({ std::ignore = f.waitAndGet(); });
     EXPECT_ANY_THROW({ std::ignore = oldLeader->getStatus(); });
     EXPECT_EQ(leaderLog->getQuickStatus().local.spearHead,
               TermIndexPair(LogTerm{2}, LogIndex{3}));
@@ -298,7 +298,7 @@ TEST_F(MultiTermTest, resign_leader_append_entries) {
 
     ASSERT_TRUE(f2.isReady());
     {
-      auto result = f2.get();
+      auto result = f2.waitAndGet();
       EXPECT_EQ(result.currentCommitIndex, LogIndex{3});
       EXPECT_EQ(result.quorum->index, LogIndex{3});
       EXPECT_EQ(result.quorum->term, LogTerm{2});

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/CoreTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/CoreTest.cpp
@@ -85,7 +85,7 @@ TEST_F(DocumentStateMachineTest,
       .Times(1);
   EXPECT_CALL(*shardHandlerMock, dropAllShards()).Times(1);
   auto res = follower->acquireSnapshot("participantId");
-  EXPECT_TRUE(res.isReady() && res.get().ok());
+  EXPECT_TRUE(res.isReady() && res.waitAndGet().ok());
   Mock::VerifyAndClearExpectations(transactionHandlerMock.get());
   Mock::VerifyAndClearExpectations(shardHandlerMock.get());
 

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/LeaderTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/LeaderTest.cpp
@@ -124,7 +124,7 @@ TEST_F(DocumentStateLeaderTest,
                              TransactionId{tid}.asFollowerTransactionId(),
                              shardId, velocypack::SharedSlice(), "root"),
                          ReplicationOptions{})
-                     .get();
+                     .waitAndGet();
       EXPECT_TRUE(res.ok()) << res.result();
     }
   }
@@ -137,7 +137,7 @@ TEST_F(DocumentStateLeaderTest,
                        ReplicatedOperation::buildAbortOperation(
                            TransactionId{5}.asFollowerTransactionId()),
                        ReplicationOptions{})
-                   .get();
+                   .waitAndGet();
     EXPECT_TRUE(res.ok()) << res.result();
     leaderState->release(TransactionId{5}.asFollowerTransactionId(), res.get());
 
@@ -146,7 +146,7 @@ TEST_F(DocumentStateLeaderTest,
                   ReplicatedOperation::buildCommitOperation(
                       TransactionId{9}.asFollowerTransactionId()),
                   ReplicationOptions{})
-              .get();
+              .waitAndGet();
     EXPECT_TRUE(res.ok()) << res.result();
     leaderState->release(TransactionId{9}.asFollowerTransactionId(), res.get());
   }
@@ -370,7 +370,7 @@ TEST_F(DocumentStateLeaderTest, leader_create_modify_and_drop_shard) {
 
   auto res =
       leaderState->createShard(shardId, TRI_COL_TYPE_DOCUMENT, properties)
-          .get();
+          .waitAndGet();
   EXPECT_TRUE(res.ok()) << res;
 
   Mock::VerifyAndClearExpectations(stream.get());
@@ -407,7 +407,7 @@ TEST_F(DocumentStateLeaderTest, leader_create_modify_and_drop_shard) {
 
   res =
       leaderState->modifyShard(shardId, collectionId, velocypack::SharedSlice())
-          .get();
+          .waitAndGet();
   EXPECT_TRUE(res.ok()) << res;
 
   Mock::VerifyAndClearExpectations(stream.get());

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/SnapshotTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/SnapshotTest.cpp
@@ -110,7 +110,7 @@ TEST_F(DocumentStateSnapshotTest,
   // Default initialize a follower
   auto follower = createFollower();
   auto res = follower->acquireSnapshot("participantId");
-  EXPECT_TRUE(res.isReady() && res.get().ok());
+  EXPECT_TRUE(res.isReady() && res.waitAndGet().ok());
 
   // Acquire a new snapshot with a different set of shards
   const ShardID shardId1{123};
@@ -150,7 +150,7 @@ TEST_F(DocumentStateSnapshotTest,
       .Times(1);
 
   std::ignore = follower->acquireSnapshot("participantId");
-  EXPECT_TRUE(res.isReady() && res.get().ok());
+  EXPECT_TRUE(res.isReady() && res.waitAndGet().ok());
 
   Mock::VerifyAndClearExpectations(shardHandlerMock.get());
   Mock::VerifyAndClearExpectations(leaderInterfaceMock.get());

--- a/tests/Replication2/ReplicatedState/StateManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateManagerTest.cpp
@@ -318,7 +318,7 @@ TEST_F(StateManagerTest_EmptyState,
   {
     ASSERT_TRUE(appendEntriesFuture.isReady());
     ASSERT_TRUE(appendEntriesFuture.hasValue());
-    auto const appendEntriesResponse = appendEntriesFuture.get();
+    auto const appendEntriesResponse = appendEntriesFuture.waitAndGet();
     EXPECT_TRUE(appendEntriesResponse.isSuccess())
         << appendEntriesResponse.errorCode;
     EXPECT_TRUE(appendEntriesResponse.snapshotAvailable);
@@ -420,7 +420,7 @@ TEST_F(
   {
     ASSERT_TRUE(appendEntriesFuture.isReady());
     ASSERT_TRUE(appendEntriesFuture.hasValue());
-    auto const appendEntriesResponse = appendEntriesFuture.get();
+    auto const appendEntriesResponse = appendEntriesFuture.waitAndGet();
     EXPECT_TRUE(appendEntriesResponse.isSuccess())
         << appendEntriesResponse.errorCode;
     EXPECT_FALSE(appendEntriesResponse.snapshotAvailable);
@@ -565,7 +565,7 @@ TEST_F(
   {
     ASSERT_TRUE(appendEntriesFuture.isReady());
     ASSERT_TRUE(appendEntriesFuture.hasValue());
-    auto const appendEntriesResponse = appendEntriesFuture.get();
+    auto const appendEntriesResponse = appendEntriesFuture.waitAndGet();
     EXPECT_TRUE(appendEntriesResponse.isSuccess())
         << appendEntriesResponse.errorCode;
     EXPECT_TRUE(appendEntriesResponse.snapshotAvailable);
@@ -663,7 +663,7 @@ TEST_F(
   {
     ASSERT_TRUE(appendEntriesFuture.isReady());
     ASSERT_TRUE(appendEntriesFuture.hasValue());
-    auto const appendEntriesResponse = appendEntriesFuture.get();
+    auto const appendEntriesResponse = appendEntriesFuture.waitAndGet();
     EXPECT_TRUE(appendEntriesResponse.isSuccess())
         << appendEntriesResponse.errorCode;
     EXPECT_FALSE(appendEntriesResponse.snapshotAvailable);
@@ -804,7 +804,7 @@ TEST_F(
   {
     ASSERT_TRUE(appendEntriesFuture.isReady());
     ASSERT_TRUE(appendEntriesFuture.hasValue());
-    auto const appendEntriesResponse = appendEntriesFuture.get();
+    auto const appendEntriesResponse = appendEntriesFuture.waitAndGet();
     EXPECT_TRUE(appendEntriesResponse.isSuccess())
         << appendEntriesResponse.errorCode;
     EXPECT_TRUE(appendEntriesResponse.snapshotAvailable);
@@ -901,7 +901,7 @@ TEST_F(StateManagerTest_FakeState, follower_acquire_snapshot) {
   {
     ASSERT_TRUE(appendEntriesFuture.isReady());
     ASSERT_TRUE(appendEntriesFuture.hasValue());
-    auto const appendEntriesResponse = appendEntriesFuture.get();
+    auto const appendEntriesResponse = appendEntriesFuture.waitAndGet();
     EXPECT_TRUE(appendEntriesResponse.isSuccess())
         << appendEntriesResponse.errorCode;
     EXPECT_FALSE(appendEntriesResponse.snapshotAvailable);

--- a/tests/Replication2/Storage/LogPersistorTest.cpp
+++ b/tests/Replication2/Storage/LogPersistorTest.cpp
@@ -102,7 +102,7 @@ struct LogPersistorTest : ::testing::Test {
 
     auto res =
         persistor->insert(log.getLogIterator(), LogPersistor::WriteOptions{})
-            .get();
+            .waitAndGet();
     ASSERT_TRUE(res.ok());
     EXPECT_EQ(res.get(), 5);
   }
@@ -227,7 +227,7 @@ TEST_F(LogPersistorTest, insert_normal_payload) {
 
   auto res =
       persistor->insert(log.getLogIterator(), LogPersistor::WriteOptions{})
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
   EXPECT_EQ(res.get(), 100);
 
@@ -245,7 +245,7 @@ TEST_F(LogPersistorTest, insert_meta_payload) {
 
   auto res =
       persistor->insert(log.getLogIterator(), LogPersistor::WriteOptions{})
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
   EXPECT_EQ(res.get(), 100);
 
@@ -301,7 +301,7 @@ TEST_F(LogPersistorTest,
 TEST_F(LogPersistorTest, removeBack) {
   insertEntries();
 
-  auto res = persistor->removeBack(LogIndex{3}, {}).get();
+  auto res = persistor->removeBack(LogIndex{3}, {}).waitAndGet();
   ASSERT_TRUE(res.ok()) << res.errorMessage();
 
   auto iter =
@@ -330,14 +330,14 @@ TEST_F(LogPersistorTest, removeBack) {
     });
     auto res =
         persistor->insert(log.getLogIterator(), LogPersistor::WriteOptions{})
-            .get();
+            .waitAndGet();
     ASSERT_TRUE(res.ok()) << res.errorMessage();
     EXPECT_EQ(res.get(), 3);
   }
 }
 
 TEST_F(LogPersistorTest, removeBack_fails_no_matching_entry_found) {
-  auto res = persistor->removeBack(LogIndex{2}, {}).get();
+  auto res = persistor->removeBack(LogIndex{2}, {}).waitAndGet();
   ASSERT_TRUE(res.fail());
   EXPECT_EQ("log file in-memory file is empty", res.errorMessage());
 }
@@ -349,7 +349,7 @@ TEST_F(LogPersistorTest, removeBack_fails_if_log_file_corrupt) {
   TRI_ASSERT(buffer.size() > sizeof(header));
   std::memcpy(buffer.data(), &header, sizeof(header));
 
-  auto res = persistor->removeBack(LogIndex{2}, {}).get();
+  auto res = persistor->removeBack(LogIndex{2}, {}).waitAndGet();
   ASSERT_TRUE(res.fail());
 }
 
@@ -362,19 +362,19 @@ TEST_F(LogPersistorTest, removeBack_fails_if_start_index_too_small) {
     });
     auto res =
         persistor->insert(log.getLogIterator(), LogPersistor::WriteOptions{})
-            .get();
+            .waitAndGet();
     ASSERT_TRUE(res.ok());
     EXPECT_EQ(res.get(), 6);
   }
 
-  auto res = persistor->removeBack(LogIndex{2}, {}).get();
+  auto res = persistor->removeBack(LogIndex{2}, {}).waitAndGet();
   ASSERT_TRUE(res.fail());
 }
 
 TEST_F(LogPersistorTest, removeBack_fails_if_start_index_too_large) {
   insertEntries();
 
-  auto res = persistor->removeBack(LogIndex{8}, {}).get();
+  auto res = persistor->removeBack(LogIndex{8}, {}).waitAndGet();
   ASSERT_TRUE(res.fail());
   EXPECT_EQ(
       "found index (5) lower than start index (7) while searching backwards",

--- a/tests/RocksDBEngine/TransactionManagerTest.cpp
+++ b/tests/RocksDBEngine/TransactionManagerTest.cpp
@@ -95,7 +95,7 @@ TEST(RocksDBTransactionManager, test_overlapping) {
   std::atomic<bool> done;
 
   auto getReadLock = [&]() -> void {
-    tm.commitManagedTrx(trxId, "foo").get();
+    tm.commitManagedTrx(trxId, "foo").waitAndGet();
     done = true;
   };
 

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -93,14 +93,14 @@ TEST_F(TransactionManagerTest, parsing_errors) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   EXPECT_TRUE(res.is(TRI_ERROR_BAD_PARAMETER));
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": \"33\"}, \"lockTimeout\": -1 }");
   res = mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                               transaction::OperationOriginTestCase{}, false)
-            .get();
+            .waitAndGet();
   EXPECT_TRUE(res.is(TRI_ERROR_BAD_PARAMETER));
 }
 
@@ -112,21 +112,21 @@ TEST_F(TransactionManagerTest, collection_not_found) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"33\"]}}");
   res = mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                               transaction::OperationOriginTestCase{}, false)
-            .get();
+            .waitAndGet();
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"exclusive\": [\"33\"]}}");
   res = mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                               transaction::OperationOriginTestCase{}, false)
-            .get();
+            .waitAndGet();
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 }
 
@@ -144,17 +144,17 @@ TEST_F(TransactionManagerTest, transaction_id_reuse) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"33\"]}}");
   res = mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                               transaction::OperationOriginTestCase{}, false)
-            .get();
+            .waitAndGet();
   EXPECT_EQ(res.errorNumber(), TRI_ERROR_TRANSACTION_INTERNAL);
 
-  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
+  res = mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet();
   ASSERT_TRUE(res.ok());
 }
 
@@ -172,12 +172,13 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   auto doc = arangodb::velocypack::Parser::fromJson("{ \"_key\": \"1\"}");
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
     auto origin = ctx->operationOrigin();
     ASSERT_EQ(transaction::OperationOrigin::Type::kInternal, origin.type);
@@ -196,7 +197,8 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
   {  // lease again
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(ctx, "testCollection",
@@ -209,12 +211,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_abort) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // cannot commit aborted transaction
   ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name())
-                  .get()
+                  .waitAndGet()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
@@ -234,11 +236,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -255,12 +258,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // cannot commit aborted transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
-                  .get()
+                  .waitAndGet()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
@@ -287,11 +290,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, true)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -308,12 +312,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_is_follower) {
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // cannot commit aborted transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
-                  .get()
+                  .waitAndGet()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
 
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
@@ -333,11 +337,12 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -349,18 +354,19 @@ TEST_F(TransactionManagerTest, simple_transaction_and_commit_while_in_use) {
     OperationOptions opts;
     auto opRes = trx.insert(coll->name(), doc->slice(), opts);
     ASSERT_TRUE(opRes.ok());
-    ASSERT_EQ(TRI_ERROR_LOCKED,
-              mgr->commitManagedTrx(tid, vocbase.name()).get().errorNumber());
+    ASSERT_EQ(
+        TRI_ERROR_LOCKED,
+        mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().errorNumber());
     ASSERT_TRUE(trx.finish(opRes.result).ok());
   }
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::RUNNING);
 
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // perform same operation
-  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   // cannot abort committed transaction
   ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name())
-                  .get()
+                  .waitAndGet()
                   .is(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION));
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::COMMITTED);
 }
@@ -379,32 +385,35 @@ TEST_F(TransactionManagerTest, leading_multiple_readonly_transactions) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
 
-    auto ctx2 = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get();
+    auto ctx2 =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).waitAndGet();
     ASSERT_NE(ctx2.get(), nullptr);
     auto state2 = ctx2->acquireState(opts, responsible);
     EXPECT_EQ(state1.get(), state2.get());
     ASSERT_TRUE(!responsible);
 
-    auto ctx3 = mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get();
+    auto ctx3 =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).waitAndGet();
     ASSERT_NE(ctx3.get(), nullptr);
     auto state3 = ctx3->acquireState(opts, responsible);
     EXPECT_EQ(state3.get(), state2.get());
     ASSERT_TRUE(!responsible);
   }
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
@@ -422,21 +431,22 @@ TEST_F(TransactionManagerTest, lock_conflict) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
   {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
     ASSERT_ANY_THROW(
-        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get());
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).waitAndGet());
   }
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
@@ -454,28 +464,29 @@ TEST_F(TransactionManagerTest, lock_conflict_side_user) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
   {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
     ASSERT_TRUE(!responsible);
     ASSERT_ANY_THROW(
-        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).get());
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, false).waitAndGet());
 
     auto ctxSide =
-        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, true).get();
+        mgr->leaseManagedTrx(tid, AccessMode::Type::READ, true).waitAndGet();
     ASSERT_NE(ctxSide.get(), nullptr);
     auto state2 = ctxSide->acquireState(opts, responsible);
     ASSERT_NE(state2.get(), nullptr);
     ASSERT_TRUE(!responsible);
   }
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet().ok());
   ASSERT_EQ(mgr->getManagedTrxStatus(tid), transaction::Status::ABORTED);
 }
 
@@ -493,13 +504,14 @@ TEST_F(TransactionManagerTest, garbage_collection_shutdown) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
   {
     transaction::Options opts;
     bool responsible;
 
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
     auto state1 = ctx->acquireState(opts, responsible);
     ASSERT_NE(state1.get(), nullptr);
@@ -565,11 +577,12 @@ TEST_F(TransactionManagerTest, abort_transactions_with_matcher) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   {
-    auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+    auto ctx =
+        mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
     ASSERT_NE(ctx.get(), nullptr);
 
     SingleCollectionTransaction trx(std::move(ctx), "testCollection",
@@ -618,16 +631,16 @@ TEST_F(TransactionManagerTest, permission_denied_readonly) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   EXPECT_TRUE(res.ok());
-  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).get().ok());
+  ASSERT_TRUE(mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet().ok());
 
   tid = TransactionId::createSingleServer();
   json = arangodb::velocypack::Parser::fromJson(
       "{ \"collections\":{\"write\": [\"42\"]}}");
   res = mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                               transaction::OperationOriginTestCase{}, false)
-            .get();
+            .waitAndGet();
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_ARANGO_READ_ONLY);
 }
 
@@ -655,7 +668,7 @@ TEST_F(TransactionManagerTest, permission_denied_forbidden) {
   Result res =
       mgr->ensureManagedTrx(vocbase, tid, json->slice(),
                             transaction::OperationOriginTestCase{}, false)
-          .get();
+          .waitAndGet();
   ASSERT_EQ(res.errorNumber(), TRI_ERROR_FORBIDDEN);
 }
 
@@ -672,10 +685,11 @@ TEST_F(TransactionManagerTest, transaction_invalid_mode) {
   Result res = mgr->ensureManagedTrx(
                       vocbase, tid, json->slice(),
                       transaction::OperationOriginInternal{"some test"}, false)
-                   .get();
+                   .waitAndGet();
   ASSERT_TRUE(res.ok());
 
-  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+  auto ctx =
+      mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
   ASSERT_NE(ctx.get(), nullptr);
 
   ASSERT_THROW(SingleCollectionTransaction(std::move(ctx), "testCollection",
@@ -683,7 +697,7 @@ TEST_F(TransactionManagerTest, transaction_invalid_mode) {
                arangodb::basics::Exception);
   ;
 
-  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
+  res = mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet();
   ASSERT_TRUE(res.ok());
 }
 
@@ -700,10 +714,11 @@ TEST_F(TransactionManagerTest, transaction_origin) {
   Result res = mgr->ensureManagedTrx(
                       vocbase, tid, json->slice(),
                       transaction::OperationOriginInternal{"some test"}, false)
-                   .get();
+                   .waitAndGet();
   ASSERT_TRUE(res.ok());
 
-  auto ctx = mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get();
+  auto ctx =
+      mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet();
   ASSERT_NE(ctx.get(), nullptr);
 
   {
@@ -715,7 +730,7 @@ TEST_F(TransactionManagerTest, transaction_origin) {
     ASSERT_EQ("some test", origin.description);
   }
 
-  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
+  res = mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet();
   ASSERT_TRUE(res.ok());
 }
 
@@ -740,7 +755,7 @@ TEST_F(TransactionManagerTest, expired_transaction) {
   Result res = mgr->ensureManagedTrx(
                       vocbase, tid, json->slice(),
                       transaction::OperationOriginInternal{"some test"}, false)
-                   .get();
+                   .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   // wait until trx is expired
@@ -748,13 +763,13 @@ TEST_F(TransactionManagerTest, expired_transaction) {
 
   // we cannot use the transaction anymore
   ASSERT_ANY_THROW(
-      mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).get());
+      mgr->leaseManagedTrx(tid, AccessMode::Type::WRITE, false).waitAndGet());
 
   // aborting it is fine though
-  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
+  res = mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet();
   ASSERT_TRUE(res.ok());
 
-  res = mgr->commitManagedTrx(tid, vocbase.name()).get();
+  res = mgr->commitManagedTrx(tid, vocbase.name()).waitAndGet();
   ASSERT_FALSE(res.ok());
   ASSERT_EQ(TRI_ERROR_TRANSACTION_DISALLOWED_OPERATION, res.errorNumber());
 }
@@ -779,7 +794,7 @@ TEST_F(TransactionManagerTest, lock_usage_of_expired_transaction) {
   Result res = mgr->ensureManagedTrx(
                       vocbase, tid, json1->slice(),
                       transaction::OperationOriginInternal{"some test"}, false)
-                   .get();
+                   .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   // wait until trx is expired
@@ -797,15 +812,15 @@ TEST_F(TransactionManagerTest, lock_usage_of_expired_transaction) {
   res = mgr->ensureManagedTrx(vocbase, tid2, json2->slice(),
                               transaction::OperationOriginInternal{"some test"},
                               false)
-            .get();
+            .waitAndGet();
   ASSERT_TRUE(res.ok());
 
   // aborting trx1 is still fine, even though it is expired
-  res = mgr->abortManagedTrx(tid, vocbase.name()).get();
+  res = mgr->abortManagedTrx(tid, vocbase.name()).waitAndGet();
   ASSERT_TRUE(res.ok());
 
   // committing trx2 must be ok
-  res = mgr->commitManagedTrx(tid2, vocbase.name()).get();
+  res = mgr->commitManagedTrx(tid2, vocbase.name()).waitAndGet();
   ASSERT_TRUE(res.ok());
 }
 #endif

--- a/tests/VocBase/ComputedValuesTest.cpp
+++ b/tests/VocBase/ComputedValuesTest.cpp
@@ -813,7 +813,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesInsertOverwriteTrue) {
                        EXPECT_EQ("test", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 
   auto doc2 = velocypack::Parser::fromJson("{\"_key\":\"test2\"}");
@@ -824,7 +824,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesInsertOverwriteTrue) {
                        EXPECT_EQ("test", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 }
 
@@ -858,7 +858,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesInsertOverwriteFalse) {
                        EXPECT_EQ("abc", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
   auto doc2 = velocypack::Parser::fromJson("{\"_key\":\"test2\"}");
   EXPECT_TRUE(trx.insert("test", doc2->slice(), OperationOptions()).ok());
@@ -868,7 +868,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesInsertOverwriteFalse) {
                        EXPECT_EQ("test", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 }
 
@@ -898,7 +898,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesUpdateOverwriteTrue) {
                        EXPECT_EQ("abc", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 
   auto doc2 =
@@ -911,7 +911,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesUpdateOverwriteTrue) {
                        EXPECT_EQ("update", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 }
 
@@ -941,7 +941,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesUpdateOverwriteFalse) {
                        EXPECT_EQ("abc", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 
   auto doc2 =
@@ -954,7 +954,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesUpdateOverwriteFalse) {
                        EXPECT_EQ("qux", doc.get("attr").stringView());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 }
 
@@ -1019,7 +1019,7 @@ TEST_F(ComputedValuesTest, createCollectionComputedValuesInvalidValuesDynamic) {
                        EXPECT_EQ(23, doc.get("value2").getNumber<int>());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 }
 
@@ -1054,7 +1054,7 @@ TEST_F(ComputedValuesTest, insertKeepNullTrue) {
                        EXPECT_TRUE(doc.get("attr").isNull());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
   auto doc2 = velocypack::Parser::fromJson(
       "{\"_key\":\"test2\", \"attr\":null, \"value\": null}");
@@ -1065,7 +1065,7 @@ TEST_F(ComputedValuesTest, insertKeepNullTrue) {
                        EXPECT_TRUE(doc.get("attr").isNull());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
   auto doc3 = velocypack::Parser::fromJson(
       "{\"_key\":\"test3\", \"attr\":null, \"value\": 1}");
@@ -1077,6 +1077,6 @@ TEST_F(ComputedValuesTest, insertKeepNullTrue) {
                        EXPECT_EQ(1, doc.get("attr").getNumber<int>());
                        return true;
                      })
-                  .get()
+                  .waitAndGet()
                   .ok());
 }


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1493

Make synchronous waiting more prominently visible.

- [X] :hammer: Refactoring/simplification

For the record; after doing `arangod/` manually, for `tests/`, I've run the following a few times until it converged:

```
cmake --build ./cmake-build-relwithdebinfo-ee-clang-16/ -j64 |&
    sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' |
    grep -E '^(.*): error: no member named '\''get'\'' in '\''arangodb::futures::Future' |
    perl -lne '($fn, $ln, $col) = /^([^:]*):(\d+):(\d+): / or die; --$col; $,=" "; print "$fn:$ln:$col"; system "sed", "-r", "-i.orig", "${ln}s/^(.{$col})\\<get\\>/\\1waitAndGet/", $fn'
```