### PR TITLE
Resolve blockage by detaching a thread in AQL write on leader waiting for replication

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.10 (XXXX-XX-XX)
 ---------------------
 
+* Sort out a thread blockage on AQL write waiting for replication.
+
 * Reduce the possibility of cache stampedes during collection count cache 
   refilling.
     

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -203,19 +203,19 @@ ExecutionState SimpleModifier<ModifierCompletion, Enable>::transact(
   // we choose a random timeout for the detaching. But first we spin a
   // while to avoid delays:
   if (!result.isReady()) {
-    auto const spinTime = std::chrono::microseconds(10'000);
+    auto const spinTime = std::chrono::milliseconds(10);
     auto start = std::chrono::steady_clock::now();
     while (!result.isReady() &&
            std::chrono::steady_clock::now() - start < spinTime) {
       basics::cpu_relax();
     }
     if (!result.isReady()) {
-      auto const detachTime = std::chrono::microseconds(
-          RandomGenerator::interval(uint32_t(100)) * 100'000);
+      auto const detachTime = std::chrono::milliseconds(
+          1000 + RandomGenerator::interval(uint32_t(100)) * 100);
       auto start = std::chrono::steady_clock::now();
       while (!result.isReady() &&
              std::chrono::steady_clock::now() - start < detachTime) {
-        std::this_thread::sleep_for(std::chrono::microseconds(1'000));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
       if (!result.isReady()) {
         LOG_TOPIC("afe32", INFO, Logger::THREADS)

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -35,8 +35,11 @@
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/application-exit.h"
+#include "Basics/cpu-relax.h"
 #include "Cluster/ServerState.h"
 #include "Logger/LogMacros.h"
+#include "Random/RandomGenerator.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
@@ -192,8 +195,53 @@ ExecutionState SimpleModifier<ModifierCompletion, Enable>::transact(
   // operations blocking as in previous versions of ArangoDB.
   // TODO: fix this and make it truly non-blocking (requires to
   // fix some lifecycle issues for AQL queries first).
-  result.wait();
 
+  // If we simply wait, it can happen that we get into a blockage in which
+  // all threads wait in the same place here and none can make progress,
+  // since the scheduler is full. This means we must detach the thread
+  // after some time. To avoid that all are detaching at the same time,
+  // we choose a random timeout for the detaching. But first we spin a
+  // while to avoid delays:
+  if (!result.isReady()) {
+    auto const spinTime = std::chrono::microseconds(10'000);
+    auto start = std::chrono::steady_clock::now();
+    while (!result.isReady() &&
+           std::chrono::steady_clock::now() - start < spinTime) {
+      basics::cpu_relax();
+    }
+    if (!result.isReady()) {
+      auto const detachTime = std::chrono::microseconds(
+          RandomGenerator::interval(uint32_t(100)) * 100'000);
+      auto start = std::chrono::steady_clock::now();
+      while (!result.isReady() &&
+             std::chrono::steady_clock::now() - start < detachTime) {
+        std::this_thread::sleep_for(std::chrono::microseconds(1'000));
+      }
+      if (!result.isReady()) {
+        LOG_TOPIC("afe32", INFO, Logger::THREADS)
+            << "Did not get replication response within " << detachTime.count()
+            << " microseconds, detaching scheduler thread.";
+        uint64_t currentNumberDetached = 0;
+        uint64_t maximumNumberDetached = 0;
+        auto res = SchedulerFeature::SCHEDULER->detachThread(
+            &currentNumberDetached, &maximumNumberDetached);
+        if (res.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
+          LOG_TOPIC("afe33", WARN, Logger::THREADS)
+              << "Could not detach scheduler thread (currently detached "
+                 "threads: "
+              << currentNumberDetached
+              << ", maximal number of detached threads: "
+              << maximumNumberDetached
+              << "), will continue to wait for replication in scheduler "
+                 "thread, this can potentially lead to blockages!";
+        }
+        result.wait();
+      }
+    }
+  }
+
+  // The following will always be true with this code, but we leave the
+  // asynchronous code below for the future.
   if (result.isReady()) {
     _results = std::move(result.get());
     return ExecutionState::DONE;


### PR DESCRIPTION
This addresses a blockage which can occur if many threads on a leader
perform AQL writes at the same time, all replicate their operations on
their followers and are all waiting for responses.

Since this is AQL execution, this usually happens on MEDIUM priority.
But due to a (for now unresolvable) bug in the scheduler, it is
sometimes possible that more threads than allowed engage in this
activity. If the number grows to more than the number of HIGH priority
operations which are allowed concurrently, we have a blockage, since 
no thread can make progress any more as no HIGH priority tasks are
executed any more (due to a shortage of free threads).

This is a special bandaid for 3.11. The problem is solved more
thoroughly in 3.12 by making this particular operation truly
asynchronous.

Here, we have to live with a hack: Namely, we detach a thread which
remains for some time in this waiting loop. This allows the scheduler to
spawn another new thread and resolve the blockage by pulling some
response from the HIGH priority queue.

Note that we detach the thread after a random time. This will lead to
the fact that if many threads are blocked, only few will at first detach
and thus resolve the blockage, so that the others can make normal
progress without detaching.

- Detach thread waiting on leader in AQL write for replication.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- This is 3.11 only.

#### Related Information

- [*] Design document: https://github.com/arangodb/documents/blob/master/DesignDocuments/02_PLANNING/GlobalOutagePrevention.md
      This should already help with the problems described in this
      document.
