### PR TITLE
[BTS-1909] Fix cluster unique aggregation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* BTS-1909, MDS-1232: Fixed a bug where COLLECT ... AGGREGATE x = UNIQUE(y)
+  could miss some results when multiple shards were aggregated in a cluster.
+
 * Fixed a bug where accessing a collection right after creation can sometimes
   fail.
 

--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -667,7 +667,7 @@ struct AggregatorUniqueStep2 final : public AggregatorUnique {
     for (VPackSlice it : VPackArrayIterator(s)) {
       if (seen.contains(it)) {
         // already saw the same value
-        return;
+        continue;
       }
 
       char* pos = allocator.store(it.startAs<char>(), it.byteSize());
@@ -742,7 +742,7 @@ struct AggregatorSortedUniqueStep2 final : public AggregatorSortedUnique {
     for (VPackSlice it : VPackArrayIterator(s)) {
       if (seen.find(it) != seen.end()) {
         // already saw the same value
-        return;
+        continue;
       }
 
       char* pos = allocator.store(it.startAs<char>(), it.byteSize());
@@ -837,9 +837,9 @@ struct AggregatorCountDistinctStep2 final : public AggregatorCountDistinct {
     }
 
     for (VPackSlice it : VPackArrayIterator(s)) {
-      if (seen.find(s) != seen.end()) {
+      if (seen.contains(it)) {
         // already saw the same value
-        return;
+        continue;
       }
 
       char* pos = allocator.store(it.startAs<char>(), it.byteSize());

--- a/tests/js/client/aql/aql-optimizer-collect-aggregate.js
+++ b/tests/js/client/aql/aql-optimizer-collect-aggregate.js
@@ -454,10 +454,11 @@ function optimizerAggregateTestSuite () {
 
       assertEqual(5, dbsCollectNode.aggregates.length);
       assertEqual("LENGTH", dbsCollectNode.aggregates[0].type);
-      assertEqual("UNIQUE", dbsCollectNode.aggregates[1].type);
-      assertEqual("UNIQUE", dbsCollectNode.aggregates[2].type);
-      assertEqual("UNIQUE", dbsCollectNode.aggregates[3].type);
-      assertEqual("UNIQUE", dbsCollectNode.aggregates[4].type);
+      const type = isCluster ? "UNIQUE" : "COUNT_DISTINCT";
+      assertEqual(type, dbsCollectNode.aggregates[1].type);
+      assertEqual(type, dbsCollectNode.aggregates[2].type);
+      assertEqual(type, dbsCollectNode.aggregates[3].type);
+      assertEqual(type, dbsCollectNode.aggregates[4].type);
 
       if (isCluster) {
         const coordCollectNode = collectNodes[1];

--- a/tests/js/client/aql/aql-optimizer-collect-aggregate.js
+++ b/tests/js/client/aql/aql-optimizer-collect-aggregate.js
@@ -219,9 +219,19 @@ function optimizerAggregateTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testAggregateUnique : function () {
-      const query = "FOR i IN " + c.name() + " COLLECT group = i.group AGGREGATE length = LENGTH(1), unique1 = UNIQUE(i.value1), unique2 = UNIQUE(i.value2), unique3 = UNIQUE(i.value3), uniqueGroup = UNIQUE(i.group) RETURN { group, length, unique1, unique2, unique3, uniqueGroup }";
+      const query = `
+        FOR i IN ${c.name()}
+        COLLECT group = i.group
+          AGGREGATE
+           length = LENGTH(1),
+           unique1 = UNIQUE(i.value1),
+           unique2 = UNIQUE(i.value2),
+           unique3 = UNIQUE(i.value3),
+           uniqueGroup = UNIQUE(i.group)
+        RETURN { group, length, unique1, unique2, unique3, uniqueGroup }
+      `;
 
-      let results = db._query(query).toArray();
+      const results = db._query(query).toArray();
       assertEqual(10, results.length);
       for (let i = 0; i < 10; ++i) {
         assertEqual("test" + i, results[i].group);
@@ -232,54 +242,64 @@ function optimizerAggregateTestSuite () {
         assertEqual([ "test" + i ], results[i].uniqueGroup);
       }
 
-      let plan = db._createStatement(query).explain().plan;
+      const plan = db._createStatement(query).explain().plan;
       // must have a SortNode
       assertNotEqual(-1, plan.nodes.map(function(node) { return node.type; }).indexOf("SortNode"));
 
-      let collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
+      const collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
       assertEqual(isCluster ? 2 : 1, collectNodes.length);
-      
-      let collectNode = collectNodes[0];
+
+      const dbsCollectNode = collectNodes[0];
+      assertEqual("hash", dbsCollectNode.collectOptions.method);
+      assertFalse(dbsCollectNode.isDistinctCommand);
+
+      assertEqual(1, dbsCollectNode.groups.length);
+
+      assertEqual(5, dbsCollectNode.aggregates.length);
+      assertEqual("LENGTH", dbsCollectNode.aggregates[0].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[1].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[2].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[3].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[4].type);
+
       if (isCluster) {
-        assertEqual("hash", collectNode.collectOptions.method);
-        assertFalse(collectNode.isDistinctCommand);
+        let coordCollectNode = collectNodes[1];
+        assertEqual("hash", coordCollectNode.collectOptions.method);
+        assertFalse(coordCollectNode.isDistinctCommand);
 
-        assertEqual(1, collectNode.groups.length);
+        assertEqual(1, coordCollectNode.groups.length);
 
-        assertEqual(5, collectNode.aggregates.length);
-        assertEqual("LENGTH", collectNode.aggregates[0].type);
-        assertEqual("UNIQUE", collectNode.aggregates[1].type);
-        assertEqual("UNIQUE", collectNode.aggregates[2].type);
-        assertEqual("UNIQUE", collectNode.aggregates[3].type);
-        assertEqual("UNIQUE", collectNode.aggregates[4].type);
-
-        collectNode = collectNodes[1];
+        assertEqual(5, coordCollectNode.aggregates.length);
+        assertEqual("SUM", coordCollectNode.aggregates[0].type);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[1].type);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[2].type);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[3].type);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[4].type);
       }
-      assertEqual("hash", collectNode.collectOptions.method);
-      assertFalse(collectNode.isDistinctCommand);
 
-      assertEqual(1, collectNode.groups.length);
-      assertEqual("group", collectNode.groups[0].outVariable.name);
-
-      assertEqual(5, collectNode.aggregates.length);
-      assertEqual("length", collectNode.aggregates[0].outVariable.name);
-      assertEqual(isCluster ? "SUM" : "LENGTH", collectNode.aggregates[0].type);
-      assertEqual("unique1", collectNode.aggregates[1].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[1].type);
-      assertEqual("unique2", collectNode.aggregates[2].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[2].type);
-      assertEqual("unique3", collectNode.aggregates[3].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[3].type);
-      assertEqual("uniqueGroup", collectNode.aggregates[4].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[4].type);
+      const finalCollect = isCluster ? collectNodes[1] : collectNodes[0];
+      assertEqual("group", finalCollect.groups[0].outVariable.name);
+      assertEqual("length", finalCollect.aggregates[0].outVariable.name);
+      assertEqual("unique1", finalCollect.aggregates[1].outVariable.name);
+      assertEqual("unique2", finalCollect.aggregates[2].outVariable.name);
+      assertEqual("unique3", finalCollect.aggregates[3].outVariable.name);
+      assertEqual("uniqueGroup", finalCollect.aggregates[4].outVariable.name);
     },
-    
-    testAggregateUnique2 : function () {
-      const query = "FOR i IN " + c.name() + " COLLECT AGGREGATE unique1 = UNIQUE(i.value1), unique2 = UNIQUE(i.value2), unique3 = UNIQUE(i.value3) RETURN { unique1, unique2, unique3 }";
 
-      let results = db._query(query).toArray();
+    testAggregateUnique2 : function () {
+      const query = `
+        FOR i IN ${c.name()}
+        COLLECT
+          AGGREGATE
+          unique1 = UNIQUE(i.value1),
+          unique2 = UNIQUE(i.value2),
+          unique3 = UNIQUE(i.value3)
+        RETURN { unique1, unique2, unique3 }
+      `;
+
+      const results = db._query(query).toArray();
       assertEqual(1, results.length);
-      let expected = [];
+      const expected = [];
       for (let i = 0; i < 2000; ++i) {
         expected.push(i);
       }
@@ -287,44 +307,56 @@ function optimizerAggregateTestSuite () {
       assertEqual([ 0, 1, 2, 3, 4 ], results[0].unique2.sort());
       assertEqual([...Array(400).keys()], _.sortBy(results[0].unique3));
 
-      let plan = db._createStatement(query).explain().plan;
+      const plan = db._createStatement(query).explain().plan;
 
-      let collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
+      const collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
       assertEqual(isCluster ? 2 : 1, collectNodes.length);
-      
-      let collectNode = collectNodes[0];
+
+      const dbsCollectNode = collectNodes[0];
+      assertFalse(dbsCollectNode.isDistinctCommand);
+
+      assertEqual(0, dbsCollectNode.groups.length);
+
+      assertEqual(3, dbsCollectNode.aggregates.length);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[0].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[1].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[2].type);
+
       if (isCluster) {
-        assertFalse(collectNode.isDistinctCommand);
+        const coordCollectNode = collectNodes[1];
+        assertFalse(coordCollectNode.isDistinctCommand);
 
-        assertEqual(0, collectNode.groups.length);
+        assertEqual(0, coordCollectNode.groups.length);
 
-        assertEqual(3, collectNode.aggregates.length);
-        assertEqual("UNIQUE", collectNode.aggregates[0].type);
-        assertEqual("UNIQUE", collectNode.aggregates[1].type);
-        assertEqual("UNIQUE", collectNode.aggregates[2].type);
-
-        collectNode = collectNodes[1];
+        assertEqual(3, coordCollectNode.aggregates.length);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[0].type);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[1].type);
+        assertEqual("UNIQUE_STEP2", coordCollectNode.aggregates[2].type);
       }
-      assertFalse(collectNode.isDistinctCommand);
 
-      assertEqual(0, collectNode.groups.length);
-
-      assertEqual(3, collectNode.aggregates.length);
-      assertEqual("unique1", collectNode.aggregates[0].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[0].type);
-      assertEqual("unique2", collectNode.aggregates[1].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[1].type);
-      assertEqual("unique3", collectNode.aggregates[2].outVariable.name);
-      assertEqual(isCluster ? "UNIQUE_STEP2" : "UNIQUE", collectNode.aggregates[2].type);
+      const finalCollectNode = isCluster ? collectNodes[1] : collectNodes[0];
+      assertEqual("unique1", finalCollectNode.aggregates[0].outVariable.name);
+      assertEqual("unique2", finalCollectNode.aggregates[1].outVariable.name);
+      assertEqual("unique3", finalCollectNode.aggregates[2].outVariable.name);
     },
-    
-    testAggregateSortedUnique : function () {
-      const query = "FOR i IN " + c.name() + " COLLECT group = i.group AGGREGATE length = LENGTH(1), unique1 = SORTED_UNIQUE(i.value1), unique2 = SORTED_UNIQUE(i.value2), unique3 = SORTED_UNIQUE(i.value3), uniqueGroup = SORTED_UNIQUE(i.group) RETURN { group, length, unique1, unique2, unique3, uniqueGroup }";
 
-      let results = db._query(query).toArray();
+    testAggregateSortedUnique : function () {
+      const query = `
+        FOR i IN ${c.name()}
+        COLLECT group = i.group
+          AGGREGATE
+            length = LENGTH(1),
+            unique1 = SORTED_UNIQUE(i.value1),
+            unique2 = SORTED_UNIQUE(i.value2),
+            unique3 = SORTED_UNIQUE(i.value3),
+            uniqueGroup = SORTED_UNIQUE(i.group)
+        RETURN { group, length, unique1, unique2, unique3, uniqueGroup }
+      `;
+
+      const results = db._query(query).toArray();
       assertEqual(10, results.length);
       for (let i = 0; i < 10; ++i) {
-        let values = [];
+        const values = [];
         for (let j = 0; j < 200; ++j) {
           values.push((10 * j) + i);
         }
@@ -337,52 +369,65 @@ function optimizerAggregateTestSuite () {
         assertEqual([ "test" + i ], results[i].uniqueGroup);
       }
 
-      let plan = db._createStatement(query).explain().plan;
+      const plan = db._createStatement(query).explain().plan;
       // must have a SortNode
       assertNotEqual(-1, plan.nodes.map(function(node) { return node.type; }).indexOf("SortNode"));
 
-      let collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
+      const collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
       assertEqual(isCluster ? 2 : 1, collectNodes.length);
-      
-      let collectNode = collectNodes[0];
+
+      const collectNode = collectNodes[0];
+      const dbsCollectNode = collectNodes[0];
+      assertEqual("hash", dbsCollectNode.collectOptions.method);
+      assertFalse(dbsCollectNode.isDistinctCommand);
+
+      assertEqual(1, dbsCollectNode.groups.length);
+
+      assertEqual(5, dbsCollectNode.aggregates.length);
+      assertEqual("LENGTH", dbsCollectNode.aggregates[0].type);
+      assertEqual("SORTED_UNIQUE", dbsCollectNode.aggregates[1].type);
+      assertEqual("SORTED_UNIQUE", dbsCollectNode.aggregates[2].type);
+      assertEqual("SORTED_UNIQUE", dbsCollectNode.aggregates[3].type);
+      assertEqual("SORTED_UNIQUE", dbsCollectNode.aggregates[4].type);
+
       if (isCluster) {
-        assertEqual("hash", collectNode.collectOptions.method);
-        assertFalse(collectNode.isDistinctCommand);
+        const coordCollectNode = collectNodes[1];
+        assertEqual("hash", coordCollectNode.collectOptions.method);
+        assertFalse(coordCollectNode.isDistinctCommand);
 
-        assertEqual(1, collectNode.groups.length);
+        assertEqual(1, coordCollectNode.groups.length);
 
-        assertEqual(5, collectNode.aggregates.length);
-        assertEqual("LENGTH", collectNode.aggregates[0].type);
-        assertEqual("SORTED_UNIQUE", collectNode.aggregates[1].type);
-        assertEqual("SORTED_UNIQUE", collectNode.aggregates[2].type);
-        assertEqual("SORTED_UNIQUE", collectNode.aggregates[3].type);
-        assertEqual("SORTED_UNIQUE", collectNode.aggregates[4].type);
-
-        collectNode = collectNodes[1];
+        assertEqual(5, coordCollectNode.aggregates.length);
+        assertEqual("SUM", coordCollectNode.aggregates[0].type);
+        assertEqual("SORTED_UNIQUE_STEP2", coordCollectNode.aggregates[1].type);
+        assertEqual("SORTED_UNIQUE_STEP2", coordCollectNode.aggregates[2].type);
+        assertEqual("SORTED_UNIQUE_STEP2", coordCollectNode.aggregates[3].type);
+        assertEqual("SORTED_UNIQUE_STEP2", coordCollectNode.aggregates[4].type);
       }
-      assertEqual("hash", collectNode.collectOptions.method);
-      assertFalse(collectNode.isDistinctCommand);
 
-      assertEqual(1, collectNode.groups.length);
-      assertEqual("group", collectNode.groups[0].outVariable.name);
-
-      assertEqual(5, collectNode.aggregates.length);
-      assertEqual("length", collectNode.aggregates[0].outVariable.name);
-      assertEqual(isCluster ? "SUM" : "LENGTH", collectNode.aggregates[0].type);
-      assertEqual("unique1", collectNode.aggregates[1].outVariable.name);
-      assertEqual(isCluster ? "SORTED_UNIQUE_STEP2" : "SORTED_UNIQUE", collectNode.aggregates[1].type);
-      assertEqual("unique2", collectNode.aggregates[2].outVariable.name);
-      assertEqual(isCluster ? "SORTED_UNIQUE_STEP2" : "SORTED_UNIQUE", collectNode.aggregates[2].type);
-      assertEqual("unique3", collectNode.aggregates[3].outVariable.name);
-      assertEqual(isCluster ? "SORTED_UNIQUE_STEP2" : "SORTED_UNIQUE", collectNode.aggregates[3].type);
-      assertEqual("uniqueGroup", collectNode.aggregates[4].outVariable.name);
-      assertEqual(isCluster ? "SORTED_UNIQUE_STEP2" : "SORTED_UNIQUE", collectNode.aggregates[4].type);
+      const finalCollectNode = isCluster ? collectNodes[1] : collectNodes[0];
+      assertEqual("group", finalCollectNode.groups[0].outVariable.name);
+      assertEqual("length", finalCollectNode.aggregates[0].outVariable.name);
+      assertEqual("unique1", finalCollectNode.aggregates[1].outVariable.name);
+      assertEqual("unique2", finalCollectNode.aggregates[2].outVariable.name);
+      assertEqual("unique3", finalCollectNode.aggregates[3].outVariable.name);
+      assertEqual("uniqueGroup", finalCollectNode.aggregates[4].outVariable.name);
     },
-    
-    testAggregateCountUnique : function () {
-      const query = "FOR i IN " + c.name() + " COLLECT group = i.group AGGREGATE length = LENGTH(1), unique1 = COUNT_UNIQUE(i.value1), unique2 = COUNT_UNIQUE(i.value2), unique3 = COUNT_UNIQUE(i.value3), uniqueGroup = COUNT_DISTINCT(i.group) RETURN { group, length, unique1, unique2, unique3, uniqueGroup }";
 
-      let results = db._query(query).toArray();
+    testAggregateCountUnique : function () {
+      const query = `
+        FOR i IN ${c.name()}
+        COLLECT group = i.group
+          AGGREGATE
+            length = LENGTH(1),
+            unique1 = COUNT_UNIQUE(i.value1),
+            unique2 = COUNT_UNIQUE(i.value2),
+            unique3 = COUNT_UNIQUE(i.value3),
+            uniqueGroup = COUNT_DISTINCT(i.group)
+        RETURN { group, length, unique1, unique2, unique3, uniqueGroup }
+      `;
+
+      const results = db._query(query).toArray();
       assertEqual(10, results.length);
       for (let i = 0; i < 10; ++i) {
         assertEqual("test" + i, results[i].group);
@@ -393,46 +438,51 @@ function optimizerAggregateTestSuite () {
         assertEqual(1, results[i].uniqueGroup);
       }
 
-      let plan = db._createStatement(query).explain().plan;
+      const plan = db._createStatement(query).explain().plan;
       // must have a SortNode
       assertNotEqual(-1, plan.nodes.map(function(node) { return node.type; }).indexOf("SortNode"));
 
-      let collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
+      const collectNodes = plan.nodes.filter(function(node) { return node.type === 'CollectNode'; });
       assertEqual(isCluster ? 2 : 1, collectNodes.length);
-      
-      let collectNode = collectNodes[0];
+
+      const dbsCollectNode = collectNodes[0];
+
+      assertEqual("hash", dbsCollectNode.collectOptions.method);
+      assertFalse(dbsCollectNode.isDistinctCommand);
+
+      assertEqual(1, dbsCollectNode.groups.length);
+
+      assertEqual(5, dbsCollectNode.aggregates.length);
+      assertEqual("LENGTH", dbsCollectNode.aggregates[0].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[1].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[2].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[3].type);
+      assertEqual("UNIQUE", dbsCollectNode.aggregates[4].type);
+
       if (isCluster) {
-        assertEqual("hash", collectNode.collectOptions.method);
-        assertFalse(collectNode.isDistinctCommand);
+        const coordCollectNode = collectNodes[1];
 
-        assertEqual(1, collectNode.groups.length);
+        assertEqual("hash", coordCollectNode.collectOptions.method);
+        assertFalse(coordCollectNode.isDistinctCommand);
 
-        assertEqual(5, collectNode.aggregates.length);
-        assertEqual("LENGTH", collectNode.aggregates[0].type);
-        assertEqual("UNIQUE", collectNode.aggregates[1].type);
-        assertEqual("UNIQUE", collectNode.aggregates[2].type);
-        assertEqual("UNIQUE", collectNode.aggregates[3].type);
-        assertEqual("UNIQUE", collectNode.aggregates[4].type);
+        assertEqual(1, coordCollectNode.groups.length);
 
-        collectNode = collectNodes[1];
+        assertEqual(5, coordCollectNode.aggregates.length);
+        assertEqual("SUM", coordCollectNode.aggregates[0].type);
+        assertEqual("COUNT_DISTINCT_STEP2", coordCollectNode.aggregates[1].type);
+        assertEqual("COUNT_DISTINCT_STEP2", coordCollectNode.aggregates[2].type);
+        assertEqual("COUNT_DISTINCT_STEP2", coordCollectNode.aggregates[3].type);
+        assertEqual("COUNT_DISTINCT_STEP2", coordCollectNode.aggregates[4].type);
       }
-      assertEqual("hash", collectNode.collectOptions.method);
-      assertFalse(collectNode.isDistinctCommand);
 
-      assertEqual(1, collectNode.groups.length);
-      assertEqual("group", collectNode.groups[0].outVariable.name);
 
-      assertEqual(5, collectNode.aggregates.length);
-      assertEqual("length", collectNode.aggregates[0].outVariable.name);
-      assertEqual(isCluster ? "SUM" : "LENGTH", collectNode.aggregates[0].type);
-      assertEqual("unique1", collectNode.aggregates[1].outVariable.name);
-      assertEqual(isCluster ? "COUNT_DISTINCT_STEP2" : "COUNT_DISTINCT", collectNode.aggregates[1].type);
-      assertEqual("unique2", collectNode.aggregates[2].outVariable.name);
-      assertEqual(isCluster ? "COUNT_DISTINCT_STEP2" : "COUNT_DISTINCT", collectNode.aggregates[2].type);
-      assertEqual("unique3", collectNode.aggregates[3].outVariable.name);
-      assertEqual(isCluster ? "COUNT_DISTINCT_STEP2" : "COUNT_DISTINCT", collectNode.aggregates[3].type);
-      assertEqual("uniqueGroup", collectNode.aggregates[4].outVariable.name);
-      assertEqual(isCluster ? "COUNT_DISTINCT_STEP2" : "COUNT_DISTINCT", collectNode.aggregates[4].type);
+      const finalCollectNode = isCluster ? collectNodes[1] : collectNodes[0];
+      assertEqual("group", finalCollectNode.groups[0].outVariable.name);
+      assertEqual("length", finalCollectNode.aggregates[0].outVariable.name);
+      assertEqual("unique1", finalCollectNode.aggregates[1].outVariable.name);
+      assertEqual("unique2", finalCollectNode.aggregates[2].outVariable.name);
+      assertEqual("unique3", finalCollectNode.aggregates[3].outVariable.name);
+      assertEqual("uniqueGroup", finalCollectNode.aggregates[4].outVariable.name);
     },
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Fix `COLLECT ... AGGREGATE x = UNIQUE(y)` in a cluster sometimes missing results. The coordinator implementation was buggy. Both hashed and sorted variants had the same bug. COUNT_UNIQUE had the same, which was obscured by another bug (which only affected performance negatively).

- [X] :hankey: Bugfix
- [X] :fire: Performance improvement

### Checklist

- [X] Tests
  - [X] **Regression tests**
  - [X] **integration tests**
- [X] :book: CHANGELOG entry made
- [X] Backports
  - [X] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21093

#### Related Information

- [X] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1909
- [X] Jira ticket: https://arangodb.atlassian.net/browse/MDS-1232
