### PR TITLE
Fix a potential data race when running multiple read-only queries on the same streaming transaction.

### DIFF
--- a/arangod/Aql/QueryRegistry.cpp
+++ b/arangod/Aql/QueryRegistry.cpp
@@ -139,6 +139,8 @@ void QueryRegistry::insertQuery(std::shared_ptr<ClusterQuery> query, double ttl,
     // no need to revert last insert
     throw;
   }
+  // we want to release the ptr before releasing the lock!
+  query.reset();
 }
 
 /// @brief open

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -862,6 +862,9 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
                             TRI_ERROR_HTTP_NOT_FOUND);
               return futures::Unit{};
             }
+            // we must be the only user of this query
+            TRI_ASSERT(query.use_count() == 1)
+                << "Finalizing query with use_count " << query.use_count();
             return query->finalizeClusterQuery(errorCode).thenValue(
                 [self = std::move(self), this,
                  q = std::move(query)](Result res) {

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -358,12 +358,16 @@ void RocksDBTrxBaseMethods::PopSavePoint() {
 
 void RocksDBTrxBaseMethods::beginQuery(
     std::shared_ptr<ResourceMonitor> resourceMonitor,
-    bool /*isModificationQuery*/) {
-  _memoryTracker.beginQuery(resourceMonitor);
+    bool isModificationQuery) {
+  if (isModificationQuery) {
+    _memoryTracker.beginQuery(resourceMonitor);
+  }
 }
 
-void RocksDBTrxBaseMethods::endQuery(bool /*isModificationQuery*/) noexcept {
-  _memoryTracker.endQuery();
+void RocksDBTrxBaseMethods::endQuery(bool isModificationQuery) noexcept {
+  if (isModificationQuery) {
+    _memoryTracker.endQuery();
+  }
 }
 
 void RocksDBTrxBaseMethods::cleanupTransaction() {


### PR DESCRIPTION
### Scope & Purpose

This race could implicitly occur when we try to start the query on the fast path in EngineInfoContainerDBServerServerBased, in case of a timeout send the cancel request and then start the new query on the slow path. It could happen that the setup request on the fast path had already inserted the query, but is still holding the shared_ptr. So the cancel request would actually find the query and remove it from the registry, but it would not yet be destroyed. Only once the shared_ptr is dropped would the query be destroyed and the memory tracker updated. But this would now race with the subsequent query on the slow path. For read-only operations we don't actually track anything in the RocksDBMethods, so we now disable tracker updates for all read-only queries, so that actual concurrent usage should be safe. In addition, we drop the query pointer earlier when inserting it into the query registry.

- [x] :hankey: Bugfix
