### PR TITLE
honor special case "OFF" for ARANGODB_BUILD_DATE cmake var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ configure_file(
 )
 
 option(ARANGODB_BUILD_DATE "Specific build date set from the outside (leave empty to auto-generate)" "")
-if (ARANGODB_BUILD_DATE STREQUAL "")
+if (ARANGODB_BUILD_DATE STREQUAL "" OR ARANGODB_BUILD_DATE STREQUAL "OFF")
   if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/lib/Basics/build-date.h")
     # auto-generate build date
     string(TIMESTAMP ARANGODB_BUILD_DATE "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
### Scope & Purpose

By default, CMake variables default to "OFF". This case was not handled separately for the `ARANGODB_BUILD_DATE` cmake variable. We only compared the value of this variable to the empty string. This PR adjusts the cmake code to also take into account the special value of "OFF", so that the build date for an ArangoDB executable will not be set to "OFF" if the build date is not explicitly set via the `ARANGODB_BUILD_DATE` cmake variable.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: 3.11 part is contained in https://github.com/arangodb/arangodb/pull/21009
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 