### PR TITLE
fix errors when restoring debug dumps

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -2645,6 +2645,8 @@ function inspectDump(filename, outfile) {
         if (details.properties.isSmart) {
           delete details.properties.numberOfShards;
         }
+        delete details.properties.objectId;
+        delete details.properties.statusString;
         print("db._createEdgeCollection(" + JSON.stringify(collection) + ", " + JSON.stringify(details.properties) + ");");
       } else {
         print("db._create(" + JSON.stringify(collection) + ", " + JSON.stringify(details.properties) + ");");


### PR DESCRIPTION
### Scope & Purpose

Fix errors when restoring debug dumps

the collection creation API changed in 3.12 and now complains about invalid attributes that are specified upon collection creation.

for example, when restoring 3.11 debug dumps into 3.12, there can be error messages logged as follows:

ERROR [ee638] {deprecation} The createCollection request contains an illegal combination and will be rejected in the future: {"errorNum":10,"errorMessage":"Found unexpected attribute 'objectId'"}

this PR removes a few invalid attributes from the debug dump, so that they will not be used when creating the collection from the dump.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 