### PR TITLE
fix data race in FollowerInfo

### DIFF
--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -189,7 +189,8 @@ Result FollowerInfo::add(ServerID const& sid) {
   }
 
   // Now tell the agency
-  auto agencyRes = persistInAgency(false);
+  auto agencyRes =
+      persistInAgency(/*isRemove*/ false, /*acquireDataLock*/ true);
   if (agencyRes.ok() || agencyRes.is(TRI_ERROR_CLUSTER_NOT_LEADER)) {
     // Not a leader is expected
     return agencyRes;
@@ -201,8 +202,7 @@ Result FollowerInfo::add(ServerID const& sid) {
     agencyRes.reset(
         agencyRes.errorNumber(),
         absl::StrCat("unable to add follower in agency, timeout in agency CAS "
-                     "operation for "
-                     "key ",
+                     "operation for key ",
                      _docColl->vocbase().name(), "/", _docColl->planId().id(),
                      ": ", TRI_errno_string(agencyRes.errorNumber())));
     LOG_TOPIC("6295b", ERR, Logger::CLUSTER) << agencyRes.errorMessage();
@@ -376,7 +376,9 @@ Result FollowerInfo::remove(ServerID const& sid) {
     _failoverCandidates = v;  // will cast to std::vector<ServerID> const
   }
 
-  Result agencyRes = persistInAgency(true);
+  TRI_ASSERT(writeLocker.isLocked());
+  Result agencyRes =
+      persistInAgency(/*isRemove*/ true, /*acquireDataLock*/ false);
   if (agencyRes.ok()) {
     // +1 for the leader (me)
     if (_followers->size() + 1 < _docColl->writeConcern()) {
@@ -534,7 +536,8 @@ bool FollowerInfo::updateFailoverCandidates() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   checkDifference(*_followers, *_failoverCandidates);
 #endif
-  Result res = persistInAgency(true);
+  TRI_ASSERT(dataLocker.isLocked());
+  Result res = persistInAgency(/*isRemove*/ true, /*acquireDataLock*/ false);
   if (!res.ok()) {
     // We could not persist the update in the agency.
     // Collection left in RO mode.
@@ -551,7 +554,8 @@ bool FollowerInfo::updateFailoverCandidates() {
 }
 
 /// @brief Persist information in Current
-Result FollowerInfo::persistInAgency(bool isRemove) const {
+Result FollowerInfo::persistInAgency(bool isRemove,
+                                     bool acquireDataLock) const {
   // Now tell the agency
   TRI_ASSERT(_docColl != nullptr);
   std::string curPath = ::currentShardPath(*_docColl);
@@ -602,7 +606,7 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
           LOG_TOPIC("42231", INFO, Logger::CLUSTER)
               << ::reportName(isRemove)
               << ", did not find myself in Plan: " << _docColl->vocbase().name()
-              << "/" << std::to_string(_docColl->planId().id())
+              << "/" << _docColl->planId().id()
               << " (can happen when the leader changed recently).";
           if (!planEntry.isNone()) {
             LOG_TOPIC("ffede", INFO, Logger::CLUSTER)
@@ -610,7 +614,11 @@ Result FollowerInfo::persistInAgency(bool isRemove) const {
           }
           return {TRI_ERROR_CLUSTER_NOT_LEADER};
         } else {
-          auto newValue = newShardEntry(currentEntry);
+          VPackBuilder newValue;
+          {
+            CONDITIONAL_READ_LOCKER(readLocker, _dataLock, acquireDataLock);
+            newValue = newShardEntry(currentEntry);
+          }
           AgencyWriteTransaction trx;
           trx.preconditions.push_back(AgencyPrecondition(
               curPath, AgencyPrecondition::Type::VALUE, currentEntry));
@@ -650,7 +658,8 @@ std::pair<size_t, size_t> FollowerInfo::injectFollowerInfo(
   return std::make_pair(_followers->size(), _failoverCandidates->size());
 }
 
-/// @brief inject the information about "servers" and "failoverCandidates"
+/// @brief inject the information about "servers" and "failoverCandidates".
+/// must be called with _dataLock locked.
 void FollowerInfo::injectFollowerInfoInternal(VPackBuilder& builder) const {
   auto ourselves = ServerState::instance()->getId();
   TRI_ASSERT(builder.isOpenObject());

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -174,11 +174,13 @@ class FollowerInfo {
       velocypack::Builder& builder) const;
 
  private:
+  /// @brief inject the information about "servers" and "failoverCandidates".
+  /// must be called with _dataLock locked.
   void injectFollowerInfoInternal(velocypack::Builder& builder) const;
 
   bool updateFailoverCandidates();
 
-  Result persistInAgency(bool isRemove) const;
+  Result persistInAgency(bool isRemove, bool acquireDataLock) const;
 
   velocypack::Builder newShardEntry(velocypack::Slice oldValue) const;
 };


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21047

fix data race in FollowerInfo

`FollowerInfo::newShardEntry()` could read instance variables without acquiring the RW lock when called from `FollowerInfo::add()`. this could lead to a situation in which a thread in `newShardEntry` reads the instance variables without synchronization, while another thread modifies the instance variables (and correctly using the RW lock in write mode when doing so).

Fixes https://circleci.com/api/v1.1/project/github/arangodb/arangodb/1993201/output/103/1?file=true&allocation-id=6669824eda09200e7e356462-1-build%2FABCDEFGH

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 