### PR TITLE
Make AQL UPSERT asynchronous

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,8 +6,9 @@ devel
   Content-Length header is set to 0, ensuring compliance with the HTTP protocol
   and preventing indefinite client waits.
 
-* Document modification operations (insert, update, etc) during an AQL query on
-  DBServers no longer block threads while waiting for replication.
+* Document modification operations (INSERT, UPDATE, REPLACE, REMOVE, and UPSERT)
+  during an AQL query on DBServers no longer block threads while waiting for
+  replication.
 
 * Fixed a bug where accessing a collection right after creation can sometimes
   fail.

--- a/arangod/Aql/Executor/ModificationExecutor.h
+++ b/arangod/Aql/Executor/ModificationExecutor.h
@@ -211,7 +211,9 @@ ModificationExecutor<FetcherType, ModifierType>::~ModificationExecutor() {
   // Clear all InputAqlItemRows the modifier still holds, and with it the
   // SharedAqlItemBlockPtrs. This is so the referenced AqlItemBlocks can be
   // returned to the AqlItemBlockManager now, while the latter still exists.
-  _modifier->clearRows();
+  // Also sets a flag in the UpsertModifier that it must no longer use the
+  // transaction Methods it might still hold a reference to.
+  _modifier->stopAndClear();
 }
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -331,6 +331,9 @@ SimpleModifier<ModifierCompletion, Enable>::getResultsIterator() const {
 template<typename ModifierCompletion, typename Enable>
 bool SimpleModifier<ModifierCompletion, Enable>::hasResultOrException()
     const noexcept {
+  // Note that this is never called while the modifier is running, that's why we
+  // don't need to lock _resultMutex. This way possible unintended races might
+  // be revealed by TSan.
   return std::visit(overload{
                         [](NoResult) { return false; },
                         [](Waiting) { return false; },
@@ -344,6 +347,9 @@ template<typename ModifierCompletion, typename Enable>
 bool SimpleModifier<ModifierCompletion,
                     Enable>::hasNeitherResultNorOperationPending()
     const noexcept {
+  // Note that this is never called while the modifier is running, that's why we
+  // don't need to lock _resultMutex. This way possible unintended races might
+  // be revealed by TSan.
   return std::visit(overload{
                         [](NoResult) { return true; },
                         [](Waiting) { return false; },

--- a/arangod/Aql/SimpleModifier.cpp
+++ b/arangod/Aql/SimpleModifier.cpp
@@ -354,7 +354,7 @@ bool SimpleModifier<ModifierCompletion,
 }
 
 template<typename ModifierCompletion, typename Enable>
-void SimpleModifier<ModifierCompletion, Enable>::clearRows() noexcept {
+void SimpleModifier<ModifierCompletion, Enable>::stopAndClear() noexcept {
   _operations.clear();
 }
 

--- a/arangod/Aql/SimpleModifier.h
+++ b/arangod/Aql/SimpleModifier.h
@@ -153,7 +153,7 @@ class SimpleModifier : public std::enable_shared_from_this<
   // Destroy all InputAqlItemRows, and with it SharedAqlItemBlockPtrs, this
   // holds. This is necessary to ensure the lifetime of the AqlItemBlocks is
   // shorter than of the AqlItemBlockManager, to which they are returned.
-  void clearRows() noexcept;
+  void stopAndClear() noexcept;
 
  private:
   [[nodiscard]] bool resultAvailable() const;

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -465,7 +465,7 @@ bool UpsertModifier::hasNeitherResultNorOperationPending() const noexcept {
                     _results);
 }
 
-void UpsertModifier::clearRows() noexcept {
+void UpsertModifier::stopAndClear() noexcept {
   _operations.clear();
   auto guard = std::lock_guard(_trxMutex);
   // should be called only once, thus...

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -300,19 +300,22 @@ ExecutionState UpsertModifier::transact(transaction::Methods& trx) {
 
   auto toInsert = _insertAccumulator.closeAndGetContents();
   if (toInsert.isArray() && toInsert.length() > 0) {
-    _insertResults =
-        trx.insert(_infos._aqlCollection->name(), toInsert, _infos._options);
+    _insertResults = trx.insertAsync(_infos._aqlCollection->name(), toInsert,
+                                     _infos._options)
+                         .waitAndGet();
     throwOperationResultException(_infos, _insertResults);
   }
 
   auto toUpdate = _updateAccumulator.closeAndGetContents();
   if (toUpdate.isArray() && toUpdate.length() > 0) {
     if (_infos._isReplace) {
-      _updateResults =
-          trx.replace(_infos._aqlCollection->name(), toUpdate, _infos._options);
+      _updateResults = trx.replaceAsync(_infos._aqlCollection->name(), toUpdate,
+                                        _infos._options)
+                           .waitAndGet();
     } else {
-      _updateResults =
-          trx.update(_infos._aqlCollection->name(), toUpdate, _infos._options);
+      _updateResults = trx.updateAsync(_infos._aqlCollection->name(), toUpdate,
+                                       _infos._options)
+                           .waitAndGet();
     }
     throwOperationResultException(_infos, _updateResults);
   }

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -446,6 +446,9 @@ size_t UpsertModifier::nrOfWritesIgnored() const { return nrOfErrors(); }
 size_t UpsertModifier::getBatchSize() const { return _batchSize; }
 
 bool UpsertModifier::hasResultOrException() const noexcept {
+  // Note that this is never called while the modifier is running, that's why we
+  // don't need to lock _resultMutex. This way possible unintended races might
+  // be revealed by TSan.
   return std::visit(overload{
                         [](NoResult) { return false; },
                         [](Waiting) { return false; },
@@ -456,6 +459,9 @@ bool UpsertModifier::hasResultOrException() const noexcept {
 }
 
 bool UpsertModifier::hasNeitherResultNorOperationPending() const noexcept {
+  // Note that this is never called while the modifier is running, that's why we
+  // don't need to lock _resultMutex. This way possible unintended races might
+  // be revealed by TSan.
   return std::visit(overload{
                         [](NoResult) { return true; },
                         [](Waiting) { return false; },

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -25,12 +25,18 @@
 
 #include "Aql/AqlValue.h"
 #include "Aql/Collection.h"
+#include "Aql/ExecutionEngine.h"
 #include "Aql/Executor/ModificationExecutor.h"
 #include "Aql/Executor/ModificationExecutorAccumulator.h"
 #include "Aql/Executor/ModificationExecutorHelpers.h"
 #include "Aql/QueryContext.h"
+#include "Aql/SharedQueryState.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Basics/application-exit.h"
+#include "Logger/LogTopic.h"
+#include "Logger/LogLevel.h"
+#include "Logger/LogMacros.h"
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
 
@@ -137,11 +143,6 @@ typename UpsertModifier::OutputIterator UpsertModifier::OutputIterator::end()
   return it;
 }
 
-ModificationExecutorResultState UpsertModifier::resultState() const noexcept {
-  std::lock_guard<std::mutex> guard(_resultStateMutex);
-  return _resultState;
-}
-
 UpsertModifier::UpsertModifier(ModificationExecutorInfos& infos)
     : _infos(infos),
       _updateResults(Result(), infos._options),
@@ -149,15 +150,14 @@ UpsertModifier::UpsertModifier(ModificationExecutorInfos& infos)
       // Batch size has to be 1 in case the upsert modifier sees its own
       // writes. otherwise it will use the default batching
       _batchSize(_infos._batchSize),
-      _resultState(ModificationExecutorResultState::NoResult) {}
+      _results(NoResult{}) {}
 
 void UpsertModifier::reset() {
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   {
-    std::unique_lock<std::mutex> guard(_resultStateMutex, std::try_to_lock);
+    std::unique_lock<std::mutex> guard(_resultMutex, std::try_to_lock);
     TRI_ASSERT(guard.owns_lock());
-    TRI_ASSERT(_resultState !=
-               ModificationExecutorResultState::WaitingForResult);
+    TRI_ASSERT(!std::holds_alternative<Waiting>(_results));
   }
 #endif
 
@@ -172,8 +172,8 @@ void UpsertModifier::reset() {
 }
 
 void UpsertModifier::resetResult() noexcept {
-  std::lock_guard<std::mutex> guard(_resultStateMutex);
-  _resultState = ModificationExecutorResultState::NoResult;
+  std::lock_guard<std::mutex> guard(_resultMutex);
+  _results = NoResult{};
 }
 
 UpsertModifier::OperationType UpsertModifier::updateReplaceCase(
@@ -277,52 +277,127 @@ void UpsertModifier::accumulate(InputAqlItemRow& row) {
 }
 
 ExecutionState UpsertModifier::transact(transaction::Methods& trx) {
-  std::lock_guard<std::mutex> guard(_resultStateMutex);
+  std::unique_lock<std::mutex> guard(_resultMutex);
 
-  switch (_resultState) {
-    case ModificationExecutorResultState::WaitingForResult:
-      // WAITING is not yet implemented for UpsertModifier, we shouldn't get
-      // here
-      TRI_ASSERT(false);
-      return ExecutionState::WAITING;
-    case ModificationExecutorResultState::HaveResult:
-      // WAITING is not yet implemented for UpsertModifier, we shouldn't get
-      // here
-      TRI_ASSERT(false);
-      return ExecutionState::DONE;
-    case ModificationExecutorResultState::NoResult:
-      // continue
-      break;
+  if (std::holds_alternative<Waiting>(_results)) {
+    return ExecutionState::WAITING;
+  } else if (std::holds_alternative<HaveResult>(_results)) {
+    return ExecutionState::DONE;
+  } else if (auto* ex = std::get_if<std::exception_ptr>(&_results);
+             ex != nullptr) {
+    std::rethrow_exception(*ex);
+  } else {
+    TRI_ASSERT(std::holds_alternative<NoResult>(_results));
   }
 
-  TRI_ASSERT(_resultState == ModificationExecutorResultState::NoResult);
-  _resultState = ModificationExecutorResultState::NoResult;
+  _results = NoResult{};
 
+  auto fut = transactInternal(trx);
+
+  if (fut.isReady()) {
+    std::move(fut).waitAndGet();
+    _results = HaveResult{};
+    return ExecutionState::DONE;
+  }
+
+  _results = Waiting{};
+
+  TRI_ASSERT(!ServerState::instance()->isSingleServer());
+  TRI_ASSERT(_infos.engine() != nullptr);
+  TRI_ASSERT(_infos.engine()->sharedState() != nullptr);
+
+  // The guard has to be unlocked before "thenValue" is called, otherwise
+  // locking the mutex there will cause a deadlock if the result is already
+  // available.
+  guard.unlock();
+
+  std::move(fut).thenFinal([self = this->shared_from_this(),
+                            sqs = _infos.engine()->sharedState()](
+                               futures::Try<futures::Unit>&& tryResult) {
+    sqs->executeAndWakeup([&]() noexcept {
+      std::unique_lock<std::mutex> guard(self->_resultMutex);
+      try {
+        TRI_ASSERT(std::holds_alternative<Waiting>(self->_results));
+        if (std::holds_alternative<Waiting>(self->_results)) {
+          // get() will throw if opRes holds an exception, which is intended.
+          std::move(tryResult).get();
+          self->_results = HaveResult{};
+        } else {
+          // This can never happen.
+          using namespace std::string_literals;
+          auto state = std::visit(
+              overload{[&](NoResult) { return "NoResults"s; },
+                       [&](Waiting) { return "Waiting"s; },
+                       [&](HaveResult) { return "Result"s; },
+                       [&](std::exception_ptr const& ep) {
+                         auto what = std::string{};
+                         try {
+                           std::rethrow_exception(ep);
+                         } catch (std::exception const& ex) {
+                           what = ex.what();
+                         } catch (...) {
+                           // Exception unknown, give up immediately.
+                           LOG_TOPIC("adb0e", FATAL, Logger::AQL)
+                               << "Caught an exception while handling another "
+                                  "one, giving up.";
+                           FATAL_ERROR_ABORT();
+                         }
+                         return StringUtils::concatT("Exception: ", what);
+                       }},
+              self->_results);
+          auto message = StringUtils::concatT(
+              "Unexpected state when reporting modification result, expected "
+              "'Waiting' but got: ",
+              state);
+          LOG_TOPIC("3b0e1", ERR, Logger::AQL) << message;
+          if (std::holds_alternative<std::exception_ptr>(self->_results)) {
+            // Avoid overwriting an exception with another exception.
+            LOG_TOPIC("78c8b", FATAL, Logger::AQL)
+                << "Caught an exception while handling another one, giving up.";
+            FATAL_ERROR_ABORT();
+          }
+          THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL_AQL,
+                                         std::move(message));
+        }
+      } catch (...) {
+        auto exptr = std::current_exception();
+        self->_results = exptr;
+      }
+      return true;
+    });
+  });
+
+  return ExecutionState::WAITING;
+}
+
+futures::Future<futures::Unit> UpsertModifier::transactInternal(
+    transaction::Methods& trx) {
   auto toInsert = _insertAccumulator.closeAndGetContents();
   if (toInsert.isArray() && toInsert.length() > 0) {
-    _insertResults = trx.insertAsync(_infos._aqlCollection->name(), toInsert,
-                                     _infos._options)
-                         .waitAndGet();
+    auto future = [&] {
+      auto guard = std::lock_guard(_trxMutex);
+      return trx.insertAsync(_infos._aqlCollection->name(), toInsert,
+                             _infos._options);
+    }();
+    _insertResults = co_await std::move(future);
     throwOperationResultException(_infos, _insertResults);
   }
 
   auto toUpdate = _updateAccumulator.closeAndGetContents();
   if (toUpdate.isArray() && toUpdate.length() > 0) {
-    if (_infos._isReplace) {
-      _updateResults = trx.replaceAsync(_infos._aqlCollection->name(), toUpdate,
-                                        _infos._options)
-                           .waitAndGet();
-    } else {
-      _updateResults = trx.updateAsync(_infos._aqlCollection->name(), toUpdate,
-                                       _infos._options)
-                           .waitAndGet();
-    }
+    auto future = [&] {
+      auto guard = std::lock_guard(_trxMutex);
+      if (_infos._isReplace) {
+        return trx.replaceAsync(_infos._aqlCollection->name(), toUpdate,
+                                _infos._options);
+      } else {
+        return trx.updateAsync(_infos._aqlCollection->name(), toUpdate,
+                               _infos._options);
+      }
+    }();
+    _updateResults = co_await std::move(future);
     throwOperationResultException(_infos, _updateResults);
   }
-
-  _resultState = ModificationExecutorResultState::HaveResult;
-
-  return ExecutionState::DONE;
 }
 
 size_t UpsertModifier::nrOfDocuments() const {
@@ -365,11 +440,29 @@ size_t UpsertModifier::nrOfWritesIgnored() const { return nrOfErrors(); }
 size_t UpsertModifier::getBatchSize() const { return _batchSize; }
 
 bool UpsertModifier::hasResultOrException() const noexcept {
-  return resultState() == ModificationExecutorResultState::HaveResult;
+  return std::visit(overload{
+                        [](NoResult) { return false; },
+                        [](Waiting) { return false; },
+                        [](HaveResult) { return true; },
+                        [](std::exception_ptr const&) { return true; },
+                    },
+                    _results);
 }
 
 bool UpsertModifier::hasNeitherResultNorOperationPending() const noexcept {
-  return resultState() == ModificationExecutorResultState::NoResult;
+  return std::visit(overload{
+                        [](NoResult) { return true; },
+                        [](Waiting) { return false; },
+                        [](HaveResult) { return false; },
+                        [](std::exception_ptr const&) { return false; },
+                    },
+                    _results);
 }
 
-void UpsertModifier::clearRows() noexcept { _operations.clear(); }
+void UpsertModifier::clearRows() noexcept {
+  _operations.clear();
+  auto guard = std::lock_guard(_trxMutex);
+  // should be called only once, thus...
+  TRI_ASSERT(_trxAlive);
+  _trxAlive = false;
+}

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -376,6 +376,9 @@ futures::Future<futures::Unit> UpsertModifier::transactInternal(
   if (toInsert.isArray() && toInsert.length() > 0) {
     auto future = [&] {
       auto guard = std::lock_guard(_trxMutex);
+      if (!_trxAlive) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+      }
       return trx.insertAsync(_infos._aqlCollection->name(), toInsert,
                              _infos._options);
     }();
@@ -387,6 +390,9 @@ futures::Future<futures::Unit> UpsertModifier::transactInternal(
   if (toUpdate.isArray() && toUpdate.length() > 0) {
     auto future = [&] {
       auto guard = std::lock_guard(_trxMutex);
+      if (!_trxAlive) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+      }
       if (_infos._isReplace) {
         return trx.replaceAsync(_infos._aqlCollection->name(), toUpdate,
                                 _infos._options);

--- a/arangod/Aql/UpsertModifier.h
+++ b/arangod/Aql/UpsertModifier.h
@@ -38,25 +38,13 @@ namespace arangodb::aql {
 
 struct ModificationExecutorInfos;
 
-// TODO Remove this state, and use a variant as in SimpleModifier.
-//      It makes most sense to do this when implementing async upsert
-//      operations, so I'm leaving it for now.
-enum class ModificationExecutorResultState {
-  // State that is used when the Executor's modifier has not been
-  // asked to produce a result.
-  // this is also the initial state.
-  NoResult,
-  // State that is used when the Executor's modifier has been asked
-  // to produce a result, but it returned a WAITING status, i.e. the
-  // result is not yet ready to consume.
-  // This state cannot happen in single servers!
-  WaitingForResult,
-  // State that is used when the Executor's modifier has produced
-  // a result that is ready to consume.
-  HaveResult,
-};
+class UpsertModifier : public std::enable_shared_from_this<UpsertModifier> {
+  struct NoResult {};
+  struct Waiting {};
+  struct HaveResult {};
+  using ResultType =
+      std::variant<NoResult, Waiting, HaveResult, std::exception_ptr>;
 
-class UpsertModifier {
  public:
   enum class OperationType {
     // Return the OLD and/or NEW value, if requested, otherwise CopyRow
@@ -95,8 +83,6 @@ class UpsertModifier {
 
   ~UpsertModifier() = default;
 
-  ModificationExecutorResultState resultState() const noexcept;
-
   void checkException() const {}
   void resetResult() noexcept;
   void reset();
@@ -119,6 +105,7 @@ class UpsertModifier {
   // Destroy all InputAqlItemRows, and with it SharedAqlItemBlockPtrs, this
   // holds. This is necessary to ensure the lifetime of the AqlItemBlocks is
   // shorter than of the AqlItemBlockManager, to which they are returned.
+  // TODO Rename this, at it does do more now.
   void clearRows() noexcept;
 
  private:
@@ -132,6 +119,8 @@ class UpsertModifier {
   OperationType insertCase(ModificationExecutorAccumulator& accu,
                            AqlValue const& insertDoc);
 
+  futures::Future<futures::Unit> transactInternal(transaction::Methods& trx);
+
   ModificationExecutorInfos& _infos;
   std::vector<ModOp> _operations;
   ModificationExecutorAccumulator _insertAccumulator;
@@ -144,8 +133,11 @@ class UpsertModifier {
 
   size_t const _batchSize;
 
-  mutable std::mutex _resultStateMutex;
-  ModificationExecutorResultState _resultState;
+  mutable std::mutex _trxMutex;
+  bool _trxAlive = true;
+
+  mutable std::mutex _resultMutex;
+  ResultType _results;
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/UpsertModifier.h
+++ b/arangod/Aql/UpsertModifier.h
@@ -105,8 +105,9 @@ class UpsertModifier : public std::enable_shared_from_this<UpsertModifier> {
   // Destroy all InputAqlItemRows, and with it SharedAqlItemBlockPtrs, this
   // holds. This is necessary to ensure the lifetime of the AqlItemBlocks is
   // shorter than of the AqlItemBlockManager, to which they are returned.
-  // TODO Rename this, at it does do more now.
-  void clearRows() noexcept;
+  // Also makes sure the transaction Methods will not be used from this point
+  // on, as they might have been destroyed.
+  void stopAndClear() noexcept;
 
  private:
   bool resultAvailable() const;

--- a/tests/js/client/shell/multi/shell-aql-kill.js
+++ b/tests/js/client/shell/multi/shell-aql-kill.js
@@ -100,6 +100,12 @@ function aqlKillSuite () {
 
     const queryId = findQueryId(query);
 
+    // Sleep a short random amount up to 10ms, to make it more likely to catch
+    // the query in different situations. Square to make shorter sleeps more
+    // likely than longer ones.
+    const sleepForMs = 10 * Math.pow(Math.random(), 2);
+    internal.wait(sleepForMs * 1e-3);
+
     assertTrue(queryId > 0);
 
     const killResult = arango.DELETE("/_api/query/" + queryId);

--- a/tests/js/client/shell/multi/shell-aql-kill.js
+++ b/tests/js/client/shell/multi/shell-aql-kill.js
@@ -62,7 +62,7 @@ function aqlKillSuite () {
     return () => {
       const queries = require("@arangodb/aql/queries").current();
       const stillThere = queries.filter(q => q.id === queryId).length > 0;
-      if (!stillThere) {
+      if (stillThere) {
         return undefined;
       } else {
         return true;

--- a/tests/js/client/shell/multi/shell-aql-kill.js
+++ b/tests/js/client/shell/multi/shell-aql-kill.js
@@ -145,7 +145,7 @@ function aqlKillSuite () {
       runAbortQueryTest("FOR i IN 1..10000000 RETURN SLEEP(1)");
     },
 
-    testAbortWriteQuery: function () {
+    testAbortInsertQuery: function () {
       runAbortQueryTest(`FOR i IN 1..10000000 INSERT {} INTO ${cn}`);
     },
 

--- a/tests/js/client/shell/multi/shell-aql-kill.js
+++ b/tests/js/client/shell/multi/shell-aql-kill.js
@@ -88,7 +88,7 @@ function aqlKillSuite () {
         .filter(q => q.query === query)
         .map(q => q.id));
     };
-    return tryForUntil({until})
+    return tryForUntil({until});
   }
 
   function runAbortQueryTest(query) {

--- a/tests/js/server/replication2/replication2-replicated-state-document-store.js
+++ b/tests/js/server/replication2/replication2-replicated-state-document-store.js
@@ -1194,7 +1194,7 @@ const replicatedStateSnapshotTransferSuite = function () {
         } catch (e) {
           print("Error: ", e);
           print("Collection contents: ", col.all().toArray());
-          fail(`Expected collection ${name} to have document ${key} - collection contents see above`);
+          fail(`Expected collection ${name} to have document ${key}, but got ${e} - collection contents see above`);
         }
       }
     },


### PR DESCRIPTION
### Scope & Purpose

Make AQL UPSERT operations asynchronous.

- [X] :hankey: Bugfix
- [X] :pizza: New feature
- [X] :fire: Performance improvement

### Checklist

- [X] Tests
  - [X] **integration tests**
- [x] :book: CHANGELOG entry made

#### Related Information

Related PR: https://github.com/arangodb/arangodb/pull/21068
