### PR TITLE
Make sure we run any acceptor operations via the io_context

### DIFF
--- a/arangod/GeneralServer/AcceptorTcp.cpp
+++ b/arangod/GeneralServer/AcceptorTcp.cpp
@@ -114,13 +114,13 @@ void AcceptorTcp<T>::close() {
     _open = false;  // make sure the _open flag is `false` before we
                     // cancel/close the acceptor, since otherwise the
                     // handleError method will restart async_accept.
-    _acceptor.close();
+    _ctx.io_context.wrap([this]() { _acceptor.close(); });
   }
 }
 
 template<SocketType T>
 void AcceptorTcp<T>::cancel() {
-  _acceptor.cancel();
+  _ctx.io_context.wrap([this]() { _acceptor.cancel(); });
 }
 
 template<>


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21131

During shutdown we previously simply closed the acceptors, not considering that we may still have active IO threads operating on the same acceptor instances. To avoid data races and other issues, we now perform these operations via the io_context.

- [x] :hankey: Bugfix

- [x] Backports
  - [x] Backport for 3.11: #21132 21132
