### PR TITLE
fix AQL ENTRIES function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix an "invalid document type" exception when using the AQL ENTRIES function
+  on a database document or edge.
+
 * Updated ArangoDB Starter to v0.19.3.
 
 * Fixed MDS-1216: restoring the previous value of the "padded" key generator

--- a/arangod/Aql/Function/ObjectFunctions.cpp
+++ b/arangod/Aql/Function/ObjectFunctions.cpp
@@ -30,6 +30,7 @@
 #include "Basics/Exceptions.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/fpconv.h"
+#include "Basics/StaticStrings.h"
 #include "Containers/FlatHashMap.h"
 #include "Containers/FlatHashSet.h"
 #include "Transaction/Context.h"
@@ -802,6 +803,8 @@ AqlValue functions::Entries(ExpressionContext* expressionContext,
     VPackArrayBuilder pair(builder.get(), true);
     builder->add(key);
     if (value.isCustom()) {
+      TRI_ASSERT(key.stringView() == StaticStrings::IdString)
+          << "found custom value for key " << key.toJson();
       builder->add(VPackValue(transaction::helpers::extractIdString(
           trx->resolver(), value, objectSlice)));
     } else {

--- a/arangod/Aql/Function/ObjectFunctions.cpp
+++ b/arangod/Aql/Function/ObjectFunctions.cpp
@@ -801,7 +801,12 @@ AqlValue functions::Entries(ExpressionContext* expressionContext,
   for (auto [key, value] : VPackObjectIterator(objectSlice, true)) {
     VPackArrayBuilder pair(builder.get(), true);
     builder->add(key);
-    builder->add(value);
+    if (value.isCustom()) {
+      builder->add(VPackValue(transaction::helpers::extractIdString(
+          trx->resolver(), value, objectSlice)));
+    } else {
+      builder->add(value);
+    }
   }
 
   builder->close();

--- a/tests/js/client/aql/aql-functions.js
+++ b/tests/js/client/aql/aql-functions.js
@@ -2574,6 +2574,24 @@ function ahuacatlFunctionsTestSuite () {
         assertEqual(Object.entries(value), actual[0], value);
       });
     },
+    
+    testOnDocuments: function () {
+      const cn = "UnitTestsCollection";
+
+      let expected = [];
+      let c = db._create(cn);
+      try {
+        for (let i = 0; i < 10; ++i) {
+          c.insert({ ["value" + i]: i, _key: "value" + i });
+          expected.push(["_id", cn + "/value" + i]);
+        }
+
+        let result = db._query(`FOR doc IN ${cn} SORT doc._key FOR entry IN ENTRIES(doc) FILTER entry[0] == '_id' RETURN entry`).toArray();
+        assertEqual(result, expected);
+      } finally {
+        db._drop(cn);
+      }
+    },
 
     testEntriesInvalid : function () {
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN ENTRIES()");


### PR DESCRIPTION
### Scope & Purpose

Fix "invalid document type" exception when applying the AQL ENTRIES function on a database document/edge.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 