### PR TITLE
OASIS-25850: Fix incomplete replacing of projection variables in traversals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+3.12.1.1 (XXXX-XX-XX)
+---------------------
+
+* OASIS-25850: Fix incomplete replacing of projection variables in traversals.
+  This fixes a regression introduced in 3.12.0.
+
+
 3.12.1 (2024-06-18)
 -------------------
 

--- a/arangod/Aql/EdgeConditionBuilder.cpp
+++ b/arangod/Aql/EdgeConditionBuilder.cpp
@@ -122,3 +122,31 @@ AstNode* EdgeConditionBuilder::getInboundCondition() {
 arangodb::ResourceMonitor& EdgeConditionBuilder::resourceMonitor() {
   return _resourceMonitor;
 }
+
+void EdgeConditionBuilder::replaceVariables(
+    std::unordered_map<VariableId, Variable const*> const& replacements) {
+  auto replace = [&](AstNode*& condition) {
+    if (condition != nullptr) {
+      condition = Ast::replaceVariables(condition, replacements, true);
+    }
+  };
+
+  replace(_fromCondition);
+  replace(_toCondition);
+  replace(_modCondition);
+}
+
+void EdgeConditionBuilder::replaceAttributeAccess(
+    Ast* ast, Variable const* searchVariable,
+    std::span<std::string_view> attribute, Variable const* replaceVariable) {
+  auto replace = [&](AstNode*& condition) {
+    if (condition != nullptr) {
+      condition = Ast::replaceAttributeAccess(ast, condition, searchVariable,
+                                              attribute, replaceVariable);
+    }
+  };
+
+  replace(_fromCondition);
+  replace(_toCondition);
+  replace(_modCondition);
+}

--- a/arangod/Aql/EdgeConditionBuilder.h
+++ b/arangod/Aql/EdgeConditionBuilder.h
@@ -25,6 +25,9 @@
 
 #include "Aql/VariableGenerator.h"
 
+#include <span>
+#include <unordered_map>
+
 namespace arangodb {
 
 namespace velocypack {
@@ -34,6 +37,7 @@ class Slice;
 
 namespace aql {
 struct AstNode;
+struct Variable;
 
 // Helper class to generate AQL AstNode conditions
 // that can be handed over to Indexes in order to
@@ -76,6 +80,13 @@ class EdgeConditionBuilder {
 
   EdgeConditionBuilder(EdgeConditionBuilder const&) = delete;
   EdgeConditionBuilder(EdgeConditionBuilder&&) = delete;
+
+  void replaceVariables(
+      std::unordered_map<VariableId, Variable const*> const& replacements);
+
+  void replaceAttributeAccess(Ast* ast, Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable);
 
   // Add a condition on the edges that is not related to
   // the direction e.g. `label == foo`

--- a/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
@@ -779,6 +779,64 @@ void EnumeratePathsNode::replaceVariables(
   if (_distributeVariable != nullptr) {
     _distributeVariable = Variable::replace(_distributeVariable, replacements);
   }
+
+  for (auto& it : _globalEdgeConditions) {
+    it = Ast::replaceVariables(const_cast<AstNode*>(it), replacements, true);
+  }
+
+  for (auto& it : _globalVertexConditions) {
+    it = Ast::replaceVariables(const_cast<AstNode*>(it), replacements, true);
+  }
+
+  if (_fromCondition != nullptr) {
+    _fromCondition = Ast::replaceVariables(_fromCondition, replacements, true);
+  }
+
+  if (_toCondition != nullptr) {
+    _toCondition = Ast::replaceVariables(_toCondition, replacements, true);
+  }
+}
+
+void EnumeratePathsNode::replaceAttributeAccess(
+    ExecutionNode const* self, Variable const* searchVariable,
+    std::span<std::string_view> attribute, Variable const* replaceVariable,
+    size_t /*index*/) {
+  if (_inStartVariable != nullptr && searchVariable == _inStartVariable &&
+      attribute.size() == 1 && attribute[0] == StaticStrings::IdString) {
+    _inStartVariable = replaceVariable;
+  }
+  if (_inTargetVariable != nullptr && searchVariable == _inTargetVariable &&
+      attribute.size() == 1 && attribute[0] == StaticStrings::IdString) {
+    _inTargetVariable = replaceVariable;
+  }
+  // note: _distributeVariable does not need to be replaced, as it is only
+  // populated by the optimizer, using a temporary calculation that the
+  // optimizer just inserted and that invokes any of the MAKE_DISTRIBUTE_...
+  // internal functions.
+
+  for (auto& it : _globalEdgeConditions) {
+    it =
+        Ast::replaceAttributeAccess(_plan->getAst(), const_cast<AstNode*>(it),
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  for (auto& it : _globalVertexConditions) {
+    it =
+        Ast::replaceAttributeAccess(_plan->getAst(), const_cast<AstNode*>(it),
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  if (_fromCondition != nullptr) {
+    _fromCondition =
+        Ast::replaceAttributeAccess(_plan->getAst(), _fromCondition,
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  if (_toCondition != nullptr) {
+    _toCondition =
+        Ast::replaceAttributeAccess(_plan->getAst(), _toCondition,
+                                    searchVariable, attribute, replaceVariable);
+  }
 }
 
 /// @brief getVariablesSetHere

--- a/arangod/Aql/ExecutionNode/EnumeratePathsNode.h
+++ b/arangod/Aql/ExecutionNode/EnumeratePathsNode.h
@@ -133,6 +133,12 @@ class EnumeratePathsNode : public virtual GraphNode {
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable,
+                              size_t index) override;
+
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;
 

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
@@ -611,6 +611,45 @@ void ShortestPathNode::replaceVariables(
   if (_distributeVariable != nullptr) {
     _distributeVariable = Variable::replace(_distributeVariable, replacements);
   }
+
+  if (_fromCondition != nullptr) {
+    _fromCondition = Ast::replaceVariables(_fromCondition, replacements, true);
+  }
+
+  if (_toCondition != nullptr) {
+    _toCondition = Ast::replaceVariables(_toCondition, replacements, true);
+  }
+}
+
+void ShortestPathNode::replaceAttributeAccess(
+    ExecutionNode const* self, Variable const* searchVariable,
+    std::span<std::string_view> attribute, Variable const* replaceVariable,
+    size_t /*index*/) {
+  if (_inStartVariable != nullptr && searchVariable == _inStartVariable &&
+      attribute.size() == 1 && attribute[0] == StaticStrings::IdString) {
+    _inStartVariable = replaceVariable;
+  }
+
+  if (_inTargetVariable != nullptr && searchVariable == _inTargetVariable &&
+      attribute.size() == 1 && attribute[0] == StaticStrings::IdString) {
+    _inTargetVariable = replaceVariable;
+  }
+  // note: _distributeVariable does not need to be replaced, as it is only
+  // populated by the optimizer, using a temporary calculation that the
+  // optimizer just inserted and that invokes any of the MAKE_DISTRIBUTE_...
+  // internal functions.
+
+  if (_fromCondition != nullptr) {
+    _fromCondition =
+        Ast::replaceAttributeAccess(_plan->getAst(), _fromCondition,
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  if (_toCondition != nullptr) {
+    _toCondition =
+        Ast::replaceAttributeAccess(_plan->getAst(), _toCondition,
+                                    searchVariable, attribute, replaceVariable);
+  }
 }
 
 /// @brief getVariablesSetHere

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.h
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.h
@@ -115,6 +115,12 @@ class ShortestPathNode : public virtual GraphNode {
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable,
+                              size_t index) override;
+
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;
 

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -377,13 +377,44 @@ void TraversalNode::replaceVariables(
 
   if (_condition) {
     _condition->replaceVariables(replacements);
+  }
 
-    // determine new set of variables used by post filters
-    _postFilterVariables.clear();
-    for (auto& it : _postFilterConditions) {
-      it = Ast::replaceVariables(const_cast<AstNode*>(it), replacements, true);
-      Ast::getReferencedVariables(it, _postFilterVariables);
+  if (_postFilterExpression != nullptr) {
+    _postFilterExpression->replaceVariables(replacements);
+  }
+
+  // determine new set of variables used by post filters
+  _postFilterVariables.clear();
+  for (auto& it : _postFilterConditions) {
+    it = Ast::replaceVariables(const_cast<AstNode*>(it), replacements, true);
+    // repopulate _postFilterVariables
+    Ast::getReferencedVariables(it, _postFilterVariables);
+  }
+
+  for (auto& it : _globalEdgeConditions) {
+    it = Ast::replaceVariables(const_cast<AstNode*>(it), replacements, true);
+  }
+
+  for (auto& it : _globalVertexConditions) {
+    it = Ast::replaceVariables(const_cast<AstNode*>(it), replacements, true);
+  }
+
+  for (auto& it : _edgeConditions) {
+    if (it.second != nullptr) {
+      it.second->replaceVariables(replacements);
     }
+  }
+
+  for (auto& it : _vertexConditions) {
+    it.second = Ast::replaceVariables(it.second, replacements, true);
+  }
+
+  if (_fromCondition != nullptr) {
+    _fromCondition = Ast::replaceVariables(_fromCondition, replacements, true);
+  }
+
+  if (_toCondition != nullptr) {
+    _toCondition = Ast::replaceVariables(_toCondition, replacements, true);
   }
 }
 
@@ -411,18 +442,61 @@ void TraversalNode::replaceAttributeAccess(
     _pruneExpression->variables(variables);
     _pruneVariables = std::move(variables);
   }
+
   if (_condition && self != this) {
     _condition->replaceAttributeAccess(searchVariable, attribute,
                                        replaceVariable);
+  }
 
-    // determine new set of variables used by post filters
-    _postFilterVariables.clear();
-    for (auto& it : _postFilterConditions) {
-      it = Ast::replaceAttributeAccess(_plan->getAst(),
-                                       const_cast<AstNode*>(it), searchVariable,
-                                       attribute, replaceVariable);
-      Ast::getReferencedVariables(it, _postFilterVariables);
+  if (_postFilterExpression != nullptr) {
+    _postFilterExpression->replaceAttributeAccess(searchVariable, attribute,
+                                                  replaceVariable);
+  }
+
+  // determine new set of variables used by post filters
+  _postFilterVariables.clear();
+  for (auto& it : _postFilterConditions) {
+    it =
+        Ast::replaceAttributeAccess(_plan->getAst(), const_cast<AstNode*>(it),
+                                    searchVariable, attribute, replaceVariable);
+    // repopulate _postFilterVariables
+    Ast::getReferencedVariables(it, _postFilterVariables);
+  }
+
+  for (auto& it : _globalEdgeConditions) {
+    it =
+        Ast::replaceAttributeAccess(_plan->getAst(), const_cast<AstNode*>(it),
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  for (auto& it : _globalVertexConditions) {
+    it =
+        Ast::replaceAttributeAccess(_plan->getAst(), const_cast<AstNode*>(it),
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  for (auto& it : _edgeConditions) {
+    if (it.second != nullptr) {
+      it.second->replaceAttributeAccess(_plan->getAst(), searchVariable,
+                                        attribute, replaceVariable);
     }
+  }
+
+  for (auto& it : _vertexConditions) {
+    it.second = Ast::replaceAttributeAccess(
+        _plan->getAst(), it.second, searchVariable, attribute, replaceVariable);
+  }
+
+  if (_fromCondition != nullptr) {
+    _fromCondition =
+        Ast::replaceAttributeAccess(_plan->getAst(), _fromCondition,
+                                    searchVariable, attribute, replaceVariable);
+  }
+
+  if (_toCondition != nullptr) {
+    _toCondition =
+        Ast::replaceAttributeAccess(_plan->getAst(), _toCondition,
+                                    searchVariable, attribute, replaceVariable);
   }
 }
 

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -503,10 +503,11 @@ AqlValue Expression::executeSimpleExpression(ExpressionContext& ctx,
                        "' is not supported in expressions"));
 
     default:
-      std::string msg("unhandled type '");
-      msg.append(node->getTypeString());
-      msg.append("' in executeSimpleExpression()");
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, msg);
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          absl::StrCat(
+              "unhandled type '", node->getTypeString(),
+              "' in executeSimpleExpression(): ", AstNode::toString(node)));
   }
 }
 

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -728,7 +728,7 @@ function printShortestPathDetails(shortestPaths) {
   stringBuilder.appendLine(line);
 
   for (let sp of shortestPaths) {
-    line = ' ' + pad(1 + maxIdLen - String(sp.id).length) + sp.id + '   ';
+    line = ' ' + pad(1 + maxIdLen - String(sp.id).length) + variable(sp.id) + '   ';
 
     if (sp.hasOwnProperty('vertexCollectionNameStr')) {
       line += sp.vertexCollectionNameStr +
@@ -1023,7 +1023,7 @@ function processQuery(query, explain, planIndex) {
       var rhs = buildExpression(node.subNodes[1]);
       if (node.subNodes.length === 3) {
         // array operator node... prepend "all" | "any" | "none" to node type
-        name = node.subNodes[2].quantifier + ' ' + name;
+        name = keyword(node.subNodes[2].quantifier.toUpperCase()) + ' ' + name;
       }
       if (node.sorted) {
         return lhs + ' ' + name + ' ' + annotation('/* sorted */') + ' ' + rhs;

--- a/tests/js/client/aql/aql-graph-enumerate-path-filter.js
+++ b/tests/js/client/aql/aql-graph-enumerate-path-filter.js
@@ -233,6 +233,30 @@ function enumeratePathsFilter() {
       assertEqual(rr.length, 1, "expecting precisely one result");
       const longPath = getVerticesAndEdgesFromPath(rr[0]);
       assertEqual(longPath.vertices.length, 5, `found path ${JSON.stringify(longPath)}`);
+      
+      const restrictedQuery2 = `
+        FOR path IN ANY K_SHORTEST_PATHS "${vName}/19" TO "${vName}/23" GRAPH "${graphName}"
+            FILTER path.edges[* RETURN CURRENT.colour] ALL == "green"
+            LIMIT 1
+            RETURN path`;
+
+      assertRuleFires(restrictedQuery2);
+      const rr2 = db._query(restrictedQuery2).toArray();
+      assertEqual(rr2.length, 1, "expecting precisely one result");
+      const longPath2 = getVerticesAndEdgesFromPath(rr2[0]);
+      assertEqual(longPath2.vertices.length, 5, `found path ${JSON.stringify(longPath)}`);
+      
+      const restrictedQuery3 = `
+        FOR path IN ANY K_SHORTEST_PATHS "${vName}/19" TO "${vName}/23" GRAPH "${graphName}"
+            FILTER path.edges[*].colour ALL == "green"
+            LIMIT 1
+            RETURN path`;
+
+      assertRuleFires(restrictedQuery3);
+      const rr3 = db._query(restrictedQuery3).toArray();
+      assertEqual(rr3.length, 1, "expecting precisely one result");
+      const longPath3 = getVerticesAndEdgesFromPath(rr3[0]);
+      assertEqual(longPath3.vertices.length, 5, `found path ${JSON.stringify(longPath)}`);
     },
   };
 

--- a/tests/js/client/aql/aql-optimizer-rule-optimize-projections.js
+++ b/tests/js/client/aql/aql-optimizer-rule-optimize-projections.js
@@ -20,9 +20,6 @@
 // / limitations under the License.
 // /
 // / Copyright holder is ArangoDB GmbH, Cologne, Germany
-// /
-/// @author Jan Steemann
-/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
@@ -146,43 +143,136 @@ function optimizerRuleTestSuite () {
       });
     },
 
+  };
+}
+
+function optimizerRuleRegressionsTestSuite () {
+  const vn = ["v1", "v2", "v3"];
+  const en = ["e1", "e2"];
+
+  return {
+    setUp : function () {
+      vn.forEach((n) => { db._create(n); });
+      en.forEach((n) => { db._createEdgeCollection(n); });
+    },
+
+    tearDown : function () {
+      vn.forEach((n) => { db._drop(n); });
+      en.forEach((n) => { db._drop(n); });
+    },
+
     // verifies an issue with projection variables not being correctly replaced
     // inside traversals
     testOptimizeProjectionsTraversalRegression: function () {
-      const vn = ["v1", "v2", "v3"];
-      const en = ["e1", "e2"];
+      let k1 = db.v1.insert({ from: 1704067200000 })._id;
+      let k2 = db.v2.insert({ from: 1514764800000 })._id;
+      let k3 = db.v3.insert({ start: 1619827200000 })._id;
 
-      vn.forEach((n) => { db._create(n); });
-      en.forEach((n) => { db._createEdgeCollection(n); });
+      db.e1.insert({ _from: k2, _to: k1 });
+      db.e2.insert({ _from: k3, _to: k2 });
 
-      try {
-        let k1 = db.v1.insert({ from: 1704067200000 })._id;
-        let k2 = db.v2.insert({ from: 1514764800000 })._id;
-        let k3 = db.v3.insert({ start: 1619827200000 })._id;
-
-        db.e1.insert({ _from: k2, _to: k1 });
-        db.e2.insert({ _from: k3, _to: k2 });
-
-        const query = `
-WITH v2, v3, v1
+      const query = `
+WITH v1, v2, v3
 FOR doc1 IN v1 FILTER doc1._id == '${k1}'
 FOR doc2 IN 1..1 INBOUND doc1 e1
 FOR doc3 IN 1..1 INBOUND doc2 e2
 FILTER doc3.start < doc1.from
 RETURN { s: doc3.start, f: doc1.from }`;
-        
-        let result = db._query(query).toArray();
-        assertEqual(1, result.length);
-        assertEqual({ s: 1619827200000, f: 1704067200000 }, result[0]);
-      } finally {
-        vn.forEach((n) => { db._drop(n); });
-        en.forEach((n) => { db._drop(n); });
-      }
+      
+      let result = db._query(query).toArray();
+      assertEqual(1, result.length);
+      assertEqual({ s: 1619827200000, f: 1704067200000 }, result[0]);
+    },
+    
+    testOptimizeProjectionsTraversalPruneRegression: function () {
+      let k1 = db.v1.insert({ from: 1704067200000 })._id;
+      let k2 = db.v2.insert({ from: 1514764800000 })._id;
+      let k3 = db.v3.insert({ start: 1619827200000 })._id;
+
+      db.e1.insert({ _from: k2, _to: k1 });
+      db.e2.insert({ _from: k3, _to: k2 });
+
+      const query = `
+WITH v1, v2, v3
+FOR doc1 IN v1 FILTER doc1._id == '${k1}'
+FOR doc2 IN 1..1 INBOUND doc1 e1
+FOR doc3 IN 1..1 INBOUND doc2 e2
+PRUNE doc3.start > doc1.from
+RETURN { s: doc3.start, f: doc1.from }`;
+      
+      let result = db._query(query).toArray();
+      assertEqual(1, result.length);
+      assertEqual({ s: 1619827200000, f: 1704067200000 }, result[0]);
+    },
+    
+    testOptimizeProjectionsKShortestPathsRegression: function () {
+      let k1 = db.v1.insert({})._id;
+      let k2 = db.v1.insert({})._id;
+      let k3 = db.v1.insert({})._id;
+
+      db.e1.insert({ _from: k2, _to: k1, value: 1 });
+      db.e1.insert({ _from: k3, _to: k2, value: 1 });
+
+      const query = `
+WITH v1
+FOR doc1 IN v1 FILTER doc1._id == '${k3}'
+FOR doc2 IN v1 FILTER doc2._id == '${k1}'
+FOR p IN OUTBOUND K_SHORTEST_PATHS doc1._id TO doc2._id e1
+FILTER p.edges[*].value ALL == 1
+RETURN p.vertices[*]._id`;
+
+      let result = db._query(query).toArray(); 
+      assertEqual(1, result.length);
+      assertEqual(3, result[0].length);
+      assertEqual([k3, k2, k1], result[0]);
+    },
+    
+    testOptimizeProjectionsKPathsRegression: function () {
+      let k1 = db.v1.insert({})._id;
+      let k2 = db.v1.insert({})._id;
+      let k3 = db.v1.insert({})._id;
+
+      db.e1.insert({ _from: k2, _to: k1, value: 1 });
+      db.e1.insert({ _from: k3, _to: k2, value: 1 });
+
+      const query = `
+WITH v1
+FOR doc1 IN v1 FILTER doc1._id == '${k3}'
+FOR doc2 IN v1 FILTER doc2._id == '${k1}'
+FOR p IN 1..5 OUTBOUND K_PATHS doc1._id TO doc2._id e1
+FILTER p.edges[*].value ALL == 1
+RETURN p.vertices[*]._id`;
+
+      let result = db._query(query).toArray(); 
+      assertEqual(1, result.length);
+      assertEqual(3, result[0].length);
+      assertEqual([k3, k2, k1], result[0]);
+    },
+    
+    testOptimizeProjectionsShortestPathRegression: function () {
+      let k1 = db.v1.insert({})._id;
+      let k2 = db.v1.insert({})._id;
+      let k3 = db.v1.insert({})._id;
+
+      db.e1.insert({ _from: k2, _to: k1 });
+      db.e1.insert({ _from: k3, _to: k2 });
+
+      const query = `
+WITH v1
+FOR doc1 IN v1 FILTER doc1._id == '${k3}'
+FOR doc2 IN v1 FILTER doc2._id == '${k1}'
+FOR v, e IN OUTBOUND SHORTEST_PATH doc1._id TO doc2._id e1
+RETURN v._id`;
+
+      let result = db._query(query).toArray();
+      assertEqual(3, result.length);
+      assertEqual([k3, k2, k1], result);
     },
 
   };
 }
 
 jsunity.run(optimizerRuleTestSuite);
+jsunity.run(optimizerRuleRegressionsTestSuite);
 
 return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21078 & https://github.com/arangodb/arangodb/pull/21083

Fixes https://arangodb.atlassian.net/browse/OASIS-25850

Enterprise companion PR: https://github.com/arangodb/enterprise/pull/1497

Replace additional variables in various members of `TraversalNode`, `EnumeratePathsNode` and `ShortestPathNode` for the projection optimization.
Also fix variable replacement in filter conditions inside `EnumeratePathsNode` for filters of type `FILTER p.edges[*].value ALL op value`. Previously this only supported filters of type `FILTER p.edges[* RETURN ...] op value` and ran into exceptions "unsupported node type no-op" with the other form.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1497
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 