### PR TITLE
fix data race in cluster selectivity estimates

### DIFF
--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -217,11 +217,11 @@ double ClusterIndex::selectivityEstimate(std::string_view) const {
 
   // floating-point tolerance
   TRI_ASSERT(_clusterSelectivity >= 0.0 && _clusterSelectivity <= 1.00001);
-  return _clusterSelectivity;
+  return _clusterSelectivity.load(std::memory_order_relaxed);
 }
 
 void ClusterIndex::updateClusterSelectivityEstimate(double estimate) {
-  _clusterSelectivity = estimate;
+  _clusterSelectivity.store(estimate, std::memory_order_relaxed);
 }
 
 bool ClusterIndex::isSorted() const {

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -30,6 +30,8 @@
 #include "Indexes/Index.h"
 #include "VocBase/Identifiers/IndexId.h"
 
+#include <atomic>
+
 namespace arangodb {
 class LogicalCollection;
 
@@ -119,7 +121,7 @@ class ClusterIndex : public Index {
   Index::IndexType _indexType;
   velocypack::Builder _info;
   bool _estimates;
-  double _clusterSelectivity;
+  std::atomic<double> _clusterSelectivity;
 
   // Only used in RocksDB edge index.
   std::vector<std::vector<basics::AttributeName>> _coveredFields;


### PR DESCRIPTION
### Scope & Purpose

Fix data-race reported by TSan via https://circleci.com/api/v1.1/project/github/arangodb/arangodb/2046644/output/103/0?file=true&allocation-id=667a128865532b545d433b6f-0-build%2FABCDEFGH

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 