### PR TITLE
Fix shutdown of partially started server

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -612,9 +612,9 @@ void ClusterFeature::prepare() {
     FATAL_ERROR_EXIT();
   }
 
-  if (_agencyCache == nullptr || _clusterInfo == nullptr) {
-    allocateMembers();
-  }
+  TRI_ASSERT(_agencyCache == nullptr);
+  TRI_ASSERT(_clusterInfo == nullptr);
+  allocateMembers();
 
   if (ServerState::instance()->isAgent() || _enableCluster) {
     AuthenticationFeature* af = AuthenticationFeature::instance();
@@ -680,18 +680,6 @@ void ClusterFeature::prepare() {
   }
 
   // This must remain here for proper function after hot restores
-  auto role = ServerState::instance()->getRole();
-  if (role != ServerState::ROLE_AGENT && role != ServerState::ROLE_UNDEFINED) {
-    if (!_agencyCache->start()) {
-      LOG_TOPIC("4680e", FATAL, Logger::CLUSTER)
-          << "unable to start agency cache thread";
-      FATAL_ERROR_EXIT();
-    }
-
-    LOG_TOPIC("bae31", DEBUG, Logger::CLUSTER)
-        << "Waiting for agency cache to become ready.";
-  }
-
   if (!ServerState::instance()->integrateIntoCluster(
           _requestedRole, _myEndpoint, _myAdvertisedEndpoint)) {
     LOG_TOPIC("fea1e", FATAL, Logger::STARTUP)
@@ -701,6 +689,7 @@ void ClusterFeature::prepare() {
 
   auto endpoints = AsyncAgencyCommManager::INSTANCE->endpoints();
 
+  auto role = ServerState::instance()->getRole();
   if (role == ServerState::ROLE_UNDEFINED) {
     // no role found
     LOG_TOPIC("613f4", FATAL, arangodb::Logger::CLUSTER)
@@ -746,6 +735,7 @@ void ClusterFeature::start() {
   }
 
   auto role = ServerState::instance()->getRole();
+  TRI_ASSERT(role != ServerState::ROLE_UNDEFINED);
 
   // We need to wait for any cluster operation, which needs access to the
   // agency cache for it to become ready. The essentials in the cluster, namely
@@ -754,6 +744,15 @@ void ClusterFeature::start() {
   // empty agency. There are also other measures that guard against such a
   // outcome. But there is also no point continuing with a first agency poll.
   if (role != ServerState::ROLE_AGENT && role != ServerState::ROLE_UNDEFINED) {
+    if (!_agencyCache->start()) {
+      LOG_TOPIC("4680e", FATAL, Logger::CLUSTER)
+          << "unable to start agency cache thread";
+      FATAL_ERROR_EXIT();
+    }
+
+    LOG_TOPIC("bae31", DEBUG, Logger::CLUSTER)
+        << "Waiting for agency cache to become ready.";
+
     _agencyCache->waitFor(1).waitAndGet();
     LOG_TOPIC("13eab", DEBUG, Logger::CLUSTER)
         << "Agency cache is ready. Starting cluster cache syncers";
@@ -836,6 +835,7 @@ void ClusterFeature::start() {
       << (_myAdvertisedEndpoint.empty() ? "-" : _myAdvertisedEndpoint)
       << ", role: " << ServerState::roleToString(role);
 
+  TRI_ASSERT(_agencyCache);
   auto [acb, idx] = _agencyCache->read(std::vector<std::string>{
       AgencyCommHelper::path("Sync/HeartbeatIntervalMs")});
   auto result = acb->slice();
@@ -982,6 +982,7 @@ void ClusterFeature::unprepare() {
       _asyncAgencyCommPool->stop();
     }
   }
+  _agencyCache.reset();
 }
 
 void ClusterFeature::shutdown() try {

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -683,7 +683,6 @@ void ClusterFeature::prepare() {
     FATAL_ERROR_EXIT();
   }
 
-  // This must remain here for proper function after hot restores
   if (!ServerState::instance()->integrateIntoCluster(
           _requestedRole, _myEndpoint, _myAdvertisedEndpoint)) {
     LOG_TOPIC("fea1e", FATAL, Logger::STARTUP)

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -612,9 +612,13 @@ void ClusterFeature::prepare() {
     FATAL_ERROR_EXIT();
   }
 
-  TRI_ASSERT(_agencyCache == nullptr);
-  TRI_ASSERT(_clusterInfo == nullptr);
-  allocateMembers();
+  // in the unit tests we have situations where prepare is called on an already
+  // prepared feature
+  if (_agencyCache == nullptr || _clusterInfo == nullptr) {
+    TRI_ASSERT(_agencyCache == nullptr);
+    TRI_ASSERT(_clusterInfo == nullptr);
+    allocateMembers();
+  }
 
   if (ServerState::instance()->isAgent() || _enableCluster) {
     AuthenticationFeature* af = AuthenticationFeature::instance();

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -713,10 +713,11 @@ void ApplicationServer::start() {
             feature.stop();
             feature.state(ApplicationFeature::State::STOPPED);
           } catch (...) {
-            // ignore errors on shutdown
-            LOG_TOPIC("13223", TRACE, Logger::STARTUP)
+            // if something goes wrong, we simply rethrow to abort!
+            LOG_TOPIC("13223", FATAL, Logger::STARTUP)
                 << "caught exception while stopping feature '" << feature.name()
                 << "'";
+            throw;
           }
         }
       }
@@ -725,18 +726,22 @@ void ApplicationServer::start() {
       for (auto it = _orderedFeatures.rbegin(); it != _orderedFeatures.rend();
            ++it) {
         ApplicationFeature& feature = *it;
-        if (feature.state() == ApplicationFeature::State::STOPPED) {
-          LOG_TOPIC("6ba4f", TRACE, Logger::STARTUP)
-              << "forcefully unpreparing feature '" << feature.name() << "'";
-          try {
-            feature.unprepare();
-            feature.state(ApplicationFeature::State::UNPREPARED);
-          } catch (...) {
-            // ignore errors on shutdown
-            LOG_TOPIC("7d68f", TRACE, Logger::STARTUP)
-                << "caught exception while unpreparing feature '"
-                << feature.name() << "'";
-          }
+        ADB_PROD_ASSERT(feature.state() == ApplicationFeature::State::STOPPED ||
+                        feature.state() == ApplicationFeature::State::PREPARED)
+            << "feature " << feature.name() << " is in state "
+            << (int)feature.state();
+
+        LOG_TOPIC("6ba4f", TRACE, Logger::STARTUP)
+            << "forcefully unpreparing feature '" << feature.name() << "'";
+        try {
+          feature.unprepare();
+          feature.state(ApplicationFeature::State::UNPREPARED);
+        } catch (...) {
+          // if something goes wrong, we simply rethrow to abort!
+          LOG_TOPIC("7d68f", FATAL, Logger::STARTUP)
+              << "caught exception while unpreparing feature '"
+              << feature.name() << "'";
+          throw;
         }
       }
       shutdownFatalError();


### PR DESCRIPTION
### Scope & Purpose

Previously when a feature returned an error during the startup phase we would shut down all started features, but also only unprepare those started features. Features that were prepared but not yet started would not be unprepared.

In the ClusterFeature we would create and start the AgencyCache thread during prepare. In a test scenario we cancel the start before we call ClusterFeature::start, so previously this feature would neither be stopped or unprepared. Thus the AgencyCache thread would keep running and potentially access data and features that are getting cleaned up during the shutdown.

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*
