### PR TITLE
Don't transfer oid etc of collections to other servers

### DIFF
--- a/arangod/Cluster/DBServerAgencySync.cpp
+++ b/arangod/Cluster/DBServerAgencySync.cpp
@@ -169,8 +169,11 @@ Result DBServerAgencySync::getLocalCollections(
 
         // generate a collection definition identical to that which would be
         // persisted in the case of SingleServer
-        collection->properties(collections,
-                               LogicalDataSource::Serialization::Persistence);
+        auto res = collection->properties(
+            collections, LogicalDataSource::Serialization::Persistence);
+        if (res.fail()) {
+          return res;
+        }
 
         auto const& folls = collection->followers();
         std::string const theLeader = folls->getLeader();

--- a/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.h
+++ b/arangod/Replication2/StateMachines/Document/MaintenanceActionExecutor.h
@@ -40,7 +40,7 @@ struct IMaintenanceActionExecutor {
 
   virtual auto executeCreateCollection(
       ShardID const& shard, TRI_col_type_e collectionType,
-      velocypack::SharedSlice const& properties) noexcept -> Result = 0;
+      velocypack::SharedSlice properties) noexcept -> Result = 0;
 
   virtual auto executeDropCollection(
       std::shared_ptr<LogicalCollection> col) noexcept -> Result = 0;
@@ -68,9 +68,10 @@ class MaintenanceActionExecutor : public IMaintenanceActionExecutor {
                             TRI_vocbase_t& vocbase,
                             LoggerContext const& loggerContext);
 
-  auto executeCreateCollection(
-      ShardID const& shard, TRI_col_type_e collectionType,
-      velocypack::SharedSlice const& properties) noexcept -> Result override;
+  auto executeCreateCollection(ShardID const& shard,
+                               TRI_col_type_e collectionType,
+                               velocypack::SharedSlice properties) noexcept
+      -> Result override;
 
   auto executeDropCollection(std::shared_ptr<LogicalCollection> col) noexcept
       -> Result override;

--- a/arangod/Replication2/StateMachines/Document/ReplicatedOperation.cpp
+++ b/arangod/Replication2/StateMachines/Document/ReplicatedOperation.cpp
@@ -79,7 +79,9 @@ auto ReplicatedOperation::buildTruncateOperation(
 auto ReplicatedOperation::buildCreateShardOperation(
     ShardID shard, TRI_col_type_e collectionType,
     velocypack::SharedSlice properties) noexcept -> ReplicatedOperation {
-  TRI_ASSERT(!properties.hasKey(StaticStrings::ObjectId));
+  // the None slice is used in the gtests
+  TRI_ASSERT(properties.isNone() ||
+             !properties.hasKey(StaticStrings::ObjectId));
   return ReplicatedOperation{
       std::in_place, CreateShard{shard, collectionType, std::move(properties)}};
 }

--- a/arangod/Replication2/StateMachines/Document/ReplicatedOperation.cpp
+++ b/arangod/Replication2/StateMachines/Document/ReplicatedOperation.cpp
@@ -22,10 +22,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Replication2/StateMachines/Document/ReplicatedOperation.h"
-#include "Replication2/StateMachines/Document/ReplicatedOperationInspectors.h"
 
 #include "Assertions/AssertionLogger.h"
 #include "Assertions/ProdAssert.h"
+#include "Basics/StaticStrings.h"
+#include "Replication2/StateMachines/Document/ReplicatedOperationInspectors.h"
 
 namespace arangodb::replication2::replicated_state::document {
 
@@ -78,6 +79,7 @@ auto ReplicatedOperation::buildTruncateOperation(
 auto ReplicatedOperation::buildCreateShardOperation(
     ShardID shard, TRI_col_type_e collectionType,
     velocypack::SharedSlice properties) noexcept -> ReplicatedOperation {
+  TRI_ASSERT(!properties.hasKey(StaticStrings::ObjectId));
   return ReplicatedOperation{
       std::in_place, CreateShard{shard, collectionType, std::move(properties)}};
 }

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -1061,8 +1061,11 @@ void RestReplicationHandler::handleCommandClusterInventory() {
       _vocbase, [&resultBuilder](LogicalView::ptr const& view) -> bool {
         if (view) {
           resultBuilder.openObject();
-          view->properties(resultBuilder,
-                           LogicalDataSource::Serialization::Inventory);
+          auto res = view->properties(
+              resultBuilder, LogicalDataSource::Serialization::Inventory);
+          if (res.fail()) {
+            THROW_ARANGO_EXCEPTION(res);
+          }
           // details, !forPersistence because on restore any
           // datasource ids will differ, so need an end-user
           // representation

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -2235,8 +2235,13 @@ Result RocksDBEngine::createView(TRI_vocbase_t& vocbase, DataSourceId id,
   VPackBuilder props;
 
   props.openObject();
-  view.properties(props,
-                  LogicalDataSource::Serialization::PersistenceWithInProgress);
+  auto result = view.properties(
+      props, LogicalDataSource::Serialization::PersistenceWithInProgress);
+  if (result.fail()) {
+    LOG_TOPIC_IF("234ae", WARN, Logger::VIEWS, !result.ok())
+        << "could not serialize view " << id << ": " << result;
+    return result;
+  }
   props.close();
 
   RocksDBValue const value = RocksDBValue::View(props.slice());
@@ -4157,5 +4162,4 @@ void RocksDBEngine::addCacheMetrics(uint64_t initial, uint64_t effective,
     _metricsEdgeCacheEmptyInserts.count(totalEmptyInserts);
   }
 }
-
 }  // namespace arangodb

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -895,7 +895,10 @@ VPackBuilder LogicalCollection::toVelocyPackIgnore(
     Serialization context) const {
   VPackBuilder full;
   full.openObject();
-  properties(full, context);
+  auto res = properties(full, context);
+  if (res.fail()) {
+    THROW_ARANGO_EXCEPTION(res);
+  }
   full.close();
   if (ignoreKeys.empty()) {
     return full;

--- a/arangod/VocBase/LogicalDataSource.h
+++ b/arangod/VocBase/LogicalDataSource.h
@@ -93,14 +93,14 @@ class LogicalDataSource {
   };
 
   //////////////////////////////////////////////////////////////////////////////
-  /// @brief append a jSON definition of the data-source to the 'builder'
+  /// @brief append a JSON definition of the data-source to the 'builder'
   /// @param build the buffer to append to, must be an open object
   /// @param ctx defines which properties to serialize
   /// @param safe true only for internal, recursive, under lock, usage
   /// @return success
   //////////////////////////////////////////////////////////////////////////////
-  Result properties(velocypack::Builder& build, Serialization ctx,
-                    bool safe = false) const;
+  [[nodiscard]] Result properties(velocypack::Builder& build, Serialization ctx,
+                                  bool safe = false) const;
 
   virtual Result rename(std::string&& newName) = 0;
   bool system() const noexcept { return _system; }

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -656,7 +656,11 @@ void TRI_vocbase_t::inventory(
       *this, [&result](LogicalView::ptr const& view) -> bool {
         if (view) {
           result.openObject();
-          view->properties(result, LogicalDataSource::Serialization::Inventory);
+          auto res = view->properties(
+              result, LogicalDataSource::Serialization::Inventory);
+          if (res.fail()) {
+            THROW_ARANGO_EXCEPTION(res);
+          }
           result.close();
         }
 

--- a/tests/IResearch/IResearchQueryLateMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryLateMaterializationTest.cpp
@@ -347,7 +347,9 @@ $0}}})",
     velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder, LogicalDataSource::Serialization::Properties);
+    auto res =
+        view->properties(builder, LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
+++ b/tests/IResearch/IResearchQueryNoMaterializationTest.cpp
@@ -245,8 +245,9 @@ class QueryNoMaterialization : public QueryTestMulti {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Properties);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -670,8 +671,9 @@ TEST_P(QueryNoMaterialization, testStoredValuesRecord) {
   arangodb::velocypack::Builder builder;
 
   builder.openObject();
-  view->properties(builder,
-                   arangodb::LogicalDataSource::Serialization::Properties);
+  auto res = view->properties(
+      builder, arangodb::LogicalDataSource::Serialization::Properties);
+  ASSERT_TRUE(res.ok());
   builder.close();
 
   auto slice = builder.slice();
@@ -834,8 +836,9 @@ TEST_P(QueryNoMaterialization, testStoredValuesRecordWithCompression) {
   arangodb::velocypack::Builder builder;
 
   builder.openObject();
-  view->properties(builder,
-                   arangodb::LogicalDataSource::Serialization::Properties);
+  auto res = view->properties(
+      builder, arangodb::LogicalDataSource::Serialization::Properties);
+  ASSERT_TRUE(res.ok());
   builder.close();
 
   auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryNumericTermTest.cpp
+++ b/tests/IResearch/IResearchQueryNumericTermTest.cpp
@@ -3159,8 +3159,9 @@ class QueryNumericTermView : public QueryNumericTerm {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(builder,
+                                  LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryOptimizationTest.cpp
+++ b/tests/IResearch/IResearchQueryOptimizationTest.cpp
@@ -275,8 +275,9 @@ class QueryOptimization : public QueryTestMulti {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Properties);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryOptionsTest.cpp
+++ b/tests/IResearch/IResearchQueryOptionsTest.cpp
@@ -1166,8 +1166,9 @@ class QueryOptionsView : public QueryOptions {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(builder,
+                                  LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryOrTest.cpp
+++ b/tests/IResearch/IResearchQueryOrTest.cpp
@@ -639,7 +639,9 @@ class QueryOrView : public QueryOr {
       velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder, LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(builder,
+                                  LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryScorerTest.cpp
+++ b/tests/IResearch/IResearchQueryScorerTest.cpp
@@ -1933,8 +1933,9 @@ class QueryScorerView : public QueryScorer {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchQuerySelectAllTest.cpp
+++ b/tests/IResearch/IResearchQuerySelectAllTest.cpp
@@ -511,8 +511,9 @@ class QuerySelectAllView : public QuerySelectAll {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryStartsWithTest.cpp
+++ b/tests/IResearch/IResearchQueryStartsWithTest.cpp
@@ -1498,8 +1498,9 @@ class QueryStartsWithView : public QueryStartsWith {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(builder,
+                                  LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchQueryStringTermTest.cpp
+++ b/tests/IResearch/IResearchQueryStringTermTest.cpp
@@ -2840,8 +2840,9 @@ class QueryStringTermView : public QueryStringTerm {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(builder,
+                                  LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -347,8 +347,9 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
     {
       arangodb::velocypack::Builder builder;
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
       auto slice = builder.slice();
       arangodb::iresearch::IResearchViewMeta meta;
@@ -769,8 +770,9 @@ TEST_F(IResearchViewCoordinatorTest, test_create_link_in_background) {
     ASSERT_NE(nullptr, logicalView);
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
     ASSERT_TRUE(builder.slice().hasKey("links"));
     auto links = builder.slice().get("links");
@@ -954,8 +956,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
     {
       VPackBuilder builder;
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       arangodb::iresearch::IResearchViewMeta meta;
@@ -995,8 +998,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
       {
         VPackBuilder builder;
         builder.openObject();
-        fullyUpdatedView->properties(
+        auto res = fullyUpdatedView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         arangodb::iresearch::IResearchViewMeta meta;
@@ -1013,8 +1017,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
       {
         VPackBuilder builder;
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         arangodb::iresearch::IResearchViewMeta meta;
@@ -1054,8 +1059,9 @@ TEST_F(IResearchViewCoordinatorTest, test_update_properties) {
       {
         VPackBuilder builder;
         builder.openObject();
-        partiallyUpdatedView->properties(
+        auto res = partiallyUpdatedView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         arangodb::iresearch::IResearchViewMeta meta;
@@ -1151,8 +1157,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_user_request) {
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1174,8 +1181,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_user_request) {
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1260,8 +1268,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_user_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1338,8 +1347,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_user_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1526,8 +1536,9 @@ TEST_F(IResearchViewCoordinatorTest,
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1549,8 +1560,9 @@ TEST_F(IResearchViewCoordinatorTest,
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1635,8 +1647,9 @@ TEST_F(IResearchViewCoordinatorTest,
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1713,8 +1726,9 @@ TEST_F(IResearchViewCoordinatorTest,
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1899,8 +1913,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_internal_request) {
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1922,8 +1937,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_internal_request) {
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2008,8 +2024,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_internal_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2086,8 +2103,9 @@ TEST_F(IResearchViewCoordinatorTest, test_properties_internal_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2274,8 +2292,9 @@ TEST_F(IResearchViewCoordinatorTest,
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2297,8 +2316,9 @@ TEST_F(IResearchViewCoordinatorTest,
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2383,8 +2403,9 @@ TEST_F(IResearchViewCoordinatorTest,
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2461,8 +2482,9 @@ TEST_F(IResearchViewCoordinatorTest,
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2616,8 +2638,9 @@ TEST_F(IResearchViewCoordinatorTest, test_primary_compression_properties) {
 
     VPackBuilder builder;
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Properties);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2673,8 +2696,9 @@ TEST_F(IResearchViewCoordinatorTest, test_primary_compression_properties) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Persistence);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -2761,8 +2785,9 @@ TEST_F(IResearchViewCoordinatorTest, test_primary_compression_properties) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Inventory);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();

--- a/tests/IResearch/IResearchViewCountApproximateTest.cpp
+++ b/tests/IResearch/IResearchViewCountApproximateTest.cpp
@@ -245,8 +245,9 @@ class IResearchViewCountApproximateTest : public IResearchQueryTest {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Properties);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();

--- a/tests/IResearch/IResearchViewDBServerTest.cpp
+++ b/tests/IResearch/IResearchViewDBServerTest.cpp
@@ -780,8 +780,9 @@ TEST_F(IResearchViewDBServerTest, test_rename) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
       EXPECT_TRUE(builder.slice().hasKey("name"));
       EXPECT_EQ(std::string("testView"),
@@ -795,8 +796,9 @@ TEST_F(IResearchViewDBServerTest, test_rename) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
       EXPECT_TRUE(builder.slice().hasKey("name"));
       EXPECT_EQ(std::string("testView"),
@@ -843,8 +845,9 @@ TEST_F(IResearchViewDBServerTest, test_rename) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
       EXPECT_TRUE(builder.slice().hasKey("name"));
       EXPECT_EQ(std::string("testView"),
@@ -858,8 +861,9 @@ TEST_F(IResearchViewDBServerTest, test_rename) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
       EXPECT_TRUE(builder.slice().hasKey("name"));
       EXPECT_EQ(std::string("testView"),
@@ -888,7 +892,9 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder, arangodb::LogicalDataSource::Serialization::List);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
     auto slice = builder.slice();
     EXPECT_EQ(4U, slice.length());

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -259,7 +259,7 @@ TEST_F(IResearchViewTest, test_defaults) {
 
     builder.openObject();
     auto res = view->properties(
-        builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        builder, arangodb::LogicalDataSource::Serialization::Properties);
     ASSERT_TRUE(res.ok());
     builder.close();
 

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -221,8 +221,8 @@ TEST_F(IResearchViewTest, test_defaults) {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Persistence);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Persistence);
     builder.close();
 
     auto slice = builder.slice();
@@ -258,8 +258,9 @@ TEST_F(IResearchViewTest, test_defaults) {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Properties);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -388,8 +389,9 @@ TEST_F(IResearchViewTest, test_defaults) {
     arangodb::velocypack::Builder builder;
 
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -451,8 +453,9 @@ TEST_F(IResearchViewTest, test_properties_user_request) {
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -473,8 +476,9 @@ TEST_F(IResearchViewTest, test_properties_user_request) {
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -558,8 +562,9 @@ TEST_F(IResearchViewTest, test_properties_user_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -637,8 +642,9 @@ TEST_F(IResearchViewTest, test_properties_user_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -783,8 +789,9 @@ TEST_F(IResearchViewTest, test_properties_user_request_explicit_version) {
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -805,8 +812,9 @@ TEST_F(IResearchViewTest, test_properties_user_request_explicit_version) {
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -890,8 +898,9 @@ TEST_F(IResearchViewTest, test_properties_user_request_explicit_version) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -968,8 +977,9 @@ TEST_F(IResearchViewTest, test_properties_user_request_explicit_version) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1113,8 +1123,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request) {
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1135,8 +1146,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request) {
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1220,8 +1232,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1298,8 +1311,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1444,8 +1458,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request_explicit_version) {
   {
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(builder,
-                            arangodb::LogicalDataSource::Serialization::List);
+    auto res = logicalView->properties(
+        builder, arangodb::LogicalDataSource::Serialization::List);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1466,8 +1481,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request_explicit_version) {
 
     VPackBuilder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Properties);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1551,8 +1567,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request_explicit_version) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -1629,8 +1646,9 @@ TEST_F(IResearchViewTest, test_properties_internal_request_explicit_version) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    logicalView->properties(
+    auto res = logicalView->properties(
         builder, arangodb::LogicalDataSource::Serialization::Inventory);
+    ASSERT_TRUE(res.ok());
     builder.close();
 
     auto slice = builder.slice();
@@ -4531,8 +4549,9 @@ TEST_F(IResearchViewTest, test_register_link) {
     {
       arangodb::velocypack::Builder builder;
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -4612,8 +4631,9 @@ TEST_F(IResearchViewTest, test_register_link) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::List);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::List);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -6245,8 +6265,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6287,8 +6308,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6316,8 +6338,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6399,8 +6422,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -6485,8 +6509,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -6544,8 +6569,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -6636,8 +6662,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6681,8 +6708,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6728,8 +6756,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6757,8 +6786,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6824,8 +6854,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6869,8 +6900,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6918,8 +6950,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -6963,8 +6996,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -7019,8 +7053,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -7048,8 +7083,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -7079,8 +7115,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -7107,8 +7144,9 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -7202,9 +7240,10 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
       arangodb::velocypack::Builder builder;
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::
                        Persistence);  // 'forPersistence' to avoid auth check
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -7234,9 +7273,10 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
       arangodb::velocypack::Builder builder;
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::
                        Persistence);  // 'forPersistence' to avoid auth check
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8038,8 +8078,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8067,8 +8108,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8116,8 +8158,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8145,8 +8188,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8198,8 +8242,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8227,8 +8272,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8286,8 +8332,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8315,8 +8362,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8374,8 +8422,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -8419,8 +8468,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -8470,8 +8520,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -8515,8 +8566,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        logicalView->properties(
+        auto res = logicalView->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -8575,8 +8627,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8601,8 +8654,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8654,8 +8708,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8698,8 +8753,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8776,8 +8832,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8820,8 +8877,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8873,8 +8931,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8902,8 +8961,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8956,8 +9016,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -8993,8 +9054,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -9044,8 +9106,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9073,8 +9136,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9114,8 +9178,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9143,8 +9208,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9193,8 +9259,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -9222,8 +9289,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -9273,8 +9341,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Properties);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Properties);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -9302,8 +9371,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
       arangodb::velocypack::Builder builder;
 
       builder.openObject();
-      view->properties(builder,
-                       arangodb::LogicalDataSource::Serialization::Persistence);
+      auto res = view->properties(
+          builder, arangodb::LogicalDataSource::Serialization::Persistence);
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -9348,8 +9418,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9372,8 +9443,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9411,8 +9483,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9435,8 +9508,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9487,8 +9561,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9516,8 +9591,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9540,8 +9616,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(builder,
-                         arangodb::LogicalDataSource::Serialization::Inventory);
+        auto res = view->properties(
+            builder, arangodb::LogicalDataSource::Serialization::Inventory);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9572,8 +9649,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9601,8 +9679,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9625,8 +9704,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(builder,
-                         arangodb::LogicalDataSource::Serialization::Inventory);
+        auto res = view->properties(
+            builder, arangodb::LogicalDataSource::Serialization::Inventory);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9657,8 +9737,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9686,8 +9767,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9710,8 +9792,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(builder,
-                         arangodb::LogicalDataSource::Serialization::Inventory);
+        auto res = view->properties(
+            builder, arangodb::LogicalDataSource::Serialization::Inventory);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9742,8 +9825,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9771,8 +9855,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9795,8 +9880,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(builder,
-                         arangodb::LogicalDataSource::Serialization::Inventory);
+        auto res = view->properties(
+            builder, arangodb::LogicalDataSource::Serialization::Inventory);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9827,8 +9913,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Properties);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9856,8 +9943,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(
+        auto res = view->properties(
             builder, arangodb::LogicalDataSource::Serialization::Persistence);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9880,8 +9968,9 @@ TEST_F(IResearchViewTest, test_update_partial) {
         arangodb::velocypack::Builder builder;
 
         builder.openObject();
-        view->properties(builder,
-                         arangodb::LogicalDataSource::Serialization::Inventory);
+        auto res = view->properties(
+            builder, arangodb::LogicalDataSource::Serialization::Inventory);
+        ASSERT_TRUE(res.ok());
         builder.close();
 
         auto slice = builder.slice();
@@ -9976,9 +10065,10 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
       arangodb::velocypack::Builder builder;
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::
                        Persistence);  // 'forPersistence' to avoid auth check
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -10008,9 +10098,10 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
       arangodb::velocypack::Builder builder;
       builder.openObject();
-      logicalView->properties(
+      auto res = logicalView->properties(
           builder, arangodb::LogicalDataSource::Serialization::
                        Persistence);  // 'forPersistence' to avoid auth check
+      ASSERT_TRUE(res.ok());
       builder.close();
 
       auto slice = builder.slice();
@@ -10695,8 +10786,9 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Persistence);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
     auto slice = builder.slice();
     arangodb::iresearch::IResearchViewMeta meta;
@@ -10759,8 +10851,9 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
 
     arangodb::velocypack::Builder builder;
     builder.openObject();
-    view->properties(builder,
-                     arangodb::LogicalDataSource::Serialization::Persistence);
+    auto res = view->properties(
+        builder, arangodb::LogicalDataSource::Serialization::Persistence);
+    ASSERT_TRUE(res.ok());
     builder.close();
     auto slice = builder.slice();
     arangodb::iresearch::IResearchViewMeta meta;
@@ -10823,8 +10916,9 @@ TEST_F(IResearchViewTest, create_view_with_stored_value_with_compression) {
 
   arangodb::velocypack::Builder builder;
   builder.openObject();
-  view->properties(builder,
-                   arangodb::LogicalDataSource::Serialization::Persistence);
+  auto res = view->properties(
+      builder, arangodb::LogicalDataSource::Serialization::Persistence);
+  ASSERT_TRUE(res.ok());
   builder.close();
   auto slice = builder.slice();
   arangodb::iresearch::IResearchViewMeta meta;

--- a/tests/Replication2/Mocks/DocumentStateMocks.h
+++ b/tests/Replication2/Mocks/DocumentStateMocks.h
@@ -261,7 +261,7 @@ struct MockDocumentStateTransactionHandler
 struct MockMaintenanceActionExecutor
     : replicated_state::document::IMaintenanceActionExecutor {
   MOCK_METHOD(Result, executeCreateCollection,
-              (ShardID const&, TRI_col_type_e, velocypack::SharedSlice const&),
+              (ShardID const&, TRI_col_type_e, velocypack::SharedSlice),
               (noexcept, override));
   MOCK_METHOD(Result, executeDropCollection,
               (std::shared_ptr<LogicalCollection>), (noexcept, override));

--- a/tests/js/server/replication2/replication2-replicated-state-document-store.js
+++ b/tests/js/server/replication2/replication2-replicated-state-document-store.js
@@ -1036,8 +1036,9 @@ const replicatedStateSnapshotTransferSuite = function () {
       });
       extraCollections.push(col2);
 
+      const numExtraCollections = 30;
       // For extra fun, create some more collections that are distributed like the first one.
-      for (let counter = 0; counter < 30; ++counter) {
+      for (let counter = 0; counter < numExtraCollections; ++counter) {
         const col = db._create(`${extraCollectionName}-${counter}`, {
           numberOfShards: 1,
           distributeShardsLike: collectionName,
@@ -1185,7 +1186,7 @@ const replicatedStateSnapshotTransferSuite = function () {
         `log contents: ${JSON.stringify(logContents)}`);
 
       // Check all other collections from this group.
-      for (let counter = 0; counter < 10; ++counter) {
+      for (let counter = 0; counter < numExtraCollections; ++counter) {
         const name = `${extraCollectionName}-${counter}`;
         const key = `${testName}-${counter}`;
         const col = db._collection(name);


### PR DESCRIPTION
### Scope & Purpose

During Replication 2 snapshot transfer, collection properties were passed including its object id (etc.), which is a strictly local property. This caused to run the tests sometimes run into the assertion

```
assertion failed in arangod/RocksDBEngine/RocksDBEngine.cpp:2371 [void arangodb::RocksDBEngine::addCollectionMapping
(uint64_t, TRI_voc_tick_t, DataSourceId)]: it->second.second == cid
```
, meaning a duplicate object id was encountered.

- [X] :hankey: Bugfix
