### PR TITLE
Use correct memory order to properly synchronize with stopping thread

### DIFF
--- a/lib/Basics/Thread.cpp
+++ b/lib/Basics/Thread.cpp
@@ -260,8 +260,10 @@ void Thread::shutdown() {
 
 /// @brief checks if the current thread was asked to stop
 bool Thread::isStopping() const noexcept {
-  auto state = _state.load(std::memory_order_relaxed);
-
+  // need acquire to ensure we establish a happens before relation with the
+  // update that updates _state, so threads that wait for isStopping to return
+  // true are properly synchronized
+  auto state = _state.load(std::memory_order_acquire);
   return state == ThreadState::STOPPING || state == ThreadState::STOPPED;
 }
 

--- a/lib/Basics/Thread.h
+++ b/lib/Basics/Thread.h
@@ -131,7 +131,10 @@ class Thread {
 
   /// @brief true, if the thread is still running
   bool isRunning() const noexcept {
-    return _state.load(std::memory_order_relaxed) != ThreadState::STOPPED;
+    // need acquire to ensure we establish a happens before relation with the
+    // update that sets the state to STOPPED, so threads that wait for isRunning
+    // to return false are properly synchronized
+    return _state.load(std::memory_order_acquire) != ThreadState::STOPPED;
   }
 
   /// @brief checks if the current thread was asked to stop


### PR DESCRIPTION
### Scope & Purpose

We often use a pattern like `while (thread.isRunning()) { /* wait */ }` during shutdown. `isRunning` returns false once the internal thread state has been set to `STOPPED`. However, previously this load used `memory_order_relaxed` and therefore did not synchronize with the operation that updated the state. Thus, we did not have a happens-before relation and strictly speaking any access to data that was previously accessed by the just stopped thread could potentially result in a data race. 

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
