### PR TITLE
We cannot use a std::mutex in a function that is a coroutine

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -27,6 +27,7 @@
 #include "Basics/ReadLocker.h"
 #include "Basics/RecursiveLocker.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/UnshackledMutex.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/WriteLocker.h"
 #include "Basics/hashes.h"
@@ -168,7 +169,7 @@ uint64_t RocksDBMetaCollection::numberDocuments(
 
 // rescans the collection to update document count
 futures::Future<uint64_t> RocksDBMetaCollection::recalculateCounts() {
-  std::unique_lock<std::mutex> guard(_recalculationLock);
+  std::unique_lock<basics::UnshackledMutex> guard(_recalculationLock);
 
   rocksdb::TransactionDB* db = _engine.db();
   const rocksdb::Snapshot* snapshot = nullptr;

--- a/arangod/RocksDBEngine/RocksDBMetaCollection.h
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.h
@@ -24,7 +24,7 @@
 #pragma once
 
 #include "Basics/FutureSharedLock.h"
-#include "Basics/ReadWriteLock.h"
+#include "Basics/UnshackledMutex.h"
 #include "Basics/ResultT.h"
 #include "Containers/MerkleTree.h"
 #include "RocksDBEngine/RocksDBCommon.h"
@@ -206,7 +206,7 @@ class RocksDBMetaCollection : public PhysicalCollection {
   using FutureLock = arangodb::futures::FutureSharedLock<SchedulerWrapper>;
   mutable FutureLock _exclusiveLock;
   /// @brief collection lock used for recalculation count values
-  mutable std::mutex _recalculationLock;
+  mutable basics::UnshackledMutex _recalculationLock;
 
   /// @brief depth for all revision trees.
   /// depth is large from the beginning so that the trees are always


### PR DESCRIPTION
### Scope & Purpose

Otherwise the mutex could be locked in one thread but unlocked in a different one, which is not supported by std::mutex
