### PR TITLE
avoid potential races during controlled leader change

### DIFF
--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -26,8 +26,9 @@
 
 #include "Agency/AgencyComm.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/ReadLocker.h"
 #include "Basics/ScopeGuard.h"
-#include "Basics/StringUtils.h"
+#include "Basics/WriteLocker.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/MaintenanceStrings.h"
 #include "Cluster/ServerState.h"
@@ -40,8 +41,9 @@
 #include "StorageEngine/StorageEngine.h"
 #include "VocBase/LogicalCollection.h"
 
+#include <absl/strings/str_cat.h>
+
 using namespace arangodb;
-namespace StringUtils = arangodb::basics::StringUtils;
 
 namespace {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
@@ -92,8 +94,8 @@ char const* reportName(bool isRemove) {
 std::string currentShardPath(arangodb::LogicalCollection const& col) {
   // Agency path is
   //   Current/Collections/<dbName>/<collectionID>/<shardID>
-  return "Current/Collections/" + col.vocbase().name() + "/" +
-         std::to_string(col.planId().id()) + "/" + col.name();
+  return absl::StrCat("Current/Collections/", col.vocbase().name(), "/",
+                      col.planId().id(), "/", col.name());
 }
 
 VPackSlice currentShardEntry(arangodb::LogicalCollection const& col,
@@ -104,8 +106,8 @@ VPackSlice currentShardEntry(arangodb::LogicalCollection const& col,
 }
 
 std::string planShardPath(arangodb::LogicalCollection const& col) {
-  return "Plan/Collections/" + col.vocbase().name() + "/" +
-         std::to_string(col.planId().id()) + "/shards/" + col.name();
+  return absl::StrCat("Plan/Collections/", col.vocbase().name(), "/",
+                      col.planId().id(), "/shards/", col.name());
 }
 
 VPackSlice planShardEntry(arangodb::LogicalCollection const& col,
@@ -117,7 +119,7 @@ VPackSlice planShardEntry(arangodb::LogicalCollection const& col,
 
 }  // namespace
 
-FollowerInfo::FollowerInfo(arangodb::LogicalCollection* d)
+FollowerInfo::FollowerInfo(LogicalCollection* d)
     : _followers(std::make_shared<std::vector<ServerID>>()),
       _failoverCandidates(std::make_shared<std::vector<ServerID>>()),
       _docColl(d),
@@ -128,12 +130,29 @@ FollowerInfo::FollowerInfo(arangodb::LogicalCollection* d)
   // This should also disable satellite tracking.
 }
 
-////////////////////////////////////////////////////////////////////////////////
+/// @brief get information about current followers of a shard.
+std::shared_ptr<std::vector<ServerID> const> FollowerInfo::get() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _followers;
+}
+
+/// @brief get a copy of the information about current followers of a shard.
+std::vector<ServerID> FollowerInfo::getCopy() const {
+  READ_LOCKER(readLocker, _dataLock);
+  TRI_ASSERT(_followers != nullptr);
+  return *_followers;
+}
+
+/// @brief get information about current followers of a shard.
+std::shared_ptr<std::vector<ServerID> const>
+FollowerInfo::getFailoverCandidates() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _failoverCandidates;
+}
+
 /// @brief add a follower to a shard, this is only done by the server side
 /// of the "get-in-sync" capabilities. This reports to the agency under
 /// `/Current` but in asynchronous "fire-and-forget" way.
-////////////////////////////////////////////////////////////////////////////////
-
 Result FollowerInfo::add(ServerID const& sid) {
   TRI_IF_FAILURE("FollowerInfo::add") {
     return {TRI_ERROR_CLUSTER_AGENCY_COMMUNICATION_FAILED,
@@ -179,15 +198,54 @@ Result FollowerInfo::add(ServerID const& sid) {
   if (!agencyRes.is(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND) &&
       !agencyRes.is(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND)) {
     // "Real error", report and log
-    auto errorMessage = StringUtils::concatT(
-        "unable to add follower in agency, timeout in agency CAS operation for "
-        "key ",
-        _docColl->vocbase().name(), "/", _docColl->planId().id(), ": ",
-        TRI_errno_string(agencyRes.errorNumber()));
-    LOG_TOPIC("6295b", ERR, Logger::CLUSTER) << errorMessage;
-    agencyRes.reset(agencyRes.errorNumber(), std::move(errorMessage));
+    agencyRes.reset(
+        agencyRes.errorNumber(),
+        absl::StrCat("unable to add follower in agency, timeout in agency CAS "
+                     "operation for "
+                     "key ",
+                     _docColl->vocbase().name(), "/", _docColl->planId().id(),
+                     ": ", TRI_errno_string(agencyRes.errorNumber())));
+    LOG_TOPIC("6295b", ERR, Logger::CLUSTER) << agencyRes.errorMessage();
   }
   return agencyRes;
+}
+
+/// @brief set leadership
+void FollowerInfo::setTheLeader(std::string const& who) {
+  // Empty leader => we are now new leader.
+  // This needs to be handled with takeOverLeadership
+  TRI_ASSERT(!who.empty());
+  WRITE_LOCKER(writeLocker, _dataLock);
+  _theLeader = who;
+  _theLeaderTouched = true;
+}
+
+// conditionally change the leader, in case the current leader is still the
+// same as expected. in this case, return true and change the leader to
+// actual. otherwise, don't change anything and return false
+bool FollowerInfo::setTheLeaderConditional(std::string const& expected,
+                                           std::string const& actual) {
+  TRI_ASSERT(!actual.empty());
+  WRITE_LOCKER(writeLocker, _dataLock);
+  if (_theLeader != expected) {
+    // leader has already changed compared to what was expected.
+    // do not modify anything and abort.
+    return false;
+  }
+  // old leader was as expected. now change it and return success.
+  _theLeader = actual;
+  _theLeaderTouched = true;
+  return true;
+}
+
+std::string FollowerInfo::getLeader() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _theLeader;
+}
+
+bool FollowerInfo::getLeaderTouched() const {
+  READ_LOCKER(readLocker, _dataLock);
+  return _theLeaderTouched;
 }
 
 FollowerInfo::WriteState FollowerInfo::allowedToWrite() {
@@ -231,8 +289,7 @@ FollowerInfo::WriteState FollowerInfo::allowedToWrite() {
           << "Shard " << _docColl->name()
           << " is temporarily in read-only mode, since we have less than "
              "writeConcern ("
-          << basics::StringUtils::itoa(_docColl->writeConcern())
-          << ") replicas in sync.";
+          << _docColl->writeConcern() << ") replicas in sync.";
       return WriteState::FORBIDDEN;
     }
   }
@@ -328,7 +385,7 @@ Result FollowerInfo::remove(ServerID const& sid) {
     // we are finished
     ++_docColl->vocbase()
           .server()
-          .getFeature<arangodb::ClusterFeature>()
+          .getFeature<ClusterFeature>()
           .followersDroppedCounter();
     LOG_TOPIC("be0cb", DEBUG, Logger::CLUSTER)
         << "Removing follower " << sid << " from " << _docColl->name()
@@ -343,7 +400,7 @@ Result FollowerInfo::remove(ServerID const& sid) {
   // rollback:
   _followers = oldFollowers;
   _failoverCandidates = oldFailovers;
-  auto errorMessage = StringUtils::concatT(
+  auto errorMessage = absl::StrCat(
       "unable to remove follower from agency, timeout in agency CAS operation "
       "for key ",
       _docColl->vocbase().name(), "/", _docColl->planId().id(), ": ",
@@ -364,22 +421,16 @@ void FollowerInfo::clear() {
   _canWrite = false;
 }
 
-//////////////////////////////////////////////////////////////////////////////
 /// @brief check whether the given server is a follower
-//////////////////////////////////////////////////////////////////////////////
-
 bool FollowerInfo::contains(ServerID const& sid) const {
   READ_LOCKER(readLocker, _dataLock);
   auto const& f = *_followers;
   return std::find(f.begin(), f.end(), sid) != f.end();
 }
 
-////////////////////////////////////////////////////////////////////////////////
 /// @brief Take over leadership for this shard.
 ///        Also inject information of a insync followers that we knew about
 ///        before a failover to this server has happened
-////////////////////////////////////////////////////////////////////////////////
-
 void FollowerInfo::takeOverLeadership(
     std::vector<ServerID> const& previousInsyncFollowers,
     std::shared_ptr<std::vector<ServerID>> realInsyncFollowers) {
@@ -395,7 +446,7 @@ void FollowerInfo::takeOverLeadership(
   // all modifications to the internal state are guaranteed to be
   // atomic
   if (previousInsyncFollowers.size() > 1) {
-    auto ourselves = arangodb::ServerState::instance()->getId();
+    auto ourselves = ServerState::instance()->getId();
     auto failoverCandidates =
         std::make_shared<std::vector<ServerID>>(previousInsyncFollowers);
     auto myEntry = std::find(failoverCandidates->begin(),
@@ -454,11 +505,9 @@ void FollowerInfo::takeOverLeadership(
   _theLeaderTouched = true;
 }
 
-////////////////////////////////////////////////////////////////////////////////
 /// @brief Update the current information in the Agency. We update the failover-
 ///        list with the newest values, after this the guarantee is that
 ///        _followers == _failoverCandidates
-////////////////////////////////////////////////////////////////////////////////
 bool FollowerInfo::updateFailoverCandidates() {
   std::lock_guard agencyLocker{_agencyMutex};
   // Acquire _canWriteLock first
@@ -501,9 +550,7 @@ bool FollowerInfo::updateFailoverCandidates() {
   return _canWrite;
 }
 
-////////////////////////////////////////////////////////////////////////////////
 /// @brief Persist information in Current
-////////////////////////////////////////////////////////////////////////////////
 Result FollowerInfo::persistInAgency(bool isRemove) const {
   // Now tell the agency
   TRI_ASSERT(_docColl != nullptr);
@@ -593,12 +640,19 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
   return TRI_ERROR_SHUTTING_DOWN;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief inject the information about "servers" and "failoverCandidates"
-////////////////////////////////////////////////////////////////////////////////
+/// @brief Inject the information about followers into the builder.
+///        Builder needs to be an open object and is not allowed to contain
+///        the keys "servers" and "failoverCandidates".
+std::pair<size_t, size_t> FollowerInfo::injectFollowerInfo(
+    velocypack::Builder& builder) const {
+  READ_LOCKER(readLockerData, _dataLock);
+  injectFollowerInfoInternal(builder);
+  return std::make_pair(_followers->size(), _failoverCandidates->size());
+}
 
+/// @brief inject the information about "servers" and "failoverCandidates"
 void FollowerInfo::injectFollowerInfoInternal(VPackBuilder& builder) const {
-  auto ourselves = arangodb::ServerState::instance()->getId();
+  auto ourselves = ServerState::instance()->getId();
   TRI_ASSERT(builder.isOpenObject());
   builder.add(VPackValue(maintenance::SERVERS));
   {

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -24,12 +24,15 @@
 
 #pragma once
 
-#include <mutex>
-
-#include "Basics/ReadLocker.h"
 #include "Basics/ReadWriteLock.h"
-#include "Basics/WriteLocker.h"
 #include "Cluster/ClusterTypes.h"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace arangodb {
 
@@ -74,10 +77,10 @@ class FollowerInfo {
   // 2.) _canWriteLock
   // 3.) _dataLock
   mutable std::mutex _agencyMutex;
-  mutable arangodb::basics::ReadWriteLock _canWriteLock;
-  mutable arangodb::basics::ReadWriteLock _dataLock;
+  mutable basics::ReadWriteLock _canWriteLock;
+  mutable basics::ReadWriteLock _dataLock;
 
-  arangodb::LogicalCollection* _docColl;
+  LogicalCollection* _docColl;
   // if the latter is empty, then we are leading
   std::string _theLeader;
   bool _theLeaderTouched;
@@ -85,162 +88,98 @@ class FollowerInfo {
   bool _canWrite;
 
  public:
-  explicit FollowerInfo(arangodb::LogicalCollection* d);
+  explicit FollowerInfo(LogicalCollection* d);
 
   enum class WriteState { ALLOWED = 0, FORBIDDEN, STARTUP, UNAVAILABLE };
 
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get information about current followers of a shard.
-  ////////////////////////////////////////////////////////////////////////////////
+  std::shared_ptr<std::vector<ServerID> const> get() const;
 
-  std::shared_ptr<std::vector<ServerID> const> get() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _followers;
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get a copy of the information about current followers of a shard.
-  ////////////////////////////////////////////////////////////////////////////////
-  std::vector<ServerID> getCopy() const {
-    READ_LOCKER(readLocker, _dataLock);
-    TRI_ASSERT(_followers != nullptr);
-    return *_followers;
-  }
+  std::vector<ServerID> getCopy() const;
 
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief get information about current followers of a shard.
-  ////////////////////////////////////////////////////////////////////////////////
+  std::shared_ptr<std::vector<ServerID> const> getFailoverCandidates() const;
 
-  std::shared_ptr<std::vector<ServerID> const> getFailoverCandidates() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _failoverCandidates;
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////
   /// @brief Take over leadership for this shard.
   ///        Also inject information of a insync followers that we knew about
   ///        before a failover to this server has happened
   ///        The second parameter may be nullptr. It is an additional list
   ///        of declared to be insync followers. If it is nullptr the follower
   ///        list is initialized empty.
-  ////////////////////////////////////////////////////////////////////////////////
-
   void takeOverLeadership(
       std::vector<ServerID> const& previousInsyncFollowers,
       std::shared_ptr<std::vector<ServerID>> realInsyncFollowers);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief add a follower to a shard, this is only done by the server side
   /// of the "get-in-sync" capabilities. This reports to the agency under
   /// `/Current` but in asynchronous "fire-and-forget" way. The method
   /// fails silently, if the follower information has since been dropped
   /// (see `dropFollowerInfo` below).
-  //////////////////////////////////////////////////////////////////////////////
-
   Result add(ServerID const& s);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief remove a follower from a shard, this is only done by the
   /// server if a synchronous replication request fails. This reports to
   /// the agency under `/Current` but in an asynchronous "fire-and-forget"
   /// way.
-  //////////////////////////////////////////////////////////////////////////////
-
   Result remove(ServerID const& s);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief explicitly set the following term id for a follower.
   /// this should only be used for special cases during upgrading or testing.
-  //////////////////////////////////////////////////////////////////////////////
   void setFollowingTermId(ServerID const& s, uint64_t value);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief for each run of the "get-in-sync" protocol we generate a
   /// random number to identify this "following term". This is created
   /// when the follower fetches the exclusive lock to finally get in sync
   /// and is stored in _followingTermId, so that it can be forwarded with
   /// each synchronous replication request. The follower can then decline
   /// the replication in case it is not "in the same term".
-  //////////////////////////////////////////////////////////////////////////////
-
   uint64_t newFollowingTermId(ServerID const& s) noexcept;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief for each run of the "get-in-sync" protocol we generate a
   /// random number to identify this "following term". This is created
   /// when the follower fetches the exclusive lock to finally get in sync
   /// and is stored in _followingTermId, so that it can be forwarded with
   /// each synchronous replication request. The follower can then decline
   /// the replication in case it is not "in the same term".
-  //////////////////////////////////////////////////////////////////////////////
-
   uint64_t getFollowingTermId(ServerID const& s) const noexcept;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief clear follower list, no changes in agency necesary
-  //////////////////////////////////////////////////////////////////////////////
-
   void clear();
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief check whether the given server is a follower
-  //////////////////////////////////////////////////////////////////////////////
-
   bool contains(ServerID const& s) const;
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief set leadership
-  //////////////////////////////////////////////////////////////////////////////
+  void setTheLeader(std::string const& who);
 
-  void setTheLeader(std::string const& who) {
-    // Empty leader => we are now new leader.
-    // This needs to be handled with takeOverLeadership
-    TRI_ASSERT(!who.empty());
-    WRITE_LOCKER(writeLocker, _dataLock);
-    _theLeader = who;
-    _theLeaderTouched = true;
-  }
+  // conditionally change the leader, in case the current leader is still the
+  // same as expected. in this case, return true and change the leader to
+  // actual. otherwise, don't change anything and return false
+  bool setTheLeaderConditional(std::string const& expected,
+                               std::string const& actual);
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief get the leader
-  //////////////////////////////////////////////////////////////////////////////
+  std::string getLeader() const;
 
-  std::string getLeader() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _theLeader;
-  }
-
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief see if leader was explicitly set
-  //////////////////////////////////////////////////////////////////////////////
-
-  bool getLeaderTouched() const {
-    READ_LOCKER(readLocker, _dataLock);
-    return _theLeaderTouched;
-  }
+  bool getLeaderTouched() const;
 
   WriteState allowedToWrite();
 
-  //////////////////////////////////////////////////////////////////////////////
   /// @brief Inject the information about followers into the builder.
   ///        Builder needs to be an open object and is not allowed to contain
   ///        the keys "servers" and "failoverCandidates".
-  //////////////////////////////////////////////////////////////////////////////
   std::pair<size_t, size_t> injectFollowerInfo(
-      arangodb::velocypack::Builder& builder) const {
-    READ_LOCKER(readLockerData, _dataLock);
-    injectFollowerInfoInternal(builder);
-    return std::make_pair(_followers->size(), _failoverCandidates->size());
-  }
+      velocypack::Builder& builder) const;
 
  private:
-  void injectFollowerInfoInternal(arangodb::velocypack::Builder& builder) const;
+  void injectFollowerInfoInternal(velocypack::Builder& builder) const;
 
   bool updateFailoverCandidates();
 
   Result persistInAgency(bool isRemove) const;
 
-  arangodb::velocypack::Builder newShardEntry(
-      arangodb::velocypack::Slice oldValue) const;
+  velocypack::Builder newShardEntry(velocypack::Slice oldValue) const;
 };
 }  // end namespace arangodb

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -2774,6 +2774,11 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
     if (followingTermId.isNumber() && !leaderId.empty() &&
         currentLeaderCopy !=
             maintenance::ResignShardLeadership::LeaderNotYetKnownString) {
+      Result res = checkPlanLeaderDirect(col, leaderId);
+      if (res.fail()) {
+        THROW_ARANGO_EXCEPTION(res);
+      }
+
       newLeader =
           absl::StrCat(leaderId, "_", followingTermId.getNumber<uint64_t>());
     }
@@ -2784,7 +2789,12 @@ void RestReplicationHandler::handleCommandSetTheLeader() {
         << "setting leader for shard '" << _vocbase.name() << "/"
         << shard.stringView() << "' from " << currentLeaderCopy << " to "
         << newLeader;
-    col->followers()->setTheLeader(newLeader);
+    if (!col->followers()->setTheLeaderConditional(currentLeaderCopy,
+                                                   newLeader)) {
+      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
+                    "leader changed concurrently during leader change attempt");
+      return;
+    }
   }
 
   VPackBuilder b;


### PR DESCRIPTION
### Scope & Purpose

this PR adds a new method `setTheLeaderConditional` to FollowerInfo, so that the leader only gets changed if the current leader is still as expected. this avoids potential races if concurrent leader changes are going on.

- [x] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 