### PR TITLE
Make sure we always report crash output

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -518,7 +518,7 @@ function unitTestPrettyPrintResults (options, results) {
     color = RED;
     statusMessage = 'Fail';
   }
-  if (results.crashed === true || cu.GDB_OUTPUT !== '') {
+  if (results.crashed === true) {
     color = RED;
     for (let failed in failedRuns) {
       crashedText += ' [' + failed + '] : ' + failedRuns[failed].replace(/^/mg, '    ');
@@ -1038,12 +1038,14 @@ function processCrashReport(result) {
       status: false,
       failed: 1,
     };
+    result.status = false;
+    result.crashed = true;
   }
 }
 
 function writeReports(options, results) {
-  fs.write(fs.join(options.testOutputDirectory, 'UNITTEST_RESULT_EXECUTIVE_SUMMARY.json'), String(results.status && cu.GDB_OUTPUT === ''), true);
-  fs.write(fs.join(options.testOutputDirectory, 'UNITTEST_RESULT_CRASHED.json'), String(results.crashed || cu.GDB_OUTPUT !== ''), true);
+  fs.write(fs.join(options.testOutputDirectory, 'UNITTEST_RESULT_EXECUTIVE_SUMMARY.json'), String(results.status), true);
+  fs.write(fs.join(options.testOutputDirectory, 'UNITTEST_RESULT_CRASHED.json'), String(results.crashed), true);
 }
 
 function dumpAllResults(options, results) {

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -1022,6 +1022,25 @@ function writeDefaultReports(options, testSuites) {
 
 }
 
+function processCrashReport(result) {
+  if (cu.GDB_OUTPUT !== '') {
+    result['crashreport'] = cu.GDB_OUTPUT;
+    result['crash'] = {
+      crash_report: {
+        status: false,
+        failed: 1,
+        all: {
+          status: false,
+          failed: 1,
+          message: (result.crashed ? "SUT crashed: \n": "SUT was aborted: \n") + cu.GDB_OUTPUT
+        }
+      },
+      status: false,
+      failed: 1,
+    };
+  }
+}
+
 function writeReports(options, results) {
   fs.write(fs.join(options.testOutputDirectory, 'UNITTEST_RESULT_EXECUTIVE_SUMMARY.json'), String(results.status && cu.GDB_OUTPUT === ''), true);
   fs.write(fs.join(options.testOutputDirectory, 'UNITTEST_RESULT_CRASHED.json'), String(results.crashed || cu.GDB_OUTPUT !== ''), true);
@@ -1120,6 +1139,7 @@ exports.gatherStatus = gatherStatus;
 exports.gatherFailed = gatherFailed;
 exports.yamlDumpResults = yamlDumpResults;
 exports.addFailRunsMessage = addFailRunsMessage;
+exports.processCrashReport = processCrashReport;
 exports.dumpAllResults = dumpAllResults;
 exports.writeDefaultReports = writeDefaultReports;
 exports.writeReports = writeReports;

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -276,22 +276,6 @@ function saveToJunitXML(options, results) {
   };
   let prefix = (options.cluster ? 'CL_' : '') + (pu.isEnterpriseClient ? 'EE_' : 'CE_');
 
-  if (results.hasOwnProperty('crashreport')) {
-    results['crash'] = {
-      crash_report: {
-        status: false,
-        failed: 1,
-        all: {
-          status: false,
-          failed: 1,
-          message: ((results.crashed)? "SUT crashed: \n": "SUT was aborted: \n") +results.crashreport
-        }
-      },
-      status: false,
-      failed: 1,
-    };
-  }
-
   const addOptionalDuration = (elem, test) => {
     if (test.hasOwnProperty('duration') && test.duration !== undefined) {
       // time is in seconds
@@ -1047,9 +1031,6 @@ function dumpAllResults(options, results) {
   let j;
 
   try {
-    if (cu.GDB_OUTPUT !== '') {
-      results['crashreport'] = cu.GDB_OUTPUT;
-    }
     j = JSON.stringify(results);
   } catch (err) {
     j = inspect(results);

--- a/js/client/modules/@arangodb/testutils/unittest.js
+++ b/js/client/modules/@arangodb/testutils/unittest.js
@@ -129,22 +129,7 @@ function main (argv) {
 
   killRemainingProcesses(result);
 
-  if (cu.GDB_OUTPUT !== '') {
-    result['crashreport'] = cu.GDB_OUTPUT;
-    result['crash'] = {
-      crash_report: {
-        status: false,
-        failed: 1,
-        all: {
-          status: false,
-          failed: 1,
-          message: (result.crashed ? "SUT crashed: \n": "SUT was aborted: \n") + cu.GDB_OUTPUT
-        }
-      },
-      status: false,
-      failed: 1,
-    };
-  }
+  rp.processCrashReport(result);
 
   try {
     rp.writeReports(options, result);

--- a/js/client/modules/@arangodb/testutils/unittest.js
+++ b/js/client/modules/@arangodb/testutils/unittest.js
@@ -150,7 +150,7 @@ function main (argv) {
   }
 
   rp.analyze.unitTestPrettyPrintResults(options, result);
-  return result.status && cu.GDB_OUTPUT === '';
+  return result.status;
 }
 
 let result = main(ARGUMENTS);

--- a/js/client/modules/@arangodb/testutils/unittest.js
+++ b/js/client/modules/@arangodb/testutils/unittest.js
@@ -129,6 +129,23 @@ function main (argv) {
 
   killRemainingProcesses(result);
 
+  if (cu.GDB_OUTPUT !== '') {
+    result['crashreport'] = cu.GDB_OUTPUT;
+    result['crash'] = {
+      crash_report: {
+        status: false,
+        failed: 1,
+        all: {
+          status: false,
+          failed: 1,
+          message: (result.crashed ? "SUT crashed: \n": "SUT was aborted: \n") + cu.GDB_OUTPUT
+        }
+      },
+      status: false,
+      failed: 1,
+    };
+  }
+
   try {
     rp.writeReports(options, result);
   } catch (x) {


### PR DESCRIPTION
### Scope & Purpose

Previously some details like sanitizer reports were only printed when `writeXmlReport` was set to true, which was confusing, especially when running sanitizer tests locally.