### PR TITLE
fix two issues with late materialization

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,12 @@ devel
 3.12.1 (XXXX-XX-XX)
 -------------------
 
+* Fix issues with late materialization being sometimes implicitly dependent on
+  the optimizer rule "optimize-projections" being enabled. Now disable some
+  late materialization optimizations in case this rule is not active.
+  Also fix a specific case in which no results were being materialized in case
+  the optimizer rule "optimize-projections" was disabled.
+
 * Fix serialization of multiple query plans using the `allPlans: true` hint
   when run `explain` on a query.
 

--- a/arangod/Aql/Executor/MaterializeExecutor.cpp
+++ b/arangod/Aql/Executor/MaterializeExecutor.cpp
@@ -104,6 +104,8 @@ MaterializeRocksDBExecutor::produceRows(AqlItemBlockInputRange& inputRange,
             _projectionsBuilder.openObject(true);
             proj.toVelocyPackFromDocument(_projectionsBuilder, doc, &_trx);
             _projectionsBuilder.close();
+            output.moveValueInto(docOutReg, *inputRowIterator,
+                                 _projectionsBuilder.slice());
           }
         } else {
           if (data) {

--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleBatchMaterializeDocuments.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleBatchMaterializeDocuments.cpp
@@ -67,6 +67,7 @@ void arangodb::aql::batchMaterializeDocumentsRule(
     Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
     OptimizerRule const& rule) {
   bool modified = false;
+
   containers::SmallVector<ExecutionNode*, 8> indexes;
   plan->findNodesOfType(indexes, EN::INDEX, /* enterSubqueries */ true);
 

--- a/tests/js/client/aql/aql-index-batch-materialize.js
+++ b/tests/js/client/aql/aql-index-batch-materialize.js
@@ -53,7 +53,7 @@ function IndexBatchMaterializeTestSuite() {
   function fillCollection(c, n) {
     let docs = [];
     for (let i = 0; i < n; i++) {
-      docs.push({x: i, y: 2 * i, z: 2 * i + 1, w: i % 10, u: i, b: i + 1, p: i, q: i});
+      docs.push({x: i, y: 2 * i, z: 2 * i + 1, w: i % 10, u: i, b: i + 1, p: i, q: i, r: i});
     }
     c.insert(docs);
   }
@@ -437,6 +437,22 @@ function IndexBatchMaterializeTestSuite() {
       const {indexNode} = expectOptimization(query);
       assertTrue(indexNode.indexCoversFilterProjections);
       assertEqual(normalize(indexNode.filterProjections), [["b"]]);
+    },
+    
+    testMaterializeIndexScanNoProjectionOptimization: function () {
+      const query = `
+        FOR doc IN ${collection}
+          FILTER doc.x > 5
+          RETURN doc.r
+      `;
+
+      expectOptimization(query, {optimizer: {rules: ["-optimize-projections"] } });
+
+      let results = db._query(query).toArray();
+      results = _.sortBy(results); 
+      for (let i = 0; i < results.length; ++i) {
+        assertEqual(results[i], i + 6);
+      }
     },
   };
 }

--- a/tests/js/client/aql/aql-optimizer-rule-late-document-materialization.js
+++ b/tests/js/client/aql/aql-optimizer-rule-late-document-materialization.js
@@ -495,6 +495,16 @@ function lateDocumentMaterializationRuleTestSuite () {
       assertEqual(1, result.length);
       assertEqual(result[0]._key, 'c0');
     },
+    testQueryResultsPrefixEarlyPruningNoOptimizeProjections() {
+      const options = {optimizer: {rules: ["-optimize-projections"] } };
+      let query = "FOR d IN " + prefixIndexCollectionName + " FILTER d.obj.b == {sb: 'b_val_0'} SORT d.obj.b LIMIT 10 RETURN d";
+      let plan = db._createStatement({query, options}).explain().plan;
+      assertNotEqual(-1, plan.rules.indexOf(ruleName));
+      assertNotEqual(-1, plan.rules.indexOf(earlyPruningRuleName));
+      let result = db._query(query, null, options).toArray();
+      assertEqual(1, result.length);
+      assertEqual(result[0]._key, 'c0');
+    },
     testConstrainedSortOnDbServer() {
       let query = "FOR d IN " + prefixIndexCollectionName  + " FILTER d.obj.b == {sb: 'b_val_0'} " +
                   "SORT d.obj.b LIMIT 10 RETURN {key: d._key, value:  d.some_value_from_doc}";


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21138

Fix issues with late materialization optimizer rules that depend on the optimize-projections rule to also run.
Also fix a case in which the late materialization actually produced no output values.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 