### PR TITLE
do not include numeric collection ids in debug packages

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -236,9 +236,9 @@ bool translateNodeStackToAttributePath(
  *
  * @param resolver CollectionNameResolver to identify category
  * @param accessType Access of this Source, NONE/READ/WRITE/EXCLUSIVE
- * @param failIfDoesNotExist If true => throws error im SourceNotFound. False =>
+ * @param failIfDoesNotExist If true => throws error if SourceNotFound. False =>
  * Treat non-existing like a collection
- * @param name Name of the datasource
+ * @param nameRef Name of the datasource (in/out parameter)
  *
  * @return The Category of this datasource (Collection or View), and a reference
  * to the translated name (cid => name if required).
@@ -247,16 +247,23 @@ LogicalDataSource::Category injectDataSourceInQuery(
     Ast& ast, CollectionNameResolver const& resolver,
     AccessMode::Type accessType, bool failIfDoesNotExist,
     std::string_view& nameRef) {
+  // NOTE nameRef may be modified later if a numeric collection ID is given
+  // instead of a collection Name. Afterwards it will contain the name.
+  if (nameRef.empty()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_ARANGO_ILLEGAL_NAME,
+                                   "empty name collections are not supported");
+  }
+
   std::string const name = std::string(nameRef);
-  // NOTE The name may be modified if a numeric collection ID is given instead
-  // of a collection Name. Afterwards it will contain the name.
   auto const dataSource = resolver.getDataSource(name);
 
   if (dataSource == nullptr) {
     // datasource not found...
     if (failIfDoesNotExist) {
-      THROW_ARANGO_EXCEPTION_FORMAT(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
-                                    "name: %s", name.c_str());
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
+          absl::StrCat(TRI_errno_string(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND),
+                       ": name: ", name));
     }
 
     // still add datasource to query, simply because the AST will also be built
@@ -274,9 +281,10 @@ LogicalDataSource::Category injectDataSourceInQuery(
   // the collection by its numeric id
   auto const& dataSourceName = dataSource->name();
 
-  if (nameRef != name) {
-    // name has changed by the lookup, so we need to reserve the collection
-    // name on the heap and update our std::string_view
+  if (name != dataSourceName) {
+    TRI_ASSERT(name.front() >= '0' && name.front() <= '9');
+    // name was a numeric collection id, so we need to store the collection
+    // name on the heap and update our std::string_view to point to it
     char* p = ast.resources().registerString(dataSourceName.data(),
                                              dataSourceName.size());
     nameRef = std::string_view(p, dataSourceName.size());
@@ -303,7 +311,7 @@ LogicalDataSource::Category injectDataSourceInQuery(
 
     ast.query().addDataSource(dataSource);
 
-    // Make sure to add all collections now:
+    // Make sure to add all collections from the view now:
     resolver.visitCollections(
         [&ast, accessType](LogicalCollection& col) -> bool {
           ast.query().collections().add(col.name(), accessType,

--- a/arangod/Aql/Collections.h
+++ b/arangod/Aql/Collections.h
@@ -52,7 +52,6 @@ class Collections {
 
   ~Collections();
 
- public:
   Collection* get(std::string_view name) const;
 
   Collection* add(std::string const& name, AccessMode::Type accessType,
@@ -62,7 +61,9 @@ class Collections {
 
   bool empty() const;
 
-  void toVelocyPack(arangodb::velocypack::Builder& builder) const;
+  void toVelocyPack(arangodb::velocypack::Builder& builder,
+                    std::function<bool(std::string const&,
+                                       Collection const&)> const& filter) const;
 
   void visit(std::function<bool(std::string const&, Collection&)> const&
                  visitor) const;

--- a/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
+++ b/arangod/Aql/EngineInfoContainerDBServerServerBased.cpp
@@ -364,7 +364,7 @@ Result EngineInfoContainerDBServerServerBased::buildEngines(
   });
 
   // remember which servers we add during our setup request
-  ::arangodb::containers::HashSet<std::string> serversAdded;
+  containers::HashSet<std::string> serversAdded;
 
   transaction::Methods& trx = _query.trxForOptimization();
   std::vector<arangodb::futures::Future<Result>> networkCalls{};

--- a/arangod/Aql/ShardLocking.h
+++ b/arangod/Aql/ShardLocking.h
@@ -139,7 +139,7 @@ class ShardLocking {
   // This will honor shard restrictions on the given snippet.
   // All shards will be returned, there will be no filtering on the server.
   std::unordered_set<ShardID> const& shardsForSnippet(
-      aql::QuerySnippet::Id snippetId, Collection const* col);
+      aql::QuerySnippet::Id snippetId, Collection const* col) const;
 
  private:
   // Adjust locking level of a single collection
@@ -148,7 +148,6 @@ class ShardLocking {
                      std::unordered_set<ShardID> const& restrictedShards,
                      bool useAsSatellite);
 
- private:
   QueryContext& _query;
 
   std::unordered_map<Collection const*, CollectionLockingInformation>

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -58,6 +58,7 @@
 #include "Cluster/MaintenanceFeature.h"
 #include "Cluster/RebootTracker.h"
 #include "Cluster/ServerState.h"
+#include "Containers/Enumerate.h"
 #include "Containers/NodeHashMap.h"
 #include "Indexes/Index.h"
 #include "Inspection/VPack.h"
@@ -91,19 +92,15 @@
 #include "VocBase/Methods/Indexes.h"
 
 #include <absl/strings/str_cat.h>
-
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <velocypack/Builder.h>
 #include <velocypack/Collection.h>
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-
 #include <chrono>
-
-#include "Containers/Enumerate.h"
 
 namespace arangodb {
 /// @brief internal helper struct for counting the number of shards etc.

--- a/tests/js/client/aql/aql-bind.js
+++ b/tests/js/client/aql/aql-bind.js
@@ -455,6 +455,11 @@ function ahuacatlBindTestSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testBindMissing : function () {
+      // when specifying an empty collection name, using a bind parameter or without a 
+      // bind parameter, we should get "illegal name" back
+      assertQueryError(errors.ERROR_ARANGO_ILLEGAL_NAME.code, "FOR doc IN @@collection RETURN doc", { "@collection": "" });
+      assertQueryError(errors.ERROR_ARANGO_ILLEGAL_NAME.code, "FOR doc IN `` RETURN doc", { });
+
       assertQueryError(errors.ERROR_QUERY_PARSE.code, "FOR u IN [ 1, 2 ] RETURN @", { });
       assertQueryError(errors.ERROR_QUERY_PARSE.code, "FOR u IN [ 1, 2 ] RETURN @@", { });
       assertQueryError(errors.ERROR_QUERY_BIND_PARAMETER_MISSING.code, "FOR u IN [ 1, 2 ] RETURN @value", { }); 


### PR DESCRIPTION
### Scope & Purpose

do not include numeric collection ids in debug packages

previously, when a query execution plan was serialized to velocypack in cluster mode, the list of collections used also included the stringified collection ids of collections that were used by views in the query. these stringified collection ids do not need to be serialized at all, as they will only lead to problems down the line.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
