### PR TITLE
avoid a few unnecessary exceptions

### DIFF
--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -700,8 +700,7 @@ std::unique_ptr<ExecutionPlan> ExecutionPlan::instantiateFromVelocyPack(
     }
   }
 
-  if (auto apfn = slice.get("asyncPrefetchNodes");
-      !apfn.isNone() && apfn.isNumber<size_t>()) {
+  if (auto apfn = slice.get("asyncPrefetchNodes"); apfn.isNumber<size_t>()) {
     plan->_asyncPrefetchNodes = apfn.getNumericValue<size_t>();
   }
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -700,7 +700,8 @@ std::unique_ptr<ExecutionPlan> ExecutionPlan::instantiateFromVelocyPack(
     }
   }
 
-  if (auto apfn = slice.get("asyncPrefetchNodes"); apfn.isNumber<size_t>()) {
+  if (auto apfn = slice.get("asyncPrefetchNodes");
+      !apfn.isNone() && apfn.isNumber<size_t>()) {
     plan->_asyncPrefetchNodes = apfn.getNumericValue<size_t>();
   }
 

--- a/arangod/Aql/QueryInfoLoggerFeature.cpp
+++ b/arangod/Aql/QueryInfoLoggerFeature.cpp
@@ -580,6 +580,11 @@ void QueryInfoLoggerFeature::beginShutdown() {
 }
 
 void QueryInfoLoggerFeature::start() {
+  if (!_logEnabled) {
+    // feature is turned off. no need to execute the garbage collection
+    return;
+  }
+
   if (!ServerState::instance()->isSingleServerOrCoordinator()) {
     // this feature is only available on single servers and coordinators
     return;

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -765,7 +765,7 @@ bool IResearchLinkMeta::init(
     constexpr std::string_view kFieldName{StaticStrings::VersionField};
 
     auto const field = slice.get(kFieldName);
-    mask->_version = !field.isNone() && field.isNumber<uint32_t>();
+    mask->_version = field.isNumber<uint32_t>();
 
     if (mask->_version) {
       _version = field.getNumber<uint32_t>();

--- a/arangod/IResearch/IResearchLinkMeta.cpp
+++ b/arangod/IResearch/IResearchLinkMeta.cpp
@@ -765,7 +765,7 @@ bool IResearchLinkMeta::init(
     constexpr std::string_view kFieldName{StaticStrings::VersionField};
 
     auto const field = slice.get(kFieldName);
-    mask->_version = field.isNumber<uint32_t>();
+    mask->_version = !field.isNone() && field.isNumber<uint32_t>();
 
     if (mask->_version) {
       _version = field.getNumber<uint32_t>();


### PR DESCRIPTION
### Scope & Purpose

Avoid a few unnecessary exceptions from being thrown:

1. when the query info logger was not enabled, it still tried to periodically run the garbage collection on the `_queries` system collection. This runs into a (handled) exception when the collection is not present. This exception can be avoided by not executing the garbage collection at all if query info logging is not enabled.
2. when unserializing a query plan from velocypack, the attribute "asyncPrefetchNodes" can unserialized into a numeric value speculatively. If the attribute is not set, then the `velocypack::Slice::isNumber(...)` throws an exception, which is handled. This exception can be avoided by not trying to serialize the value into a number if it is not set at all.
3. same for some the optional" view/link attribute

All these exceptions were handled properly before. However, when working with the debugger and looking for "real" exceptions, these above exceptions are just in the way and create noise. 

This PR updates the bundled version of velocypack to fix issues 2. and 3. The update also includes an unrelated gdb debugging improvement made by @goedderz a while ago.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 