### PR TITLE
fix a potential assertion failure in RocksDBMetaCollection

### DIFF
--- a/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBMetaCollection.cpp
@@ -1611,7 +1611,8 @@ Result RocksDBMetaCollection::applyUpdatesForTransaction(
     containers::RevisionTree& tree, rocksdb::SequenceNumber commitSeq,
     std::unique_lock<std::mutex>& lock) const {
   TRI_ASSERT(lock.owns_lock());
-  TRI_ASSERT(_logicalCollection.useSyncByRevision());
+  TRI_ASSERT(_logicalCollection.useSyncByRevision() ||
+             _logicalCollection.deleted());
 
   return basics::catchVoidToResult([&]() -> void {
     auto insertIt = _revisionInsertBuffers.begin();


### PR DESCRIPTION
### Scope & Purpose

Fix an assertion failure in applyUpdatesForTransaction if a collection is set to deleted shortly before the call executes.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 