### PR TITLE
BTS-1893: make sure environment variable names are unique

### DIFF
--- a/lib/Basics/process-utils.cpp
+++ b/lib/Basics/process-utils.cpp
@@ -38,9 +38,6 @@
 #include <absl/strings/str_cat.h>
 
 #include "process-utils.h"
-#include "signals.h"
-#include "Basics/ScopeGuard.h"
-#include "Basics/system-functions.h"
 
 #if defined(TRI_HAVE_MACOS_MEM_STATS)
 #include <sys/sysctl.h>
@@ -76,18 +73,25 @@
 
 #include "Basics/NumberUtils.h"
 #include "Basics/PageSize.h"
+#include "Basics/ScopeGuard.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Thread.h"
 #include "Basics/debugging.h"
 #include "Basics/error.h"
+#include "Basics/files.h"
 #include "Basics/memory.h"
 #include "Basics/operating-system.h"
+#include "Basics/signals.h"
+#include "Basics/system-functions.h"
 #include "Basics/tri-strings.h"
 #include "Basics/voc-errors.h"
-#include "Basics/files.h"
+#include "Containers/FlatHashMap.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+
+#include <algorithm>
+#include <string_view>
 
 using namespace arangodb;
 
@@ -301,15 +305,49 @@ static void StartExternalProcessPosixSpawn(
     return;
   }
 
+  auto extractName = [](char const* value) noexcept {
+    std::string_view v;
+    if (value != nullptr) {
+      v = value;
+      if (auto pos = v.find('='); pos != std::string_view::npos) {
+        v = v.substr(0, pos);
+      }
+    }
+    return v;
+  };
+
+  // note the position in the envs vector for every unique environment variable.
+  // we do this to make the passed environment variables unique, e.g. in case
+  // the original env contains a setting with is later overriden by
+  // additionalEnv. in this case we want additionalEnv to win.
+  containers::FlatHashMap<std::string_view, size_t> positions;
+
   std::vector<char*> envs;
   for (char** e = environ; *e != nullptr; ++e) {
+    positions.insert_or_assign(extractName(*e), envs.size());
     envs.push_back(*e);
   }
 
   envs.reserve(envs.size() + additionalEnv.size() + 1);
-  std::transform(
-      additionalEnv.begin(), additionalEnv.end(), std::back_inserter(envs),
-      [](auto& str) -> char* { return const_cast<char*>(str.data()); });
+  for (auto const& e : additionalEnv) {
+    auto name = extractName(e.data());
+    if (auto it = positions.find(name); it != positions.end()) {
+      // environment variable already set. now update it
+      envs[it->second] = const_cast<char*>(e.data());
+    } else {
+      // new environment variable
+      positions.emplace(name, envs.size());
+      envs.push_back(const_cast<char*>(e.data()));
+    }
+  }
+
+  TRI_ASSERT(std::unique(envs.begin(), envs.end(),
+                         [&](char const* lhs, char const* rhs) {
+                           return extractName(lhs) == extractName(rhs);
+                         }) == envs.end());
+
+  // terminate the array with a null pointer entry. this is required for
+  // posix_spawnp
   envs.emplace_back(nullptr);
 
   int result = posix_spawnp(&external->_pid, external->_executable.c_str(),


### PR DESCRIPTION
### Scope & Purpose

make sure environment variable names are unique

when starting an external process, we pass a list of environment variables to the system call that starts the process. the names of environment variables are not guaranteed to be unique, so when an environment variable is specified multiple times, it is not guaranteed that the last occurrence wins. this is problematic in case we pass additional environment variables to the process, which should always win over whatever settings were originally in the environment.

note that this assumes that there should not be multiple mentions of the same environment variable, e.g. `USER=foo USER=bar`. this is technically valid, and up to now, the 2 values would be passed to the new process. with this change, we will only pass a single value to the new process, which is the last occurrence (i.e. `bar` in this case).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 