### PR TITLE
extend chaos tests and fix a potential Merkle tree corruption issue

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1501,7 +1501,8 @@ void RocksDBMetaCollection::applyUpdates(
               << _logicalCollection.name() << ": " << ex.what();
           // it is pretty bad if this fails in real life, but we would trigger
           // this assertion during failure testing as well, so we cannot enable
-          // it TRI_ASSERT(false);
+          // it
+          TRI_ASSERT(false);
 
           // if an exception escapes from here, the same remove will be retried
           // next time.

--- a/lib/Containers/MerkleTree.cpp
+++ b/lib/Containers/MerkleTree.cpp
@@ -21,27 +21,6 @@
 /// @author Dan Larkin-York
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <algorithm>
-#include <cmath>
-#include <cstddef>
-#include <cstring>
-#include <functional>
-#include <limits>
-#include <memory>
-#include <mutex>
-#include <shared_mutex>
-#include <stdexcept>
-#include <string>
-#include <string_view>
-#include <utility>
-#include <vector>
-
-#include <snappy.h>
-
-#include <velocypack/Builder.h>
-#include <velocypack/Iterator.h>
-#include <velocypack/Slice.h>
-
 #include "MerkleTree.h"
 
 #include "Basics/Endian.h"
@@ -56,6 +35,27 @@
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
 #include "Random/RandomGenerator.h"
 #endif
+
+#include <snappy.h>
+
+#include <velocypack/Builder.h>
+#include <velocypack/Iterator.h>
+#include <velocypack/Slice.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
 // can turn this on for more aggressive and expensive consistency checks
 // #define PARANOID_TREE_CHECKS
@@ -612,6 +612,9 @@ void MerkleTree<Hasher, BranchingBits>::insert(
   }
 
   std::vector<std::uint64_t> sortedKeys = keys;
+  // we need to sort here so that we can easily determine the
+  // minimum and maximum key values. we need these values to do
+  // the bounds-check on the tree later.
   std::sort(sortedKeys.begin(), sortedKeys.end());
 
   std::uint64_t minKey = sortedKeys[0];
@@ -649,6 +652,9 @@ void MerkleTree<Hasher, BranchingBits>::remove(
   }
 
   std::vector<std::uint64_t> sortedKeys = keys;
+  // we need to sort here so that we can easily determine the
+  // minimum and maximum key values. we need these values to do
+  // the bounds-check on the tree later.
   std::sort(sortedKeys.begin(), sortedKeys.end());
 
   std::uint64_t minKey = sortedKeys[0];
@@ -656,12 +662,28 @@ void MerkleTree<Hasher, BranchingBits>::remove(
 
   std::unique_lock<std::shared_mutex> guard(_dataLock);
 
+  // we don't grow the tree automatically here, as remove operations
+  // are only expected for keys that have been added before.
   if (minKey < meta().rangeMin || maxKey >= meta().rangeMax) {
     throw std::out_of_range("Cannot remove, key out of current range.");
   }
 
   modify(sortedKeys, /*isInsert*/ false);
 }
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+template<typename Hasher, std::uint64_t const BranchingBits>
+void MerkleTree<Hasher, BranchingBits>::removeUnsorted(
+    std::vector<std::uint64_t> const& keys) {
+  if (keys.size() < 2) {
+    return remove(keys);
+  }
+
+  std::unique_lock<std::shared_mutex> guard(_dataLock);
+
+  modify(keys, /*isInsert*/ false);
+}
+#endif
 
 template<typename Hasher, std::uint64_t const BranchingBits>
 void MerkleTree<Hasher, BranchingBits>::clear() {
@@ -1268,7 +1290,7 @@ void MerkleTree<Hasher, BranchingBits>::modify(std::uint64_t key,
                                                bool isInsert) {
   // not thread-safe, shared-lock buffer from outside
   Hasher h;
-  std::uint64_t const value = h.hash(key);
+  std::uint64_t value = h.hash(key);
 
   // adjust bucket node
   bool success = modifyLocal(key, value, isInsert);
@@ -1290,13 +1312,14 @@ void MerkleTree<Hasher, BranchingBits>::modify(
   for (std::uint64_t key : keys) {
     std::uint64_t value = h.hash(key);
     bool success = modifyLocal(key, value, isInsert);
-    if (ADB_UNLIKELY(!success)) {
+    if (ADB_UNLIKELY(!success && totalCount > 0)) {
       // roll back the changes we already made, using best effort
-      for (std::uint64_t k : keys) {
-        if (k == key) {
-          break;
-        }
+      TRI_ASSERT(!isInsert);
+      for (std::uint64_t i = 0; i < totalCount; ++i) {
+        TRI_ASSERT(i < keys.size());
+        std::uint64_t k = keys[i];
         [[maybe_unused]] bool rolledBack = modifyLocal(k, h.hash(k), !isInsert);
+        TRI_ASSERT(rolledBack);
       }
       throw std::invalid_argument("Tried to remove key that is not present.");
     }
@@ -1326,7 +1349,10 @@ bool MerkleTree<Hasher, BranchingBits>::modifyLocal(Node& node,
   node.hash ^= value;
 
   TRI_ASSERT(node.count > 0 || node.hash == 0)
-      << "node count: " << node.count << ", hash: " << node.hash;
+      << "node count: " << node.count << ", hash: " << node.hash
+      << ", count: " << count << ", value: " << value
+      << ", isInsert: " << isInsert
+      << ", isRoot: " << (&node == &(meta().summary));
   return true;
 }
 
@@ -1336,6 +1362,7 @@ bool MerkleTree<Hasher, BranchingBits>::modifyLocal(std::uint64_t key,
                                                     bool isInsert) {
   // only use via modify
   std::uint64_t index = this->index(key);
+  TRI_ASSERT(&(this->node(index)) != &(meta().summary));
   return modifyLocal(this->node(index), 1, value, isInsert);
 }
 

--- a/lib/Containers/MerkleTree.h
+++ b/lib/Containers/MerkleTree.h
@@ -372,6 +372,20 @@ class MerkleTree : public MerkleTreeBase {
    */
   void remove(std::vector<std::uint64_t> const& keys);
 
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  /**
+   * @brief Remove a batch of keys (as values) from the tree.
+   *        This is a special version of remove that processes the keys in
+   *        the specified order, without sorting them first.
+   *
+   * @param keys  The keys to be removed. Each key will be hashed to generate
+   *              a value, then removed as if by the basic single removal
+   *              method. This batch method is considerably more efficient.
+   * @throws std::invalid_argument  If remove hits a node with 0 count
+   */
+  void removeUnsorted(std::vector<std::uint64_t> const& keys);
+#endif
+
   /**
    * @brief Remove all values from the tree.
    */

--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -278,6 +278,54 @@ TEST_F(InternalMerkleTreeTest, test_modify) {
   }
 }
 
+TEST(MerkleTreeTest, test_insert_and_remove) {
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
+      t(6, 0, 1ULL << 18);
+
+  std::vector<std::uint64_t> keys = {100, 193295, 2958836, 959302056027,
+                                     29994232};
+  t.insert(keys);
+  EXPECT_EQ(5, t.count());
+  EXPECT_EQ(10532320421211682024ULL, t.rootValue());
+
+  keys = {100, 193295, 2958836, 959302056027, 29994232};
+  t.remove(keys);
+  EXPECT_EQ(0, t.count());
+  EXPECT_EQ(0, t.rootValue());
+}
+
+TEST(MerkleTreeTest, test_insert_and_rollback) {
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
+      t(6, 0, 1ULL << 18);
+
+  std::vector<std::uint64_t> keys = {100, 193295, 2958836, 959302056027,
+                                     29994232};
+  t.insert(keys);
+  EXPECT_EQ(5, t.count());
+  EXPECT_EQ(10532320421211682024ULL, t.rootValue());
+
+  keys.clear();
+  keys = {100, 193295, 2958836, 959302056027, 29994232, 100};
+  EXPECT_THROW(t.removeUnsorted(keys), std::invalid_argument);
+
+  EXPECT_EQ(5, t.count());
+  EXPECT_EQ(10532320421211682024ULL, t.rootValue());
+}
+
+TEST(MerkleTreeTest, test_remove_out_of_range) {
+  ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
+      t(6, 0, 1ULL << 18);
+
+  t.insert(123);
+  EXPECT_EQ(1, t.count());
+  EXPECT_EQ(10276731894227909406ULL, t.rootValue());
+
+  EXPECT_THROW(t.remove(12345678901234567890ULL), std::out_of_range);
+
+  EXPECT_EQ(1, t.count());
+  EXPECT_EQ(10276731894227909406ULL, t.rootValue());
+}
+
 TEST_F(InternalMerkleTreeTest, test_grow) {
   std::pair<std::uint64_t, std::uint64_t> range = this->range();
   EXPECT_EQ(range.first, 0);

--- a/tests/js/client/chaos/test-chaos-load-common.inc
+++ b/tests/js/client/chaos/test-chaos-load-common.inc
@@ -54,8 +54,8 @@ const fetchRevisionTree = (serverUrl, shardId) => {
   }
   
   result = request({ method: "GET",
-    url: serverUrl + `/_api/replication/revisions/tree?collection=${encodeURIComponent(shardId)}&verification=true&batchId=${batch.id}`});
-  assertEqual(200, result.statusCode);
+    url: serverUrl + `/_api/replication/revisions/tree?collection=${encodeURIComponent(shardId)}&verification=true&batchId=${batch.id}&onlyPopulated=true`});
+  assertEqual(200, result.statusCode, result);
   request({ method: "DELETE", url: serverUrl + `/_api/replication/batch/${batch.id}`});
   return JSON.parse(result.body);
 };
@@ -70,11 +70,13 @@ const checkCollectionConsistency = (cn) => {
   const servers = getDBServers();
   const shardInfo = c.shards(true);
   
-  let failed = false;
+  let failed;
+  let message = "";
   const getServerUrl = (serverId) => servers.filter((server) => server.id === serverId)[0].url;
   let tries = 0;
   do {
     failed = false;
+    message = "";
     Object.entries(shardInfo).forEach(
       ([shard, [leader, follower]]) => {
         const leaderTree = fetchRevisionTree(getServerUrl(leader), shard);
@@ -84,33 +86,40 @@ const checkCollectionConsistency = (cn) => {
         leaderTree.computed.nodes = "<reduced>";
         leaderTree.stored.nodes = "<reduced>";
         if (!leaderTree.equal) {
-          console.error(`Leader has inconsistent tree for shard ${shard}:`, leaderTree);
+          message = `Leader has inconsistent tree for shard ${shard}: ${JSON.stringify(leaderTree)}`;
           failed = true;
+        }
+       
+        // note: with rf > 1, follower is always present. the code is generalized however so
+        // that the tests can easily be run with rf = 1 for debugging purposes.
+        if (follower) {
+          const followerTree = fetchRevisionTree(getServerUrl(follower), shard);
+          followerTree.computed.nodes = "<reduced>";
+          followerTree.stored.nodes = "<reduced>";
+          if (!followerTree.equal) {
+            message = `Follower has inconsistent tree for shard ${shard}: ${JSON.stringify(followerTree)}`;
+            failed = true;
+          }
+
+          if (!compareTree(leaderTree.computed, followerTree.computed)) {
+            message = `Leader and follower have different trees for shard ${shard}. Leader: ${JSON.stringify(leaderTree)}, Follower: ${JSON.stringify(followerTree)}`;
+            failed = true;
+          }
         }
         
-        const followerTree = fetchRevisionTree(getServerUrl(follower), shard);
-        followerTree.computed.nodes = "<reduced>";
-        followerTree.stored.nodes = "<reduced>";
-        if (!followerTree.equal) {
-          console.error(`Follower has inconsistent tree for shard ${shard}:`, followerTree);
-          failed = true;
-        }
-
-        if (!compareTree(leaderTree.computed, followerTree.computed)) {
-          console.error(`Leader and follower have different trees for shard ${shard}`);
-          console.error("Leader: ", leaderTree);
-          console.error("Follower: ", followerTree);
-          failed = true;
+        if (failed) {
+          assertNotEqual("", message);
+          console.error(message);
         }
       });
     if (failed) {
-      if (++tries >= 3) {
+      if (++tries >= 6) {
         assertFalse(failed, `Cluster still not in sync - giving up!`);
       }
       console.warn(`Found some inconsistencies! Giving cluster some more time to get in sync before checking again... try=${tries}`);
       internal.sleep(10);
     }
-  } while(failed);
+  } while (failed);
 };
 
 const viewName = (name, isSearchAlias) => {
@@ -390,17 +399,8 @@ function BaseChaosSuite(testOpts) {
         };
 
         let c = db._collection(testOpts.collection);
-        const opts = (length, keepNull = false) => {
+        const opts = (keepNull = false) => {
           let result = {};
-          if (testOpts.withIntermediateCommits) {
-            if (Math.random() <= 0.5) {
-              result.intermediateCommitCount = 7 + Math.floor(Math.random() * 10);
-              if (2 <= length && length <= result.intermediateCommitCount) {
-                result.intermediateCommitCount = length / 2;
-              }
-            }
-          }
-          
           if (testOpts.withVaryingOverwriteMode) {
             const r = Math.random();
             if (r >= 0.75) {
@@ -414,6 +414,18 @@ function BaseChaosSuite(testOpts) {
 
           if (keepNull && Math.random() >= 0.5) {
             result.keepNull = true;
+          }
+          return result;
+        };
+        const queryOptions = (length) => {
+          let result = {};
+          if (testOpts.withIntermediateCommits) {
+            if (Math.random() <= 0.5) {
+              result.intermediateCommitCount = 7 + Math.floor(Math.random() * 10);
+              if (2 <= length && length <= result.intermediateCommitCount) {
+                result.intermediateCommitCount = length / 2;
+              }
+            }
           }
           return result;
         };
@@ -448,44 +460,46 @@ function BaseChaosSuite(testOpts) {
               c.truncate();
             } else if (d >= 0.9) {
               let d = docs();
-              let o = opts(d.length);
-              log(`RUNNING AQL INSERT WITH ${d.length} DOCS. OPTIONS: ${JSON.stringify(o)}`);
-              query("FOR doc IN @docs INSERT doc INTO " + c.name(), {docs: d}, o);
+              let o = opts();
+              let qo = queryOptions(d.length);
+              log(`RUNNING AQL INSERT WITH ${d.length} DOCS. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN @docs INSERT doc INTO ${c.name()} OPTIONS ${JSON.stringify(o)}`, {docs: d}, qo);
             } else if (d >= 0.8) {
               const limit = Math.floor(Math.random() * 200);
-              let o = opts(limit);
-              log(`RUNNING AQL REMOVE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit REMOVE doc IN " + c.name(), {limit}, o);
+              let qo = queryOptions(limit);
+              log(`RUNNING AQL REMOVE WITH LIMIT=${limit}. QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN ${c.name()} LIMIT @limit REMOVE doc IN ${c.name()}`, {limit}, qo);
             } else if (d >= 0.75) {
               const limit = Math.floor(Math.random() * 2000);
-              let o = opts(limit);
-              log(`RUNNING AQL REPLACE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
+              let qo = queryOptions(limit);
+              log(`RUNNING AQL REPLACE WITH LIMIT=${limit}. QUERY OPTIONS: ${JSON.stringify(qo)}`);
               // generate random attribute values for random attribures
-              query("FOR doc IN " + c.name() + " LIMIT @limit REPLACE doc WITH { pfihg: 434, fjgjg: RAND(), " + generateAttributes(3) + " } IN " + c.name(), {limit}, o);
+              query(`FOR doc IN ${c.name()} LIMIT @limit REPLACE doc WITH { pfihg: 434, fjgjg: RAND(), ${generateAttributes(3)} } IN ${c.name()}`, {limit}, qo);
             } else if (d >= 0.70) {
               const limit = Math.floor(Math.random() * 2000);
-              let o = opts(limit, /*keepNull*/ true);
-              log(`RUNNING AQL UPDATE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
+              let o = opts(/*keepNull*/ true);
+              let qo = queryOptions(limit);
+              log(`RUNNING AQL UPDATE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
               // generate random attribute values for random attribures
-              query("FOR doc IN " + c.name() + " LIMIT @limit UPDATE doc WITH { pfihg: RAND(), " + generateAttributes(3) + " } IN " + c.name(), {limit}, o);
+              query(`FOR doc IN ${c.name()} LIMIT @limit UPDATE doc WITH { pfihg: RAND(), ${generateAttributes(3)} } IN ${c.name()} OPTIONS ${JSON.stringify(o)}`, {limit}, qo);
             } else if (d >= 0.68) {
               const limit = Math.floor(Math.random() * 10) + 1;
               log(`RUNNING DOCUMENT SINGLE LOOKUP QUERY WITH LIMIT=${limit}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit RETURN DOCUMENT(doc._id)", {limit});
+              query(`FOR doc IN ${c.name()} LIMIT @limit RETURN DOCUMENT(doc._id)`, {limit});
             } else if (d >= 0.66) {
               const limit = Math.floor(Math.random() * 10) + 1;
               log(`RUNNING DOCUMENT ARRAY LOOKUP QUERY WITH LIMIT=${limit}`);
-              query("LET keys = (FOR doc IN " + c.name() + " LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)", {limit});
+              query(`LET keys = (FOR doc IN ${c.name()} LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)`, {limit});
               const lookupViews = (isSearchAlias) => {
                 const r = Math.random();
                 if (r < 0.25) {
-                  query("LET keys = (FOR doc IN " + viewName(cn + "_view", isSearchAlias) + " LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)", {limit});
+                  query(`LET keys = (FOR doc IN ${viewName(cn + "_view", isSearchAlias)} LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)`, {limit});
                 } else if (r < 0.5) {
-                  query("LET keys = (FOR doc IN " + viewName(cn + "_view_ps", isSearchAlias) + " LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)", {limit});
+                  query(`LET keys = (FOR doc IN ${viewName(cn + "_view_ps", isSearchAlias)} LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)`, {limit});
                 } else if (r < 0.75) {
-                  query("LET keys = (FOR doc IN " + viewName(cn + "_view_sv", isSearchAlias) + " LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)", {limit});
+                  query(`LET keys = (FOR doc IN ${viewName(cn + "_view_sv", isSearchAlias)} LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)`, {limit});
                 } else {
-                  query("LET keys = (FOR doc IN " + viewName(cn + "_view_ps_sv", isSearchAlias) + " LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)", {limit});
+                  query(`LET keys = (FOR doc IN ${viewName(cn + "_view_ps_sv", isSearchAlias)} LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)`, {limit});
                 }
               };
               if (testOpts.withViews) {
@@ -497,12 +511,13 @@ function BaseChaosSuite(testOpts) {
               }
             } else if (d >= 0.65) {
               const limit = Math.floor(Math.random() * 10) + 1;
-              let o = opts(limit);
-              log(`RUNNING DOCUMENT LOOKUP AND WRITE QUERY WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(0)}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit LET d = DOCUMENT(doc._id) INSERT UNSET(doc, '_key') INTO " + c.name(), {limit}, o);
+              let o = opts();
+              let qo = queryOptions(limit);
+              log(`RUNNING DOCUMENT LOOKUP AND WRITE QUERY WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN ${c.name()} LIMIT @limit LET d = DOCUMENT(doc._id) INSERT UNSET(doc, '_key') INTO ${c.name()} OPTIONS ${JSON.stringify(o)}`, {limit}, qo);
             } else if (d >= 0.25) {
               let d = docs();
-              let o = opts(d.length);
+              let o = Object.assign(opts(), queryOptions(d.length));
               log(`RUNNING INSERT WITH ${d.length} DOCS. OPTIONS: ${JSON.stringify(o)}`);
               d = d.length === 1 ? d[0] : d;
               c.insert(d, o);
@@ -512,7 +527,20 @@ function BaseChaosSuite(testOpts) {
               d = d.length === 1 ? d[0] : d;
               c.remove(d);
             }
-          } catch (err) {}
+          } catch (err) {
+            log(`executing previous command triggered exception ${err}`);
+            // none of the following errors are expected in this test:
+            if (require("@arangodb").errors.ERROR_QUERY_PARSE === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_EMPTY === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_COMPILE_TIME_OPTIONS === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_ACCESS_AFTER_MODIFICATION === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETERS_INVALID === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETER_MISSING === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETER_UNDECLARED === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETER_TYPE === err.errorNum) {
+              throw err;
+            }
+          }
         }
         
         let willAbort = Math.random() < 0.2;
@@ -539,8 +567,9 @@ function BaseChaosSuite(testOpts) {
       testOpts.collection = cn;
       code = `(${code.toString()})(${JSON.stringify(testOpts)});`;
       
+      const concurrency = 4;
       let tests = [];
-      for (let i = 0; i < 3; ++i) {
+      for (let i = 0; i < concurrency; ++i) {
         tests.push(["p" + i, code]);
       }
 

--- a/tests/js/client/chaos/test-deadlock-cluster.js
+++ b/tests/js/client/chaos/test-deadlock-cluster.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global fail, print, assertEqual, assertFalse */
+/* global fail, print, assertEqual, assertFalse, assertNotEqual */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -43,7 +43,7 @@ const fetchRevisionTree = (serverUrl, shardId) => {
   
   result = request({ method: "GET",
     url: serverUrl + `/_api/replication/revisions/tree?collection=${encodeURIComponent(shardId)}&verification=true&batchId=${batch.id}`});
-  assertEqual(200, result.statusCode);
+  assertEqual(200, result.statusCode, result);
   request({ method: "DELETE", url: serverUrl + `/_api/replication/batch/${batch.id}`});
   return JSON.parse(result.body);
 };
@@ -58,11 +58,13 @@ const checkCollectionConsistency = (cn) => {
   const servers = getDBServers();
   const shardInfo = c.shards(true);
   
-  let failed = false;
+  let failed;
+  let message;
   const getServerUrl = (serverId) => servers.filter((server) => server.id === serverId)[0].url;
   let tries = 0;
   do {
     failed = false;
+    message = "";
     Object.entries(shardInfo).forEach(
       ([shard, [leader, follower]]) => {
         const leaderTree = fetchRevisionTree(getServerUrl(leader), shard);
@@ -72,33 +74,40 @@ const checkCollectionConsistency = (cn) => {
         leaderTree.computed.nodes = "<reduced>";
         leaderTree.stored.nodes = "<reduced>";
         if (!leaderTree.equal) {
-          console.error(`Leader has inconsistent tree for shard ${shard}:`, leaderTree);
-          failed = true;
-        }
-        
-        const followerTree = fetchRevisionTree(getServerUrl(follower), shard);
-        followerTree.computed.nodes = "<reduced>";
-        followerTree.stored.nodes = "<reduced>";
-        if (!followerTree.equal) {
-          console.error(`Follower has inconsistent tree for shard ${shard}:`, followerTree);
+          message = `Leader has inconsistent tree for shard ${shard}: ${JSON.stringify(leaderTree)}`;
           failed = true;
         }
 
-        if (!compareTree(leaderTree.computed, followerTree.computed)) {
-          console.error(`Leader and follower have different trees for shard ${shard}`);
-          console.error("Leader: ", leaderTree);
-          console.error("Follower: ", followerTree);
-          failed = true;
+        // note: with rf > 1, follower is always present. the code is generalized however so
+        // that the tests can easily be run with rf = 1 for debugging purposes.
+        if (follower) {
+          const followerTree = fetchRevisionTree(getServerUrl(follower), shard);
+          followerTree.computed.nodes = "<reduced>";
+          followerTree.stored.nodes = "<reduced>";
+          if (!followerTree.equal) {
+            message = `Follower has inconsistent tree for shard ${shard}: ${JSON.stringify(followerTree)}`;
+            failed = true;
+          }
+
+          if (!compareTree(leaderTree.computed, followerTree.computed)) {
+            message = `Leader and follower have different trees for shard ${shard}. Leader: ${JSON.stringify(leaderTree)}, Follower: ${JSON.stringify(followerTree)}`;
+            failed = true;
+          }
+        }
+
+        if (failed) {
+          assertNotEqual("", message);
+          console.error(message);
         }
       });
     if (failed) {
-      if (++tries >= 3) {
-        assertFalse(failed, `Cluster still not in sync - giving up!`);
+      if (++tries >= 6) {
+        assertFalse(failed, `Cluster still not in sync - giving up! ${message}`);
       }
       console.warn(`Found some inconsistencies! Giving cluster some more time to get in sync before checking again... try=${tries}`);
       internal.sleep(10);
     }
-  } while(failed);
+  } while (failed);
 };
 
 function DeadlockSuite() { 
@@ -155,7 +164,7 @@ function DeadlockSuite() {
         const key = () => "testmann" + Math.floor(Math.random() * 100000000);
         const docs = () => {
           let result = [];
-          const max = 2000;
+          const max = 4000;
           let r = Math.floor(Math.random() * max) + 1;
           if (r > (max * 0.8)) {
             // we want ~20% of all requests to be single document operations
@@ -169,7 +178,7 @@ function DeadlockSuite() {
 
         let collectionName = testOpts.collection + Math.floor(Math.random() * testOpts.numCollections);
         let c = db._collection(collectionName);
-        const opts = (length, keepNull = false) => {
+        const opts = (keepNull = false) => {
           let result = {};
           const r = Math.random();
           if (r >= 0.75) {
@@ -182,6 +191,16 @@ function DeadlockSuite() {
 
           if (keepNull && Math.random() >= 0.5) {
             result.keepNull = true;
+          }
+          return result;
+        };
+        const queryOptions = (fullCount = false) => {
+          let result = {};
+          if (fullCount && Math.random() >= 0.5) {
+            result.fullCount = true;
+          }
+          if (Math.random() >= 0.5) {
+            result.maxRuntime = Math.random() * 10;
           }
           return result;
         };
@@ -220,42 +239,53 @@ function DeadlockSuite() {
               c.truncate();
             } else if (d >= 0.9) {
               let d = docs();
-              let o = opts(d.length);
-              log(`RUNNING AQL INSERT WITH ${d.length} DOCS. OPTIONS: ${JSON.stringify(o)}`);
-              query("FOR doc IN @docs INSERT doc INTO " + c.name(), {docs: d}, o);
+              let o = opts();
+              let qo = queryOptions();
+              log(`RUNNING AQL INSERT WITH ${d.length} DOCS. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN @docs INSERT doc INTO ${c.name()} OPTIONS ${JSON.stringify(o)}`, {docs: d}, qo);
             } else if (d >= 0.8) {
               const limit = Math.floor(Math.random() * 200);
-              let o = opts(limit);
-              log(`RUNNING AQL REMOVE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit REMOVE doc IN " + c.name(), {limit}, o);
+              let o = opts();
+              let qo = queryOptions();
+              log(`RUNNING AQL REMOVE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN ${c.name()} LIMIT @limit REMOVE doc IN ${c.name()}`, {limit}, qo);
             } else if (d >= 0.75) {
               const limit = Math.floor(Math.random() * 2000);
-              let o = opts(limit);
-              log(`RUNNING AQL REPLACE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
-              // generate random attribute values for random attribures
-              query("FOR doc IN " + c.name() + " LIMIT @limit REPLACE doc WITH { pfihg: 434, fjgjg: RAND(), " + generateAttributes(3) + " } IN " + c.name(), {limit}, o);
+              let o = opts();
+              let qo = queryOptions();
+              log(`RUNNING AQL REPLACE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              // generate random attribute values for random attributes
+              query(`FOR doc IN ${c.name()} LIMIT @limit REPLACE doc WITH { pfihg: 434, fjgjg: RAND(), ${generateAttributes(3)} } IN ${c.name()}`, {limit}, qo);
             } else if (d >= 0.70) {
               const limit = Math.floor(Math.random() * 2000);
-              let o = opts(limit, /*keepNull*/ true);
-              log(`RUNNING AQL UPDATE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}`);
-              // generate random attribute values for random attribures
-              query("FOR doc IN " + c.name() + " LIMIT @limit UPDATE doc WITH { pfihg: RAND(), " + generateAttributes(3) + " } IN " + c.name(), {limit}, o);
+              let o = opts(/*keepNull*/ true);
+              let qo = queryOptions();
+              log(`RUNNING AQL UPDATE WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              // generate random attribute values for random attributes
+              query(`FOR doc IN ${c.name()} LIMIT @limit UPDATE doc WITH { pfihg: RAND(), ${generateAttributes(3)} } IN ${c.name()} OPTIONS ${JSON.stringify(o)}`, {limit}, qo);
             } else if (d >= 0.68) {
               const limit = Math.floor(Math.random() * 10) + 1;
               log(`RUNNING DOCUMENT SINGLE LOOKUP QUERY WITH LIMIT=${limit}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit RETURN DOCUMENT(doc._id)", {limit});
+              query(`FOR doc IN ${c.name()} LIMIT @limit RETURN DOCUMENT(doc._id)`, {limit});
             } else if (d >= 0.66) {
               const limit = Math.floor(Math.random() * 10) + 1;
               log(`RUNNING DOCUMENT ARRAY LOOKUP QUERY WITH LIMIT=${limit}`);
-              query("LET keys = (FOR doc IN " + c.name() + " LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)", {limit});
+              query(`LET keys = (FOR doc IN ${c.name()} LIMIT @limit RETURN doc._id) RETURN DOCUMENT(keys)`, {limit});
             } else if (d >= 0.65) {
               const limit = Math.floor(Math.random() * 10) + 1;
-              let o = opts(limit);
-              log(`RUNNING DOCUMENT LOOKUP AND WRITE QUERY WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(0)}`);
-              query("FOR doc IN " + c.name() + " LIMIT @limit LET d = DOCUMENT(doc._id) INSERT UNSET(doc, '_key') INTO " + c.name(), {limit}, o);
+              let o = opts();
+              let qo = queryOptions();
+              log(`RUNNING DOCUMENT LOOKUP AND WRITE QUERY WITH LIMIT=${limit}. OPTIONS: ${JSON.stringify(o)}, QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN ${c.name()} LIMIT @limit LET d = DOCUMENT(doc._id) INSERT UNSET(doc, '_key') INTO ${c.name()} OPTIONS ${JSON.stringify(o)}`, {limit}, qo);
+            } else if (d >= 0.63) {
+              const skip = Math.floor(Math.random() * 100) + 1;
+              const limit = Math.floor(Math.random() * 100) + 1;
+              let qo = queryOptions(/*fullCount*/ true);
+              log(`RUNNING DOCUMENT LOOKUP WITH LIMIT ${skip},${limit}. QUERY OPTIONS: ${JSON.stringify(qo)}`);
+              query(`FOR doc IN ${c.name()} LIMIT @skip, @limit RETURN doc`, {skip, limit}, qo);
             } else if (d >= 0.25) {
               let d = docs();
-              let o = opts(d.length);
+              let o = Object.assign(opts(), queryOptions());
               log(`RUNNING INSERT WITH ${d.length} DOCS. OPTIONS: ${JSON.stringify(o)}`);
               d = d.length === 1 ? d[0] : d;
               c.insert(d, o);
@@ -267,8 +297,20 @@ function DeadlockSuite() {
             }
           } catch (err) {
             log(`executing previous command triggered exception ${err}`);
+            // none of the following errors are expected in this test:
             if (require("@arangodb").errors.ERROR_CLUSTER_TIMEOUT.code === err.errorNum ||
-                require("@arangodb").errors.ERROR_LOCK_TIMEOUT.code === err.errorNum) {
+                require("@arangodb").errors.ERROR_CLUSTER_BACKEND_UNAVAILABLE === err.errorNum ||
+                require("@arangodb").errors.ERROR_CLUSTER_CONNECTION_LOST === err.errorNum ||
+                require("@arangodb").errors.ERROR_LOCK_TIMEOUT.code === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_PARSE === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_EMPTY === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_COMPILE_TIME_OPTIONS === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_ACCESS_AFTER_MODIFICATION === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETERS_INVALID === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETER_MISSING === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETER_UNDECLARED === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUERY_BIND_PARAMETER_TYPE === err.errorNum ||
+                require("@arangodb").errors.ERROR_QUEUE_FULL === err.errorNum) {
               throw err;
             }
           }
@@ -312,13 +354,13 @@ function DeadlockSuite() {
       };
       code = `(${code.toString()})(${JSON.stringify(testOpts)});`;
       
-      const concurrency = 10;
+      const concurrency = 12;
       let tests = [];
       for (let i = 0; i < concurrency; ++i) {
         tests.push(["p" + i, code]);
       }
 
-      // run the suite for 3 minutes
+      // run the suite for a few minutes
       let client_ret = runParallelArangoshTests(tests, 3 * 60, coordination_cn);
       client_ret.forEach(client => { 
         if (client.failed) { 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21018

Extend chaos tests and fix a potential data corruption in a collection's Merkle tree, in case a write operation in a streaming transaction ran into the transaction's maximum size limit and failed. If the transaction was continued afterwards and more operations were pushed into it, the leftovers of the failed operation were not removed from the collection's in-memory buffers that contained all modifications for the collection's Merkle tree upon commit of that transaction.

Sequence of events needed:
1. streaming transaction
2. write operation in streaming transaction ran into transaction size limit error
3. the write operation error was ignored by the user
4. the transaction was committed anyway

The bugfix in this PR is to call the `RocksDBSavepoint::finish()` operation _before_ revision ids are added to the collection's in-memory Merkle tree state in RocksDBCollection.cpp. Previously it was the other way around.
The problem is that `RocksDBSavepoint::finish()` can fail if the transaction runs into the maximum size limit. In this case the in-memory Merkle tree state was not cleaned up before. We now avoid this problem by calling `finish()` and checking its return value before we add the changes to the in-memory Merkle tree state.

The PR also extends the CI chaos tests to cover more cases.
It also adds an assertion that will be triggered if documents cannot be removed successfully from the collection's Merkle tree.
Additionally, tests are added for a few more Merkle tree cases (insert-then-remove and rollback).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 