### PR TITLE
fix serialization of multiple query plans and its memory accounting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ devel
 3.12.1 (XXXX-XX-XX)
 -------------------
 
+* Fix serialization of multiple query plans using the `allPlans: true` hint
+  when run `explain` on a query.
+
 * Support indexHint AQL option for traversals.
   The structure of traversal index hints is as follows:
 

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -829,12 +829,15 @@ function processQuery(query, explain, planIndex) {
     maxRuntimeLen = String('Runtime [s]').length,
     stats = explain.stats;
 
-  let plan = explain.plan;
-  if (plan === undefined) {
+  if (explain === undefined || (explain.plan === undefined && explain.plans === undefined)) {
     throw "incomplete query execution plan data - this should not happen unless when connected to a DB-Server. fetching query plans/profiles from a DB-Server is not supported!";
   }
+  
+  let plan;
   if (planIndex !== undefined) {
     plan = explain.plans[planIndex];
+  } else {
+    plan = explain.plan;
   }
 
   /// mode with actual runtime stats per node

--- a/tests/js/client/aql/aql-failures-noncluster.js
+++ b/tests/js/client/aql/aql-failures-noncluster.js
@@ -90,6 +90,53 @@ function ahuacatlFailureSuite () {
         idx = null;
       }
     },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test error during plan serialization
+////////////////////////////////////////////////////////////////////////////////
+    
+    testProfileSerialization : function () {
+      ["Query::serializePlans1", "Query::serializePlans2"].forEach((where) => {
+        internal.debugClearFailAt();
+        internal.debugSetFailAt(where);
+
+        try {
+          db._profileQuery(`FOR doc IN ${cn} FILTER doc._key == 'test' RETURN doc`);
+          fail();
+        } catch (err) {
+          assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
+        }
+      });
+    },
+
+    testPlanSerialization : function () {
+      ["Query::serializePlans1", "Query::serializePlans2"].forEach((where) => {
+        internal.debugClearFailAt();
+        internal.debugSetFailAt(where);
+
+        try {
+          db._explain(`FOR doc IN ${cn} FILTER doc._key == 'test' RETURN doc`);
+          fail();
+        } catch (err) {
+          assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
+        }
+      });
+    },
+    
+    testAllPlansSerialization : function () {
+      ["Query::serializePlans1", "Query::serializePlans2"].forEach((where) => {
+        internal.debugClearFailAt();
+        internal.debugSetFailAt(where);
+
+        try {
+          db._explain(`FOR doc IN ${cn} FILTER doc._key == 'test' RETURN doc`, null, {allPlans: true});
+          fail();
+        } catch (err) {
+          assertEqual(internal.errors.ERROR_DEBUG.code, err.errorNum);
+        }
+      });
+    },
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test UNION for memleaks
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21129

Fix serialization of query plans when multiple query plans need to be serialized, using the `allPlans: true` value when explaining. In this case the explainer returned an error because the `plan` attribute was missing from the result, although the result contained a `plans` attribute.
Also fix an issue with memory accounting when plan serialization to velocypack goes wrong and throws an exception (which it should not do under normal conditions, but it will do if plan serialization runs into OOM or has a logical error).

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 