### PR TITLE
remove unused "mmap" log topic

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Remove unused "mmap" log topic.
+
 * Support array and object destructuring for FOR loops that refer to simple
   expressions or collections.
 

--- a/lib/Basics/files.cpp
+++ b/lib/Basics/files.cpp
@@ -714,7 +714,6 @@ std::vector<std::string> TRI_FullTreeDirectory(char const* path) {
 
 ErrorCode TRI_RenameFile(char const* old, char const* filename,
                          long* systemError, std::string* systemErrorStr) {
-  TRI_ERRORBUF;
   int res = rename(old, filename);
 
   if (res != 0) {
@@ -1862,7 +1861,6 @@ arangodb::Result TRI_GetDiskSpaceInfo(std::string const& path,
   struct statvfs stat;
 
   if (statvfs(path.c_str(), &stat) == -1) {
-    TRI_SYSTEM_ERROR();
     TRI_set_errno(TRI_ERROR_SYS_ERROR);
     return {TRI_errno(), TRI_last_error()};
   }
@@ -1893,7 +1891,6 @@ arangodb::Result TRI_GetINodesInfo(std::string const& path,
   struct statvfs stat;
 
   if (statvfs(path.c_str(), &stat) == -1) {
-    TRI_SYSTEM_ERROR();
     TRI_set_errno(TRI_ERROR_SYS_ERROR);
     return {TRI_errno(), TRI_last_error()};
   }

--- a/lib/Basics/operating-system.h
+++ b/lib/Basics/operating-system.h
@@ -99,20 +99,14 @@
 #define ARANGODB_HAVE_SETGID 1
 #define ARANGODB_HAVE_SETUID 1
 
-#define TRI_random ::rand
-#define TRI_srandom ::srand
-
 // available features
 
 #define TRI_HAVE_POSIX 1
 
 #define TRI_HAVE_LINUX_PROC 1
 #define ARANGODB_HAVE_DOMAIN_SOCKETS 1
-#define TRI_HAVE_POSIX_MMAP 1
 #define TRI_HAVE_POSIX_PWD_GRP 1
 #define TRI_HAVE_POSIX_THREADS 1
-
-#define TRI_HAVE_ANONYMOUS_MMAP 1
 
 // alignment and limits
 
@@ -159,12 +153,7 @@
 #define TRI_stat_t struct stat
 #define TRI_write_t size_t
 
-#define TRI_ERRORBUF \
-  {}
-#define TRI_GET_ERRORBUF ::strerror(errno)
 #define TRI_LAST_ERROR_STR ::strerror(errno)
-#define TRI_SYSTEM_ERROR() \
-  {}
 #define TRI_GET_ARGV(ARGC, ARGV)
 
 // sockets
@@ -261,17 +250,11 @@
 #define ARANGODB_HAVE_DOMAIN_SOCKETS 1
 #define ARANGODB_HAVE_THREAD_AFFINITY 1
 #define TRI_HAVE_LINUX_PROC 1
-#define TRI_HAVE_POSIX_MMAP 1
 #define TRI_HAVE_POSIX_PWD_GRP 1
 #define TRI_HAVE_POSIX_THREADS 1
 #define TRI_HAVE_SC_PHYS_PAGES 1
 
-#define TRI_HAVE_ANONYMOUS_MMAP 1
-
 #define TRI_SC_NPROCESSORS_ONLN 1
-
-#define TRI_random ::rand
-#define TRI_srandom ::srand
 
 // alignment and limits
 
@@ -318,12 +301,7 @@
 #define TRI_stat_t struct stat
 #define TRI_write_t size_t
 
-#define TRI_ERRORBUF \
-  {}
-#define TRI_GET_ERRORBUF ::strerror(errno)
 #define TRI_LAST_ERROR_STR ::strerror(errno)
-#define TRI_SYSTEM_ERROR() \
-  {}
 #define TRI_GET_ARGV(ARGC, ARGV)
 
 // sockets

--- a/lib/Basics/tri-zip.cpp
+++ b/lib/Basics/tri-zip.cpp
@@ -425,8 +425,6 @@ ErrorCode TRI_Adler32(char const* filename, uint32_t& checksum) {
   TRI_stat_t statbuf;
   int res = TRI_FSTAT(fd, &statbuf);
   if (res < 0) {
-    TRI_ERRORBUF;
-    TRI_SYSTEM_ERROR();
     return TRI_set_errno(TRI_ERROR_SYS_ERROR);
   }
 

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -131,10 +131,8 @@ std::shared_ptr<LogAppenderFile> LogAppenderFileFactory::getFileAppender(
   int fd = TRI_CREATE(filename.c_str(),
                       O_APPEND | O_CREAT | O_WRONLY | TRI_O_CLOEXEC, _fileMode);
   if (fd < 0) {
-    TRI_ERRORBUF;
-    TRI_SYSTEM_ERROR();
     std::cerr << "cannot write to file '" << filename
-              << "': " << TRI_GET_ERRORBUF << std::endl;
+              << "': " << TRI_LAST_ERROR_STR << std::endl;
 
     THROW_ARANGO_EXCEPTION(TRI_ERROR_CANNOT_WRITE_FILE);
   }

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -135,7 +135,6 @@ LogTopic Logger::HTTPCLIENT("httpclient", LogLevel::WARN);
 LogTopic Logger::LICENSE("license", LogLevel::INFO);
 LogTopic Logger::MAINTENANCE("maintenance", LogLevel::INFO);
 LogTopic Logger::MEMORY("memory", LogLevel::INFO);
-LogTopic Logger::MMAP("mmap");
 LogTopic Logger::QUERIES("queries", LogLevel::INFO);
 LogTopic Logger::REPLICATION("replication", LogLevel::INFO);
 LogTopic Logger::REPLICATION2("replication2", LogLevel::WARN);

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -182,7 +182,6 @@ class Logger {
   static LogTopic LICENSE;
   static LogTopic MAINTENANCE;
   static LogTopic MEMORY;
-  static LogTopic MMAP;
   static LogTopic QUERIES;
   static LogTopic REPLICATION;
   static LogTopic REPLICATION2;


### PR DESCRIPTION
### Scope & Purpose

Remove unused "mmap" log topic.
Also remove a few unused defines from `operating-system.h`. These defines were unused since 3.12.0.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
