### PR TITLE
Fixing tsan issues

### DIFF
--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -310,12 +310,15 @@ class Supervision : public ServerThread<ArangodServer> {
   arangodb::basics::ConditionVariable _cv; /**< @brief Control if thread
                                               should run */
 
-  double _frequency;
-  double _gracePeriod;
-  double _okThreshold;
-  uint64_t _delayAddFollower;
-  uint64_t _delayFailedFollower;
-  bool _failedLeaderAddsFollower;
+  // The following variables can be set from the outside during runtime
+  // and can create data races between the rest handler and the supervision
+  // thread.
+  std::atomic<double> _frequency;
+  std::atomic<double> _gracePeriod;
+  std::atomic<double> _okThreshold;
+  std::atomic<uint64_t> _delayAddFollower;
+  std::atomic<uint64_t> _delayFailedFollower;
+  std::atomic<bool> _failedLeaderAddsFollower;
   uint64_t _jobId;
   uint64_t _jobIdMax;
   uint64_t _lastUpdateIndex;

--- a/client-tools/Import/SenderThread.cpp
+++ b/client-tools/Import/SenderThread.cpp
@@ -161,6 +161,8 @@ void SenderThread::handleResult(httpclient::SimpleHttpResult* result) {
     return;
   }
 
+  std::unique_lock guardError{_condition.mutex};
+
   std::shared_ptr<VPackBuilder> parsedBody;
   try {
     parsedBody = result->getBodyVelocyPack();


### PR DESCRIPTION
### Scope & Purpose
Fixing two tsan issues that are not critical.
1. During tests we change some values in the supervision. This is done using the API. The RestHandler updates those values in the supervision which might read at the same time, causing a data race. See introduction of atomics below.
2. In the import tool, `_hasError` was accessed without acquiring the mutex first.