### PR TITLE
fix data race in FollowerInfo

### DIFF
--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -176,11 +176,13 @@ class FollowerInfo {
       velocypack::Builder& builder) const;
 
  private:
+  /// @brief inject the information about "servers" and "failoverCandidates".
+  /// must be called with _dataLock locked.
   void injectFollowerInfoInternal(velocypack::Builder& builder) const;
 
   bool updateFailoverCandidates();
 
-  Result persistInAgency(bool isRemove) const;
+  Result persistInAgency(bool isRemove, bool acquireDataLock) const;
 
   velocypack::Builder newShardEntry(velocypack::Slice oldValue) const;
 };


### PR DESCRIPTION
### Scope & Purpose

fix data race in FollowerInfo

`FollowerInfo::newShardEntry()` could read instance variables without acquiring the RW lock when called from `FollowerInfo::add()`. this could lead to a situation in which a thread in `newShardEntry` reads the instance variables without synchronization, while another thread modifies the instance variables (and correctly using the RW lock in write mode when doing so).

Fixes https://circleci.com/api/v1.1/project/github/arangodb/arangodb/1993201/output/103/1?file=true&allocation-id=6669824eda09200e7e356462-1-build%2FABCDEFGH

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 