### PR TITLE
clean up a few code parts

### DIFF
--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -1474,7 +1474,7 @@ ExecutionNode::getVariableIdsUsedHere() const {
 
 bool ExecutionNode::setsVariable(VarSet const& which) const {
   for (auto const& v : getVariablesSetHere()) {
-    if (which.find(v) != which.end()) {
+    if (which.contains(v)) {
       return true;
     }
   }

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
@@ -307,7 +307,7 @@ ShortestPathNode::_buildOutputRegisters() const {
   return std::make_pair(outputRegisters, outputRegisterMapping);
 };
 
-RegIdSet ShortestPathNode::_buildVariableInformation() const {
+RegIdSet ShortestPathNode::buildVariableInformation() const {
   auto inputRegisters = RegIdSet();
   auto& varInfo = getRegisterPlan()->varInfo;
   if (usesStartInVariable()) {
@@ -329,7 +329,7 @@ RegIdSet ShortestPathNode::_buildVariableInformation() const {
 // 3. or ClusterProvider<ClusterProviderStep>
 
 template<typename ShortestPath, typename Provider, typename ProviderOptions>
-std::unique_ptr<ExecutionBlock> ShortestPathNode::_makeExecutionBlockImpl(
+std::unique_ptr<ExecutionBlock> ShortestPathNode::makeExecutionBlockImpl(
     ShortestPathOptions* opts, ProviderOptions forwardProviderOptions,
     ProviderOptions backwardProviderOptions,
     arangodb::graph::TwoSidedEnumeratorOptions enumeratorOptions,
@@ -361,7 +361,7 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
     ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
-  auto inputRegisters = _buildVariableInformation();
+  auto inputRegisters = buildVariableInformation();
 
   auto opts = static_cast<ShortestPathOptions*>(options());
 
@@ -453,25 +453,25 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
             _buildOutputRegisters<WeightedShortestPath>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return _makeExecutionBlockImpl<WeightedShortestPathEnumerator<Provider>,
-                                       Provider,
-                                       SingleServerBaseProviderOptions>(
+        return makeExecutionBlockImpl<WeightedShortestPathEnumerator<Provider>,
+                                      Provider,
+                                      SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
-            sourceInput, targetInput, registerInfos);
+            sourceInput, targetInput, std::move(registerInfos));
       } else {
         auto [outputRegisters, outputRegisterMapping] =
             _buildOutputRegisters<ShortestPath>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return _makeExecutionBlockImpl<ShortestPathEnumerator<Provider>,
-                                       Provider,
-                                       SingleServerBaseProviderOptions>(
+        return makeExecutionBlockImpl<ShortestPathEnumerator<Provider>,
+                                      Provider,
+                                      SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
-            sourceInput, targetInput, registerInfos);
+            sourceInput, targetInput, std::move(registerInfos));
       }
     } else {
       // SingleServer Tracing enabled
@@ -480,25 +480,25 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
             _buildOutputRegisters<WeightedShortestPathTracer>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return _makeExecutionBlockImpl<
+        return makeExecutionBlockImpl<
             TracedWeightedShortestPathEnumerator<Provider>,
             ProviderTracer<Provider>, SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
-            sourceInput, targetInput, registerInfos);
+            sourceInput, targetInput, std::move(registerInfos));
       } else {
         auto [outputRegisters, outputRegisterMapping] =
             _buildOutputRegisters<ShortestPathTracer>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return _makeExecutionBlockImpl<TracedShortestPathEnumerator<Provider>,
-                                       ProviderTracer<Provider>,
-                                       SingleServerBaseProviderOptions>(
+        return makeExecutionBlockImpl<TracedShortestPathEnumerator<Provider>,
+                                      ProviderTracer<Provider>,
+                                      SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
-            sourceInput, targetInput, registerInfos);
+            sourceInput, targetInput, std::move(registerInfos));
       }
     }
   } else {
@@ -522,25 +522,25 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
             _buildOutputRegisters<WeightedShortestPathCluster>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return _makeExecutionBlockImpl<
+        return makeExecutionBlockImpl<
             WeightedShortestPathEnumerator<ClusterProvider>, ClusterProvider,
             ClusterBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
-            sourceInput, targetInput, registerInfos);
+            sourceInput, targetInput, std::move(registerInfos));
       } else {
         auto [outputRegisters, outputRegisterMapping] =
             _buildOutputRegisters<ShortestPathCluster>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return _makeExecutionBlockImpl<ShortestPathEnumerator<ClusterProvider>,
-                                       ClusterProvider,
-                                       ClusterBaseProviderOptions>(
+        return makeExecutionBlockImpl<ShortestPathEnumerator<ClusterProvider>,
+                                      ClusterProvider,
+                                      ClusterBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
-            sourceInput, targetInput, registerInfos);
+            sourceInput, targetInput, std::move(registerInfos));
       }
     } else {
       auto [outputRegisters, outputRegisterMapping] =
@@ -548,13 +548,13 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
       auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                std::move(outputRegisters));
 
-      return _makeExecutionBlockImpl<
+      return makeExecutionBlockImpl<
           TracedShortestPathEnumerator<ClusterProvider>,
           ProviderTracer<ClusterProvider>, ClusterBaseProviderOptions>(
           opts, std::move(forwardProviderOptions),
           std::move(backwardProviderOptions), enumeratorOptions,
           validatorOptions, std::move(outputRegisterMapping), engine,
-          sourceInput, targetInput, registerInfos);
+          sourceInput, targetInput, std::move(registerInfos));
     }
   }
   TRI_ASSERT(false);

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.h
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.h
@@ -170,7 +170,7 @@ class ShortestPathNode : public virtual GraphNode {
   /// DBServer cannot map the Vertex to its shard.
   Variable const* _distributeVariable;
 
-  RegIdSet _buildVariableInformation() const;
+  RegIdSet buildVariableInformation() const;
 
   template<typename ShortestPathEnumeratorType>
   std::pair<RegIdSet, typename ShortestPathExecutorInfos<
@@ -179,7 +179,7 @@ class ShortestPathNode : public virtual GraphNode {
 
   template<typename ShortestPathRefactored, typename Provider,
            typename ProviderOptions>
-  std::unique_ptr<ExecutionBlock> _makeExecutionBlockImpl(
+  std::unique_ptr<ExecutionBlock> makeExecutionBlockImpl(
       graph::ShortestPathOptions* opts, ProviderOptions forwardProviderOptions,
       ProviderOptions backwardProviderOptions,
       arangodb::graph::TwoSidedEnumeratorOptions enumeratorOptions,

--- a/arangod/Aql/ExecutionNode/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/SubqueryEndExecutionNode.cpp
@@ -98,7 +98,8 @@ std::unique_ptr<ExecutionBlock> SubqueryEndNode::createBlock(
 
   auto const& vpackOptions = engine.getQuery().vpackOptions();
   auto executorInfos = SubqueryEndExecutorInfos(
-      &vpackOptions, engine.getQuery().resourceMonitor(), inReg, outReg);
+      &vpackOptions, engine.getQuery().resourceMonitor(), std::move(inReg),
+      std::move(outReg));
 
   return std::make_unique<ExecutionBlockImpl<SubqueryEndExecutor>>(
       &engine, this, std::move(registerInfos), std::move(executorInfos));

--- a/arangod/Aql/ExecutionNode/SubqueryStartExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/SubqueryStartExecutionNode.cpp
@@ -35,8 +35,7 @@
 
 #include <velocypack/Iterator.h>
 
-namespace arangodb {
-namespace aql {
+namespace arangodb::aql {
 
 SubqueryStartNode::SubqueryStartNode(ExecutionPlan* plan,
                                      arangodb::velocypack::Slice const& base)
@@ -74,14 +73,11 @@ std::unique_ptr<ExecutionBlock> SubqueryStartNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  auto inputRegisters = std::make_shared<std::unordered_set<RegisterId>>();
-  auto outputRegisters = std::make_shared<std::unordered_set<RegisterId>>();
-
   auto registerInfos = createRegisterInfos({}, {});
 
   // On purpose exclude the _subqueryOutVariable
   return std::make_unique<ExecutionBlockImpl<SubqueryStartExecutor>>(
-      &engine, this, registerInfos, registerInfos);
+      &engine, this, registerInfos, std::move(registerInfos));
 }
 
 ExecutionNode* SubqueryStartNode::clone(ExecutionPlan* plan,
@@ -101,5 +97,4 @@ bool SubqueryStartNode::isEqualTo(ExecutionNode const& other) const {
 
 size_t SubqueryStartNode::getMemoryUsedBytes() const { return sizeof(*this); }
 
-}  // namespace aql
-}  // namespace arangodb
+}  // namespace arangodb::aql

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -1003,8 +1003,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     if (isSmart() && !isDisjoint()) {
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
-                         outputRegisterMapping, inputRegister, registerInfos,
-                         engines(), true /*isSmart*/);
+                         outputRegisterMapping, inputRegister,
+                         std::move(registerInfos), engines(), true /*isSmart*/);
 
     } else {
 #endif
@@ -1013,8 +1013,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
        */
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
-                         outputRegisterMapping, inputRegister, registerInfos,
-                         engines());
+                         outputRegisterMapping, inputRegister,
+                         std::move(registerInfos), engines());
 
 #ifdef USE_ENTERPRISE
     }
@@ -1034,8 +1034,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
 
   return createBlock(engine, std::move(filterConditionVariables),
                      checkPruneAvailability, checkPostFilterAvailability,
-                     outputRegisterMapping, inputRegister, registerInfos,
-                     nullptr);
+                     outputRegisterMapping, inputRegister,
+                     std::move(registerInfos), nullptr);
 }
 
 /// @brief clone ExecutionNode recursively

--- a/arangod/Aql/Executor/SubqueryStartExecutor.cpp
+++ b/arangod/Aql/Executor/SubqueryStartExecutor.cpp
@@ -28,8 +28,6 @@
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/Stats.h"
 
-#include "Logger/LogMacros.h"
-
 using namespace arangodb;
 using namespace arangodb::aql;
 


### PR DESCRIPTION
### Scope & Purpose

Clean up a few code parts:
- remove a few unused variables
- prefer container.contains() over container.find() != container.end()
- remove leading underscore for private method names
- use std::move() in several more cases

All changes done by this PR should be internal and not change the behavior of any existing functionality.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
