### PR TITLE
Increase cursor TTL for subquery chaos test

### DIFF
--- a/js/common/modules/@arangodb/test-generators/subquery-chaos-test.js
+++ b/js/common/modules/@arangodb/test-generators/subquery-chaos-test.js
@@ -305,7 +305,7 @@ function runQuery(query, queryOptions, testOptions) {
   }
 
   /* Run query */
-  const result = db._createStatement({query: query.queryString, batchSize, options: queryOptions})
+  const result = db._createStatement({query: query.queryString, batchSize, options: queryOptions, ttl: 600})
     .execute();
 
   if (testOptions.enableLogging) {


### PR DESCRIPTION
### Scope & Purpose

Add an increased TTL value for query cursors in nightly subquery chaos tests

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 