### PR TITLE
Opt out of /etc/nsswitch.conf for host and user lookup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 devel
 -----
 
-* Use __nss_configure_lookup to opt out of /etc/nsswitch.conf. Add option
-  --honour-nsswitch to cancel the opt out.
+* Use __nss_configure_lookup to opt out of /etc/nsswitch.conf.
+  Add the startup option --honor-nsswitch to cancel the opt-out.
 
 * Make constrained heap sort in AQL report all filtered rows as "filtered" in
   the query profile.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Use __nss_configure_lookup to opt out of /etc/nsswitch.conf. Add option
+  --honour-nsswitch to cancel the opt out.
+
 * Make constrained heap sort in AQL report all filtered rows as "filtered" in
   the query profile.
 

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -79,10 +79,10 @@ void ConfigFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
                                           arangodb::options::Flags::Command));
 
   options->addOption(
-      "--honour-nsswitch",
+      "--honor-nsswitch",
       "Allow hostname lookup configuration via /etc/nsswitch.conf if on "
       "Linux/glibc.",
-      new BooleanParameter(&_honourNsswitch),
+      new BooleanParameter(&_honorNsswitch),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
 }
 
@@ -278,14 +278,14 @@ void ConfigFeature::prepare() {
   // If this happens on a system with a different version of glibc installed
   // (like for example an older Ubuntu system or a Debian or RedHat system),
   // then glibc tries to dynamically load a module which does not fit and the
-  // process crashes with a high likelyhood. To prevent this, we use the
+  // process crashes with a high likelihood. To prevent this, we use the
   // (undocumented) override function below. This has the consequence that the
   // host name lookup will always just use /etc/hosts and normal DNS lookup. And
   // username lookup will always just use /etc/passwd, regardless of the system
   // configuration. There is an opt-out for this in form of the configuration
-  // option --honour-nsswitch. Use this only if you are running on a system
+  // option --honor-nsswitch. Use this only if you are running on a system
   // without glibc installed, or with glibc version 2.39.0.
-  if (!_honourNsswitch) {
+  if (!_honorNsswitch) {
     __nss_configure_lookup("hosts", "files dns");
     __nss_configure_lookup("passwd", "files");
     __nss_configure_lookup("group", "files");

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -80,7 +80,7 @@ void ConfigFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
 
   options->addOption(
       "--honour-nsswitch",
-      "Allow hostname lookup configuration via /etc/nsswtich.conf if on "
+      "Allow hostname lookup configuration via /etc/nsswitch.conf if on "
       "Linux/glibc.",
       new BooleanParameter(&_honourNsswitch),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -42,6 +42,12 @@
 
 #include <cstdlib>
 
+#ifdef __linux__
+#ifdef __GLIBC__
+#include <nss.h>
+#endif
+#endif
+
 using namespace arangodb::basics;
 using namespace arangodb::options;
 
@@ -71,6 +77,13 @@ void ConfigFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
       new BooleanParameter(&_checkConfiguration),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon,
                                           arangodb::options::Flags::Command));
+
+  options->addOption(
+      "--honour-nsswitch",
+      "Allow hostname lookup configuration via /etc/nsswtich.conf if on "
+      "Linux/glibc.",
+      new BooleanParameter(&_honourNsswitch),
+      arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
 }
 
 void ConfigFeature::loadOptions(std::shared_ptr<ProgramOptions> options,
@@ -250,4 +263,34 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
   }
 }
 
+void ConfigFeature::prepare() {
+#ifdef __linux__
+#ifdef __GLIBC__
+  // This code deserves and explanation.
+  // Our release builds use Ubuntu 24.04 with glibc 2.39.0 (at the time of this
+  // writing) and build static executables. This is all nice and convenient but
+  // it has one disadvantage: If host name lookups or user name lookups happen,
+  // the glibc uses the configuration file /etc/nsswitch.conf to decide how to
+  // do these lookups. This is a runtime configuration option of glibc.
+  // Unfortunately, glibc implements some of the options via dynamically loaded
+  // modules (notably mdns4_minimal via libnss_mdns4_minimal.so) and does not
+  // do versioned symbols for this.
+  // If this happens on a system with a different version of glibc installed
+  // (like for example an older Ubuntu system or a Debian or RedHat system),
+  // then glibc tries to dynamically load a module which does not fit and the
+  // process crashes with a high likelyhood. To prevent this, we use the
+  // (undocumented) override function below. This has the consequence that the
+  // host name lookup will always just use /etc/hosts and normal DNS lookup. And
+  // username lookup will always just use /etc/passwd, regardless of the system
+  // configuration. There is an opt-out for this in form of the configuration
+  // option --honour-nsswitch. Use this only if you are running on a system
+  // without glibc installed, or with glibc version 2.39.0.
+  if (!_honourNsswitch) {
+    __nss_configure_lookup("hosts", "files dns");
+    __nss_configure_lookup("passwd", "files");
+    __nss_configure_lookup("group", "files");
+  }
+#endif
+#endif
+}
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/ConfigFeature.h
+++ b/lib/ApplicationFeatures/ConfigFeature.h
@@ -54,7 +54,7 @@ class ConfigFeature final : public application_features::ApplicationFeature {
         _file(configFilename),
         _progname(progname),
         _checkConfiguration(false),
-        _honourNsswitch(false) {
+        _honorNsswitch(false) {
     static_assert(
         Server::template isCreatedAfter<ConfigFeature, VersionFeature>());
 
@@ -78,7 +78,7 @@ class ConfigFeature final : public application_features::ApplicationFeature {
   std::string _progname;
   std::vector<std::string> _defines;
   bool _checkConfiguration;
-  bool _honourNsswitch;  // If this is set to true, the internal override is
+  bool _honorNsswitch;  // If this is set to true, the internal override is
                          // deactivated.
 };
 

--- a/lib/ApplicationFeatures/ConfigFeature.h
+++ b/lib/ApplicationFeatures/ConfigFeature.h
@@ -79,7 +79,7 @@ class ConfigFeature final : public application_features::ApplicationFeature {
   std::vector<std::string> _defines;
   bool _checkConfiguration;
   bool _honorNsswitch;  // If this is set to true, the internal override is
-                         // deactivated.
+                        // deactivated.
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/ConfigFeature.h
+++ b/lib/ApplicationFeatures/ConfigFeature.h
@@ -53,7 +53,8 @@ class ConfigFeature final : public application_features::ApplicationFeature {
         }()},
         _file(configFilename),
         _progname(progname),
-        _checkConfiguration(false) {
+        _checkConfiguration(false),
+        _honourNsswitch(false) {
     static_assert(
         Server::template isCreatedAfter<ConfigFeature, VersionFeature>());
 
@@ -66,6 +67,8 @@ class ConfigFeature final : public application_features::ApplicationFeature {
   void loadOptions(std::shared_ptr<options::ProgramOptions>,
                    char const* binaryPath) override final;
 
+  void prepare() override final;
+
  private:
   void loadConfigFile(std::shared_ptr<options::ProgramOptions>,
                       std::string const& progname, char const* binaryPath);
@@ -75,6 +78,8 @@ class ConfigFeature final : public application_features::ApplicationFeature {
   std::string _progname;
   std::vector<std::string> _defines;
   bool _checkConfiguration;
+  bool _honourNsswitch;  // If this is set to true, the internal override is
+                         // deactivated.
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

This is the next try to solve the problems described in
  https://arangodb.atlassian.net/wiki/spaces/DEV/pages/2188673090/etc+nsswitch.conf+incompatibility+with+glibc+static+executables

This PR uses the function `__nss_configure_lookup` to opt out of the
usage of /etc/nsswitch.conf for host name lookup and for user lookup.
It hard codes the lookup to /etc/hosts and normal DNS lookup, as well
as to /etc/passwd and /etc/group. There is a command line switch to
disable this opt out.

Note that this is an unofficial functionality of glibc. We only use
it when building under Linux and with glibc. Future versions might
not support it although this seems unlikely since glibc uses it in their
own tests.

This should prevent crashes of our static executables on systems which
provide a different glibc version than the one we build with.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21144
  - [*] Backport for 3.12.1: https://github.com/arangodb/arangodb/pull/21135

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/wiki/spaces/DEV/pages/2188673090/etc+nsswitch.conf+incompatibility+with+glibc+static+executables
