### PR TITLE
fix a TSan data race in Methods::MultiGet()

### DIFF
--- a/arangod/RocksDBEngine/Methods/RocksDBReadOnlyBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBReadOnlyBaseMethods.cpp
@@ -127,13 +127,12 @@ void RocksDBReadOnlyBaseMethods::MultiGet(rocksdb::Snapshot const* snapshot,
                                           rocksdb::Slice const* keys,
                                           rocksdb::PinnableSlice* values,
                                           rocksdb::Status* statuses) {
-  absl::Cleanup restore = [&, was = _readOptions.snapshot] {
-    _readOptions.snapshot = was;
-  };
-  _readOptions.snapshot = snapshot;
+  // make a copy of the ReadOptions, as we are going to modify the snapshot
+  ReadOptions ro = _readOptions;
+  ro.snapshot = snapshot;
 
   // Timestamps and multiple ColumnFamilies are not necessary for us
-  _db->MultiGet(_readOptions, &family, count, keys, values, statuses, false);
+  _db->MultiGet(ro, &family, count, keys, values, statuses, false);
 }
 
 void RocksDBReadOnlyBaseMethods::MultiGet(rocksdb::ColumnFamilyHandle& family,

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -575,13 +575,12 @@ void RocksDBTrxBaseMethods::MultiGet(rocksdb::Snapshot const* snapshot,
                                      size_t count, rocksdb::Slice const* keys,
                                      rocksdb::PinnableSlice* values,
                                      rocksdb::Status* statuses) {
-  absl::Cleanup restore = [&, was = _readOptions.snapshot] {
-    _readOptions.snapshot = was;
-  };
-  _readOptions.snapshot = snapshot;
+  // make a copy of the ReadOptions, as we are going to modify the snapshot
+  ReadOptions ro = _readOptions;
+  ro.snapshot = snapshot;
 
   // Timestamps and multiple ColumnFamilies are not necessary for us
-  _db->MultiGet(_readOptions, &family, count, keys, values, statuses, false);
+  _db->MultiGet(ro, &family, count, keys, values, statuses, false);
 }
 
 void RocksDBTrxBaseMethods::MultiGet(rocksdb::ColumnFamilyHandle& family,


### PR DESCRIPTION
### Scope & Purpose

Fix a data race reported by TSan in Methods::MultiGet().
The instance variable `_readOptions` is temporarily modified by the `MultiGet()` w/ snapshot method. This method can run in parallel with other threads that read the `_readOptions` member of the same object.
This PR fixes it by making a copy of the `_readOptions` member, and then modifying only the copy.

No backport is needed for 3.11 as MultiGet is not used in 3.11.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 