### PR TITLE
BindParameters to Variables

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2219,6 +2219,7 @@ void Ast::injectBindParametersSecondStage(BindParameters& parameters) {
       }
       return node;
     };
+
     _root = traverseAndModify(_root, func);
   }
 }
@@ -2258,6 +2259,7 @@ AstNode* Ast::replaceValueBindParameter(AstNode* node,
   } else {
     // bind parameter containing a value literal. not processed before.
     node = nodeFromVPack(value, true);
+
     if (node != nullptr) {
       if (constantParameter) {
         // already mark node as constant here if parameters are constant

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2228,7 +2228,7 @@ void Ast::replaceBindParametersWithValues(BindParameters& parameters) {
 /// (i.e. all value bind parameters)
 void Ast::injectBindParametersSecondStage(BindParameters& parameters) {
   if (_containsBindParameters) {
-    if (query().queryOptions().cachePlan) {
+    if (query().queryOptions().optimizePlanForCaching) {
       replaceBindParametersWithVariables(parameters);
     } else {
       // put in value bind parameters.

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2209,7 +2209,7 @@ void Ast::replaceBindParametersWithVariables(BindParameters& parameters) {
 
 /// @brief injects second-stage bind parameter values into the AST
 /// (i.e. all value bind parameters)
-void Ast::injectBindParametersSecondStage(BindParameters& parameters) {
+void Ast::replaceBindParametersWithValues(BindParameters& parameters) {
   if (_containsBindParameters) {
     auto func = [&](AstNode* node) -> AstNode* {
       if (node->type == NODE_TYPE_PARAMETER) {
@@ -2221,6 +2221,19 @@ void Ast::injectBindParametersSecondStage(BindParameters& parameters) {
     };
 
     _root = traverseAndModify(_root, func);
+  }
+}
+
+/// @brief injects second-stage bind parameter values into the AST
+/// (i.e. all value bind parameters)
+void Ast::injectBindParametersSecondStage(BindParameters& parameters) {
+  if (_containsBindParameters) {
+    if (query().queryOptions().cachePlan) {
+      replaceBindParametersWithVariables(parameters);
+    } else {
+      // put in value bind parameters.
+      replaceBindParametersWithValues(parameters);
+    }
   }
 }
 
@@ -4433,8 +4446,7 @@ std::unordered_set<std::string> Ast::bindParameterNames() const {
   return std::unordered_set<std::string>(_bindParameters);
 }
 
-std::unordered_map<std::string_view, Variable const*>
-Ast::bindParameterVariables() const {
+BindParameterVariableMapping Ast::bindParameterVariables() const {
   return _bindParameterVariables;
 }
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -136,8 +136,7 @@ class Ast {
   /// @brief return a copy of our own bind parameters
   std::unordered_set<std::string> bindParameterNames() const;
 
-  std::unordered_map<std::string_view, Variable const*> bindParameterVariables()
-      const;
+  BindParameterVariableMapping bindParameterVariables() const;
 
   /// @brief get the query scopes
   Scopes* scopes();
@@ -466,6 +465,10 @@ class Ast {
   /// for query plan caching.
   void replaceBindParametersWithVariables(BindParameters& parameters);
 
+  /// @brief replaces bind parameters with special variables. This is used
+  /// for query plan caching.
+  void replaceBindParametersWithValues(BindParameters& parameters);
+
   /// @brief replace variables
   ///        the unlock parameter will unlock the variable node before it
   ///        replaces the variable. This unlock is potentially dangerous if the
@@ -759,7 +762,7 @@ class Ast {
   AstPropertiesFlagsType _astFlags;
 
   /// @brief variables that bind parameters were replaced with
-  std::unordered_map<std::string_view, Variable const*> _bindParameterVariables;
+  BindParameterVariableMapping _bindParameterVariables;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -134,7 +134,10 @@ class Ast {
   bool isInSubQuery() const noexcept;
 
   /// @brief return a copy of our own bind parameters
-  std::unordered_set<std::string> bindParameters() const;
+  std::unordered_set<std::string> bindParametersAsBuilder() const;
+
+  std::unordered_map<std::string_view, Variable const*> bindParameterVariables()
+      const;
 
   /// @brief get the query scopes
   Scopes* scopes();
@@ -750,6 +753,9 @@ class Ast {
 
   /// @brief ast flags
   AstPropertiesFlagsType _astFlags;
+
+  /// @brief variables that bind parameters were replaced with
+  std::unordered_map<std::string_view, Variable const*> _bindParameterVariables;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -134,7 +134,7 @@ class Ast {
   bool isInSubQuery() const noexcept;
 
   /// @brief return a copy of our own bind parameters
-  std::unordered_set<std::string> bindParametersAsBuilder() const;
+  std::unordered_set<std::string> bindParameterNames() const;
 
   std::unordered_map<std::string_view, Variable const*> bindParameterVariables()
       const;
@@ -461,6 +461,10 @@ class Ast {
   /// @brief injects second-stage bind parameter values into the AST
   /// (i.e. all value bind parameters)
   void injectBindParametersSecondStage(BindParameters& parameters);
+
+  /// @brief replaces bind parameters with special variables. This is used
+  /// for query plan caching.
+  void replaceBindParametersWithVariables(BindParameters& parameters);
 
   /// @brief replace variables
   ///        the unlock parameter will unlock the variable node before it

--- a/arangod/Aql/AstNode.cpp
+++ b/arangod/Aql/AstNode.cpp
@@ -1015,7 +1015,7 @@ bool AstNode::valueHasVelocyPackRepresentation() const {
 /// @brief build a VelocyPack representation of the node value
 ///        Can throw Out of Memory Error
 void AstNode::toVelocyPackValue(VPackBuilder& builder) const {
-  TRI_ASSERT(valueHasVelocyPackRepresentation());
+  TRI_ASSERT(valueHasVelocyPackRepresentation()) << this->toString();
   if (type == NODE_TYPE_VALUE) {
     // dump value of "value" node
     switch (value.type) {

--- a/arangod/Aql/ClusterQuery.h
+++ b/arangod/Aql/ClusterQuery.h
@@ -41,8 +41,8 @@ class ClusterQuery : public Query {
   /// Used to construct a cluster query. the constructor is protected to ensure
   /// that call sites only create ClusterQuery objects using the `create`
   /// factory method
-  ClusterQuery(QueryId id, std::shared_ptr<transaction::Context> ctx,
-               QueryOptions options);
+  ClusterQuery(QueryId id, std::shared_ptr<velocypack::Builder> bindParameters,
+               std::shared_ptr<transaction::Context> ctx, QueryOptions options);
 
   ~ClusterQuery() override;
 
@@ -50,8 +50,8 @@ class ClusterQuery : public Query {
   /// @brief factory method for creating a cluster query. this must be used to
   /// ensure that ClusterQuery objects are always created using shared_ptrs.
   static std::shared_ptr<ClusterQuery> create(
-      QueryId id, std::shared_ptr<transaction::Context> ctx,
-      QueryOptions options);
+      QueryId id, std::shared_ptr<velocypack::Builder> bindParameters,
+      std::shared_ptr<transaction::Context> ctx, QueryOptions options);
 
   /// @brief prepare a query out of some velocypack data.
   /// only to be used on a DB server.

--- a/arangod/Aql/DocumentExpressionContext.cpp
+++ b/arangod/Aql/DocumentExpressionContext.cpp
@@ -92,7 +92,8 @@ AqlValue GenericDocumentExpressionContext::getVariableValue(
             << ") not found";
         if (ADB_LIKELY(regId != RegisterId::maxRegisterId)) {
           // we can only get here in a post-filter expression
-          TRI_ASSERT(regId < _inputRow.getNumRegisters())
+          TRI_ASSERT(regId.isConstRegister() ||
+                     regId < _inputRow.getNumRegisters())
               << "variable " << variable->name << " (" << variable->id
               << "), register " << regId.value() << " not found";
           if (doCopy) {

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -176,6 +176,10 @@ std::vector<bool> EngineInfoContainerDBServerServerBased::buildEngineInfo(
   infoBuilder.add(StaticStrings::AttrCoordinatorId,
                   VPackValue(ServerState::instance()->getId()));
 
+  if (_query.queryOptions().cachePlan) {
+    infoBuilder.add("bindParameters", q->bindParametersAsBuilder()->slice());
+  }
+
   addSnippetPart(nodesById, infoBuilder, _shardLocking, nodeAliases, server);
   TRI_ASSERT(infoBuilder.isOpenObject());
   auto shardMapping = _shardLocking.getShardMapping();

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -176,7 +176,7 @@ std::vector<bool> EngineInfoContainerDBServerServerBased::buildEngineInfo(
   infoBuilder.add(StaticStrings::AttrCoordinatorId,
                   VPackValue(ServerState::instance()->getId()));
 
-  if (_query.queryOptions().cachePlan) {
+  if (_query.queryOptions().optimizePlanForCaching) {
     infoBuilder.add("bindParameters", q->bindParametersAsBuilder()->slice());
   }
 

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -871,8 +871,6 @@ void ExecutionEngine::initializeConstValueBlock(
               block->emplaceValue(0, reg.value(), AqlValue(value.slice()));
             }
           } else if (var->type() == Variable::Type::BindParameter) {
-            LOG_DEVEL << "CONSTANT REGISTER BIND VARIABLE "
-                      << var->bindParameterName();
             RegisterId reg = regPlan->variableToOptionalRegisterId(var->id);
             if (reg.value() != RegisterId::maxRegisterId) {
               auto [slice, node] = bindParameters.get(var->bindParameterName());
@@ -880,7 +878,6 @@ void ExecutionEngine::initializeConstValueBlock(
                 THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_BIND_PARAMETER_MISSING);
               }
 
-              LOG_DEVEL << var->bindParameterName() << " = " << slice.toJson();
               block->emplaceValue(0, reg.value(), AqlValue(slice));
             }
           }

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -736,7 +736,7 @@ void ExecutionEngine::instantiateFromPlan(Query& query, ExecutionPlan& plan,
 #endif
 
   auto& mgr = query.itemBlockManager();
-  initializeConstValueBlock(plan, mgr);
+  initializeConstValueBlock(plan, query.bindParameters(), mgr);
 
   aql::SnippetList& snippets = query.snippets();
   TRI_ASSERT(snippets.empty() || ServerState::instance()->isClusterRole(role));
@@ -841,7 +841,8 @@ void arangodb::aql::ExecutionEngine::initFromPlanForCalculation(
     ExecutionPlan& plan) {
   plan.findVarUsage();
   plan.planRegisters(ExplainRegisterPlan::No);
-  initializeConstValueBlock(plan, _itemBlockManager);
+  initializeConstValueBlock(plan, BindParameters{_query.resourceMonitor()},
+                            _itemBlockManager);
 
   SingleServerQueryInstanciator inst(*this);
   plan.root()->walk(inst);
@@ -849,17 +850,18 @@ void arangodb::aql::ExecutionEngine::initFromPlanForCalculation(
   setupEngineRoot(*inst.root);
 }
 
-void ExecutionEngine::initializeConstValueBlock(ExecutionPlan& plan,
-                                                AqlItemBlockManager& mgr) {
+void ExecutionEngine::initializeConstValueBlock(
+    ExecutionPlan& plan, BindParameters const& bindParameters,
+    AqlItemBlockManager& mgr) {
   auto registerPlan = plan.root()->getRegisterPlan();
   auto nrConstRegs = registerPlan->nrConstRegs;
   if (nrConstRegs > 0 && mgr.getConstValueBlock() == nullptr) {
     mgr.initializeConstValueBlock(nrConstRegs);
     plan.getAst()->variables()->visit(
-        [plan = plan.root()->getRegisterPlan(),
+        [&, regPlan = plan.root()->getRegisterPlan(),
          block = mgr.getConstValueBlock()](Variable* var) {
           if (var->type() == Variable::Type::Const) {
-            RegisterId reg = plan->variableToOptionalRegisterId(var->id);
+            RegisterId reg = regPlan->variableToOptionalRegisterId(var->id);
             if (reg.value() != RegisterId::maxRegisterId) {
               TRI_ASSERT(reg.isConstRegister());
               AqlValue value = var->constantValue();
@@ -867,6 +869,19 @@ void ExecutionEngine::initializeConstValueBlock(ExecutionPlan& plan,
               // the constValueBlock takes ownership, so we have to create a
               // copy here.
               block->emplaceValue(0, reg.value(), AqlValue(value.slice()));
+            }
+          } else if (var->type() == Variable::Type::BindParameter) {
+            LOG_DEVEL << "CONSTANT REGISTER BIND VARIABLE "
+                      << var->bindParameterName();
+            RegisterId reg = regPlan->variableToOptionalRegisterId(var->id);
+            if (reg.value() != RegisterId::maxRegisterId) {
+              auto [slice, node] = bindParameters.get(var->bindParameterName());
+              if (slice.isNone()) {
+                THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_BIND_PARAMETER_MISSING);
+              }
+
+              LOG_DEVEL << var->bindParameterName() << " = " << slice.toJson();
+              block->emplaceValue(0, reg.value(), AqlValue(slice));
             }
           }
         });

--- a/arangod/Aql/ExecutionEngine.h
+++ b/arangod/Aql/ExecutionEngine.h
@@ -42,6 +42,7 @@ namespace arangodb::aql {
 class AqlCallStack;
 class AqlItemBlock;
 class AqlItemBlockManager;
+class BindParameters;
 class ExecutionBlock;
 class ExecutionNode;
 class ExecutionPlan;
@@ -152,6 +153,7 @@ class ExecutionEngine {
   void setupEngineRoot(ExecutionBlock& planRoot);
 
   static void initializeConstValueBlock(ExecutionPlan& plan,
+                                        BindParameters const& bindParameters,
                                         AqlItemBlockManager& mgr);
 
   EngineId const _engineId;

--- a/arangod/Aql/ExecutionNode/SingletonNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingletonNode.cpp
@@ -33,18 +33,20 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 
-SingletonNode::SingletonNode(
-    ExecutionPlan* plan, ExecutionNodeId id,
-    std::unordered_map<std::string_view, Variable const*> bindParameterOutVars)
+SingletonNode::SingletonNode(ExecutionPlan* plan, ExecutionNodeId id,
+                             BindParameterVariableMapping bindParameterOutVars)
     : ExecutionNode(plan, id),
       _bindParameterOutVars(std::move(bindParameterOutVars)) {}
+
+SingletonNode::SingletonNode(ExecutionPlan* plan, ExecutionNodeId id)
+    : ExecutionNode(plan, id) {}
 
 SingletonNode::SingletonNode(ExecutionPlan* plan,
                              arangodb::velocypack::Slice base)
     : ExecutionNode(plan, base) {
   if (auto bindVars = base.get("bindParameterVariables"); !bindVars.isNone()) {
     for (auto [key, value] : VPackObjectIterator(bindVars)) {
-      _bindParameterOutVars[key.stringView()] =
+      _bindParameterOutVars[key.copyString()] =
           Variable::varFromVPack(plan->getAst(), base, key.stringView());
     }
   }

--- a/arangod/Aql/ExecutionNode/SingletonNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingletonNode.cpp
@@ -47,7 +47,7 @@ SingletonNode::SingletonNode(ExecutionPlan* plan,
   if (auto bindVars = base.get("bindParameterVariables"); !bindVars.isNone()) {
     for (auto [key, value] : VPackObjectIterator(bindVars)) {
       _bindParameterOutVars[key.copyString()] =
-          Variable::varFromVPack(plan->getAst(), base, key.stringView());
+          Variable::varFromVPack(plan->getAst(), bindVars, key.stringView());
     }
   }
 }

--- a/arangod/Aql/ExecutionNode/SingletonNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingletonNode.cpp
@@ -33,12 +33,22 @@
 using namespace arangodb;
 using namespace arangodb::aql;
 
-SingletonNode::SingletonNode(ExecutionPlan* plan, ExecutionNodeId id)
-    : ExecutionNode(plan, id) {}
+SingletonNode::SingletonNode(
+    ExecutionPlan* plan, ExecutionNodeId id,
+    std::unordered_map<std::string_view, Variable const*> bindParameterOutVars)
+    : ExecutionNode(plan, id),
+      _bindParameterOutVars(std::move(bindParameterOutVars)) {}
 
 SingletonNode::SingletonNode(ExecutionPlan* plan,
                              arangodb::velocypack::Slice base)
-    : ExecutionNode(plan, base) {}
+    : ExecutionNode(plan, base) {
+  if (auto bindVars = base.get("bindParameterVariables"); !bindVars.isNone()) {
+    for (auto [key, value] : VPackObjectIterator(bindVars)) {
+      _bindParameterOutVars[key.stringView()] =
+          Variable::varFromVPack(plan->getAst(), base, key.stringView());
+    }
+  }
+}
 
 /// @brief creates corresponding ExecutionBlock
 std::unique_ptr<ExecutionBlock> SingletonNode::createBlock(
@@ -56,13 +66,21 @@ std::unique_ptr<ExecutionBlock> SingletonNode::createBlock(
 /// @brief clone ExecutionNode recursively
 ExecutionNode* SingletonNode::clone(ExecutionPlan* plan,
                                     bool withDependencies) const {
-  return cloneHelper(std::make_unique<SingletonNode>(plan, _id),
-                     withDependencies);
+  return cloneHelper(
+      std::make_unique<SingletonNode>(plan, _id, _bindParameterOutVars),
+      withDependencies);
 }
 
 /// @brief doToVelocyPack, for SingletonNode
-void SingletonNode::doToVelocyPack(velocypack::Builder&, unsigned) const {
-  // nothing to do here!
+void SingletonNode::doToVelocyPack(velocypack::Builder& builder,
+                                   unsigned) const {
+  builder.add(VPackValue("bindParameterVariables"));
+  builder.openObject();
+  for (auto const& [name, var] : _bindParameterOutVars) {
+    builder.add(VPackValue(name));
+    var->toVelocyPack(builder);
+  }
+  builder.close();
 }
 
 /// @brief the cost of a singleton is 1, it produces one item only
@@ -83,3 +101,12 @@ AsyncPrefetchEligibility SingletonNode::canUseAsyncPrefetching()
 ExecutionNode::NodeType SingletonNode::getType() const { return SINGLETON; }
 
 size_t SingletonNode::getMemoryUsedBytes() const { return sizeof(*this); }
+
+std::vector<const Variable*> SingletonNode::getVariablesSetHere() const {
+  std::vector<const Variable*> result;
+  result.reserve(_bindParameterOutVars.size());
+  std::transform(_bindParameterOutVars.begin(), _bindParameterOutVars.end(),
+                 std::back_inserter(result),
+                 [](auto const& pair) { return pair.second; });
+  return result;
+}

--- a/arangod/Aql/ExecutionNode/SingletonNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingletonNode.cpp
@@ -45,7 +45,7 @@ SingletonNode::SingletonNode(ExecutionPlan* plan,
                              arangodb::velocypack::Slice base)
     : ExecutionNode(plan, base) {
   if (auto bindVars = base.get("bindParameterVariables"); !bindVars.isNone()) {
-    for (auto [key, value] : VPackObjectIterator(bindVars)) {
+    for (auto [key, value] : VPackObjectIterator(bindVars, true)) {
       _bindParameterOutVars[key.copyString()] =
           Variable::varFromVPack(plan->getAst(), bindVars, key.stringView());
     }

--- a/arangod/Aql/ExecutionNode/SingletonNode.h
+++ b/arangod/Aql/ExecutionNode/SingletonNode.h
@@ -45,7 +45,9 @@ class SingletonNode : public ExecutionNode {
 
   /// @brief constructor with an id
  public:
-  SingletonNode(ExecutionPlan* plan, ExecutionNodeId id);
+  SingletonNode(ExecutionPlan* plan, ExecutionNodeId id,
+                std::unordered_map<std::string_view, Variable const*>
+                    bindParameterOutVars);
 
   SingletonNode(ExecutionPlan* plan, arangodb::velocypack::Slice base);
 
@@ -69,10 +71,14 @@ class SingletonNode : public ExecutionNode {
   AsyncPrefetchEligibility canUseAsyncPrefetching()
       const noexcept override final;
 
+  std::vector<const Variable*> getVariablesSetHere() const override;
+
  protected:
   /// @brief export to VelocyPack
   void doToVelocyPack(arangodb::velocypack::Builder&,
                       unsigned flags) const override final;
+
+  std::unordered_map<std::string_view, Variable const*> _bindParameterOutVars;
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionNode/SingletonNode.h
+++ b/arangod/Aql/ExecutionNode/SingletonNode.h
@@ -46,8 +46,8 @@ class SingletonNode : public ExecutionNode {
   /// @brief constructor with an id
  public:
   SingletonNode(ExecutionPlan* plan, ExecutionNodeId id,
-                std::unordered_map<std::string_view, Variable const*>
-                    bindParameterOutVars);
+                BindParameterVariableMapping bindParameterOutVars);
+  SingletonNode(ExecutionPlan* plan, ExecutionNodeId id);
 
   SingletonNode(ExecutionPlan* plan, arangodb::velocypack::Slice base);
 
@@ -78,7 +78,7 @@ class SingletonNode : public ExecutionNode {
   void doToVelocyPack(arangodb::velocypack::Builder&,
                       unsigned flags) const override final;
 
-  std::unordered_map<std::string_view, Variable const*> _bindParameterOutVars;
+  BindParameterVariableMapping _bindParameterOutVars;
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2406,7 +2406,8 @@ ExecutionNode* ExecutionPlan::fromNodeWindow(ExecutionNode* previous,
 ExecutionNode* ExecutionPlan::fromNode(AstNode const* node) {
   TRI_ASSERT(node != nullptr);
 
-  ExecutionNode* en = createNode<SingletonNode>(this, nextId());
+  ExecutionNode* en =
+      createNode<SingletonNode>(this, nextId(), _ast->bindParameterVariables());
 
   size_t const n = node->numMembers();
 

--- a/arangod/Aql/Optimizer/Rule/OptimizerRulesReplaceFunctions.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRulesReplaceFunctions.cpp
@@ -161,8 +161,8 @@ AstNode* createSubqueryWithLimit(ExecutionPlan* plan, ExecutionNode* node,
   auto* ast = plan->getAst();
 
   /// singleton
-  ExecutionNode* eSingleton =
-      plan->createNode<SingletonNode>(plan, plan->nextId());
+  ExecutionNode* eSingleton = plan->createNode<SingletonNode>(
+      plan, plan->nextId(), ast->bindParameterVariables());
 
   /// return
   /// link output of index with the return node

--- a/arangod/Aql/Parser.cpp
+++ b/arangod/Aql/Parser.cpp
@@ -136,7 +136,7 @@ QueryResult Parser::parseWithDetails() {
 
   QueryResult result;
   result.collectionNames = _query.collections().collectionNames();
-  result.bindParameters = _ast.bindParametersAsBuilder();
+  result.bindParameters = _ast.bindParameterNames();
   auto builder = std::make_shared<VPackBuilder>();
   _ast.toVelocyPack(*builder, false);
   result.data = std::move(builder);

--- a/arangod/Aql/Parser.cpp
+++ b/arangod/Aql/Parser.cpp
@@ -136,7 +136,7 @@ QueryResult Parser::parseWithDetails() {
 
   QueryResult result;
   result.collectionNames = _query.collections().collectionNames();
-  result.bindParameters = _ast.bindParameters();
+  result.bindParameters = _ast.bindParametersAsBuilder();
   auto builder = std::make_shared<VPackBuilder>();
   _ast.toVelocyPack(*builder, false);
   result.data = std::move(builder);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -564,7 +564,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
         if (useQueryCache) {
           // check the query cache for an existing result
           auto cacheEntry = QueryCache::instance()->lookup(
-              &_vocbase, hash(), _queryString, bindParameters());
+              &_vocbase, hash(), _queryString, bindParametersAsBuilder());
 
           if (cacheEntry != nullptr) {
             if (cacheEntry->currentUserHasPermissions()) {
@@ -687,7 +687,7 @@ ExecutionState Query::execute(QueryResult& queryResult) {
 
           // create a query cache entry for later storage
           _cacheEntry = std::make_unique<QueryCacheResultEntry>(
-              hash(), _queryString, queryResult.data, bindParameters(),
+              hash(), _queryString, queryResult.data, bindParametersAsBuilder(),
               std::move(dataSources)  // query DataSources
           );
         }
@@ -791,7 +791,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
     if (useQueryCache) {
       // check the query cache for an existing result
       auto cacheEntry = QueryCache::instance()->lookup(
-          &_vocbase, hash(), _queryString, bindParameters());
+          &_vocbase, hash(), _queryString, bindParametersAsBuilder());
 
       if (cacheEntry != nullptr) {
         if (cacheEntry->currentUserHasPermissions()) {
@@ -934,7 +934,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
 
       // create a cache entry for later usage
       _cacheEntry = std::make_unique<QueryCacheResultEntry>(
-          hash(), _queryString, builder, bindParameters(),
+          hash(), _queryString, builder, bindParametersAsBuilder(),
           std::move(dataSources)  // query DataSources
       );
     }
@@ -1499,7 +1499,7 @@ std::string Query::extractQueryString(size_t maxLength, bool show) const {
 
 void Query::stringifyBindParameters(std::string& out, std::string_view prefix,
                                     size_t maxLength) const {
-  auto bp = bindParameters();
+  auto bp = bindParametersAsBuilder();
   if (bp != nullptr && !bp->slice().isNone() && maxLength >= 3) {
     // append prefix, e.g. "bind parameters: "
     out.append(prefix);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1386,7 +1386,8 @@ void Query::init(bool createProfile) {
 
   TRI_ASSERT(_ast == nullptr);
   AstPropertiesFlagsType flags = AstPropertyFlag::AST_FLAG_DEFAULT;
-  if (_queryOptions.cachePlan) {
+  // Create a plan that can be executed with different sets of bind parameters.
+  if (_queryOptions.optimizePlanForCaching) {
     flags |= AstPropertyFlag::NON_CONST_PARAMETERS;
   }
   _ast = std::make_unique<Ast>(*this, flags);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -468,12 +468,10 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   // doc.@attr).
   _ast->injectBindParametersFirstStage(_bindParameters, this->resolver());
 
-  bool constexpr enableCaching = true;
-
-  // put in value bind parameters.
-  if (enableCaching) {
+  if (_queryOptions.cachePlan) {
     _ast->replaceBindParametersWithVariables(_bindParameters);
   } else {
+    // put in value bind parameters.
     _ast->injectBindParametersSecondStage(_bindParameters);
   }
 
@@ -1084,7 +1082,12 @@ QueryResult Query::explain() {
     // put in bind parameters
     parser.ast()->injectBindParametersFirstStage(_bindParameters,
                                                  this->resolver());
-    parser.ast()->injectBindParametersSecondStage(_bindParameters);
+    if (_queryOptions.cachePlan) {
+      _ast->replaceBindParametersWithVariables(_bindParameters);
+    } else {
+      // put in value bind parameters.
+      _ast->injectBindParametersSecondStage(_bindParameters);
+    }
     _bindParameters.validateAllUsed();
 
     // optimize and validate the ast

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -468,10 +468,14 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
   // doc.@attr).
   _ast->injectBindParametersFirstStage(_bindParameters, this->resolver());
 
-  // put in value bind parameters. TODO: move this further down in the process,
-  // so that the optimizer can run with value bind parameters still unreplaced
-  // in the AST.
-  _ast->injectBindParametersSecondStage(_bindParameters);
+  bool constexpr enableCaching = true;
+
+  // put in value bind parameters.
+  if (enableCaching) {
+    _ast->replaceBindParametersWithVariables(_bindParameters);
+  } else {
+    _ast->injectBindParametersSecondStage(_bindParameters);
+  }
 
   if (parser.ast()->containsUpsertNode()) {
     // UPSERTs and intermediate commits do not play nice together, because the

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -204,9 +204,10 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   ErrorCode resultCode() const noexcept;
 
   /// @brief return the bind parameters as passed by the user
-  std::shared_ptr<velocypack::Builder> bindParameters() const {
+  std::shared_ptr<velocypack::Builder> bindParametersAsBuilder() const {
     return _bindParameters.builder();
   }
+  BindParameters const& bindParameters() const { return _bindParameters; }
 
   /// @brief return the query's shared state
   std::shared_ptr<SharedQueryState> sharedState() const;

--- a/arangod/Aql/QueryList.cpp
+++ b/arangod/Aql/QueryList.cpp
@@ -228,7 +228,7 @@ void QueryList::remove(Query& query) {
 
       _slow.emplace_back(
           query.id(), query.vocbase().name(), query.user(), std::move(q),
-          _trackBindVars ? query.bindParameters() : nullptr,
+          _trackBindVars ? query.bindParametersAsBuilder() : nullptr,
           _trackDataSources ? query.collectionNames()
                             : std::vector<std::string>(),
           now - elapsed, /* start timestamp */
@@ -336,7 +336,7 @@ std::vector<QueryEntryCopy> QueryList::listCurrent() {
       result.emplace_back(
           query.id(), query.vocbase().name(), query.user(),
           query.extractQueryString(maxLength, showQueryString),
-          _trackBindVars ? query.bindParameters() : nullptr,
+          _trackBindVars ? query.bindParametersAsBuilder() : nullptr,
           _trackDataSources ? query.collectionNames()
                             : std::vector<std::string>(),
           now - elapsed /* start timestamp */, elapsed /* run time */,

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -76,7 +76,7 @@ QueryOptions::QueryOptions()
       fullCount(false),
       count(false),
       skipAudit(false),
-      cachePlan(false),
+      optimizePlanForCaching(false),
       explainRegisters(ExplainRegisterPlan::No),
       desiredJoinStrategy(JoinStrategyType::kDefault) {
   // now set some default values from server configuration options
@@ -208,8 +208,8 @@ void QueryOptions::fromVelocyPack(VPackSlice slice) {
   if (VPackSlice value = slice.get("cache"); value.isBool()) {
     cache = value.isTrue();
   }
-  if (VPackSlice value = slice.get("cachePlan"); value.isBool()) {
-    cachePlan = value.isTrue();
+  if (VPackSlice value = slice.get("optimizePlanForCaching"); value.isBool()) {
+    optimizePlanForCaching = value.isTrue();
   }
   if (VPackSlice value = slice.get("fullCount"); value.isBool()) {
     fullCount = value.isTrue();
@@ -301,7 +301,7 @@ void QueryOptions::toVelocyPack(VPackBuilder& builder,
   builder.add("silent", VPackValue(silent));
   builder.add("failOnWarning", VPackValue(failOnWarning));
   builder.add("cache", VPackValue(cache));
-  builder.add("cachePlan", VPackValue(cachePlan));
+  builder.add("optimizePlanForCaching", VPackValue(optimizePlanForCaching));
   builder.add("fullCount", VPackValue(fullCount));
   builder.add("count", VPackValue(count));
 

--- a/arangod/Aql/QueryOptions.cpp
+++ b/arangod/Aql/QueryOptions.cpp
@@ -76,6 +76,7 @@ QueryOptions::QueryOptions()
       fullCount(false),
       count(false),
       skipAudit(false),
+      cachePlan(false),
       explainRegisters(ExplainRegisterPlan::No),
       desiredJoinStrategy(JoinStrategyType::kDefault) {
   // now set some default values from server configuration options
@@ -207,6 +208,9 @@ void QueryOptions::fromVelocyPack(VPackSlice slice) {
   if (VPackSlice value = slice.get("cache"); value.isBool()) {
     cache = value.isTrue();
   }
+  if (VPackSlice value = slice.get("cachePlan"); value.isBool()) {
+    cachePlan = value.isTrue();
+  }
   if (VPackSlice value = slice.get("fullCount"); value.isBool()) {
     fullCount = value.isTrue();
   }
@@ -297,6 +301,7 @@ void QueryOptions::toVelocyPack(VPackBuilder& builder,
   builder.add("silent", VPackValue(silent));
   builder.add("failOnWarning", VPackValue(failOnWarning));
   builder.add("cache", VPackValue(cache));
+  builder.add("cachePlan", VPackValue(cachePlan));
   builder.add("fullCount", VPackValue(fullCount));
   builder.add("count", VPackValue(count));
 

--- a/arangod/Aql/QueryOptions.h
+++ b/arangod/Aql/QueryOptions.h
@@ -100,7 +100,7 @@ struct QueryOptions {
   // skips audit logging - used only internally
   bool skipAudit;
   // whether or not the optimizer result should be cached
-  bool cachePlan;
+  bool optimizePlanForCaching;
 
   ExplainRegisterPlan explainRegisters;
 

--- a/arangod/Aql/QueryOptions.h
+++ b/arangod/Aql/QueryOptions.h
@@ -99,6 +99,8 @@ struct QueryOptions {
   bool count;
   // skips audit logging - used only internally
   bool skipAudit;
+  // whether or not the optimizer result should be cached
+  bool cachePlan;
 
   ExplainRegisterPlan explainRegisters;
 

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -486,7 +486,8 @@ template<typename T>
 RegisterId RegisterPlanT<T>::registerVariable(
     Variable const* v, std::set<RegisterId>& unusedRegisters) {
   RegisterId regId;
-  if (v->type() == Variable::Type::Const) {
+  if (v->type() == Variable::Type::Const ||
+      v->type() == Variable::Type::BindParameter) {
     regId = RegisterId::makeConst(nrConstRegs++);
   } else if (unusedRegisters.empty()) {
     regId = addRegister();
@@ -495,7 +496,9 @@ RegisterId RegisterPlanT<T>::registerVariable(
     regId = *iter;
     unusedRegisters.erase(iter);
   }
-  TRI_ASSERT(regId.isConstRegister() == (v->type() == Variable::Type::Const));
+  TRI_ASSERT(regId.isConstRegister() ==
+             (v->type() == Variable::Type::Const ||
+              v->type() == Variable::Type::BindParameter));
 
   auto [_, inserted] = varInfo.try_emplace(v->id, VarInfo(depth, regId));
   TRI_ASSERT(inserted);

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -323,7 +323,7 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
 
   auto origin = transaction::OperationOriginAQL{"running AQL query"};
 
-  TRI_ASSERT(bindParameter == nullptr || options.cachePlan)
+  TRI_ASSERT(bindParameter == nullptr || options.optimizePlanForCaching)
       << "Queries running in cluster only have bind variables attached, if "
          "plan caching is enabled";
   double const ttl = options.ttl;

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -210,11 +210,11 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
     co_return;
   }
 
-  std::shared_ptr<VPackBuilder> bindParameter = nullptr;
+  std::shared_ptr<VPackBuilder> bindParameters = nullptr;
   {
-    VPackSlice bindParameterSlice = querySlice.get("bindParameters");
-    if (bindParameterSlice.isObject()) {
-      bindParameter = std::make_shared<VPackBuilder>(bindParameterSlice);
+    VPackSlice bindParametersSlice = querySlice.get("bindParameters");
+    if (bindParametersSlice.isObject()) {
+      bindParameters = std::make_shared<VPackBuilder>(bindParametersSlice);
     }
   }
 
@@ -323,13 +323,13 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
 
   auto origin = transaction::OperationOriginAQL{"running AQL query"};
 
-  TRI_ASSERT(bindParameter == nullptr || options.optimizePlanForCaching)
+  TRI_ASSERT(bindParameters == nullptr || options.optimizePlanForCaching)
       << "Queries running in cluster only have bind variables attached, if "
          "plan caching is enabled";
   double const ttl = options.ttl;
   // creates a StandaloneContext or a leased context
   auto q = ClusterQuery::create(
-      clusterQueryId, std::move(bindParameter),
+      clusterQueryId, std::move(bindParameters),
       co_await createTransactionContext(access, origin), std::move(options));
   TRI_ASSERT(clusterQueryId == 0 || clusterQueryId == q->id());
 

--- a/arangod/Aql/Variable.cpp
+++ b/arangod/Aql/Variable.cpp
@@ -96,8 +96,6 @@ void Variable::toVelocyPack(velocypack::Builder& builder,
   if (type() == Variable::Type::Const) {
     builder.add(VPackValue("constantValue"));
     _constantValue.toVelocyPack(nullptr, builder, /*allowUnindexed*/ true);
-  } else if (type() == Variable::Type::BindParameter) {
-    builder.add("bindParameter", VPackValue(_bindParameterName));
   }
 }
 
@@ -106,6 +104,9 @@ void Variable::toVelocyPackCommon(velocypack::Builder& builder) const {
   builder.add("name", VPackValue(name));
   builder.add("isFullDocumentFromCollection",
               VPackValue(isFullDocumentFromCollection));
+  if (type() == Variable::Type::BindParameter) {
+    builder.add("bindParameter", VPackValue(_bindParameterName));
+  }
 }
 
 /// @brief replace a variable by another

--- a/arangod/Aql/Variable.h
+++ b/arangod/Aql/Variable.h
@@ -58,7 +58,9 @@ struct Variable {
     /// query
     Regular,
     /// @brief a variable with a constant value
-    Const
+    Const,
+    /// @brief
+    BindParameter,
   };
 
   /// @brief create the variable
@@ -110,6 +112,10 @@ struct Variable {
   /// This implicitly changes the type -> see type()
   void setConstantValue(AqlValue value);
 
+  void setBindParameterReplacement(std::string name);
+
+  std::string_view bindParameterName() const noexcept;
+
   /// @brief variable id
   VariableId const id;
 
@@ -131,6 +137,8 @@ struct Variable {
   // while initializing the plan. Note: the variable takes ownership of this
   // value and destroys it
   AqlValue _constantValue;
+
+  std::string _bindParameterName;
 };
 }  // namespace aql
 }  // namespace arangodb

--- a/arangod/Aql/Variable.h
+++ b/arangod/Aql/Variable.h
@@ -59,7 +59,7 @@ struct Variable {
     Regular,
     /// @brief a variable with a constant value
     Const,
-    /// @brief
+    /// @brief variable is a replacement for a bind parameter
     BindParameter,
   };
 

--- a/arangod/Aql/types.h
+++ b/arangod/Aql/types.h
@@ -97,6 +97,9 @@ using RegIdOrderedSetStack = std::vector<RegIdOrderedSet>;
 using RegIdFlatSet = containers::flat_set<RegisterId>;
 using RegIdFlatSetStack = std::vector<containers::flat_set<RegisterId>>;
 
+using BindParameterVariableMapping =
+    absl::flat_hash_map<std::string, Variable const*>;
+
 }  // namespace aql
 
 namespace traverser {

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -1391,7 +1391,13 @@ function processQuery(query, explain, planIndex) {
 
     switch (node.type) {
       case 'SingletonNode':
-        return keyword('ROOT');
+        let bindVars = [];
+        if (node.bindParameterVariables) {
+          for (const [name, bindVar] of Object.entries(node.bindParameterVariables)) {
+            bindVars.push(variableName(bindVar) + ' = ' + variable("@" + name));
+          }
+        }
+        return keyword('ROOT') + ' ' + bindVars.join(', ');
       case 'NoResultsNode':
         return keyword('EMPTY') + '   ' + annotation('/* empty result set */');
       case 'EnumerateCollectionNode':

--- a/tests/js/client/aql/aql-bind-parameter-variables.js
+++ b/tests/js/client/aql/aql-bind-parameter-variables.js
@@ -1,29 +1,28 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertException */
+/*global fail, assertEqual, assertNotEqual, assertTrue, assertFalse */
 
-// //////////////////////////////////////////////////////////////////////////////
-// / DISCLAIMER
-// /
-// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
-// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
-// /
-// / Licensed under the Business Source License 1.1 (the "License");
-// / you may not use this file except in compliance with the License.
-// / You may obtain a copy of the License at
-// /
-// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
-// /
-// / Unless required by applicable law or agreed to in writing, software
-// / distributed under the License is distributed on an "AS IS" BASIS,
-// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// / See the License for the specific language governing permissions and
-// / limitations under the License.
-// /
-// / Copyright holder is ArangoDB GmbH, Cologne, Germany
-// /
-/// @author Jan Steemann
-/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
-// //////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Lars Maier
+////////////////////////////////////////////////////////////////////////////////
 
 const internal = require("internal");
 const {db} = require("@arangodb");
@@ -140,6 +139,21 @@ function aqlBindParameterVariableTest() {
 
       const result = stmt.execute().toArray();
       assertEqual(result, [0, 4, 8, 12, 16, 20]);
+    },
+
+    testFilterDocumentsReturnBindParameter: function () {
+      const query = `
+        FOR doc IN ${collection}
+        SORT doc.i
+        LIMIT 10
+        RETURN [doc.i, @${bind}]
+      `;
+      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {cachePlan: true}});
+      const result = stmt.execute().toArray();
+      result.forEach(function ([a, b], idx) {
+        assertEqual(a, idx);
+        assertEqual(b, 4);
+      });
     }
 
   };

--- a/tests/js/client/aql/aql-bind-parameter-variables.js
+++ b/tests/js/client/aql/aql-bind-parameter-variables.js
@@ -1,0 +1,128 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertException */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Jan Steemann
+/// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const internal = require("internal");
+const {db} = require("@arangodb");
+const jsunity = require("jsunity");
+const helper = require("@arangodb/aql-helper");
+
+const database = "BindParameterVarsTestDb";
+
+function aqlBindParameterVariableTest() {
+
+  const bind = "param";
+
+
+  return {
+    setUpAll: function () {
+      db._createDatabase(database);
+      db._useDatabase(database);
+
+      const C = db._create("C");
+      let docs = [];
+      for (let i = 0; i < 100; i++) {
+        docs.push({_key: `v${i}`, i, j: 2*i});
+      }
+      C.save(docs);
+    },
+
+    tearDownAll: function () {
+      db._useDatabase("_system");
+      db._dropDatabase(database);
+    },
+
+    testReturnBindParameter: function () {
+
+      const query = `
+        RETURN @${bind}
+      `;
+      const stmt = db._createStatement({query, bindVars: {param: 12}, options: {cachePlan: true}});
+      const plan = stmt.explain().plan;
+
+      const [singleton, returnNode] = plan.nodes;
+      assertEqual(singleton.type, "SingletonNode");
+      assertEqual(returnNode.type, "ReturnNode");
+
+      const bindParameter = singleton.bindParameterVariables;
+      assertEqual(Object.keys(bindParameter), [bind]);
+
+      assertEqual(bindParameter[bind].id, returnNode.inVariable.id);
+
+      const result = stmt.execute().toArray();
+      assertEqual(result, [12]);
+    },
+
+    testReturnMultipleBindParameter: function () {
+
+      const query = `
+        RETURN [@${bind}, @other, @third]
+      `;
+      const stmt = db._createStatement({
+        query,
+        bindVars: {[bind]: 12, other: true, third: "Hello"},
+        options: {cachePlan: true}
+      });
+      const plan = stmt.explain().plan;
+
+      const [singleton, calculation, returnNode] = plan.nodes;
+      assertEqual(singleton.type, "SingletonNode");
+      assertEqual(calculation.type, "CalculationNode");
+      assertEqual(returnNode.type, "ReturnNode");
+
+      const bindParameter = singleton.bindParameterVariables;
+      assertEqual(Object.keys(bindParameter).sort(), [bind, "other", "third"].sort());
+
+
+      const result = stmt.execute().toArray();
+      assertEqual(result, [[12, true, "Hello"]]);
+    },
+
+    testFilterBindParameter: function () {
+      const query = `
+        FOR i IN 1..20
+        FILTER i % @${bind} == 0
+        RETURN i
+      `;
+      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {cachePlan: true}});
+      const plan = stmt.explain().plan;
+
+      const singleton = plan.nodes[0];
+      assertEqual(singleton.type, "SingletonNode");
+
+      const bindParameter = singleton.bindParameterVariables;
+      assertEqual(Object.keys(bindParameter), [bind]);
+
+      const result = stmt.execute().toArray();
+      assertEqual(result, [4, 8, 12, 16, 20]);
+    }
+
+  };
+}
+
+jsunity.run(aqlBindParameterVariableTest);
+
+return jsunity.done();

--- a/tests/js/client/aql/aql-bind-parameter-variables.js
+++ b/tests/js/client/aql/aql-bind-parameter-variables.js
@@ -60,7 +60,7 @@ function aqlBindParameterVariableTest() {
       const query = `
         RETURN @${bind}
       `;
-      const stmt = db._createStatement({query, bindVars: {param: 12}, options: {cachePlan: true}});
+      const stmt = db._createStatement({query, bindVars: {param: 12}, options: {optimizePlanForCaching: true}});
       const plan = stmt.explain().plan;
 
       const [singleton, returnNode] = plan.nodes;
@@ -84,7 +84,7 @@ function aqlBindParameterVariableTest() {
       const stmt = db._createStatement({
         query,
         bindVars: {[bind]: 12, other: true, third: "Hello"},
-        options: {cachePlan: true}
+        options: {optimizePlanForCaching: true}
       });
       const plan = stmt.explain().plan;
 
@@ -107,7 +107,7 @@ function aqlBindParameterVariableTest() {
         FILTER i % @${bind} == 0
         RETURN i
       `;
-      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {cachePlan: true}});
+      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {optimizePlanForCaching: true}});
       const plan = stmt.explain().plan;
 
       const singleton = plan.nodes[0];
@@ -128,7 +128,7 @@ function aqlBindParameterVariableTest() {
         LIMIT 6
         RETURN doc.i
       `;
-      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {cachePlan: true}});
+      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {optimizePlanForCaching: true}});
       const plan = stmt.explain().plan;
 
       const singleton = plan.nodes[0];
@@ -148,7 +148,7 @@ function aqlBindParameterVariableTest() {
         LIMIT 10
         RETURN [doc.i, @${bind}]
       `;
-      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {cachePlan: true}});
+      const stmt = db._createStatement({query, bindVars: {param: 4}, options: {optimizePlanForCaching: true}});
       const result = stmt.execute().toArray();
       result.forEach(function ([a, b], idx) {
         assertEqual(a, idx);


### PR DESCRIPTION
This PR adds a special flag to the query options `optimizePlanForCaching`. If this flag is set to true, bind parameters will be replaced with variables before optimization. The resulting plan can be executed with a different set of bind parameters and yields the correct result. As a side effect, the bind parameters have to sent to the database servers at query setup time. For now, whether the flag is specified or not, the query should be executed correctly.

For now there is no user of this flag, but any query plan caching strategy will make use of this feature eventually. 