### PR TITLE
Join maintenance thread on shutdown

### DIFF
--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -878,6 +878,9 @@ void HeartbeatThread::beginShutdown() {
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
+    // otherwise FATAL_ERROR_EXIT
+    TRI_ASSERT(!_maintenanceThread->isRunning());
+    _maintenanceThread->shutdown();
   }
 
   // And now the heartbeat thread:


### PR DESCRIPTION
### Scope & Purpose

TSan reported a leaked thread and indeed, the maintenance thread is not joined (although we wait for it to terminate).