### PR TITLE
Try to speed up arangodump with few shards

### DIFF
--- a/arangod/RocksDBEngine/RocksDBDumpContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.cpp
@@ -267,11 +267,12 @@ RocksDBDumpContext::RocksDBDumpContext(RocksDBEngine& engine,
             // only dealing with a single shard:
             std::uint64_t batchSize = (max - min) / _options.parallelism + 1;
             std::uint64_t pos = min;
-            LOG_DEVEL << "Hacking range " << min << " .. " << max
-                      << " to pieces...";
+            LOG_TOPIC("22222", INFO, Logger::DUMP)
+                << "Hacking range " << min << " .. " << max << " to pieces...";
             while (pos < max) {
-              LOG_DEVEL << "Piece: " << pos << " .. "
-                        << std::min(pos + batchSize, max);
+              LOG_TOPIC("33333", INFO, Logger::DUMP)
+                  << "Piece: " << pos << " .. "
+                  << std::min(pos + batchSize, max);
               _workItems.push({ci, pos, std::min(pos + batchSize, max)});
               pos += batchSize;
             }

--- a/arangod/RocksDBEngine/RocksDBDumpManager.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpManager.cpp
@@ -81,6 +81,8 @@ std::shared_ptr<RocksDBDumpContext> RocksDBDumpManager::createContext(
                               _limits.batchSizeUpperBound);
   opts.parallelism = std::clamp(opts.parallelism, _limits.parallelismLowerBound,
                                 _limits.parallelismUpperBound);
+  LOG_TOPIC("11111", INFO, Logger::DUMP)
+      << "Using parallelism: " << opts.parallelism;
 
   // If the local RocksDB database still uses little endian key encoding,
   // then the whole new dump method does not work, since ranges in _revs


### PR DESCRIPTION
### Scope & Purpose

This is an experiment.

We try to speed up arangodump by splitting larger workitems into smaller
ones allowing for more parallelism in case only few shards are dumped.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
