### PR TITLE
Request hangs when async HEAD request is retrieved

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fixed an issue where the request would hang when retrieving the result of an
+  asynchronous HEAD request. Now, the response body is cleared and the
+  Content-Length header is set to 0, ensuring compliance with the HTTP protocol
+  and preventing indefinite client waits.
+
 * Document modification operations (insert, update, etc) during an AQL query on
   DBServers no longer block threads while waiting for replication.
 

--- a/arangod/RestHandler/RestJobHandler.cpp
+++ b/arangod/RestHandler/RestJobHandler.cpp
@@ -102,6 +102,13 @@ void RestJobHandler::putJob() {
 
   // plus a new header
   _response->setHeaderNC(StaticStrings::AsyncId, value);
+
+  if (!_response->generateBody() && _response->bodySize() > 0) {
+    // We cannot return a `Content-Length` header without a body, in response to
+    // a PUT request. That would cause the client to hang indefinitely, while
+    // waiting for the body to be sent.
+    _response->clearBody();
+  }
 }
 
 void RestJobHandler::putJobMethod() {

--- a/lib/Rest/GeneralResponse.h
+++ b/lib/Rest/GeneralResponse.h
@@ -161,6 +161,8 @@ class GeneralResponse {
 
   virtual size_t bodySize() const = 0;
 
+  virtual void clearBody() noexcept = 0;
+
   /// used for head
   bool generateBody() const noexcept { return _generateBody; }
 

--- a/lib/Rest/HttpResponse.h
+++ b/lib/Rest/HttpResponse.h
@@ -71,10 +71,7 @@ class HttpResponse : public GeneralResponse {
   // you should call writeHeader only after the body has been created
   void writeHeader(basics::StringBuffer*);  // override;
 
-  void clearBody() noexcept {
-    _body->clear();
-    _bodySize = 0;
-  }
+  void clearBody() noexcept override;
 
   void reset(ResponseCode code) override final;
 

--- a/tests/IResearch/RestHandlerMock.h
+++ b/tests/IResearch/RestHandlerMock.h
@@ -83,4 +83,5 @@ struct GeneralResponseMock : public arangodb::GeneralResponse {
   virtual ErrorCode zlibDeflate(bool onlyIfSmaller) override;
   virtual ErrorCode gzipCompress(bool onlyIfSmaller) override;
   virtual ErrorCode lz4Compress(bool onlyIfSmaller) override;
+  void clearBody() noexcept override { _payload.clear(); }
 };


### PR DESCRIPTION
### Scope & Purpose

**Intruduction**
Sending an async request (using the `X-Arango-Async` header) may involve storing the result on the server, which can later be retrieved via a PUT request. The PUT request is supposed to return the `Content-Length` along with the body of the original async request.

**Problem**
A [HEAD request](https://docs.arangodb.com/3.11/develop/http-api/documents/#get-a-document-header) is used to lookup a document, while retrieving only the document headers, without any content. However, the `Content-Length` header is returned, which offers a good indication of the document's size. This is allowed for a HEAD request. But, when such a request is made in _async_ mode, the client no longer retrieves the response through the initial HEAD request, but through a PUT instead. This causes a violation of the HTTP protocol, because the client sees a `Content-Length` field and then waits indefinitely for the request body to arrive. This happens only when the `Content-Length` field is greater than 0 (i.e for cases when the document exists).

1. Send an async request to get the HEAD of an **existing document**:
    -  `curl --header "x-arango-async: store" -I http://127.0.0.1:8529/_db/test/_api/document/test/foo` 
2. The job appears as done
    - `curl  http://127.0.0.1:8529/_db/test/_api/job/{job_id}` => `200`
3.  When retrieving the result the query never returns
    - `curl -X PUT http://127.0.0.1:8529/_db/test/_api/job/{job_id}` => Runs indefinitely

**Solution**
Upon returning the response of an async HEAD request, the body is "cleared" (it is empty whatsoever), and the `Content-Length` is set to 0.

**Discussion**
The initial idea was to completely omit the `Content-Length` field from such responses. However, this field can be quite useful for a regular HEAD request, as it allows one to judge the size of a document without actually having to retrieve it. But, stripping the `Content-Length` only from the PUT response could've been a valid solution. However, the field is needed to detect premature message truncation when servers crash and to properly segment messages that share a persistent connection. According to my research, I believe eliminating this field (in our specific case) falls into a grey zone, even more so because other related fields (eg `Content-Type`) would still be present.. See [RFC 2616](https://greenbytes.de/tech/webdav/rfc2616.html#message.length) for more info. Also, a major deterrent for going with this solution is that it requires a more complex refactoring, as it's not easy to change the headers of a stored async response.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification
