### PR TITLE
Forcefully kill all running AQL queries on server shutdown.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Forcefully kill all running AQL queries on server shutdown.
+  This allows for a faster server shutdown even if there are some long-running
+  AQL queries ongoing.
+
 * FE-457: fix query UI result table headers & table/geo detection.
 
 * Add optimizer rule `push-limit-into-index` that pushes a limit down into index

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -867,6 +867,10 @@ template<class Executor>
 auto ExecutionBlockImpl<Executor>::executeFetcher(ExecutionContext& ctx,
                                                   AqlCallType const& aqlCall)
     -> std::tuple<ExecutionState, SkipResult, typename Fetcher::DataRange> {
+  if (getQuery().killed()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+  }
+
   double start = -1.0;
   auto profilingGuard = scopeGuard([&]() noexcept {
     _execNodeStats.fetching += currentSteadyClockValue() - start;

--- a/arangod/Aql/Executor/CalculationExecutor.cpp
+++ b/arangod/Aql/Executor/CalculationExecutor.cpp
@@ -115,6 +115,11 @@ CalculationExecutor<calculationType>::produceRows(
     // by exterior.
     TRI_ASSERT(!shouldExitContextBetweenBlocks() || !_hasEnteredExecutor ||
                state == ExecutorState::HASMORE);
+
+    _killCheckCounter = (_killCheckCounter + 1) % 1024;
+    if (ADB_UNLIKELY(_killCheckCounter == 0 && _infos.getQuery().killed())) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+    }
   }
 
   return {inputRange.upstreamState(), NoStats{}, output.getClientCall()};

--- a/arangod/Aql/Executor/CalculationExecutor.h
+++ b/arangod/Aql/Executor/CalculationExecutor.h
@@ -127,7 +127,6 @@ class CalculationExecutor {
 
   [[nodiscard]] bool shouldExitContextBetweenBlocks() const noexcept;
 
- private:
   CalculationExecutorInfos& _infos;
   transaction::Methods _trx;
   aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
@@ -141,6 +140,9 @@ class CalculationExecutor {
   // Necessary for owned executors, which will not be exited when we call
   // exitContext; but only for assertions in maintainer mode.
   bool _hasEnteredExecutor;
+
+  // note: it is fine if this counter overflows
+  uint_fast16_t _killCheckCounter = 0;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Executor/EnumerateListExecutor.cpp
+++ b/arangod/Aql/Executor/EnumerateListExecutor.cpp
@@ -262,6 +262,11 @@ EnumerateListExecutor::produceRows(AqlItemBlockInputRange& inputRange,
       stats.incrFiltered();
     }
     ++_inputArrayPosition;
+
+    _killCheckCounter = (_killCheckCounter + 1) % 1024;
+    if (ADB_UNLIKELY(_killCheckCounter == 0 && _infos.getQuery().killed())) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+    }
   }
 
   if (_inputArrayLength == _inputArrayPosition) {
@@ -323,6 +328,11 @@ EnumerateListExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
       auto const skipped = skipArrayElement(skip);
       // the call to skipArrayElement has advanced the input position already
       call.didSkip(skipped);
+    }
+
+    _killCheckCounter = (_killCheckCounter + 1) % 1024;
+    if (ADB_UNLIKELY(_killCheckCounter == 0 && _infos.getQuery().killed())) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
     }
   }
 

--- a/arangod/Aql/Executor/EnumerateListExecutor.h
+++ b/arangod/Aql/Executor/EnumerateListExecutor.h
@@ -146,7 +146,6 @@ class EnumerateListExecutor {
 
   bool checkFilter(AqlValue const& currentValue);
 
- private:
   EnumerateListExecutorInfos& _infos;
   transaction::Methods _trx;
   aql::AqlFunctionsInternalCache _aqlFunctionsInternalCache;
@@ -155,6 +154,9 @@ class EnumerateListExecutor {
   size_t _inputArrayPosition;
   size_t _inputArrayLength;
   std::unique_ptr<EnumerateListExpressionContext> _expressionContext;
+
+  // note: it is fine if this counter overflows
+  uint_fast16_t _killCheckCounter = 0;
 };
 
 }  // namespace arangodb::aql

--- a/arangod/RestServer/BootstrapFeature.cpp
+++ b/arangod/RestServer/BootstrapFeature.cpp
@@ -363,8 +363,17 @@ void BootstrapFeature::start() {
   _isReady = true;
 }
 
+void BootstrapFeature::stop() {
+  // notify all currently running queries about the shutdown
+  killRunningQueries();
+}
+
 void BootstrapFeature::unprepare() {
   // notify all currently running queries about the shutdown
+  killRunningQueries();
+}
+
+void BootstrapFeature::killRunningQueries() {
   auto& databaseFeature = server().getFeature<DatabaseFeature>();
 
   for (auto& name : databaseFeature.getDatabaseNames()) {

--- a/arangod/RestServer/BootstrapFeature.h
+++ b/arangod/RestServer/BootstrapFeature.h
@@ -36,16 +36,17 @@ class BootstrapFeature final : public ArangodFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void start() override final;
+  void stop() override final;
   void unprepare() override final;
 
   bool isReady() const;
 
  private:
+  void killRunningQueries();
   void waitForHealthEntry();
   /// @brief wait for databases to appear in Plan and Current
   void waitForDatabases() const;
 
- private:
   bool _isReady;
   bool _bark;
 };


### PR DESCRIPTION
### Scope & Purpose

Should address https://github.com/arangodb/arangodb/issues/13156#issuecomment-2244724718

Forcefully kill all running AQL queries on server shutdown.
This allows for a faster server shutdown even if there are some long-running AQL queries ongoing.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 