### PR TITLE
Fix shutdown race

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -974,16 +974,14 @@ void ClusterFeature::stop() {
     // We try to actively cancel all open requests that may still be in the
     // Agency. We cannot react to them anymore.
     _asyncAgencyCommPool->shutdownConnections();
+    _asyncAgencyCommPool->drainConnections();
+    _asyncAgencyCommPool->stop();
   }
 }
 
 void ClusterFeature::unprepare() {
   if (_enableCluster) {
     _clusterInfo->unprepare();
-    if (_asyncAgencyCommPool) {
-      _asyncAgencyCommPool->drainConnections();
-      _asyncAgencyCommPool->stop();
-    }
   }
   _agencyCache.reset();
 }

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -351,9 +351,6 @@ NetworkFeature::NetworkFeature(Server& server, metrics::MetricsFeature& metrics,
 }
 
 NetworkFeature::~NetworkFeature() {
-  if (_retryThread) {
-    _retryThread->beginShutdown();
-  }
   if (_pool) {
     _pool->stop();
   }
@@ -589,23 +586,12 @@ void NetworkFeature::stop() {
   if (_pool) {
     _pool->shutdownConnections();
     _pool->drainConnections();
-  }
-  if (_retryThread) {
-    _retryThread->beginShutdown();
-    _retryThread.reset();
-  }
-}
-
-void NetworkFeature::unprepare() {
-  cancelGarbageCollection();
-  if (_pool) {
     _pool->stop();
   }
-  if (_retryThread) {
-    _retryThread->beginShutdown();
-    _retryThread.reset();
-  }
+  _retryThread.reset();
 }
+
+void NetworkFeature::unprepare() { cancelGarbageCollection(); }
 
 void NetworkFeature::cancelGarbageCollection() noexcept try {
   std::lock_guard<std::mutex> guard(_workItemMutex);


### PR DESCRIPTION
### Scope & Purpose

Stop the connection pool in NetworkFeature stop to ensure that all requests are processed and the IO threads are stopped. Previously this was not guaranteed which would lead to data races and other kinds of undefined behavior because things could get destroyed even though some network callbacks would still try to access them.

- [x] :hankey: Bugfix