### PR TITLE
Improve CI test runtimes

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -273,15 +273,16 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: << parameters.s3-prefix >>
       CC: /tools/clang
       CXX: /tools/clang++
+    working_directory: /mnt/ramdisk/project
     steps:
       - checkout-arangodb:
           with-submodules: true
-          destination: "/root/project"
+          destination: "/mnt/ramdisk/project"
       - when:
           condition: << parameters.enterprise >>
           steps:
             - checkout-enterprise:
-                destination: "/root/project/enterprise"
+                destination: "/mnt/ramdisk/project/enterprise"
       - run:
           name: Print SCCache Settings
           command: sccache -s

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -273,16 +273,15 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: << parameters.s3-prefix >>
       CC: /tools/clang
       CXX: /tools/clang++
-    working_directory: /mnt/ramdisk/project
     steps:
       - checkout-arangodb:
           with-submodules: true
-          destination: "/mnt/ramdisk/project"
+          destination: "/root/project"
       - when:
           condition: << parameters.enterprise >>
           steps:
             - checkout-enterprise:
-                destination: "/mnt/ramdisk/project/enterprise"
+                destination: "/root/project/enterprise"
       - run:
           name: Print SCCache Settings
           command: sccache -s

--- a/tests/js/client/resilience/failover/resilience-synchronous-repl-cluster-fail-leader-part1.js
+++ b/tests/js/client/resilience/failover/resilience-synchronous-repl-cluster-fail-leader-part1.js
@@ -1,0 +1,148 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertTrue, assertFalse, assertEqual, fail, instanceInfo */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Max Neunhoeffer
+/// @author Copyright 2016, ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const fs = require('fs');
+const internal = require('internal');
+
+function SynchronousReplicationFailLeaderSuitePart1 () {
+  'use strict';
+  const suite = internal.load(fs.join(internal.pathForTesting('client'), 'resilience', 'failover', 'resilience-synchronous-repl-cluster.inc'));
+
+  return {
+    setUp : suite.setUp,
+    tearDown : suite.tearDown,
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief run a standard check with failures:
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsFailureLeader : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.failLeader();
+      suite.runBasicOperations({}, {});
+      suite.healLeader();
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 1
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail1 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:1, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 2
+////////////////////////////////////////////////////////////////////////////////
+    testBasicOperationsLeaderFail2 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:2, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 3
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail3 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:3, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 4
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail4 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:4, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 5
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail5 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:5, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 6
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail6 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:6, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 7
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail7 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:7, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief fail leader in place 8
+////////////////////////////////////////////////////////////////////////////////
+
+    testBasicOperationsLeaderFail8 : function () {
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+      suite.runBasicOperations({place:8, follower: false},
+                         {place:18, follower: false});
+      assertTrue(suite.waitForSynchronousReplication("_system"));
+    },
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(SynchronousReplicationFailLeaderSuitePart1);
+
+return jsunity.done();
+

--- a/tests/js/client/resilience/failover/resilience-synchronous-repl-cluster-fail-leader-part2.js
+++ b/tests/js/client/resilience/failover/resilience-synchronous-repl-cluster-fail-leader-part2.js
@@ -29,112 +29,13 @@ const jsunity = require("jsunity");
 const fs = require('fs');
 const internal = require('internal');
 
-function SynchronousReplicationFailLeaderSuite () {
+function SynchronousReplicationFailLeaderSuitePart2 () {
   'use strict';
   const suite = internal.load(fs.join(internal.pathForTesting('client'), 'resilience', 'failover', 'resilience-synchronous-repl-cluster.inc'));
 
   return {
     setUp : suite.setUp,
     tearDown : suite.tearDown,
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief run a standard check with failures:
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsFailureLeader : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.failLeader();
-      suite.runBasicOperations({}, {});
-      suite.healLeader();
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 1
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail1 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:1, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 2
-////////////////////////////////////////////////////////////////////////////////
-    testBasicOperationsLeaderFail2 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:2, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 3
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail3 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:3, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 4
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail4 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:4, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 5
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail5 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:5, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 6
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail6 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:6, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 7
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail7 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:7, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief fail leader in place 8
-////////////////////////////////////////////////////////////////////////////////
-
-    testBasicOperationsLeaderFail8 : function () {
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-      suite.runBasicOperations({place:8, follower: false},
-                         {place:18, follower: false});
-      assertTrue(suite.waitForSynchronousReplication("_system"));
-    },
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief fail leader in place 9
@@ -252,7 +153,7 @@ function SynchronousReplicationFailLeaderSuite () {
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
 
-jsunity.run(SynchronousReplicationFailLeaderSuite);
+jsunity.run(SynchronousReplicationFailLeaderSuitePart2);
 
 return jsunity.done();
 

--- a/tests/js/client/shell/arangosearch-memory-metrics-cluster.js
+++ b/tests/js/client/shell/arangosearch-memory-metrics-cluster.js
@@ -27,36 +27,22 @@
 const jsunity = require("jsunity");
 const internal = require("internal");
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-const base = require("fs").join(internal.pathForTesting('client'), 
-    'shell', 'shell-improved-metrics-accounting.inc');
-const ImprovedMemoryAccounting = internal.load(base);
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suite
-////////////////////////////////////////////////////////////////////////////////
+const arangosearch_base = require("fs").join(internal.pathForTesting('client'), 
+    'shell', 'api', 'arangosearch-memory-metrics.inc');
+const ImprovedMemoryAccountingArangoSearch = internal.load(arangosearch_base);
 
-if (internal.debugCanUseFailAt()) {
-    const base_fail_at = require("fs").join(internal.pathForTesting('client'), 
-    'shell', 'shell-improved-metrics-accounting-fail-at.inc');
-    const ImprovedMemoryAccountingFailAt = internal.load(base_fail_at);
-
-    jsunity.run(function ImprovedMemoryAccountingFailAtTestSuite_no_repl() {
-        let suite = {};
-        deriveTestSuite(
-            ImprovedMemoryAccountingFailAt("ImprovedMemoryAccountingFailAtTestSuite_NoRepl",null, {}),
-            suite,
-            "_NoRepl"
-        );
-        return suite;
-      });
-}
-
-jsunity.run(function ImprovedMemoryAccountingTestSuite_no_repl() {
-    let suite = {};  
+jsunity.run(function ImprovedMemoryAccountingArangoSearchTestSuite_repl() {
+    let suite = {
+    };
+  
     deriveTestSuite(
-      ImprovedMemoryAccounting("ImprovedMemoryAccountingTestSuite_NoRepl", null, {}),
+      ImprovedMemoryAccountingArangoSearch("ImprovedMemoryAccountingArangoSearch_Repl", null, {
+        replicationFactor:3, 
+        writeConcern:1, 
+        numberOfShards : 3}, false),
         suite,
-        "_NoRepl"
+        "_Repl"
     );
     return suite;
 });

--- a/tests/js/client/shell/arangosearch-memory-metrics-no-repl.js
+++ b/tests/js/client/shell/arangosearch-memory-metrics-no-repl.js
@@ -27,34 +27,17 @@
 const jsunity = require("jsunity");
 const internal = require("internal");
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-const base = require("fs").join(internal.pathForTesting('client'), 
-    'shell', 'shell-improved-metrics-accounting.inc');
-const ImprovedMemoryAccounting = internal.load(base);
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suite
-////////////////////////////////////////////////////////////////////////////////
+const arangosearch_base = require("fs").join(internal.pathForTesting('client'), 
+    'shell', 'api', 'arangosearch-memory-metrics.inc');
+const ImprovedMemoryAccountingArangoSearch = internal.load(arangosearch_base);
 
-if (internal.debugCanUseFailAt()) {
-    const base_fail_at = require("fs").join(internal.pathForTesting('client'), 
-    'shell', 'shell-improved-metrics-accounting-fail-at.inc');
-    const ImprovedMemoryAccountingFailAt = internal.load(base_fail_at);
-
-    jsunity.run(function ImprovedMemoryAccountingFailAtTestSuite_no_repl() {
-        let suite = {};
-        deriveTestSuite(
-            ImprovedMemoryAccountingFailAt("ImprovedMemoryAccountingFailAtTestSuite_NoRepl",null, {}),
-            suite,
-            "_NoRepl"
-        );
-        return suite;
-      });
-}
-
-jsunity.run(function ImprovedMemoryAccountingTestSuite_no_repl() {
-    let suite = {};  
+jsunity.run(function ImprovedMemoryAccountingArangoSearchTestSuite_no_repl() {
+    let suite = {
+    };
+  
     deriveTestSuite(
-      ImprovedMemoryAccounting("ImprovedMemoryAccountingTestSuite_NoRepl", null, {}),
+      ImprovedMemoryAccountingArangoSearch("ImprovedMemoryAccountingArangoSearch_NoRepl", null, {}),
         suite,
         "_NoRepl"
     );

--- a/tests/js/client/shell/arangosearch-memory-metrics-oneshard-cluster.js
+++ b/tests/js/client/shell/arangosearch-memory-metrics-oneshard-cluster.js
@@ -27,36 +27,19 @@
 const jsunity = require("jsunity");
 const internal = require("internal");
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-const base = require("fs").join(internal.pathForTesting('client'), 
-    'shell', 'shell-improved-metrics-accounting.inc');
-const ImprovedMemoryAccounting = internal.load(base);
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief executes the test suite
-////////////////////////////////////////////////////////////////////////////////
+const arangosearch_base = require("fs").join(internal.pathForTesting('client'), 
+    'shell', 'api', 'arangosearch-memory-metrics.inc');
+const ImprovedMemoryAccountingArangoSearch = internal.load(arangosearch_base);
 
-if (internal.debugCanUseFailAt()) {
-    const base_fail_at = require("fs").join(internal.pathForTesting('client'), 
-    'shell', 'shell-improved-metrics-accounting-fail-at.inc');
-    const ImprovedMemoryAccountingFailAt = internal.load(base_fail_at);
-
-    jsunity.run(function ImprovedMemoryAccountingFailAtTestSuite_no_repl() {
-        let suite = {};
-        deriveTestSuite(
-            ImprovedMemoryAccountingFailAt("ImprovedMemoryAccountingFailAtTestSuite_NoRepl",null, {}),
-            suite,
-            "_NoRepl"
-        );
-        return suite;
-      });
-}
-
-jsunity.run(function ImprovedMemoryAccountingTestSuite_no_repl() {
-    let suite = {};  
+jsunity.run(function ImprovedMemoryAccountingArangoSearchTestSuite_oneshard() {
+    let suite = {
+    };
+  
     deriveTestSuite(
-      ImprovedMemoryAccounting("ImprovedMemoryAccountingTestSuite_NoRepl", null, {}),
+      ImprovedMemoryAccountingArangoSearch("ImprovedMemoryAccountingArangoSearch_OneShard", {sharding: "single"}, {}),
         suite,
-        "_NoRepl"
+        "_OneShard"
     );
     return suite;
 });

--- a/tests/js/client/shell/shell-improved-metrics-accounting-cluster.js
+++ b/tests/js/client/shell/shell-improved-metrics-accounting-cluster.js
@@ -27,27 +27,20 @@
 const jsunity = require("jsunity");
 const internal = require("internal");
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-const base = require("fs").join(require('internal').pathForTesting('client'), 
+const base = require("fs").join(internal.pathForTesting('client'), 
     'shell', 'shell-improved-metrics-accounting.inc');
-
-const arangosearch_base = require("fs").join(require('internal').pathForTesting('client'), 
-    'shell', 'api', 'arangosearch-memory-metrics.inc');    
-
-const ImprovedMemoryAccounting = require("internal").load(base);
-const ImprovedMemoryAccountingArangoSearch = require("internal").load(arangosearch_base);
+const ImprovedMemoryAccounting = internal.load(base);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
 if (internal.debugCanUseFailAt()) {
-    const base_fail_at = require("fs").join(require('internal').pathForTesting('client'), 
+    const base_fail_at = require("fs").join(internal.pathForTesting('client'), 
     'shell', 'shell-improved-metrics-accounting-fail-at.inc');
-    const ImprovedMemoryAccountingFailAt = require("internal").load(base_fail_at);
+    const ImprovedMemoryAccountingFailAt = internal.load(base_fail_at);
 
     jsunity.run(function ImprovedMemoryAccountingFailAtTestSuite_repl() {
-        let suite = {
-        };
-      
+        let suite = {};
         deriveTestSuite(
             ImprovedMemoryAccountingFailAt("ImprovedMemoryAccountingFailAtTestSuite_Repl", null, {
             replicationFactor:3, 
@@ -61,26 +54,9 @@ if (internal.debugCanUseFailAt()) {
 }
 
 jsunity.run(function ImprovedMemoryAccountingTestSuite_repl() {
-    let suite = {
-    };
-  
+    let suite = {};
     deriveTestSuite(
       ImprovedMemoryAccounting("ImprovedMemoryAccountingTestSuite_Repl", null, {
-        replicationFactor:3, 
-        writeConcern:1, 
-        numberOfShards : 3}, false),
-        suite,
-        "_Repl"
-    );
-    return suite;
-});
-
-jsunity.run(function ImprovedMemoryAccountingArangoSearchTestSuite_repl() {
-    let suite = {
-    };
-  
-    deriveTestSuite(
-      ImprovedMemoryAccountingArangoSearch("ImprovedMemoryAccountingArangoSearch_Repl", null, {
         replicationFactor:3, 
         writeConcern:1, 
         numberOfShards : 3}, false),

--- a/tests/js/client/shell/shell-improved-metrics-accounting-oneshard-cluster.js
+++ b/tests/js/client/shell/shell-improved-metrics-accounting-oneshard-cluster.js
@@ -27,28 +27,21 @@
 const jsunity = require("jsunity");
 const internal = require("internal");
 const deriveTestSuite = require('@arangodb/test-helper').deriveTestSuite;
-const base = require("fs").join(require('internal').pathForTesting('client'), 
+const base = require("fs").join(internal.pathForTesting('client'), 
     'shell', 'shell-improved-metrics-accounting.inc');
-
-const arangosearch_base = require("fs").join(require('internal').pathForTesting('client'), 
-    'shell', 'api', 'arangosearch-memory-metrics.inc');    
-
-const ImprovedMemoryAccounting = require("internal").load(base);
-const ImprovedMemoryAccountingArangoSearch = require("internal").load(arangosearch_base);
+const ImprovedMemoryAccounting = internal.load(base);
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief executes the test suite
 ////////////////////////////////////////////////////////////////////////////////
 
 if (internal.debugCanUseFailAt()) {
-    const base_fail_at = require("fs").join(require('internal').pathForTesting('client'), 
+    const base_fail_at = require("fs").join(internal.pathForTesting('client'), 
     'shell', 'shell-improved-metrics-accounting-fail-at.inc');
-    const ImprovedMemoryAccountingFailAt = require("internal").load(base_fail_at);
+    const ImprovedMemoryAccountingFailAt = internal.load(base_fail_at);
 
     jsunity.run(function ImprovedMemoryAccountingFailAtTestSuite_oneshard() {
-        let suite = {
-        };
-      
+        let suite = {};
         deriveTestSuite(
             ImprovedMemoryAccountingFailAt("InvertedIndexSearchAliasqlTestSuite_OneShard", {sharding: "single"}, {}),
             suite,
@@ -59,9 +52,7 @@ if (internal.debugCanUseFailAt()) {
 }
 
 jsunity.run(function ImprovedMemoryAccountingTestSuite_oneshard() {
-    let suite = {
-    };
-  
+    let suite = {};
     deriveTestSuite(
       ImprovedMemoryAccounting("ImprovedMemoryAccountingTestSuite_OneShard", {sharding: "single"}, {}),
         suite,
@@ -70,15 +61,4 @@ jsunity.run(function ImprovedMemoryAccountingTestSuite_oneshard() {
     return suite;
 });
 
-jsunity.run(function ImprovedMemoryAccountingArangoSearchTestSuite_oneshard() {
-    let suite = {
-    };
-  
-    deriveTestSuite(
-      ImprovedMemoryAccountingArangoSearch("ImprovedMemoryAccountingArangoSearch_OneShard", {sharding: "single"}, {}),
-        suite,
-        "_OneShard"
-    );
-    return suite;
-});
 return jsunity.done();

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -29,7 +29,7 @@ endpoints priority=250 single -- --skipEndpointsIpv6 true
 
 recovery priority=2000 buckets=3 parallelity=3 size=small single
 # cluster
-recovery_cluster priority=2000 size=small cluster buckets=5
+recovery_cluster priority=2000 size=small cluster buckets=8
 
 recovery_server priority=2000 buckets=3 parallelity=3 size=small single
 # cluster
@@ -109,7 +109,8 @@ hot_backup enterprise size=large -- --dumpAgencyOnError true
 # frequent restarts impose more threats to the SUT, increase parallelity.
 server_parameters priority=1000 parallelity=3 buckets=3 single -- --dumpAgencyOnError true
 server_parameters priority=1000 parallelity=5 buckets=6 cluster -- --dumpAgencyOnError true
-server_permissions,server_secrets priority=1000 parallelity=5 size=small -- --dumpAgencyOnError true
+server_permissions priority=1000 parallelity=5 size=small buckets=2 -- --dumpAgencyOnError true
+server_secrets priority=1000 parallelity=5 size=small -- --dumpAgencyOnError true
 
 # Dump Tests
 dump size=medium -- --dumpAgencyOnError true

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -93,7 +93,7 @@ shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 
 # different number of buckets in cluster
 shell_client_aql priority=1000 size=medium+ cluster buckets=17 -- --dumpAgencyOnError true
-shell_client priority=500 cluster size=medium+ buckets=10 -- --dumpAgencyOnError true
+shell_client priority=500 cluster size=medium+ buckets=14 -- --dumpAgencyOnError true
 shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5 -- --dumpAgencyOnError true
 shell_client_replication2_recovery priority=500 size=medium cluster -- --dumpAgencyOnError true
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -108,7 +108,7 @@ hot_backup enterprise size=large -- --dumpAgencyOnError true
 
 # frequent restarts impose more threats to the SUT, increase parallelity.
 server_parameters priority=1000 parallelity=3 buckets=3 single -- --dumpAgencyOnError true
-server_parameters priority=1000 parallelity=5 buckets=6 cluster -- --dumpAgencyOnError true
+server_parameters priority=1000 parallelity=5 buckets=10 cluster -- --dumpAgencyOnError true
 server_permissions priority=1000 parallelity=5 size=small buckets=2 -- --dumpAgencyOnError true
 server_secrets priority=1000 parallelity=5 size=small -- --dumpAgencyOnError true
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -124,7 +124,8 @@ dump_encrypted enterprise size=medium -- --dumpAgencyOnError true
 dump_mixed_cluster_single size=medium -- --dumpAgencyOnError true
 dump_mixed_single_cluster size=large -- --dumpAgencyOnError true
 # takes long, needs to go first. However, doesn't utilize the SUT hard.
-dump_with_crashes size=medium parallelity=1 priority=2000 -- --dumpAgencyOnError true
+dump_with_crashes single size=medium parallelity=1 priority=2000 -- --dumpAgencyOnError true
+dump_with_crashes full cluster size=medium parallelity=1 priority=2000 -- --dumpAgencyOnError true
 dump_with_crashes_non_parallel size=medium parallelity=1 priority=2000 -- --dumpAgencyOnError true 
 
 # Audit Tests

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -27,7 +27,7 @@ agency,agency-restart priority=350 parallelity=3 size=small single -- --dumpAgen
 authentication priority=1000 single
 endpoints priority=250 single -- --skipEndpointsIpv6 true
 
-recovery priority=2000 buckets=3 parallelity=3 size=small single
+recovery priority=2000 buckets=6 parallelity=3 size=small single
 # cluster
 recovery_cluster priority=2000 size=small cluster buckets=8
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -79,7 +79,7 @@ replication2_client size=small cluster
 replication2_server size=medium cluster buckets=3 -- --dumpAgencyOnError true
 
 resilience_analyzers priority=500 size=medium cluster -- --dumpAgencyOnError true
-resilience_failover priority=1200 size=medium buckets=2 cluster -- --dumpAgencyOnError true
+resilience_failover priority=1200 size=medium buckets=4 cluster -- --dumpAgencyOnError true
 resilience_move priority=600 size=medium buckets=3 cluster -- --dumpAgencyOnError true
 resilience_sharddist size=small cluster -- --dumpAgencyOnError true
 


### PR DESCRIPTION
### Scope & Purpose

- Move arangosearch-memory-metrics tests into separate files for better distribution into test buckets.
- Split resilience-synchronous-repl-cluster-fail-leader.js into two files.
- Run cluster dump_with_crashes for nightlies only
- Increase number of buckets for a number of other suites

- [x] :hammer: Refactoring/simplification
