### PR TITLE
fix a data race in ConnectionCache

### DIFF
--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -61,7 +62,7 @@ struct ConnectionLease {
 
   ConnectionCache* _cache;
   std::unique_ptr<GeneralClientConnection> _connection;
-  bool _preventRecycling;
+  std::atomic<bool> _preventRecycling;
 };
 
 class ConnectionCache {
@@ -76,9 +77,8 @@ class ConnectionCache {
     size_t maxConnectionsPerEndpoint;
   };
 
-  ConnectionCache(
-      arangodb::application_features::CommunicationFeaturePhase& comm,
-      Options const& options);
+  ConnectionCache(application_features::CommunicationFeaturePhase& comm,
+                  Options const& options);
 
   ConnectionLease acquire(std::string endpoint, double connectTimeout,
                           double requestTimeout, size_t connectRetries,
@@ -98,7 +98,7 @@ class ConnectionCache {
 #endif
 
  private:
-  arangodb::application_features::CommunicationFeaturePhase& _comm;
+  application_features::CommunicationFeaturePhase& _comm;
 
   Options const _options;
 


### PR DESCRIPTION
### Scope & Purpose

Fixes one part of https://arangodb.atlassian.net/browse/BTS-1868

fix a data race in ConnectionCache by turning `_preventRecycling` into an atomic variable

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1868
- [ ] Design document: 
