### PR TITLE
optional HTTPS certificate verification in requests module

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* Added `verifyCertificates` attribute option for the `requests` JavaScript
+  module. This option defaults to false, so that no certificates will be 
+  verified in an HTTPS connection made with the `requests` module. If the
+  option is set to true, the server certificate of the remote server will be
+  verified using the default certificate store of the system.
+  There is also a `verifyDepth` attribute to limit the maximum length of the 
+  certificate chain that counts as valid.
 
 
 3.12.1 (XXXX-XX-XX)

--- a/js/common/modules/@arangodb/request.js
+++ b/js/common/modules/@arangodb/request.js
@@ -190,6 +190,12 @@ function request (req) {
   if (req.sslProtocol) {
     options.sslProtocol = req.sslProtocol;
   }
+  if (is.existy(req.verifyCertificates)) {
+    options.verifyCertificates = req.verifyCertificates;
+  }
+  if (is.existy(req.verifyDepth)) {
+    options.verifyDepth = req.verifyDepth;
+  }
   if (is.existy(req.auth)) {
     if (is.existy(req.auth.jwt)) {
       options.jwt = req.auth.jwt;

--- a/lib/SimpleHttpClient/SslClientConnection.cpp
+++ b/lib/SimpleHttpClient/SslClientConnection.cpp
@@ -22,8 +22,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 #include "Basics/operating-system.h"
 
@@ -56,7 +58,6 @@
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 #include "Ssl/ssl-helper.h"
-#include <chrono>
 
 #undef TRACE_SSL_CONNECTIONS
 
@@ -69,7 +70,7 @@ using namespace arangodb::httpclient;
 namespace {
 
 #ifdef TRACE_SSL_CONNECTIONS
-static char const* tlsTypeName(int type) {
+static std::string_view tlsTypeName(int type) {
   switch (type) {
 #ifdef SSL3_RT_HEADER
     case SSL3_RT_HEADER:
@@ -83,6 +84,8 @@ static char const* tlsTypeName(int type) {
       return "TLS handshake";
     case SSL3_RT_APPLICATION_DATA:
       return "TLS app data";
+    case SSL3_RT_INNER_CONTENT_TYPE:
+      return "TLS inner content type";
     default:
       return "TLS Unknown";
   }
@@ -153,7 +156,7 @@ static void sslTlsTrace(int direction, int sslVersion, int contentType,
   // enable this for tracing SSL connections
   if (sslVersion) {
     sslVersion >>= 8; /* check the upper 8 bits only below */
-    char const* tlsRtName;
+    std::string_view tlsRtName;
     if (sslVersion == SSL3_VERSION_MAJOR && contentType)
       tlsRtName = tlsTypeName(contentType);
     else
@@ -182,7 +185,9 @@ SslClientConnection::SslClientConnection(
       _ssl(nullptr),
       _ctx(nullptr),
       _sslProtocol(sslProtocol),
-      _socketFlags(0) {
+      _socketFlags(0),
+      _verifyDepth(10),
+      _verifyCertificates(false) {
   init(sslProtocol);
 }
 
@@ -195,7 +200,8 @@ SslClientConnection::SslClientConnection(
       _ssl(nullptr),
       _ctx(nullptr),
       _sslProtocol(sslProtocol),
-      _socketFlags(0) {
+      _socketFlags(0),
+      _verifyCertificates(false) {
   init(sslProtocol);
 }
 
@@ -352,7 +358,15 @@ bool SslClientConnection::connectSocket() {
     return false;
   }
 
-  SSL_set_verify(_ssl, SSL_VERIFY_NONE, nullptr);
+  if (_verifyCertificates) {
+    SSL_set_verify(_ssl, SSL_VERIFY_PEER, nullptr);
+    SSL_set_verify_depth(_ssl, _verifyDepth);
+
+    SSL_CTX_set_default_verify_paths(_ctx);
+    SSL_CTX_set_default_verify_dir(_ctx);
+  } else {
+    SSL_set_verify(_ssl, SSL_VERIFY_NONE, nullptr);
+  }
 
   ERR_clear_error();
 
@@ -402,6 +416,8 @@ bool SslClientConnection::connectSocket() {
     /* Gets the earliest error code from the
        thread's error queue and removes the entry. */
     unsigned long lastError = ERR_get_error();
+
+    _errorDetails.append(ERR_error_string(lastError, nullptr)).append(" - ");
 
     if (errorDetail == SSL_ERROR_SYSCALL && lastError == 0) {
       if (ret == 0) {

--- a/lib/SimpleHttpClient/SslClientConnection.h
+++ b/lib/SimpleHttpClient/SslClientConnection.h
@@ -69,6 +69,10 @@ class SslClientConnection final : public GeneralClientConnection {
 
   uint64_t sslProtocol() const { return _sslProtocol; }
 
+  void setVerifyCertificates(bool value) { _verifyCertificates = value; }
+
+  void setVerifyDepth(int value) { _verifyDepth = value; }
+
  protected:
   //////////////////////////////////////////////////////////////////////////////
   /// @brief internal initialization method, called from ctor
@@ -131,6 +135,10 @@ class SslClientConnection final : public GeneralClientConnection {
   //////////////////////////////////////////////////////////////////////////////
 
   int _socketFlags;
+
+  int _verifyDepth;
+
+  bool _verifyCertificates;
 };
 }  // namespace httpclient
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

optional HTTPS certificate verification in requests module

* Added `verifyCertificates` attribute option for the `requests` JavaScript module. This option defaults to false, so that no certificates will be verified in an HTTPS connection made with the `requests` module. If the option is set to true, the server certificate of the remote server will be verified using the default certificate store of the system. There is also a `verifyDepth` attribute to limit the maximum length of the certificate chain that counts as valid.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [x] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21118
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 