### PR TITLE
fix AQL query explainer for MaterializeNode

### DIFF
--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -2048,10 +2048,14 @@ function processQuery(query, explain, planIndex) {
           }
         }
         let varString = '';
-        if (node.outVariable.id !== node.oldDocVariable.id) {
-          varString = variableName(node.oldDocVariable) + ' ' + keyword('INTO') + ' ' + variableName(node.outVariable);
+        if (node.hasOwnProperty('oldDocVariable')) {
+          if (node.outVariable.id !== node.oldDocVariable.id) {
+            varString = variableName(node.oldDocVariable) + ' ' + keyword('INTO') + ' ' + variableName(node.outVariable);
+          } else {
+            varString = variableName(node.oldDocVariable);
+          }
         } else {
-          varString = variableName(node.oldDocVariable);
+          varString = variableName(node.outVariable);
         }
         return keyword('MATERIALIZE') + ' ' + varString + (annotations.length > 0 ? annotation(` /*${annotations} */`) : '') + accessString;
       case 'OffsetMaterializeNode':


### PR DESCRIPTION
### Scope & Purpose

fix AQL query explainer for MaterializeNode

MaterializeNodes got additional properties in 3.12 and higher, but they are not present in 3.11 yet. When restoring data from a 3.11 debug dump, these properties were not present, so the explainer would with an exception when trying to explain 3.11 queries.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 