### PR TITLE
FE-454: Fix saving document in "Tree" mode 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* FE-454: Fix saving document in "Tree" mode.
+
 * FE-310: Query editor in web UI can now be resized vertically.
 
 

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/documentView.js
@@ -409,7 +409,9 @@
     },
 
     saveDocument: function () {
-      this.editor.repair();
+      if (this.editor.repair) {
+        this.editor.repair();
+      }
       if ($('#saveDocumentButton').attr('disabled') === undefined) {
         if (this.collection.first().attributes._id.substr(0, 1) === '_') {
           var buttons = []; var tableContent = [];


### PR DESCRIPTION
### Scope & Purpose

Fixes a regression caused in https://github.com/arangodb/arangodb/pull/20894, where the JSON editor was not saving in "tree" mode

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested
- [x] Backports
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21070

#### Related Information


- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-454

