### PR TITLE
async<T>

### DIFF
--- a/lib/Basics/async.h
+++ b/lib/Basics/async.h
@@ -58,8 +58,9 @@ struct async_promise_base {
 
 template<typename T>
 struct async_promise : async_promise_base<T> {
-  void return_value(T v) {
-    async_promise_base<T>::_value.emplace(std::move(v));
+  template<typename V = T>
+  void return_value(V&& v) {
+    async_promise_base<T>::_value.emplace(std::forward<V>(v));
   }
 };
 

--- a/lib/Basics/async.h
+++ b/lib/Basics/async.h
@@ -1,0 +1,305 @@
+#pragma once
+#include <coroutine>
+#include <atomic>
+#include <stdexcept>
+#include <utility>
+#include <source_location>
+
+#include <iostream>
+
+namespace arangodb {
+
+template<typename T>
+struct expected {
+  expected() {}
+
+  template<typename... Args>
+  explicit expected(std::in_place_t, Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<T, Args...>) requires
+      std::constructible_from<T, Args...> {
+    new (&_value) T(std::forward<Args>(args)...);
+    _state = kValue;
+  }
+
+  explicit expected(std::exception_ptr ex) {
+    _exception = ex;
+    _state = kException;
+  }
+
+  expected(expected const& other) noexcept(
+      std::is_nothrow_copy_constructible_v<T>) requires
+      std::copy_constructible<T> {
+    if (other._state == kValue) {
+      new (&_value) T(other._value);
+      _state = kValue;
+    } else if (other._state == kException) {
+      static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+      new (&_exception) std::exception_ptr(other._exception);
+      _state = kException;
+    }
+  }
+
+  expected(expected&& other) noexcept(
+      std::is_nothrow_move_constructible_v<T>) requires
+      std::move_constructible<T> {
+    if (other._state == kValue) {
+      new (&_value) T(std::move(other._value));
+      _state = kValue;
+    } else if (other._state == kException) {
+      static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>);
+      new (&_exception) std::exception_ptr(std::move(other._exception));
+      _state = kException;
+    }
+  }
+
+  expected& operator=(expected const& other) noexcept(
+      std::is_nothrow_copy_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&& std::is_nothrow_copy_assignable_v<
+              T>) requires(std::copy_constructible<T>&&
+                               std::is_copy_assignable_v<T>) {
+    if (this != &other) {
+      if (other._state == kValue && _state == kValue) {
+        _state = other._state;
+      } else {
+        reset();
+        if (other._state == kValue) {
+          new (&_value) T(other._value);
+          _state = kValue;
+        } else if (other._state == kException) {
+          static_assert(
+              std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+          new (&_exception) std::exception_ptr(other._exception);
+          _state = kException;
+        }
+      }
+    }
+    return *this;
+  }
+
+  expected& operator=(expected&& other) noexcept(
+      std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&& std::is_nothrow_move_assignable_v<
+              T>) requires(std::move_constructible<T>&&
+                               std::is_move_assignable_v<T>) {
+    if (this != &other) {
+      if (other._state == kValue && _state == kValue) {
+        _state = std::move(other._state);
+      } else {
+        reset();
+        if (other._state == kValue) {
+          new (&_value) T(other._value);
+          _state = kValue;
+        } else if (other._state == kException) {
+          static_assert(
+              std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+          new (&_exception) std::exception_ptr(other._exception);
+          _state = kException;
+        }
+        other.reset();
+      }
+    }
+    return *this;
+  }
+
+  template<typename... Args>
+  T& emplace(Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<T, Args...>&&
+          std::is_nothrow_destructible_v<T>) requires
+      std::constructible_from<T, Args...> {
+    reset();
+    new (&_value) T(std::forward<Args>(args)...);
+    _state = kValue;
+    return _value;
+  }
+
+  void set_exception(std::exception_ptr const& ex) noexcept(
+      std::is_nothrow_destructible_v<T>) {
+    reset();
+    new (&_exception) std::exception_ptr(ex);
+    _state = kException;
+  }
+
+  T& get() & {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return _value;
+    }
+  }
+
+  T const& get() const& {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return _value;
+    }
+  }
+
+  T&& get() && {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return std::move(_value);
+    }
+  }
+
+  T const&& get() const&& {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return std::move(_value);
+    }
+  }
+
+  // It is debatable if -> and * operators should rethrow an exception within
+  T* operator->() noexcept { return &_value; }
+  T const* operator->() const noexcept { return &_value; }
+  T& operator*() noexcept { return &_value; }
+  T const& operator*() const noexcept { return &_value; }
+
+  ~expected() { reset(); }
+
+  void reset() {
+    if (_state == kValue) {
+      _value.~T();
+    } else if (_state == kException) {
+      _exception.~exception_ptr();
+    }
+    _state = kEmpty;
+  }
+
+ private:
+  union {
+    T _value;
+    std::exception_ptr _exception;
+  };
+
+  enum { kEmpty, kValue, kException } _state = kEmpty;
+};
+
+template<>
+struct expected<void> {
+  expected() = default;
+  explicit expected(std::exception_ptr ex) : _exception(std::move(ex)) {}
+  void reset() { _exception = nullptr; }
+
+  void get() const {
+    if (_exception) {
+      std::rethrow_exception(_exception);
+    }
+  }
+
+  void set_exception(std::exception_ptr const& ex) { _exception = ex; }
+
+  void emplace() noexcept { reset(); }
+
+ private:
+  std::exception_ptr _exception;
+};
+
+template<typename T>
+struct async_promise;
+template<typename T>
+struct async;
+
+template<typename T>
+struct async_promise_base {
+  using promise_type = async_promise<T>;
+
+  std::suspend_never initial_suspend() noexcept { return {}; }
+  auto final_suspend() noexcept {
+    struct awaitable {
+      bool await_ready() noexcept { return false; }
+      std::coroutine_handle<> await_suspend(std::coroutine_handle<>) noexcept {
+        auto addr =
+            _promise->_continuation.exchange(std::noop_coroutine().address());
+        if (addr == nullptr) {
+          return std::noop_coroutine();
+        } else {
+          return std::coroutine_handle<>::from_address(addr);
+        }
+      }
+      void await_resume() noexcept {}
+      async_promise_base* _promise;
+    };
+    return awaitable{this};
+  }
+  void unhandled_exception() { _value.set_exception(std::current_exception()); }
+  auto get_return_object() {
+    return async<T>{std::coroutine_handle<promise_type>::from_promise(
+        *static_cast<promise_type*>(this))};
+  }
+
+  std::atomic<void*> _continuation = nullptr;
+  expected<T> _value;
+};
+
+template<typename T>
+struct async_promise : async_promise_base<T> {
+  void return_value(T v) {
+    async_promise_base<T>::_value.emplace(std::move(v));
+  }
+};
+
+template<>
+struct async_promise<void> : async_promise_base<void> {
+  void return_void() { async_promise_base<void>::_value.emplace(); }
+};
+
+template<typename T>
+struct async {
+  using promise_type = async_promise<T>;
+
+  auto operator co_await() && {
+    struct awaitable {
+      bool await_ready() noexcept {
+        return _handle.promise()._continuation.load(
+                   std::memory_order_relaxed) != nullptr;
+      }
+      bool await_suspend(std::coroutine_handle<> c) noexcept {
+        return _handle.promise()._continuation.exchange(c.address()) == nullptr;
+      }
+      auto await_resume() {
+        expected<T> r = std::move(_handle.promise()._value);
+        _handle.destroy();
+        return std::move(r).get();
+      }
+      std::coroutine_handle<promise_type> _handle;
+    };
+
+    auto r = awaitable{_handle};
+    _handle = nullptr;
+    return r;
+  }
+
+  void reset() {
+    if (_handle) {
+      if (_handle.promise()._continuation.exchange(
+              std::noop_coroutine().address(), std::memory_order_release) !=
+          nullptr) {
+        _handle.destroy();
+      }
+      _handle = nullptr;
+    }
+  }
+
+  bool valid() const noexcept { return _handle != nullptr; }
+  operator bool() const noexcept { return valid(); }
+
+  ~async() { reset(); }
+
+  explicit async(std::coroutine_handle<promise_type> h) : _handle(h) {}
+
+ private:
+  std::coroutine_handle<promise_type> _handle;
+};
+
+}  // namespace arangodb

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -23,7 +23,7 @@ struct expected {
 
   expected(expected const& other) noexcept(
       std::is_nothrow_copy_constructible_v<T>) requires
-      std::copy_constructible<T> {
+      std::is_copy_constructible_v<T> {
     if (other._state == kValue) {
       new (&_value) T(other._value);
       _state = kValue;
@@ -50,7 +50,7 @@ struct expected {
   expected& operator=(expected const& other) noexcept(
       std::is_nothrow_copy_constructible_v<T>&&
           std::is_nothrow_destructible_v<T>&& std::is_nothrow_copy_assignable_v<
-              T>) requires(std::copy_constructible<T>&&
+              T>) requires(std::is_copy_constructible_v<T>&&
                                std::is_copy_assignable_v<T>) {
     if (this != &other) {
       if (other._state == kValue && _state == kValue) {

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -3,6 +3,9 @@
 #include <type_traits>
 #include "Assertions/Assert.h"
 
+static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>);
+
 namespace arangodb {
 template<typename T>
 struct expected {
@@ -18,9 +21,7 @@ struct expected {
   }
 
   explicit expected(std::exception_ptr ex) noexcept
-      : _exception(std::move(ex)), _state(kException) {
-    static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>);
-  }
+      : _exception(std::move(ex)), _state(kException) {}
 
  private:
   auto copy_from(expected const& other) noexcept(
@@ -31,7 +32,6 @@ struct expected {
       new (&_value) T(other._value);
       _state = kValue;
     } else if (other._state == kException) {
-      static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>);
       new (&_exception) std::exception_ptr(other._exception);
       _state = kException;
     }
@@ -70,7 +70,6 @@ struct expected {
       new (&_value) T(std::move(other._value));
       _state = kValue;
     } else if (other._state == kException) {
-      static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>);
       new (&_exception) std::exception_ptr(std::move(other._exception));
       _state = kException;
     }

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -205,6 +205,7 @@ struct expected<void> {
   }
 
   void set_exception(std::exception_ptr ex) noexcept {
+    static_assert(std::is_nothrow_move_assignable_v<std::exception_ptr>);
     _exception = std::move(ex);
   }
 

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -3,9 +3,6 @@
 #include <type_traits>
 #include "Assertions/Assert.h"
 
-static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>);
-static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>);
-
 namespace arangodb {
 template<typename T>
 struct expected {

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -78,7 +78,7 @@ struct expected {
                                std::is_move_assignable_v<T>) {
     if (this != &other) {
       if (other._state == kValue && _state == kValue) {
-        _state = std::move(other._state);
+        _value = std::move(other._value);
       } else {
         reset();
         if (other._state == kValue) {

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -1,0 +1,201 @@
+#pragma once
+#include <stdexcept>
+#include <type_traits>
+
+namespace arangodb {
+template<typename T>
+struct expected {
+  expected() {}
+
+  template<typename... Args>
+  explicit expected(std::in_place_t, Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<T, Args...>) requires
+      std::constructible_from<T, Args...> {
+    new (&_value) T(std::forward<Args>(args)...);
+    _state = kValue;
+  }
+
+  explicit expected(std::exception_ptr ex) {
+    _exception = ex;
+    _state = kException;
+  }
+
+  expected(expected const& other) noexcept(
+      std::is_nothrow_copy_constructible_v<T>) requires
+      std::copy_constructible<T> {
+    if (other._state == kValue) {
+      new (&_value) T(other._value);
+      _state = kValue;
+    } else if (other._state == kException) {
+      static_assert(std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+      new (&_exception) std::exception_ptr(other._exception);
+      _state = kException;
+    }
+  }
+
+  expected(expected&& other) noexcept(
+      std::is_nothrow_move_constructible_v<T>) requires
+      std::move_constructible<T> {
+    if (other._state == kValue) {
+      new (&_value) T(std::move(other._value));
+      _state = kValue;
+    } else if (other._state == kException) {
+      static_assert(std::is_nothrow_move_constructible_v<std::exception_ptr>);
+      new (&_exception) std::exception_ptr(std::move(other._exception));
+      _state = kException;
+    }
+  }
+
+  expected& operator=(expected const& other) noexcept(
+      std::is_nothrow_copy_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&& std::is_nothrow_copy_assignable_v<
+              T>) requires(std::copy_constructible<T>&&
+                               std::is_copy_assignable_v<T>) {
+    if (this != &other) {
+      if (other._state == kValue && _state == kValue) {
+        _state = other._state;
+      } else {
+        reset();
+        if (other._state == kValue) {
+          new (&_value) T(other._value);
+          _state = kValue;
+        } else if (other._state == kException) {
+          static_assert(
+              std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+          new (&_exception) std::exception_ptr(other._exception);
+          _state = kException;
+        }
+      }
+    }
+    return *this;
+  }
+
+  expected& operator=(expected&& other) noexcept(
+      std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&& std::is_nothrow_move_assignable_v<
+              T>) requires(std::move_constructible<T>&&
+                               std::is_move_assignable_v<T>) {
+    if (this != &other) {
+      if (other._state == kValue && _state == kValue) {
+        _state = std::move(other._state);
+      } else {
+        reset();
+        if (other._state == kValue) {
+          new (&_value) T(other._value);
+          _state = kValue;
+        } else if (other._state == kException) {
+          static_assert(
+              std::is_nothrow_copy_constructible_v<std::exception_ptr>);
+          new (&_exception) std::exception_ptr(other._exception);
+          _state = kException;
+        }
+        other.reset();
+      }
+    }
+    return *this;
+  }
+
+  template<typename... Args>
+  T& emplace(Args&&... args) noexcept(
+      std::is_nothrow_constructible_v<T, Args...>&&
+          std::is_nothrow_destructible_v<T>) requires
+      std::constructible_from<T, Args...> {
+    reset();
+    new (&_value) T(std::forward<Args>(args)...);
+    _state = kValue;
+    return _value;
+  }
+
+  void set_exception(std::exception_ptr const& ex) noexcept(
+      std::is_nothrow_destructible_v<T>) {
+    reset();
+    new (&_exception) std::exception_ptr(ex);
+    _state = kException;
+  }
+
+  T& get() & {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return _value;
+    }
+  }
+
+  T const& get() const& {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return _value;
+    }
+  }
+
+  T&& get() && {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return std::move(_value);
+    }
+  }
+
+  T const&& get() const&& {
+    if (_state == kEmpty) {
+      throw std::runtime_error("accessing empty expected");
+    } else if (_state == kException) {
+      std::rethrow_exception(_exception);
+    } else {
+      return std::move(_value);
+    }
+  }
+
+  // It is debatable if -> and * operators should rethrow an exception within
+  T* operator->() noexcept { return &_value; }
+  T const* operator->() const noexcept { return &_value; }
+  T& operator*() noexcept { return &_value; }
+  T const& operator*() const noexcept { return &_value; }
+
+  ~expected() { reset(); }
+
+  void reset() {
+    if (_state == kValue) {
+      _value.~T();
+    } else if (_state == kException) {
+      _exception.~exception_ptr();
+    }
+    _state = kEmpty;
+  }
+
+ private:
+  union {
+    T _value;
+    std::exception_ptr _exception;
+  };
+
+  enum { kEmpty, kValue, kException } _state = kEmpty;
+};
+
+template<>
+struct expected<void> {
+  expected() = default;
+  explicit expected(std::exception_ptr ex) : _exception(std::move(ex)) {}
+  void reset() { _exception = nullptr; }
+
+  void get() const {
+    if (_exception) {
+      std::rethrow_exception(_exception);
+    }
+  }
+
+  void set_exception(std::exception_ptr const& ex) { _exception = ex; }
+
+  void emplace() noexcept { reset(); }
+
+ private:
+  std::exception_ptr _exception;
+};
+}  // namespace arangodb

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -13,9 +13,8 @@ struct expected {
 
   template<typename... Args>
   explicit expected(std::in_place_t, Args&&... args) noexcept(
-      std::is_nothrow_constructible_v<T, Args...>)
-    requires std::constructible_from<T, Args...>
-  {
+      std::is_nothrow_constructible_v<T, Args...>) requires
+      std::constructible_from<T, Args...> {
     new (&_value) T(std::forward<Args>(args)...);
     _state = kValue;
   }
@@ -25,9 +24,8 @@ struct expected {
 
  private:
   auto copy_from(expected const& other) noexcept(
-      std::is_nothrow_copy_constructible_v<T>)
-    requires std::is_copy_constructible_v<T>
-  {
+      std::is_nothrow_copy_constructible_v<T>) requires
+      std::is_copy_constructible_v<T> {
     if (other._state == kValue) {
       new (&_value) T(other._value);
       _state = kValue;
@@ -37,19 +35,17 @@ struct expected {
     }
   }
 
- public:
-  expected(expected const& other) noexcept(
-      std::is_nothrow_copy_constructible_v<T>)
-    requires std::is_copy_constructible_v<T>
-  {
+ public : expected(expected const& other) noexcept(
+              std::is_nothrow_copy_constructible_v<T>) requires
+          std::is_copy_constructible_v<T> {
     copy_from(other);
   }
 
   expected& operator=(expected const& other) noexcept(
-      std::is_nothrow_copy_constructible_v<T>&& std::is_nothrow_destructible_v<
-          T>&& std::is_nothrow_copy_assignable_v<T>)
-    requires(std::is_copy_constructible_v<T> && std::is_copy_assignable_v<T>)
-  {
+      std::is_nothrow_copy_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&& std::is_nothrow_copy_assignable_v<
+              T>) requires(std::is_copy_constructible_v<T>&&
+                               std::is_copy_assignable_v<T>) {
     if (this != &other) {
       if (other._state == kValue && _state == kValue) {
         _value = other._value;
@@ -61,11 +57,9 @@ struct expected {
     return *this;
   }
 
- private:
-  auto move_from(expected&& other) noexcept(
-      std::is_nothrow_move_constructible_v<T>)
-    requires std::move_constructible<T>
-  {
+ private : auto move_from(expected&& other) noexcept(
+               std::is_nothrow_move_constructible_v<T>) requires
+           std::move_constructible<T> {
     if (other._state == kValue) {
       new (&_value) T(std::move(other._value));
       _state = kValue;
@@ -75,18 +69,17 @@ struct expected {
     }
   }
 
- public:
-  expected(expected&& other) noexcept(std::is_nothrow_move_constructible_v<T>)
-    requires std::move_constructible<T>
-  {
+ public : expected(expected&& other) noexcept(
+              std::is_nothrow_move_constructible_v<T>) requires
+          std::move_constructible<T> {
     move_from(other);
   }
 
   expected& operator=(expected&& other) noexcept(
-      std::is_nothrow_move_constructible_v<T>&& std::is_nothrow_destructible_v<
-          T>&& std::is_nothrow_move_assignable_v<T>)
-    requires(std::move_constructible<T> && std::is_move_assignable_v<T>)
-  {
+      std::is_nothrow_move_constructible_v<T>&&
+          std::is_nothrow_destructible_v<T>&& std::is_nothrow_move_assignable_v<
+              T>) requires(std::move_constructible<T>&&
+                               std::is_move_assignable_v<T>) {
     if (this != &other) {
       if (other._state == kValue && _state == kValue) {
         _value = std::move(other._value);
@@ -101,9 +94,8 @@ struct expected {
   template<typename... Args>
   T& emplace(Args&&... args) noexcept(
       std::is_nothrow_constructible_v<T, Args...>&&
-          std::is_nothrow_destructible_v<T>)
-    requires std::constructible_from<T, Args...>
-  {
+          std::is_nothrow_destructible_v<T>) requires
+      std::constructible_from<T, Args...> {
     reset();
     new (&_value) T(std::forward<Args>(args)...);
     _state = kValue;

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -72,7 +72,7 @@ struct expected {
  public : expected(expected&& other) noexcept(
               std::is_nothrow_move_constructible_v<T>) requires
           std::move_constructible<T> {
-    move_from(other);
+    move_from(std::move(other));
   }
 
   expected& operator=(expected&& other) noexcept(
@@ -85,7 +85,7 @@ struct expected {
         _value = std::move(other._value);
       } else {
         reset();
-        move_from(other);
+        move_from(std::move(other));
       }
     }
     return *this;

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -50,10 +50,8 @@ struct expected {
   }
 
   expected& operator=(expected&& other) noexcept(
-      std::is_nothrow_move_constructible_v<T>&&
-          std::is_nothrow_destructible_v<T>&& std::is_nothrow_move_assignable_v<
-              T>) requires(std::move_constructible<T>&&
-                               std::is_move_assignable_v<T>) {
+      std::is_nothrow_destructible_v<T>&& std::is_nothrow_move_assignable_v<
+          T>) requires(std::is_move_assignable_v<T>) {
     if (this != &other) {
       if (other._state == kValue && _state == kValue) {
         _value = std::move(other._value);
@@ -158,7 +156,7 @@ struct expected {
  private:
   auto copy_from(expected const& other) noexcept(
       std::is_nothrow_copy_constructible_v<T>) requires
-      std::is_copy_constructible_v<T> {
+      std::copy_constructible<T> {
     if (other._state == kValue) {
       new (&_value) T(other._value);
       _state = kValue;

--- a/lib/Basics/expected.h
+++ b/lib/Basics/expected.h
@@ -201,8 +201,9 @@ struct expected {
 template<>
 struct expected<void> {
   expected() = default;
-  explicit expected(std::exception_ptr ex) : _exception(std::move(ex)) {}
-  void reset() { _exception = nullptr; }
+  explicit expected(std::exception_ptr ex) noexcept
+      : _exception(std::move(ex)) {}
+  void reset() noexcept { _exception = nullptr; }
 
   void get() const {
     if (_exception) {
@@ -210,7 +211,9 @@ struct expected<void> {
     }
   }
 
-  void set_exception(std::exception_ptr ex) { _exception = std::move(ex); }
+  void set_exception(std::exception_ptr ex) noexcept {
+    _exception = std::move(ex);
+  }
 
   void emplace() noexcept { reset(); }
 

--- a/tests/Basics/AsyncTest.cpp
+++ b/tests/Basics/AsyncTest.cpp
@@ -137,9 +137,9 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
 
 using MyTypes = ::testing::Types<
     std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>,
-    std::pair<ConcurrentNoWait, MoveOnlyValue>,
-    std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>,
-    std::pair<ConcurrentNoWait, CopyOnlyValue>>;
+    /*std::pair<ConcurrentNoWait, MoveOnlyValue>,*/
+    std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>/*,
+    std::pair<ConcurrentNoWait, CopyOnlyValue>*/>;
 TYPED_TEST_SUITE(AsyncTest, MyTypes);
 
 using namespace arangodb;

--- a/tests/Basics/AsyncTest.cpp
+++ b/tests/Basics/AsyncTest.cpp
@@ -1,0 +1,213 @@
+#include "Basics/async.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+struct WaitSlot {
+  void resume() { _continuation.resume(); }
+
+  std::coroutine_handle<> _continuation;
+
+  bool await_ready() { return false; }
+  void await_resume() {}
+  void await_suspend(std::coroutine_handle<> continuation) {
+    _continuation = continuation;
+  }
+};
+
+struct NoWait {
+  void resume() {}
+
+  auto operator co_await() { return std::suspend_never{}; }
+};
+
+struct InstanceCounterValue {
+  InstanceCounterValue() { instanceCounter += 1; }
+  InstanceCounterValue(InstanceCounterValue const& o) { instanceCounter += 1; }
+  InstanceCounterValue(InstanceCounterValue&& o) { instanceCounter += 1; }
+
+  ~InstanceCounterValue() {
+    if (instanceCounter == 0) {
+      abort();
+    }
+    instanceCounter -= 1;
+  }
+  static std::size_t instanceCounter;
+};
+
+std::size_t InstanceCounterValue::instanceCounter = 0;
+
+struct CopyOnlyValue : InstanceCounterValue {
+  CopyOnlyValue(int x) : x(x) {}
+  CopyOnlyValue(CopyOnlyValue const& x) : x(x) {}
+
+  auto operator<=>(int y) const noexcept { return x <=> y; }
+  operator int() const noexcept { return x; }
+  int x;
+};
+
+struct MoveOnlyValue : InstanceCounterValue {
+  MoveOnlyValue(int x) : x(x) {}
+  MoveOnlyValue(MoveOnlyValue&& x) : x(x) {}
+  MoveOnlyValue(MoveOnlyValue const& x) = delete;
+
+  auto operator<=>(int y) const noexcept { return x <=> y; }
+  operator int() const noexcept { return x; }
+  int x;
+};
+
+}  // namespace
+
+template<typename>
+struct AsyncTest;
+
+template<typename WaitType, typename ValueType>
+struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
+  void SetUp() override { InstanceCounterValue::instanceCounter = 0; }
+
+  void TearDown() override {
+    EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
+  }
+
+  WaitType _wait;
+};
+
+using MyTypes = ::testing::Types<
+    std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>,
+    std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>>;
+TYPED_TEST_SUITE(AsyncTest, MyTypes);
+
+using namespace arangodb;
+
+TYPED_TEST(AsyncTest, async_return) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<ValueType> {
+    co_await this->_wait;
+    co_return 12;
+  }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(a.valid());
+  auto awaitable = std::move(a).operator co_await();
+  EXPECT_FALSE(a.valid());
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_EQ(awaitable.await_resume(), 12);
+}
+
+TYPED_TEST(AsyncTest, async_return_destroy) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<ValueType> {
+    co_await this->_wait;
+    co_return 12;
+  }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(a.valid());
+  a.reset();
+  EXPECT_FALSE(a.valid());
+}
+
+TYPED_TEST(AsyncTest, await_ready_async) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<ValueType> {
+    co_await this->_wait;
+    co_return 12;
+  }();
+
+  auto b = [&]() -> async<ValueType> { co_return 2 * co_await std::move(a); }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(b.valid());
+  EXPECT_FALSE(a.valid());
+  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_EQ(awaitable.await_resume(), 24);
+}
+
+TYPED_TEST(AsyncTest, async_throw) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<ValueType> {
+    co_await this->_wait;
+    throw std::runtime_error("TEST!");
+  }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(a.valid());
+  auto awaitable = std::move(a).operator co_await();
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_THROW(awaitable.await_resume(), std::runtime_error);
+}
+
+TYPED_TEST(AsyncTest, await_throw_async) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<ValueType> {
+    co_await this->_wait;
+    throw std::runtime_error("TEST!");
+  }();
+
+  auto b = [&]() -> async<ValueType> {
+    try {
+      co_return 2 * co_await std::move(a);
+    } catch (std::runtime_error const&) {
+      co_return 0;
+    }
+  }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(b.valid());
+  EXPECT_FALSE(a.valid());
+  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_EQ(awaitable.await_resume(), 0);
+}
+
+TYPED_TEST(AsyncTest, await_async_void) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<void> {
+    co_await this->_wait;
+    co_return;
+  }();
+
+  auto b = [&]() -> async<ValueType> {
+    co_await std::move(a);
+    co_return 2;
+  }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(b.valid());
+  EXPECT_FALSE(a.valid());
+  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_EQ(awaitable.await_resume(), 2);
+}
+
+TYPED_TEST(AsyncTest, await_async_void_exception) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<void> {
+    co_await this->_wait;
+    throw std::runtime_error("TEST!");
+  }();
+
+  auto b = [&]() -> async<ValueType> {
+    try {
+      co_await std::move(a);
+      co_return 2;
+    } catch (std::runtime_error const&) {
+      co_return 0;
+    }
+  }();
+
+  this->_wait.resume();
+  EXPECT_TRUE(b.valid());
+  EXPECT_FALSE(a.valid());
+  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_EQ(awaitable.await_resume(), 0);
+}

--- a/tests/Basics/AsyncTest.cpp
+++ b/tests/Basics/AsyncTest.cpp
@@ -6,17 +6,22 @@
 namespace {
 
 struct WaitSlot {
-  void resume() { _continuation.resume(); }
+  void resume() {
+    ready = true;
+    _continuation.resume();
+  }
 
   void await() {}
 
   std::coroutine_handle<> _continuation;
 
-  bool await_ready() { return false; }
+  bool await_ready() { return ready; }
   void await_resume() {}
   void await_suspend(std::coroutine_handle<> continuation) {
     _continuation = continuation;
   }
+
+  bool ready = false;
 };
 
 struct NoWait {
@@ -28,31 +33,51 @@ struct NoWait {
 
 struct ConcurrentNoWait {
   void resume() {}
-  void await() { _thread.join(); }
+  void await() {
+    await_suspend(std::noop_coroutine());
+    _thread.join();
+  }
 
   bool await_ready() { return false; }
   void await_resume() {}
   void await_suspend(std::coroutine_handle<> handle) {
     {
       std::unique_lock guard(_mutex);
-      _coro = handle;
+      _coro.emplace_back(handle);
     }
     _cv.notify_one();
   }
-
   ConcurrentNoWait()
       : _thread([&] {
-          {
-            std::unique_lock guard(_mutex);
-            _cv.wait(guard, [&] { return _coro != nullptr; });
+          bool stopping = false;
+          while (true) {
+            std::coroutine_handle<> handle;
+            {
+              std::unique_lock guard(_mutex);
+              if (_coro.empty() && stopping) {
+                break;
+              }
+              _cv.wait(guard, [&] { return !_coro.empty(); });
+              handle = _coro.front();
+              _coro.pop_front();
+            }
+            if (handle == std::noop_coroutine()) {
+              stopping = true;
+            }
+            handle.resume();
           }
-
-          _coro.resume();
         }) {}
+
+  ~ConcurrentNoWait() {
+    if (_thread.joinable()) {
+      await_suspend(std::noop_coroutine());
+      _thread.join();
+    }
+  }
 
   std::mutex _mutex;
   std::condition_variable_any _cv;
-  std::coroutine_handle<> _coro;
+  std::deque<std::coroutine_handle<>> _coro;
 
   std::jthread _thread;
 };
@@ -276,6 +301,30 @@ TYPED_TEST(AsyncTest, await_async_void_exception) {
   this->wait.resume();
   EXPECT_TRUE(b.valid());
   EXPECT_FALSE(a.valid());
+  auto awaitable = std::move(b).operator co_await();
+  this->wait.await();
+  EXPECT_TRUE(awaitable.await_ready());
+  EXPECT_EQ(awaitable.await_resume(), 0);
+}
+
+TYPED_TEST(AsyncTest, multiple_suspension_points) {
+  using ValueType = TypeParam::second_type;
+
+  auto a = [&]() -> async<ValueType> {
+    co_await this->wait;
+    co_return 12;
+  };
+
+  auto b = [&]() -> async<ValueType> {
+    for (int i = 0; i < 10; i++) {
+      co_await a();
+    }
+
+    co_return 0;
+  }();
+
+  this->wait.resume();
+  EXPECT_TRUE(b.valid());
   auto awaitable = std::move(b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());

--- a/tests/Basics/AsyncTest.cpp
+++ b/tests/Basics/AsyncTest.cpp
@@ -137,9 +137,9 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
 
 using MyTypes = ::testing::Types<
     std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>,
-    /*std::pair<ConcurrentNoWait, MoveOnlyValue>,*/
-    std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>/*,
-    std::pair<ConcurrentNoWait, CopyOnlyValue>*/>;
+    std::pair<ConcurrentNoWait, MoveOnlyValue>,
+    std::pair<NoWait, CopyOnlyValue>, std::pair<WaitSlot, MoveOnlyValue>,
+    std::pair<ConcurrentNoWait, CopyOnlyValue>>;
 TYPED_TEST_SUITE(AsyncTest, MyTypes);
 
 using namespace arangodb;
@@ -315,13 +315,15 @@ TYPED_TEST(AsyncTest, multiple_suspension_points) {
     co_return 12;
   };
 
-  auto b = [&]() -> async<ValueType> {
+  auto lambda = [&]() -> async<ValueType> {
     for (int i = 0; i < 10; i++) {
       co_await a();
     }
 
     co_return 0;
-  }();
+  };
+
+  auto b = lambda();
 
   this->wait.resume();
   EXPECT_TRUE(b.valid());

--- a/tests/Basics/CMakeLists.txt
+++ b/tests/Basics/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(arangodbtests
   ConversionsTest.cpp
   CsvTest.cpp
   datetime.cpp
+  ExpectedTests.cpp
   FilesTest.cpp
   FpConvTest.cpp
   FutureSharedLockTest.cpp

--- a/tests/Basics/CMakeLists.txt
+++ b/tests/Basics/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(arangodbtests
   PRIVATE
+  AsyncTest.cpp
   ConversionsTest.cpp
   CsvTest.cpp
   datetime.cpp

--- a/tests/Basics/ExpectedTests.cpp
+++ b/tests/Basics/ExpectedTests.cpp
@@ -213,3 +213,26 @@ TEST_F(ExpectedTest, copy_assignment_value) {
     EXPECT_EQ(o.get(), str);
   }
 }
+
+TEST_F(ExpectedTest, copy_move_value) {
+  std::string str = "Hello World!";
+  {
+    expected<std::string> e{std::in_place, str};
+    expected<std::string> o;
+    o = std::move(e);
+    EXPECT_EQ(o.get(), str);
+  }
+  {
+    expected<std::string> e{std::in_place, str};
+    expected<std::string> o{std::in_place, "Other"};
+    o = std::move(e);
+    EXPECT_EQ(o.get(), str);
+  }
+  {
+    expected<std::string> e{std::in_place, str};
+    expected<std::string> o{
+        std::make_exception_ptr(std::runtime_error("TEST!"))};
+    o = std::move(e);
+    EXPECT_EQ(o.get(), str);
+  }
+}

--- a/tests/Basics/ExpectedTests.cpp
+++ b/tests/Basics/ExpectedTests.cpp
@@ -1,0 +1,90 @@
+#include "Basics/expected.h"
+#include <gtest/gtest.h>
+
+namespace {
+struct ExpectedTest : ::testing::Test {};
+
+struct Constructible {
+  Constructible(int) noexcept {}
+
+  Constructible(unsigned) noexcept(false) {}
+};
+
+struct NothrowDestructible {
+  ~NothrowDestructible() noexcept {}
+};
+
+struct NotNothrowDestructible {
+  ~NotNothrowDestructible() noexcept(false) {}
+};
+
+}  // namespace
+
+using namespace arangodb;
+
+static_assert(std::is_nothrow_constructible_v<expected<Constructible>,
+                                              std::in_place_t, int>);
+static_assert(!std::is_nothrow_constructible_v<expected<Constructible>,
+                                               std::in_place_t, unsigned int>);
+static_assert(!std::is_constructible_v<expected<Constructible>, std::in_place_t,
+                                       std::string>);
+static_assert(std::is_constructible_v<expected<Constructible>, std::in_place_t,
+                                      unsigned int>);
+static_assert(std::is_nothrow_constructible_v<expected<Constructible>,
+                                              std::exception_ptr>);
+static_assert(std::is_nothrow_default_constructible_v<expected<Constructible>>);
+static_assert(std::is_nothrow_destructible_v<expected<NothrowDestructible>>);
+
+static_assert(
+    !std::is_nothrow_destructible_v<expected<NotNothrowDestructible>>);
+
+TEST_F(ExpectedTest, construct_default) { expected<Constructible> e; }
+
+TEST_F(ExpectedTest, construct_nothrow) {
+  expected<Constructible> e{std::in_place, 12};
+}
+
+TEST_F(ExpectedTest, construct_exception) {
+  expected<Constructible> e{
+      std::make_exception_ptr(std::runtime_error{"TEST!"})};
+}
+
+TEST_F(ExpectedTest, access_value_empty) {
+  expected<Constructible> e;
+
+  EXPECT_THROW({ e.get(); }, std::runtime_error);
+  EXPECT_THROW({ std::cref(e).get().get(); }, std::runtime_error);
+  EXPECT_THROW({ std::move(e).get(); }, std::runtime_error);
+  EXPECT_THROW({ std::move(std::cref(e).get()).get(); }, std::runtime_error);
+}
+
+TEST_F(ExpectedTest, access_value_exception) {
+  struct my_exception : std::runtime_error {
+    using std::runtime_error::runtime_error;
+  };
+  expected<Constructible> e{std::make_exception_ptr(my_exception{"TEST!"})};
+
+  EXPECT_THROW({ e.get(); }, my_exception);
+  EXPECT_THROW({ std::cref(e).get().get(); }, my_exception);
+  EXPECT_THROW({ std::move(e).get(); }, my_exception);
+  EXPECT_THROW({ std::move(std::cref(e).get()).get(); }, my_exception);
+}
+
+TEST_F(ExpectedTest, access_value_value) {
+  expected<int> e{std::in_place, 12};
+
+  EXPECT_EQ(e.get(), 12);
+  EXPECT_EQ(std::cref(e).get().get(), 12);
+  EXPECT_EQ(std::move(e).get(), 12);
+  EXPECT_EQ(std::move(std::cref(e).get()).get(), 12);
+
+  static_assert(std::is_reference_v<decltype(e.get())>);
+  static_assert(std::is_reference_v<decltype(std::cref(e).get().get())>);
+  static_assert(std::is_const_v<
+                std::remove_reference_t<decltype(std::cref(e).get().get())>>);
+  static_assert(std::is_rvalue_reference_v<decltype(std::move(e).get())>);
+  static_assert(std::is_rvalue_reference_v<
+                decltype(std::move(std::cref(e).get()).get())>);
+  static_assert(std::is_const_v<std::remove_reference_t<
+                    decltype(std::move(std::cref(e).get()).get())>>);
+}

--- a/tests/Basics/ExpectedTests.cpp
+++ b/tests/Basics/ExpectedTests.cpp
@@ -18,6 +18,49 @@ struct NotNothrowDestructible {
   ~NotNothrowDestructible() noexcept(false) {}
 };
 
+struct CopyConstructible {
+  explicit CopyConstructible(int) {}
+  CopyConstructible(CopyConstructible const&) {}
+  CopyConstructible(CopyConstructible&&) = delete;
+  CopyConstructible& operator=(CopyConstructible const&) { return *this; };
+  CopyConstructible& operator=(CopyConstructible&&) = delete;
+};
+
+struct NothrowCopyConstructible {
+  explicit NothrowCopyConstructible(int) {}
+  NothrowCopyConstructible(NothrowCopyConstructible const&) noexcept {}
+  NothrowCopyConstructible(NothrowCopyConstructible&&) = delete;
+  NothrowCopyConstructible& operator=(
+      NothrowCopyConstructible const&) noexcept {
+    return *this;
+  }
+  NothrowCopyConstructible& operator=(NothrowCopyConstructible&&) = delete;
+};
+
+struct MoveConstructible {
+  explicit MoveConstructible(int) {}
+  MoveConstructible(MoveConstructible const&) = delete;
+  MoveConstructible(MoveConstructible&&) noexcept(false) {}
+  MoveConstructible& operator=(MoveConstructible const&) = delete;
+  MoveConstructible& operator=(MoveConstructible&&) noexcept(false) {
+    return *this;
+  }
+};
+
+struct NothrowMoveConstructible {
+  explicit NothrowMoveConstructible(int) {}
+  NothrowMoveConstructible(NothrowMoveConstructible const&) = delete;
+  NothrowMoveConstructible(NothrowMoveConstructible&&) noexcept(true){};
+  NothrowMoveConstructible& operator=(NothrowMoveConstructible const&) = delete;
+  NothrowMoveConstructible& operator=(NothrowMoveConstructible&&) noexcept(
+      true) {
+    return *this;
+  }
+};
+
+struct my_exception : std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
 }  // namespace
 
 using namespace arangodb;
@@ -37,6 +80,50 @@ static_assert(std::is_nothrow_destructible_v<expected<NothrowDestructible>>);
 
 static_assert(
     !std::is_nothrow_destructible_v<expected<NotNothrowDestructible>>);
+
+static_assert(std::is_copy_constructible_v<CopyConstructible>);
+static_assert(std::is_copy_constructible_v<expected<CopyConstructible>>);
+static_assert(!std::is_nothrow_copy_constructible_v<CopyConstructible>);
+static_assert(
+    !std::is_nothrow_copy_constructible_v<expected<CopyConstructible>>);
+
+static_assert(std::is_nothrow_copy_constructible_v<NothrowCopyConstructible>);
+static_assert(
+    std::is_nothrow_copy_constructible_v<expected<NothrowCopyConstructible>>);
+
+static_assert(!std::is_copy_constructible_v<MoveConstructible>);
+static_assert(!std::is_copy_constructible_v<expected<MoveConstructible>>);
+
+static_assert(std::is_move_constructible_v<MoveConstructible>);
+static_assert(std::is_move_constructible_v<expected<MoveConstructible>>);
+static_assert(!std::is_nothrow_move_constructible_v<MoveConstructible>);
+static_assert(
+    !std::is_nothrow_move_constructible_v<expected<MoveConstructible>>);
+
+static_assert(std::is_nothrow_move_constructible_v<NothrowMoveConstructible>);
+static_assert(
+    std::is_nothrow_move_constructible_v<expected<NothrowMoveConstructible>>);
+
+static_assert(std::is_copy_assignable_v<CopyConstructible>);
+static_assert(std::is_copy_assignable_v<expected<CopyConstructible>>);
+static_assert(!std::is_nothrow_copy_assignable_v<CopyConstructible>);
+static_assert(!std::is_nothrow_copy_assignable_v<expected<CopyConstructible>>);
+
+static_assert(std::is_nothrow_copy_assignable_v<NothrowCopyConstructible>);
+static_assert(
+    std::is_nothrow_copy_assignable_v<expected<NothrowCopyConstructible>>);
+
+static_assert(!std::is_copy_assignable_v<MoveConstructible>);
+static_assert(!std::is_copy_assignable_v<expected<MoveConstructible>>);
+
+static_assert(std::is_move_assignable_v<MoveConstructible>);
+static_assert(std::is_move_assignable_v<expected<MoveConstructible>>);
+static_assert(!std::is_nothrow_move_assignable_v<MoveConstructible>);
+static_assert(!std::is_nothrow_move_assignable_v<expected<MoveConstructible>>);
+
+static_assert(std::is_nothrow_move_assignable_v<NothrowMoveConstructible>);
+static_assert(
+    std::is_nothrow_move_assignable_v<expected<NothrowMoveConstructible>>);
 
 TEST_F(ExpectedTest, construct_default) { expected<Constructible> e; }
 
@@ -59,9 +146,6 @@ TEST_F(ExpectedTest, access_value_empty) {
 }
 
 TEST_F(ExpectedTest, access_value_exception) {
-  struct my_exception : std::runtime_error {
-    using std::runtime_error::runtime_error;
-  };
   expected<Constructible> e{std::make_exception_ptr(my_exception{"TEST!"})};
 
   EXPECT_THROW({ e.get(); }, my_exception);
@@ -87,4 +171,45 @@ TEST_F(ExpectedTest, access_value_value) {
                 decltype(std::move(std::cref(e).get()).get())>);
   static_assert(std::is_const_v<std::remove_reference_t<
                     decltype(std::move(std::cref(e).get()).get())>>);
+}
+
+TEST_F(ExpectedTest, copy_construction_value) {
+  {
+    std::string str = "Hello World!";
+    expected<std::string> e{std::in_place, str};
+    expected<std::string> o{e};
+    EXPECT_EQ(o.get(), str);
+  }
+
+  {
+    expected<std::string> e;
+    expected<std::string> o{e};
+    EXPECT_THROW({ o.get(); }, std::runtime_error);
+  }
+  {
+    expected<std::string> e{std::make_exception_ptr(my_exception("TEST!"))};
+    expected<std::string> o{e};
+    EXPECT_THROW({ o.get(); }, my_exception);
+  }
+}
+
+TEST_F(ExpectedTest, copy_assignment_value) {
+  std::string str = "Hello World!";
+  expected<std::string> e{std::in_place, str};
+  {
+    expected<std::string> o;
+    o = e;
+    EXPECT_EQ(o.get(), str);
+  }
+  {
+    expected<std::string> o{std::in_place, "Other"};
+    o = e;
+    EXPECT_EQ(o.get(), str);
+  }
+  {
+    expected<std::string> o{
+        std::make_exception_ptr(std::runtime_error("TEST!"))};
+    o = e;
+    EXPECT_EQ(o.get(), str);
+  }
 }


### PR DESCRIPTION
### Scope & Purpose
This PR introduces a new coroutine type `async<T>` which just provides the coroutine implementation and should not be confused with `Future<T>` `Promise<T>` pairs. 

It is designed to replace all usages of `Future<T>` at some point **later**.

We decided that the current `Future<T>` implementation and API is too specific and hard to implement in an optimal way using coroutines. Existing futures integrate well with the new `async<T>`. The later will have additional debug capabilities, which allow to query suspended coroutines at runtime.