### PR TITLE
array & object destructuring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,68 @@
 devel
 -----
 
+* Added array and object destructuring to AQL LET statements.
+
+  * Array Destructuring: Array destructuring is the assignment of array values
+    into one or multiple variables with a single `LET` assignment. This can be
+    achieved by putting the target assignment variables of the `LET` assignment
+    into angular brackets.
+
+    For example, the statement:
+
+        LET [y, z] = [1, 2]
+
+    will assign the value `1` to variable `y` and the value `2` to variable `z`.
+    The mapping of input array members to the target variables is positional.
+
+    It is also possible to skip over unneeded array values. The following 
+    assignment will assign the value `2` to variable `y` and the value `3` to 
+    variable `z`. The array member with value `1` will not be assigned to any 
+    variable:
+
+        LET [, y, z] = [1, 2, 3]
+
+    When there are more variables assigned than there are array members, the 
+    target variables that are mapped to non-existing array members are 
+    populated with a value of `null`. The assigned target variables will also
+    receive a value of `null` when the destructuring is used on a non-array.
+
+    Destructuring can also be applied on nested arrays, e.g.
+
+        LET [[sub1], [sub2, sub3]] = [["foo", "bar"], [1, 2, 3]]
+
+    In the above example, the value of variable `sub1` will be `foo`, the value
+    of variable `sub2` will be `1` and the value of variable `sub3` will be `2`.
+
+  * Object Destructuring: Object destructuring is the assignment of multiple
+    target variables from a source object value. This is achieved by using the
+    curly brackets after the `LET` assignment token:
+
+        LET { name, age } = { valid: true, age: 39, name: "John Doe" }
+
+    The mapping of input object members to the target variables is by name.
+    In the above example, the variable `name` will get a value of `John Doe`,
+    the variable `age` will get a value of `39`. The attribute `valid` from the
+    source object will be ignored.
+
+    Object destructuring also works with nested objects, e.g.
+
+        LET { name: {first, last} } = { name: { first: "John", middle: "J", last: "Doe" } }
+
+    The above statement will assign the value `John` to the variable `first` 
+    and the value `Doe` to the variable `last`. The attribute `middle` from the
+    source object is ignored.
+    Note that here only variables `first` and `last` will be populated, but
+    variable `name` is not.
+
+    It is also possible for the target variable to get a different name than in
+    the source object, e.g.
+
+        LET { name: {first: firstName, last: lastName} } = { name: { first: "John", last: "Doe" } }
+
+    The above statement assigns the value `John` to the target variable
+    `firstName` and the value `Doe` to the target variable `lastName`. Note
+    that neither of these attributes exist in the source object.
 
 
 3.12.1 (XXXX-XX-XX)

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
@@ -55,18 +55,20 @@ static void parseNodeInput(AstNode const* node, std::string& id,
     case NODE_TYPE_VALUE:
       if (node->value.type != VALUE_TYPE_STRING) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
-            TRI_ERROR_QUERY_PARSE, std::string("invalid ") + part +
-                                       " vertex. Must either be "
-                                       "an _id string or an object with _id.");
+            TRI_ERROR_QUERY_PARSE,
+            absl::StrCat("invalid ", part,
+                         " vertex. Must either be "
+                         "an _id string or an object with _id."));
       }
       variable = nullptr;
       id = node->getString();
       break;
     default:
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
-                                     std::string("invalid ") + part +
-                                         " vertex. Must either be an "
-                                         "_id string or an object with _id.");
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_QUERY_PARSE,
+          absl::StrCat("invalid ", part,
+                       " vertex. Must either be an "
+                       "_id string or an object with _id."));
   }
 }
 static GraphNode::InputVertex prepareVertexInput(ShortestPathNode const* node,

--- a/arangod/Aql/grammar.cpp
+++ b/arangod/Aql/grammar.cpp
@@ -246,99 +246,105 @@ enum yysymbol_kind_t
   YYSYMBOL_let_statement = 104,            /* let_statement  */
   YYSYMBOL_let_list = 105,                 /* let_list  */
   YYSYMBOL_let_element = 106,              /* let_element  */
-  YYSYMBOL_count_into = 107,               /* count_into  */
-  YYSYMBOL_collect_variable_list = 108,    /* collect_variable_list  */
-  YYSYMBOL_109_4 = 109,                    /* $@4  */
-  YYSYMBOL_collect_statement = 110,        /* collect_statement  */
-  YYSYMBOL_collect_list = 111,             /* collect_list  */
-  YYSYMBOL_collect_element = 112,          /* collect_element  */
-  YYSYMBOL_collect_optional_into = 113,    /* collect_optional_into  */
-  YYSYMBOL_variable_list = 114,            /* variable_list  */
-  YYSYMBOL_keep = 115,                     /* keep  */
-  YYSYMBOL_116_5 = 116,                    /* $@5  */
-  YYSYMBOL_aggregate = 117,                /* aggregate  */
-  YYSYMBOL_118_6 = 118,                    /* $@6  */
-  YYSYMBOL_aggregate_list = 119,           /* aggregate_list  */
-  YYSYMBOL_aggregate_element = 120,        /* aggregate_element  */
-  YYSYMBOL_aggregate_function_call = 121,  /* aggregate_function_call  */
+  YYSYMBOL_array_destructuring = 107,      /* array_destructuring  */
+  YYSYMBOL_108_4 = 108,                    /* $@4  */
+  YYSYMBOL_array_destructuring_element = 109, /* array_destructuring_element  */
+  YYSYMBOL_object_destructuring = 110,     /* object_destructuring  */
+  YYSYMBOL_111_5 = 111,                    /* $@5  */
+  YYSYMBOL_object_destructuring_element = 112, /* object_destructuring_element  */
+  YYSYMBOL_count_into = 113,               /* count_into  */
+  YYSYMBOL_collect_variable_list = 114,    /* collect_variable_list  */
+  YYSYMBOL_115_6 = 115,                    /* $@6  */
+  YYSYMBOL_collect_statement = 116,        /* collect_statement  */
+  YYSYMBOL_collect_list = 117,             /* collect_list  */
+  YYSYMBOL_collect_element = 118,          /* collect_element  */
+  YYSYMBOL_collect_optional_into = 119,    /* collect_optional_into  */
+  YYSYMBOL_variable_list = 120,            /* variable_list  */
+  YYSYMBOL_keep = 121,                     /* keep  */
   YYSYMBOL_122_7 = 122,                    /* $@7  */
-  YYSYMBOL_sort_statement = 123,           /* sort_statement  */
+  YYSYMBOL_aggregate = 123,                /* aggregate  */
   YYSYMBOL_124_8 = 124,                    /* $@8  */
-  YYSYMBOL_sort_list = 125,                /* sort_list  */
-  YYSYMBOL_sort_element = 126,             /* sort_element  */
-  YYSYMBOL_sort_direction = 127,           /* sort_direction  */
-  YYSYMBOL_limit_statement = 128,          /* limit_statement  */
-  YYSYMBOL_window_statement = 129,         /* window_statement  */
-  YYSYMBOL_return_statement = 130,         /* return_statement  */
-  YYSYMBOL_in_or_into_collection = 131,    /* in_or_into_collection  */
-  YYSYMBOL_remove_statement = 132,         /* remove_statement  */
-  YYSYMBOL_insert_statement = 133,         /* insert_statement  */
-  YYSYMBOL_update_parameters = 134,        /* update_parameters  */
-  YYSYMBOL_update_statement = 135,         /* update_statement  */
-  YYSYMBOL_replace_parameters = 136,       /* replace_parameters  */
-  YYSYMBOL_replace_statement = 137,        /* replace_statement  */
-  YYSYMBOL_update_or_replace = 138,        /* update_or_replace  */
-  YYSYMBOL_upsert_input = 139,             /* upsert_input  */
-  YYSYMBOL_upsert_statement = 140,         /* upsert_statement  */
-  YYSYMBOL_141_9 = 141,                    /* $@9  */
-  YYSYMBOL_142_10 = 142,                   /* $@10  */
-  YYSYMBOL_143_11 = 143,                   /* $@11  */
-  YYSYMBOL_quantifier = 144,               /* quantifier  */
-  YYSYMBOL_distinct_expression = 145,      /* distinct_expression  */
-  YYSYMBOL_146_12 = 146,                   /* $@12  */
-  YYSYMBOL_expression = 147,               /* expression  */
-  YYSYMBOL_function_name = 148,            /* function_name  */
-  YYSYMBOL_function_call = 149,            /* function_call  */
-  YYSYMBOL_150_13 = 150,                   /* $@13  */
-  YYSYMBOL_151_14 = 151,                   /* $@14  */
-  YYSYMBOL_operator_unary = 152,           /* operator_unary  */
-  YYSYMBOL_operator_binary = 153,          /* operator_binary  */
-  YYSYMBOL_154_15 = 154,                   /* $@15  */
-  YYSYMBOL_155_16 = 155,                   /* $@16  */
-  YYSYMBOL_operator_ternary = 156,         /* operator_ternary  */
-  YYSYMBOL_157_17 = 157,                   /* $@17  */
-  YYSYMBOL_158_18 = 158,                   /* $@18  */
-  YYSYMBOL_159_19 = 159,                   /* $@19  */
-  YYSYMBOL_optional_function_call_arguments = 160, /* optional_function_call_arguments  */
-  YYSYMBOL_expression_or_query = 161,      /* expression_or_query  */
-  YYSYMBOL_162_20 = 162,                   /* $@20  */
-  YYSYMBOL_function_arguments_list = 163,  /* function_arguments_list  */
-  YYSYMBOL_compound_value = 164,           /* compound_value  */
-  YYSYMBOL_array = 165,                    /* array  */
-  YYSYMBOL_166_21 = 166,                   /* $@21  */
-  YYSYMBOL_optional_array_elements = 167,  /* optional_array_elements  */
-  YYSYMBOL_array_elements_list = 168,      /* array_elements_list  */
-  YYSYMBOL_array_element = 169,            /* array_element  */
-  YYSYMBOL_for_options = 170,              /* for_options  */
-  YYSYMBOL_options = 171,                  /* options  */
-  YYSYMBOL_object = 172,                   /* object  */
-  YYSYMBOL_173_22 = 173,                   /* $@22  */
-  YYSYMBOL_optional_object_elements = 174, /* optional_object_elements  */
-  YYSYMBOL_object_elements_list = 175,     /* object_elements_list  */
-  YYSYMBOL_object_element = 176,           /* object_element  */
-  YYSYMBOL_array_filter_operator = 177,    /* array_filter_operator  */
-  YYSYMBOL_array_map_operator = 178,       /* array_map_operator  */
-  YYSYMBOL_optional_array_filter = 179,    /* optional_array_filter  */
-  YYSYMBOL_optional_array_limit = 180,     /* optional_array_limit  */
-  YYSYMBOL_optional_array_return = 181,    /* optional_array_return  */
-  YYSYMBOL_graph_collection = 182,         /* graph_collection  */
-  YYSYMBOL_graph_collection_list = 183,    /* graph_collection_list  */
-  YYSYMBOL_graph_subject = 184,            /* graph_subject  */
-  YYSYMBOL_185_23 = 185,                   /* $@23  */
-  YYSYMBOL_graph_direction = 186,          /* graph_direction  */
-  YYSYMBOL_graph_direction_steps = 187,    /* graph_direction_steps  */
-  YYSYMBOL_reference = 188,                /* reference  */
-  YYSYMBOL_189_24 = 189,                   /* $@24  */
-  YYSYMBOL_190_25 = 190,                   /* $@25  */
-  YYSYMBOL_191_26 = 191,                   /* $@26  */
-  YYSYMBOL_simple_value = 192,             /* simple_value  */
-  YYSYMBOL_numeric_value = 193,            /* numeric_value  */
-  YYSYMBOL_value_literal = 194,            /* value_literal  */
-  YYSYMBOL_in_or_into_collection_name = 195, /* in_or_into_collection_name  */
-  YYSYMBOL_bind_parameter = 196,           /* bind_parameter  */
-  YYSYMBOL_bind_parameter_datasource_expected = 197, /* bind_parameter_datasource_expected  */
-  YYSYMBOL_object_element_name = 198,      /* object_element_name  */
-  YYSYMBOL_variable_name = 199             /* variable_name  */
+  YYSYMBOL_aggregate_list = 125,           /* aggregate_list  */
+  YYSYMBOL_aggregate_element = 126,        /* aggregate_element  */
+  YYSYMBOL_aggregate_function_call = 127,  /* aggregate_function_call  */
+  YYSYMBOL_128_9 = 128,                    /* $@9  */
+  YYSYMBOL_sort_statement = 129,           /* sort_statement  */
+  YYSYMBOL_130_10 = 130,                   /* $@10  */
+  YYSYMBOL_sort_list = 131,                /* sort_list  */
+  YYSYMBOL_sort_element = 132,             /* sort_element  */
+  YYSYMBOL_sort_direction = 133,           /* sort_direction  */
+  YYSYMBOL_limit_statement = 134,          /* limit_statement  */
+  YYSYMBOL_window_statement = 135,         /* window_statement  */
+  YYSYMBOL_return_statement = 136,         /* return_statement  */
+  YYSYMBOL_in_or_into_collection = 137,    /* in_or_into_collection  */
+  YYSYMBOL_remove_statement = 138,         /* remove_statement  */
+  YYSYMBOL_insert_statement = 139,         /* insert_statement  */
+  YYSYMBOL_update_parameters = 140,        /* update_parameters  */
+  YYSYMBOL_update_statement = 141,         /* update_statement  */
+  YYSYMBOL_replace_parameters = 142,       /* replace_parameters  */
+  YYSYMBOL_replace_statement = 143,        /* replace_statement  */
+  YYSYMBOL_update_or_replace = 144,        /* update_or_replace  */
+  YYSYMBOL_upsert_input = 145,             /* upsert_input  */
+  YYSYMBOL_upsert_statement = 146,         /* upsert_statement  */
+  YYSYMBOL_147_11 = 147,                   /* $@11  */
+  YYSYMBOL_148_12 = 148,                   /* $@12  */
+  YYSYMBOL_149_13 = 149,                   /* $@13  */
+  YYSYMBOL_quantifier = 150,               /* quantifier  */
+  YYSYMBOL_distinct_expression = 151,      /* distinct_expression  */
+  YYSYMBOL_152_14 = 152,                   /* $@14  */
+  YYSYMBOL_expression = 153,               /* expression  */
+  YYSYMBOL_function_name = 154,            /* function_name  */
+  YYSYMBOL_function_call = 155,            /* function_call  */
+  YYSYMBOL_156_15 = 156,                   /* $@15  */
+  YYSYMBOL_157_16 = 157,                   /* $@16  */
+  YYSYMBOL_operator_unary = 158,           /* operator_unary  */
+  YYSYMBOL_operator_binary = 159,          /* operator_binary  */
+  YYSYMBOL_160_17 = 160,                   /* $@17  */
+  YYSYMBOL_161_18 = 161,                   /* $@18  */
+  YYSYMBOL_operator_ternary = 162,         /* operator_ternary  */
+  YYSYMBOL_163_19 = 163,                   /* $@19  */
+  YYSYMBOL_164_20 = 164,                   /* $@20  */
+  YYSYMBOL_165_21 = 165,                   /* $@21  */
+  YYSYMBOL_optional_function_call_arguments = 166, /* optional_function_call_arguments  */
+  YYSYMBOL_expression_or_query = 167,      /* expression_or_query  */
+  YYSYMBOL_168_22 = 168,                   /* $@22  */
+  YYSYMBOL_function_arguments_list = 169,  /* function_arguments_list  */
+  YYSYMBOL_compound_value = 170,           /* compound_value  */
+  YYSYMBOL_array = 171,                    /* array  */
+  YYSYMBOL_172_23 = 172,                   /* $@23  */
+  YYSYMBOL_optional_array_elements = 173,  /* optional_array_elements  */
+  YYSYMBOL_array_elements_list = 174,      /* array_elements_list  */
+  YYSYMBOL_array_element = 175,            /* array_element  */
+  YYSYMBOL_for_options = 176,              /* for_options  */
+  YYSYMBOL_options = 177,                  /* options  */
+  YYSYMBOL_object = 178,                   /* object  */
+  YYSYMBOL_179_24 = 179,                   /* $@24  */
+  YYSYMBOL_optional_object_elements = 180, /* optional_object_elements  */
+  YYSYMBOL_object_elements_list = 181,     /* object_elements_list  */
+  YYSYMBOL_object_element = 182,           /* object_element  */
+  YYSYMBOL_array_filter_operator = 183,    /* array_filter_operator  */
+  YYSYMBOL_array_map_operator = 184,       /* array_map_operator  */
+  YYSYMBOL_optional_array_filter = 185,    /* optional_array_filter  */
+  YYSYMBOL_optional_array_limit = 186,     /* optional_array_limit  */
+  YYSYMBOL_optional_array_return = 187,    /* optional_array_return  */
+  YYSYMBOL_graph_collection = 188,         /* graph_collection  */
+  YYSYMBOL_graph_collection_list = 189,    /* graph_collection_list  */
+  YYSYMBOL_graph_subject = 190,            /* graph_subject  */
+  YYSYMBOL_191_25 = 191,                   /* $@25  */
+  YYSYMBOL_graph_direction = 192,          /* graph_direction  */
+  YYSYMBOL_graph_direction_steps = 193,    /* graph_direction_steps  */
+  YYSYMBOL_reference = 194,                /* reference  */
+  YYSYMBOL_195_26 = 195,                   /* $@26  */
+  YYSYMBOL_196_27 = 196,                   /* $@27  */
+  YYSYMBOL_197_28 = 197,                   /* $@28  */
+  YYSYMBOL_simple_value = 198,             /* simple_value  */
+  YYSYMBOL_numeric_value = 199,            /* numeric_value  */
+  YYSYMBOL_value_literal = 200,            /* value_literal  */
+  YYSYMBOL_in_or_into_collection_name = 201, /* in_or_into_collection_name  */
+  YYSYMBOL_bind_parameter = 202,           /* bind_parameter  */
+  YYSYMBOL_bind_parameter_datasource_expected = 203, /* bind_parameter_datasource_expected  */
+  YYSYMBOL_object_element_name = 204,      /* object_element_name  */
+  YYSYMBOL_variable_name = 205             /* variable_name  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
@@ -362,6 +368,82 @@ void Aqlerror(YYLTYPE* locp,
 }
 
 namespace {
+
+// forward declaration
+void destructureObject(Parser* parser, std::string_view sourceVariable, 
+                       arangodb::containers::SmallVector<AstNode const*, 8>& paths, AstNode const* array);
+
+void destructureArray(Parser* parser, std::string_view sourceVariable, 
+                      arangodb::containers::SmallVector<AstNode const*, 8>& paths, AstNode const* array) {
+  int64_t index = 0;
+  size_t const n = array->numMembers();
+
+  for (size_t i = 0; i < n; ++i) {
+    auto member = array->getMember(i);
+    
+    if (member->type == NODE_TYPE_ARRAY) {
+      // array value => recurse
+      AstNode* indexNode = parser->ast()->createNodeValueInt(index);
+      paths.emplace_back(indexNode);
+ 
+      int64_t tag = member->getIntValue(true);
+      if (tag == 1) {
+        destructureArray(parser, sourceVariable, paths, member);
+      } else {
+        destructureObject(parser, sourceVariable, paths, member);
+      }
+
+      paths.pop_back();
+    } else if (member->type == NODE_TYPE_VARIABLE) {
+      // an actual variable assignment. we need to do something!
+      AstNode* indexNode = parser->ast()->createNodeValueInt(index);
+      paths.emplace_back(indexNode);
+
+      AstNode const* accessor = parser->ast()->createNodeReference(sourceVariable);
+      for (auto const& it : paths) {
+        accessor = parser->ast()->createNodeIndexedAccess(accessor, it);
+      }
+      AstNode* node = parser->ast()->createNodeLet(member, accessor);
+      parser->ast()->addOperation(node);
+      
+      paths.pop_back();
+    }
+
+    ++index;
+  }
+}
+
+void destructureObject(Parser* parser, std::string_view sourceVariable, 
+                       arangodb::containers::SmallVector<AstNode const*, 8>& paths, AstNode const* array) {
+  size_t const n = array->numMembers();
+  
+  for (size_t i = 0; i < n; i += 2) {
+    auto member = array->getMember(i);
+    
+    if (member->isStringValue()) {
+      AstNode const* assigned = array->getMember(i + 1);
+      
+      paths.emplace_back(member);
+      if (assigned->type == NODE_TYPE_ARRAY) {
+        // need to recurse
+        int64_t tag = assigned->getIntValue(true);
+        if (tag == 1) {
+          destructureArray(parser, sourceVariable, paths, assigned);
+        } else {
+          destructureObject(parser, sourceVariable, paths, assigned);
+        }
+      } else if (assigned->type == NODE_TYPE_VARIABLE) {
+        AstNode* accessor = parser->ast()->createNodeReference(sourceVariable);
+        for (auto const& it : paths) {
+          accessor = parser->ast()->createNodeIndexedAccess(accessor, it);
+        }
+        AstNode* node = parser->ast()->createNodeLet(assigned, accessor);
+        parser->ast()->addOperation(node);
+      }
+      paths.pop_back();
+    }
+  }
+}
 
 bool caseInsensitiveEqual(std::string_view lhs, std::string_view rhs) noexcept {
   return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](char l, char r) {
@@ -660,7 +742,7 @@ AstNode* transformOutputVariables(Parser* parser, AstNode const* names) {
 } // namespace
 
 
-#line 663 "grammar.cpp"
+#line 745 "grammar.cpp"
 
 
 #ifdef short
@@ -987,16 +1069,16 @@ union yyalloc
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  7
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST   2018
+#define YYLAST   1977
 
 /* YYNTOKENS -- Number of terminals.  */
 #define YYNTOKENS  81
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS  119
+#define YYNNTS  125
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES  288
+#define YYNRULES  305
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES  513
+#define YYNSTATES  539
 
 /* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   334
@@ -1053,35 +1135,37 @@ static const yytype_int8 yytranslate[] =
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_int16 yyrline[] =
 {
-       0,   574,   574,   580,   590,   593,   599,   603,   607,   614,
-     616,   616,   628,   633,   638,   640,   643,   646,   649,   652,
-     658,   660,   665,   667,   669,   671,   673,   675,   677,   679,
-     681,   683,   685,   687,   692,   699,   706,   712,   719,   743,
-     766,   779,   785,   791,   797,   806,   806,   864,   864,   904,
-     916,   928,   940,   955,   963,   968,   970,   975,   982,   993,
-     993,  1004,  1014,  1027,  1051,  1106,  1125,  1156,  1158,  1163,
-    1170,  1173,  1176,  1185,  1198,  1214,  1214,  1229,  1229,  1239,
-    1241,  1246,  1253,  1253,  1265,  1265,  1276,  1279,  1285,  1291,
-    1294,  1297,  1300,  1306,  1311,  1318,  1333,  1351,  1359,  1362,
-    1368,  1378,  1388,  1396,  1407,  1412,  1420,  1431,  1436,  1439,
-    1445,  1448,  1454,  1470,  1454,  1517,  1517,  1576,  1579,  1582,
-    1588,  1588,  1598,  1604,  1607,  1610,  1613,  1616,  1619,  1625,
-    1628,  1641,  1641,  1648,  1648,  1658,  1661,  1664,  1670,  1670,
-    1676,  1676,  1682,  1685,  1688,  1691,  1694,  1697,  1700,  1703,
-    1706,  1709,  1712,  1715,  1718,  1721,  1728,  1735,  1741,  1747,
-    1753,  1760,  1763,  1766,  1769,  1772,  1775,  1778,  1781,  1784,
-    1788,  1792,  1796,  1800,  1804,  1808,  1812,  1819,  1855,  1819,
-    1863,  1863,  1896,  1898,  1903,  1906,  1906,  1926,  1929,  1935,
-    1938,  1944,  1944,  1953,  1955,  1957,  1962,  1964,  1969,  1975,
-    1978,  2003,  2023,  2026,  2041,  2041,  2050,  2052,  2054,  2059,
-    2061,  2066,  2082,  2086,  2090,  2094,  2098,  2102,  2106,  2110,
-    2114,  2118,  2122,  2126,  2136,  2143,  2146,  2152,  2155,  2161,
-    2164,  2168,  2172,  2176,  2184,  2187,  2190,  2196,  2199,  2205,
-    2208,  2211,  2215,  2221,  2225,  2232,  2238,  2238,  2247,  2251,
-    2255,  2264,  2267,  2270,  2276,  2279,  2285,  2317,  2320,  2323,
-    2327,  2336,  2336,  2353,  2368,  2381,  2394,  2394,  2439,  2439,
-    2497,  2500,  2506,  2510,  2517,  2520,  2523,  2526,  2529,  2535,
-    2540,  2545,  2556,  2564,  2571,  2579,  2587,  2590,  2595
+       0,   652,   652,   658,   668,   671,   677,   681,   685,   692,
+     694,   694,   706,   711,   716,   718,   721,   724,   727,   730,
+     736,   738,   743,   745,   747,   749,   751,   753,   755,   757,
+     759,   761,   763,   765,   770,   777,   784,   790,   797,   821,
+     844,   857,   863,   869,   875,   884,   884,   942,   942,   982,
+     994,  1006,  1018,  1033,  1041,  1046,  1048,  1053,  1057,  1065,
+    1076,  1076,  1086,  1089,  1092,  1095,  1098,  1103,  1103,  1113,
+    1117,  1121,  1125,  1129,  1133,  1138,  1149,  1149,  1160,  1170,
+    1183,  1207,  1262,  1281,  1312,  1314,  1319,  1326,  1329,  1332,
+    1341,  1354,  1370,  1370,  1385,  1385,  1395,  1397,  1402,  1409,
+    1409,  1421,  1421,  1432,  1435,  1441,  1447,  1450,  1453,  1456,
+    1462,  1467,  1474,  1489,  1507,  1515,  1518,  1524,  1534,  1544,
+    1552,  1563,  1568,  1576,  1587,  1592,  1595,  1601,  1604,  1610,
+    1626,  1610,  1673,  1673,  1732,  1735,  1738,  1744,  1744,  1754,
+    1760,  1763,  1766,  1769,  1772,  1775,  1781,  1784,  1797,  1797,
+    1804,  1804,  1814,  1817,  1820,  1826,  1826,  1832,  1832,  1838,
+    1841,  1844,  1847,  1850,  1853,  1856,  1859,  1862,  1865,  1868,
+    1871,  1874,  1877,  1884,  1891,  1897,  1903,  1909,  1916,  1919,
+    1922,  1925,  1928,  1931,  1934,  1937,  1940,  1944,  1948,  1952,
+    1956,  1960,  1964,  1968,  1975,  2011,  1975,  2019,  2019,  2052,
+    2054,  2059,  2062,  2062,  2082,  2085,  2091,  2094,  2100,  2100,
+    2109,  2111,  2113,  2118,  2120,  2125,  2131,  2134,  2159,  2179,
+    2182,  2197,  2197,  2206,  2208,  2210,  2215,  2217,  2222,  2238,
+    2242,  2246,  2250,  2254,  2258,  2262,  2266,  2270,  2274,  2278,
+    2282,  2292,  2299,  2302,  2308,  2311,  2317,  2320,  2324,  2328,
+    2332,  2340,  2343,  2346,  2352,  2355,  2361,  2364,  2367,  2371,
+    2377,  2381,  2388,  2394,  2394,  2403,  2407,  2411,  2420,  2423,
+    2426,  2432,  2435,  2441,  2473,  2476,  2479,  2483,  2492,  2492,
+    2509,  2524,  2537,  2550,  2550,  2595,  2595,  2653,  2656,  2662,
+    2666,  2673,  2676,  2679,  2682,  2685,  2691,  2696,  2701,  2712,
+    2720,  2727,  2735,  2743,  2746,  2751
 };
 #endif
 
@@ -1129,28 +1213,30 @@ static const char *const yytname[] =
   "shortest_path_graph_info", "k_shortest_paths_graph_info",
   "k_paths_graph_info", "all_shortest_paths_graph_info", "for_statement",
   "$@2", "$@3", "filter_statement", "let_statement", "let_list",
-  "let_element", "count_into", "collect_variable_list", "$@4",
-  "collect_statement", "collect_list", "collect_element",
-  "collect_optional_into", "variable_list", "keep", "$@5", "aggregate",
-  "$@6", "aggregate_list", "aggregate_element", "aggregate_function_call",
-  "$@7", "sort_statement", "$@8", "sort_list", "sort_element",
+  "let_element", "array_destructuring", "$@4",
+  "array_destructuring_element", "object_destructuring", "$@5",
+  "object_destructuring_element", "count_into", "collect_variable_list",
+  "$@6", "collect_statement", "collect_list", "collect_element",
+  "collect_optional_into", "variable_list", "keep", "$@7", "aggregate",
+  "$@8", "aggregate_list", "aggregate_element", "aggregate_function_call",
+  "$@9", "sort_statement", "$@10", "sort_list", "sort_element",
   "sort_direction", "limit_statement", "window_statement",
   "return_statement", "in_or_into_collection", "remove_statement",
   "insert_statement", "update_parameters", "update_statement",
   "replace_parameters", "replace_statement", "update_or_replace",
-  "upsert_input", "upsert_statement", "$@9", "$@10", "$@11", "quantifier",
-  "distinct_expression", "$@12", "expression", "function_name",
-  "function_call", "$@13", "$@14", "operator_unary", "operator_binary",
-  "$@15", "$@16", "operator_ternary", "$@17", "$@18", "$@19",
-  "optional_function_call_arguments", "expression_or_query", "$@20",
-  "function_arguments_list", "compound_value", "array", "$@21",
+  "upsert_input", "upsert_statement", "$@11", "$@12", "$@13", "quantifier",
+  "distinct_expression", "$@14", "expression", "function_name",
+  "function_call", "$@15", "$@16", "operator_unary", "operator_binary",
+  "$@17", "$@18", "operator_ternary", "$@19", "$@20", "$@21",
+  "optional_function_call_arguments", "expression_or_query", "$@22",
+  "function_arguments_list", "compound_value", "array", "$@23",
   "optional_array_elements", "array_elements_list", "array_element",
-  "for_options", "options", "object", "$@22", "optional_object_elements",
+  "for_options", "options", "object", "$@24", "optional_object_elements",
   "object_elements_list", "object_element", "array_filter_operator",
   "array_map_operator", "optional_array_filter", "optional_array_limit",
   "optional_array_return", "graph_collection", "graph_collection_list",
-  "graph_subject", "$@23", "graph_direction", "graph_direction_steps",
-  "reference", "$@24", "$@25", "$@26", "simple_value", "numeric_value",
+  "graph_subject", "$@25", "graph_direction", "graph_direction_steps",
+  "reference", "$@26", "$@27", "$@28", "simple_value", "numeric_value",
   "value_literal", "in_or_into_collection_name", "bind_parameter",
   "bind_parameter_datasource_expected", "object_element_name",
   "variable_name", YY_NULLPTR
@@ -1163,12 +1249,12 @@ yysymbol_name (yysymbol_kind_t yysymbol)
 }
 #endif
 
-#define YYPACT_NINF (-449)
+#define YYPACT_NINF (-464)
 
 #define yypact_value_is_default(Yyn) \
   ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF (-289)
+#define YYTABLE_NINF (-306)
 
 #define yytable_value_is_error(Yyn) \
   0
@@ -1177,58 +1263,60 @@ yysymbol_name (yysymbol_kind_t yysymbol)
    STATE-NUM.  */
 static const yytype_int16 yypact[] =
 {
-       9,  -449,  -449,    55,   238,  -449,   627,  -449,  -449,  -449,
-    -449,  -449,   167,  -449,    25,    25,  1877,  1721,    76,  -449,
-    1877,  1877,  1877,  1877,  1877,  1877,   101,  -449,  -449,  -449,
-    -449,  -449,   231,  -449,  -449,  -449,  -449,  -449,    24,    38,
-      39,    67,    68,   238,  -449,  -449,     0,    51,  -449,    17,
-    -449,    46,  -449,  -449,  -449,    80,  -449,  -449,  -449,  -449,
-    -449,  1877,    36,  1877,  1877,  1877,  -449,  -449,  1589,    93,
-    -449,  -449,  -449,  -449,  -449,  -449,  -449,   -36,  -449,  -449,
-    -449,  -449,  -449,  1589,    71,  -449,    92,    25,   130,  1877,
-     927,   971,    91,  1016,  1016,  -449,   744,  -449,   791,  -449,
-    -449,  -449,  -449,    25,    92,   134,   130,  -449,    25,  1759,
-      25,  1877,  -449,  -449,  -449,  -449,  1060,  -449,    11,  1877,
-    1877,   118,  -449,  -449,  1877,  1877,  1877,  1877,  1877,  1877,
-    1877,  1877,  1877,  1877,  1877,  1877,  1877,  1877,  1877,   120,
-    1877,  -449,  -449,  -449,   108,   126,   149,  -449,  1801,   246,
-    1877,   177,    25,   141,  -449,   140,  -449,   160,    92,   151,
-    -449,   653,  1877,   141,  -449,  1915,   112,    92,    92,  1877,
-      92,  1877,    92,  1877,   192,   176,  -449,   141,    92,  -449,
-      92,  -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,
-     835,   257,   420,  -449,  1589,  1839,  -449,   155,   169,   180,
-     181,   197,   204,  -449,   226,   227,  1877,   229,   230,   241,
-     248,   254,   250,   252,  -449,   264,  1589,   259,   263,  -449,
-     326,  1877,  1877,  1877,  1877,  1877,   326,   211,   211,   211,
-     211,   189,   189,   189,   189,   211,   240,   240,  -449,  -449,
-    -449,  1877,   269,   265,  1877,  1877,  1877,  1877,  1877,  1877,
-    1877,  1877,  1877,  -449,  1839,  -449,  -449,  1104,   280,   285,
-    -449,  -449,  1589,    25,   279,  -449,   303,  -449,    25,  1877,
-    -449,  1877,  -449,  -449,  -449,  -449,  -449,  -449,  1589,    91,
-      27,   324,   618,  -449,  -449,  -449,  -449,  -449,  -449,  -449,
-    1016,  -449,  1016,  -449,  1589,  1877,  1877,    25,  -449,  -449,
-     310,   137,   311,  -449,  1877,  1877,  1877,  1877,   697,  1589,
-     282,  -449,  -449,   286,  -449,  1877,  1877,  1877,  1877,  1877,
-    1877,  1148,  1877,  1877,  1877,  1877,  1877,  -449,    11,  1877,
-    -449,  1877,   211,   211,   211,  1676,  1633,  1192,  1877,  1237,
-     326,   326,   211,   211,   189,   189,   189,   189,   283,  -449,
-    -449,   545,  -449,   545,  -449,    25,   322,  -449,  1589,  -449,
-    -449,    92,    92,   333,   883,  1589,   298,  -449,  1953,  -449,
-    1877,  -449,  1281,  1325,  1369,  1413,   236,  -449,   299,  -449,
-     261,  -449,  -449,  -449,  1877,  1589,  1589,  1589,  1589,  1589,
-    1589,   304,  1589,  1589,  1589,  1589,  1589,  -449,  1589,  -449,
-    -449,  1589,   174,  -449,  1877,   302,   355,   493,   301,   356,
-    -449,  -449,  -449,    98,  -449,  -449,  1877,  -449,  -449,  1877,
-      25,     4,   337,  1589,   327,  1457,  1877,  1877,  1877,  1877,
-    -449,  -449,  -449,  -449,  -449,  -449,  -449,  1877,  1877,  1877,
-    1877,  1877,  1877,  1877,  1877,  1877,  1877,  1589,  1877,  1877,
-    1877,  -449,  1877,   363,  -449,   883,  1016,  -449,   141,  1877,
-    1877,   697,   697,   697,   697,   127,  1589,  1589,   326,   326,
-     211,   211,   189,   189,   189,   189,  1501,  1589,  1589,  1545,
-    1877,   305,  1839,  1877,    92,  -449,  1589,  1589,    92,    92,
-      92,    92,  -449,   329,   365,  1877,  1589,  -449,   325,  1016,
-    -449,  -449,  -449,  -449,  -449,   127,  1877,  1589,  -449,    92,
-    -449,  1589,  -449
+      17,  -464,  -464,    48,    79,  -464,   381,  -464,  -464,  -464,
+    -464,  -464,    19,  -464,    38,    -1,  1836,  1680,   125,  -464,
+    1836,  1836,  1836,  1836,  1836,  1836,   108,  -464,  -464,  -464,
+    -464,  -464,   200,  -464,  -464,  -464,  -464,  -464,    12,    26,
+      27,    45,    46,    79,  -464,  -464,    10,    71,  -464,  -464,
+    -464,    30,  -464,    61,    62,    96,  -464,  -464,  -464,   -25,
+    -464,  -464,  -464,  -464,  -464,  1836,   105,  1836,  1836,  1836,
+    -464,  -464,  1548,    97,  -464,  -464,  -464,  -464,  -464,  -464,
+    -464,   -45,  -464,  -464,  -464,  -464,  -464,  1548,   141,  -464,
+     146,    38,   164,  1836,   886,   930,   169,   975,   975,  -464,
+     703,  -464,   750,  -464,  -464,  -464,  -464,    38,   146,   159,
+     164,  -464,    38,  1718,    38,    -1,    -1,  1836,  1836,  1836,
+    -464,  -464,  -464,  -464,  1019,  -464,   568,  1836,  1836,    95,
+    -464,  -464,  1836,  1836,  1836,  1836,  1836,  1836,  1836,  1836,
+    1836,  1836,  1836,  1836,  1836,  1836,  1836,    99,  1836,  -464,
+    -464,  -464,   142,   163,   174,  -464,  1760,   165,  1836,   205,
+      38,   179,  -464,   172,  -464,   189,   146,   183,  -464,   612,
+    1836,   179,  -464,  1874,   166,   146,   146,  1836,   146,  1836,
+     146,  1836,   229,   218,  -464,   179,   146,  -464,   146,  -464,
+    -464,  -464,  -464,  -464,  -464,  -464,  -464,  -464,   794,    57,
+     447,    40,   211,  -464,     7,  -464,  -464,  -464,  1548,  1548,
+    1548,  1798,  -464,   214,   220,   235,   237,   251,   253,  -464,
+     254,   261,  1836,   262,   269,   276,   278,   280,   274,   279,
+    -464,   283,  1548,   275,   282,  -464,   558,  1836,  1836,  1836,
+    1836,  1836,   558,   140,   140,   140,   140,   231,   231,   231,
+     231,   140,   248,   248,  -464,  -464,  -464,  1836,   287,   185,
+    1836,  1836,  1836,  1836,  1836,  1836,  1836,  1836,  1836,  -464,
+    1798,  -464,  -464,  1063,   289,   293,  -464,  -464,  1548,    38,
+     288,  -464,   312,  -464,    38,  1836,  -464,  1836,  -464,  -464,
+    -464,  -464,  -464,  -464,  1548,   169,    34,   536,   566,  -464,
+    -464,  -464,  -464,  -464,  -464,  -464,   975,  -464,   975,  -464,
+    1548,  1836,  1836,    38,  -464,  -464,   320,   268,   322,  -464,
+    1836,  1836,  1836,  1836,   656,    38,  -464,    -1,    -1,  -464,
+    1548,   292,  -464,  -464,   290,  -464,  1836,  1836,  1836,  1836,
+    1836,  1836,  1107,  1836,  1836,  1836,  1836,  1836,  -464,   568,
+    1836,  -464,  1836,   140,   140,   140,  1635,  1592,  1151,  1836,
+    1196,   558,   558,   140,   140,   231,   231,   231,   231,   295,
+    -464,  -464,   228,  -464,   228,  -464,    38,   324,  -464,  1548,
+    -464,  -464,   146,   146,   335,   842,  1548,   301,  -464,  1912,
+    -464,  1836,  -464,  1240,  1284,  1328,  1372,   116,  -464,   302,
+    -464,   182,  -464,  -464,  -464,  -464,  -464,  -464,  -464,  -464,
+    1836,  1548,  1548,  1548,  1548,  1548,  1548,   313,  1548,  1548,
+    1548,  1548,  1548,  -464,  1548,  -464,  -464,  1548,   319,  -464,
+    1836,   308,   366,   479,   306,   367,  -464,  -464,  -464,   209,
+    -464,  -464,  1836,  -464,  -464,  1836,    38,   112,   346,  1548,
+     342,  1416,  1836,  1836,  1836,  1836,  -464,  -464,  -464,  -464,
+    -464,  -464,  -464,  1836,  1836,  1836,  1836,  1836,  1836,  1836,
+    1836,  1836,  1836,  1548,  1836,  1836,  1836,  -464,  1836,   374,
+    -464,   842,   975,  -464,   179,  1836,  1836,   656,   656,   656,
+     656,   100,  1548,  1548,   558,   558,   140,   140,   231,   231,
+     231,   231,  1460,  1548,  1548,  1504,  1836,   316,  1798,  1836,
+     146,  -464,  1548,  1548,   146,   146,   146,   146,  -464,   323,
+     387,  1836,  1548,  -464,   332,   975,  -464,  -464,  -464,  -464,
+    -464,   100,  1836,  1548,  -464,   146,  -464,  1548,  -464
 };
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
@@ -1236,92 +1324,96 @@ static const yytype_int16 yypact[] =
    means the default is an error.  */
 static const yytype_int16 yydefact[] =
 {
-       9,    10,    20,     0,     0,    12,     0,     1,     4,   285,
-     284,     6,    11,     5,     0,     0,     0,     0,    59,    84,
+       9,    10,    20,     0,     0,    12,     0,     1,     4,   302,
+     301,     6,    11,     5,     0,     0,     0,     0,    76,   101,
        0,     0,     0,     0,     0,     0,     0,    13,    21,    22,
-      24,    23,    70,    25,    26,    27,    28,    14,    29,    30,
-      31,    32,    33,     0,     8,   288,    36,     0,    34,    54,
-      55,     0,   276,   277,   278,   256,   274,   272,   273,   283,
-     282,     0,     0,     0,     0,   261,   204,   191,    53,     0,
-     259,   123,   124,   125,   257,   189,   190,   127,   275,   126,
-     258,   120,    97,   122,     0,    77,   202,     0,    70,     0,
-      93,     0,   190,     0,     0,   104,     0,   107,     0,   112,
-     115,   110,   111,     0,   202,   202,    70,     7,     0,     0,
-       0,     0,   137,   133,   135,   136,     0,    20,   206,   193,
-       0,     0,   140,   138,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   177,
-       0,   118,   117,   119,     0,     0,     0,   131,     0,     0,
-       0,     0,     0,     0,    61,    60,    67,     0,   202,    85,
-      86,    89,     0,     0,    95,     0,     0,   202,   202,     0,
-     202,     0,   202,     0,     0,    71,    62,    75,   202,    65,
-     202,    35,   251,   252,   253,    47,    49,    50,    51,    52,
-      45,   254,     0,    56,    57,   185,   260,     0,     0,     0,
-       0,     0,   211,   287,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   207,   209,     0,   198,     0,   194,   196,
-     153,     0,     0,     0,     0,     0,   154,   159,   160,   147,
-     148,   149,   150,   151,   152,   158,   142,   143,   144,   145,
-     146,     0,     0,   128,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   130,   185,   227,   225,     0,   266,   268,
-     263,   264,   121,     0,    78,    79,     0,   203,     0,     0,
-      63,     0,    90,    91,    88,    92,   270,   271,    94,     0,
-     256,   274,   282,    98,   279,   280,   281,    99,   100,   101,
-       0,   102,     0,   105,   113,     0,     0,     0,    66,    64,
-      37,   253,   199,   255,     0,     0,     0,     0,     0,   184,
-       0,   187,    20,   183,   262,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   205,   208,     0,
-     192,   195,   156,   157,   155,   141,   139,     0,     0,     0,
-     167,   168,   161,   162,   163,   164,   165,   166,     0,   265,
-     226,   229,   228,   229,    58,     0,     0,    68,    69,    87,
-      96,   202,   202,     0,     0,    72,    76,    73,     0,    48,
-       0,    46,     0,     0,     0,     0,     0,   239,   245,    40,
-       0,   240,   134,   186,   185,   221,   220,   219,   218,   223,
-     217,     0,   213,   212,   214,   215,   216,   210,   222,   197,
-     178,   181,     0,   132,     0,     0,     0,     0,     0,   234,
-      80,   129,    81,     0,   103,   106,     0,   108,   109,     0,
-       0,   256,    38,     2,     0,   200,     0,     0,     0,     0,
-     250,   249,   248,   246,   241,   242,   188,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   230,     0,     0,
-       0,   267,     0,   237,    82,     0,     0,    74,     0,     0,
-       0,     0,     0,     0,     0,     0,   224,   179,   175,   176,
-     169,   170,   171,   172,   173,   174,     0,   231,   233,   235,
-       0,     0,   185,     0,   202,    39,     3,   201,   202,   202,
-     202,   202,   243,   247,     0,     0,   238,   269,     0,     0,
-     116,    41,    42,    44,    43,     0,     0,   236,    83,   202,
-     244,   232,   114
+      24,    23,    87,    25,    26,    27,    28,    14,    29,    30,
+      31,    32,    33,     0,     8,   305,    36,     0,    34,    67,
+      60,    54,    55,     0,     0,     0,   293,   294,   295,   273,
+     291,   289,   290,   300,   299,     0,     0,     0,     0,   278,
+     221,   208,    53,     0,   276,   140,   141,   142,   274,   206,
+     207,   144,   292,   143,   275,   137,   114,   139,     0,    94,
+     219,     0,    87,     0,   110,     0,   207,     0,     0,   121,
+       0,   124,     0,   129,   132,   127,   128,     0,   219,   219,
+      87,     7,     0,     0,    69,    62,     0,     0,     0,     0,
+     154,   150,   152,   153,     0,    20,   223,   210,     0,     0,
+     157,   155,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   194,     0,   135,
+     134,   136,     0,     0,     0,   148,     0,     0,     0,     0,
+       0,     0,    78,    77,    84,     0,   219,   102,   103,   106,
+       0,     0,   112,     0,     0,   219,   219,     0,   219,     0,
+     219,     0,     0,    88,    79,    92,   219,    82,   219,    35,
+     268,   269,   270,    47,    49,    50,    51,    52,    45,   271,
+       0,     0,    70,    64,     0,    65,    63,    56,    58,    59,
+      57,   202,   277,     0,     0,     0,     0,     0,   228,   304,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   224,
+     226,     0,   215,     0,   211,   213,   170,     0,     0,     0,
+       0,     0,   171,   176,   177,   164,   165,   166,   167,   168,
+     169,   175,   159,   160,   161,   162,   163,     0,     0,   145,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   147,
+     202,   244,   242,     0,   283,   285,   280,   281,   138,     0,
+      95,    96,     0,   220,     0,     0,    80,     0,   107,   108,
+     105,   109,   287,   288,   111,     0,   273,   291,   299,   115,
+     296,   297,   298,   116,   117,   118,     0,   119,     0,   122,
+     130,     0,     0,     0,    83,    81,    37,   270,   216,   272,
+       0,     0,     0,     0,     0,    69,    68,     0,    62,    61,
+     201,     0,   204,    20,   200,   279,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   222,   225,
+       0,   209,   212,   173,   174,   172,   158,   156,     0,     0,
+       0,   184,   185,   178,   179,   180,   181,   182,   183,     0,
+     282,   243,   246,   245,   246,    75,     0,     0,    85,    86,
+     104,   113,   219,   219,     0,     0,    89,    93,    90,     0,
+      48,     0,    46,     0,     0,     0,     0,     0,   256,   262,
+      40,     0,   257,    74,    73,    72,    71,    66,   151,   203,
+     202,   238,   237,   236,   235,   240,   234,     0,   230,   229,
+     231,   232,   233,   227,   239,   214,   195,   198,     0,   149,
+       0,     0,     0,     0,     0,   251,    97,   146,    98,     0,
+     120,   123,     0,   125,   126,     0,     0,   273,    38,     2,
+       0,   217,     0,     0,     0,     0,   267,   266,   265,   263,
+     258,   259,   205,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   247,     0,     0,     0,   284,     0,   254,
+      99,     0,     0,    91,     0,     0,     0,     0,     0,     0,
+       0,     0,   241,   196,   192,   193,   186,   187,   188,   189,
+     190,   191,     0,   248,   250,   252,     0,     0,   202,     0,
+     219,    39,     3,   218,   219,   219,   219,   219,   260,   264,
+       0,     0,   255,   286,     0,     0,   133,    41,    42,    44,
+      43,     0,     0,   253,   100,   219,   261,   249,   131
 };
 
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
-    -449,  -449,    16,  -449,  -449,  -449,  -449,   -98,  -449,  -449,
-    -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,
-    -449,  -449,  -449,  -449,  -449,   281,   358,  -449,  -449,  -449,
-    -449,   124,   -66,  -449,  -449,  -449,   -29,  -449,  -449,    40,
-    -449,  -449,  -449,  -449,  -449,   122,  -449,  -449,  -449,  -449,
-     -80,  -449,  -449,  -449,  -449,  -449,  -449,   -61,  -449,  -449,
-    -449,  -449,  -449,  -220,  -449,  -449,   -16,    41,  -449,  -449,
-    -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,  -449,  -243,
-      12,  -449,  -449,  -449,  -449,  -449,  -449,  -449,    70,  -449,
-      21,   -11,  -449,  -449,  -449,    74,  -449,  -449,    45,  -449,
-    -449,  -448,  -449,  -392,  -449,   -96,  -449,  -449,  -449,  -449,
-    -449,  -449,  -449,   243,   233,   -14,    62,  -449,   -12
+    -464,  -464,    20,  -464,  -464,  -464,  -464,  -114,  -464,  -464,
+    -464,  -464,  -464,  -464,  -464,  -464,  -464,  -464,  -464,  -464,
+    -464,  -464,  -464,  -464,  -464,   281,   -97,  -464,    70,   -93,
+    -464,    74,   368,  -464,  -464,  -464,  -464,   117,   -63,  -464,
+    -464,  -464,   -30,  -464,  -464,    33,  -464,  -464,  -464,  -464,
+    -464,   115,  -464,  -464,  -464,  -464,   -79,  -464,  -464,  -464,
+    -464,  -464,  -464,   -71,  -464,  -464,  -464,  -464,  -464,  -210,
+    -464,  -464,   -16,    35,  -464,  -464,  -464,  -464,  -464,  -464,
+    -464,  -464,  -464,  -464,  -464,  -254,     1,  -464,  -464,  -464,
+    -464,  -464,  -464,  -464,    64,  -464,   -95,   -11,  -464,  -464,
+    -464,    69,  -464,  -464,    39,  -464,  -464,  -463,  -464,  -215,
+    -464,   -89,  -464,  -464,  -464,  -464,  -464,  -464,  -464,   255,
+     243,   -23,    13,  -464,    68
 };
 
 /* YYDEFGOTO[NTERM-NUM].  */
 static const yytype_int16 yydefgoto[] =
 {
-       0,   422,    11,    12,     2,     4,     3,     5,    27,     6,
-      28,    46,    47,   369,   185,   186,   187,   188,   189,    29,
-     302,   300,    30,    31,    49,    50,    86,    32,    87,    33,
-     155,   156,   105,   366,   178,   297,    88,   152,   264,   265,
-     412,   482,    34,    89,   159,   160,   274,    35,    36,    37,
-     167,    38,    39,    95,    40,    97,    41,   419,   100,    42,
-     173,   363,   174,   145,    82,   150,   309,    69,    70,   254,
-     195,    71,    72,   225,   224,    73,   241,   438,   242,   310,
-     311,   312,   313,    74,    75,   119,   217,   218,   219,   371,
-     154,    76,   118,   212,   213,   214,   258,   259,   408,   453,
-     481,   378,   493,   379,   465,   380,   192,    77,   117,   351,
-     353,   275,    78,    79,   283,    80,   381,   215,    51
+       0,   448,    11,    12,     2,     4,     3,     5,    27,     6,
+      28,    46,    47,   390,   193,   194,   195,   196,   197,    29,
+     318,   316,    30,    31,    51,    52,    53,   115,   204,    54,
+     114,   201,    90,    32,    91,    33,   163,   164,   109,   387,
+     186,   313,    92,   160,   280,   281,   438,   508,    34,    93,
+     167,   168,   290,    35,    36,    37,   175,    38,    39,    99,
+      40,   101,    41,   445,   104,    42,   181,   384,   182,   153,
+      86,   158,   330,    73,    74,   270,   211,    75,    76,   241,
+     240,    77,   257,   464,   258,   331,   332,   333,   334,    78,
+      79,   127,   233,   234,   235,   392,   162,    80,   126,   228,
+     229,   230,   274,   275,   434,   479,   507,   399,   519,   400,
+     491,   401,   200,    81,   125,   372,   374,   291,    82,    83,
+     299,    84,   402,   231,    55
 };
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
@@ -1329,317 +1421,353 @@ static const yytype_int16 yydefgoto[] =
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
-      68,    83,    48,   106,    90,    91,    93,    94,    96,    98,
-      92,   348,   102,   191,   168,   101,   170,   492,   172,   197,
-     198,   199,   158,     1,   -15,   200,   201,  -279,    44,   148,
-    -279,  -279,  -279,  -279,  -279,  -279,  -279,  -279,   -16,   -17,
-     180,  -288,   202,   203,   149,   112,   204,   114,   115,   116,
-    -279,  -279,  -279,  -279,  -279,     7,    45,   510,  -279,   107,
-     108,   205,  -129,   164,   109,  -129,    13,   -18,   -19,   488,
-     489,   490,   491,   161,    13,   157,   206,   110,   207,   208,
-     209,   210,   211,   111,   -15,  -129,   -15,  -279,  -129,  -279,
-      84,   175,    85,   190,   303,   194,   181,   113,   -16,   -17,
-     -16,   -17,   151,   216,   220,    13,    99,    85,   226,   227,
-     228,   229,   230,   231,   232,   233,   234,   235,   236,   237,
-     238,   239,   240,   153,   243,   176,   179,   -18,   -19,   -18,
-     -19,   406,   257,   406,   262,   261,    59,    60,  -129,   245,
-     266,  -129,   267,   284,   285,   103,   278,   277,   286,   220,
-    -118,   146,   279,   290,   147,   292,   146,   294,   377,   454,
-     221,   222,     9,    10,    66,   177,   267,   246,   223,   244,
-     247,   248,   249,   250,   251,   252,   308,  -180,  -118,   270,
-     253,  -118,  -118,  -118,  -118,  -118,  -118,   439,   288,   289,
-     321,   291,   263,   293,   182,   183,   184,   269,     8,   298,
-     268,   299,     9,    10,    66,   332,   333,   334,   335,   336,
-     361,   271,   362,   296,   383,   440,   295,   314,   441,   442,
-     443,   444,   445,   446,   120,   337,   315,    43,   339,   340,
-     341,   342,   343,   344,   345,   346,   347,   316,   317,   498,
-     134,   135,   136,   137,   138,    84,   103,    85,   140,   121,
-     360,   354,   124,   358,   318,   161,   157,   129,   130,   131,
-     132,  -286,   134,   135,   136,   137,   138,   430,   431,     8,
-     140,    59,    60,     9,    10,   304,   305,   260,   306,   364,
-     365,    59,    60,   319,   320,   367,   322,   323,   372,   373,
-     374,   375,   434,   136,   137,   138,    59,    60,   324,   385,
-     386,   387,   388,   389,   390,   325,   392,   393,   394,   395,
-     396,   326,   328,   398,   327,   216,   134,   135,   136,   137,
-     138,   329,   401,   331,  -280,   330,   338,  -280,  -280,  -280,
-    -280,  -280,  -280,  -280,  -280,   407,   350,   407,   352,   355,
-     356,   368,   370,   266,   382,   403,   384,  -280,  -280,  -280,
-    -280,  -280,   423,   411,   425,  -280,   424,   416,   420,   433,
-     449,   437,   432,   448,   459,   452,   435,   451,   458,   480,
-     506,   497,   129,   130,   131,   132,   484,   134,   135,   136,
-     137,   138,   414,   415,  -280,   140,  -280,   508,   447,   505,
-     104,   193,   357,   359,   483,   410,   436,   413,   409,   287,
-     455,   399,   397,   456,   276,     0,     0,     0,   457,     0,
-     461,   462,   463,   464,     0,     0,     0,     0,     0,   509,
-       0,   466,   467,   468,   469,   470,   471,   472,   473,   474,
-     475,     0,   476,   477,   478,     0,   479,     0,     0,     0,
-     307,     0,     0,   486,   487,     0,     0,   485,    52,    53,
-      54,    55,    56,    57,    58,    59,    60,     0,    61,     0,
-       0,     0,     0,     0,   496,     0,     0,   499,     0,     0,
-      62,    63,    64,     0,     0,     0,     0,     0,     0,   507,
-       0,    65,     0,    66,     0,    67,     0,     0,     0,     0,
-     511,     0,     0,     0,     0,     0,     0,     0,   450,     0,
-       0,     0,     0,     0,     0,   500,   120,     0,     0,   501,
-     502,   503,   504,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     512,   121,   122,   123,   124,   125,   126,   127,   128,   129,
-     130,   131,   132,   133,   134,   135,   136,   137,   138,   139,
-     404,     0,   140,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   141,   142,   143,   144,     0,     0,     0,     0,
-       0,     0,     0,    52,    53,    54,    55,    56,    57,    58,
-      59,    60,     0,    61,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    62,    63,    64,     0,     0,
-       0,     0,     0,     0,     0,     0,    65,     0,    66,     0,
-      67,     0,     0,     0,   141,   142,   143,   405,  -281,     0,
-       0,  -281,  -281,  -281,  -281,  -281,  -281,  -281,  -281,     0,
-      14,    15,    16,    17,    18,    19,    20,    21,     0,     0,
-       0,  -281,  -281,  -281,  -281,  -281,     0,     0,     0,  -281,
-      22,    23,    24,    25,    26,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   272,   273,   120,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,  -281,     0,
-    -281,    52,    53,    54,     0,    56,    57,    58,    59,    60,
-       0,   121,   122,   123,   124,   125,   126,   127,   128,   129,
-     130,   131,   132,   133,   134,   135,   136,   137,   138,   139,
-     120,     0,   140,     0,   376,     0,     0,     0,     0,     0,
-       0,     0,   141,   142,   143,   144,     0,     0,   377,     0,
-       0,     0,     9,    10,     0,   121,   122,   123,   124,   125,
-     126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,   139,     0,     0,   140,   165,   169,   166,
-       0,     0,     0,     0,   182,   183,   301,   142,   143,   144,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   121,   122,   123,   124,   125,   126,   127,   128,
+      72,    87,   110,   106,    94,    95,    97,    98,   100,   102,
+      96,   213,   -15,   184,   187,   105,   369,    13,   203,   176,
+     156,   178,   205,   180,   199,    13,   -16,   -17,   518,   166,
+      45,     1,    44,  -146,  -296,   157,  -146,  -296,  -296,  -296,
+    -296,  -296,  -296,  -296,  -296,   -18,   -19,   188,     7,   120,
+       8,   122,   123,   124,     9,    10,    13,  -296,  -296,  -296,
+    -296,  -296,    49,   111,    50,  -296,   172,   328,   536,    45,
+     112,   286,   -15,   329,   -15,   320,   321,   169,   322,    43,
+     304,   305,    48,   307,   113,   309,   -16,   -17,   -16,   -17,
+     116,   314,  -146,   315,  -296,  -146,  -296,   198,   117,   118,
+     325,   208,   209,   210,   326,   -18,   -19,   -18,   -19,   319,
+       8,   232,   236,   103,     9,    10,   242,   243,   244,   245,
+     246,   247,   248,   249,   250,   251,   252,   253,   254,   255,
+     256,   398,   259,   119,   277,     9,    10,   237,   238,    88,
+     273,    89,   278,    63,    64,   239,   293,   456,   457,  -305,
+     283,    63,    64,   128,   294,   154,  -197,   236,   155,   165,
+     295,   306,   432,   308,   432,   310,   121,   190,   191,   192,
+    -146,    70,   159,  -146,   283,   183,   261,   161,   129,   107,
+     189,   132,   202,   206,   324,    89,   137,   138,   139,   140,
+     185,   142,   143,   144,   145,   146,   276,   300,   301,   148,
+      63,    64,   302,   260,   262,   269,   342,   263,   264,   265,
+     266,   267,   268,   460,    88,   107,    89,    63,    64,   409,
+     279,   353,   354,   355,   356,   357,   285,   382,   282,   383,
+     404,   203,   284,   430,   405,   205,   142,   143,   144,   145,
+     146,   358,    70,   287,   360,   361,   362,   363,   364,   365,
+     366,   367,   368,   311,   524,   312,    56,    57,    58,    59,
+      60,    61,    62,    63,    64,   381,    65,   154,   327,   379,
+     480,   169,   514,   515,   516,   517,   335,   336,    66,    67,
+      68,  -135,   142,   143,   144,   145,   146,   440,   441,    69,
+     148,    70,   337,    71,   338,   385,   386,   149,   150,   151,
+     431,   144,   145,   146,   393,   394,   395,   396,   339,  -135,
+    -303,   340,  -135,  -135,  -135,  -135,  -135,  -135,   341,   343,
+     411,   412,   413,   414,   415,   416,   344,   418,   419,   420,
+     421,   422,   465,   345,   424,   346,   232,   347,   348,   349,
+     350,   351,   352,   427,   359,   371,   373,   375,   376,   377,
+     410,   389,   165,   391,   408,   437,   433,   429,   433,   442,
+     466,   446,   459,   467,   468,   469,   470,   471,   472,   474,
+     463,   475,   477,   449,   458,   451,   478,   484,   461,   485,
+     506,   388,   523,   531,    14,    15,    16,    17,    18,    19,
+      20,    21,   532,   202,   534,   406,   206,   207,   407,   403,
+     108,   378,   380,   510,    22,    23,    24,    25,    26,   436,
+     509,   462,   439,   435,   473,   526,   425,   303,   423,   527,
+     528,   529,   530,     0,   292,     0,   481,     0,     0,   482,
+       0,     0,     0,     0,     0,     0,   487,   488,   489,   490,
+     538,     0,     0,     0,   282,     0,   535,   492,   493,   494,
+     495,   496,   497,   498,   499,   500,   501,   450,   502,   503,
+     504,     0,   505,     0,     0,     0,     0,   323,     0,   512,
+     513,     0,     0,   511,     0,    56,    57,    58,    59,    60,
+      61,    62,    63,    64,   476,    65,     0,     0,     0,     0,
+     522,     0,   128,   525,     0,     0,     0,    66,    67,    68,
+       0,     0,     0,     0,     0,   533,     0,     0,    69,     0,
+      70,     0,    71,     0,   483,     0,   537,   129,   130,   131,
+     132,   133,   134,   135,   136,   137,   138,   139,   140,   141,
+     142,   143,   144,   145,   146,   147,  -297,     0,   148,  -297,
+    -297,  -297,  -297,  -297,  -297,  -297,  -297,     0,   149,   150,
+     151,   152,     0,     0,     0,     0,     0,     0,     0,  -297,
+    -297,  -297,  -297,  -297,     0,     0,  -298,  -297,     0,  -298,
+    -298,  -298,  -298,  -298,  -298,  -298,  -298,   214,   215,     0,
+       0,     0,   216,   217,     0,     0,     0,     0,     0,  -298,
+    -298,  -298,  -298,  -298,     0,     0,  -297,  -298,  -297,   218,
+     219,     0,     0,   220,   137,   138,   139,   140,     0,   142,
+     143,   144,   145,   146,     0,     0,     0,   148,   221,     0,
+       0,     0,     0,   288,   289,   128,  -298,     0,  -298,     0,
+       0,     0,     0,   222,     0,   223,   224,   225,   226,   227,
+      56,    57,    58,     0,    60,    61,    62,    63,    64,     0,
      129,   130,   131,   132,   133,   134,   135,   136,   137,   138,
-     139,     0,     0,   140,   165,   171,   166,     0,     0,     0,
-       0,     0,     0,   141,   142,   143,   144,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   121,
-     122,   123,   124,   125,   126,   127,   128,   129,   130,   131,
-     132,   133,   134,   135,   136,   137,   138,   139,   120,     0,
-     140,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     141,   142,   143,   144,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   121,   122,   123,   124,   125,   126,   127,
-     128,   129,   130,   131,   132,   133,   134,   135,   136,   137,
-     138,   139,     0,     0,   140,     0,   120,     0,     0,     0,
-       0,     0,   182,   183,   301,   142,   143,   144,   417,   418,
+     139,   140,   141,   142,   143,   144,   145,   146,   147,   128,
+       0,   148,     0,   397,     0,     0,     0,     0,     0,     0,
+       0,   149,   150,   151,   152,     0,     0,   398,     0,     0,
+       0,     9,    10,     0,   129,   130,   131,   132,   133,   134,
+     135,   136,   137,   138,   139,   140,   141,   142,   143,   144,
+     145,   146,   147,     0,     0,   148,   173,   177,   174,     0,
+       0,     0,     0,   190,   191,   317,   150,   151,   152,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   121,   122,   123,   124,   125,   126,   127,   128,   129,
-     130,   131,   132,   133,   134,   135,   136,   137,   138,   139,
-     120,     0,   140,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   141,   142,   143,   144,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   121,   122,   123,   124,   125,
-     126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,   139,   120,   163,   140,   162,     0,     0,
-       0,     0,     0,     0,     0,     0,   141,   142,   143,   144,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   121,
-     122,   123,   124,   125,   126,   127,   128,   129,   130,   131,
-     132,   133,   134,   135,   136,   137,   138,   139,     0,   165,
-     140,   166,     0,     0,     0,     0,     0,     0,     0,     0,
-     141,   142,   143,   144,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   121,   122,   123,   124,   125,   126,
-     127,   128,   129,   130,   131,   132,   133,   134,   135,   136,
-     137,   138,   139,   120,     0,   140,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   141,   142,   143,   144,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   121,   122,
-     123,   124,   125,   126,   127,   128,   129,   130,   131,   132,
-     133,   134,   135,   136,   137,   138,   139,   120,     0,   140,
-       0,     0,   196,     0,     0,     0,     0,     0,     0,   141,
-     142,   143,   144,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   121,   122,   123,   124,   125,   126,   127,   128,
+       0,   129,   130,   131,   132,   133,   134,   135,   136,   137,
+     138,   139,   140,   141,   142,   143,   144,   145,   146,   147,
+       0,     0,   148,   173,   179,   174,     0,     0,     0,     0,
+       0,     0,   149,   150,   151,   152,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   129,   130,
+     131,   132,   133,   134,   135,   136,   137,   138,   139,   140,
+     141,   142,   143,   144,   145,   146,   147,   128,     0,   148,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   149,
+     150,   151,   152,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   129,   130,   131,   132,   133,   134,   135,   136,
+     137,   138,   139,   140,   141,   142,   143,   144,   145,   146,
+     147,     0,     0,   148,     0,   128,     0,     0,     0,     0,
+       0,   190,   191,   317,   150,   151,   152,   443,   444,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
      129,   130,   131,   132,   133,   134,   135,   136,   137,   138,
-     139,   120,     0,   140,     0,     0,     0,     0,     0,     0,
-     349,     0,     0,   141,   142,   143,   144,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   121,   122,   123,   124,
-     125,   126,   127,   128,   129,   130,   131,   132,   133,   134,
-     135,   136,   137,   138,   139,   120,     0,   140,     0,     0,
-       0,     0,     0,     0,   391,     0,     0,   141,   142,   143,
-     144,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     121,   122,   123,   124,   125,   126,   127,   128,   129,   130,
-     131,   132,   133,   134,   135,   136,   137,   138,   139,   400,
-     120,   140,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   141,   142,   143,   144,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,   121,   122,   123,   124,   125,
-     126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,   139,   120,     0,   140,     0,     0,   402,
-       0,     0,     0,     0,     0,     0,   141,   142,   143,   144,
-       0,     0,   426,     0,     0,     0,     0,     0,     0,   121,
-     122,   123,   124,   125,   126,   127,   128,   129,   130,   131,
-     132,   133,   134,   135,   136,   137,   138,   139,   120,     0,
-     140,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-     141,   142,   143,   144,     0,     0,   427,     0,     0,     0,
-       0,     0,     0,   121,   122,   123,   124,   125,   126,   127,
-     128,   129,   130,   131,   132,   133,   134,   135,   136,   137,
-     138,   139,   120,     0,   140,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,   141,   142,   143,   144,     0,     0,
-     428,     0,     0,     0,     0,     0,     0,   121,   122,   123,
-     124,   125,   126,   127,   128,   129,   130,   131,   132,   133,
-     134,   135,   136,   137,   138,   139,   120,     0,   140,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   141,   142,
-     143,   144,     0,     0,   429,     0,     0,     0,     0,     0,
-       0,   121,   122,   123,   124,   125,   126,   127,   128,   129,
+     139,   140,   141,   142,   143,   144,   145,   146,   147,   128,
+       0,   148,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   149,   150,   151,   152,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   129,   130,   131,   132,   133,   134,
+     135,   136,   137,   138,   139,   140,   141,   142,   143,   144,
+     145,   146,   147,   128,   171,   148,   170,     0,     0,     0,
+       0,     0,     0,     0,     0,   149,   150,   151,   152,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   129,   130,
+     131,   132,   133,   134,   135,   136,   137,   138,   139,   140,
+     141,   142,   143,   144,   145,   146,   147,     0,   173,   148,
+     174,     0,     0,     0,     0,     0,     0,     0,     0,   149,
+     150,   151,   152,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   129,   130,   131,   132,   133,   134,   135,
+     136,   137,   138,   139,   140,   141,   142,   143,   144,   145,
+     146,   147,   128,     0,   148,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   149,   150,   151,   152,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   129,   130,   131,
+     132,   133,   134,   135,   136,   137,   138,   139,   140,   141,
+     142,   143,   144,   145,   146,   147,   128,     0,   148,     0,
+       0,   212,     0,     0,     0,     0,     0,     0,   149,   150,
+     151,   152,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   129,   130,   131,   132,   133,   134,   135,   136,   137,
+     138,   139,   140,   141,   142,   143,   144,   145,   146,   147,
+     128,     0,   148,     0,     0,     0,     0,     0,     0,   370,
+       0,     0,   149,   150,   151,   152,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   129,   130,   131,   132,   133,
+     134,   135,   136,   137,   138,   139,   140,   141,   142,   143,
+     144,   145,   146,   147,   128,     0,   148,     0,     0,     0,
+       0,     0,     0,   417,     0,     0,   149,   150,   151,   152,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   129,
      130,   131,   132,   133,   134,   135,   136,   137,   138,   139,
-     120,     0,   140,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   141,   142,   143,   144,     0,     0,   460,     0,
-       0,     0,     0,     0,     0,   121,   122,   123,   124,   125,
-     126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,   139,   120,     0,   140,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,   141,   142,   143,   144,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,   121,
-     122,   123,   124,   125,   126,   127,   128,   129,   130,   131,
-     132,   133,   134,   135,   136,   137,   138,   139,   120,     0,
-     140,     0,     0,   494,     0,     0,     0,     0,     0,     0,
-     141,   142,   143,   144,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,   121,   122,   123,   124,   125,   126,   127,
-     128,   129,   130,   131,   132,   133,   134,   135,   136,   137,
-     138,   139,   120,     0,   140,   495,     0,     0,     0,     0,
-       0,     0,     0,     0,   141,   142,   143,   144,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,   121,   122,   123,
-     124,   125,   126,   127,   128,   129,   130,   131,   132,   133,
-     134,   135,   136,   137,   138,   139,   120,     0,   140,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,   141,   142,
-     143,   144,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,   121,   122,     0,   124,   125,   126,   127,   128,   129,
-     130,   131,   132,   133,   134,   135,   136,   137,   138,   120,
-       0,     0,   140,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,   141,   142,   143,   144,     0,     0,     0,     0,
-       0,     0,     0,     0,   121,     0,     0,   124,   125,   126,
-     127,   128,   129,   130,   131,   132,   133,   134,   135,   136,
-     137,   138,     0,     0,     0,   140,     0,     0,     0,     0,
-       0,     0,     0,    81,     0,   141,   142,   143,   144,    52,
-      53,    54,    55,    56,    57,    58,    59,    60,     0,    61,
+     140,   141,   142,   143,   144,   145,   146,   147,   426,   128,
+     148,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     149,   150,   151,   152,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,   129,   130,   131,   132,   133,   134,
+     135,   136,   137,   138,   139,   140,   141,   142,   143,   144,
+     145,   146,   147,   128,     0,   148,     0,     0,   428,     0,
+       0,     0,     0,     0,     0,   149,   150,   151,   152,     0,
+       0,   452,     0,     0,     0,     0,     0,     0,   129,   130,
+     131,   132,   133,   134,   135,   136,   137,   138,   139,   140,
+     141,   142,   143,   144,   145,   146,   147,   128,     0,   148,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,   149,
+     150,   151,   152,     0,     0,   453,     0,     0,     0,     0,
+       0,     0,   129,   130,   131,   132,   133,   134,   135,   136,
+     137,   138,   139,   140,   141,   142,   143,   144,   145,   146,
+     147,   128,     0,   148,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,   149,   150,   151,   152,     0,     0,   454,
+       0,     0,     0,     0,     0,     0,   129,   130,   131,   132,
+     133,   134,   135,   136,   137,   138,   139,   140,   141,   142,
+     143,   144,   145,   146,   147,   128,     0,   148,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   149,   150,   151,
+     152,     0,     0,   455,     0,     0,     0,     0,     0,     0,
+     129,   130,   131,   132,   133,   134,   135,   136,   137,   138,
+     139,   140,   141,   142,   143,   144,   145,   146,   147,   128,
+       0,   148,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   149,   150,   151,   152,     0,     0,   486,     0,     0,
+       0,     0,     0,     0,   129,   130,   131,   132,   133,   134,
+     135,   136,   137,   138,   139,   140,   141,   142,   143,   144,
+     145,   146,   147,   128,     0,   148,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,   149,   150,   151,   152,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,   129,   130,
+     131,   132,   133,   134,   135,   136,   137,   138,   139,   140,
+     141,   142,   143,   144,   145,   146,   147,   128,     0,   148,
+       0,     0,   520,     0,     0,     0,     0,     0,     0,   149,
+     150,   151,   152,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,   129,   130,   131,   132,   133,   134,   135,   136,
+     137,   138,   139,   140,   141,   142,   143,   144,   145,   146,
+     147,   128,     0,   148,   521,     0,     0,     0,     0,     0,
+       0,     0,     0,   149,   150,   151,   152,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,   129,   130,   131,   132,
+     133,   134,   135,   136,   137,   138,   139,   140,   141,   142,
+     143,   144,   145,   146,   147,   128,     0,   148,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,   149,   150,   151,
+     152,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+     129,   130,     0,   132,   133,   134,   135,   136,   137,   138,
+     139,   140,   141,   142,   143,   144,   145,   146,   128,     0,
+       0,   148,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,   149,   150,   151,   152,     0,     0,     0,     0,     0,
+       0,     0,     0,   129,     0,     0,   132,   133,   134,   135,
+     136,   137,   138,   139,   140,   141,   142,   143,   144,   145,
+     146,     0,     0,     0,   148,     0,     0,     0,     0,     0,
+       0,     0,    85,     0,   149,   150,   151,   152,    56,    57,
+      58,    59,    60,    61,    62,    63,    64,     0,    65,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    62,    63,    64,     0,     0,     0,     0,     0,     0,
-       0,     0,    65,     0,    66,     0,    67,    52,    53,    54,
-      55,    56,    57,    58,    59,    60,     0,    61,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    62,
-      63,    64,     0,     0,     0,     0,     0,     0,     0,     0,
-      65,     0,    66,     0,    67,     0,   182,   183,   184,    52,
-      53,    54,    55,    56,    57,    58,    59,    60,     0,    61,
+      66,    67,    68,     0,     0,     0,     0,     0,     0,     0,
+       0,    69,     0,    70,     0,    71,    56,    57,    58,    59,
+      60,    61,    62,    63,    64,     0,    65,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    66,    67,
+      68,     0,     0,     0,     0,     0,     0,     0,     0,    69,
+       0,    70,     0,    71,     0,   190,   191,   192,    56,    57,
+      58,    59,    60,    61,    62,    63,    64,     0,    65,     0,
        0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,    62,    63,    64,   255,     0,     0,   256,     0,     0,
-       0,     0,    65,     0,    66,     0,    67,    52,    53,    54,
-      55,    56,    57,    58,    59,    60,     0,    61,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,     0,     0,    62,
-      63,    64,     0,     0,     0,     0,     0,     0,     0,     0,
-      65,  -182,    66,     0,    67,    52,    53,    54,    55,    56,
-      57,    58,    59,    60,     0,    61,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,     0,     0,    62,    63,    64,
-       0,     0,     0,     0,     0,     0,     0,     0,    65,     0,
-      66,     0,    67,    52,    53,    54,   280,   281,    57,    58,
-      59,   282,     0,    61,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,     0,     0,    62,    63,    64,     0,     0,
-       0,     0,     0,     0,     0,     0,    65,     0,    66,     0,
-      67,    52,    53,    54,   421,    56,    57,    58,    59,    60,
-       0,    61,     0,     0,     0,     0,     0,     0,     0,     0,
-       0,     0,     0,    62,    63,    64,     0,     0,     0,     0,
-       0,     0,     0,     0,    65,     0,    66,     0,    67
+      66,    67,    68,   271,     0,     0,   272,     0,     0,     0,
+       0,    69,     0,    70,     0,    71,    56,    57,    58,    59,
+      60,    61,    62,    63,    64,     0,    65,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,    66,    67,
+      68,     0,     0,     0,     0,     0,     0,     0,     0,    69,
+    -199,    70,     0,    71,    56,    57,    58,    59,    60,    61,
+      62,    63,    64,     0,    65,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,    66,    67,    68,     0,
+       0,     0,     0,     0,     0,     0,     0,    69,     0,    70,
+       0,    71,    56,    57,    58,   296,   297,    61,    62,    63,
+     298,     0,    65,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,    66,    67,    68,     0,     0,     0,
+       0,     0,     0,     0,     0,    69,     0,    70,     0,    71,
+      56,    57,    58,   447,    60,    61,    62,    63,    64,     0,
+      65,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,    66,    67,    68,     0,     0,     0,     0,     0,
+       0,     0,     0,    69,     0,    70,     0,    71
 };
 
 static const yytype_int16 yycheck[] =
 {
-      16,    17,    14,    32,    20,    21,    22,    23,    24,    25,
-      21,   254,    26,   109,    94,    26,    96,   465,    98,   117,
-       9,    10,    88,    14,     0,    14,    15,     0,    12,    65,
-       3,     4,     5,     6,     7,     8,     9,    10,     0,     0,
-     106,    37,    31,    32,    80,    61,    35,    63,    64,    65,
-      23,    24,    25,    26,    27,     0,    31,   505,    31,    43,
-      60,    50,    58,    92,    13,    61,     4,     0,     0,   461,
-     462,   463,   464,    89,    12,    87,    65,    60,    67,    68,
-      69,    70,    71,    37,    60,    58,    62,    60,    61,    62,
-      14,   103,    16,   109,   190,   111,   108,    61,    60,    60,
-      62,    62,    31,   119,   120,    43,     5,    16,   124,   125,
-     126,   127,   128,   129,   130,   131,   132,   133,   134,   135,
-     136,   137,   138,    31,   140,   104,   105,    60,    60,    62,
-      62,   351,   148,   353,   150,   149,    35,    36,    58,    13,
-     152,    61,   153,    31,    32,    15,   162,   161,    36,   165,
-      13,    58,   163,   169,    61,   171,    58,   173,    31,    61,
-      42,    43,    35,    36,    63,    31,   177,    41,    50,    61,
-      44,    45,    46,    47,    48,    49,   192,    57,    41,   158,
-      31,    44,    45,    46,    47,    48,    49,    13,   167,   168,
-     206,   170,    15,   172,    67,    68,    69,    37,    31,   178,
-      60,   180,    35,    36,    63,   221,   222,   223,   224,   225,
-     290,    60,   292,    37,   312,    41,    24,    62,    44,    45,
-      46,    47,    48,    49,    13,   241,    57,    60,   244,   245,
-     246,   247,   248,   249,   250,   251,   252,    57,    57,   482,
-      51,    52,    53,    54,    55,    14,    15,    16,    59,    38,
-     279,   263,    41,   269,    57,   271,   268,    46,    47,    48,
-      49,    57,    51,    52,    53,    54,    55,    31,    32,    31,
-      59,    35,    36,    35,    36,    18,    19,    31,    21,   295,
-     296,    35,    36,    57,    57,   297,    57,    57,   304,   305,
-     306,   307,    31,    53,    54,    55,    35,    36,    57,   315,
-     316,   317,   318,   319,   320,    57,   322,   323,   324,   325,
-     326,    57,    60,   329,    64,   331,    51,    52,    53,    54,
-      55,    57,   338,    60,     0,    66,    57,     3,     4,     5,
-       6,     7,     8,     9,    10,   351,    56,   353,    53,    60,
-      37,    31,    31,   355,    62,    62,    60,    23,    24,    25,
-      26,    27,   368,    31,   370,    31,   368,    24,    60,    60,
-       5,    57,   376,    61,    37,     9,   380,    66,    31,     6,
-       5,    66,    46,    47,    48,    49,   456,    51,    52,    53,
-      54,    55,   361,   362,    60,    59,    62,    62,   404,    60,
-      32,   110,   268,   271,   455,   355,   384,   356,   353,   166,
-     416,   331,   328,   419,   161,    -1,    -1,    -1,   420,    -1,
-     426,   427,   428,   429,    -1,    -1,    -1,    -1,    -1,   499,
-      -1,   437,   438,   439,   440,   441,   442,   443,   444,   445,
-     446,    -1,   448,   449,   450,    -1,   452,    -1,    -1,    -1,
-      20,    -1,    -1,   459,   460,    -1,    -1,   458,    28,    29,
-      30,    31,    32,    33,    34,    35,    36,    -1,    38,    -1,
-      -1,    -1,    -1,    -1,   480,    -1,    -1,   483,    -1,    -1,
-      50,    51,    52,    -1,    -1,    -1,    -1,    -1,    -1,   495,
-      -1,    61,    -1,    63,    -1,    65,    -1,    -1,    -1,    -1,
-     506,    -1,    -1,    -1,    -1,    -1,    -1,    -1,     5,    -1,
-      -1,    -1,    -1,    -1,    -1,   484,    13,    -1,    -1,   488,
-     489,   490,   491,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      16,    17,    32,    26,    20,    21,    22,    23,    24,    25,
+      21,   125,     0,   108,   109,    26,   270,     4,   115,    98,
+      65,   100,   115,   102,   113,    12,     0,     0,   491,    92,
+      31,    14,    12,    58,     0,    80,    61,     3,     4,     5,
+       6,     7,     8,     9,    10,     0,     0,   110,     0,    65,
+      31,    67,    68,    69,    35,    36,    43,    23,    24,    25,
+      26,    27,    63,    43,    65,    31,    96,    60,   531,    31,
+      60,   166,    60,    66,    62,    18,    19,    93,    21,    60,
+     175,   176,    14,   178,    13,   180,    60,    60,    62,    62,
+      60,   186,    58,   188,    60,    61,    62,   113,    37,    37,
+      60,   117,   118,   119,    64,    60,    60,    62,    62,   198,
+      31,   127,   128,     5,    35,    36,   132,   133,   134,   135,
+     136,   137,   138,   139,   140,   141,   142,   143,   144,   145,
+     146,    31,   148,    37,   157,    35,    36,    42,    43,    14,
+     156,    16,   158,    35,    36,    50,   169,    31,    32,    37,
+     161,    35,    36,    13,   170,    58,    57,   173,    61,    91,
+     171,   177,   372,   179,   374,   181,    61,    67,    68,    69,
+      58,    63,    31,    61,   185,   107,    13,    31,    38,    15,
+     112,    41,   114,   115,   200,    16,    46,    47,    48,    49,
+      31,    51,    52,    53,    54,    55,    31,    31,    32,    59,
+      35,    36,    36,    61,    41,    31,   222,    44,    45,    46,
+      47,    48,    49,    31,    14,    15,    16,    35,    36,   333,
+      15,   237,   238,   239,   240,   241,    37,   306,   160,   308,
+     327,   328,    60,     5,   327,   328,    51,    52,    53,    54,
+      55,   257,    63,    60,   260,   261,   262,   263,   264,   265,
+     266,   267,   268,    24,   508,    37,    28,    29,    30,    31,
+      32,    33,    34,    35,    36,   295,    38,    58,    57,   285,
+      61,   287,   487,   488,   489,   490,    62,    57,    50,    51,
+      52,    13,    51,    52,    53,    54,    55,   382,   383,    61,
+      59,    63,    57,    65,    57,   311,   312,    69,    70,    71,
+      72,    53,    54,    55,   320,   321,   322,   323,    57,    41,
+      57,    57,    44,    45,    46,    47,    48,    49,    57,    57,
+     336,   337,   338,   339,   340,   341,    57,   343,   344,   345,
+     346,   347,    13,    57,   350,    57,   352,    57,    64,    60,
+      57,    66,    60,   359,    57,    56,    53,   279,    60,    37,
+      60,    31,   284,    31,    62,    31,   372,    62,   374,    24,
+      41,    60,    60,    44,    45,    46,    47,    48,    49,    61,
+      57,     5,    66,   389,   397,   391,     9,    31,   401,    37,
+       6,   313,    66,    60,     3,     4,     5,     6,     7,     8,
+       9,    10,     5,   325,    62,   327,   328,   116,   328,   325,
+      32,   284,   287,   482,    23,    24,    25,    26,    27,   376,
+     481,   410,   377,   374,   430,   510,   352,   174,   349,   514,
+     515,   516,   517,    -1,   169,    -1,   442,    -1,    -1,   445,
+      -1,    -1,    -1,    -1,    -1,    -1,   452,   453,   454,   455,
+     535,    -1,    -1,    -1,   376,    -1,   525,   463,   464,   465,
+     466,   467,   468,   469,   470,   471,   472,   389,   474,   475,
+     476,    -1,   478,    -1,    -1,    -1,    -1,    20,    -1,   485,
+     486,    -1,    -1,   484,    -1,    28,    29,    30,    31,    32,
+      33,    34,    35,    36,     5,    38,    -1,    -1,    -1,    -1,
+     506,    -1,    13,   509,    -1,    -1,    -1,    50,    51,    52,
+      -1,    -1,    -1,    -1,    -1,   521,    -1,    -1,    61,    -1,
+      63,    -1,    65,    -1,   446,    -1,   532,    38,    39,    40,
+      41,    42,    43,    44,    45,    46,    47,    48,    49,    50,
+      51,    52,    53,    54,    55,    56,     0,    -1,    59,     3,
+       4,     5,     6,     7,     8,     9,    10,    -1,    69,    70,
+      71,    72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    23,
+      24,    25,    26,    27,    -1,    -1,     0,    31,    -1,     3,
+       4,     5,     6,     7,     8,     9,    10,     9,    10,    -1,
+      -1,    -1,    14,    15,    -1,    -1,    -1,    -1,    -1,    23,
+      24,    25,    26,    27,    -1,    -1,    60,    31,    62,    31,
+      32,    -1,    -1,    35,    46,    47,    48,    49,    -1,    51,
+      52,    53,    54,    55,    -1,    -1,    -1,    59,    50,    -1,
+      -1,    -1,    -1,    11,    12,    13,    60,    -1,    62,    -1,
+      -1,    -1,    -1,    65,    -1,    67,    68,    69,    70,    71,
+      28,    29,    30,    -1,    32,    33,    34,    35,    36,    -1,
+      38,    39,    40,    41,    42,    43,    44,    45,    46,    47,
+      48,    49,    50,    51,    52,    53,    54,    55,    56,    13,
+      -1,    59,    -1,    17,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    69,    70,    71,    72,    -1,    -1,    31,    -1,    -1,
+      -1,    35,    36,    -1,    38,    39,    40,    41,    42,    43,
+      44,    45,    46,    47,    48,    49,    50,    51,    52,    53,
+      54,    55,    56,    -1,    -1,    59,    13,    14,    15,    -1,
+      -1,    -1,    -1,    67,    68,    69,    70,    71,    72,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-     509,    38,    39,    40,    41,    42,    43,    44,    45,    46,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-       5,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    28,    29,    30,    31,    32,    33,    34,
-      35,    36,    -1,    38,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    50,    51,    52,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    61,    -1,    63,    -1,
-      65,    -1,    -1,    -1,    69,    70,    71,    72,     0,    -1,
-      -1,     3,     4,     5,     6,     7,     8,     9,    10,    -1,
-       3,     4,     5,     6,     7,     8,     9,    10,    -1,    -1,
-      -1,    23,    24,    25,    26,    27,    -1,    -1,    -1,    31,
-      23,    24,    25,    26,    27,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    11,    12,    13,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    60,    -1,
-      62,    28,    29,    30,    -1,    32,    33,    34,    35,    36,
       -1,    38,    39,    40,    41,    42,    43,    44,    45,    46,
       47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      13,    -1,    59,    -1,    17,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    69,    70,    71,    72,    -1,    -1,    31,    -1,
-      -1,    -1,    35,    36,    -1,    38,    39,    40,    41,    42,
-      43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    -1,    -1,    59,    13,    14,    15,
-      -1,    -1,    -1,    -1,    67,    68,    69,    70,    71,    72,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    59,    13,    14,    15,    -1,    -1,    -1,    -1,
+      -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,
+      40,    41,    42,    43,    44,    45,    46,    47,    48,    49,
+      50,    51,    52,    53,    54,    55,    56,    13,    -1,    59,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,
+      70,    71,    72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    38,    39,    40,    41,    42,    43,    44,    45,
       46,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    -1,    -1,    59,    13,    14,    15,    -1,    -1,    -1,
-      -1,    -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,
-      39,    40,    41,    42,    43,    44,    45,    46,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    13,    -1,
-      59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      69,    70,    71,    72,    -1,    -1,    -1,    -1,    -1,    -1,
+      56,    -1,    -1,    59,    -1,    13,    -1,    -1,    -1,    -1,
+      -1,    67,    68,    69,    70,    71,    72,    25,    26,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      38,    39,    40,    41,    42,    43,    44,    45,    46,    47,
+      48,    49,    50,    51,    52,    53,    54,    55,    56,    13,
+      -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    69,    70,    71,    72,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    38,    39,    40,    41,    42,    43,
+      44,    45,    46,    47,    48,    49,    50,    51,    52,    53,
+      54,    55,    56,    13,    14,    59,    60,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    69,    70,    71,    72,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,
+      40,    41,    42,    43,    44,    45,    46,    47,    48,    49,
+      50,    51,    52,    53,    54,    55,    56,    -1,    13,    59,
+      15,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,
+      70,    71,    72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    38,    39,    40,    41,    42,    43,    44,
       45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    56,    -1,    -1,    59,    -1,    13,    -1,    -1,    -1,
-      -1,    -1,    67,    68,    69,    70,    71,    72,    25,    26,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      55,    56,    13,    -1,    59,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    69,    70,    71,    72,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,
+      41,    42,    43,    44,    45,    46,    47,    48,    49,    50,
+      51,    52,    53,    54,    55,    56,    13,    -1,    59,    -1,
+      -1,    62,    -1,    -1,    -1,    -1,    -1,    -1,    69,    70,
+      71,    72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    38,    39,    40,    41,    42,    43,    44,    45,    46,
       47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      13,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      13,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    66,
       -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    38,    39,    40,    41,    42,
       43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    13,    14,    59,    60,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    69,    70,    71,    72,
+      53,    54,    55,    56,    13,    -1,    59,    -1,    -1,    -1,
+      -1,    -1,    -1,    66,    -1,    -1,    69,    70,    71,    72,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,
       39,    40,    41,    42,    43,    44,    45,    46,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    -1,    13,
-      59,    15,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      49,    50,    51,    52,    53,    54,    55,    56,    57,    13,
+      59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       69,    70,    71,    72,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    38,    39,    40,    41,    42,    43,
+      44,    45,    46,    47,    48,    49,    50,    51,    52,    53,
+      54,    55,    56,    13,    -1,    59,    -1,    -1,    62,    -1,
+      -1,    -1,    -1,    -1,    -1,    69,    70,    71,    72,    -1,
+      -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,
+      40,    41,    42,    43,    44,    45,    46,    47,    48,    49,
+      50,    51,    52,    53,    54,    55,    56,    13,    -1,    59,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,
+      70,    71,    72,    -1,    -1,    31,    -1,    -1,    -1,    -1,
+      -1,    -1,    38,    39,    40,    41,    42,    43,    44,    45,
+      46,    47,    48,    49,    50,    51,    52,    53,    54,    55,
+      56,    13,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    69,    70,    71,    72,    -1,    -1,    31,
+      -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,    41,
+      42,    43,    44,    45,    46,    47,    48,    49,    50,    51,
+      52,    53,    54,    55,    56,    13,    -1,    59,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,    70,    71,
+      72,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,
+      38,    39,    40,    41,    42,    43,    44,    45,    46,    47,
+      48,    49,    50,    51,    52,    53,    54,    55,    56,    13,
+      -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    69,    70,    71,    72,    -1,    -1,    31,    -1,    -1,
       -1,    -1,    -1,    -1,    38,    39,    40,    41,    42,    43,
       44,    45,    46,    47,    48,    49,    50,    51,    52,    53,
       54,    55,    56,    13,    -1,    59,    -1,    -1,    -1,    -1,
@@ -1651,92 +1779,48 @@ static const yytype_int16 yycheck[] =
       70,    71,    72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    -1,    38,    39,    40,    41,    42,    43,    44,    45,
       46,    47,    48,    49,    50,    51,    52,    53,    54,    55,
-      56,    13,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,
-      66,    -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,
+      56,    13,    -1,    59,    60,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,    41,
       42,    43,    44,    45,    46,    47,    48,    49,    50,    51,
       52,    53,    54,    55,    56,    13,    -1,    59,    -1,    -1,
-      -1,    -1,    -1,    -1,    66,    -1,    -1,    69,    70,    71,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,    70,    71,
       72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      38,    39,    40,    41,    42,    43,    44,    45,    46,    47,
-      48,    49,    50,    51,    52,    53,    54,    55,    56,    57,
-      13,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      38,    39,    -1,    41,    42,    43,    44,    45,    46,    47,
+      48,    49,    50,    51,    52,    53,    54,    55,    13,    -1,
+      -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
       -1,    69,    70,    71,    72,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    38,    39,    40,    41,    42,
-      43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    13,    -1,    59,    -1,    -1,    62,
-      -1,    -1,    -1,    -1,    -1,    -1,    69,    70,    71,    72,
-      -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,    -1,    38,
-      39,    40,    41,    42,    43,    44,    45,    46,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    13,    -1,
-      59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      69,    70,    71,    72,    -1,    -1,    31,    -1,    -1,    -1,
-      -1,    -1,    -1,    38,    39,    40,    41,    42,    43,    44,
+      -1,    -1,    -1,    38,    -1,    -1,    41,    42,    43,    44,
       45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    56,    13,    -1,    59,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    69,    70,    71,    72,    -1,    -1,
-      31,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,
-      41,    42,    43,    44,    45,    46,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    13,    -1,    59,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,    70,
-      71,    72,    -1,    -1,    31,    -1,    -1,    -1,    -1,    -1,
-      -1,    38,    39,    40,    41,    42,    43,    44,    45,    46,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      13,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    69,    70,    71,    72,    -1,    -1,    31,    -1,
-      -1,    -1,    -1,    -1,    -1,    38,    39,    40,    41,    42,
-      43,    44,    45,    46,    47,    48,    49,    50,    51,    52,
-      53,    54,    55,    56,    13,    -1,    59,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    69,    70,    71,    72,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,
-      39,    40,    41,    42,    43,    44,    45,    46,    47,    48,
-      49,    50,    51,    52,    53,    54,    55,    56,    13,    -1,
-      59,    -1,    -1,    62,    -1,    -1,    -1,    -1,    -1,    -1,
-      69,    70,    71,    72,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    38,    39,    40,    41,    42,    43,    44,
-      45,    46,    47,    48,    49,    50,    51,    52,    53,    54,
-      55,    56,    13,    -1,    59,    60,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    69,    70,    71,    72,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    38,    39,    40,
-      41,    42,    43,    44,    45,    46,    47,    48,    49,    50,
-      51,    52,    53,    54,    55,    56,    13,    -1,    59,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    69,    70,
-      71,    72,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    38,    39,    -1,    41,    42,    43,    44,    45,    46,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    13,
-      -1,    -1,    59,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    69,    70,    71,    72,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    38,    -1,    -1,    41,    42,    43,
-      44,    45,    46,    47,    48,    49,    50,    51,    52,    53,
-      54,    55,    -1,    -1,    -1,    59,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    22,    -1,    69,    70,    71,    72,    28,
-      29,    30,    31,    32,    33,    34,    35,    36,    -1,    38,
+      55,    -1,    -1,    -1,    59,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    22,    -1,    69,    70,    71,    72,    28,    29,
+      30,    31,    32,    33,    34,    35,    36,    -1,    38,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    50,    51,    52,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    61,    -1,    63,    -1,    65,    28,    29,    30,
-      31,    32,    33,    34,    35,    36,    -1,    38,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    50,
-      51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      61,    -1,    63,    -1,    65,    -1,    67,    68,    69,    28,
-      29,    30,    31,    32,    33,    34,    35,    36,    -1,    38,
+      50,    51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    61,    -1,    63,    -1,    65,    28,    29,    30,    31,
+      32,    33,    34,    35,    36,    -1,    38,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    50,    51,
+      52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    61,
+      -1,    63,    -1,    65,    -1,    67,    68,    69,    28,    29,
+      30,    31,    32,    33,    34,    35,    36,    -1,    38,    -1,
       -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    50,    51,    52,    53,    -1,    -1,    56,    -1,    -1,
-      -1,    -1,    61,    -1,    63,    -1,    65,    28,    29,    30,
-      31,    32,    33,    34,    35,    36,    -1,    38,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    50,
-      51,    52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      61,    62,    63,    -1,    65,    28,    29,    30,    31,    32,
-      33,    34,    35,    36,    -1,    38,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    50,    51,    52,
-      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    61,    -1,
-      63,    -1,    65,    28,    29,    30,    31,    32,    33,    34,
-      35,    36,    -1,    38,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    50,    51,    52,    -1,    -1,
-      -1,    -1,    -1,    -1,    -1,    -1,    61,    -1,    63,    -1,
-      65,    28,    29,    30,    31,    32,    33,    34,    35,    36,
-      -1,    38,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    50,    51,    52,    -1,    -1,    -1,    -1,
-      -1,    -1,    -1,    -1,    61,    -1,    63,    -1,    65
+      50,    51,    52,    53,    -1,    -1,    56,    -1,    -1,    -1,
+      -1,    61,    -1,    63,    -1,    65,    28,    29,    30,    31,
+      32,    33,    34,    35,    36,    -1,    38,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    50,    51,
+      52,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    61,
+      62,    63,    -1,    65,    28,    29,    30,    31,    32,    33,
+      34,    35,    36,    -1,    38,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    50,    51,    52,    -1,
+      -1,    -1,    -1,    -1,    -1,    -1,    -1,    61,    -1,    63,
+      -1,    65,    28,    29,    30,    31,    32,    33,    34,    35,
+      36,    -1,    38,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    50,    51,    52,    -1,    -1,    -1,
+      -1,    -1,    -1,    -1,    -1,    61,    -1,    63,    -1,    65,
+      28,    29,    30,    31,    32,    33,    34,    35,    36,    -1,
+      38,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    50,    51,    52,    -1,    -1,    -1,    -1,    -1,
+      -1,    -1,    -1,    61,    -1,    63,    -1,    65
 };
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
@@ -1744,57 +1828,59 @@ static const yytype_int16 yycheck[] =
 static const yytype_uint8 yystos[] =
 {
        0,    14,    85,    87,    86,    88,    90,     0,    31,    35,
-      36,    83,    84,   197,     3,     4,     5,     6,     7,     8,
+      36,    83,    84,   203,     3,     4,     5,     6,     7,     8,
        9,    10,    23,    24,    25,    26,    27,    89,    91,   100,
-     103,   104,   108,   110,   123,   128,   129,   130,   132,   133,
-     135,   137,   140,    60,    83,    31,    92,    93,   199,   105,
-     106,   199,    28,    29,    30,    31,    32,    33,    34,    35,
-      36,    38,    50,    51,    52,    61,    63,    65,   147,   148,
-     149,   152,   153,   156,   164,   165,   172,   188,   193,   194,
-     196,    22,   145,   147,    14,    16,   107,   109,   117,   124,
-     147,   147,   172,   147,   147,   134,   147,   136,   147,     5,
-     139,   172,   196,    15,   107,   113,   117,    83,    60,    13,
-      60,    37,   147,    61,   147,   147,   147,   189,   173,   166,
-      13,    38,    39,    40,    41,    42,    43,    44,    45,    46,
-      47,    48,    49,    50,    51,    52,    53,    54,    55,    56,
-      59,    69,    70,    71,    72,   144,    58,    61,    65,    80,
-     146,    31,   118,    31,   171,   111,   112,   199,   113,   125,
-     126,   147,    60,    14,   117,    13,    15,   131,   131,    14,
-     131,    14,   131,   141,   143,   199,   171,    31,   115,   171,
-     113,   199,    67,    68,    69,    95,    96,    97,    98,    99,
-     147,   186,   187,   106,   147,   151,    62,    88,     9,    10,
-      14,    15,    31,    32,    35,    50,    65,    67,    68,    69,
-      70,    71,   174,   175,   176,   198,   147,   167,   168,   169,
-     147,    42,    43,    50,   155,   154,   147,   147,   147,   147,
-     147,   147,   147,   147,   147,   147,   147,   147,   147,   147,
-     147,   157,   159,   147,    61,    13,    41,    44,    45,    46,
-      47,    48,    49,    31,   150,    53,    56,   147,   177,   178,
-      31,   196,   147,    15,   119,   120,   199,   172,    60,    37,
-     171,    60,    11,    12,   127,   192,   194,   196,   147,   172,
-      31,    32,    36,   195,    31,    32,    36,   195,   171,   171,
-     147,   171,   147,   171,   147,    24,    37,   116,   171,   171,
-     102,    69,   101,   186,    18,    19,    21,    20,   147,   147,
-     160,   161,   162,   163,    62,    57,    57,    57,    57,    57,
-      57,   147,    57,    57,    57,    57,    57,    64,    60,    57,
-      66,    60,   147,   147,   147,   147,   147,   147,    57,   147,
-     147,   147,   147,   147,   147,   147,   147,   147,   160,    66,
-      56,   190,    53,   191,   199,    60,    37,   112,   147,   126,
-     117,   131,   131,   142,   147,   147,   114,   199,    31,    94,
-      31,   170,   147,   147,   147,   147,    17,    31,   182,   184,
-     186,   197,    62,    88,    60,   147,   147,   147,   147,   147,
-     147,    66,   147,   147,   147,   147,   147,   176,   147,   169,
-      57,   147,    62,    62,     5,    72,   144,   147,   179,   179,
-     120,    31,   121,   148,   171,   171,    24,    25,    26,   138,
-      60,    31,    82,   147,   199,   147,    31,    31,    31,    31,
-      31,    32,   196,    60,    31,   196,   161,    57,   158,    13,
-      41,    44,    45,    46,    47,    48,    49,   147,    61,     5,
-       5,    66,     9,   180,    61,   147,   147,   199,    31,    37,
-      31,   147,   147,   147,   147,   185,   147,   147,   147,   147,
-     147,   147,   147,   147,   147,   147,   147,   147,   147,   147,
-       6,   181,   122,   138,   131,   172,   147,   147,   184,   184,
-     184,   184,   182,   183,    62,    60,   147,    66,   160,   147,
-     171,   171,   171,   171,   171,    60,     5,   147,    62,   131,
-     182,   147,   171
+     103,   104,   114,   116,   129,   134,   135,   136,   138,   139,
+     141,   143,   146,    60,    83,    31,    92,    93,   205,    63,
+      65,   105,   106,   107,   110,   205,    28,    29,    30,    31,
+      32,    33,    34,    35,    36,    38,    50,    51,    52,    61,
+      63,    65,   153,   154,   155,   158,   159,   162,   170,   171,
+     178,   194,   199,   200,   202,    22,   151,   153,    14,    16,
+     113,   115,   123,   130,   153,   153,   178,   153,   153,   140,
+     153,   142,   153,     5,   145,   178,   202,    15,   113,   119,
+     123,    83,    60,    13,   111,   108,    60,    37,    37,    37,
+     153,    61,   153,   153,   153,   195,   179,   172,    13,    38,
+      39,    40,    41,    42,    43,    44,    45,    46,    47,    48,
+      49,    50,    51,    52,    53,    54,    55,    56,    59,    69,
+      70,    71,    72,   150,    58,    61,    65,    80,   152,    31,
+     124,    31,   177,   117,   118,   205,   119,   131,   132,   153,
+      60,    14,   123,    13,    15,   137,   137,    14,   137,    14,
+     137,   147,   149,   205,   177,    31,   121,   177,   119,   205,
+      67,    68,    69,    95,    96,    97,    98,    99,   153,   192,
+     193,   112,   205,   107,   109,   110,   205,   106,   153,   153,
+     153,   157,    62,    88,     9,    10,    14,    15,    31,    32,
+      35,    50,    65,    67,    68,    69,    70,    71,   180,   181,
+     182,   204,   153,   173,   174,   175,   153,    42,    43,    50,
+     161,   160,   153,   153,   153,   153,   153,   153,   153,   153,
+     153,   153,   153,   153,   153,   153,   153,   163,   165,   153,
+      61,    13,    41,    44,    45,    46,    47,    48,    49,    31,
+     156,    53,    56,   153,   183,   184,    31,   202,   153,    15,
+     125,   126,   205,   178,    60,    37,   177,    60,    11,    12,
+     133,   198,   200,   202,   153,   178,    31,    32,    36,   201,
+      31,    32,    36,   201,   177,   177,   153,   177,   153,   177,
+     153,    24,    37,   122,   177,   177,   102,    69,   101,   192,
+      18,    19,    21,    20,   153,    60,    64,    57,    60,    66,
+     153,   166,   167,   168,   169,    62,    57,    57,    57,    57,
+      57,    57,   153,    57,    57,    57,    57,    57,    64,    60,
+      57,    66,    60,   153,   153,   153,   153,   153,   153,    57,
+     153,   153,   153,   153,   153,   153,   153,   153,   153,   166,
+      66,    56,   196,    53,   197,   205,    60,    37,   118,   153,
+     132,   123,   137,   137,   148,   153,   153,   120,   205,    31,
+      94,    31,   176,   153,   153,   153,   153,    17,    31,   188,
+     190,   192,   203,   112,   107,   110,   205,   109,    62,    88,
+      60,   153,   153,   153,   153,   153,   153,    66,   153,   153,
+     153,   153,   153,   182,   153,   175,    57,   153,    62,    62,
+       5,    72,   150,   153,   185,   185,   126,    31,   127,   154,
+     177,   177,    24,    25,    26,   144,    60,    31,    82,   153,
+     205,   153,    31,    31,    31,    31,    31,    32,   202,    60,
+      31,   202,   167,    57,   164,    13,    41,    44,    45,    46,
+      47,    48,    49,   153,    61,     5,     5,    66,     9,   186,
+      61,   153,   153,   205,    31,    37,    31,   153,   153,   153,
+     153,   191,   153,   153,   153,   153,   153,   153,   153,   153,
+     153,   153,   153,   153,   153,   153,     6,   187,   128,   144,
+     137,   178,   153,   153,   190,   190,   190,   190,   188,   189,
+      62,    60,   153,    66,   166,   153,   177,   177,   177,   177,
+     177,    60,     5,   153,    62,   137,   188,   153,   177
 };
 
 /* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
@@ -1805,30 +1891,32 @@ static const yytype_uint8 yyr1[] =
       90,    90,    91,    91,    91,    91,    91,    91,    91,    91,
       91,    91,    91,    91,    92,    92,    93,    94,    94,    94,
       95,    96,    97,    98,    99,   101,   100,   102,   100,   100,
-     100,   100,   100,   103,   104,   105,   105,   106,   107,   109,
-     108,   110,   110,   110,   110,   110,   110,   111,   111,   112,
-     113,   113,   113,   114,   114,   116,   115,   118,   117,   119,
-     119,   120,   122,   121,   124,   123,   125,   125,   126,   127,
-     127,   127,   127,   128,   128,   129,   129,   130,   131,   131,
-     132,   133,   134,   134,   135,   136,   136,   137,   138,   138,
-     139,   139,   141,   142,   140,   143,   140,   144,   144,   144,
-     146,   145,   145,   147,   147,   147,   147,   147,   147,   148,
-     148,   150,   149,   151,   149,   152,   152,   152,   154,   153,
-     155,   153,   153,   153,   153,   153,   153,   153,   153,   153,
-     153,   153,   153,   153,   153,   153,   153,   153,   153,   153,
-     153,   153,   153,   153,   153,   153,   153,   153,   153,   153,
-     153,   153,   153,   153,   153,   153,   153,   157,   158,   156,
-     159,   156,   160,   160,   161,   162,   161,   163,   163,   164,
-     164,   166,   165,   167,   167,   167,   168,   168,   169,   170,
-     170,   170,   171,   171,   173,   172,   174,   174,   174,   175,
-     175,   176,   176,   176,   176,   176,   176,   176,   176,   176,
-     176,   176,   176,   176,   176,   177,   177,   178,   178,   179,
-     179,   179,   179,   179,   180,   180,   180,   181,   181,   182,
-     182,   182,   182,   183,   183,   184,   185,   184,   184,   184,
-     184,   186,   186,   186,   187,   187,   188,   188,   188,   188,
-     188,   189,   188,   188,   188,   188,   190,   188,   191,   188,
-     192,   192,   193,   193,   194,   194,   194,   194,   194,   195,
-     195,   195,   196,   196,   197,   197,   198,   198,   199
+     100,   100,   100,   103,   104,   105,   105,   106,   106,   106,
+     108,   107,   109,   109,   109,   109,   109,   111,   110,   112,
+     112,   112,   112,   112,   112,   113,   115,   114,   116,   116,
+     116,   116,   116,   116,   117,   117,   118,   119,   119,   119,
+     120,   120,   122,   121,   124,   123,   125,   125,   126,   128,
+     127,   130,   129,   131,   131,   132,   133,   133,   133,   133,
+     134,   134,   135,   135,   136,   137,   137,   138,   139,   140,
+     140,   141,   142,   142,   143,   144,   144,   145,   145,   147,
+     148,   146,   149,   146,   150,   150,   150,   152,   151,   151,
+     153,   153,   153,   153,   153,   153,   154,   154,   156,   155,
+     157,   155,   158,   158,   158,   160,   159,   161,   159,   159,
+     159,   159,   159,   159,   159,   159,   159,   159,   159,   159,
+     159,   159,   159,   159,   159,   159,   159,   159,   159,   159,
+     159,   159,   159,   159,   159,   159,   159,   159,   159,   159,
+     159,   159,   159,   159,   163,   164,   162,   165,   162,   166,
+     166,   167,   168,   167,   169,   169,   170,   170,   172,   171,
+     173,   173,   173,   174,   174,   175,   176,   176,   176,   177,
+     177,   179,   178,   180,   180,   180,   181,   181,   182,   182,
+     182,   182,   182,   182,   182,   182,   182,   182,   182,   182,
+     182,   182,   183,   183,   184,   184,   185,   185,   185,   185,
+     185,   186,   186,   186,   187,   187,   188,   188,   188,   188,
+     189,   189,   190,   191,   190,   190,   190,   190,   192,   192,
+     192,   193,   193,   194,   194,   194,   194,   194,   195,   194,
+     194,   194,   194,   196,   194,   197,   194,   198,   198,   199,
+     199,   200,   200,   200,   200,   200,   201,   201,   201,   202,
+     202,   203,   203,   204,   204,   205
 };
 
 /* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
@@ -1839,30 +1927,32 @@ static const yytype_int8 yyr2[] =
        0,     2,     1,     1,     1,     1,     1,     1,     1,     1,
        1,     1,     1,     1,     1,     3,     1,     0,     2,     4,
        3,     7,     7,     7,     7,     0,     6,     0,     6,     4,
-       4,     4,     4,     2,     2,     1,     3,     3,     4,     0,
-       3,     3,     3,     4,     4,     3,     4,     1,     3,     3,
-       0,     2,     4,     1,     3,     0,     3,     0,     3,     1,
-       3,     3,     0,     5,     0,     3,     1,     3,     2,     0,
-       1,     1,     1,     2,     4,     3,     5,     2,     2,     2,
-       4,     4,     3,     5,     2,     3,     5,     2,     1,     1,
-       1,     1,     0,     0,    11,     0,     9,     1,     1,     1,
-       0,     3,     1,     1,     1,     1,     1,     1,     3,     1,
-       3,     0,     5,     0,     5,     2,     2,     2,     0,     4,
-       0,     4,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     3,     4,     4,     4,     3,     3,
-       3,     4,     4,     4,     4,     4,     4,     4,     4,     7,
-       7,     7,     7,     7,     7,     7,     7,     0,     0,     7,
-       0,     5,     0,     1,     1,     0,     2,     1,     3,     1,
-       1,     0,     4,     0,     1,     2,     1,     3,     1,     0,
-       2,     4,     0,     2,     0,     4,     0,     1,     2,     1,
-       3,     1,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     5,     1,     2,     1,     2,     0,
-       2,     3,     6,     3,     0,     2,     4,     0,     2,     1,
-       1,     2,     2,     1,     3,     1,     0,     4,     2,     2,
-       2,     1,     1,     1,     1,     2,     1,     1,     1,     1,
-       3,     0,     4,     3,     3,     4,     0,     6,     0,     8,
+       4,     4,     4,     2,     2,     1,     3,     3,     3,     3,
+       0,     4,     0,     1,     1,     1,     3,     0,     4,     0,
+       1,     3,     3,     3,     3,     4,     0,     3,     3,     3,
+       4,     4,     3,     4,     1,     3,     3,     0,     2,     4,
+       1,     3,     0,     3,     0,     3,     1,     3,     3,     0,
+       5,     0,     3,     1,     3,     2,     0,     1,     1,     1,
+       2,     4,     3,     5,     2,     2,     2,     4,     4,     3,
+       5,     2,     3,     5,     2,     1,     1,     1,     1,     0,
+       0,    11,     0,     9,     1,     1,     1,     0,     3,     1,
+       1,     1,     1,     1,     1,     3,     1,     3,     0,     5,
+       0,     5,     2,     2,     2,     0,     4,     0,     4,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     4,     4,     4,     3,     3,     3,     4,     4,
+       4,     4,     4,     4,     4,     4,     7,     7,     7,     7,
+       7,     7,     7,     7,     0,     0,     7,     0,     5,     0,
+       1,     1,     0,     2,     1,     3,     1,     1,     0,     4,
+       0,     1,     2,     1,     3,     1,     0,     2,     4,     0,
+       2,     0,     4,     0,     1,     2,     1,     3,     1,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     5,     1,     2,     1,     2,     0,     2,     3,     6,
+       3,     0,     2,     4,     0,     2,     1,     1,     2,     2,
+       1,     3,     1,     0,     4,     2,     2,     2,     1,     1,
+       1,     1,     2,     1,     1,     1,     1,     3,     0,     4,
+       3,     3,     4,     0,     6,     0,     8,     1,     1,     1,
        1,     1,     1,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     1,     1,     1,     1
+       1,     1,     1,     1,     1,     1
 };
 
 
@@ -2720,18 +2810,18 @@ yyreduce:
   switch (yyn)
     {
   case 2: /* optional_prune_variable: expression  */
-#line 574 "grammar.y"
+#line 652 "grammar.y"
                {
       AstNode* node = parser->ast()->createNodeArray();
       node->addMember(parser->ast()->createNodeNop());
       node->addMember((yyvsp[0].node));
       (yyval.node) = node;
     }
-#line 2730 "grammar.cpp"
+#line 2820 "grammar.cpp"
     break;
 
   case 3: /* optional_prune_variable: variable_name "assignment" expression  */
-#line 580 "grammar.y"
+#line 658 "grammar.y"
                                       {
       AstNode* node = parser->ast()->createNodeArray();
       AstNode* variableNode = parser->ast()->createNodeLet((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node), true);
@@ -2739,240 +2829,240 @@ yyreduce:
       node->addMember((yyvsp[0].node));
       (yyval.node) = node;    
   }
-#line 2742 "grammar.cpp"
+#line 2832 "grammar.cpp"
     break;
 
   case 4: /* with_collection: "identifier"  */
-#line 590 "grammar.y"
+#line 668 "grammar.y"
              {
       (yyval.node) = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
     }
-#line 2750 "grammar.cpp"
+#line 2840 "grammar.cpp"
     break;
 
   case 5: /* with_collection: bind_parameter_datasource_expected  */
-#line 593 "grammar.y"
+#line 671 "grammar.y"
                                        {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 2758 "grammar.cpp"
+#line 2848 "grammar.cpp"
     break;
 
   case 6: /* with_collection_list: with_collection  */
-#line 599 "grammar.y"
+#line 677 "grammar.y"
                      {
        auto node = static_cast<AstNode*>(parser->peekStack());
        node->addMember((yyvsp[0].node));
      }
-#line 2767 "grammar.cpp"
+#line 2857 "grammar.cpp"
     break;
 
   case 7: /* with_collection_list: with_collection_list "," with_collection  */
-#line 603 "grammar.y"
+#line 681 "grammar.y"
                                                   {
        auto node = static_cast<AstNode*>(parser->peekStack());
        node->addMember((yyvsp[0].node));
      }
-#line 2776 "grammar.cpp"
+#line 2866 "grammar.cpp"
     break;
 
   case 8: /* with_collection_list: with_collection_list with_collection  */
-#line 607 "grammar.y"
+#line 685 "grammar.y"
                                           {
        auto node = static_cast<AstNode*>(parser->peekStack());
        node->addMember((yyvsp[0].node));
      }
-#line 2785 "grammar.cpp"
+#line 2875 "grammar.cpp"
     break;
 
   case 9: /* optional_with: %empty  */
-#line 614 "grammar.y"
+#line 692 "grammar.y"
                  {
      }
-#line 2792 "grammar.cpp"
+#line 2882 "grammar.cpp"
     break;
 
   case 10: /* $@1: %empty  */
-#line 616 "grammar.y"
+#line 694 "grammar.y"
             {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
      }
-#line 2801 "grammar.cpp"
+#line 2891 "grammar.cpp"
     break;
 
   case 11: /* optional_with: "WITH keyword" $@1 with_collection_list  */
-#line 619 "grammar.y"
+#line 697 "grammar.y"
                             {
       auto node = static_cast<AstNode*>(parser->popStack());
       auto const& resolver = parser->query().resolver();
       auto withNode = parser->ast()->createNodeWithCollections(node, resolver);
       parser->ast()->addOperation(withNode);
      }
-#line 2812 "grammar.cpp"
+#line 2902 "grammar.cpp"
     break;
 
   case 12: /* queryStart: optional_with query  */
-#line 628 "grammar.y"
+#line 706 "grammar.y"
                         {
     }
-#line 2819 "grammar.cpp"
+#line 2909 "grammar.cpp"
     break;
 
   case 13: /* query: optional_statement_block_statements final_statement  */
-#line 633 "grammar.y"
+#line 711 "grammar.y"
                                                         {
     }
-#line 2826 "grammar.cpp"
+#line 2916 "grammar.cpp"
     break;
 
   case 14: /* final_statement: return_statement  */
-#line 638 "grammar.y"
+#line 716 "grammar.y"
                      {
     }
-#line 2833 "grammar.cpp"
+#line 2923 "grammar.cpp"
     break;
 
   case 15: /* final_statement: remove_statement  */
-#line 640 "grammar.y"
+#line 718 "grammar.y"
                      {
       parser->ast()->scopes()->endNested();
     }
-#line 2841 "grammar.cpp"
+#line 2931 "grammar.cpp"
     break;
 
   case 16: /* final_statement: insert_statement  */
-#line 643 "grammar.y"
+#line 721 "grammar.y"
                      {
       parser->ast()->scopes()->endNested();
     }
-#line 2849 "grammar.cpp"
+#line 2939 "grammar.cpp"
     break;
 
   case 17: /* final_statement: update_statement  */
-#line 646 "grammar.y"
+#line 724 "grammar.y"
                      {
       parser->ast()->scopes()->endNested();
     }
-#line 2857 "grammar.cpp"
+#line 2947 "grammar.cpp"
     break;
 
   case 18: /* final_statement: replace_statement  */
-#line 649 "grammar.y"
+#line 727 "grammar.y"
                       {
       parser->ast()->scopes()->endNested();
     }
-#line 2865 "grammar.cpp"
+#line 2955 "grammar.cpp"
     break;
 
   case 19: /* final_statement: upsert_statement  */
-#line 652 "grammar.y"
+#line 730 "grammar.y"
                      {
       parser->ast()->scopes()->endNested();
     }
-#line 2873 "grammar.cpp"
+#line 2963 "grammar.cpp"
     break;
 
   case 20: /* optional_statement_block_statements: %empty  */
-#line 658 "grammar.y"
+#line 736 "grammar.y"
                 {
     }
-#line 2880 "grammar.cpp"
+#line 2970 "grammar.cpp"
     break;
 
   case 21: /* optional_statement_block_statements: optional_statement_block_statements statement_block_statement  */
-#line 660 "grammar.y"
+#line 738 "grammar.y"
                                                                   {
     }
-#line 2887 "grammar.cpp"
+#line 2977 "grammar.cpp"
     break;
 
   case 22: /* statement_block_statement: for_statement  */
-#line 665 "grammar.y"
+#line 743 "grammar.y"
                   {
     }
-#line 2894 "grammar.cpp"
+#line 2984 "grammar.cpp"
     break;
 
   case 23: /* statement_block_statement: let_statement  */
-#line 667 "grammar.y"
+#line 745 "grammar.y"
                   {
     }
-#line 2901 "grammar.cpp"
+#line 2991 "grammar.cpp"
     break;
 
   case 24: /* statement_block_statement: filter_statement  */
-#line 669 "grammar.y"
+#line 747 "grammar.y"
                      {
     }
-#line 2908 "grammar.cpp"
+#line 2998 "grammar.cpp"
     break;
 
   case 25: /* statement_block_statement: collect_statement  */
-#line 671 "grammar.y"
+#line 749 "grammar.y"
                       {
     }
-#line 2915 "grammar.cpp"
+#line 3005 "grammar.cpp"
     break;
 
   case 26: /* statement_block_statement: sort_statement  */
-#line 673 "grammar.y"
+#line 751 "grammar.y"
                    {
     }
-#line 2922 "grammar.cpp"
+#line 3012 "grammar.cpp"
     break;
 
   case 27: /* statement_block_statement: limit_statement  */
-#line 675 "grammar.y"
+#line 753 "grammar.y"
                     {
     }
-#line 2929 "grammar.cpp"
+#line 3019 "grammar.cpp"
     break;
 
   case 28: /* statement_block_statement: window_statement  */
-#line 677 "grammar.y"
+#line 755 "grammar.y"
                      {
     }
-#line 2936 "grammar.cpp"
+#line 3026 "grammar.cpp"
     break;
 
   case 29: /* statement_block_statement: remove_statement  */
-#line 679 "grammar.y"
+#line 757 "grammar.y"
                      {
     }
-#line 2943 "grammar.cpp"
+#line 3033 "grammar.cpp"
     break;
 
   case 30: /* statement_block_statement: insert_statement  */
-#line 681 "grammar.y"
+#line 759 "grammar.y"
                      {
     }
-#line 2950 "grammar.cpp"
+#line 3040 "grammar.cpp"
     break;
 
   case 31: /* statement_block_statement: update_statement  */
-#line 683 "grammar.y"
+#line 761 "grammar.y"
                      {
     }
-#line 2957 "grammar.cpp"
+#line 3047 "grammar.cpp"
     break;
 
   case 32: /* statement_block_statement: replace_statement  */
-#line 685 "grammar.y"
+#line 763 "grammar.y"
                       {
     }
-#line 2964 "grammar.cpp"
+#line 3054 "grammar.cpp"
     break;
 
   case 33: /* statement_block_statement: upsert_statement  */
-#line 687 "grammar.y"
+#line 765 "grammar.y"
                      {
     }
-#line 2971 "grammar.cpp"
+#line 3061 "grammar.cpp"
     break;
 
   case 34: /* more_output_variables: variable_name  */
-#line 692 "grammar.y"
+#line 770 "grammar.y"
                   {
       auto wrapperNode = parser->ast()->createNodeArray();
       parser->pushArray(wrapperNode);
@@ -2980,28 +3070,28 @@ yyreduce:
       AstNode* node = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       parser->pushArrayElement(node);
     }
-#line 2983 "grammar.cpp"
+#line 3073 "grammar.cpp"
     break;
 
   case 35: /* more_output_variables: more_output_variables "," variable_name  */
-#line 699 "grammar.y"
+#line 777 "grammar.y"
                                                   {
       AstNode* node = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       parser->pushArrayElement(node);
     }
-#line 2992 "grammar.cpp"
+#line 3082 "grammar.cpp"
     break;
 
   case 36: /* for_output_variables: more_output_variables  */
-#line 706 "grammar.y"
+#line 784 "grammar.y"
                           {
       (yyval.node) = parser->popArray();
     }
-#line 3000 "grammar.cpp"
+#line 3090 "grammar.cpp"
     break;
 
   case 37: /* prune_and_options: %empty  */
-#line 712 "grammar.y"
+#line 790 "grammar.y"
                                                    {
       auto node = static_cast<AstNode*>(parser->peekStack());
       // Prune
@@ -3009,11 +3099,11 @@ yyreduce:
       // Options
       node->addMember(parser->ast()->createNodeNop());
     }
-#line 3012 "grammar.cpp"
+#line 3102 "grammar.cpp"
     break;
 
   case 38: /* prune_and_options: "identifier" optional_prune_variable  */
-#line 719 "grammar.y"
+#line 797 "grammar.y"
                                      {
       std::string_view operation((yyvsp[-1].strval).value, (yyvsp[-1].strval).length);
 
@@ -3038,11 +3128,11 @@ yyreduce:
         parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'PRUNE' or 'OPTIONS'", operation, yylloc.first_line, yylloc.first_column);
       }
     }
-#line 3041 "grammar.cpp"
+#line 3131 "grammar.cpp"
     break;
 
   case 39: /* prune_and_options: "identifier" optional_prune_variable "identifier" object  */
-#line 743 "grammar.y"
+#line 821 "grammar.y"
                                                      {
       /* prune and options */
       std::string_view operation((yyvsp[-3].strval).value, (yyvsp[-3].strval).length);
@@ -3063,11 +3153,11 @@ yyreduce:
       // Options
       node->addMember((yyvsp[0].node));
     }
-#line 3066 "grammar.cpp"
+#line 3156 "grammar.cpp"
     break;
 
   case 40: /* traversal_graph_info: graph_direction_steps expression graph_subject  */
-#line 766 "grammar.y"
+#line 844 "grammar.y"
                                                    {
       auto infoNode = parser->ast()->createNodeArray();
       // Direction
@@ -3078,46 +3168,46 @@ yyreduce:
       infoNode->addMember((yyvsp[0].node));
       (yyval.node) = infoNode;
     }
-#line 3081 "grammar.cpp"
+#line 3171 "grammar.cpp"
     break;
 
   case 41: /* shortest_path_graph_info: graph_direction "SHORTEST_PATH keyword" expression "identifier" expression graph_subject options  */
-#line 779 "grammar.y"
+#line 857 "grammar.y"
                                                                                          {
       (yyval.node) = ::buildShortestPathInfo(parser, (yyvsp[-3].strval).value, parser->ast()->createNodeDirection((yyvsp[-6].intval), 1), (yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node), yyloc);
     }
-#line 3089 "grammar.cpp"
+#line 3179 "grammar.cpp"
     break;
 
   case 42: /* k_shortest_paths_graph_info: graph_direction "K_SHORTEST_PATHS keyword" expression "identifier" expression graph_subject options  */
-#line 785 "grammar.y"
+#line 863 "grammar.y"
                                                                                             {
       (yyval.node) = ::buildShortestPathInfo(parser, (yyvsp[-3].strval).value, parser->ast()->createNodeDirection((yyvsp[-6].intval), 1), (yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node), yyloc);
     }
-#line 3097 "grammar.cpp"
+#line 3187 "grammar.cpp"
     break;
 
   case 43: /* k_paths_graph_info: graph_direction_steps "K_PATHS keyword" expression "identifier" expression graph_subject options  */
-#line 791 "grammar.y"
+#line 869 "grammar.y"
                                                                                          {
       (yyval.node) = ::buildShortestPathInfo(parser, (yyvsp[-3].strval).value, (yyvsp[-6].node), (yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node), yyloc);
     }
-#line 3105 "grammar.cpp"
+#line 3195 "grammar.cpp"
     break;
 
   case 44: /* all_shortest_paths_graph_info: graph_direction "ALL_SHORTEST_PATHS keyword" expression "identifier" expression graph_subject options  */
-#line 797 "grammar.y"
+#line 875 "grammar.y"
                                                                                               {
       auto nodeStart = parser->ast()->createNodeValueInt(0);
       auto nodeEnd = parser->ast()->createNodeValueInt(INT64_MAX-1);
       auto nodeRange = parser->ast()->createNodeRange(nodeStart, nodeEnd);
       (yyval.node) = ::buildShortestPathInfo(parser, (yyvsp[-3].strval).value, parser->ast()->createNodeDirection((yyvsp[-6].intval), nodeRange), (yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node), yyloc);
     }
-#line 3116 "grammar.cpp"
+#line 3206 "grammar.cpp"
     break;
 
   case 45: /* $@2: %empty  */
-#line 806 "grammar.y"
+#line 884 "grammar.y"
                                                {
       AstNode* variablesNode = static_cast<AstNode*>((yyvsp[-2].node));
       ::checkOutVariables(parser, variablesNode, 1, 1, "Collections and views FOR loops only allow a single return variable", yyloc);
@@ -3135,11 +3225,11 @@ yyreduce:
       // condition
       parser->lazyConditions().pushForceInline();
     }
-#line 3138 "grammar.cpp"
+#line 3228 "grammar.cpp"
     break;
 
   case 46: /* for_statement: "FOR declaration" for_output_variables "IN keyword" expression $@2 for_options  */
-#line 822 "grammar.y"
+#line 900 "grammar.y"
                   {
       parser->lazyConditions().popForceInline();
 
@@ -3182,11 +3272,11 @@ yyreduce:
 
       parser->ast()->addOperation(node);
     }
-#line 3185 "grammar.cpp"
+#line 3275 "grammar.cpp"
     break;
 
   case 47: /* $@3: %empty  */
-#line 864 "grammar.y"
+#line 942 "grammar.y"
                                                          {
       // Traversal
       auto variableNamesNode = static_cast<AstNode*>((yyvsp[-2].node));
@@ -3204,11 +3294,11 @@ yyreduce:
       // evaluating the PRUNE condition, which must remain a single condition
       parser->lazyConditions().pushForceInline();
     }
-#line 3207 "grammar.cpp"
+#line 3297 "grammar.cpp"
     break;
 
   case 48: /* for_statement: "FOR declaration" for_output_variables "IN keyword" traversal_graph_info $@3 prune_and_options  */
-#line 880 "grammar.y"
+#line 958 "grammar.y"
                         {
       parser->lazyConditions().popForceInline();
 
@@ -3233,11 +3323,11 @@ yyreduce:
         parser->ast()->addOperation(pruneLetVariableName);
       }
     }
-#line 3236 "grammar.cpp"
+#line 3326 "grammar.cpp"
     break;
 
   case 49: /* for_statement: "FOR declaration" for_output_variables "IN keyword" shortest_path_graph_info  */
-#line 904 "grammar.y"
+#line 982 "grammar.y"
                                                              {
       // Shortest Path
       auto variableNamesNode = static_cast<AstNode*>((yyvsp[-2].node));
@@ -3250,11 +3340,11 @@ yyreduce:
       auto node = parser->ast()->createNodeShortestPath(variablesNode, graphInfoNode);
       parser->ast()->addOperation(node);
     }
-#line 3253 "grammar.cpp"
+#line 3343 "grammar.cpp"
     break;
 
   case 50: /* for_statement: "FOR declaration" for_output_variables "IN keyword" k_shortest_paths_graph_info  */
-#line 916 "grammar.y"
+#line 994 "grammar.y"
                                                                 {
       // K Shortest Paths
       auto variableNamesNode = static_cast<AstNode*>((yyvsp[-2].node));
@@ -3267,11 +3357,11 @@ yyreduce:
       auto node = parser->ast()->createNodeEnumeratePaths(arangodb::graph::PathType::Type::KShortestPaths, variablesNode, graphInfoNode);
       parser->ast()->addOperation(node);
     }
-#line 3270 "grammar.cpp"
+#line 3360 "grammar.cpp"
     break;
 
   case 51: /* for_statement: "FOR declaration" for_output_variables "IN keyword" k_paths_graph_info  */
-#line 928 "grammar.y"
+#line 1006 "grammar.y"
                                                        {
       // K Paths
       auto variableNamesNode = static_cast<AstNode*>((yyvsp[-2].node));
@@ -3284,11 +3374,11 @@ yyreduce:
       auto node = parser->ast()->createNodeEnumeratePaths(arangodb::graph::PathType::Type::KPaths, variablesNode, graphInfoNode);
       parser->ast()->addOperation(node);
     }
-#line 3287 "grammar.cpp"
+#line 3377 "grammar.cpp"
     break;
 
   case 52: /* for_statement: "FOR declaration" for_output_variables "IN keyword" all_shortest_paths_graph_info  */
-#line 940 "grammar.y"
+#line 1018 "grammar.y"
                                                                   {
       // All Shortest Paths
       auto variableNamesNode = static_cast<AstNode*>((yyvsp[-2].node));
@@ -3301,51 +3391,204 @@ yyreduce:
       auto node = parser->ast()->createNodeEnumeratePaths(arangodb::graph::PathType::Type::AllShortestPaths, variablesNode, graphInfoNode);
       parser->ast()->addOperation(node);
     }
-#line 3304 "grammar.cpp"
+#line 3394 "grammar.cpp"
     break;
 
   case 53: /* filter_statement: "FILTER declaration" expression  */
-#line 955 "grammar.y"
+#line 1033 "grammar.y"
                         {
       // operand is a reference. can use it directly
       auto node = parser->ast()->createNodeFilter((yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3314 "grammar.cpp"
+#line 3404 "grammar.cpp"
     break;
 
   case 54: /* let_statement: "LET declaration" let_list  */
-#line 963 "grammar.y"
+#line 1041 "grammar.y"
                    {
     }
-#line 3321 "grammar.cpp"
+#line 3411 "grammar.cpp"
     break;
 
   case 55: /* let_list: let_element  */
-#line 968 "grammar.y"
+#line 1046 "grammar.y"
                 {
     }
-#line 3328 "grammar.cpp"
+#line 3418 "grammar.cpp"
     break;
 
   case 56: /* let_list: let_list "," let_element  */
-#line 970 "grammar.y"
+#line 1048 "grammar.y"
                                  {
     }
-#line 3335 "grammar.cpp"
+#line 3425 "grammar.cpp"
     break;
 
   case 57: /* let_element: variable_name "assignment" expression  */
-#line 975 "grammar.y"
+#line 1053 "grammar.y"
                                       {
       auto node = parser->ast()->createNodeLet((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node), true);
       parser->ast()->addOperation(node);
     }
-#line 3344 "grammar.cpp"
+#line 3434 "grammar.cpp"
     break;
 
-  case 58: /* count_into: "WITH keyword" "identifier" "INTO keyword" variable_name  */
-#line 982 "grammar.y"
+  case 58: /* let_element: array_destructuring "assignment" expression  */
+#line 1057 "grammar.y"
+                                            {
+      std::string nextName = parser->ast()->variables()->nextName();
+      auto node = parser->ast()->createNodeLet(nextName.c_str(), nextName.size(), (yyvsp[0].node), false);
+      parser->ast()->addOperation(node);
+
+      arangodb::containers::SmallVector<AstNode const*, 8> paths;
+      ::destructureArray(parser, nextName, paths, (yyvsp[-2].node));
+    }
+#line 3447 "grammar.cpp"
+    break;
+
+  case 59: /* let_element: object_destructuring "assignment" expression  */
+#line 1065 "grammar.y"
+                                             {
+      std::string nextName = parser->ast()->variables()->nextName();
+      auto node = parser->ast()->createNodeLet(nextName.c_str(), nextName.size(), (yyvsp[0].node), false);
+      parser->ast()->addOperation(node);
+
+      arangodb::containers::SmallVector<AstNode const*, 8> paths;
+      ::destructureObject(parser, nextName, paths, (yyvsp[-2].node));
+    }
+#line 3460 "grammar.cpp"
+    break;
+
+  case 60: /* $@4: %empty  */
+#line 1076 "grammar.y"
+                 {
+      AstNode* node = parser->ast()->createNodeArray();
+      node->setIntValue(1);
+      parser->pushStack(node);
+    }
+#line 3470 "grammar.cpp"
+    break;
+
+  case 61: /* array_destructuring: "[" $@4 array_destructuring_element "]"  */
+#line 1080 "grammar.y"
+                                                {
+      (yyval.node) = static_cast<AstNode*>(parser->popStack());
+    }
+#line 3478 "grammar.cpp"
+    break;
+
+  case 62: /* array_destructuring_element: %empty  */
+#line 1086 "grammar.y"
+                {
+      parser->pushArrayElement(parser->ast()->createNodeValueNull());
+    }
+#line 3486 "grammar.cpp"
+    break;
+
+  case 63: /* array_destructuring_element: variable_name  */
+#line 1089 "grammar.y"
+                  {
+      parser->pushArrayElement(parser->ast()->createNodeVariable({(yyvsp[0].strval).value, (yyvsp[0].strval).length}, true));
+    }
+#line 3494 "grammar.cpp"
+    break;
+
+  case 64: /* array_destructuring_element: array_destructuring  */
+#line 1092 "grammar.y"
+                        {
+      parser->pushArrayElement((yyvsp[0].node));
+    }
+#line 3502 "grammar.cpp"
+    break;
+
+  case 65: /* array_destructuring_element: object_destructuring  */
+#line 1095 "grammar.y"
+                         {
+      parser->pushArrayElement((yyvsp[0].node));
+    }
+#line 3510 "grammar.cpp"
+    break;
+
+  case 66: /* array_destructuring_element: array_destructuring_element "," array_destructuring_element  */
+#line 1098 "grammar.y"
+                                                                    {
+    }
+#line 3517 "grammar.cpp"
+    break;
+
+  case 67: /* $@5: %empty  */
+#line 1103 "grammar.y"
+                  {
+      AstNode* node = parser->ast()->createNodeArray();
+      node->setIntValue(2);
+      parser->pushStack(node);
+    }
+#line 3527 "grammar.cpp"
+    break;
+
+  case 68: /* object_destructuring: "{" $@5 object_destructuring_element "}"  */
+#line 1107 "grammar.y"
+                                                  {
+      (yyval.node) = static_cast<AstNode*>(parser->popStack());
+    }
+#line 3535 "grammar.cpp"
+    break;
+
+  case 69: /* object_destructuring_element: %empty  */
+#line 1113 "grammar.y"
+                {
+      parser->pushArrayElement(parser->ast()->createNodeValueNull());
+      parser->pushArrayElement(parser->ast()->createNodeValueNull());
+    }
+#line 3544 "grammar.cpp"
+    break;
+
+  case 70: /* object_destructuring_element: variable_name  */
+#line 1117 "grammar.y"
+                  {
+      parser->pushArrayElement(parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length));
+      parser->pushArrayElement(parser->ast()->createNodeVariable({(yyvsp[0].strval).value, (yyvsp[0].strval).length}, true));
+    }
+#line 3553 "grammar.cpp"
+    break;
+
+  case 71: /* object_destructuring_element: variable_name ":" variable_name  */
+#line 1121 "grammar.y"
+                                        {
+      parser->pushArrayElement(parser->ast()->createNodeValueString((yyvsp[-2].strval).value, (yyvsp[-2].strval).length));
+      parser->pushArrayElement(parser->ast()->createNodeVariable({(yyvsp[0].strval).value, (yyvsp[0].strval).length}, true));
+    }
+#line 3562 "grammar.cpp"
+    break;
+
+  case 72: /* object_destructuring_element: variable_name ":" object_destructuring  */
+#line 1125 "grammar.y"
+                                               {
+      parser->pushArrayElement(parser->ast()->createNodeValueString((yyvsp[-2].strval).value, (yyvsp[-2].strval).length));
+      parser->pushArrayElement((yyvsp[0].node));
+    }
+#line 3571 "grammar.cpp"
+    break;
+
+  case 73: /* object_destructuring_element: variable_name ":" array_destructuring  */
+#line 1129 "grammar.y"
+                                              {
+      parser->pushArrayElement(parser->ast()->createNodeValueString((yyvsp[-2].strval).value, (yyvsp[-2].strval).length));
+      parser->pushArrayElement((yyvsp[0].node));
+    }
+#line 3580 "grammar.cpp"
+    break;
+
+  case 74: /* object_destructuring_element: object_destructuring_element "," object_destructuring_element  */
+#line 1133 "grammar.y"
+                                                                      {
+    }
+#line 3587 "grammar.cpp"
+    break;
+
+  case 75: /* count_into: "WITH keyword" "identifier" "INTO keyword" variable_name  */
+#line 1138 "grammar.y"
                                          {
       std::string_view operation((yyvsp[-2].strval).value, (yyvsp[-2].strval).length);
       if (!::caseInsensitiveEqual(operation, "COUNT")) {
@@ -3354,30 +3597,30 @@ yyreduce:
 
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 3357 "grammar.cpp"
+#line 3600 "grammar.cpp"
     break;
 
-  case 59: /* $@4: %empty  */
-#line 993 "grammar.y"
+  case 76: /* $@6: %empty  */
+#line 1149 "grammar.y"
               {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     }
-#line 3366 "grammar.cpp"
+#line 3609 "grammar.cpp"
     break;
 
-  case 60: /* collect_variable_list: "COLLECT declaration" $@4 collect_list  */
-#line 996 "grammar.y"
+  case 77: /* collect_variable_list: "COLLECT declaration" $@6 collect_list  */
+#line 1152 "grammar.y"
                    {
       auto list = static_cast<AstNode*>(parser->popStack());
       TRI_ASSERT(list != nullptr);
       (yyval.node) = list;
     }
-#line 3376 "grammar.cpp"
+#line 3619 "grammar.cpp"
     break;
 
-  case 61: /* collect_statement: "COLLECT declaration" count_into options  */
-#line 1004 "grammar.y"
+  case 78: /* collect_statement: "COLLECT declaration" count_into options  */
+#line 1160 "grammar.y"
                                  {
       /* COLLECT WITH COUNT INTO var OPTIONS ... */
       auto scopes = parser->ast()->scopes();
@@ -3388,11 +3631,11 @@ yyreduce:
       auto node = parser->ast()->createNodeCollectCount(parser->ast()->createNodeArray(), (yyvsp[-1].strval).value, (yyvsp[-1].strval).length, (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3391 "grammar.cpp"
+#line 3634 "grammar.cpp"
     break;
 
-  case 62: /* collect_statement: collect_variable_list count_into options  */
-#line 1014 "grammar.y"
+  case 79: /* collect_statement: collect_variable_list count_into options  */
+#line 1170 "grammar.y"
                                              {
       /* COLLECT var = expr WITH COUNT INTO var OPTIONS ... */
       auto scopes = parser->ast()->scopes();
@@ -3406,11 +3649,11 @@ yyreduce:
       auto node = parser->ast()->createNodeCollectCount((yyvsp[-2].node), (yyvsp[-1].strval).value, (yyvsp[-1].strval).length, (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3409 "grammar.cpp"
+#line 3652 "grammar.cpp"
     break;
 
-  case 63: /* collect_statement: "COLLECT declaration" aggregate collect_optional_into options  */
-#line 1027 "grammar.y"
+  case 80: /* collect_statement: "COLLECT declaration" aggregate collect_optional_into options  */
+#line 1183 "grammar.y"
                                                       {
       /* AGGREGATE var = expr OPTIONS ... */
       VarSet variablesIntroduced{};
@@ -3435,11 +3678,11 @@ yyreduce:
       auto node = parser->ast()->createNodeCollect(parser->ast()->createNodeArray(), (yyvsp[-2].node), into, intoExpression, nullptr, (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3438 "grammar.cpp"
+#line 3681 "grammar.cpp"
     break;
 
-  case 64: /* collect_statement: collect_variable_list aggregate collect_optional_into options  */
-#line 1051 "grammar.y"
+  case 81: /* collect_statement: collect_variable_list aggregate collect_optional_into options  */
+#line 1207 "grammar.y"
                                                                   {
       /* COLLECT var = expr AGGREGATE var = expr OPTIONS ... */
       VarSet variablesIntroduced{};
@@ -3495,11 +3738,11 @@ yyreduce:
       auto node = parser->ast()->createNodeCollect((yyvsp[-3].node), (yyvsp[-2].node), into, intoExpression, nullptr, (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3498 "grammar.cpp"
+#line 3741 "grammar.cpp"
     break;
 
-  case 65: /* collect_statement: collect_variable_list collect_optional_into options  */
-#line 1106 "grammar.y"
+  case 82: /* collect_statement: collect_variable_list collect_optional_into options  */
+#line 1262 "grammar.y"
                                                         {
       /* COLLECT var = expr INTO var OPTIONS ... */
       VarSet variablesIntroduced{};
@@ -3519,11 +3762,11 @@ yyreduce:
       auto node = parser->ast()->createNodeCollect((yyvsp[-2].node), parser->ast()->createNodeArray(), into, intoExpression, nullptr, (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3522 "grammar.cpp"
+#line 3765 "grammar.cpp"
     break;
 
-  case 66: /* collect_statement: collect_variable_list collect_optional_into keep options  */
-#line 1125 "grammar.y"
+  case 83: /* collect_statement: collect_variable_list collect_optional_into keep options  */
+#line 1281 "grammar.y"
                                                              {
       /* COLLECT var = expr INTO var KEEP ... OPTIONS ... */
       VarSet variablesIntroduced{};
@@ -3552,61 +3795,61 @@ yyreduce:
       auto node = parser->ast()->createNodeCollect((yyvsp[-3].node), parser->ast()->createNodeArray(), into, intoExpression, (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3555 "grammar.cpp"
+#line 3798 "grammar.cpp"
     break;
 
-  case 67: /* collect_list: collect_element  */
-#line 1156 "grammar.y"
+  case 84: /* collect_list: collect_element  */
+#line 1312 "grammar.y"
                     {
     }
-#line 3562 "grammar.cpp"
+#line 3805 "grammar.cpp"
     break;
 
-  case 68: /* collect_list: collect_list "," collect_element  */
-#line 1158 "grammar.y"
+  case 85: /* collect_list: collect_list "," collect_element  */
+#line 1314 "grammar.y"
                                          {
     }
-#line 3569 "grammar.cpp"
+#line 3812 "grammar.cpp"
     break;
 
-  case 69: /* collect_element: variable_name "assignment" expression  */
-#line 1163 "grammar.y"
+  case 86: /* collect_element: variable_name "assignment" expression  */
+#line 1319 "grammar.y"
                                       {
       auto node = parser->ast()->createNodeAssign((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
       parser->pushArrayElement(node);
     }
-#line 3578 "grammar.cpp"
+#line 3821 "grammar.cpp"
     break;
 
-  case 70: /* collect_optional_into: %empty  */
-#line 1170 "grammar.y"
+  case 87: /* collect_optional_into: %empty  */
+#line 1326 "grammar.y"
                 {
       (yyval.node) = nullptr;
     }
-#line 3586 "grammar.cpp"
+#line 3829 "grammar.cpp"
     break;
 
-  case 71: /* collect_optional_into: "INTO keyword" variable_name  */
-#line 1173 "grammar.y"
+  case 88: /* collect_optional_into: "INTO keyword" variable_name  */
+#line 1329 "grammar.y"
                          {
       (yyval.node) = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
     }
-#line 3594 "grammar.cpp"
+#line 3837 "grammar.cpp"
     break;
 
-  case 72: /* collect_optional_into: "INTO keyword" variable_name "assignment" expression  */
-#line 1176 "grammar.y"
+  case 89: /* collect_optional_into: "INTO keyword" variable_name "assignment" expression  */
+#line 1332 "grammar.y"
                                              {
       auto node = parser->ast()->createNodeArray();
       node->addMember(parser->ast()->createNodeValueString((yyvsp[-2].strval).value, (yyvsp[-2].strval).length));
       node->addMember((yyvsp[0].node));
       (yyval.node) = node;
     }
-#line 3605 "grammar.cpp"
+#line 3848 "grammar.cpp"
     break;
 
-  case 73: /* variable_list: variable_name  */
-#line 1185 "grammar.y"
+  case 90: /* variable_list: variable_name  */
+#line 1341 "grammar.y"
                   {
       std::string_view variableName((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       if (!parser->ast()->scopes()->existsVariable(variableName)) {
@@ -3620,11 +3863,11 @@ yyreduce:
       node->setFlag(FLAG_KEEP_VARIABLENAME);
       parser->pushArrayElement(node);
     }
-#line 3623 "grammar.cpp"
+#line 3866 "grammar.cpp"
     break;
 
-  case 74: /* variable_list: variable_list "," variable_name  */
-#line 1198 "grammar.y"
+  case 91: /* variable_list: variable_list "," variable_name  */
+#line 1354 "grammar.y"
                                         {
       std::string_view variableName((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       if (!parser->ast()->scopes()->existsVariable(variableName)) {
@@ -3638,11 +3881,11 @@ yyreduce:
       node->setFlag(FLAG_KEEP_VARIABLENAME);
       parser->pushArrayElement(node);
     }
-#line 3641 "grammar.cpp"
+#line 3884 "grammar.cpp"
     break;
 
-  case 75: /* $@5: %empty  */
-#line 1214 "grammar.y"
+  case 92: /* $@7: %empty  */
+#line 1370 "grammar.y"
              {
       std::string_view operation((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       if (!::caseInsensitiveEqual(operation, "KEEP")) {
@@ -3652,175 +3895,175 @@ yyreduce:
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     }
-#line 3655 "grammar.cpp"
+#line 3898 "grammar.cpp"
     break;
 
-  case 76: /* keep: "identifier" $@5 variable_list  */
-#line 1222 "grammar.y"
+  case 93: /* keep: "identifier" $@7 variable_list  */
+#line 1378 "grammar.y"
                     {
       auto list = static_cast<AstNode*>(parser->popStack());
       (yyval.node) = list;
     }
-#line 3664 "grammar.cpp"
+#line 3907 "grammar.cpp"
     break;
 
-  case 77: /* $@6: %empty  */
-#line 1229 "grammar.y"
+  case 94: /* $@8: %empty  */
+#line 1385 "grammar.y"
                 {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     }
-#line 3673 "grammar.cpp"
+#line 3916 "grammar.cpp"
     break;
 
-  case 78: /* aggregate: "AGGREGATE keyword" $@6 aggregate_list  */
-#line 1232 "grammar.y"
+  case 95: /* aggregate: "AGGREGATE keyword" $@8 aggregate_list  */
+#line 1388 "grammar.y"
                      {
       auto list = static_cast<AstNode*>(parser->popStack());
       (yyval.node) = list;
     }
-#line 3682 "grammar.cpp"
+#line 3925 "grammar.cpp"
     break;
 
-  case 79: /* aggregate_list: aggregate_element  */
-#line 1239 "grammar.y"
+  case 96: /* aggregate_list: aggregate_element  */
+#line 1395 "grammar.y"
                       {
     }
-#line 3689 "grammar.cpp"
+#line 3932 "grammar.cpp"
     break;
 
-  case 80: /* aggregate_list: aggregate_list "," aggregate_element  */
-#line 1241 "grammar.y"
+  case 97: /* aggregate_list: aggregate_list "," aggregate_element  */
+#line 1397 "grammar.y"
                                              {
     }
-#line 3696 "grammar.cpp"
+#line 3939 "grammar.cpp"
     break;
 
-  case 81: /* aggregate_element: variable_name "assignment" aggregate_function_call  */
-#line 1246 "grammar.y"
+  case 98: /* aggregate_element: variable_name "assignment" aggregate_function_call  */
+#line 1402 "grammar.y"
                                                    {
       auto node = parser->ast()->createNodeAssign((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
       parser->pushArrayElement(node);
     }
-#line 3705 "grammar.cpp"
+#line 3948 "grammar.cpp"
     break;
 
-  case 82: /* $@7: %empty  */
-#line 1253 "grammar.y"
+  case 99: /* $@9: %empty  */
+#line 1409 "grammar.y"
                          {
       parser->pushStack((yyvsp[-1].strval).value);
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     }
-#line 3715 "grammar.cpp"
+#line 3958 "grammar.cpp"
     break;
 
-  case 83: /* aggregate_function_call: function_name "(" $@7 optional_function_call_arguments ")"  */
-#line 1257 "grammar.y"
+  case 100: /* aggregate_function_call: function_name "(" $@9 optional_function_call_arguments ")"  */
+#line 1413 "grammar.y"
                                                               {
       auto list = static_cast<AstNode const*>(parser->popStack());
       // this works because the function name here is always NUL-terminated
       (yyval.node) = parser->ast()->createNodeAggregateFunctionCall(static_cast<char const*>(parser->popStack()), list);
     }
-#line 3725 "grammar.cpp"
+#line 3968 "grammar.cpp"
     break;
 
-  case 84: /* $@8: %empty  */
-#line 1265 "grammar.y"
+  case 101: /* $@10: %empty  */
+#line 1421 "grammar.y"
            {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     }
-#line 3734 "grammar.cpp"
+#line 3977 "grammar.cpp"
     break;
 
-  case 85: /* sort_statement: "SORT declaration" $@8 sort_list  */
-#line 1268 "grammar.y"
+  case 102: /* sort_statement: "SORT declaration" $@10 sort_list  */
+#line 1424 "grammar.y"
                 {
       auto list = static_cast<AstNode const*>(parser->popStack());
       auto node = parser->ast()->createNodeSort(list);
       parser->ast()->addOperation(node);
     }
-#line 3744 "grammar.cpp"
+#line 3987 "grammar.cpp"
     break;
 
-  case 86: /* sort_list: sort_element  */
-#line 1276 "grammar.y"
+  case 103: /* sort_list: sort_element  */
+#line 1432 "grammar.y"
                  {
       parser->pushArrayElement((yyvsp[0].node));
     }
-#line 3752 "grammar.cpp"
+#line 3995 "grammar.cpp"
     break;
 
-  case 87: /* sort_list: sort_list "," sort_element  */
-#line 1279 "grammar.y"
+  case 104: /* sort_list: sort_list "," sort_element  */
+#line 1435 "grammar.y"
                                    {
       parser->pushArrayElement((yyvsp[0].node));
     }
-#line 3760 "grammar.cpp"
+#line 4003 "grammar.cpp"
     break;
 
-  case 88: /* sort_element: expression sort_direction  */
-#line 1285 "grammar.y"
+  case 105: /* sort_element: expression sort_direction  */
+#line 1441 "grammar.y"
                               {
       (yyval.node) = parser->ast()->createNodeSortElement((yyvsp[-1].node), (yyvsp[0].node));
     }
-#line 3768 "grammar.cpp"
+#line 4011 "grammar.cpp"
     break;
 
-  case 89: /* sort_direction: %empty  */
-#line 1291 "grammar.y"
+  case 106: /* sort_direction: %empty  */
+#line 1447 "grammar.y"
                 {
       (yyval.node) = parser->ast()->createNodeValueBool(true);
     }
-#line 3776 "grammar.cpp"
+#line 4019 "grammar.cpp"
     break;
 
-  case 90: /* sort_direction: "ASC keyword"  */
-#line 1294 "grammar.y"
+  case 107: /* sort_direction: "ASC keyword"  */
+#line 1450 "grammar.y"
           {
       (yyval.node) = parser->ast()->createNodeValueBool(true);
     }
-#line 3784 "grammar.cpp"
+#line 4027 "grammar.cpp"
     break;
 
-  case 91: /* sort_direction: "DESC keyword"  */
-#line 1297 "grammar.y"
+  case 108: /* sort_direction: "DESC keyword"  */
+#line 1453 "grammar.y"
            {
       (yyval.node) = parser->ast()->createNodeValueBool(false);
     }
-#line 3792 "grammar.cpp"
+#line 4035 "grammar.cpp"
     break;
 
-  case 92: /* sort_direction: simple_value  */
-#line 1300 "grammar.y"
+  case 109: /* sort_direction: simple_value  */
+#line 1456 "grammar.y"
                  {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 3800 "grammar.cpp"
+#line 4043 "grammar.cpp"
     break;
 
-  case 93: /* limit_statement: "LIMIT declaration" expression  */
-#line 1306 "grammar.y"
+  case 110: /* limit_statement: "LIMIT declaration" expression  */
+#line 1462 "grammar.y"
                        {
       auto offset = parser->ast()->createNodeValueInt(0);
       auto node = parser->ast()->createNodeLimit(offset, (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3810 "grammar.cpp"
+#line 4053 "grammar.cpp"
     break;
 
-  case 94: /* limit_statement: "LIMIT declaration" expression "," expression  */
-#line 1311 "grammar.y"
+  case 111: /* limit_statement: "LIMIT declaration" expression "," expression  */
+#line 1467 "grammar.y"
                                           {
       auto node = parser->ast()->createNodeLimit((yyvsp[-2].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3819 "grammar.cpp"
+#line 4062 "grammar.cpp"
     break;
 
-  case 95: /* window_statement: "WINDOW declaration" object aggregate  */
-#line 1318 "grammar.y"
+  case 112: /* window_statement: "WINDOW declaration" object aggregate  */
+#line 1474 "grammar.y"
                               {
       /* WINDOW {preceding:2, following:2} AGGREGATE x = AVG(x) */
       
@@ -3836,11 +4079,11 @@ yyreduce:
       auto node = parser->ast()->createNodeWindow(/*spec*/(yyvsp[-1].node), /*range*/nullptr, /*aggrs*/(yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3839 "grammar.cpp"
+#line 4082 "grammar.cpp"
     break;
 
-  case 96: /* window_statement: "WINDOW declaration" expression "WITH keyword" object aggregate  */
-#line 1333 "grammar.y"
+  case 113: /* window_statement: "WINDOW declaration" expression "WITH keyword" object aggregate  */
+#line 1489 "grammar.y"
                                                 {
     /* WINDOW rangeVar WITH {preceding:"1d", following:"1d"} AGGREGATE x = AVG(x) */
     
@@ -3856,37 +4099,37 @@ yyreduce:
     auto node = parser->ast()->createNodeWindow(/*spec*/(yyvsp[-1].node), /*range*/(yyvsp[-3].node), /*aggrs*/(yyvsp[0].node));
     parser->ast()->addOperation(node);
   }
-#line 3859 "grammar.cpp"
+#line 4102 "grammar.cpp"
     break;
 
-  case 97: /* return_statement: "RETURN declaration" distinct_expression  */
-#line 1351 "grammar.y"
+  case 114: /* return_statement: "RETURN declaration" distinct_expression  */
+#line 1507 "grammar.y"
                                  {
       auto node = parser->ast()->createNodeReturn((yyvsp[0].node));
       parser->ast()->addOperation(node);
       parser->ast()->scopes()->endNested();
     }
-#line 3869 "grammar.cpp"
+#line 4112 "grammar.cpp"
     break;
 
-  case 98: /* in_or_into_collection: "IN keyword" in_or_into_collection_name  */
-#line 1359 "grammar.y"
+  case 115: /* in_or_into_collection: "IN keyword" in_or_into_collection_name  */
+#line 1515 "grammar.y"
                                     {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 3877 "grammar.cpp"
+#line 4120 "grammar.cpp"
     break;
 
-  case 99: /* in_or_into_collection: "INTO keyword" in_or_into_collection_name  */
-#line 1362 "grammar.y"
+  case 116: /* in_or_into_collection: "INTO keyword" in_or_into_collection_name  */
+#line 1518 "grammar.y"
                                       {
        (yyval.node) = (yyvsp[0].node);
      }
-#line 3885 "grammar.cpp"
+#line 4128 "grammar.cpp"
     break;
 
-  case 100: /* remove_statement: "REMOVE command" expression in_or_into_collection options  */
-#line 1368 "grammar.y"
+  case 117: /* remove_statement: "REMOVE command" expression in_or_into_collection options  */
+#line 1524 "grammar.y"
                                                       {
       if (!parser->configureWriteQuery((yyvsp[-1].node), (yyvsp[0].node))) {
         YYABORT;
@@ -3894,11 +4137,11 @@ yyreduce:
       auto node = parser->ast()->createNodeRemove((yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3897 "grammar.cpp"
+#line 4140 "grammar.cpp"
     break;
 
-  case 101: /* insert_statement: "INSERT command" expression in_or_into_collection options  */
-#line 1378 "grammar.y"
+  case 118: /* insert_statement: "INSERT command" expression in_or_into_collection options  */
+#line 1534 "grammar.y"
                                                       {
       if (!parser->configureWriteQuery((yyvsp[-1].node), (yyvsp[0].node))) {
         YYABORT;
@@ -3906,11 +4149,11 @@ yyreduce:
       auto node = parser->ast()->createNodeInsert((yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3909 "grammar.cpp"
+#line 4152 "grammar.cpp"
     break;
 
-  case 102: /* update_parameters: expression in_or_into_collection options  */
-#line 1388 "grammar.y"
+  case 119: /* update_parameters: expression in_or_into_collection options  */
+#line 1544 "grammar.y"
                                              {
       if (!parser->configureWriteQuery((yyvsp[-1].node), (yyvsp[0].node))) {
         YYABORT;
@@ -3919,11 +4162,11 @@ yyreduce:
       AstNode* node = parser->ast()->createNodeUpdate(nullptr, (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3922 "grammar.cpp"
+#line 4165 "grammar.cpp"
     break;
 
-  case 103: /* update_parameters: expression "WITH keyword" expression in_or_into_collection options  */
-#line 1396 "grammar.y"
+  case 120: /* update_parameters: expression "WITH keyword" expression in_or_into_collection options  */
+#line 1552 "grammar.y"
                                                                {
       if (!parser->configureWriteQuery((yyvsp[-1].node), (yyvsp[0].node))) {
         YYABORT;
@@ -3932,18 +4175,18 @@ yyreduce:
       AstNode* node = parser->ast()->createNodeUpdate((yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3935 "grammar.cpp"
+#line 4178 "grammar.cpp"
     break;
 
-  case 104: /* update_statement: "UPDATE command" update_parameters  */
-#line 1407 "grammar.y"
+  case 121: /* update_statement: "UPDATE command" update_parameters  */
+#line 1563 "grammar.y"
                                {
     }
-#line 3942 "grammar.cpp"
+#line 4185 "grammar.cpp"
     break;
 
-  case 105: /* replace_parameters: expression in_or_into_collection options  */
-#line 1412 "grammar.y"
+  case 122: /* replace_parameters: expression in_or_into_collection options  */
+#line 1568 "grammar.y"
                                              {
       if (!parser->configureWriteQuery((yyvsp[-1].node), (yyvsp[0].node))) {
         YYABORT;
@@ -3952,11 +4195,11 @@ yyreduce:
       AstNode* node = parser->ast()->createNodeReplace(nullptr, (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3955 "grammar.cpp"
+#line 4198 "grammar.cpp"
     break;
 
-  case 106: /* replace_parameters: expression "WITH keyword" expression in_or_into_collection options  */
-#line 1420 "grammar.y"
+  case 123: /* replace_parameters: expression "WITH keyword" expression in_or_into_collection options  */
+#line 1576 "grammar.y"
                                                                {
       if (!parser->configureWriteQuery((yyvsp[-1].node), (yyvsp[0].node))) {
         YYABORT;
@@ -3965,50 +4208,50 @@ yyreduce:
       AstNode* node = parser->ast()->createNodeReplace((yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), (yyvsp[0].node));
       parser->ast()->addOperation(node);
     }
-#line 3968 "grammar.cpp"
+#line 4211 "grammar.cpp"
     break;
 
-  case 107: /* replace_statement: "REPLACE command" replace_parameters  */
-#line 1431 "grammar.y"
+  case 124: /* replace_statement: "REPLACE command" replace_parameters  */
+#line 1587 "grammar.y"
                                  {
     }
-#line 3975 "grammar.cpp"
+#line 4218 "grammar.cpp"
     break;
 
-  case 108: /* update_or_replace: "UPDATE command"  */
-#line 1436 "grammar.y"
+  case 125: /* update_or_replace: "UPDATE command"  */
+#line 1592 "grammar.y"
              {
       (yyval.intval) = static_cast<int64_t>(NODE_TYPE_UPDATE);
     }
-#line 3983 "grammar.cpp"
+#line 4226 "grammar.cpp"
     break;
 
-  case 109: /* update_or_replace: "REPLACE command"  */
-#line 1439 "grammar.y"
+  case 126: /* update_or_replace: "REPLACE command"  */
+#line 1595 "grammar.y"
               {
       (yyval.intval) = static_cast<int64_t>(NODE_TYPE_REPLACE);
     }
-#line 3991 "grammar.cpp"
+#line 4234 "grammar.cpp"
     break;
 
-  case 110: /* upsert_input: object  */
-#line 1445 "grammar.y"
+  case 127: /* upsert_input: object  */
+#line 1601 "grammar.y"
            {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 3999 "grammar.cpp"
+#line 4242 "grammar.cpp"
     break;
 
-  case 111: /* upsert_input: bind_parameter  */
-#line 1448 "grammar.y"
+  case 128: /* upsert_input: bind_parameter  */
+#line 1604 "grammar.y"
                    {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4007 "grammar.cpp"
+#line 4250 "grammar.cpp"
     break;
 
-  case 112: /* $@9: %empty  */
-#line 1454 "grammar.y"
+  case 129: /* $@11: %empty  */
+#line 1610 "grammar.y"
                       {
       // reserve a variable named "$OLD", we might need it in the update expression
       // and in a later return thing
@@ -4026,11 +4269,11 @@ yyreduce:
       parser->ast()->addOperation(forNode);
       parser->pushStack(forNode);
     }
-#line 4029 "grammar.cpp"
+#line 4272 "grammar.cpp"
     break;
 
-  case 113: /* $@10: %empty  */
-#line 1470 "grammar.y"
+  case 130: /* $@12: %empty  */
+#line 1626 "grammar.y"
                  {
       AstNode* forNode = static_cast<AstNode*>(parser->popStack());
       AstNode* variableNode = static_cast<AstNode*>(parser->popStack());
@@ -4063,11 +4306,11 @@ yyreduce:
 
       parser->pushStack(forNode);
     }
-#line 4066 "grammar.cpp"
+#line 4309 "grammar.cpp"
     break;
 
-  case 114: /* upsert_statement: "UPSERT command" "FILTER declaration" $@9 expression $@10 "INSERT command" expression update_or_replace expression in_or_into_collection options  */
-#line 1501 "grammar.y"
+  case 131: /* upsert_statement: "UPSERT command" "FILTER declaration" $@11 expression $@12 "INSERT command" expression update_or_replace expression in_or_into_collection options  */
+#line 1657 "grammar.y"
                                                                                      {
       AstNode* forNode = static_cast<AstNode*>(parser->popStack());
       forNode->changeMember(1, (yyvsp[-1].node));
@@ -4084,11 +4327,11 @@ yyreduce:
       auto node = parser->ast()->createNodeUpsert(static_cast<AstNodeType>((yyvsp[-3].intval)), parser->ast()->createNodeReference(Variable::NAME_OLD), (yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), upsertOptionsNode, canReadOwnWrites);
       parser->ast()->addOperation(node);
     }
-#line 4087 "grammar.cpp"
+#line 4330 "grammar.cpp"
     break;
 
-  case 115: /* $@11: %empty  */
-#line 1517 "grammar.y"
+  case 132: /* $@13: %empty  */
+#line 1673 "grammar.y"
                           {
       // reserve a variable named "$OLD", we might need it in the update expression
       // and in a later return thing
@@ -4130,11 +4373,11 @@ yyreduce:
 
       parser->pushStack(forNode);
     }
-#line 4133 "grammar.cpp"
+#line 4376 "grammar.cpp"
     break;
 
-  case 116: /* upsert_statement: "UPSERT command" upsert_input $@11 "INSERT command" expression update_or_replace expression in_or_into_collection options  */
-#line 1557 "grammar.y"
+  case 133: /* upsert_statement: "UPSERT command" upsert_input $@13 "INSERT command" expression update_or_replace expression in_or_into_collection options  */
+#line 1713 "grammar.y"
                                                                                      {
       AstNode* forNode = static_cast<AstNode*>(parser->popStack());
       forNode->changeMember(1, (yyvsp[-1].node));
@@ -4151,35 +4394,35 @@ yyreduce:
       auto node = parser->ast()->createNodeUpsert(static_cast<AstNodeType>((yyvsp[-3].intval)), parser->ast()->createNodeReference(Variable::NAME_OLD), (yyvsp[-4].node), (yyvsp[-2].node), (yyvsp[-1].node), upsertOptionsNode, canReadOwnWrites);
       parser->ast()->addOperation(node);
     }
-#line 4154 "grammar.cpp"
+#line 4397 "grammar.cpp"
     break;
 
-  case 117: /* quantifier: "all modifier"  */
-#line 1576 "grammar.y"
+  case 134: /* quantifier: "all modifier"  */
+#line 1732 "grammar.y"
           {
       (yyval.node) = parser->ast()->createNodeQuantifier(Quantifier::Type::kAll);
     }
-#line 4162 "grammar.cpp"
+#line 4405 "grammar.cpp"
     break;
 
-  case 118: /* quantifier: "any modifier"  */
-#line 1579 "grammar.y"
+  case 135: /* quantifier: "any modifier"  */
+#line 1735 "grammar.y"
           {
       (yyval.node) = parser->ast()->createNodeQuantifier(Quantifier::Type::kAny);
     }
-#line 4170 "grammar.cpp"
+#line 4413 "grammar.cpp"
     break;
 
-  case 119: /* quantifier: "none modifier"  */
-#line 1582 "grammar.y"
+  case 136: /* quantifier: "none modifier"  */
+#line 1738 "grammar.y"
            {
       (yyval.node) = parser->ast()->createNodeQuantifier(Quantifier::Type::kNone);
     }
-#line 4178 "grammar.cpp"
+#line 4421 "grammar.cpp"
     break;
 
-  case 120: /* $@12: %empty  */
-#line 1588 "grammar.y"
+  case 137: /* $@14: %empty  */
+#line 1744 "grammar.y"
                {
       auto const scopeType = parser->ast()->scopes()->type();
 
@@ -4188,83 +4431,83 @@ yyreduce:
         parser->registerParseError(TRI_ERROR_QUERY_PARSE, "cannot use DISTINCT modifier on top-level query element", yylloc.first_line, yylloc.first_column);
       }
     }
-#line 4191 "grammar.cpp"
+#line 4434 "grammar.cpp"
     break;
 
-  case 121: /* distinct_expression: "DISTINCT modifier" $@12 expression  */
-#line 1595 "grammar.y"
+  case 138: /* distinct_expression: "DISTINCT modifier" $@14 expression  */
+#line 1751 "grammar.y"
                  {
       (yyval.node) = parser->ast()->createNodeDistinct((yyvsp[0].node));
     }
-#line 4199 "grammar.cpp"
+#line 4442 "grammar.cpp"
     break;
 
-  case 122: /* distinct_expression: expression  */
-#line 1598 "grammar.y"
+  case 139: /* distinct_expression: expression  */
+#line 1754 "grammar.y"
                {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4207 "grammar.cpp"
+#line 4450 "grammar.cpp"
     break;
 
-  case 123: /* expression: operator_unary  */
-#line 1604 "grammar.y"
+  case 140: /* expression: operator_unary  */
+#line 1760 "grammar.y"
                    {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4215 "grammar.cpp"
+#line 4458 "grammar.cpp"
     break;
 
-  case 124: /* expression: operator_binary  */
-#line 1607 "grammar.y"
+  case 141: /* expression: operator_binary  */
+#line 1763 "grammar.y"
                     {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4223 "grammar.cpp"
+#line 4466 "grammar.cpp"
     break;
 
-  case 125: /* expression: operator_ternary  */
-#line 1610 "grammar.y"
+  case 142: /* expression: operator_ternary  */
+#line 1766 "grammar.y"
                      {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4231 "grammar.cpp"
+#line 4474 "grammar.cpp"
     break;
 
-  case 126: /* expression: value_literal  */
-#line 1613 "grammar.y"
+  case 143: /* expression: value_literal  */
+#line 1769 "grammar.y"
                   {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4239 "grammar.cpp"
+#line 4482 "grammar.cpp"
     break;
 
-  case 127: /* expression: reference  */
-#line 1616 "grammar.y"
+  case 144: /* expression: reference  */
+#line 1772 "grammar.y"
               {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4247 "grammar.cpp"
+#line 4490 "grammar.cpp"
     break;
 
-  case 128: /* expression: expression ".." expression  */
-#line 1619 "grammar.y"
+  case 145: /* expression: expression ".." expression  */
+#line 1775 "grammar.y"
                                   {
       (yyval.node) = parser->ast()->createNodeRange((yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4255 "grammar.cpp"
+#line 4498 "grammar.cpp"
     break;
 
-  case 129: /* function_name: "identifier"  */
-#line 1625 "grammar.y"
+  case 146: /* function_name: "identifier"  */
+#line 1781 "grammar.y"
              {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 4263 "grammar.cpp"
+#line 4506 "grammar.cpp"
     break;
 
-  case 130: /* function_name: function_name "::" "identifier"  */
-#line 1628 "grammar.y"
+  case 147: /* function_name: function_name "::" "identifier"  */
+#line 1784 "grammar.y"
                                    {
       std::string temp((yyvsp[-2].strval).value, (yyvsp[-2].strval).length);
       temp.append("::");
@@ -4275,209 +4518,209 @@ yyreduce:
       (yyval.strval).value = p;
       (yyval.strval).length = temp.size();
     }
-#line 4278 "grammar.cpp"
+#line 4521 "grammar.cpp"
     break;
 
-  case 131: /* $@13: %empty  */
-#line 1641 "grammar.y"
+  case 148: /* $@15: %empty  */
+#line 1797 "grammar.y"
                          {
       auto args = parser->ast()->createNodeArray();
       parser->pushStack(args);
     }
-#line 4287 "grammar.cpp"
+#line 4530 "grammar.cpp"
     break;
 
-  case 132: /* function_call: function_name "(" $@13 optional_function_call_arguments ")"  */
-#line 1644 "grammar.y"
+  case 149: /* function_call: function_name "(" $@15 optional_function_call_arguments ")"  */
+#line 1800 "grammar.y"
                                                               {
       auto args = static_cast<AstNode const*>(parser->popStack());
       (yyval.node) = parser->ast()->createNodeFunctionCall(/*function name*/ {(yyvsp[-4].strval).value, (yyvsp[-4].strval).length}, args, false);
     }
-#line 4296 "grammar.cpp"
+#line 4539 "grammar.cpp"
     break;
 
-  case 133: /* $@14: %empty  */
-#line 1648 "grammar.y"
+  case 150: /* $@16: %empty  */
+#line 1804 "grammar.y"
                   {
       auto args = parser->ast()->createNodeArray();
       parser->pushStack(args);
     }
-#line 4305 "grammar.cpp"
+#line 4548 "grammar.cpp"
     break;
 
-  case 134: /* function_call: "like operator" "(" $@14 optional_function_call_arguments ")"  */
-#line 1651 "grammar.y"
+  case 151: /* function_call: "like operator" "(" $@16 optional_function_call_arguments ")"  */
+#line 1807 "grammar.y"
                                                               {
       auto args = static_cast<AstNode const*>(parser->popStack());
       (yyval.node) = parser->ast()->createNodeFunctionCall("LIKE", args, false);
     }
-#line 4314 "grammar.cpp"
+#line 4557 "grammar.cpp"
     break;
 
-  case 135: /* operator_unary: "+ operator" expression  */
-#line 1658 "grammar.y"
+  case 152: /* operator_unary: "+ operator" expression  */
+#line 1814 "grammar.y"
                                   {
       (yyval.node) = parser->ast()->optimizeUnaryOperatorArithmetic(parser->ast()->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_PLUS, (yyvsp[0].node)));
     }
-#line 4322 "grammar.cpp"
+#line 4565 "grammar.cpp"
     break;
 
-  case 136: /* operator_unary: "- operator" expression  */
-#line 1661 "grammar.y"
+  case 153: /* operator_unary: "- operator" expression  */
+#line 1817 "grammar.y"
                                     {
       (yyval.node) = parser->ast()->optimizeUnaryOperatorArithmetic(parser->ast()->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_MINUS, (yyvsp[0].node)));
     }
-#line 4330 "grammar.cpp"
+#line 4573 "grammar.cpp"
     break;
 
-  case 137: /* operator_unary: "not operator" expression  */
-#line 1664 "grammar.y"
+  case 154: /* operator_unary: "not operator" expression  */
+#line 1820 "grammar.y"
                                      {
       (yyval.node) = parser->ast()->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_NOT, (yyvsp[0].node));
     }
-#line 4338 "grammar.cpp"
+#line 4581 "grammar.cpp"
     break;
 
-  case 138: /* $@15: %empty  */
-#line 1670 "grammar.y"
+  case 155: /* $@17: %empty  */
+#line 1826 "grammar.y"
                     {
       parser->lazyConditions().push((yyvsp[-1].node), /*negated*/ true);
     }
-#line 4346 "grammar.cpp"
+#line 4589 "grammar.cpp"
     break;
 
-  case 139: /* operator_binary: expression "or operator" $@15 expression  */
-#line 1672 "grammar.y"
+  case 156: /* operator_binary: expression "or operator" $@17 expression  */
+#line 1828 "grammar.y"
                  {
       LazyCondition previous = parser->lazyConditions().pop();
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_OR, previous.condition, (yyvsp[0].node));
     }
-#line 4355 "grammar.cpp"
+#line 4598 "grammar.cpp"
     break;
 
-  case 140: /* $@16: %empty  */
-#line 1676 "grammar.y"
+  case 157: /* $@18: %empty  */
+#line 1832 "grammar.y"
                      {
       parser->lazyConditions().push((yyvsp[-1].node), /*negated*/ false);
     }
-#line 4363 "grammar.cpp"
+#line 4606 "grammar.cpp"
     break;
 
-  case 141: /* operator_binary: expression "and operator" $@16 expression  */
-#line 1678 "grammar.y"
+  case 158: /* operator_binary: expression "and operator" $@18 expression  */
+#line 1834 "grammar.y"
                  {
       LazyCondition previous = parser->lazyConditions().pop();
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_AND, previous.condition, (yyvsp[0].node));
     }
-#line 4372 "grammar.cpp"
+#line 4615 "grammar.cpp"
     break;
 
-  case 142: /* operator_binary: expression "+ operator" expression  */
-#line 1682 "grammar.y"
+  case 159: /* operator_binary: expression "+ operator" expression  */
+#line 1838 "grammar.y"
                                  {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_PLUS, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4380 "grammar.cpp"
+#line 4623 "grammar.cpp"
     break;
 
-  case 143: /* operator_binary: expression "- operator" expression  */
-#line 1685 "grammar.y"
+  case 160: /* operator_binary: expression "- operator" expression  */
+#line 1841 "grammar.y"
                                   {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_MINUS, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4388 "grammar.cpp"
+#line 4631 "grammar.cpp"
     break;
 
-  case 144: /* operator_binary: expression "* operator" expression  */
-#line 1688 "grammar.y"
+  case 161: /* operator_binary: expression "* operator" expression  */
+#line 1844 "grammar.y"
                                   {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_TIMES, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4396 "grammar.cpp"
+#line 4639 "grammar.cpp"
     break;
 
-  case 145: /* operator_binary: expression "/ operator" expression  */
-#line 1691 "grammar.y"
+  case 162: /* operator_binary: expression "/ operator" expression  */
+#line 1847 "grammar.y"
                                 {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_DIV, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4404 "grammar.cpp"
+#line 4647 "grammar.cpp"
     break;
 
-  case 146: /* operator_binary: expression "% operator" expression  */
-#line 1694 "grammar.y"
+  case 163: /* operator_binary: expression "% operator" expression  */
+#line 1850 "grammar.y"
                                 {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_MOD, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4412 "grammar.cpp"
+#line 4655 "grammar.cpp"
     break;
 
-  case 147: /* operator_binary: expression "== operator" expression  */
-#line 1697 "grammar.y"
+  case 164: /* operator_binary: expression "== operator" expression  */
+#line 1853 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_EQ, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4420 "grammar.cpp"
+#line 4663 "grammar.cpp"
     break;
 
-  case 148: /* operator_binary: expression "!= operator" expression  */
-#line 1700 "grammar.y"
+  case 165: /* operator_binary: expression "!= operator" expression  */
+#line 1856 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_NE, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4428 "grammar.cpp"
+#line 4671 "grammar.cpp"
     break;
 
-  case 149: /* operator_binary: expression "< operator" expression  */
-#line 1703 "grammar.y"
+  case 166: /* operator_binary: expression "< operator" expression  */
+#line 1859 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_LT, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4436 "grammar.cpp"
+#line 4679 "grammar.cpp"
     break;
 
-  case 150: /* operator_binary: expression "> operator" expression  */
-#line 1706 "grammar.y"
+  case 167: /* operator_binary: expression "> operator" expression  */
+#line 1862 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_GT, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4444 "grammar.cpp"
+#line 4687 "grammar.cpp"
     break;
 
-  case 151: /* operator_binary: expression "<= operator" expression  */
-#line 1709 "grammar.y"
+  case 168: /* operator_binary: expression "<= operator" expression  */
+#line 1865 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_LE, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4452 "grammar.cpp"
+#line 4695 "grammar.cpp"
     break;
 
-  case 152: /* operator_binary: expression ">= operator" expression  */
-#line 1712 "grammar.y"
+  case 169: /* operator_binary: expression ">= operator" expression  */
+#line 1868 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_GE, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4460 "grammar.cpp"
+#line 4703 "grammar.cpp"
     break;
 
-  case 153: /* operator_binary: expression "IN keyword" expression  */
-#line 1715 "grammar.y"
+  case 170: /* operator_binary: expression "IN keyword" expression  */
+#line 1871 "grammar.y"
                                {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_IN, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4468 "grammar.cpp"
+#line 4711 "grammar.cpp"
     break;
 
-  case 154: /* operator_binary: expression "not in operator" expression  */
-#line 1718 "grammar.y"
+  case 171: /* operator_binary: expression "not in operator" expression  */
+#line 1874 "grammar.y"
                                    {
       (yyval.node) = parser->ast()->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_NIN, (yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 4476 "grammar.cpp"
+#line 4719 "grammar.cpp"
     break;
 
-  case 155: /* operator_binary: expression "not operator" "like operator" expression  */
-#line 1721 "grammar.y"
+  case 172: /* operator_binary: expression "not operator" "like operator" expression  */
+#line 1877 "grammar.y"
                                        {
       AstNode* arguments = parser->ast()->createNodeArray(2);
       arguments->addMember((yyvsp[-3].node));
@@ -4485,11 +4728,11 @@ yyreduce:
       AstNode* expression = parser->ast()->createNodeFunctionCall("LIKE", arguments, false);
       (yyval.node) = parser->ast()->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_NOT, expression);
     }
-#line 4488 "grammar.cpp"
+#line 4731 "grammar.cpp"
     break;
 
-  case 156: /* operator_binary: expression "not operator" "~= operator" expression  */
-#line 1728 "grammar.y"
+  case 173: /* operator_binary: expression "not operator" "~= operator" expression  */
+#line 1884 "grammar.y"
                                               {
       AstNode* arguments = parser->ast()->createNodeArray(2);
       arguments->addMember((yyvsp[-3].node));
@@ -4497,44 +4740,44 @@ yyreduce:
       AstNode* expression = parser->ast()->createNodeFunctionCall("REGEX_TEST", arguments, false);
       (yyval.node) = parser->ast()->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_NOT, expression);
     }
-#line 4500 "grammar.cpp"
+#line 4743 "grammar.cpp"
     break;
 
-  case 157: /* operator_binary: expression "not operator" "~! operator" expression  */
-#line 1735 "grammar.y"
+  case 174: /* operator_binary: expression "not operator" "~! operator" expression  */
+#line 1891 "grammar.y"
                                                   {
       AstNode* arguments = parser->ast()->createNodeArray(2);
       arguments->addMember((yyvsp[-3].node));
       arguments->addMember((yyvsp[0].node));
       (yyval.node) = parser->ast()->createNodeFunctionCall("REGEX_TEST", arguments, false);
     }
-#line 4511 "grammar.cpp"
+#line 4754 "grammar.cpp"
     break;
 
-  case 158: /* operator_binary: expression "like operator" expression  */
-#line 1741 "grammar.y"
+  case 175: /* operator_binary: expression "like operator" expression  */
+#line 1897 "grammar.y"
                                  {
       AstNode* arguments = parser->ast()->createNodeArray(2);
       arguments->addMember((yyvsp[-2].node));
       arguments->addMember((yyvsp[0].node));
       (yyval.node) = parser->ast()->createNodeFunctionCall("LIKE", arguments, false);
     }
-#line 4522 "grammar.cpp"
+#line 4765 "grammar.cpp"
     break;
 
-  case 159: /* operator_binary: expression "~= operator" expression  */
-#line 1747 "grammar.y"
+  case 176: /* operator_binary: expression "~= operator" expression  */
+#line 1903 "grammar.y"
                                         {
       AstNode* arguments = parser->ast()->createNodeArray(2);
       arguments->addMember((yyvsp[-2].node));
       arguments->addMember((yyvsp[0].node));
       (yyval.node) = parser->ast()->createNodeFunctionCall("REGEX_TEST", arguments, false);
     }
-#line 4533 "grammar.cpp"
+#line 4776 "grammar.cpp"
     break;
 
-  case 160: /* operator_binary: expression "~! operator" expression  */
-#line 1753 "grammar.y"
+  case 177: /* operator_binary: expression "~! operator" expression  */
+#line 1909 "grammar.y"
                                             {
       AstNode* arguments = parser->ast()->createNodeArray(2);
       arguments->addMember((yyvsp[-2].node));
@@ -4542,147 +4785,147 @@ yyreduce:
       AstNode* node = parser->ast()->createNodeFunctionCall("REGEX_TEST", arguments, false);
       (yyval.node) = parser->ast()->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_NOT, node);
     }
-#line 4545 "grammar.cpp"
+#line 4788 "grammar.cpp"
     break;
 
-  case 161: /* operator_binary: expression quantifier "== operator" expression  */
-#line 1760 "grammar.y"
+  case 178: /* operator_binary: expression quantifier "== operator" expression  */
+#line 1916 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_EQ, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4553 "grammar.cpp"
+#line 4796 "grammar.cpp"
     break;
 
-  case 162: /* operator_binary: expression quantifier "!= operator" expression  */
-#line 1763 "grammar.y"
+  case 179: /* operator_binary: expression quantifier "!= operator" expression  */
+#line 1919 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_NE, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4561 "grammar.cpp"
+#line 4804 "grammar.cpp"
     break;
 
-  case 163: /* operator_binary: expression quantifier "< operator" expression  */
-#line 1766 "grammar.y"
+  case 180: /* operator_binary: expression quantifier "< operator" expression  */
+#line 1922 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_LT, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4569 "grammar.cpp"
+#line 4812 "grammar.cpp"
     break;
 
-  case 164: /* operator_binary: expression quantifier "> operator" expression  */
-#line 1769 "grammar.y"
+  case 181: /* operator_binary: expression quantifier "> operator" expression  */
+#line 1925 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_GT, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4577 "grammar.cpp"
+#line 4820 "grammar.cpp"
     break;
 
-  case 165: /* operator_binary: expression quantifier "<= operator" expression  */
-#line 1772 "grammar.y"
+  case 182: /* operator_binary: expression quantifier "<= operator" expression  */
+#line 1928 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_LE, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4585 "grammar.cpp"
+#line 4828 "grammar.cpp"
     break;
 
-  case 166: /* operator_binary: expression quantifier ">= operator" expression  */
-#line 1775 "grammar.y"
+  case 183: /* operator_binary: expression quantifier ">= operator" expression  */
+#line 1931 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_GE, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4593 "grammar.cpp"
+#line 4836 "grammar.cpp"
     break;
 
-  case 167: /* operator_binary: expression quantifier "IN keyword" expression  */
-#line 1778 "grammar.y"
+  case 184: /* operator_binary: expression quantifier "IN keyword" expression  */
+#line 1934 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_IN, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4601 "grammar.cpp"
+#line 4844 "grammar.cpp"
     break;
 
-  case 168: /* operator_binary: expression quantifier "not in operator" expression  */
-#line 1781 "grammar.y"
+  case 185: /* operator_binary: expression quantifier "not in operator" expression  */
+#line 1937 "grammar.y"
                                               {
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_NIN, (yyvsp[-3].node), (yyvsp[0].node), (yyvsp[-2].node));
     }
-#line 4609 "grammar.cpp"
+#line 4852 "grammar.cpp"
     break;
 
-  case 169: /* operator_binary: expression "at least modifier" "(" expression ")" "== operator" expression  */
-#line 1784 "grammar.y"
+  case 186: /* operator_binary: expression "at least modifier" "(" expression ")" "== operator" expression  */
+#line 1940 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_EQ, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4618 "grammar.cpp"
+#line 4861 "grammar.cpp"
     break;
 
-  case 170: /* operator_binary: expression "at least modifier" "(" expression ")" "!= operator" expression  */
-#line 1788 "grammar.y"
+  case 187: /* operator_binary: expression "at least modifier" "(" expression ")" "!= operator" expression  */
+#line 1944 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_NE, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4627 "grammar.cpp"
+#line 4870 "grammar.cpp"
     break;
 
-  case 171: /* operator_binary: expression "at least modifier" "(" expression ")" "< operator" expression  */
-#line 1792 "grammar.y"
+  case 188: /* operator_binary: expression "at least modifier" "(" expression ")" "< operator" expression  */
+#line 1948 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_LT, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4636 "grammar.cpp"
+#line 4879 "grammar.cpp"
     break;
 
-  case 172: /* operator_binary: expression "at least modifier" "(" expression ")" "> operator" expression  */
-#line 1796 "grammar.y"
+  case 189: /* operator_binary: expression "at least modifier" "(" expression ")" "> operator" expression  */
+#line 1952 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_GT, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4645 "grammar.cpp"
+#line 4888 "grammar.cpp"
     break;
 
-  case 173: /* operator_binary: expression "at least modifier" "(" expression ")" "<= operator" expression  */
-#line 1800 "grammar.y"
+  case 190: /* operator_binary: expression "at least modifier" "(" expression ")" "<= operator" expression  */
+#line 1956 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_LE, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4654 "grammar.cpp"
+#line 4897 "grammar.cpp"
     break;
 
-  case 174: /* operator_binary: expression "at least modifier" "(" expression ")" ">= operator" expression  */
-#line 1804 "grammar.y"
+  case 191: /* operator_binary: expression "at least modifier" "(" expression ")" ">= operator" expression  */
+#line 1960 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_GE, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4663 "grammar.cpp"
+#line 4906 "grammar.cpp"
     break;
 
-  case 175: /* operator_binary: expression "at least modifier" "(" expression ")" "IN keyword" expression  */
-#line 1808 "grammar.y"
+  case 192: /* operator_binary: expression "at least modifier" "(" expression ")" "IN keyword" expression  */
+#line 1964 "grammar.y"
                                                                     {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_IN, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4672 "grammar.cpp"
+#line 4915 "grammar.cpp"
     break;
 
-  case 176: /* operator_binary: expression "at least modifier" "(" expression ")" "not in operator" expression  */
-#line 1812 "grammar.y"
+  case 193: /* operator_binary: expression "at least modifier" "(" expression ")" "not in operator" expression  */
+#line 1968 "grammar.y"
                                                                         {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeBinaryArrayOperator(NODE_TYPE_OPERATOR_BINARY_ARRAY_NIN, (yyvsp[-6].node), (yyvsp[0].node), quantifier);
     }
-#line 4681 "grammar.cpp"
+#line 4924 "grammar.cpp"
     break;
 
-  case 177: /* $@17: %empty  */
-#line 1819 "grammar.y"
+  case 194: /* $@19: %empty  */
+#line 1975 "grammar.y"
                           {
       // ternary operator: 
       //   condition ? true part : false part
@@ -4720,30 +4963,30 @@ yyreduce:
       // condition is falsy.
       parser->lazyConditions().push((yyvsp[-1].node), /*negated*/ false);
     }
-#line 4723 "grammar.cpp"
+#line 4966 "grammar.cpp"
     break;
 
-  case 178: /* $@18: %empty  */
-#line 1855 "grammar.y"
+  case 195: /* $@20: %empty  */
+#line 2011 "grammar.y"
                          {
       LazyCondition previous = parser->lazyConditions().pop();
       // negate the condition and push the negated version onto the stack
       parser->lazyConditions().push(previous.condition, /*negated*/ true);
     }
-#line 4733 "grammar.cpp"
+#line 4976 "grammar.cpp"
     break;
 
-  case 179: /* operator_ternary: expression "?" $@17 expression ":" $@18 expression  */
-#line 1859 "grammar.y"
+  case 196: /* operator_ternary: expression "?" $@19 expression ":" $@20 expression  */
+#line 2015 "grammar.y"
                  {
       LazyCondition previous = parser->lazyConditions().pop();
       (yyval.node) = parser->ast()->createNodeTernaryOperator(previous.condition, (yyvsp[-3].node), (yyvsp[0].node));
     }
-#line 4742 "grammar.cpp"
+#line 4985 "grammar.cpp"
     break;
 
-  case 180: /* $@19: %empty  */
-#line 1863 "grammar.y"
+  case 197: /* $@21: %empty  */
+#line 2019 "grammar.y"
                           {
       // shortcut ternary operator: 
       //   condition ? : false part
@@ -4771,42 +5014,42 @@ yyreduce:
       // condition is falsy.
       parser->lazyConditions().push((yyvsp[-1].node), /*negated*/ true);
     }
-#line 4774 "grammar.cpp"
+#line 5017 "grammar.cpp"
     break;
 
-  case 181: /* operator_ternary: expression "?" $@19 ":" expression  */
-#line 1889 "grammar.y"
+  case 198: /* operator_ternary: expression "?" $@21 ":" expression  */
+#line 2045 "grammar.y"
                          {
       LazyCondition previous = parser->lazyConditions().pop();
       (yyval.node) = parser->ast()->createNodeTernaryOperator(previous.condition, (yyvsp[0].node));
     }
-#line 4783 "grammar.cpp"
+#line 5026 "grammar.cpp"
     break;
 
-  case 182: /* optional_function_call_arguments: %empty  */
-#line 1896 "grammar.y"
+  case 199: /* optional_function_call_arguments: %empty  */
+#line 2052 "grammar.y"
                 {
     }
-#line 4790 "grammar.cpp"
+#line 5033 "grammar.cpp"
     break;
 
-  case 183: /* optional_function_call_arguments: function_arguments_list  */
-#line 1898 "grammar.y"
+  case 200: /* optional_function_call_arguments: function_arguments_list  */
+#line 2054 "grammar.y"
                             {
     }
-#line 4797 "grammar.cpp"
+#line 5040 "grammar.cpp"
     break;
 
-  case 184: /* expression_or_query: expression  */
-#line 1903 "grammar.y"
+  case 201: /* expression_or_query: expression  */
+#line 2059 "grammar.y"
                {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4805 "grammar.cpp"
+#line 5048 "grammar.cpp"
     break;
 
-  case 185: /* $@20: %empty  */
-#line 1906 "grammar.y"
+  case 202: /* $@22: %empty  */
+#line 2062 "grammar.y"
     {
       parser->lazyConditions().flushAssignments();
 
@@ -4815,11 +5058,11 @@ yyreduce:
 
       parser->lazyConditions().flushFilters();
     }
-#line 4818 "grammar.cpp"
+#line 5061 "grammar.cpp"
     break;
 
-  case 186: /* expression_or_query: $@20 query  */
-#line 1913 "grammar.y"
+  case 203: /* expression_or_query: $@22 query  */
+#line 2069 "grammar.y"
             {
       AstNode* node = parser->ast()->endSubQuery();
       parser->ast()->scopes()->endCurrent();
@@ -4830,111 +5073,111 @@ yyreduce:
 
       (yyval.node) = parser->ast()->createNodeSubqueryReference(variableName, node);
     }
-#line 4833 "grammar.cpp"
+#line 5076 "grammar.cpp"
     break;
 
-  case 187: /* function_arguments_list: expression_or_query  */
-#line 1926 "grammar.y"
+  case 204: /* function_arguments_list: expression_or_query  */
+#line 2082 "grammar.y"
                         {
       parser->pushArrayElement((yyvsp[0].node));
     }
-#line 4841 "grammar.cpp"
+#line 5084 "grammar.cpp"
     break;
 
-  case 188: /* function_arguments_list: function_arguments_list "," expression_or_query  */
-#line 1929 "grammar.y"
+  case 205: /* function_arguments_list: function_arguments_list "," expression_or_query  */
+#line 2085 "grammar.y"
                                                         {
       parser->pushArrayElement((yyvsp[0].node));
     }
-#line 4849 "grammar.cpp"
+#line 5092 "grammar.cpp"
     break;
 
-  case 189: /* compound_value: array  */
-#line 1935 "grammar.y"
+  case 206: /* compound_value: array  */
+#line 2091 "grammar.y"
           {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4857 "grammar.cpp"
+#line 5100 "grammar.cpp"
     break;
 
-  case 190: /* compound_value: object  */
-#line 1938 "grammar.y"
+  case 207: /* compound_value: object  */
+#line 2094 "grammar.y"
            {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 4865 "grammar.cpp"
+#line 5108 "grammar.cpp"
     break;
 
-  case 191: /* $@21: %empty  */
-#line 1944 "grammar.y"
+  case 208: /* $@23: %empty  */
+#line 2100 "grammar.y"
                  {
       auto node = parser->ast()->createNodeArray();
       parser->pushArray(node);
     }
-#line 4874 "grammar.cpp"
+#line 5117 "grammar.cpp"
     break;
 
-  case 192: /* array: "[" $@21 optional_array_elements "]"  */
-#line 1947 "grammar.y"
+  case 209: /* array: "[" $@23 optional_array_elements "]"  */
+#line 2103 "grammar.y"
                                             {
       (yyval.node) = parser->popArray();
     }
-#line 4882 "grammar.cpp"
+#line 5125 "grammar.cpp"
     break;
 
-  case 193: /* optional_array_elements: %empty  */
-#line 1953 "grammar.y"
+  case 210: /* optional_array_elements: %empty  */
+#line 2109 "grammar.y"
                 {
     }
-#line 4889 "grammar.cpp"
+#line 5132 "grammar.cpp"
     break;
 
-  case 194: /* optional_array_elements: array_elements_list  */
-#line 1955 "grammar.y"
+  case 211: /* optional_array_elements: array_elements_list  */
+#line 2111 "grammar.y"
                         {
     }
-#line 4896 "grammar.cpp"
+#line 5139 "grammar.cpp"
     break;
 
-  case 195: /* optional_array_elements: array_elements_list ","  */
-#line 1957 "grammar.y"
+  case 212: /* optional_array_elements: array_elements_list ","  */
+#line 2113 "grammar.y"
                                 {
     }
-#line 4903 "grammar.cpp"
+#line 5146 "grammar.cpp"
     break;
 
-  case 196: /* array_elements_list: array_element  */
-#line 1962 "grammar.y"
+  case 213: /* array_elements_list: array_element  */
+#line 2118 "grammar.y"
                   {
     }
-#line 4910 "grammar.cpp"
+#line 5153 "grammar.cpp"
     break;
 
-  case 197: /* array_elements_list: array_elements_list "," array_element  */
-#line 1964 "grammar.y"
+  case 214: /* array_elements_list: array_elements_list "," array_element  */
+#line 2120 "grammar.y"
                                               {
     }
-#line 4917 "grammar.cpp"
+#line 5160 "grammar.cpp"
     break;
 
-  case 198: /* array_element: expression  */
-#line 1969 "grammar.y"
+  case 215: /* array_element: expression  */
+#line 2125 "grammar.y"
                {
       parser->pushArrayElement((yyvsp[0].node));
     }
-#line 4925 "grammar.cpp"
+#line 5168 "grammar.cpp"
     break;
 
-  case 199: /* for_options: %empty  */
-#line 1975 "grammar.y"
+  case 216: /* for_options: %empty  */
+#line 2131 "grammar.y"
                 {
       (yyval.node) = nullptr;
     }
-#line 4933 "grammar.cpp"
+#line 5176 "grammar.cpp"
     break;
 
-  case 200: /* for_options: "identifier" expression  */
-#line 1978 "grammar.y"
+  case 217: /* for_options: "identifier" expression  */
+#line 2134 "grammar.y"
                         {
       std::string_view operation((yyvsp[-1].strval).value, (yyvsp[-1].strval).length);
       TRI_ASSERT((yyvsp[0].node) != nullptr);
@@ -4960,11 +5203,11 @@ yyreduce:
 
       (yyval.node) = node;
     }
-#line 4963 "grammar.cpp"
+#line 5206 "grammar.cpp"
     break;
 
-  case 201: /* for_options: "identifier" expression "identifier" expression  */
-#line 2003 "grammar.y"
+  case 218: /* for_options: "identifier" expression "identifier" expression  */
+#line 2159 "grammar.y"
                                             {
       std::string_view operation((yyvsp[-3].strval).value, (yyvsp[-3].strval).length);
       TRI_ASSERT((yyvsp[-2].node) != nullptr);
@@ -4982,19 +5225,19 @@ yyreduce:
       node->addMember((yyvsp[0].node));
       (yyval.node) = node;
     }
-#line 4985 "grammar.cpp"
+#line 5228 "grammar.cpp"
     break;
 
-  case 202: /* options: %empty  */
-#line 2023 "grammar.y"
+  case 219: /* options: %empty  */
+#line 2179 "grammar.y"
                 {
       (yyval.node) = nullptr;
     }
-#line 4993 "grammar.cpp"
+#line 5236 "grammar.cpp"
     break;
 
-  case 203: /* options: "identifier" object  */
-#line 2026 "grammar.y"
+  case 220: /* options: "identifier" object  */
+#line 2182 "grammar.y"
                     {
       std::string_view operation((yyvsp[-1].strval).value, (yyvsp[-1].strval).length);
       TRI_ASSERT((yyvsp[0].node) != nullptr);
@@ -5007,63 +5250,63 @@ yyreduce:
 
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5010 "grammar.cpp"
+#line 5253 "grammar.cpp"
     break;
 
-  case 204: /* $@22: %empty  */
-#line 2041 "grammar.y"
+  case 221: /* $@24: %empty  */
+#line 2197 "grammar.y"
                   {
       auto node = parser->ast()->createNodeObject();
       parser->pushStack(node);
     }
-#line 5019 "grammar.cpp"
+#line 5262 "grammar.cpp"
     break;
 
-  case 205: /* object: "{" $@22 optional_object_elements "}"  */
-#line 2044 "grammar.y"
+  case 222: /* object: "{" $@24 optional_object_elements "}"  */
+#line 2200 "grammar.y"
                                               {
       (yyval.node) = static_cast<AstNode*>(parser->popStack());
     }
-#line 5027 "grammar.cpp"
+#line 5270 "grammar.cpp"
     break;
 
-  case 206: /* optional_object_elements: %empty  */
-#line 2050 "grammar.y"
+  case 223: /* optional_object_elements: %empty  */
+#line 2206 "grammar.y"
                 {
     }
-#line 5034 "grammar.cpp"
+#line 5277 "grammar.cpp"
     break;
 
-  case 207: /* optional_object_elements: object_elements_list  */
-#line 2052 "grammar.y"
+  case 224: /* optional_object_elements: object_elements_list  */
+#line 2208 "grammar.y"
                          {
     }
-#line 5041 "grammar.cpp"
+#line 5284 "grammar.cpp"
     break;
 
-  case 208: /* optional_object_elements: object_elements_list ","  */
-#line 2054 "grammar.y"
+  case 225: /* optional_object_elements: object_elements_list ","  */
+#line 2210 "grammar.y"
                                  {
     }
-#line 5048 "grammar.cpp"
+#line 5291 "grammar.cpp"
     break;
 
-  case 209: /* object_elements_list: object_element  */
-#line 2059 "grammar.y"
+  case 226: /* object_elements_list: object_element  */
+#line 2215 "grammar.y"
                    {
     }
-#line 5055 "grammar.cpp"
+#line 5298 "grammar.cpp"
     break;
 
-  case 210: /* object_elements_list: object_elements_list "," object_element  */
-#line 2061 "grammar.y"
+  case 227: /* object_elements_list: object_elements_list "," object_element  */
+#line 2217 "grammar.y"
                                                 {
     }
-#line 5062 "grammar.cpp"
+#line 5305 "grammar.cpp"
     break;
 
-  case 211: /* object_element: "identifier"  */
-#line 2066 "grammar.y"
+  case 228: /* object_element: "identifier"  */
+#line 2222 "grammar.y"
              {
       // attribute-name-only (comparable to JS enhanced object literals, e.g. { foo, bar })
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
@@ -5080,110 +5323,110 @@ yyreduce:
       auto node = ast->createNodeReference(variable);
       parser->pushObjectElement((yyvsp[0].strval).value, (yyvsp[0].strval).length, node);
     }
-#line 5083 "grammar.cpp"
+#line 5326 "grammar.cpp"
     break;
 
-  case 212: /* object_element: "inbound modifier" ":" expression  */
-#line 2082 "grammar.y"
+  case 229: /* object_element: "inbound modifier" ":" expression  */
+#line 2238 "grammar.y"
                                  {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5092 "grammar.cpp"
+#line 5335 "grammar.cpp"
     break;
 
-  case 213: /* object_element: "outbound modifier" ":" expression  */
-#line 2086 "grammar.y"
+  case 230: /* object_element: "outbound modifier" ":" expression  */
+#line 2242 "grammar.y"
                                   {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5101 "grammar.cpp"
+#line 5344 "grammar.cpp"
     break;
 
-  case 214: /* object_element: "any modifier" ":" expression  */
-#line 2090 "grammar.y"
+  case 231: /* object_element: "any modifier" ":" expression  */
+#line 2246 "grammar.y"
                              {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5110 "grammar.cpp"
+#line 5353 "grammar.cpp"
     break;
 
-  case 215: /* object_element: "all modifier" ":" expression  */
-#line 2094 "grammar.y"
+  case 232: /* object_element: "all modifier" ":" expression  */
+#line 2250 "grammar.y"
                              {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5119 "grammar.cpp"
+#line 5362 "grammar.cpp"
     break;
 
-  case 216: /* object_element: "none modifier" ":" expression  */
-#line 2098 "grammar.y"
+  case 233: /* object_element: "none modifier" ":" expression  */
+#line 2254 "grammar.y"
                               {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5128 "grammar.cpp"
+#line 5371 "grammar.cpp"
     break;
 
-  case 217: /* object_element: "like operator" ":" expression  */
-#line 2102 "grammar.y"
+  case 234: /* object_element: "like operator" ":" expression  */
+#line 2258 "grammar.y"
                               {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5137 "grammar.cpp"
+#line 5380 "grammar.cpp"
     break;
 
-  case 218: /* object_element: "INTO keyword" ":" expression  */
-#line 2106 "grammar.y"
+  case 235: /* object_element: "INTO keyword" ":" expression  */
+#line 2262 "grammar.y"
                               {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5146 "grammar.cpp"
+#line 5389 "grammar.cpp"
     break;
 
-  case 219: /* object_element: "WITH keyword" ":" expression  */
-#line 2110 "grammar.y"
+  case 236: /* object_element: "WITH keyword" ":" expression  */
+#line 2266 "grammar.y"
                               {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5155 "grammar.cpp"
+#line 5398 "grammar.cpp"
     break;
 
-  case 220: /* object_element: "WINDOW declaration" ":" expression  */
-#line 2114 "grammar.y"
+  case 237: /* object_element: "WINDOW declaration" ":" expression  */
+#line 2270 "grammar.y"
                                 {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5164 "grammar.cpp"
+#line 5407 "grammar.cpp"
     break;
 
-  case 221: /* object_element: "LIMIT declaration" ":" expression  */
-#line 2118 "grammar.y"
+  case 238: /* object_element: "LIMIT declaration" ":" expression  */
+#line 2274 "grammar.y"
                                {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5173 "grammar.cpp"
+#line 5416 "grammar.cpp"
     break;
 
-  case 222: /* object_element: object_element_name ":" expression  */
-#line 2122 "grammar.y"
+  case 239: /* object_element: object_element_name ":" expression  */
+#line 2278 "grammar.y"
                                            {
       // attribute-name : attribute-value
       parser->pushObjectElement((yyvsp[-2].strval).value, (yyvsp[-2].strval).length, (yyvsp[0].node));
     }
-#line 5182 "grammar.cpp"
+#line 5425 "grammar.cpp"
     break;
 
-  case 223: /* object_element: "bind parameter" ":" expression  */
-#line 2126 "grammar.y"
+  case 240: /* object_element: "bind parameter" ":" expression  */
+#line 2282 "grammar.y"
                                    {
       // bind-parameter : attribute-value
       std::string_view name((yyvsp[-2].strval).value, (yyvsp[-2].strval).length);
@@ -5194,286 +5437,286 @@ yyreduce:
       auto param = parser->ast()->createNodeParameter(name);
       parser->pushObjectElement(param, (yyvsp[0].node));
     }
-#line 5197 "grammar.cpp"
+#line 5440 "grammar.cpp"
     break;
 
-  case 224: /* object_element: "[" expression "]" ":" expression  */
-#line 2136 "grammar.y"
+  case 241: /* object_element: "[" expression "]" ":" expression  */
+#line 2292 "grammar.y"
                                                              {
       // [ attribute-name-expression ] : attribute-value
       parser->pushObjectElement((yyvsp[-3].node), (yyvsp[0].node));
     }
-#line 5206 "grammar.cpp"
+#line 5449 "grammar.cpp"
     break;
 
-  case 225: /* array_filter_operator: "?"  */
-#line 2143 "grammar.y"
+  case 242: /* array_filter_operator: "?"  */
+#line 2299 "grammar.y"
                {
       (yyval.intval) = 1;
     }
-#line 5214 "grammar.cpp"
+#line 5457 "grammar.cpp"
     break;
 
-  case 226: /* array_filter_operator: array_filter_operator "?"  */
-#line 2146 "grammar.y"
+  case 243: /* array_filter_operator: array_filter_operator "?"  */
+#line 2302 "grammar.y"
                                      {
       (yyval.intval) = (yyvsp[-1].intval) + 1;
     }
-#line 5222 "grammar.cpp"
+#line 5465 "grammar.cpp"
     break;
 
-  case 227: /* array_map_operator: "* operator"  */
-#line 2152 "grammar.y"
+  case 244: /* array_map_operator: "* operator"  */
+#line 2308 "grammar.y"
             {
       (yyval.intval) = 1;
     }
-#line 5230 "grammar.cpp"
+#line 5473 "grammar.cpp"
     break;
 
-  case 228: /* array_map_operator: array_map_operator "* operator"  */
-#line 2155 "grammar.y"
+  case 245: /* array_map_operator: array_map_operator "* operator"  */
+#line 2311 "grammar.y"
                                {
       (yyval.intval) = (yyvsp[-1].intval) + 1;
     }
-#line 5238 "grammar.cpp"
+#line 5481 "grammar.cpp"
     break;
 
-  case 229: /* optional_array_filter: %empty  */
-#line 2161 "grammar.y"
+  case 246: /* optional_array_filter: %empty  */
+#line 2317 "grammar.y"
                 {
       (yyval.node) = nullptr;
     }
-#line 5246 "grammar.cpp"
+#line 5489 "grammar.cpp"
     break;
 
-  case 230: /* optional_array_filter: "FILTER declaration" expression  */
-#line 2164 "grammar.y"
+  case 247: /* optional_array_filter: "FILTER declaration" expression  */
+#line 2320 "grammar.y"
                         {
       // FILTER filter-condition
       (yyval.node) = parser->ast()->createNodeArrayFilter(nullptr, (yyvsp[0].node));
     }
-#line 5255 "grammar.cpp"
+#line 5498 "grammar.cpp"
     break;
 
-  case 231: /* optional_array_filter: quantifier "FILTER declaration" expression  */
-#line 2168 "grammar.y"
+  case 248: /* optional_array_filter: quantifier "FILTER declaration" expression  */
+#line 2324 "grammar.y"
                                    {
       // ALL|ANY|NONE|AT LEAST FILTER filter-condition
       (yyval.node) = parser->ast()->createNodeArrayFilter((yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 5264 "grammar.cpp"
+#line 5507 "grammar.cpp"
     break;
 
-  case 232: /* optional_array_filter: "at least modifier" "(" expression ")" "FILTER declaration" expression  */
-#line 2172 "grammar.y"
+  case 249: /* optional_array_filter: "at least modifier" "(" expression ")" "FILTER declaration" expression  */
+#line 2328 "grammar.y"
                                                              {
       AstNode* quantifier = parser->ast()->createNodeQuantifier(Quantifier::Type::kAtLeast, (yyvsp[-3].node));
       (yyval.node) = parser->ast()->createNodeArrayFilter(quantifier, (yyvsp[0].node));
     }
-#line 5273 "grammar.cpp"
+#line 5516 "grammar.cpp"
     break;
 
-  case 233: /* optional_array_filter: expression "FILTER declaration" expression  */
-#line 2176 "grammar.y"
+  case 250: /* optional_array_filter: expression "FILTER declaration" expression  */
+#line 2332 "grammar.y"
                                    {
       // 1    FILTER filter-condition
       // 2..5 FILTER filter-condition
       (yyval.node) = parser->ast()->createNodeArrayFilter((yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 5283 "grammar.cpp"
+#line 5526 "grammar.cpp"
     break;
 
-  case 234: /* optional_array_limit: %empty  */
-#line 2184 "grammar.y"
+  case 251: /* optional_array_limit: %empty  */
+#line 2340 "grammar.y"
                 {
       (yyval.node) = nullptr;
     }
-#line 5291 "grammar.cpp"
+#line 5534 "grammar.cpp"
     break;
 
-  case 235: /* optional_array_limit: "LIMIT declaration" expression  */
-#line 2187 "grammar.y"
+  case 252: /* optional_array_limit: "LIMIT declaration" expression  */
+#line 2343 "grammar.y"
                        {
       (yyval.node) = parser->ast()->createNodeArrayLimit(nullptr, (yyvsp[0].node));
     }
-#line 5299 "grammar.cpp"
+#line 5542 "grammar.cpp"
     break;
 
-  case 236: /* optional_array_limit: "LIMIT declaration" expression "," expression  */
-#line 2190 "grammar.y"
+  case 253: /* optional_array_limit: "LIMIT declaration" expression "," expression  */
+#line 2346 "grammar.y"
                                           {
       (yyval.node) = parser->ast()->createNodeArrayLimit((yyvsp[-2].node), (yyvsp[0].node));
     }
-#line 5307 "grammar.cpp"
+#line 5550 "grammar.cpp"
     break;
 
-  case 237: /* optional_array_return: %empty  */
-#line 2196 "grammar.y"
+  case 254: /* optional_array_return: %empty  */
+#line 2352 "grammar.y"
                 {
       (yyval.node) = nullptr;
     }
-#line 5315 "grammar.cpp"
+#line 5558 "grammar.cpp"
     break;
 
-  case 238: /* optional_array_return: "RETURN declaration" expression  */
-#line 2199 "grammar.y"
+  case 255: /* optional_array_return: "RETURN declaration" expression  */
+#line 2355 "grammar.y"
                         {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5323 "grammar.cpp"
+#line 5566 "grammar.cpp"
     break;
 
-  case 239: /* graph_collection: "identifier"  */
-#line 2205 "grammar.y"
+  case 256: /* graph_collection: "identifier"  */
+#line 2361 "grammar.y"
              {
       (yyval.node) = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
     }
-#line 5331 "grammar.cpp"
+#line 5574 "grammar.cpp"
     break;
 
-  case 240: /* graph_collection: bind_parameter_datasource_expected  */
-#line 2208 "grammar.y"
+  case 257: /* graph_collection: bind_parameter_datasource_expected  */
+#line 2364 "grammar.y"
                                        {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5339 "grammar.cpp"
+#line 5582 "grammar.cpp"
     break;
 
-  case 241: /* graph_collection: graph_direction "identifier"  */
-#line 2211 "grammar.y"
+  case 258: /* graph_collection: graph_direction "identifier"  */
+#line 2367 "grammar.y"
                              {
       auto tmp = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       (yyval.node) = parser->ast()->createNodeCollectionDirection((yyvsp[-1].intval), tmp);
     }
-#line 5348 "grammar.cpp"
+#line 5591 "grammar.cpp"
     break;
 
-  case 242: /* graph_collection: graph_direction bind_parameter  */
-#line 2215 "grammar.y"
+  case 259: /* graph_collection: graph_direction bind_parameter  */
+#line 2371 "grammar.y"
                                    {
       (yyval.node) = parser->ast()->createNodeCollectionDirection((yyvsp[-1].intval), (yyvsp[0].node));
     }
-#line 5356 "grammar.cpp"
+#line 5599 "grammar.cpp"
     break;
 
-  case 243: /* graph_collection_list: graph_collection  */
-#line 2221 "grammar.y"
+  case 260: /* graph_collection_list: graph_collection  */
+#line 2377 "grammar.y"
                       {
        auto node = static_cast<AstNode*>(parser->peekStack());
        node->addMember((yyvsp[0].node));
      }
-#line 5365 "grammar.cpp"
+#line 5608 "grammar.cpp"
     break;
 
-  case 244: /* graph_collection_list: graph_collection_list "," graph_collection  */
-#line 2225 "grammar.y"
+  case 261: /* graph_collection_list: graph_collection_list "," graph_collection  */
+#line 2381 "grammar.y"
                                                     {
        auto node = static_cast<AstNode*>(parser->peekStack());
        node->addMember((yyvsp[0].node));
      }
-#line 5374 "grammar.cpp"
+#line 5617 "grammar.cpp"
     break;
 
-  case 245: /* graph_subject: graph_collection  */
-#line 2232 "grammar.y"
+  case 262: /* graph_subject: graph_collection  */
+#line 2388 "grammar.y"
                      {
       auto node = parser->ast()->createNodeArray();
       node->addMember((yyvsp[0].node));
       auto const& resolver = parser->query().resolver();
       (yyval.node) = parser->ast()->createNodeCollectionList(node, resolver);
     }
-#line 5385 "grammar.cpp"
+#line 5628 "grammar.cpp"
     break;
 
-  case 246: /* $@23: %empty  */
-#line 2238 "grammar.y"
+  case 263: /* $@25: %empty  */
+#line 2394 "grammar.y"
                              {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
       node->addMember((yyvsp[-1].node));
     }
-#line 5395 "grammar.cpp"
+#line 5638 "grammar.cpp"
     break;
 
-  case 247: /* graph_subject: graph_collection "," $@23 graph_collection_list  */
-#line 2242 "grammar.y"
+  case 264: /* graph_subject: graph_collection "," $@25 graph_collection_list  */
+#line 2398 "grammar.y"
                             {
       auto node = static_cast<AstNode*>(parser->popStack());
       auto const& resolver = parser->query().resolver();
       (yyval.node) = parser->ast()->createNodeCollectionList(node, resolver);
     }
-#line 5405 "grammar.cpp"
+#line 5648 "grammar.cpp"
     break;
 
-  case 248: /* graph_subject: "GRAPH keyword" bind_parameter  */
-#line 2247 "grammar.y"
+  case 265: /* graph_subject: "GRAPH keyword" bind_parameter  */
+#line 2403 "grammar.y"
                            {
       // graph name
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5414 "grammar.cpp"
+#line 5657 "grammar.cpp"
     break;
 
-  case 249: /* graph_subject: "GRAPH keyword" "quoted string"  */
-#line 2251 "grammar.y"
+  case 266: /* graph_subject: "GRAPH keyword" "quoted string"  */
+#line 2407 "grammar.y"
                             {
       // graph name
       (yyval.node) = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
     }
-#line 5423 "grammar.cpp"
+#line 5666 "grammar.cpp"
     break;
 
-  case 250: /* graph_subject: "GRAPH keyword" "identifier"  */
-#line 2255 "grammar.y"
+  case 267: /* graph_subject: "GRAPH keyword" "identifier"  */
+#line 2411 "grammar.y"
                      {
       // graph name
       (yyval.node) = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
     }
-#line 5432 "grammar.cpp"
+#line 5675 "grammar.cpp"
     break;
 
-  case 251: /* graph_direction: "outbound modifier"  */
-#line 2264 "grammar.y"
+  case 268: /* graph_direction: "outbound modifier"  */
+#line 2420 "grammar.y"
                {
       (yyval.intval) = 2;
     }
-#line 5440 "grammar.cpp"
+#line 5683 "grammar.cpp"
     break;
 
-  case 252: /* graph_direction: "inbound modifier"  */
-#line 2267 "grammar.y"
+  case 269: /* graph_direction: "inbound modifier"  */
+#line 2423 "grammar.y"
               {
       (yyval.intval) = 1;
     }
-#line 5448 "grammar.cpp"
+#line 5691 "grammar.cpp"
     break;
 
-  case 253: /* graph_direction: "any modifier"  */
-#line 2270 "grammar.y"
+  case 270: /* graph_direction: "any modifier"  */
+#line 2426 "grammar.y"
           {
       (yyval.intval) = 0;
     }
-#line 5456 "grammar.cpp"
+#line 5699 "grammar.cpp"
     break;
 
-  case 254: /* graph_direction_steps: graph_direction  */
-#line 2276 "grammar.y"
+  case 271: /* graph_direction_steps: graph_direction  */
+#line 2432 "grammar.y"
                     {
       (yyval.node) = parser->ast()->createNodeDirection((yyvsp[0].intval), 1);
     }
-#line 5464 "grammar.cpp"
+#line 5707 "grammar.cpp"
     break;
 
-  case 255: /* graph_direction_steps: expression graph_direction  */
-#line 2279 "grammar.y"
+  case 272: /* graph_direction_steps: expression graph_direction  */
+#line 2435 "grammar.y"
                                                 {
       (yyval.node) = parser->ast()->createNodeDirection((yyvsp[0].intval), (yyvsp[-1].node));
     }
-#line 5472 "grammar.cpp"
+#line 5715 "grammar.cpp"
     break;
 
-  case 256: /* reference: "identifier"  */
-#line 2285 "grammar.y"
+  case 273: /* reference: "identifier"  */
+#line 2441 "grammar.y"
              {
       // variable or collection or view
       auto ast = parser->ast();
@@ -5506,36 +5749,36 @@ yyreduce:
 
       (yyval.node) = node;
     }
-#line 5509 "grammar.cpp"
+#line 5752 "grammar.cpp"
     break;
 
-  case 257: /* reference: compound_value  */
-#line 2317 "grammar.y"
+  case 274: /* reference: compound_value  */
+#line 2473 "grammar.y"
                    {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5517 "grammar.cpp"
+#line 5760 "grammar.cpp"
     break;
 
-  case 258: /* reference: bind_parameter  */
-#line 2320 "grammar.y"
+  case 275: /* reference: bind_parameter  */
+#line 2476 "grammar.y"
                    {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5525 "grammar.cpp"
+#line 5768 "grammar.cpp"
     break;
 
-  case 259: /* reference: function_call  */
-#line 2323 "grammar.y"
+  case 276: /* reference: function_call  */
+#line 2479 "grammar.y"
                   {
       TRI_ASSERT((yyvsp[0].node) != nullptr);
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5534 "grammar.cpp"
+#line 5777 "grammar.cpp"
     break;
 
-  case 260: /* reference: "(" expression ")"  */
-#line 2327 "grammar.y"
+  case 277: /* reference: "(" expression ")"  */
+#line 2483 "grammar.y"
                               {
       if ((yyvsp[-1].node)->type == NODE_TYPE_EXPANSION) {
         // create a dummy passthru node that reduces and evaluates the expansion first
@@ -5545,11 +5788,11 @@ yyreduce:
         (yyval.node) = (yyvsp[-1].node);
       }
     }
-#line 5548 "grammar.cpp"
+#line 5791 "grammar.cpp"
     break;
 
-  case 261: /* $@24: %empty  */
-#line 2336 "grammar.y"
+  case 278: /* $@26: %empty  */
+#line 2492 "grammar.y"
            {
       parser->lazyConditions().flushAssignments();
 
@@ -5558,11 +5801,11 @@ yyreduce:
       
       parser->lazyConditions().flushFilters();
     }
-#line 5561 "grammar.cpp"
+#line 5804 "grammar.cpp"
     break;
 
-  case 262: /* reference: "(" $@24 query ")"  */
-#line 2343 "grammar.y"
+  case 279: /* reference: "(" $@26 query ")"  */
+#line 2499 "grammar.y"
                     {
       AstNode* node = parser->ast()->endSubQuery();
       parser->ast()->scopes()->endCurrent();
@@ -5573,11 +5816,11 @@ yyreduce:
 
       (yyval.node) = parser->ast()->createNodeSubqueryReference(variableName, node);
     }
-#line 5576 "grammar.cpp"
+#line 5819 "grammar.cpp"
     break;
 
-  case 263: /* reference: reference '.' "identifier"  */
-#line 2353 "grammar.y"
+  case 280: /* reference: reference '.' "identifier"  */
+#line 2509 "grammar.y"
                                            {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       // named variable access, e.g. variable.reference
@@ -5593,11 +5836,11 @@ yyreduce:
         (yyval.node) = parser->ast()->createNodeAttributeAccess((yyvsp[-2].node), name);
       }
     }
-#line 5596 "grammar.cpp"
+#line 5839 "grammar.cpp"
     break;
 
-  case 264: /* reference: reference '.' bind_parameter  */
-#line 2368 "grammar.y"
+  case 281: /* reference: reference '.' bind_parameter  */
+#line 2524 "grammar.y"
                                                  {
       // named variable access, e.g. variable.@reference
       if ((yyvsp[-2].node)->type == NODE_TYPE_EXPANSION) {
@@ -5611,11 +5854,11 @@ yyreduce:
         (yyval.node) = parser->ast()->createNodeBoundAttributeAccess((yyvsp[-2].node), (yyvsp[0].node));
       }
     }
-#line 5614 "grammar.cpp"
+#line 5857 "grammar.cpp"
     break;
 
-  case 265: /* reference: reference "[" expression "]"  */
-#line 2381 "grammar.y"
+  case 282: /* reference: reference "[" expression "]"  */
+#line 2537 "grammar.y"
                                                                   {
       // indexed variable access, e.g. variable[index]
       if ((yyvsp[-3].node)->type == NODE_TYPE_EXPANSION) {
@@ -5629,11 +5872,11 @@ yyreduce:
         (yyval.node) = parser->ast()->createNodeIndexedAccess((yyvsp[-3].node), (yyvsp[-1].node));
       }
     }
-#line 5632 "grammar.cpp"
+#line 5875 "grammar.cpp"
     break;
 
-  case 266: /* $@25: %empty  */
-#line 2394 "grammar.y"
+  case 283: /* $@27: %empty  */
+#line 2550 "grammar.y"
                                                  {
       // variable expansion, e.g. variable[?], with optional FILTER clause
       if ((yyvsp[0].intval) > 1 && (yyvsp[-2].node)->type == NODE_TYPE_EXPANSION) {
@@ -5661,11 +5904,11 @@ yyreduce:
       // condition
       parser->lazyConditions().pushForceInline();
     }
-#line 5664 "grammar.cpp"
+#line 5907 "grammar.cpp"
     break;
 
-  case 267: /* reference: reference "[" array_filter_operator $@25 optional_array_filter "]"  */
-#line 2420 "grammar.y"
+  case 284: /* reference: reference "[" array_filter_operator $@27 optional_array_filter "]"  */
+#line 2576 "grammar.y"
                                                           {
       parser->lazyConditions().popForceInline();
 
@@ -5685,11 +5928,11 @@ yyreduce:
         (yyval.node) = parser->ast()->createNodeBooleanExpansion((yyvsp[-3].intval), iterator, parser->ast()->createNodeReference(variable->name), (yyvsp[-1].node));
       }
     }
-#line 5688 "grammar.cpp"
+#line 5931 "grammar.cpp"
     break;
 
-  case 268: /* $@26: %empty  */
-#line 2439 "grammar.y"
+  case 285: /* $@28: %empty  */
+#line 2595 "grammar.y"
                                               {
       // variable expansion, e.g. variable[*], with optional FILTER, LIMIT and RETURN clauses
       if ((yyvsp[0].intval) > 1 && (yyvsp[-2].node)->type == NODE_TYPE_EXPANSION) {
@@ -5717,11 +5960,11 @@ yyreduce:
       // condition
       parser->lazyConditions().pushForceInline();
     }
-#line 5720 "grammar.cpp"
+#line 5963 "grammar.cpp"
     break;
 
-  case 269: /* reference: reference "[" array_map_operator $@26 optional_array_filter optional_array_limit optional_array_return "]"  */
-#line 2465 "grammar.y"
+  case 286: /* reference: reference "[" array_map_operator $@28 optional_array_filter optional_array_limit optional_array_return "]"  */
+#line 2621 "grammar.y"
                                                                                                      {
       parser->lazyConditions().popForceInline();
 
@@ -5751,105 +5994,105 @@ yyreduce:
         (yyval.node) = parser->ast()->createNodeExpansion((yyvsp[-5].intval), iterator, parser->ast()->createNodeReference(variable->name), (yyvsp[-3].node), (yyvsp[-2].node), (yyvsp[-1].node));
       }
     }
-#line 5754 "grammar.cpp"
+#line 5997 "grammar.cpp"
     break;
 
-  case 270: /* simple_value: value_literal  */
-#line 2497 "grammar.y"
+  case 287: /* simple_value: value_literal  */
+#line 2653 "grammar.y"
                   {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5762 "grammar.cpp"
+#line 6005 "grammar.cpp"
     break;
 
-  case 271: /* simple_value: bind_parameter  */
-#line 2500 "grammar.y"
+  case 288: /* simple_value: bind_parameter  */
+#line 2656 "grammar.y"
                    {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5770 "grammar.cpp"
+#line 6013 "grammar.cpp"
     break;
 
-  case 272: /* numeric_value: "integer number"  */
-#line 2506 "grammar.y"
+  case 289: /* numeric_value: "integer number"  */
+#line 2662 "grammar.y"
               {
       TRI_ASSERT((yyvsp[0].node) != nullptr);
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5779 "grammar.cpp"
+#line 6022 "grammar.cpp"
     break;
 
-  case 273: /* numeric_value: "number"  */
-#line 2510 "grammar.y"
+  case 290: /* numeric_value: "number"  */
+#line 2666 "grammar.y"
              {
       TRI_ASSERT((yyvsp[0].node) != nullptr);
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5788 "grammar.cpp"
+#line 6031 "grammar.cpp"
     break;
 
-  case 274: /* value_literal: "quoted string"  */
-#line 2517 "grammar.y"
+  case 291: /* value_literal: "quoted string"  */
+#line 2673 "grammar.y"
                     {
       (yyval.node) = parser->ast()->createNodeValueString((yyvsp[0].strval).value, (yyvsp[0].strval).length);
     }
-#line 5796 "grammar.cpp"
+#line 6039 "grammar.cpp"
     break;
 
-  case 275: /* value_literal: numeric_value  */
-#line 2520 "grammar.y"
+  case 292: /* value_literal: numeric_value  */
+#line 2676 "grammar.y"
                   {
       (yyval.node) = (yyvsp[0].node);
     }
-#line 5804 "grammar.cpp"
+#line 6047 "grammar.cpp"
     break;
 
-  case 276: /* value_literal: "null"  */
-#line 2523 "grammar.y"
+  case 293: /* value_literal: "null"  */
+#line 2679 "grammar.y"
            {
       (yyval.node) = parser->ast()->createNodeValueNull();
     }
-#line 5812 "grammar.cpp"
+#line 6055 "grammar.cpp"
     break;
 
-  case 277: /* value_literal: "true"  */
-#line 2526 "grammar.y"
+  case 294: /* value_literal: "true"  */
+#line 2682 "grammar.y"
            {
       (yyval.node) = parser->ast()->createNodeValueBool(true);
     }
-#line 5820 "grammar.cpp"
+#line 6063 "grammar.cpp"
     break;
 
-  case 278: /* value_literal: "false"  */
-#line 2529 "grammar.y"
+  case 295: /* value_literal: "false"  */
+#line 2685 "grammar.y"
             {
       (yyval.node) = parser->ast()->createNodeValueBool(false);
     }
-#line 5828 "grammar.cpp"
+#line 6071 "grammar.cpp"
     break;
 
-  case 279: /* in_or_into_collection_name: "identifier"  */
-#line 2535 "grammar.y"
+  case 296: /* in_or_into_collection_name: "identifier"  */
+#line 2691 "grammar.y"
              {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       auto const& resolver = parser->query().resolver();
       (yyval.node) = parser->ast()->createNodeCollection(resolver, name, arangodb::AccessMode::Type::WRITE);
     }
-#line 5838 "grammar.cpp"
+#line 6081 "grammar.cpp"
     break;
 
-  case 280: /* in_or_into_collection_name: "quoted string"  */
-#line 2540 "grammar.y"
+  case 297: /* in_or_into_collection_name: "quoted string"  */
+#line 2696 "grammar.y"
                     {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       auto const& resolver = parser->query().resolver();
       (yyval.node) = parser->ast()->createNodeCollection(resolver, name, arangodb::AccessMode::Type::WRITE);
     }
-#line 5848 "grammar.cpp"
+#line 6091 "grammar.cpp"
     break;
 
-  case 281: /* in_or_into_collection_name: "bind data source parameter"  */
-#line 2545 "grammar.y"
+  case 298: /* in_or_into_collection_name: "bind data source parameter"  */
+#line 2701 "grammar.y"
                             {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       if (name.size() < 2 || name.front() != '@') {
@@ -5858,11 +6101,11 @@ yyreduce:
 
       (yyval.node) = parser->ast()->createNodeParameterDatasource(name);
     }
-#line 5861 "grammar.cpp"
+#line 6104 "grammar.cpp"
     break;
 
-  case 282: /* bind_parameter: "bind data source parameter"  */
-#line 2556 "grammar.y"
+  case 299: /* bind_parameter: "bind data source parameter"  */
+#line 2712 "grammar.y"
                             {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       if (name.size() < 2 || name.front() != '@') {
@@ -5871,20 +6114,20 @@ yyreduce:
 
       (yyval.node) = parser->ast()->createNodeParameterDatasource(name);
     }
-#line 5874 "grammar.cpp"
+#line 6117 "grammar.cpp"
     break;
 
-  case 283: /* bind_parameter: "bind parameter"  */
-#line 2564 "grammar.y"
+  case 300: /* bind_parameter: "bind parameter"  */
+#line 2720 "grammar.y"
                 {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       (yyval.node) = parser->ast()->createNodeParameter(name);
     }
-#line 5883 "grammar.cpp"
+#line 6126 "grammar.cpp"
     break;
 
-  case 284: /* bind_parameter_datasource_expected: "bind data source parameter"  */
-#line 2571 "grammar.y"
+  case 301: /* bind_parameter_datasource_expected: "bind data source parameter"  */
+#line 2727 "grammar.y"
                             {
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       if (name.size() < 2 || name.front() != '@') {
@@ -5893,45 +6136,45 @@ yyreduce:
 
       (yyval.node) = parser->ast()->createNodeParameterDatasource(name);
     }
-#line 5896 "grammar.cpp"
+#line 6139 "grammar.cpp"
     break;
 
-  case 285: /* bind_parameter_datasource_expected: "bind parameter"  */
-#line 2579 "grammar.y"
+  case 302: /* bind_parameter_datasource_expected: "bind parameter"  */
+#line 2735 "grammar.y"
                 {
       // convert normal value bind parameter into datasource bind parameter
       std::string_view name((yyvsp[0].strval).value, (yyvsp[0].strval).length);
       (yyval.node) = parser->ast()->createNodeParameterDatasource(name);
     }
-#line 5906 "grammar.cpp"
+#line 6149 "grammar.cpp"
     break;
 
-  case 286: /* object_element_name: "identifier"  */
-#line 2587 "grammar.y"
+  case 303: /* object_element_name: "identifier"  */
+#line 2743 "grammar.y"
              {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 5914 "grammar.cpp"
+#line 6157 "grammar.cpp"
     break;
 
-  case 287: /* object_element_name: "quoted string"  */
-#line 2590 "grammar.y"
+  case 304: /* object_element_name: "quoted string"  */
+#line 2746 "grammar.y"
                     {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 5922 "grammar.cpp"
+#line 6165 "grammar.cpp"
     break;
 
-  case 288: /* variable_name: "identifier"  */
-#line 2595 "grammar.y"
+  case 305: /* variable_name: "identifier"  */
+#line 2751 "grammar.y"
              {
       (yyval.strval) = (yyvsp[0].strval);
     }
-#line 5930 "grammar.cpp"
+#line 6173 "grammar.cpp"
     break;
 
 
-#line 5934 "grammar.cpp"
+#line 6177 "grammar.cpp"
 
       default: break;
     }

--- a/tests/js/client/aql/aql-destructuring.js
+++ b/tests/js/client/aql/aql-destructuring.js
@@ -1,0 +1,350 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const internal = require("internal");
+const jsunity = require("jsunity");
+const db = internal.db;
+const helper = require("@arangodb/aql-helper");
+const assertQueryError = helper.assertQueryError;
+const errors = internal.errors;
+
+function destructuringSuite () {
+  return {
+    testArrayDestructuringNonArraySource : function ()  {
+      [ 
+        null,
+        false,
+        true,
+        -1,
+        1045,
+        "",
+        " ",
+        "foobar"
+      ].forEach(function(value) {
+        let query = `LET a = ${JSON.stringify(value)} LET [x] = a RETURN x`;
+        let res = db._query(query).toArray();
+        assertEqual(null, res[0]);
+      });
+    },
+    
+    testArrayDestructuringDirectAssignment : function ()  {
+      let query = `LET [] = [] RETURN {}`;
+      // should just parse correctly
+      let res = db._query(query).toArray();
+      assertEqual({}, res[0]);
+      
+      query = `LET [y, z] = [] RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: null, z: null}, res[0]);
+      
+      query = `LET [y, z] = [1] RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: 1, z: null}, res[0]);
+      
+      query = `LET [y, z] = [1, 2] RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: 1, z: 2}, res[0]);
+      
+      query = `LET [y, z] = [1, 2, 3] RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: 1, z: 2}, res[0]);
+      
+      query = `LET [, y, z] = [1, 2, 3] RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: 2, z: 3}, res[0]);
+      
+      query = `LET [, , y, z] = [1, 2, 3] RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: 3, z: null}, res[0]);
+    },
+      
+    testArrayDestructuringEmptySourceNoAssignments : function ()  {
+      let query = `LET a = [] LET [] = a RETURN {}`;
+      // this should simply parse correctly
+      let res = db._query(query).toArray();
+      assertEqual({}, res[0]);
+    },
+    
+    testArrayDestructuringEmptySourceSomeAssignments : function ()  {
+      let query = `LET a = [] LET [x] = a RETURN {x}`;
+      let res = db._query(query).toArray();
+      assertEqual({x: null}, res[0]);
+      
+      query = `LET a = [] LET [x, y] = a RETURN {x, y}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null}, res[0]);
+      
+      query = `LET a = [] LET [x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null, z: null}, res[0]);
+    },
+    
+    testArrayDestructuringEmptySourceSomeAssignmentsHoles : function ()  {
+      let query = `LET a = [] LET [, y, z] = a RETURN {y, z}`;
+      let res = db._query(query).toArray();
+      assertEqual({y: null, z: null}, res[0]);
+      
+      query = `LET a = [] LET [, , z] = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: null}, res[0]);
+      
+      query = `LET a = [] LET [x, , z] = a RETURN {x, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, z: null}, res[0]);
+      
+      query = `LET a = [] LET [x, y] = a RETURN {x, y}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null}, res[0]);
+      
+      query = `LET a = [] LET [, y, z] = a RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: null, z: null}, res[0]);
+    },
+    
+    testArrayDestructuringSomeAssignments : function ()  {
+      let query = `LET a = [1, 2, 3, 4, 5] LET [x] = a RETURN {x}`;
+      let res = db._query(query).toArray();
+      assertEqual({x: 1}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [x, y] = a RETURN {x, y}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 1, y: 2}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 1, y: 2, z: 3}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 2, y: 3, z: 4}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 3, y: 4, z: 5}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , , x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 4, y: 5, z: null}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , , , x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 5, y: null, z: null}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , , , , x, y, z] = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null, z: null}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [x, , z] = a RETURN {x, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: 1, z: 3}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, z] = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: 2}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , z] = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: 3}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , , z] = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: 4}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , , , z] = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: 5}, res[0]);
+      
+      query = `LET a = [1, 2, 3, 4, 5] LET [, , , , , z] = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: null}, res[0]);
+    },
+    
+    testArrayDestructuringRecursive : function ()  {
+      let query = `LET a = [1, ["foo", "bar"], ["baz"], [9, 8, 7, 6]] LET [a1, a2, a3, a4] = a RETURN {a1, a2, a3, a4}`;
+      let res = db._query(query).toArray();
+      assertEqual({a1: 1, a2: ["foo", "bar"], a3: ["baz"], a4: [9, 8, 7, 6]}, res[0]);
+      
+      query = `LET a = [1, ["foo", "bar"], ["baz"], [9, 8, 7, 6]] LET [[a1], [a2], [a3], [a4]] = a RETURN {a1, a2, a3, a4}`;
+      res = db._query(query).toArray();
+      assertEqual({a1: null, a2: "foo", a3: "baz", a4: 9}, res[0]);
+      
+      query = `LET a = [1, ["foo", "bar"], ["baz"], [9, 8, 7, 6]] LET [[a11, a12], [a21, a22], [a31, a32], [a41, a42, a43, a44, a45]] = a RETURN {a11, a12, a21, a22, a31, a32, a41, a42, a43, a44, a45}`;
+      res = db._query(query).toArray();
+      assertEqual({a11: null, a12: null, a21: "foo", a22: "bar", a31: "baz", a32: null, a41: 9, a42: 8, a43: 7, a44: 6, a45: null}, res[0]);
+      
+      query = `LET a = [1, [2, [3, 4, [5, 6, [7, 8]]]]] LET [a1, a2, a3, a4, a5, a6] = a RETURN {a1, a2, a3, a4, a5, a6}`;
+      res = db._query(query).toArray();
+      assertEqual({a1: 1, a2: [2, [3, 4, [5, 6, [7, 8]]]], a3: null, a4: null, a5: null, a6: null}, res[0]);
+      
+      query = `LET a = [1, [2, [3, 4, [5, 6, [7, 8]]]]] LET [a1, [a2, [a3, a4, [a5, a6]]]] = a RETURN {a1, a2, a3, a4, a5, a6}`;
+      res = db._query(query).toArray();
+      assertEqual({a1: 1, a2: 2, a3: 3, a4: 4, a5: 5, a6: 6}, res[0]);
+    },
+
+    testArrayDestructuringExample : function ()  {
+      let query = `LET a = ["foo", "bar", "baz", [1, 2, 3], false, "meow"] LET [foo, bar, baz, [sub1, , sub3], , meow] = a RETURN { foo, bar, baz, sub1, sub3, meow }`;
+
+      let res = db._query(query).toArray();
+
+      assertEqual({ foo: "foo", bar: "bar", baz: "baz", sub1: 1, sub3: 3, meow: "meow" }, res[0]);
+    },
+    
+    testObjectDestructuringNonObjectSource : function ()  {
+      [ 
+        null,
+        false,
+        true,
+        -1,
+        1045,
+        "",
+        " ",
+        "foobar"
+      ].forEach(function(value) {
+        let query = `LET a = ${JSON.stringify(value)} LET {x} = a RETURN x`;
+        let res = db._query(query).toArray();
+        assertEqual(null, res[0]);
+      });
+    },
+    
+    testObjectDestructuringEmptySourceNoAssignments : function ()  {
+      let query = `LET a = {} LET {} = a RETURN {}`;
+      // this should simply parse correctly
+      let res = db._query(query).toArray();
+      assertEqual({}, res[0]);
+    },
+    
+    testObjectDestructuringEmptySourceSomeAssignments : function ()  {
+      let query = `LET a = {} LET {x} = a RETURN {x}`;
+      let res = db._query(query).toArray();
+      assertEqual({x: null}, res[0]);
+      
+      query = `LET a = {} LET {x, y} = a RETURN {x, y}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null}, res[0]);
+      
+      query = `LET a = {} LET {x, y, z} = a RETURN {x, y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null, z: null}, res[0]);
+    },
+    
+    testObjectDestructuringEmptySourceSomeAssignmentsHoles : function ()  {
+      let query = `LET a = {} LET {, y, z} = a RETURN {y, z}`;
+      let res = db._query(query).toArray();
+      assertEqual({y: null, z: null}, res[0]);
+      
+      query = `LET a = {} LET {, , z} = a RETURN {z}`;
+      res = db._query(query).toArray();
+      assertEqual({z: null}, res[0]);
+      
+      query = `LET a = {} LET {x, , z} = a RETURN {x, z}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, z: null}, res[0]);
+      
+      query = `LET a = {} LET {x, y} = a RETURN {x, y}`;
+      res = db._query(query).toArray();
+      assertEqual({x: null, y: null}, res[0]);
+      
+      query = `LET a = {} LET {, y, z} = a RETURN {y, z}`;
+      res = db._query(query).toArray();
+      assertEqual({y: null, z: null}, res[0]);
+    },
+    
+    testObjectDestructuringSomeAssignments : function ()  {
+      let query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c} = a RETURN {c}`;
+      let res = db._query(query).toArray();
+      assertEqual({c: 1}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c, d} = a RETURN {c, d}`;
+      res = db._query(query).toArray();
+      assertEqual({c: 1, d: 2}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c, d, e} = a RETURN {c, d, e}`;
+      res = db._query(query).toArray();
+      assertEqual({c: 1, d: 2, e: 3}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c, d, e, f, g, h, i} = a RETURN {c, d, e, f, g, h, i}`;
+      res = db._query(query).toArray();
+      assertEqual({c: 1, d: 2, e: 3, f: 4, g: 5, h: null, i: null}, res[0]);
+    },
+    
+    testObjectDestructuringRecursive : function ()  {
+      let query = `LET a = {c: 1, d: { e: 1, f: 2 }, g: { h: ["one", "two"], i: "baz" } } LET {c, d, e, f, g, h, i} = a RETURN {c, d, e, f, g, h, i}`;
+      let res = db._query(query).toArray();
+      assertEqual({c: 1, d: {e: 1, f: 2}, e: null, f: null, g: {h: ["one", "two"], i: "baz"}, h: null, i: null}, res[0]);
+     
+      query = `LET a = {c: 1, d: { e: 2, f: 3 } } LET {c, d: {e}} = a RETURN {c, e}`;
+      res = db._query(query).toArray();
+      assertEqual({c: 1, e: 2}, res[0]);
+      
+      query = `LET a = {c: 1, d: { e: 2, f: 3 } } LET {c, d: {e}} = a RETURN {c, d, e}`;
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_NAME_UNKNOWN.code, query);
+      
+      query = `LET a = {c: 1, d: { e: 2, f: 3 } } LET {c, d: {e, f}} = a RETURN {c, e, f}`;
+      res = db._query(query).toArray();
+      assertEqual({c: 1, e: 2, f: 3}, res[0]);
+    },
+    
+    testObjectDestructuringRenaming : function ()  {
+      let query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c: z} = a RETURN {z}`;
+      let res = db._query(query).toArray();
+      assertEqual({z: 1}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {g: z, d: l, e: h} = a RETURN {z, l, h}`;
+      res = db._query(query).toArray();
+      assertEqual({z: 5, l: 2, h: 3}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {d: z, f: b} = a RETURN {z, b}`;
+      res = db._query(query).toArray();
+      assertEqual({z: 2, b: 4}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c: one, d: two, e: three, f: four} = a RETURN {one, two, three, four}`;
+      res = db._query(query).toArray();
+      assertEqual({one: 1, two: 2, three: 3, four: 4}, res[0]);
+      
+      query = `LET a = {c: 1, d: 2, e: 3, f: 4, g: 5} LET {c: ´foo_bar_baz´, d: ´a.b.c´} = a RETURN {´foo_bar_baz´, ´a.b.c´}`;
+      res = db._query(query).toArray();
+      assertEqual({"foo_bar_baz": 1, "a.b.c": 2}, res[0]);
+    },
+
+    testObjectDestructuringExample: function () {
+      let query = `LET data = { title: "Scratchpad", translations: [ { locale: "de", localization_tags: [], last_edit: "2014-04-14T08:43:37", url: "/de/docs/Tools/Scratchpad", title: "JavaScript-Umgebung" } ], url: "/en-US/docs/Tools/Scratchpad" } LET { title: englishTitle, translations: [{ title: localeTitle }] } = data RETURN { englishTitle, localeTitle }`;
+
+      let res = db._query(query).toArray();
+      assertEqual({ englishTitle: "Scratchpad", localeTitle: "JavaScript-Umgebung"}, res[0]);
+    },
+    
+    testReassigning : function ()  {
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_REDECLARED.code, `LET a = [1, 2, 3] LET [c, c] = a RETURN c`);
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_REDECLARED.code, `LET a = [1, 2, 3] LET [c, d, c] = a RETURN c`);
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_REDECLARED.code, `LET a = [1, 2, 3] LET [c, d, a] = a RETURN c`);
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_REDECLARED.code, `LET a = {c: 1, d: 2, e: 3} LET {c, c} = a RETURN c`);
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_REDECLARED.code, `LET a = {c: 1, d: 2, e: 3} LET {c, d, c} = a RETURN c`);
+      assertQueryError(errors.ERROR_QUERY_VARIABLE_REDECLARED.code, `LET a = {c: 1, d: 2, e: 3} LET {c, d, a} = a RETURN c`);
+    },
+
+  };
+}
+
+jsunity.run(destructuringSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Revive https://github.com/arangodb/arangodb/pull/4718.

* Added array and object destructuring to AQL LET statements.

  * Array Destructuring: Array destructuring is the assignment of array values
    into one or multiple variables with a single `LET` assignment. This can be
    achieved by putting the target assignment variables of the `LET` assignment
    into angular brackets.

    For example, the statement:

        LET [y, z] = [1, 2]

    will assign the value `1` to variable `y` and the value `2` to variable `z`.
    The mapping of input array members to the target variables is positional.

    It is also possible to skip over unneeded array values. The following 
    assignment will assign the value `2` to variable `y` and the value `3` to 
    variable `z`. The array member with value `1` will not be assigned to any 
    variable:

        LET [, y, z] = [1, 2, 3]

    When there are more variables assigned than there are array members, the 
    target variables that are mapped to non-existing array members are 
    populated with a value of `null`. The assigned target variables will also
    receive a value of `null` when the destructuring is used on a non-array.

    Destructuring can also be applied on nested arrays, e.g.

        LET [[sub1], [sub2, sub3]] = [["foo", "bar"], [1, 2, 3]]

    In the above example, the value of variable `sub1` will be `foo`, the value
    of variable `sub2` will be `1` and the value of variable `sub3` will be `2`.

  * Object Destructuring: Object destructuring is the assignment of multiple
    target variables from a source object value. This is achieved by using the
    curly brackets after the `LET` assignment token:

        LET { name, age } = { valid: true, age: 39, name: "John Doe" }

    The mapping of input object members to the target variables is by name.
    In the above example, the variable `name` will get a value of `John Doe`,
    the variable `age` will get a value of `39`. The attribute `valid` from the
    source object will be ignored.

    Object destructuring also works with nested objects, e.g.

        LET { name: {first, last} } = { name: { first: "John", middle: "J", last: "Doe" } }

    The above statement will assign the value `John` to the variable `first` 
    and the value `Doe` to the variable `last`. The attribute `middle` from the
    source object is ignored.
    Note that here only variables `first` and `last` will be populated, but
    variable `name` is not.

    It is also possible for the target variable to get a different name than in
    the source object, e.g.

        LET { name: {first: firstName, last: lastName} } = { name: { first: "John", last: "Doe" } }

    The above statement assigns the value `John` to the target variable
    `firstName` and the value `Doe` to the target variable `lastName`. Note
    that neither of these attributes exist in the source object.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
