### PR TITLE
Add --build parameter to test launcher

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -483,8 +483,7 @@ jobs:
             python3 -u scripts/test/test_launch_controller.py << parameters.suites >> \
               --testBuckets $CIRCLE_NODE_TOTAL/$CIRCLE_NODE_INDEX \
               --cluster << parameters.cluster >> \
-              --extraArgs " << parameters.extraArgs >>" \
-              --definition tests/test-definitions.txt
+              --extraArgs " << parameters.extraArgs >>"
       - run:
           name: Copy test results
           when: always

--- a/scripts/test/arangosh.py
+++ b/scripts/test/arangosh.py
@@ -94,6 +94,8 @@ class ArangoshExecutor(ArangoCLIprogressiveTimeoutExecutor):
                 # ATM CircleCI does not support to attach debuggers, so we generate core dumps instead
                 "--coreAbort",
                 "true",
+                "--build",
+                self.cfg.build_dir,
             ]
             + self.get_memory_limit_arg()
             + testing_args

--- a/scripts/test/launch_handler.py
+++ b/scripts/test/launch_handler.py
@@ -6,29 +6,7 @@ import sys
 import time
 from threading import Thread
 from traceback import print_exc
-
-from site_config import SiteConfig
-from testing_runner import TestingRunner
 from dmesg import DmesgWatcher, dmesg_runner
-
-
-# pylint: disable=broad-except
-def launch(args, tests):
-    """Manage test execution on our own"""
-    runner = None
-    try:
-        runner = TestingRunner(SiteConfig(Path(args.definitions).resolve()))
-        for test in tests:
-            runner.register_test_func(test)
-        runner.sort_by_priority()
-    except Exception as exc:
-        logging.exception("exception in launch")
-        raise exc
-    create_report = True
-    if args.no_report:
-        logging.info("won't generate report as you demanded!")
-        create_report = False
-    launch_runner(runner, create_report)
 
 
 def launch_runner(runner, create_report):

--- a/scripts/test/site_config.py
+++ b/scripts/test/site_config.py
@@ -80,7 +80,7 @@ class SiteConfig:
     """this environment - adapted to oskar defaults"""
 
     # pylint: disable=too-few-public-methods disable=too-many-instance-attributes
-    def __init__(self, definition_file):
+    def __init__(self, base_source_dir, build_dir):
         # pylint: disable=too-many-statements disable=too-many-branches
         self.datetime_format = "%Y-%m-%dT%H%M%SZ"
         self.trace = False
@@ -142,12 +142,7 @@ class SiteConfig:
             self.max_load /= 2
         self.deadline = datetime.now() + timedelta(seconds=self.timeout)
         self.hard_deadline = datetime.now() + timedelta(seconds=self.timeout + 660)
-        if definition_file.is_file():
-            definition_file = definition_file.parent
-        # base_source_dir = (definition_file / '..').resolve()
-        # TODO - find a better solution
-        base_source_dir = Path(".").resolve()
-        bin_dir = (base_source_dir / "build" / "bin").resolve()
+        bin_dir = (build_dir / "bin").resolve()
         socket_count = "was not allowed to see socket counts!"
         try:
             socket_count = str(get_socket_count())
@@ -173,6 +168,7 @@ class SiteConfig:
 {san_gcov_msg}"""
         )
         self.cfgdir = base_source_dir / "etc" / "testing"
+        self.build_dir = build_dir
         self.bin_dir = bin_dir
         self.base_path = base_source_dir
         self.test_data_dir = base_source_dir

--- a/scripts/test/test_launch_controller.py
+++ b/scripts/test/test_launch_controller.py
@@ -48,9 +48,7 @@ def parse_arguments():
     )
     parser.add_argument("--extraArgs", help="", type=str)
     parser.add_argument("--suffix", help="", type=str)
-    parser.add_argument(
-        "--definitions", help="path to the test definitions file", type=str
-    )
+    parser.add_argument("--build", help="build folder", type=str)
     return parser.parse_args()
 
 
@@ -67,7 +65,13 @@ def main():
         if args.cluster:
             extra_args += ["--cluster", "true", "--dumpAgencyOnError", "true"]
         extra_args += ["--testBuckets", args.testBuckets]
-        runner = TestingRunner(SiteConfig(Path(args.definitions).resolve()))
+        base_source_dir = Path(".").resolve()
+        build_dir = (
+            Path(args.build).resolve()
+            if args.build is not None
+            else base_source_dir / "build"
+        )
+        runner = TestingRunner(SiteConfig(base_source_dir, build_dir))
         runner.scenarios.append(
             TestConfig(runner.cfg, name, suite, [*extra_args], 1, 1, [])
         )


### PR DESCRIPTION
### Scope & Purpose

This allows specifying the build directory to be used. By default we just use the local "build" folder. The specified build folder is also forwarded to testing.js.
This PR also removes the unused `--definitions` parameter.