### PR TITLE
fix potential use-after-free in replication

### DIFF
--- a/arangod/Replication/Syncer.cpp
+++ b/arangod/Replication/Syncer.cpp
@@ -295,8 +295,7 @@ arangodb::Result applyCollectionDumpMarkerInternal(
 
 namespace arangodb {
 
-Syncer::JobSynchronizer::JobSynchronizer(
-    std::shared_ptr<Syncer const> const& syncer)
+Syncer::JobSynchronizer::JobSynchronizer(std::shared_ptr<Syncer const> syncer)
     : _syncer(syncer), _gotResponse(false), _time(0.0), _jobsInFlight(0) {}
 
 Syncer::JobSynchronizer::~JobSynchronizer() {
@@ -443,6 +442,36 @@ bool Syncer::JobSynchronizer::hasJobInFlight() const noexcept {
 
   TRI_ASSERT(_jobsInFlight <= 1);
   return _jobsInFlight > 0;
+}
+
+Syncer::JobSynchronizerScope::JobSynchronizerScope(
+    std::shared_ptr<Syncer const> syncer)
+    : _synchronizer(std::make_shared<JobSynchronizer>(std::move(syncer))) {
+  TRI_ASSERT(_synchronizer.use_count() == 1);
+}
+
+Syncer::JobSynchronizerScope::~JobSynchronizerScope() {
+  // if use_count is > 1, it means that we have copied the JobSynchronizer's
+  // shared_ptr already and dispatched a background task.
+  // we need to wait until the background task is fully done.
+  while (_synchronizer.use_count() > 1) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    std::this_thread::yield();
+  }
+}
+
+Syncer::JobSynchronizer* Syncer::JobSynchronizerScope::operator->() {
+  return _synchronizer.get();
+}
+
+Syncer::JobSynchronizer const* Syncer::JobSynchronizerScope::operator->()
+    const {
+  return _synchronizer.get();
+}
+
+std::shared_ptr<Syncer::JobSynchronizer> Syncer::JobSynchronizerScope::clone()
+    const {
+  return _synchronizer;
 }
 
 /**

--- a/arangod/Replication/Syncer.h
+++ b/arangod/Replication/Syncer.h
@@ -64,7 +64,7 @@ class Syncer : public std::enable_shared_from_this<Syncer> {
     JobSynchronizer(JobSynchronizer const&) = delete;
     JobSynchronizer& operator=(JobSynchronizer const&) = delete;
 
-    explicit JobSynchronizer(std::shared_ptr<Syncer const> const& syncer);
+    explicit JobSynchronizer(std::shared_ptr<Syncer const> syncer);
     ~JobSynchronizer();
 
     /// @brief whether or not a response has arrived
@@ -127,6 +127,23 @@ class Syncer : public std::enable_shared_from_this<Syncer> {
 
     /// @brief number of posted jobs in flight
     uint64_t _jobsInFlight;
+  };
+
+  class JobSynchronizerScope {
+   public:
+    JobSynchronizerScope(JobSynchronizerScope const&) = delete;
+    JobSynchronizerScope& operator=(JobSynchronizerScope const&) = delete;
+
+    explicit JobSynchronizerScope(std::shared_ptr<Syncer const> syncer);
+    ~JobSynchronizerScope();
+
+    JobSynchronizer* operator->();
+    JobSynchronizer const* operator->() const;
+
+    std::shared_ptr<JobSynchronizer> clone() const;
+
+   private:
+    std::shared_ptr<JobSynchronizer> _synchronizer;
   };
 
   struct SyncerState {

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1655,7 +1655,7 @@ Result TailingSyncer::runContinuousSync() {
   // the shared status will wait in its destructor until all posted
   // requests have been completed/canceled!
   auto self = shared_from_this();
-  auto sharedStatus = std::make_shared<Syncer::JobSynchronizer>(self);
+  Syncer::JobSynchronizerScope sharedStatus(self);
 
   bool worked = false;
   bool mustFetchBatch = true;
@@ -1676,7 +1676,7 @@ Result TailingSyncer::runContinuousSync() {
     // false" to processLeaderLog requires that processLeaderLog has already
     // requested the next batch in the background on the previous invocation
     Result res = processLeaderLog(
-        sharedStatus, builder, fetchTick, lastScannedTick, fromTick,
+        sharedStatus.clone(), builder, fetchTick, lastScannedTick, fromTick,
         _state.applier._ignoreErrors, worked, mustFetchBatch);
 
     uint64_t sleepTime;
@@ -1988,10 +1988,10 @@ Result TailingSyncer::processLeaderLog(
     // do not fetch the same batch next time we enter processLeaderLog
     // (that would be duplicate work)
     mustFetchBatch = false;
-    sharedStatus->request([this, self = shared_from_this(), sharedStatus,
-                           fetchTick, lastScannedTick, firstRegularTick]() {
-      fetchLeaderLog(sharedStatus, fetchTick, lastScannedTick,
-                     firstRegularTick);
+    sharedStatus->request([self = shared_from_this(), sharedStatus, fetchTick,
+                           lastScannedTick, firstRegularTick]() {
+      std::static_pointer_cast<TailingSyncer>(self)->fetchLeaderLog(
+          sharedStatus, fetchTick, lastScannedTick, firstRegularTick);
     });
   }
 


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21044

the variable `requestPayload` was only present inside a certain block of code, and would be destroyed when leaving the code block. however, tasks could have been scheduled that still referred to this variable by reference, so the tasks referring to the variable could outlive the lifetime of the variable itself.
this is now fixed by moving the `requestPayload` variable outside of the scope, so it is guaranteed to stay valid until the very end of the scope.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 