### PR TITLE
Swagger UI: Remove fragment identifiers from request URLs

### DIFF
--- a/3rdParty/README_maintainers.md
+++ b/3rdParty/README_maintainers.md
@@ -300,7 +300,15 @@ the _Execute_ button.
   user is authorized to execute, the response should not indicate an
   ArangoDB authentication error.
 
-  This confirms the `requestInterceptor`-related changes were applied correctly.
+  This confirms the `requestInterceptor`-related changes for authentication
+  were applied correctly.
+
+* When using the `POST /_api/index#persistent` endpoint with any collection name,
+  the response URL should contain `?collection=<collection-name>` but not contain
+  `#persistent` anywhere.
+
+  This confirms the `requestInterceptor`-related changes for removing
+  fragment identifiers used for disambiguation in OpenAPI were applied correctly.
 
 * All text in the API documentation should use readable color combinations.
   The API documentation should NOT look obviously "broken" or "ugly".

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 devel
 -----
 
-
+* Swagger UI: Remove fragment identifiers from request URLs. They are merely
+  used to disambiguate polymorphic endpoints in the OpenAPI descriptions of
+  the HTTP API documentation.
 
 3.12.1 (XXXX-XX-XX)
 -------------------

--- a/js/server/assets/swagger/swagger-initializer.js
+++ b/js/server/assets/swagger/swagger-initializer.js
@@ -23,12 +23,16 @@ window.onload = function() {
     validatorUrl: null,
     docExpansion: new URL(location).searchParams.has("collapsed") ? "none" : "list",
     requestInterceptor: function (request) {
-      var jwt = sessionStorage.getItem("jwt");
+      // Remove fragment identifier from URL, which is between the path and the
+      // query parameters if present. It is merely used to disambiguate
+      // polymorphic endpoints in the OpenAPI descriptions.
+      request.url = request.url.replace(/#[^?]*/, "");
       // Inject the web interface JWT for bearer authentication if the
       // request would otherwise not send an authorization header.
       // This is necessary for the ArangoDB HTTP API documentation to work
       // and for the swagger.json files to be loaded correctly in the
       // API documentation mounted by the ArangoDB web interface in an iframe.
+      var jwt = sessionStorage.getItem("jwt");
       if (jwt && !request.headers.Authorization && !request.headers.authorization) {
         request.headers.Authorization = 'bearer ' + jwt;
       }


### PR DESCRIPTION
### Scope & Purpose

They are merely used to disambiguate polymorphic endpoints in the OpenAPI descriptions.

Example: `/_api/index#persistent` is the path we use for persistent indexes. We also have other index types with different sets of attributes and we want to document them separately. It is not possible to use the same path multiple times because it is used as an attribute key in the OpenAPI JSON. We use fragment identifiers (aka anchors) as a workaround but this can break the "Try out" feature of Swagger UI.

Consider this request URL: `http://localhost:8529/_api/index#persistent?collection=coll`
Anything after `#` does not make it over the wire, or is at least ignored, cutting off the required query parameter.
This patch intercepts the "Try out" requests and removes any fragment identifier while retaining query parameters.
Note that it is applied unconditionally to all requests of Swagger UI, which includes Foxx services with an OpenAPI description. I don't think that removing fragment identifiers is a problem here, as they are not intended to be used in requests, but are something a client like a browser is supposed to handle locally.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested
- [x] :book: CHANGELOG entry made
- [x] :books: documentation written
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: Revisit of BTS-746
- [ ] Design document: 
