### PR TITLE
fix a potential race when killing queries

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -322,6 +322,10 @@ void Query::kill() {
   }
 }
 
+void Query::setKillFlag() {
+  _queryKilled.store(true, std::memory_order_acq_rel);
+}
+
 /// @brief the query's transaction id. returns 0 if no transaction
 /// has been assigned to the query yet. use this only for informational
 /// purposes

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -115,6 +115,8 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// @brief set the query to killed
   void kill();
 
+  void setKillFlag();
+
   /// @brief setter and getter methods for the query lockTimeout.
   void setLockTimeout(double timeout) noexcept final;
   double getLockTimeout() const noexcept final;

--- a/arangod/GeneralServer/AsyncJobManager.cpp
+++ b/arangod/GeneralServer/AsyncJobManager.cpp
@@ -34,6 +34,8 @@
 #include "RestServer/SoftShutdownFeature.h"
 #include "Utils/ExecContext.h"
 
+#include <absl/strings/str_cat.h>
+
 namespace {
 bool authorized(
     std::pair<std::string, arangodb::rest::AsyncJobResult> const& job) {
@@ -183,8 +185,8 @@ Result AsyncJobManager::cancelJob(AsyncJobResult::IdType jobId) {
 
   if (it == _jobs.end() || !::authorized(it->second)) {
     rv.reset(TRI_ERROR_HTTP_NOT_FOUND,
-             "could not find job (" + std::to_string(jobId) +
-                 ") in AsyncJobManager during cancel operation");
+             absl::StrCat("could not find job (", jobId,
+                          ") in AsyncJobManager during cancel operation"));
     return rv;
   }
 


### PR DESCRIPTION
### Scope & Purpose

canceling an async job that executes an AQL query via the RestJobHandler's `cancel` operation could lead to a race between the RestJobHandler calling `cancel` on the RestCursorHandler which owns the query, and the RestCursorHandler object that currently executed the query.
the cancel operation could lead to the query being shut down while it was operating, which was not race-free. instead of trying to attempt a full shutdown during a cancel operation, we are now only setting the kill flag on the coordinator in a soft way, which avoids all potential races, but may lead to a later shutdown of the query. this is potentially a good tradeoff, as the RestJobHandler's cancel operation should be used only very rarely in practice.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 