### PR TITLE
fix compilation of tests without failure test mode

### DIFF
--- a/tests/Containers/MerkleTreeTest.cpp
+++ b/tests/Containers/MerkleTreeTest.cpp
@@ -294,6 +294,7 @@ TEST(MerkleTreeTest, test_insert_and_remove) {
   EXPECT_EQ(0, t.rootValue());
 }
 
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
 TEST(MerkleTreeTest, test_insert_and_rollback) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>
       t(6, 0, 1ULL << 18);
@@ -311,6 +312,7 @@ TEST(MerkleTreeTest, test_insert_and_rollback) {
   EXPECT_EQ(5, t.count());
   EXPECT_EQ(10532320421211682024ULL, t.rootValue());
 }
+#endif
 
 TEST(MerkleTreeTest, test_remove_out_of_range) {
   ::arangodb::containers::MerkleTree<::arangodb::containers::FnvHashProvider, 3>


### PR DESCRIPTION
### Scope & Purpose

Fix compilation of a C++ unit test in case the define `ARANGODB_ENABLE_FAILURE_TESTS` was not set.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 