### PR TITLE
Wait for ClusterInfo to catch up after collection creation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fixed a bug where accessing a collection right after creation can sometimes
+  fail.
+
 * FE-454: Fix saving document in "Tree" mode.
 
 * FE-310: Query editor in web UI can now be resized vertically.

--- a/tests/js/client/shell/shell-cluster-collection.js
+++ b/tests/js/client/shell/shell-cluster-collection.js
@@ -989,6 +989,47 @@ function ClusterCollectionSuite () {
       }
     },
 
+    // regression test for https://github.com/arangodb/arangodb/pull/21071
+    testCreateWithSlowCurrentUpdate : function () {
+      let setFailAt;
+      let removeFailAt;
+      if (isServer) {
+        if (internal.debugCanUseFailAt()) {
+          setFailAt = internal.debugSetFailAt;
+          removeFailAt = internal.debugRemoveFailAt;
+        }
+      } else {
+        const arango = internal.arango;
+        const coordinatorEndpoint = arango.getEndpoint();
+        if (debugCanUseFailAt(coordinatorEndpoint)) {
+          setFailAt = failurePoint => debugSetFailAt(coordinatorEndpoint, failurePoint);
+          removeFailAt = failurePoint => debugRemoveFailAt(coordinatorEndpoint, failurePoint);
+        }
+      }
+      if (!setFailAt) {
+        console.info('Failure tests disabled, skipping...');
+        return;
+      }
+
+      const failurePoint = 'ClusterInfo::slowCurrentSyncer';
+      const cn = "UnitTestsClusterCrud";
+      try {
+        // delay updates for current in the syncer thread
+        setFailAt(failurePoint);
+        // create a collection
+        const c = db._create(cn, { numberOfShards: 1, replicationFactor: 1 });
+        const docs = [];
+        for (let i = 0; i < 100; ++i) {
+          docs.push({ _key: "test" + i });
+        }
+        // inserting a document fails if it needs to look up a shard and
+        // ClusterInfo/Current hasn't caught up yet
+        c.insert(docs);
+      } finally {
+        removeFailAt(failurePoint);
+        db._drop(cn);
+      }
+    },
   };
 }
 

--- a/tests/js/client/shell/shell-cluster-collection.js
+++ b/tests/js/client/shell/shell-cluster-collection.js
@@ -993,18 +993,10 @@ function ClusterCollectionSuite () {
     testCreateWithSlowCurrentUpdate : function () {
       let setFailAt;
       let removeFailAt;
-      if (isServer) {
-        if (internal.debugCanUseFailAt()) {
-          setFailAt = internal.debugSetFailAt;
-          removeFailAt = internal.debugRemoveFailAt;
-        }
-      } else {
-        const arango = internal.arango;
-        const coordinatorEndpoint = arango.getEndpoint();
-        if (debugCanUseFailAt(coordinatorEndpoint)) {
-          setFailAt = failurePoint => debugSetFailAt(coordinatorEndpoint, failurePoint);
-          removeFailAt = failurePoint => debugRemoveFailAt(coordinatorEndpoint, failurePoint);
-        }
+      const coordinatorEndpoint = internal.arango.getEndpoint();
+      if (debugCanUseFailAt(coordinatorEndpoint)) {
+        setFailAt = failurePoint => debugSetFailAt(coordinatorEndpoint, failurePoint);
+        removeFailAt = failurePoint => debugRemoveFailAt(coordinatorEndpoint, failurePoint);
       }
       if (!setFailAt) {
         console.info('Failure tests disabled, skipping...');
@@ -1023,7 +1015,8 @@ function ClusterCollectionSuite () {
           docs.push({ _key: "test" + i });
         }
         // inserting a document fails if it needs to look up a shard and
-        // ClusterInfo/Current hasn't caught up yet
+        // ClusterInfo/Current hasn't caught up yet, in which case insert
+        // throws an exception.
         c.insert(docs);
       } finally {
         removeFailAt(failurePoint);


### PR DESCRIPTION
### Scope & Purpose

Collection creation (with Replication 1) on a Coordinator waited for the ClusterInfo to catch up with a recent enough Plan to see the collection, but did not wait for Current. This can lead to races where accessing a collection right after creation might lead to errors (e.g. getResponsibleServer cannot find servers for a shard of the collection).

- [X] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

Similar fix for Replication 2.0 collection creation: https://github.com/arangodb/arangodb/pull/20929
