### PR TITLE
Check projections when optimizing for joins.

### DIFF
--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -831,6 +831,34 @@ const IndexJoinTestSuite = function () {
       assertEqual(nodes.indexOf("JoinNode"), -1);
     },
 
+    testJoinWithPrimaryIndexProjections: function () {
+      const A = createCollection("A", ["_key"]);
+      fillCollection("A", singleAttributeGenerator(20, "_key", x => `${x}`));
+      A.ensureIndex({type: "persistent", fields: ["x", "y"]});
+      const documentIdsOfA = [];
+      A.all().toArray().forEach((document) => {
+        documentIdsOfA.push(document._id);
+      });
+      fillEdgeCollectionWith("B", documentIdsOfA);
+
+      const query = `
+          FOR doc1 IN A
+          SORT doc1._key
+            FOR doc2 IN B
+            FILTER doc1._key == doc2.x
+            RETURN [doc1, doc2.x, doc1._id]
+        `;
+
+      // Testing with edge index based on `_from` attribute
+      let plan = db._createStatement({
+        query: query,
+        bindVars: null,
+        options: queryOptions
+      }).explain().plan;
+      let nodes = plan.nodes.map(x => x.type);
+      assertEqual(nodes.indexOf("JoinNode"), -1);
+    },
+
     testJoinMultipleJoins: function () {
       const A1 = createCollection("A1", ["x"], "prototype1");
       A1.ensureIndex({type: "persistent", fields: ["x"]});

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -841,6 +841,8 @@ const IndexJoinTestSuite = function () {
       });
       fillEdgeCollectionWith("B", documentIdsOfA);
 
+      // Using the attribute _id causes the primary index to reject the streaming request.
+      // Thus, we expect no join to be created.
       const query = `
           FOR doc1 IN A
           SORT doc1._key
@@ -849,7 +851,6 @@ const IndexJoinTestSuite = function () {
             RETURN [doc1, doc2.x, doc1._id]
         `;
 
-      // Testing with edge index based on `_from` attribute
       let plan = db._createStatement({
         query: query,
         bindVars: null,


### PR DESCRIPTION
### Scope & Purpose

This PR adds a missing check, if the index supports streaming with the required projections. This check was missing and caused an internal error later, when the streams were constructed.

In particular the PrimaryIndex does not support projecting the `_id` attribute in streaming mode. (We should fix that in the future)