### PR TITLE
fix a flaky test

### DIFF
--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -1718,9 +1718,6 @@ TEST_F(IResearchLinkTest, test_maintenance_disabled_at_creation) {
     ASSERT_NE(nullptr, link);
 
     // 1st - tasks active(), 2nd - tasks pending(), 3rd - threads()
-    ASSERT_EQ(std::make_tuple(size_t(1), size_t(0), size_t(1)),
-              feature.stats(ThreadGroup::_0));
-
     std::tuple<size_t, size_t, size_t> stats;
     do {
       stats = feature.stats(ThreadGroup::_1);


### PR DESCRIPTION
### Scope & Purpose

Fix a flaky IResearch test. 
There was previous fix attempt for this test, which made the test retry in case the thread numbers were not yet as expected. This is sensible because the thread numbers depend on thread scheduling, which is beyond control of this particular test.
The intention of the previous fix was to make the test spin until the thread numbers are as expected, and only then validate them. Unfortunately I forgot to remove the initial line that checks the thread numbers before spinning, which rendered the previous fix attempt useless.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 