### PR TITLE
Attempt to stabilize sanitizer builds

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -473,10 +473,11 @@ jobs:
           condition:
             not:
               equal: [ << pipeline.parameters.sanitizer >>, ""]
-          name: Symbolizer server
           steps:
-            - run: ./utils/llvm-symbolizer-server.py
-          background: true
+            - run:
+                name: Symbolizer server
+                command: ./utils/llvm-symbolizer-server.py
+                background: true
       - run:
           name: Run << parameters.suiteName >> tests
           # we increase the no_output_timeout so our own timeout mechanism can kick in and gather more information

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -464,13 +464,16 @@ jobs:
           command: |
             mkdir work
             if [ "<< pipeline.parameters.sanitizer >>" = "alubsan" ]; then
-              export ASAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:handle_ioctl=true:check_initialization_order=true:detect_container_overflow=true:detect_stack_use_after_return=false:detect_odr_violation=1:strict_init_order=true"
+              export ASAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:handle_ioctl=true:check_initialization_order=true:detect_container_overflow=true:detect_stack_use_after_return=false:detect_odr_violation=1:strict_init_order=true:external_symbolizer_path=`pwd`/utils/llvm-symbolizer-client.py"
               export LSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:suppressions=lsan_arangodb_suppressions.txt:print_suppressions=0"
-              export UBSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:print_stacktrace=1:suppressions=ubsan_arangodb_suppressions.txt:print_suppressions=0"
+              export UBSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/alubsan.log:print_stacktrace=1:suppressions=ubsan_arangodb_suppressions.txt:print_suppressions=0:external_symbolizer_path=`pwd`/utils/llvm-symbolizer-client.py"
               export SAN_MODE=alubsan
             elif [ "<< pipeline.parameters.sanitizer >>" = "tsan" ]; then
-              export TSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/tsan.log:detect_deadlocks=true:second_deadlock_stack=1:suppressions=tsan_arangodb_suppressions.txt:print_suppressions=0"
+              export TSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/tsan.log:detect_deadlocks=true:second_deadlock_stack=1:suppressions=tsan_arangodb_suppressions.txt:print_suppressions=0:external_symbolizer_path=`pwd`/utils/llvm-symbolizer-client.py"
               export SAN_MODE=tsan
+            fi
+            if [ "<< pipeline.parameters.sanitizer >>" != "" ]; then
+              ./utils/llvm-symbolizer-server.py > ./work/symbolizer-server.log &
             fi
 
             # check if promtool is available and if so set the environment variable to enable the according tests

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -465,7 +465,7 @@ jobs:
             echo "======"
             while true; do
               sleep 3
-              ps -a | grep "arangod " | grep -v grep | while read line ; do echo "$(date +"%T") > $line" ; done ;
+              ps -a | grep "[a]rangod " || true | while read line ; do echo "$(date +"%T") > $line" ; done ;
               echo "======"
             done
           background: true

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -464,7 +464,7 @@ jobs:
             echo "======"
             while true; do
               sleep 5
-              ps v | grep "arangod " | while read line ; do echo "$(date +"%T") > $line" ; done ;
+              ps v | grep "arangod " | grep -v grep | while read line ; do echo "$(date +"%T") > $line" ; done ;
               echo "======"
             done
           background: true

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -460,14 +460,22 @@ jobs:
       - run:
           name: Log processes
           command: |
-            export PS_FORMAT="pid,%cpu,%mem,rss,thcount,args"
+            export PS_FORMAT="pid,%cpu,%mem,rss,thcount,oom,oomadj,args"
             ps | head -n 1
             echo "======"
             while true; do
               sleep 3
-              ps | grep "arangod " | grep -v grep | while read line ; do echo "$(date +"%T") > $line" ; done ;
+              ps -a | grep "arangod " | grep -v grep | while read line ; do echo "$(date +"%T") > $line" ; done ;
               echo "======"
             done
+          background: true
+      - when:
+          condition:
+            not:
+              equal: [ << << pipeline.parameters.sanitizer >> >>, ""]
+          name: Symbolizer server
+          steps:
+            - run: ./utils/llvm-symbolizer-server.py
           background: true
       - run:
           name: Run << parameters.suiteName >> tests
@@ -483,9 +491,6 @@ jobs:
             elif [ "<< pipeline.parameters.sanitizer >>" = "tsan" ]; then
               export TSAN_OPTIONS="log_exe_name=true:log_path=`pwd`/work/tsan.log:detect_deadlocks=true:second_deadlock_stack=1:suppressions=tsan_arangodb_suppressions.txt:print_suppressions=0:external_symbolizer_path=`pwd`/utils/llvm-symbolizer-client.py"
               export SAN_MODE=tsan
-            fi
-            if [ "<< pipeline.parameters.sanitizer >>" != "" ]; then
-              ./utils/llvm-symbolizer-server.py > ./work/symbolizer-server.log &
             fi
 
             # check if promtool is available and if so set the environment variable to enable the according tests

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -458,6 +458,17 @@ jobs:
           name: Enabled coredumps
           command: ulimit -c unlimited
       - run:
+          name: Log processes
+          command: |
+            ps v | head -n 1
+            echo "======"
+            while true; do
+              sleep 5
+              ps v | grep "arangod " | while read line ; do echo "$(date +"%T") > $line" ; done ;
+              echo "======"
+            done
+          background: true
+      - run:
           name: Run << parameters.suiteName >> tests
           # we increase the no_output_timeout so our own timeout mechanism can kick in and gather more information
           no_output_timeout: 20m

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -460,11 +460,12 @@ jobs:
       - run:
           name: Log processes
           command: |
-            ps v | head -n 1
+            export PS_FORMAT="pid,%cpu,%mem,rss,thcount,args"
+            ps | head -n 1
             echo "======"
             while true; do
-              sleep 5
-              ps v | grep "arangod " | grep -v grep | while read line ; do echo "$(date +"%T") > $line" ; done ;
+              sleep 3
+              ps | grep "arangod " | grep -v grep | while read line ; do echo "$(date +"%T") > $line" ; done ;
               echo "======"
             done
           background: true

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -472,7 +472,7 @@ jobs:
       - when:
           condition:
             not:
-              equal: [ << << pipeline.parameters.sanitizer >> >>, ""]
+              equal: [ << pipeline.parameters.sanitizer >>, ""]
           name: Symbolizer server
           steps:
             - run: ./utils/llvm-symbolizer-server.py

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -80,7 +80,7 @@
       "cacheVariables": {
         "USE_JEMALLOC": "Off",
         "STATIC_EXECUTABLES": "Off",
-        "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+        "CMAKE_CXX_FLAGS": "-fsanitize=thread -fsanitize-blacklist=${sourceDir}/tsan_blacklist.txt",
         "CMAKE_C_FLAGS": "-fsanitize=thread",
         "USE_MINIMAL_DEBUGINFO": "On"
       }

--- a/tsan_blacklist.txt
+++ b/tsan_blacklist.txt
@@ -1,0 +1,9 @@
+# blacklist functions with known races to avoid instrumentation and the overhead involved
+# note that we have to used mangled names here!
+
+# boost::lockfree::* namespace
+fun:_ZN5boost8lockfree*
+
+# v8::* namespace
+fun:ZN2v8*
+fun:_ZN2v8*

--- a/utils/llvm-symbolizer-client.py
+++ b/utils/llvm-symbolizer-client.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import urllib.request
+import sys
+
+
+def run():
+    url = "http://localhost:43210"
+    for line in sys.stdin:
+        data = line.encode("utf8")
+        headers = {"content-type": "text/plain"}
+        req = urllib.request.Request(url, data=data, headers=headers)
+        response = urllib.request.urlopen(req)
+        sys.stdout.write(response.read().decode("utf8"))
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    run()

--- a/utils/llvm-symbolizer-server.py
+++ b/utils/llvm-symbolizer-server.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import subprocess
+
+symbolizer = subprocess.Popen(
+    ["llvm-symbolizer-16", "--demangle", "--inlines", "--default-arch=x86_64"],
+    stdout=subprocess.PIPE,
+    stdin=subprocess.PIPE,
+)
+
+
+def symbolize(line):
+    symbolizer.stdin.write(line)
+    symbolizer.stdin.flush()
+    result = ""
+    while True:
+        line = symbolizer.stdout.readline().decode("utf8")
+        result += line
+        if line == "\n":
+            break
+    return result
+
+
+class Server(BaseHTTPRequestHandler):
+    def do_POST(self):
+        content_length = int(self.headers["Content-Length"])
+        body = self.rfile.read(content_length)
+        print(body)
+        resp = symbolize(body)
+        print(resp)
+        self.send_response(200)
+        self.send_header("Content-type", "text/plain")
+        self.end_headers()
+        self.wfile.write(resp.encode("utf8"))
+
+
+def run():
+    port = 43210
+    server_address = ("localhost", port)
+    httpd = HTTPServer(server_address, Server)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    httpd.server_close()
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
### Scope & Purpose

Add tsan_blacklist and use it in tsan preset to blacklist functions with known races to avoid instrumentation and the overhead involved
Add simple client/server scripts to manage a shared llvm-symbolizer instance and set the client script as external symbolizer in the sanitizer options. This allows all processes to use a shared llvm-symbolizer instance and thereby save a lot of memory.