### PR TITLE
OASIS-25850: Fix incomplete replacing of projection variables in traversals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 devel
 -----
 
-* Fix incomplete replacing of projection variables in traversals. This fixes a
-  regression introduced in 3.12.0.
+* OASIS-25850: Fix incomplete replacing of projection variables in traversals.
+  This fixes a regression introduced in 3.12.0.
 
 
 3.12.1 (XXXX-XX-XX)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix incomplete replacing of projection variables in traversals. This fixes a
+  regression introduced in 3.12.0.
 
 
 3.12.1 (XXXX-XX-XX)


### PR DESCRIPTION
### Scope & Purpose

Fixes https://arangodb.atlassian.net/browse/OASIS-25850

OASIS-25850: Fix incomplete replacing of projection variables in traversals
This fixes a regression introduced in 3.12.0.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-25850
- [ ] Design document: 