### PR TITLE
Detach AQL threads in UPSERT when waiting on replication for too long

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Sort out a thread blockage on AQL upsert waiting for replication.
+
 * Fixed an issue where the request would hang when retrieving the result of an
   asynchronous HEAD request. Now, the response body is cleared and the
   Content-Length header is set to 0, ensuring compliance with the HTTP protocol
@@ -18,8 +20,6 @@ devel
 
 3.12.1 (XXXX-XX-XX)
 -------------------
-
-* Sort out a thread blockage on AQL upsert waiting for replication.
 
 * FE-454: Fix saving document in "Tree" mode.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,8 @@ devel
 3.12.1 (XXXX-XX-XX)
 -------------------
 
+* Sort out a thread blockage on AQL upsert waiting for replication.
+
 * FE-454: Fix saving document in "Tree" mode.
 
 * FE-310: Query editor in web UI can now be resized vertically.

--- a/arangod/Aql/Executor/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/Executor/ModificationExecutorHelpers.cpp
@@ -270,7 +270,7 @@ void ModificationExecutorHelpers::waitAndDetach(
       if (!future.isReady()) {
         LOG_TOPIC("afe32", INFO, Logger::THREADS)
             << "Did not get replication response within " << detachTime.count()
-            << " microseconds, detaching scheduler thread.";
+            << " milliseconds, detaching scheduler thread.";
         uint64_t currentNumberDetached = 0;
         uint64_t maximumNumberDetached = 0;
         auto res = SchedulerFeature::SCHEDULER->detachThread(

--- a/arangod/Aql/Executor/ModificationExecutorHelpers.cpp
+++ b/arangod/Aql/Executor/ModificationExecutorHelpers.cpp
@@ -28,6 +28,11 @@
 #include "Aql/Executor/ModificationExecutorInfos.h"
 #include "Basics/Result.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/cpu-relax.h"
+#include "Logger/LogLevel.h"
+#include "Logger/LogMacros.h"
+#include "Random/RandomGenerator.h"
+#include "Scheduler/SchedulerFeature.h"
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/OperationResult.h"
 
@@ -36,6 +41,7 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
+#include <chrono>
 #include <string>
 
 using namespace arangodb;
@@ -234,4 +240,53 @@ AqlValue ModificationExecutorHelpers::getDocumentOrNull(
     return AqlValue{s};
   }
   return AqlValue(AqlValueHintNull());
+}
+
+// If we simply wait, it can happen that we get into a blockage in which
+// all threads wait in the same place here and none can make progress,
+// since the scheduler is full. This means we must detach the thread
+// after some time. To avoid that all are detaching at the same time,
+// we choose a random timeout for the detaching. But first we spin a
+// while to avoid delays:
+void ModificationExecutorHelpers::waitAndDetach(
+    futures::Future<OperationResult>& future) {
+  if (!future.isReady()) {
+    {
+      auto const spinTime = std::chrono::milliseconds(10);
+      auto const start = std::chrono::steady_clock::now();
+      while (!future.isReady() &&
+             std::chrono::steady_clock::now() - start < spinTime) {
+        basics::cpu_relax();
+      }
+    }
+    if (!future.isReady()) {
+      auto const detachTime = std::chrono::milliseconds(
+          1000 + RandomGenerator::interval(uint32_t(100)) * 100);
+      auto start = std::chrono::steady_clock::now();
+      while (!future.isReady() &&
+             std::chrono::steady_clock::now() - start < detachTime) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      if (!future.isReady()) {
+        LOG_TOPIC("afe32", INFO, Logger::THREADS)
+            << "Did not get replication response within " << detachTime.count()
+            << " microseconds, detaching scheduler thread.";
+        uint64_t currentNumberDetached = 0;
+        uint64_t maximumNumberDetached = 0;
+        auto res = SchedulerFeature::SCHEDULER->detachThread(
+            &currentNumberDetached, &maximumNumberDetached);
+        if (res.is(TRI_ERROR_TOO_MANY_DETACHED_THREADS)) {
+          LOG_TOPIC("afe33", WARN, Logger::THREADS)
+              << "Could not detach scheduler thread (currently detached "
+                 "threads: "
+              << currentNumberDetached
+              << ", maximal number of detached threads: "
+              << maximumNumberDetached
+              << "), will continue to wait for replication in scheduler "
+                 "thread, this can potentially lead to blockages!";
+        }
+        future.wait();
+      }
+    }
+  }
 }

--- a/arangod/Aql/Executor/ModificationExecutorHelpers.h
+++ b/arangod/Aql/Executor/ModificationExecutorHelpers.h
@@ -36,6 +36,10 @@
 #include <string>
 
 namespace arangodb {
+namespace futures {
+template<typename T>
+class Future;
+}
 namespace aql {
 
 struct ModificationExecutorInfos;
@@ -94,6 +98,8 @@ OperationOptions convertOptions(ModificationOptions const& in,
                                 Variable const* outVariableOld);
 
 AqlValue getDocumentOrNull(velocypack::Slice elm, std::string const& key);
+
+void waitAndDetach(futures::Future<OperationResult>& future);
 
 }  // namespace ModificationExecutorHelpers
 }  // namespace aql

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -300,19 +300,25 @@ ExecutionState UpsertModifier::transact(transaction::Methods& trx) {
 
   auto toInsert = _insertAccumulator.closeAndGetContents();
   if (toInsert.isArray() && toInsert.length() > 0) {
-    _insertResults =
-        trx.insert(_infos._aqlCollection->name(), toInsert, _infos._options);
+    auto future = trx.insertAsync(_infos._aqlCollection->name(), toInsert,
+                                  _infos._options);
+    waitAndDetach(future);
+    _insertResults = std::move(future).get();
     throwOperationResultException(_infos, _insertResults);
   }
 
   auto toUpdate = _updateAccumulator.closeAndGetContents();
   if (toUpdate.isArray() && toUpdate.length() > 0) {
     if (_infos._isReplace) {
-      _updateResults =
-          trx.replace(_infos._aqlCollection->name(), toUpdate, _infos._options);
+      auto future = trx.replaceAsync(_infos._aqlCollection->name(), toUpdate,
+                                     _infos._options);
+      waitAndDetach(future);
+      _updateResults = std::move(future).get();
     } else {
-      _updateResults =
-          trx.update(_infos._aqlCollection->name(), toUpdate, _infos._options);
+      auto future = trx.updateAsync(_infos._aqlCollection->name(), toUpdate,
+                                    _infos._options);
+      waitAndDetach(future);
+      _updateResults = std::move(future).get();
     }
     throwOperationResultException(_infos, _updateResults);
   }

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -303,7 +303,7 @@ ExecutionState UpsertModifier::transact(transaction::Methods& trx) {
     auto future = trx.insertAsync(_infos._aqlCollection->name(), toInsert,
                                   _infos._options);
     waitAndDetach(future);
-    _insertResults = std::move(future).get();
+    _insertResults = std::move(future).waitAndGet();
     throwOperationResultException(_infos, _insertResults);
   }
 
@@ -313,12 +313,12 @@ ExecutionState UpsertModifier::transact(transaction::Methods& trx) {
       auto future = trx.replaceAsync(_infos._aqlCollection->name(), toUpdate,
                                      _infos._options);
       waitAndDetach(future);
-      _updateResults = std::move(future).get();
+      _updateResults = std::move(future).waitAndGet();
     } else {
       auto future = trx.updateAsync(_infos._aqlCollection->name(), toUpdate,
                                     _infos._options);
       waitAndDetach(future);
-      _updateResults = std::move(future).get();
+      _updateResults = std::move(future).waitAndGet();
     }
     throwOperationResultException(_infos, _updateResults);
   }


### PR DESCRIPTION
### Scope & Purpose

Forward-port of https://github.com/arangodb/arangodb/pull/21094. We don't want this to stay in devel/3.12, but rather make UPSERT truly asynchronous like the other modification operations (see https://github.com/arangodb/arangodb/pull/21068). This is just so devel isn't worse off than 3.11, and will hopefully be superseded quickly.

- [X] :hankey: Bugfix
