### PR TITLE
Forcefully kill all running AQL queries on server shutdown.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.11 (XXXX-XX-XX)
 ---------------------
 
+* Forcefully kill all running AQL queries on server shutdown.
+  This allows for a faster server shutdown even if there are some long-running
+  AQL queries ongoing.
+
 * Updated ArangoDB Starter to v0.18.7 and arangosync to v2.19.8.
 
 * Fixed MDS-1216: restoring the previous value of the "padded" key generator

--- a/arangod/Aql/CalculationExecutor.cpp
+++ b/arangod/Aql/CalculationExecutor.cpp
@@ -114,6 +114,11 @@ CalculationExecutor<calculationType>::produceRows(
     // by exterior.
     TRI_ASSERT(!shouldExitContextBetweenBlocks() || !_hasEnteredContext ||
                state == ExecutorState::HASMORE);
+
+    _killCheckCounter = (_killCheckCounter + 1) % 1024;
+    if (ADB_UNLIKELY(_killCheckCounter == 0 && _infos.getQuery().killed())) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+    }
   }
 
   return {inputRange.upstreamState(), NoStats{}, output.getClientCall()};

--- a/arangod/Aql/CalculationExecutor.h
+++ b/arangod/Aql/CalculationExecutor.h
@@ -137,6 +137,9 @@ class CalculationExecutor {
   // Necessary for owned contexts, which will not be exited when we call
   // exitContext; but only for assertions in maintainer mode.
   bool _hasEnteredContext;
+
+  // note: it is fine if this counter overflows
+  uint_fast16_t _killCheckCounter = 0;
 };
 
 }  // namespace aql

--- a/arangod/Aql/EnumerateListExecutor.h
+++ b/arangod/Aql/EnumerateListExecutor.h
@@ -46,12 +46,13 @@ class AqlItemBlockInputRange;
 class RegisterInfos;
 class OutputAqlItemRow;
 class NoStats;
+class QueryContext;
 template<BlockPassthrough>
 class SingleRowFetcher;
 
 class EnumerateListExecutorInfos {
  public:
-  EnumerateListExecutorInfos(RegisterId inputRegister,
+  EnumerateListExecutorInfos(QueryContext& query, RegisterId inputRegister,
                              RegisterId outputRegister);
 
   EnumerateListExecutorInfos() = delete;
@@ -61,8 +62,10 @@ class EnumerateListExecutorInfos {
 
   RegisterId getInputRegister() const noexcept;
   RegisterId getOutputRegister() const noexcept;
+  QueryContext& getQuery() const noexcept;
 
  private:
+  QueryContext& _query;
   // These two are exactly the values in the parent members
   // ExecutorInfo::_inRegs and ExecutorInfo::_outRegs, respectively
   // getInputRegisters() and getOutputRegisters().
@@ -135,6 +138,9 @@ class EnumerateListExecutor {
   ExecutorState _currentRowState;
   size_t _inputArrayPosition;
   size_t _inputArrayLength;
+
+  // note: it is fine if this counter overflows
+  uint_fast16_t _killCheckCounter = 0;
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -815,6 +815,10 @@ template<class Executor>
 auto ExecutionBlockImpl<Executor>::executeFetcher(ExecutionContext& ctx,
                                                   AqlCallType const& aqlCall)
     -> std::tuple<ExecutionState, SkipResult, typename Fetcher::DataRange> {
+  if (getQuery().killed()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+  }
+
   // TODO The logic in the MultiDependencySingleRowFetcher branch should be
   //      moved into the MultiDependencySingleRowFetcher.
   static_assert(isMultiDepExecutor<Executor> ==

--- a/arangod/Aql/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode.cpp
@@ -1865,7 +1865,8 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
   RegisterId outRegister = variableToRegisterId(_outVariable);
   auto registerInfos =
       createRegisterInfos(RegIdSet{inputRegister}, RegIdSet{outRegister});
-  auto executorInfos = EnumerateListExecutorInfos(inputRegister, outRegister);
+  auto executorInfos =
+      EnumerateListExecutorInfos(engine.getQuery(), inputRegister, outRegister);
   return std::make_unique<ExecutionBlockImpl<EnumerateListExecutor>>(
       &engine, this, std::move(registerInfos), std::move(executorInfos));
 }

--- a/arangod/RestServer/BootstrapFeature.cpp
+++ b/arangod/RestServer/BootstrapFeature.cpp
@@ -403,8 +403,17 @@ void BootstrapFeature::start() {
   _isReady = true;
 }
 
+void BootstrapFeature::stop() {
+  // notify all currently running queries about the shutdown
+  killRunningQueries();
+}
+
 void BootstrapFeature::unprepare() {
   // notify all currently running queries about the shutdown
+  killRunningQueries();
+}
+
+void BootstrapFeature::killRunningQueries() {
   auto& databaseFeature = server().getFeature<DatabaseFeature>();
 
   for (auto& name : databaseFeature.getDatabaseNames()) {

--- a/arangod/RestServer/BootstrapFeature.h
+++ b/arangod/RestServer/BootstrapFeature.h
@@ -36,16 +36,17 @@ class BootstrapFeature final : public ArangodFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void start() override final;
+  void stop() override final;
   void unprepare() override final;
 
   bool isReady() const;
 
  private:
+  void killRunningQueries();
   void waitForHealthEntry();
   /// @brief wait for databases to appear in Plan and Current
   void waitForDatabases() const;
 
- private:
   bool _isReady;
   bool _bark;
 };

--- a/tests/Aql/EnumerateListExecutorTest.cpp
+++ b/tests/Aql/EnumerateListExecutorTest.cpp
@@ -53,7 +53,7 @@ namespace tests {
 namespace aql {
 
 // test inner executor behaviour
-class EnumerateListExecutorTest : public ::testing::Test {
+class EnumerateListExecutorTest : public AqlExecutorTestCase<false> {
  protected:
   ExecutionState state;
   NoStats stats;
@@ -81,7 +81,7 @@ TEST_F(EnumerateListExecutorTest, test_check_state_first_row_border) {
   SharedAqlItemBlockPtr block{new AqlItemBlock(itemBlockManager, 1000, 5)};
   RegisterInfos registerInfos(RegIdSet{3}, RegIdSet{4}, 4, 5, {},
                               {RegIdSet{0, 1, 2, 3}});
-  EnumerateListExecutorInfos executorInfos(3, 4);
+  EnumerateListExecutorInfos executorInfos(*fakedQuery, 3, 4);
   EnumerateListExecutor testee(fetcher, executorInfos);
   SharedAqlItemBlockPtr inBlock =
       buildBlock<4>(itemBlockManager, {{{{1}, {2}, {3}, {R"([true, 1, 2])"}}},
@@ -120,7 +120,7 @@ TEST_F(EnumerateListExecutorTest, test_check_state_second_row_border) {
   SharedAqlItemBlockPtr block{new AqlItemBlock(itemBlockManager, 1000, 5)};
   RegisterInfos registerInfos(RegIdSet{3}, RegIdSet{4}, 4, 5, {},
                               {RegIdSet{0, 1, 2, 3}});
-  EnumerateListExecutorInfos executorInfos(3, 4);
+  EnumerateListExecutorInfos executorInfos(*fakedQuery, 3, 4);
   EnumerateListExecutor testee(fetcher, executorInfos);
   SharedAqlItemBlockPtr inBlock =
       buildBlock<4>(itemBlockManager, {{{{1}, {2}, {3}, {R"([true, 1, 2])"}}},
@@ -157,7 +157,7 @@ class EnumerateListExecutorTestProduce
   SharedAqlItemBlockPtr block;
   NoStats stats;
 
-  EnumerateListExecutorTestProduce() : executorInfos(0, 1) {}
+  EnumerateListExecutorTestProduce() : executorInfos(*fakedQuery, 0, 1) {}
 
   auto makeRegisterInfos(RegisterId inputRegister = 0,
                          RegisterId outputRegister = 1,
@@ -178,7 +178,8 @@ class EnumerateListExecutorTestProduce
   auto makeExecutorInfos(RegisterId inputRegister = 0,
                          RegisterId outputRegister = 1)
       -> EnumerateListExecutorInfos {
-    EnumerateListExecutorInfos infos{inputRegister, outputRegister};
+    EnumerateListExecutorInfos infos{*fakedQuery, inputRegister,
+                                     outputRegister};
     return infos;
   }
 };


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21196

Should address https://github.com/arangodb/arangodb/issues/13156#issuecomment-2244724718

Forcefully kill all running AQL queries on server shutdown.
This allows for a faster server shutdown even if there are some long-running AQL queries ongoing.
The query killing is done in the "stop" phase of the BootstrapFeature and thus only after the "beginShutdown" phase. Thus it should not interfere with the "soft shutdown" feature at all, and queries can still run to completion in case of a soft shutdown.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 