### PR TITLE
move creation of SortElements into factory functions

### DIFF
--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -500,10 +500,9 @@ class ExecutionNode {
   /// coming out of the node
   virtual CostEstimate estimateCost() const = 0;
 
-  /// @brief factory for sort elements
+  /// @brief factory for sort elements, used by SortNode and GatherNode
   static void getSortElements(SortElementVector& elements, ExecutionPlan* plan,
-                              arangodb::velocypack::Slice slice,
-                              char const* which);
+                              velocypack::Slice slice, std::string_view which);
 
   RegisterId variableToRegisterId(Variable const*) const;
 

--- a/arangod/Aql/ExecutionNode/MultipleRemoteModificationNode.cpp
+++ b/arangod/Aql/ExecutionNode/MultipleRemoteModificationNode.cpp
@@ -34,7 +34,6 @@
 #include "Aql/Executor/ModificationExecutorInfos.h"
 #include "Aql/Executor/MultipleRemoteModificationExecutor.h"
 #include "Aql/OptimizerRulesFeature.h"
-#include "Aql/SortRegister.h"
 #include "Aql/types.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/Aql/ExecutionNode/SingleRemoteOperationNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingleRemoteOperationNode.cpp
@@ -33,7 +33,6 @@
 #include "Aql/Executor/SingleRemoteModificationExecutor.h"
 #include "Aql/Query.h"
 #include "Aql/RegisterInfos.h"
-#include "Aql/SortRegister.h"
 #include "Aql/types.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"

--- a/arangod/Aql/ExecutionNode/SortNode.cpp
+++ b/arangod/Aql/ExecutionNode/SortNode.cpp
@@ -64,17 +64,7 @@ void SortNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
   {
     VPackArrayBuilder guard(&nodes);
     for (auto const& it : _elements) {
-      VPackObjectBuilder obj(&nodes);
-      nodes.add(VPackValue("inVariable"));
-      it.var->toVelocyPack(nodes);
-      nodes.add("ascending", VPackValue(it.ascending));
-      if (!it.attributePath.empty()) {
-        nodes.add(VPackValue("path"));
-        VPackArrayBuilder arr(&nodes);
-        for (auto const& a : it.attributePath) {
-          nodes.add(VPackValue(a));
-        }
-      }
+      it.toVelocyPack(nodes);
     }
   }
   nodes.add("stable", VPackValue(_stable));
@@ -233,6 +223,16 @@ void SortNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   for (auto& variable : _elements) {
     variable.var = Variable::replace(variable.var, replacements);
+  }
+}
+
+void SortNode::replaceAttributeAccess(ExecutionNode const* self,
+                                      Variable const* searchVariable,
+                                      std::span<std::string_view> attribute,
+                                      Variable const* replaceVariable,
+                                      size_t /*index*/) {
+  for (auto& it : _elements) {
+    it.replaceAttributeAccess(searchVariable, attribute, replaceVariable);
   }
 }
 

--- a/arangod/Aql/ExecutionNode/SortNode.h
+++ b/arangod/Aql/ExecutionNode/SortNode.h
@@ -87,6 +87,14 @@ class SortNode : public ExecutionNode {
   void replaceVariables(std::unordered_map<VariableId, Variable const*> const&
                             replacements) override;
 
+  /// @brief replaces an attribute access in the internals of the execution
+  /// node with a simple variable access
+  void replaceAttributeAccess(ExecutionNode const* self,
+                              Variable const* searchVariable,
+                              std::span<std::string_view> attribute,
+                              Variable const* replaceVariable,
+                              size_t index) override;
+
   /// @brief getVariablesUsedHere, modifying the set in-place
   void getVariablesUsedHere(VarSet& vars) const override final;
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1784,11 +1784,12 @@ ExecutionNode* ExecutionPlan::fromNodeSort(ExecutionNode* previous,
       // sort operand is a variable
       auto v = static_cast<Variable*>(expression->getData());
       TRI_ASSERT(v != nullptr);
-      elements.emplace_back(v, isAscending);
+      elements.push_back(SortElement::create(v, isAscending));
     } else {
       // sort operand is some misc expression
       auto calc = createTemporaryCalculation(expression, previous);
-      elements.emplace_back(getOutVariable(calc), isAscending);
+      elements.push_back(
+          SortElement::create(getOutVariable(calc), isAscending));
       previous = calc;
     }
   }
@@ -2345,7 +2346,7 @@ ExecutionNode* ExecutionPlan::fromNodeWindow(ExecutionNode* previous,
 
     // add a sort on rangeVariable in front of the WINDOW
     SortElementVector elements;
-    elements.emplace_back(rangeVar, /*isAscending*/ true);
+    elements.push_back(SortElement::create(rangeVar, /*isAscending*/ true));
     auto en = registerNode(
         std::make_unique<SortNode>(this, nextId(), std::move(elements), false));
     previous = addDependency(previous, en);

--- a/arangod/Aql/Executor/JoinExecutor.cpp
+++ b/arangod/Aql/Executor/JoinExecutor.cpp
@@ -728,7 +728,7 @@ void JoinExecutor::constructStrategy() {
 
   // TODO actually we want to have different strategies, like hash join and
   // special implementations for n = 2, 3, ...
-  // TODO maybe make this an template parameter
+  // TODO maybe make this a template parameter
   _strategy = IndexJoinStrategyFactory{}.createStrategy(
       std::move(indexDescription),
       _infos.query->queryOptions().desiredJoinStrategy);

--- a/arangod/Aql/Executor/SortingGatherExecutor.cpp
+++ b/arangod/Aql/Executor/SortingGatherExecutor.cpp
@@ -41,7 +41,7 @@ namespace {
 /// @brief OurLessThan: comparison method for elements of SortingGatherBlock
 class OurLessThan {
  public:
-  OurLessThan(arangodb::aql::QueryContext& query,
+  OurLessThan(aql::QueryContext& query,
               std::vector<SortRegister>& sortRegisters) noexcept
       : _resolver(query.resolver()),
         _vpackOptions(query.vpackOptions()),
@@ -93,8 +93,8 @@ class OurLessThan {
   }
 
  private:
-  arangodb::CollectionNameResolver const& _resolver;
-  arangodb::velocypack::Options const& _vpackOptions;
+  CollectionNameResolver const& _resolver;
+  velocypack::Options const& _vpackOptions;
   std::vector<SortRegister>& _sortRegisters;
 };  // OurLessThan
 
@@ -105,7 +105,7 @@ class OurLessThan {
 class HeapSorting final : public SortingGatherExecutor::SortingStrategy,
                           private OurLessThan {
  public:
-  HeapSorting(arangodb::aql::QueryContext& query,
+  HeapSorting(QueryContext& query,
               std::vector<SortRegister>& sortRegisters) noexcept
       : OurLessThan(query, sortRegisters) {}
 
@@ -154,7 +154,7 @@ class HeapSorting final : public SortingGatherExecutor::SortingStrategy,
 class MinElementSorting final : public SortingGatherExecutor::SortingStrategy,
                                 private OurLessThan {
  public:
-  MinElementSorting(arangodb::aql::QueryContext& query,
+  MinElementSorting(QueryContext& query,
                     std::vector<SortRegister>& sortRegisters) noexcept
       : OurLessThan(query, sortRegisters), _blockPos(nullptr) {}
 
@@ -187,9 +187,8 @@ SortingGatherExecutor::ValueType::ValueType(size_t index, InputAqlItemRow prow,
     : dependencyIndex{index}, row{std::move(prow)}, state{pstate} {}
 
 SortingGatherExecutorInfos::SortingGatherExecutorInfos(
-    std::vector<SortRegister>&& sortRegister,
-    arangodb::aql::QueryContext& query, GatherNode::SortMode sortMode,
-    size_t limit, GatherNode::Parallelism p)
+    std::vector<SortRegister>&& sortRegister, QueryContext& query,
+    GatherNode::SortMode sortMode, size_t limit, GatherNode::Parallelism p)
     : _sortRegister(std::move(sortRegister)),
       _query(query),
       _sortMode(sortMode),
@@ -197,12 +196,12 @@ SortingGatherExecutorInfos::SortingGatherExecutorInfos(
       _limit(limit) {}
 
 SortingGatherExecutor::SortingGatherExecutor(Fetcher& fetcher, Infos& infos)
-    : _numberDependencies(0),
+    : _fetchParallel(infos.parallelism() == GatherNode::Parallelism::Parallel),
+      _numberDependencies(0),
       _inputRows(),
       _limit(infos.limit()),
       _rowsReturned(0),
-      _strategy(nullptr),
-      _fetchParallel(infos.parallelism() == GatherNode::Parallelism::Parallel) {
+      _strategy(nullptr) {
   switch (infos.sortMode()) {
     case GatherNode::SortMode::MinElement:
       _strategy = std::make_unique<MinElementSorting>(infos.query(),

--- a/arangod/Aql/Executor/SortingGatherExecutor.h
+++ b/arangod/Aql/Executor/SortingGatherExecutor.h
@@ -196,6 +196,8 @@ class SortingGatherExecutor {
       AqlCall const& clientCall) const noexcept -> AqlCallList;
 
  private:
+  bool const _fetchParallel;
+
   // Flag if we are past the initialize phase (fetched one block for every
   // dependency).
   bool _initialized = false;
@@ -218,8 +220,6 @@ class SortingGatherExecutor {
 
   /// @brief sorting strategy
   std::unique_ptr<SortingStrategy> _strategy;
-
-  const bool _fetchParallel;
 
   std::optional<size_t> _depToUpdate = std::nullopt;
 };

--- a/arangod/Aql/Optimizer/Rule/OptimizerRulesReplaceFunctions.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRulesReplaceFunctions.cpp
@@ -327,7 +327,8 @@ AstNode* replaceNearOrWithin(AstNode* funAstNode, ExecutionNode* calcNode,
   ExecutionNode* eSortOrFilter = nullptr;
   if (isNear) {
     // use calculation node in sort node
-    SortElementVector sortElements{SortElement{calcOutVariable, /*asc*/ true}};
+    SortElementVector sortElements;
+    sortElements.push_back(SortElement::create(calcOutVariable, /*asc*/ true));
     eSortOrFilter =
         plan->createNode<SortNode>(plan, plan->nextId(), sortElements, false);
   } else {

--- a/arangod/Aql/SortElement.cpp
+++ b/arangod/Aql/SortElement.cpp
@@ -27,6 +27,9 @@
 #include "Basics/debugging.h"
 
 #include <absl/strings/str_cat.h>
+#include <velocypack/Builder.h>
+#include <velocypack/Slice.h>
+#include <velocypack/Iterator.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -41,6 +44,60 @@ SortElement::SortElement(Variable const* v, bool asc,
   attributePath = std::move(path);
 }
 
+SortElement SortElement::create(Variable const* v, bool asc) {
+  return SortElement(v, asc);
+}
+
+SortElement SortElement::createWithPath(Variable const* v, bool asc,
+                                        std::vector<std::string> path) {
+  return SortElement(v, asc, std::move(path));
+}
+
+/// @brief resets variable to var, and clears the attributePath
+void SortElement::resetTo(Variable const* v) {
+  var = v;
+  attributePath.clear();
+}
+
+void SortElement::replaceVariables(
+    std::unordered_map<VariableId, Variable const*> const& replacements) {
+  var = Variable::replace(var, replacements);
+}
+
+void SortElement::replaceAttributeAccess(Variable const* searchVariable,
+                                         std::span<std::string_view> attribute,
+                                         Variable const* replaceVariable) {
+  if (var != searchVariable) {
+    return;
+  }
+
+  // if the attribute path is  $var.a.b and we replace $var.a by $other,
+  // the attribute path should become just `b`, i.e. $other.b.
+
+  auto it1 = attributePath.begin();
+  auto it2 = attribute.begin();
+
+  bool isPrefix = true;
+  while (it2 != attribute.end()) {
+    if (it1 == attributePath.end() || *it1 != *it2) {
+      // this path does not match the prefix
+      isPrefix = false;
+      break;
+    }
+    ++it1;
+    ++it2;
+  }
+
+  if (!isPrefix) {
+    return;
+  }
+
+  // it1 now points to the remainder. Remove the prefix.
+  attributePath.erase(attributePath.cbegin(), it1);
+
+  var = replaceVariable;
+}
+
 std::string SortElement::toString() const {
   std::string result = absl::StrCat("$", var->id);
   for (auto const& it : attributePath) {
@@ -48,4 +105,35 @@ std::string SortElement::toString() const {
   }
   absl::StrAppend(&result, ascending ? " ASC" : " DESC");
   return result;
+}
+
+void SortElement::toVelocyPack(velocypack::Builder& builder) const {
+  VPackObjectBuilder obj(&builder);
+  builder.add(VPackValue("inVariable"));
+  var->toVelocyPack(builder);
+  builder.add("ascending", VPackValue(ascending));
+  if (!attributePath.empty()) {
+    builder.add(VPackValue("path"));
+    VPackArrayBuilder arr(&builder);
+    for (auto const& a : attributePath) {
+      builder.add(VPackValue(a));
+    }
+  }
+}
+
+SortElement SortElement::fromVelocyPack(Ast* ast, velocypack::Slice info) {
+  bool ascending = info.get("ascending").getBoolean();
+  Variable* v = Variable::varFromVPack(ast, info, "inVariable");
+
+  SortElement elem(v, ascending);
+  // Is there an attribute path?
+  if (auto path = info.get("path"); path.isArray()) {
+    // Get a list of strings out and add to the path:
+    for (auto it : VPackArrayIterator(path)) {
+      if (it.isString()) {
+        elem.attributePath.emplace_back(it.copyString());
+      }
+    }
+  }
+  return elem;
 }

--- a/arangod/Aql/SortRegister.cpp
+++ b/arangod/Aql/SortRegister.cpp
@@ -25,6 +25,7 @@
 #include "SortRegister.h"
 
 #include "Aql/RegisterPlan.h"
+#include "Aql/SortElement.h"
 #include "Aql/Variable.h"
 
 namespace arangodb::aql {

--- a/arangod/Aql/SortRegister.h
+++ b/arangod/Aql/SortRegister.h
@@ -24,8 +24,6 @@
 
 #pragma once
 
-#include "Aql/SortElement.h"
-#include "Aql/SortRegister.h"
 #include "Aql/types.h"
 
 #include <string>
@@ -37,11 +35,13 @@ class ExecutionPlan;
 template<typename T>
 struct RegisterPlanT;
 using RegisterPlan = RegisterPlanT<ExecutionNode>;
+struct SortElement;
 
 /// @brief sort element for block, consisting of register, sort direction,
 /// and a possible attribute path to dig into the document
 struct SortRegister {
-  SortRegister(SortRegister&) = delete;  // we can not copy the ireseach scorer
+  SortRegister(SortRegister const&) =
+      delete;  // we can not copy the iresearch scorer
   SortRegister(SortRegister&&) = default;
 
   std::vector<std::string> const& attributePath;

--- a/tests/Aql/Executor/GatherExecutorCommonTest.cpp
+++ b/tests/Aql/Executor/GatherExecutorCommonTest.cpp
@@ -696,7 +696,7 @@ class CommonGatherExecutorTest
   // We need to retain the memory of this SortElement. Otherwise we have invalid
   // memory access, for sorting nodes.
   aql::Variable _variable{"fuxx", 1, false, _resMonitor};
-  SortElement _sortElement{&_variable, true};
+  SortElement _sortElement = SortElement::create(&_variable, true);
 
 };  // namespace arangodb::tests::aql
 

--- a/tests/Aql/Executor/SortExecutorTest.cpp
+++ b/tests/Aql/Executor/SortExecutorTest.cpp
@@ -71,7 +71,7 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
   }
 
   auto makeRegisterInfos(size_t nestingLevel = 1) -> RegisterInfos {
-    SortElement sl{&sortVar, true};
+    SortElement sl = SortElement::create(&sortVar, true);
     SortRegister sortReg{0, sl};
     std::vector<SortRegister> sortRegisters;
     sortRegisters.emplace_back(std::move(sortReg));
@@ -89,7 +89,7 @@ class SortExecutorTest : public AqlExecutorTestCaseWithParam<SortInputParam> {
       tempStorage = std::make_unique<TemporaryStorageFeature>(
           fakedQuery->vocbase().server());
     }
-    SortElement sl{&sortVar, true};
+    SortElement sl = SortElement::create(&sortVar, true);
     SortRegister sortReg{0, sl};
     std::vector<SortRegister> sortRegisters;
     sortRegisters.emplace_back(std::move(sortReg));


### PR DESCRIPTION
### Scope & Purpose

move creation of SortElements into factory functions

the goal of this PR is to make it easier to see and control who can set the initial data for SortElement objects, and who is able to modify them later on.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 