### PR TITLE
Fix numerical sorting for VelocyPackHelper

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,19 @@ v3.11.11 (XXXX-XX-XX)
 * Fixed FE-435: drop collections checkbox in graph settings modal was not
   aligned.
 
+* Include LANGUAGE file in hotbackups. This is necessary to be able to detect
+  locale changes across a hotbackup create/restore process.
+
+* Fix sorting behaviour of VelocyPack values w.r.t. numbers. This has an
+  impact on indexes indexing VPackValues. Therefore, after an upgrade the 
+  old sorting order will be retained to allow smooth upgrades. Newly started
+  instances with a fresh database directory will only use the new sorting
+  method. There is also a migration API under 
+  GET /_admin/cluster/vpackSortMigration/check and 
+  PUT /_admin/cluster/vpackSortMigration/migrate to check for problematic
+  indexes and - provided there are none - to migrate the instance to 
+  the new sorting order.
+
 * Forcefully kill all running AQL queries on server shutdown.
   This allows for a faster server shutdown even if there are some long-running
   AQL queries ongoing.

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -59,6 +59,7 @@
 #include "Network/NetworkFeature.h"
 #include "Scheduler/SchedulerFeature.h"
 #include "Sharding/ShardDistributionReporter.h"
+#include "StorageEngine/VPackSortMigration.h"
 #include "Utils/ExecContext.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Databases.h"
@@ -294,6 +295,11 @@ std::string const RestAdminClusterHandler::RemoveServer = "removeServer";
 std::string const RestAdminClusterHandler::RebalanceShards = "rebalanceShards";
 std::string const RestAdminClusterHandler::Rebalance = "rebalance";
 std::string const RestAdminClusterHandler::ShardStatistics = "shardStatistics";
+std::string const RestAdminClusterHandler::VPackSortMigration =
+    "vpackSortMigration";
+std::string const RestAdminClusterHandler::VPackSortMigrationCheck = "check";
+std::string const RestAdminClusterHandler::VPackSortMigrationMigrate =
+    "migrate";
 std::string const RestAdminClusterHandler::FailureOracle = "failureOracle";
 
 RestStatus RestAdminClusterHandler::execute() {
@@ -383,6 +389,8 @@ RestStatus RestAdminClusterHandler::execute() {
       return handleRebalance();
     } else if (command == Maintenance) {
       return handleDBServerMaintenance(suffixes.at(1));
+    } else if (command == VPackSortMigration) {
+      return waitForFuture(handleVPackSortMigration(suffixes.at(1)));
     } else {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     std::string("invalid command '") + command +
@@ -2969,4 +2977,56 @@ RestStatus RestAdminClusterHandler::handleFailureOracleFlush() {
   failureOracle.flush();
   generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
   return RestStatus::DONE;
+}
+
+RestAdminClusterHandler::FutureVoid
+RestAdminClusterHandler::handleVPackSortMigration(
+    std::string const& subCommand) {
+  // First we do the authentication: We only allow superuser access, since
+  // this is a critical migration operation:
+  if (ExecContext::isAuthEnabled() && !ExecContext::current().isSuperuser()) {
+    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
+                  "only superusers may run vpack index migration");
+    co_return;
+  }
+
+  // First check methods:
+  if (!((request()->requestType() == rest::RequestType::GET &&
+         subCommand == VPackSortMigrationCheck) ||
+        (request()->requestType() == rest::RequestType::PUT &&
+         subCommand == VPackSortMigrationMigrate))) {
+    generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
+                  TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
+    co_return;
+  }
+
+  // We behave differently on a coordinator and on a single server,
+  // dbserver or agent.
+  // On a coordinator, we basically implement a trampoline to all dbservers.
+  // On the other instance types, we implement the actual checking and
+  // migration logic. Agents do not have to be checked since they do not
+  // use VPack indexes.
+  VPackBuilder result;
+  Result res;
+  if (!ServerState::instance()->isCoordinator()) {
+    if (request()->requestType() == rest::RequestType::GET) {
+      res = ::analyzeVPackIndexSorting(_vocbase, result);
+    } else {  // PUT
+      res = ::migrateVPackIndexSorting(_vocbase, result);
+    }
+  } else {
+    // Coordinators from here:
+    if (request()->requestType() == rest::RequestType::GET) {
+      res = co_await handleVPackSortMigrationTest(_vocbase, result);
+    } else {  // PUT
+      res = co_await handleVPackSortMigrationAction(_vocbase, result);
+    }
+  }
+  if (res.fail()) {
+    generateError(rest::ResponseCode::SERVER_ERROR, res.errorNumber(),
+                  res.errorMessage());
+  } else {
+    generateOk(rest::ResponseCode::OK, result.slice());
+  }
+  co_return;
 }

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -115,7 +115,7 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
 
   typedef futures::Future<futures::Unit> FutureVoid;
 
-  FutureVoid handleVPackSortMigration(std::string const& subCommand);
+  RestStatus handleVPackSortMigration(std::string const& subCommand);
 
   struct MoveShardContext {
     std::string database;

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -66,6 +66,9 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   static std::string const RebalanceShards;
   static std::string const Rebalance;
   static std::string const ShardStatistics;
+  static std::string const VPackSortMigration;
+  static std::string const VPackSortMigrationCheck;
+  static std::string const VPackSortMigrationMigrate;
   static std::string const FailureOracle;
 
   RestStatus handleHealth();
@@ -110,7 +113,10 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
 
   RestStatus handleFailureOracle();
 
- private:
+  typedef futures::Future<futures::Unit> FutureVoid;
+
+  FutureVoid handleVPackSortMigration(std::string const& subCommand);
+
   struct MoveShardContext {
     std::string database;
     std::string collection;
@@ -149,7 +155,6 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   RestStatus handleFailureOracleFlush();
 
   typedef std::chrono::steady_clock clock;
-  typedef futures::Future<futures::Unit> FutureVoid;
 
   FutureVoid waitForSupervisionState(bool state,
                                      std::string const& reactivationTime,

--- a/arangod/RocksDBEngine/RocksDBComparator.cpp
+++ b/arangod/RocksDBEngine/RocksDBComparator.cpp
@@ -24,7 +24,6 @@
 
 #include "RocksDBComparator.h"
 
-#include "Basics/VelocyPackHelper.h"
 #include "Basics/system-compiler.h"
 #include "RocksDBEngine/RocksDBKey.h"
 #include "RocksDBEngine/RocksDBPrefixExtractor.h"
@@ -33,10 +32,9 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
-using namespace arangodb;
-
 namespace {
 
+template<arangodb::basics::VelocyPackHelper::SortingMethod sortingMethod>
 int compareIndexedValues(arangodb::velocypack::Slice const& lhs,
                          arangodb::velocypack::Slice const& rhs) {
   TRI_ASSERT(lhs.isArray());
@@ -53,9 +51,17 @@ int compareIndexedValues(arangodb::velocypack::Slice const& lhs,
       return static_cast<int>(lhsIter.size() - rhsIter.size());
     }
 
-    int res = arangodb::basics::VelocyPackHelper::compare(
-        (lhsValid ? *lhsIter : VPackSlice::noneSlice()),
-        (rhsValid ? *rhsIter : VPackSlice::noneSlice()), true);
+    int res;
+    if constexpr (sortingMethod ==
+                  arangodb::basics::VelocyPackHelper::SortingMethod::Legacy) {
+      res = arangodb::basics::VelocyPackHelper::compareLegacy(
+          (lhsValid ? *lhsIter : VPackSlice::noneSlice()),
+          (rhsValid ? *rhsIter : VPackSlice::noneSlice()), true);
+    } else {
+      res = arangodb::basics::VelocyPackHelper::compare(
+          (lhsValid ? *lhsIter : VPackSlice::noneSlice()),
+          (rhsValid ? *rhsIter : VPackSlice::noneSlice()), true);
+    }
     if (res != 0) {
       return res;
     }
@@ -67,7 +73,10 @@ int compareIndexedValues(arangodb::velocypack::Slice const& lhs,
 
 }  // namespace
 
-int RocksDBVPackComparator::compareIndexValues(
+namespace arangodb {
+
+template<arangodb::basics::VelocyPackHelper::SortingMethod sortingMethod>
+int RocksDBVPackComparator<sortingMethod>::compareIndexValues(
     rocksdb::Slice const& lhs, rocksdb::Slice const& rhs) const {
   constexpr size_t objectIDLength = RocksDBKey::objectIdSize();
 
@@ -94,7 +103,7 @@ int RocksDBVPackComparator::compareIndexValues(
   VPackSlice const rSlice = VPackSlice(
       reinterpret_cast<uint8_t const*>(rhs.data()) + sizeof(uint64_t));
 
-  r = ::compareIndexedValues(lSlice, rSlice);
+  r = ::compareIndexedValues<sortingMethod>(lSlice, rSlice);
 
   if (r != 0) {
     // comparison of index values produced an unambiguous result
@@ -122,3 +131,11 @@ int RocksDBVPackComparator::compareIndexValues(
 
   return static_cast<int>(lSize - rSize);
 }
+
+// Now explicitly instantiate the two cases:
+template class RocksDBVPackComparator<
+    arangodb::basics::VelocyPackHelper::SortingMethod::Legacy>;
+template class RocksDBVPackComparator<
+    arangodb::basics::VelocyPackHelper::SortingMethod::Correct>;
+
+}  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBComparator.h
+++ b/arangod/RocksDBEngine/RocksDBComparator.h
@@ -29,8 +29,11 @@
 #include <rocksdb/comparator.h>
 #include <rocksdb/slice.h>
 
+#include "Basics/VelocyPackHelper.h"
+
 namespace arangodb {
 
+template<arangodb::basics::VelocyPackHelper::SortingMethod sortingMethod>
 class RocksDBVPackComparator final : public rocksdb::Comparator {
  public:
   RocksDBVPackComparator() = default;

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -3890,6 +3890,16 @@ void RocksDBEngine::waitForCompactionJobsToFinish() {
       LOG_TOPIC("9cbfd", INFO, Logger::ENGINES)
           << "waiting for " << numRunning << " compaction job(s) to finish...";
     }
+    // Maybe a flush can help?
+    if (iterations == 100) {
+      Result res =
+          flushWal(false /* waitForSync */, true /* flushColumnFamilies */);
+      if (res.fail()) {
+        LOG_TOPIC("25161", WARN, Logger::ENGINES)
+            << "Error on flushWal during waitForCompactionJobsToFinish: "
+            << res.errorMessage();
+      }
+    }
     // unfortunately there is not much we can do except waiting for
     // RocksDB's compaction job(s) to finish.
     std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -4079,6 +4079,13 @@ SortingMethod RocksDBEngine::readSortingFile() {
     sortingMethod =
         (value == "LEGACY") ? SortingMethod::Legacy : SortingMethod::Correct;
   } catch (std::exception const& ex) {
+    // To find out if we are an agent, we need to check if the AgencyFeature
+    // is activated! Note that we cannot use ServerState::isAgent here for
+    // the following reason: When we run an upgraded version for the first
+    // time, we almost certainly run with --database.auto-upgrade=true .
+    // But in this case, the AgencyFeature and the ClusterFeature are
+    // disabled! Therefore, the role of the server is not correctly
+    // reported to the ServerState class!
     auto& agencyFeature = server().getFeature<AgencyFeature>();
     // When we see a database directory without SORTING file, we fall back
     // to legacy mode, except for agents. Since agents have never used

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -23,6 +23,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "RocksDBEngine.h"
+#include "Agency/AgencyFeature.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/LanguageFeature.h"
 #include "Basics/Exceptions.h"
@@ -4078,12 +4079,13 @@ SortingMethod RocksDBEngine::readSortingFile() {
     sortingMethod =
         (value == "LEGACY") ? SortingMethod::Legacy : SortingMethod::Correct;
   } catch (std::exception const& ex) {
+    auto& agencyFeature = server().getFeature<AgencyFeature>();
     // When we see a database directory without SORTING file, we fall back
     // to legacy mode, except for agents. Since agents have never used
     // VPackIndexes before we fixed the sorting order, we might as well
     // directly consider them to be migrated to the CORRECT sorting order:
-    sortingMethod = ServerState::instance()->isAgent() ? SortingMethod::Correct
-                                                       : SortingMethod::Legacy;
+    sortingMethod = agencyFeature.activated() ? SortingMethod::Correct
+                                              : SortingMethod::Legacy;
     LOG_TOPIC("8ff0e", WARN, Logger::STARTUP)
         << "unable to read 'SORTING' file '" << path << "': " << ex.what()
         << ". This is expected directly after an upgrade and will then be "

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -75,7 +75,6 @@ class RocksDBReplicationManager;
 class RocksDBSettingsManager;
 class RocksDBSyncThread;
 class RocksDBThrottle;  // breaks tons if RocksDBThrottle.h included here
-class RocksDBVPackComparator;
 class RocksDBWalAccess;
 class TransactionCollection;
 class TransactionState;
@@ -389,6 +388,10 @@ class RocksDBEngine final : public StorageEngine {
   void trackRevisionTreeMemoryIncrease(std::uint64_t value) noexcept;
   void trackRevisionTreeMemoryDecrease(std::uint64_t value) noexcept;
 
+  std::string getSortingMethodFile() const;
+
+  std::string getLanguageFile() const;
+
 #ifdef USE_ENTERPRISE
   bool encryptionKeyRotationEnabled() const;
 
@@ -534,6 +537,15 @@ class RocksDBEngine final : public StorageEngine {
 
   bool checkExistingDB(
       std::vector<rocksdb::ColumnFamilyDescriptor> const& cfFamilies);
+
+ public:
+  Result writeSortingFile(
+      arangodb::basics::VelocyPackHelper::SortingMethod sortingMethod);
+
+ private:
+  // The following method returns what is detected for the sorting method.
+  // If no SORTING file is detected, a new one with "LEGACY" will be created.
+  arangodb::basics::VelocyPackHelper::SortingMethod readSortingFile();
 
   RocksDBOptionsProvider const& _optionsProvider;
 
@@ -757,9 +769,17 @@ class RocksDBEngine final : public StorageEngine {
   std::unique_ptr<rocksdb::Env> _checksumEnv;
 
   std::unique_ptr<RocksDBDumpManager> _dumpManager;
+
+  // For command line option to force legacy even for new databases.
+  bool _forceLegacySortingMethod;
+
+  arangodb::basics::VelocyPackHelper::SortingMethod
+      _sortingMethod;  // Detected at startup in the prepare method
 };
 
 static constexpr const char* kEncryptionTypeFile = "ENCRYPTION";
 static constexpr const char* kEncryptionKeystoreFolder = "ENCRYPTION-KEYS";
+static constexpr const char* kSortingMethodFile = "SORTING";
+static constexpr const char* kLanguageFile = "LANGUAGE";
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -37,6 +37,7 @@
 
 #include "Basics/Common.h"
 #include "Basics/ReadWriteLock.h"
+#include "Basics/VelocyPackHelper.h"
 #include "RocksDBEngine/RocksDBKeyBounds.h"
 #include "RocksDBEngine/RocksDBTypes.h"
 #include "StorageEngine/StorageEngine.h"

--- a/arangod/RocksDBEngine/RocksDBOptionsProvider.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionsProvider.cpp
@@ -23,6 +23,8 @@
 
 #include "RocksDBEngine/RocksDBOptionsProvider.h"
 
+#include "Basics/VelocyPackHelper.h"
+#include "RocksDBEngine/RocksDBComparator.h"
 #include "RocksDBEngine/RocksDBPrefixExtractor.h"
 
 #include <rocksdb/slice_transform.h>
@@ -30,7 +32,9 @@
 namespace arangodb {
 
 RocksDBOptionsProvider::RocksDBOptionsProvider()
-    : _vpackCmp(std::make_unique<RocksDBVPackComparator>()) {}
+    : _vpackCmp(
+          std::make_unique<RocksDBVPackComparator<
+              arangodb::basics::VelocyPackHelper::SortingMethod::Correct>>()) {}
 
 rocksdb::Options const& RocksDBOptionsProvider::getOptions() const {
   if (!_options) {

--- a/arangod/RocksDBEngine/RocksDBOptionsProvider.h
+++ b/arangod/RocksDBEngine/RocksDBOptionsProvider.h
@@ -33,8 +33,6 @@
 
 namespace arangodb {
 
-class RocksDBVPackComparator;
-
 struct RocksDBOptionsProvider {
   RocksDBOptionsProvider();
   virtual ~RocksDBOptionsProvider() = default;
@@ -44,6 +42,10 @@ struct RocksDBOptionsProvider {
   rocksdb::BlockBasedTableOptions const& getTableOptions() const;
   virtual rocksdb::ColumnFamilyOptions getColumnFamilyOptions(
       RocksDBColumnFamilyManager::Family family) const;
+  void resetVPackComparator(
+      std::unique_ptr<rocksdb::Comparator> newComparator) {
+    _vpackCmp = std::move(newComparator);
+  }
 
   virtual bool useFileLogging() const noexcept { return false; }
   virtual bool limitOpenFilesAtStartup() const noexcept { return false; }
@@ -58,7 +60,7 @@ struct RocksDBOptionsProvider {
 
  private:
   /// arangodb comparator - required because of vpack in keys
-  std::unique_ptr<RocksDBVPackComparator> _vpackCmp;
+  std::unique_ptr<rocksdb::Comparator> _vpackCmp;
   mutable std::optional<rocksdb::Options> _options;
   mutable std::optional<rocksdb::BlockBasedTableOptions> _tableOptions;
 };

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -542,7 +542,7 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
       RocksDBVPackIndexSearchValueFormat format)
       : IndexIterator(collection, trx, readOwnWrites),
         _index(index),
-        _cmp(static_cast<RocksDBVPackComparator const*>(index->comparator())),
+        _cmp(index->comparator()),
         _cache(std::static_pointer_cast<VPackIndexCacheType>(std::move(cache))),
         _resourceMonitor(monitor),
         _builderOptions(VPackOptions::Defaults),
@@ -1149,7 +1149,7 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
   static constexpr size_t expectedIteratorMemoryUsage = 8192;
 
   RocksDBVPackIndex const* _index;
-  RocksDBVPackComparator const* _cmp;
+  rocksdb::Comparator const* _cmp;
   std::unique_ptr<rocksdb::Iterator> _iterator;
   std::shared_ptr<VPackIndexCacheType> _cache;
   ResourceMonitor& _resourceMonitor;
@@ -2849,7 +2849,8 @@ void RocksDBVPackIndex::warmupInternal(transaction::Methods* trx) {
     rocksdb::Slice key = it->key();
     TRI_ASSERT(objectId() == RocksDBKey::objectId(key));
     VPackSlice v = RocksDBKey::indexedVPack(key);
-    if (basics::VelocyPackHelper::compare(v, builder.slice(), true) != 0) {
+    int cmp = basics::VelocyPackHelper::compare(v, builder.slice(), true);
+    if (cmp != 0) {
       // index values are different. now do a lookup in cache/rocksdb
       builder.clear();
       builder.add(v);

--- a/arangod/StorageEngine/CMakeLists.txt
+++ b/arangod/StorageEngine/CMakeLists.txt
@@ -11,7 +11,8 @@ add_library(arango_storage_engine STATIC
   PhysicalCollection.cpp
   TransactionCollection.cpp
   TransactionState.cpp
-  StorageEngine.cpp)
+  StorageEngine.cpp
+  VPackSortMigration.cpp)
 target_link_libraries(arango_storage_engine
   arango_cluster_engine
   arango_cluster_methods

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -1,0 +1,282 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Max Neunhoeffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "VPackSortMigration.h"
+#include <rocksdb/utilities/transaction_db.h>
+
+#include "Indexes/Index.h"
+#include "Logger/LogMacros.h"
+#include "RestServer/DatabaseFeature.h"
+#include "RocksDBEngine/RocksDBComparator.h"
+#include "RocksDBEngine/RocksDBEngine.h"
+#include "RocksDBEngine/RocksDBIndex.h"
+#include "StorageEngine/EngineSelectorFeature.h"
+#include "StorageEngine/PhysicalCollection.h"
+#include "Utils/SingleCollectionTransaction.h"
+#include "Transaction/StandaloneContext.h"
+#include "VocBase/LogicalCollection.h"
+
+#include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
+
+#include "Network/NetworkFeature.h"
+#include "Network/Methods.h"
+
+namespace arangodb {
+
+// On dbservers, agents and single servers:
+Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
+  // Just for the sake of completeness, restrict ourselves to the RocksDB
+  // storage engine:
+  auto& engineSelectorFeature =
+      vocbase.server().getFeature<EngineSelectorFeature>();
+  if (!engineSelectorFeature.isRocksDB()) {
+    return Result(TRI_ERROR_NOT_IMPLEMENTED,
+                  "VPack sorting migration is unnecessary for storage engines "
+                  "other than RocksDB");
+  }
+
+  auto& engine = engineSelectorFeature.engine<RocksDBEngine>();
+  auto* db = engine.db();
+
+  using IndexType = arangodb::Index::IndexType;
+  DatabaseFeature& databaseFeature =
+      vocbase.server().getFeature<DatabaseFeature>();
+  auto newComparator = RocksDBVPackComparator<
+      arangodb::basics::VelocyPackHelper::SortingMethod::Correct>();
+
+  // Collect problems here:
+  result.clear();
+  {
+    VPackObjectBuilder guardO(&result);
+    bool problemFound = false;
+    guardO->add(VPackValue("affected"));  // just write key
+    {
+      VPackArrayBuilder guardA(&result);
+
+      for (auto const& name : databaseFeature.getDatabaseNames()) {
+        auto database = databaseFeature.useDatabase(name);
+        if (database == nullptr) {
+          continue;
+        }
+        LOG_TOPIC("76521", DEBUG, Logger::ENGINES)
+            << "Checking VPackSortMigration for database " << name;
+        database->processCollections([&](LogicalCollection* collection) {
+          LOG_TOPIC("42537", DEBUG, Logger::ENGINES)
+              << "Checking VPackSortMigration for collection "
+              << collection->name();
+          for (auto& index : collection->getPhysical()->getReadyIndexes()) {
+            LOG_TOPIC("42538", DEBUG, Logger::ENGINES)
+                << "Checking VPackSortMigration for index with ID "
+                << index->id().id() << " and name " << index->name();
+            if (auto type = index->type();
+                type == IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX ||
+                type == IndexType::TRI_IDX_TYPE_HASH_INDEX ||
+                type == IndexType::TRI_IDX_TYPE_SKIPLIST_INDEX ||
+                type == IndexType::TRI_IDX_TYPE_MDI_PREFIXED_INDEX) {
+              RocksDBIndex* rocksDBIndex =
+                  dynamic_cast<RocksDBIndex*>(index.get());
+              if (rocksDBIndex != nullptr) {
+                // The above types will all be instances of RocksDBIndex, but
+                // we check just in case!
+                auto objectId = rocksDBIndex->objectId();
+                LOG_TOPIC("42539", DEBUG, Logger::ENGINES)
+                    << "VPackSortMigration: RocksDBIndex, objectId: "
+                    << std::hex << objectId;
+                auto bounds = rocksDBIndex->getBounds(objectId);
+                auto columnFamily = rocksDBIndex->columnFamily();
+
+                // Note that the below iterator will automatically create a
+                // RocksDB read snapshot
+                rocksdb::Slice const end = bounds.end();
+                rocksdb::ReadOptions options;
+                options.iterate_upper_bound =
+                    &end;  // safe to use on rocksb::DB directly
+                options.prefix_same_as_start = true;
+                options.verify_checksums = false;
+                options.fill_cache = false;
+                std::unique_ptr<rocksdb::Iterator> it(
+                    db->NewIterator(options, columnFamily));
+                std::string prev_key;  // copy the previous key, since the
+                                       // slice to which the it->key() points
+                                       // is not guaranteed to keep its value!
+                bool alarm = false;
+                for (it->Seek(bounds.start()); it->Valid(); it->Next()) {
+                  rocksdb::Slice key = it->key();
+                  if (!prev_key.empty()) {
+                    LOG_TOPIC("42540", TRACE, Logger::ENGINES)
+                        << "VPackSortMigration: comparing keys: "
+                        << key.ToString(true) << " with "
+                        << rocksdb::Slice(prev_key.data(), prev_key.size())
+                               .ToString(true);
+                    // Note that there is an implicit conversion from
+                    // std::string to rocksdb::Slice:
+                    if (newComparator.Compare(prev_key, key) > 0) {
+                      LOG_TOPIC("42541", WARN, Logger::ENGINES)
+                          << "VPackSortMigration: found problematic key for "
+                             "database "
+                          << name << ", collection " << collection->name()
+                          << ", index with ID " << index->id().id()
+                          << " and name " << index->name();
+                      alarm = true;
+                      break;
+                    }
+                  }
+                  prev_key.assign(key.data(), key.size());
+                }
+                if (alarm) {
+                  problemFound = true;
+                  {
+                    VPackObjectBuilder guardO2(&result);
+                    guardO2->add("database", VPackValue(name));
+                    guardO2->add("collection", VPackValue(collection->name()));
+                    guardO2->add("indexId", VPackValue(index->id().id()));
+                    guardO2->add("indexName", VPackValue(index->name()));
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
+    }
+
+    if (!problemFound) {
+      guardO->add(StaticStrings::Error, VPackValue(false));
+      guardO->add(StaticStrings::ErrorCode, VPackValue(0));
+      guardO->add(StaticStrings::ErrorMessage,
+                  VPackValue("all good with sorting order"));
+    } else {
+      guardO->add(StaticStrings::Error, VPackValue(true));
+      guardO->add(StaticStrings::ErrorCode,
+                  VPackValue(TRI_ERROR_ARANGO_INDEX_HAS_LEGACY_SORTED_KEYS));
+      guardO->add(StaticStrings::ErrorMessage,
+                  VPackValue("some indexes have legacy sorted keys"));
+    }
+  }
+
+  return {};
+}
+
+Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
+  // Just for the sake of completeness, restrict ourselves to the RocksDB
+  // storage engine:
+  result.clear();
+  auto& engineSelectorFeature =
+      vocbase.server().getFeature<EngineSelectorFeature>();
+  if (!engineSelectorFeature.isRocksDB()) {
+    return Result(TRI_ERROR_NOT_IMPLEMENTED,
+                  "VPack sorting migration is unnecessary for storage engines "
+                  "other than RocksDB");
+  }
+
+  auto& engine = engineSelectorFeature.engine<RocksDBEngine>();
+  Result res = engine.writeSortingFile(
+      arangodb::basics::VelocyPackHelper::SortingMethod::Correct);
+
+  if (res.ok()) {
+    VPackObjectBuilder guard(&result);
+    guard->add(StaticStrings::Error, VPackValue(false));
+    guard->add(StaticStrings::ErrorCode, VPackValue(0));
+    guard->add(StaticStrings::ErrorMessage,
+               VPackValue("VPack sorting migration done."));
+    return {};
+  }
+  return res;
+}
+
+namespace {
+async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
+                             VPackBuilder& result, bool includeAgents) {
+  TRI_ASSERT(ServerState::instance()->isCoordinator());
+
+  auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
+  auto& nf = vocbase.server().getFeature<NetworkFeature>();
+
+  auto dbs = ci.getCurrentDBServers();
+  std::vector<futures::Future<network::Response>> requests;
+  requests.reserve(dbs.size());
+
+  network::RequestOptions opts;
+  opts.database = vocbase.name();
+
+  std::string path =
+      absl::StrCat("/_admin/cluster/vpackSortMigration/",
+                   verb == fuerte::RestVerb::Get ? "check" : "migrate");
+  for (auto const& server : dbs) {
+    auto f = network::sendRequest(nf.pool(), "server:" + server, verb, path, {},
+                                  opts);
+    requests.emplace_back(std::move(f).then(
+        [server](auto&& response) { return std::move(response).get(); }));
+  }
+
+  LOG_TOPIC("22535", DEBUG, Logger::ENGINES)
+      << "VPackSortMigration: awaiting all results";
+  auto responses = co_await futures::collectAll(requests);
+  LOG_TOPIC("22536", DEBUG, Logger::ENGINES)
+      << "VPackSortMigration: all servers responded";
+
+  {
+    VPackObjectBuilder b(&result);
+    for (auto& resp : responses) {
+      auto res = basics::catchToResultT([&] { return std::move(resp).get(); });
+
+      {
+        // result.add(VPackValue(*(server++)));
+        std::string server = res.get().destination;
+        if (server.starts_with("server:")) {
+          server = server.substr(7);
+        }
+        result.add(VPackValue(server));
+        if (res.fail()) {
+          VPackObjectBuilder ob{&result};
+          result.add(StaticStrings::Error, VPackValue(true));
+          result.add(StaticStrings::ErrorMessage,
+                     VPackValue(res.errorMessage()));
+          result.add(StaticStrings::ErrorCode, VPackValue(res.errorNumber()));
+        } else {
+          result.add(res.get().slice());
+        }
+      }
+    }
+  }
+
+  co_return {};
+}
+}  // namespace
+
+// On coordinators:
+async<Result> handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
+                                           VPackBuilder& result) {
+  TRI_ASSERT(ServerState::instance()->isCoordinator());
+
+  return fanOutRequests(vocbase, fuerte::RestVerb::Get, result, false);
+}
+
+async<Result> handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
+                                             VPackBuilder& result) {
+  TRI_ASSERT(ServerState::instance()->isCoordinator());
+
+  return fanOutRequests(vocbase, fuerte::RestVerb::Put, result, true);
+}
+
+}  // namespace arangodb

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -91,8 +91,7 @@ Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
             if (auto type = index->type();
                 type == IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX ||
                 type == IndexType::TRI_IDX_TYPE_HASH_INDEX ||
-                type == IndexType::TRI_IDX_TYPE_SKIPLIST_INDEX ||
-                type == IndexType::TRI_IDX_TYPE_MDI_PREFIXED_INDEX) {
+                type == IndexType::TRI_IDX_TYPE_SKIPLIST_INDEX) {
               RocksDBIndex* rocksDBIndex =
                   dynamic_cast<RocksDBIndex*>(index.get());
               if (rocksDBIndex != nullptr) {

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -208,7 +208,7 @@ Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
 
 namespace {
 Result fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
-                      VPackBuilder& result, bool includeAgents) {
+                      VPackBuilder& result) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
   auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
@@ -219,6 +219,12 @@ Result fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
   requests.reserve(dbs.size());
 
   network::RequestOptions opts;
+  if (verb == fuerte::RestVerb::Get) {
+    // We want to use a long timeout for the check, since going through
+    // the indexes might take a while. The user is supposed to call this
+    // route asynchronously anyway:
+    opts.timeout = arangodb::network::Timeout(12 * 3600.0);
+  }
   opts.database = vocbase.name();
 
   std::string path =
@@ -271,14 +277,14 @@ Result handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
                                     VPackBuilder& result) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
-  return fanOutRequests(vocbase, fuerte::RestVerb::Get, result, false);
+  return fanOutRequests(vocbase, fuerte::RestVerb::Get, result);
 }
 
 Result handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
                                       VPackBuilder& result) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
-  return fanOutRequests(vocbase, fuerte::RestVerb::Put, result, true);
+  return fanOutRequests(vocbase, fuerte::RestVerb::Put, result);
 }
 
 }  // namespace arangodb

--- a/arangod/StorageEngine/VPackSortMigration.h
+++ b/arangod/StorageEngine/VPackSortMigration.h
@@ -1,0 +1,39 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Max Neunhoeffer
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Basics/Result.h"
+#include "Basics/async.h"
+#include "VocBase/vocbase.h"
+
+namespace arangodb {
+
+// On dbservers, agents and single servers:
+Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
+Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
+
+// On coordinators:
+async<Result> handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
+                                           VPackBuilder& result);
+async<Result> handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
+                                             VPackBuilder& result);
+
+}  // namespace arangodb

--- a/arangod/StorageEngine/VPackSortMigration.h
+++ b/arangod/StorageEngine/VPackSortMigration.h
@@ -21,7 +21,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Basics/Result.h"
-#include "Basics/async.h"
 #include "VocBase/vocbase.h"
 
 namespace arangodb {
@@ -31,9 +30,9 @@ Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
 Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
 
 // On coordinators:
-async<Result> handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
-                                           VPackBuilder& result);
-async<Result> handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
-                                             VPackBuilder& result);
+Result handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
+                                    VPackBuilder& result);
+Result handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
+                                      VPackBuilder& result);
 
 }  // namespace arangodb

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -102,6 +102,7 @@
     "ERROR_ARANGO_DOCUMENT_REV_BAD" : { "code" : 1239, "message" : "illegal document revision" },
     "ERROR_ARANGO_INCOMPLETE_READ" : { "code" : 1240, "message" : "incomplete read" },
     "ERROR_ARANGO_OLD_ROCKSDB_FORMAT" : { "code" : 1241, "message" : "not supported by old legacy data format" },
+    "ERROR_ARANGO_INDEX_HAS_LEGACY_SORTED_KEYS" : { "code" : 1242, "message" : "an index with legacy sorted keys has been found" },
     "ERROR_ARANGO_EMPTY_DATADIR"   : { "code" : 1301, "message" : "server database directory is empty" },
     "ERROR_ARANGO_TRY_AGAIN"       : { "code" : 1302, "message" : "operation should be tried again" },
     "ERROR_ARANGO_BUSY"            : { "code" : 1303, "message" : "engine is busy" },

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -59,9 +59,6 @@
 #include "Basics/system-compiler.h"
 #include "Logger/LogMacros.h"
 
-using namespace arangodb;
-using VelocyPackHelper = arangodb::basics::VelocyPackHelper;
-
 namespace {
 
 constexpr std::string_view idRef("id");
@@ -70,9 +67,75 @@ constexpr std::string_view cidRef("cid");
 static std::unique_ptr<VPackAttributeTranslator> translator;
 static std::unique_ptr<VPackCustomTypeHandler> customTypeHandler;
 
-template<bool useUtf8, typename Comparator>
-int compareObjects(VPackSlice lhs, VPackSlice rhs,
-                   VPackOptions const* options) {
+// statically computed table of type weights
+// the weight for type MinKey must be lowest, the weight for type MaxKey must be
+// highest the table contains a special value -50 to indicate that the value is
+// an external which must be resolved further the type Custom has the same
+// weight as the String type, because the Custom type is used to store _id
+// (which is a string)
+static int8_t const typeWeights[256] = {
+    0 /* 0x00 */,   5 /* 0x01 */,  5 /* 0x02 */, 5 /* 0x03 */,  5 /* 0x04 */,
+    5 /* 0x05 */,   5 /* 0x06 */,  5 /* 0x07 */, 5 /* 0x08 */,  5 /* 0x09 */,
+    6 /* 0x0a */,   6 /* 0x0b */,  6 /* 0x0c */, 6 /* 0x0d */,  6 /* 0x0e */,
+    6 /* 0x0f */,   6 /* 0x10 */,  6 /* 0x11 */, 6 /* 0x12 */,  5 /* 0x13 */,
+    6 /* 0x14 */,   0 /* 0x15 */,  0 /* 0x16 */, -1 /* 0x17 */, 0 /* 0x18 */,
+    1 /* 0x19 */,   1 /* 0x1a */,  2 /* 0x1b */, 3 /* 0x1c */,  -50 /* 0x1d */,
+    -99 /* 0x1e */, 99 /* 0x1f */, 2 /* 0x20 */, 2 /* 0x21 */,  2 /* 0x22 */,
+    2 /* 0x23 */,   2 /* 0x24 */,  2 /* 0x25 */, 2 /* 0x26 */,  2 /* 0x27 */,
+    2 /* 0x28 */,   2 /* 0x29 */,  2 /* 0x2a */, 2 /* 0x2b */,  2 /* 0x2c */,
+    2 /* 0x2d */,   2 /* 0x2e */,  2 /* 0x2f */, 2 /* 0x30 */,  2 /* 0x31 */,
+    2 /* 0x32 */,   2 /* 0x33 */,  2 /* 0x34 */, 2 /* 0x35 */,  2 /* 0x36 */,
+    2 /* 0x37 */,   2 /* 0x38 */,  2 /* 0x39 */, 2 /* 0x3a */,  2 /* 0x3b */,
+    2 /* 0x3c */,   2 /* 0x3d */,  2 /* 0x3e */, 2 /* 0x3f */,  4 /* 0x40 */,
+    4 /* 0x41 */,   4 /* 0x42 */,  4 /* 0x43 */, 4 /* 0x44 */,  4 /* 0x45 */,
+    4 /* 0x46 */,   4 /* 0x47 */,  4 /* 0x48 */, 4 /* 0x49 */,  4 /* 0x4a */,
+    4 /* 0x4b */,   4 /* 0x4c */,  4 /* 0x4d */, 4 /* 0x4e */,  4 /* 0x4f */,
+    4 /* 0x50 */,   4 /* 0x51 */,  4 /* 0x52 */, 4 /* 0x53 */,  4 /* 0x54 */,
+    4 /* 0x55 */,   4 /* 0x56 */,  4 /* 0x57 */, 4 /* 0x58 */,  4 /* 0x59 */,
+    4 /* 0x5a */,   4 /* 0x5b */,  4 /* 0x5c */, 4 /* 0x5d */,  4 /* 0x5e */,
+    4 /* 0x5f */,   4 /* 0x60 */,  4 /* 0x61 */, 4 /* 0x62 */,  4 /* 0x63 */,
+    4 /* 0x64 */,   4 /* 0x65 */,  4 /* 0x66 */, 4 /* 0x67 */,  4 /* 0x68 */,
+    4 /* 0x69 */,   4 /* 0x6a */,  4 /* 0x6b */, 4 /* 0x6c */,  4 /* 0x6d */,
+    4 /* 0x6e */,   4 /* 0x6f */,  4 /* 0x70 */, 4 /* 0x71 */,  4 /* 0x72 */,
+    4 /* 0x73 */,   4 /* 0x74 */,  4 /* 0x75 */, 4 /* 0x76 */,  4 /* 0x77 */,
+    4 /* 0x78 */,   4 /* 0x79 */,  4 /* 0x7a */, 4 /* 0x7b */,  4 /* 0x7c */,
+    4 /* 0x7d */,   4 /* 0x7e */,  4 /* 0x7f */, 4 /* 0x80 */,  4 /* 0x81 */,
+    4 /* 0x82 */,   4 /* 0x83 */,  4 /* 0x84 */, 4 /* 0x85 */,  4 /* 0x86 */,
+    4 /* 0x87 */,   4 /* 0x88 */,  4 /* 0x89 */, 4 /* 0x8a */,  4 /* 0x8b */,
+    4 /* 0x8c */,   4 /* 0x8d */,  4 /* 0x8e */, 4 /* 0x8f */,  4 /* 0x90 */,
+    4 /* 0x91 */,   4 /* 0x92 */,  4 /* 0x93 */, 4 /* 0x94 */,  4 /* 0x95 */,
+    4 /* 0x96 */,   4 /* 0x97 */,  4 /* 0x98 */, 4 /* 0x99 */,  4 /* 0x9a */,
+    4 /* 0x9b */,   4 /* 0x9c */,  4 /* 0x9d */, 4 /* 0x9e */,  4 /* 0x9f */,
+    4 /* 0xa0 */,   4 /* 0xa1 */,  4 /* 0xa2 */, 4 /* 0xa3 */,  4 /* 0xa4 */,
+    4 /* 0xa5 */,   4 /* 0xa6 */,  4 /* 0xa7 */, 4 /* 0xa8 */,  4 /* 0xa9 */,
+    4 /* 0xaa */,   4 /* 0xab */,  4 /* 0xac */, 4 /* 0xad */,  4 /* 0xae */,
+    4 /* 0xaf */,   4 /* 0xb0 */,  4 /* 0xb1 */, 4 /* 0xb2 */,  4 /* 0xb3 */,
+    4 /* 0xb4 */,   4 /* 0xb5 */,  4 /* 0xb6 */, 4 /* 0xb7 */,  4 /* 0xb8 */,
+    4 /* 0xb9 */,   4 /* 0xba */,  4 /* 0xbb */, 4 /* 0xbc */,  4 /* 0xbd */,
+    4 /* 0xbe */,   4 /* 0xbf */,  4 /* 0xc0 */, 4 /* 0xc1 */,  4 /* 0xc2 */,
+    4 /* 0xc3 */,   4 /* 0xc4 */,  4 /* 0xc5 */, 4 /* 0xc6 */,  4 /* 0xc7 */,
+    2 /* 0xc8 */,   2 /* 0xc9 */,  2 /* 0xca */, 2 /* 0xcb */,  2 /* 0xcc */,
+    2 /* 0xcd */,   2 /* 0xce */,  2 /* 0xcf */, 2 /* 0xd0 */,  2 /* 0xd1 */,
+    2 /* 0xd2 */,   2 /* 0xd3 */,  2 /* 0xd4 */, 2 /* 0xd5 */,  2 /* 0xd6 */,
+    2 /* 0xd7 */,   0 /* 0xd8 */,  0 /* 0xd9 */, 0 /* 0xda */,  0 /* 0xdb */,
+    0 /* 0xdc */,   0 /* 0xdd */,  0 /* 0xde */, 0 /* 0xdf */,  0 /* 0xe0 */,
+    0 /* 0xe1 */,   0 /* 0xe2 */,  0 /* 0xe3 */, 0 /* 0xe4 */,  0 /* 0xe5 */,
+    0 /* 0xe6 */,   0 /* 0xe7 */,  0 /* 0xe8 */, 0 /* 0xe9 */,  0 /* 0xea */,
+    0 /* 0xeb */,   0 /* 0xec */,  0 /* 0xed */, 0 /* 0xee */,  0 /* 0xef */,
+    4 /* 0xf0 */,   4 /* 0xf1 */,  4 /* 0xf2 */, 4 /* 0xf3 */,  4 /* 0xf4 */,
+    4 /* 0xf5 */,   4 /* 0xf6 */,  4 /* 0xf7 */, 4 /* 0xf8 */,  4 /* 0xf9 */,
+    4 /* 0xfa */,   4 /* 0xfb */,  4 /* 0xfc */, 4 /* 0xfd */,  4 /* 0xfe */,
+    4 /* 0xff */,
+};
+
+}  // namespace
+
+namespace arangodb::basics {
+
+template<bool useUtf8, typename Comparator,
+         VelocyPackHelper::SortingMethod sortingMethod>
+int VelocyPackHelper::compareObjects(VPackSlice lhs, VPackSlice rhs,
+                                     VPackOptions const* options) {
   // compare two velocypack objects
   std::set<std::string_view, Comparator> keys;
   VPackCollection::unorderedKeys(lhs, keys);
@@ -89,8 +152,8 @@ int compareObjects(VPackSlice lhs, VPackSlice rhs,
       rhsValue = VPackSlice::nullSlice();
     }
 
-    int result = VelocyPackHelper::compare(lhsValue, rhsValue, useUtf8, options,
-                                           &lhs, &rhs);
+    int result = VelocyPackHelper::compareInternal<sortingMethod>(
+        lhsValue, rhsValue, useUtf8, options, &lhs, &rhs);
 
     if (result != 0) {
       return result;
@@ -99,69 +162,6 @@ int compareObjects(VPackSlice lhs, VPackSlice rhs,
 
   return 0;
 }
-
-// statically computed table of type weights
-// the weight for type MinKey must be lowest, the weight for type MaxKey must be
-// highest the table contains a special value -50 to indicate that the value is
-// an external which must be resolved further the type Custom has the same
-// weight as the String type, because the Custom type is used to store _id
-// (which is a string)
-static int8_t const typeWeights[256] = {
-    0 /* 0x00 */,   4 /* 0x01 */,  4 /* 0x02 */, 4 /* 0x03 */,  4 /* 0x04 */,
-    4 /* 0x05 */,   4 /* 0x06 */,  4 /* 0x07 */, 4 /* 0x08 */,  4 /* 0x09 */,
-    5 /* 0x0a */,   5 /* 0x0b */,  5 /* 0x0c */, 5 /* 0x0d */,  5 /* 0x0e */,
-    5 /* 0x0f */,   5 /* 0x10 */,  5 /* 0x11 */, 5 /* 0x12 */,  4 /* 0x13 */,
-    5 /* 0x14 */,   0 /* 0x15 */,  0 /* 0x16 */, -1 /* 0x17 */, 0 /* 0x18 */,
-    1 /* 0x19 */,   1 /* 0x1a */,  2 /* 0x1b */, 2 /* 0x1c */,  -50 /* 0x1d */,
-    -99 /* 0x1e */, 99 /* 0x1f */, 2 /* 0x20 */, 2 /* 0x21 */,  2 /* 0x22 */,
-    2 /* 0x23 */,   2 /* 0x24 */,  2 /* 0x25 */, 2 /* 0x26 */,  2 /* 0x27 */,
-    2 /* 0x28 */,   2 /* 0x29 */,  2 /* 0x2a */, 2 /* 0x2b */,  2 /* 0x2c */,
-    2 /* 0x2d */,   2 /* 0x2e */,  2 /* 0x2f */, 2 /* 0x30 */,  2 /* 0x31 */,
-    2 /* 0x32 */,   2 /* 0x33 */,  2 /* 0x34 */, 2 /* 0x35 */,  2 /* 0x36 */,
-    2 /* 0x37 */,   2 /* 0x38 */,  2 /* 0x39 */, 2 /* 0x3a */,  2 /* 0x3b */,
-    2 /* 0x3c */,   2 /* 0x3d */,  2 /* 0x3e */, 2 /* 0x3f */,  3 /* 0x40 */,
-    3 /* 0x41 */,   3 /* 0x42 */,  3 /* 0x43 */, 3 /* 0x44 */,  3 /* 0x45 */,
-    3 /* 0x46 */,   3 /* 0x47 */,  3 /* 0x48 */, 3 /* 0x49 */,  3 /* 0x4a */,
-    3 /* 0x4b */,   3 /* 0x4c */,  3 /* 0x4d */, 3 /* 0x4e */,  3 /* 0x4f */,
-    3 /* 0x50 */,   3 /* 0x51 */,  3 /* 0x52 */, 3 /* 0x53 */,  3 /* 0x54 */,
-    3 /* 0x55 */,   3 /* 0x56 */,  3 /* 0x57 */, 3 /* 0x58 */,  3 /* 0x59 */,
-    3 /* 0x5a */,   3 /* 0x5b */,  3 /* 0x5c */, 3 /* 0x5d */,  3 /* 0x5e */,
-    3 /* 0x5f */,   3 /* 0x60 */,  3 /* 0x61 */, 3 /* 0x62 */,  3 /* 0x63 */,
-    3 /* 0x64 */,   3 /* 0x65 */,  3 /* 0x66 */, 3 /* 0x67 */,  3 /* 0x68 */,
-    3 /* 0x69 */,   3 /* 0x6a */,  3 /* 0x6b */, 3 /* 0x6c */,  3 /* 0x6d */,
-    3 /* 0x6e */,   3 /* 0x6f */,  3 /* 0x70 */, 3 /* 0x71 */,  3 /* 0x72 */,
-    3 /* 0x73 */,   3 /* 0x74 */,  3 /* 0x75 */, 3 /* 0x76 */,  3 /* 0x77 */,
-    3 /* 0x78 */,   3 /* 0x79 */,  3 /* 0x7a */, 3 /* 0x7b */,  3 /* 0x7c */,
-    3 /* 0x7d */,   3 /* 0x7e */,  3 /* 0x7f */, 3 /* 0x80 */,  3 /* 0x81 */,
-    3 /* 0x82 */,   3 /* 0x83 */,  3 /* 0x84 */, 3 /* 0x85 */,  3 /* 0x86 */,
-    3 /* 0x87 */,   3 /* 0x88 */,  3 /* 0x89 */, 3 /* 0x8a */,  3 /* 0x8b */,
-    3 /* 0x8c */,   3 /* 0x8d */,  3 /* 0x8e */, 3 /* 0x8f */,  3 /* 0x90 */,
-    3 /* 0x91 */,   3 /* 0x92 */,  3 /* 0x93 */, 3 /* 0x94 */,  3 /* 0x95 */,
-    3 /* 0x96 */,   3 /* 0x97 */,  3 /* 0x98 */, 3 /* 0x99 */,  3 /* 0x9a */,
-    3 /* 0x9b */,   3 /* 0x9c */,  3 /* 0x9d */, 3 /* 0x9e */,  3 /* 0x9f */,
-    3 /* 0xa0 */,   3 /* 0xa1 */,  3 /* 0xa2 */, 3 /* 0xa3 */,  3 /* 0xa4 */,
-    3 /* 0xa5 */,   3 /* 0xa6 */,  3 /* 0xa7 */, 3 /* 0xa8 */,  3 /* 0xa9 */,
-    3 /* 0xaa */,   3 /* 0xab */,  3 /* 0xac */, 3 /* 0xad */,  3 /* 0xae */,
-    3 /* 0xaf */,   3 /* 0xb0 */,  3 /* 0xb1 */, 3 /* 0xb2 */,  3 /* 0xb3 */,
-    3 /* 0xb4 */,   3 /* 0xb5 */,  3 /* 0xb6 */, 3 /* 0xb7 */,  3 /* 0xb8 */,
-    3 /* 0xb9 */,   3 /* 0xba */,  3 /* 0xbb */, 3 /* 0xbc */,  3 /* 0xbd */,
-    3 /* 0xbe */,   3 /* 0xbf */,  3 /* 0xc0 */, 3 /* 0xc1 */,  3 /* 0xc2 */,
-    3 /* 0xc3 */,   3 /* 0xc4 */,  3 /* 0xc5 */, 3 /* 0xc6 */,  3 /* 0xc7 */,
-    2 /* 0xc8 */,   2 /* 0xc9 */,  2 /* 0xca */, 2 /* 0xcb */,  2 /* 0xcc */,
-    2 /* 0xcd */,   2 /* 0xce */,  2 /* 0xcf */, 2 /* 0xd0 */,  2 /* 0xd1 */,
-    2 /* 0xd2 */,   2 /* 0xd3 */,  2 /* 0xd4 */, 2 /* 0xd5 */,  2 /* 0xd6 */,
-    2 /* 0xd7 */,   0 /* 0xd8 */,  0 /* 0xd9 */, 0 /* 0xda */,  0 /* 0xdb */,
-    0 /* 0xdc */,   0 /* 0xdd */,  0 /* 0xde */, 0 /* 0xdf */,  0 /* 0xe0 */,
-    0 /* 0xe1 */,   0 /* 0xe2 */,  0 /* 0xe3 */, 0 /* 0xe4 */,  0 /* 0xe5 */,
-    0 /* 0xe6 */,   0 /* 0xe7 */,  0 /* 0xe8 */, 0 /* 0xe9 */,  0 /* 0xea */,
-    0 /* 0xeb */,   0 /* 0xec */,  0 /* 0xed */, 0 /* 0xee */,  0 /* 0xef */,
-    3 /* 0xf0 */,   3 /* 0xf1 */,  3 /* 0xf2 */, 3 /* 0xf3 */,  3 /* 0xf4 */,
-    3 /* 0xf5 */,   3 /* 0xf6 */,  3 /* 0xf7 */, 3 /* 0xf8 */,  3 /* 0xf9 */,
-    3 /* 0xfa */,   3 /* 0xfb */,  3 /* 0xfc */, 3 /* 0xfd */,  3 /* 0xfe */,
-    3 /* 0xff */,
-};
-
-}  // namespace
 
 // a default custom type handler that prevents throwing exceptions when
 // custom types are encountered during Slice.toJson() and family
@@ -354,8 +354,13 @@ bool VelocyPackHelper::VPackStringEqual::operator()(
           0);
 }
 
-int VelocyPackHelper::compareNumberValues(VPackValueType lhsType,
-                                          VPackSlice lhs, VPackSlice rhs) {
+int VelocyPackHelper::compareNumberValuesLegacy(VPackValueType lhsType,
+                                                VPackSlice lhs,
+                                                VPackSlice rhs) {
+  // This function is only for legacy code. The problem is that it casts
+  // all integer types to double, which can lose precision. See
+  // `VelocyPackHelper::compareNumberValuesCorrectly` for a correct
+  // implementation. This is only used for legacy vpack indexes.
   if (lhsType == rhs.type()) {
     // both types are equal
     if (lhsType == VPackValueType::Int || lhsType == VPackValueType::SmallInt) {
@@ -386,6 +391,223 @@ int VelocyPackHelper::compareNumberValues(VPackValueType lhsType,
     return 0;
   }
   return (l < r ? -1 : 1);
+}
+
+namespace {
+
+template<typename T>
+int comp(T a, T b) {
+  if (a == b) {
+    return VelocyPackHelper::cmp_equal;
+  }
+  return a < b ? VelocyPackHelper::cmp_less : VelocyPackHelper::cmp_greater;
+}
+
+// The following function deserves an explanation: We want to compare
+// numerically. If i is negative, we are good, since all unsigned numbers
+// are numerically non-negative. Otherwise, we know that i can be cast
+// statically to uint64_t and we can compare there.
+int compareInt64UInt64(int64_t i, uint64_t u) {
+  if (i < 0) {
+    return VelocyPackHelper::cmp_less;
+  }
+  return comp<uint64_t>(static_cast<uint64_t>(i), u);
+}
+
+// We use the following constants below for case distinctions,
+// we use static asserts to ensure that the `double` implementation
+// is actually IEEE 754 with 64 bits, otherwise our comparison method
+// will be faulty:
+
+constexpr uint64_t uint64_2_63 = uint64_t{1} << 63;
+
+static_assert(53 == std::numeric_limits<double>::digits);
+static_assert(63 == std::numeric_limits<int64_t>::digits);
+
+// This function deserves an explanation: Not all possible values of
+// uint64_t can be represented faithfully as double (IEEE 754 64bit).
+// At the same time, there are lots of values of double which cannot
+// be represented as uint64_t. Therefore, proper numerical comparison
+// is somewhat of a challenge. We cannot just cast one to the other
+// and then compare. First we need to handle NaN separately. Then, we
+// need to carefully cast u to double and keep track what we lost due to
+// the limited precision of double. Then we can evaluate the result.
+// This method has been evaluated using godbolt. Only change if you
+// know what you are doing!
+int compareUInt64Double(uint64_t u, double d) {
+  if (std::isnan(d)) [[unlikely]] {
+    return VelocyPackHelper::cmp_less;
+  }
+  // We essentially want to cast to double, but we want to explicitly
+  // round downwards if necessary and also keep the low bits which we
+  // lose due to limited precision of doubles. Therefore we determine
+  // the number of leading zero bits and from this the number of low bits
+  // we will lose on the conversion. Including the topmost one bit, a
+  // IEEE 754 double can store 53 bits of precision. Therefore, we can
+  // accomodate clz+53 bits in the double (which could be all 64 bits!).
+  // We can then mask the low bits out and do a static cast:
+  //  u    = 0 ... 0 1 ? ... ? 1 0 ... 0
+  //         \ clz / \  <= 53  / \rbits/
+  //  mask = 0 ...         ... 0 1 ... 1
+  auto clz = std::countl_zero(u);
+  auto rbits = 64 - std::min(64, clz + 53);
+  auto const mask = (std::uint64_t{1} << rbits) - 1;
+  auto ud = static_cast<double>(u & ~mask);
+  // Now ud is u cast to double with rounding down. If ud and d are not
+  // equal as doubles, then the comparison result is correct. If not, we
+  // need to distinguish if we lost bits above (in which case u was actually
+  // larger than d numerically), or not (in which case they represent the
+  // same integral value):
+  if (ud == d) {
+    return (mask & u) != 0 ? VelocyPackHelper::cmp_greater
+                           : VelocyPackHelper::cmp_equal;
+  }
+  return ud < d ? VelocyPackHelper::cmp_less : VelocyPackHelper::cmp_greater;
+}
+
+// The following function deserves an explanation. We want to compare
+// numerically. We want to delegate to the above comparison function
+// for unsigned integers by negating both arguments if the integer is
+// negative and then flipping the result. The only difficulty we are
+// facing is for signed integers here, because we cannot just take the
+// negative of an int64_t because of the twos-complement implementation
+// and the one negative value which does not have a positive counterpart.
+// We also have to handle NaN separately.
+int compareInt64Double(int64_t i, double d) {
+  if (std::isnan(d)) [[unlikely]] {
+    return VelocyPackHelper::cmp_less;
+  }
+  if (i < 0) {
+    uint64_t u =
+        (i == std::numeric_limits<int64_t>::min() ? uint64_2_63
+                                                  : static_cast<uint64_t>(-i));
+    return -compareUInt64Double(u, -d);
+  }
+  return compareUInt64Double(static_cast<uint64_t>(i), d);
+}
+
+}  // namespace
+
+int VelocyPackHelper::compareNumberValuesCorrectly(VPackValueType lhsType,
+
+                                                   VPackSlice lhs,
+                                                   VPackSlice rhs) {
+  VPackValueType rhsType = rhs.type();
+  if (lhsType == rhsType) {
+    // both types are equal
+    if (lhsType == VPackValueType::Int || lhsType == VPackValueType::SmallInt) {
+      // use exact comparisons. no need to cast to double
+      int64_t l = lhs.getIntUnchecked();
+      int64_t r = rhs.getIntUnchecked();
+      return comp<int64_t>(l, r);
+    }
+
+    if (lhsType == VPackValueType::UInt) {
+      // use exact comparisons. no need to cast to double
+      uint64_t l = lhs.getUIntUnchecked();
+      uint64_t r = rhs.getUIntUnchecked();
+      return comp<uint64_t>(l, r);
+    }
+
+    if (lhsType == VPackValueType::Double) {
+      double l = lhs.getDouble();
+      double r = rhs.getDouble();
+      if (std::isnan(l)) [[unlikely]] {
+        if (std::isnan(r)) [[unlikely]] {
+          return VelocyPackHelper::cmp_equal;
+        }
+        return VelocyPackHelper::cmp_greater;
+      } else if (std::isnan(r)) [[unlikely]] {
+        return VelocyPackHelper::cmp_less;
+      }
+      // No NaN on either side!
+      return comp<double>(l, r);
+    }
+  }
+
+  // Formally, we now have to face 12 different cases, since each side
+  // can be one of SmallInt, Int, UInt, double but the two are
+  // different types. Let's reduce this to only 3 cases by reducing
+  // SmallInt and Int to i64, UInt to u64 and by reordering
+  // to have only I ~ U, I ~ D and U ~ D:
+
+  union Number {
+    int64_t i;
+    uint64_t u;
+    double d;
+  };
+
+  Number l;
+  Number r;
+  enum Type {
+    kSignedIntegral = 0,
+    kUnsignedIntegral = 1,
+    kDouble = 2,
+    kNumTypes = 3
+  };
+  Type lhst;
+  switch (lhsType) {
+    case VPackValueType::SmallInt:
+    case VPackValueType::Int:
+      l.i = lhs.getIntUnchecked();
+      lhst = Type::kSignedIntegral;
+      break;
+    case VPackValueType::UInt:
+      l.u = lhs.getUIntUnchecked();
+      lhst = Type::kUnsignedIntegral;
+      break;
+    case VPackValueType::Double:
+      l.d = lhs.getNumericValue<double>();
+      lhst = Type::kDouble;
+      break;
+    default:    // does not happen, just to please the compiler!
+      l.u = 0;  // treat anything else as 0
+      lhst = Type::kUnsignedIntegral;
+      break;
+  }
+  Type rhst;
+  switch (rhsType) {
+    case VPackValueType::SmallInt:
+    case VPackValueType::Int:
+      r.i = rhs.getIntUnchecked();
+      rhst = Type::kSignedIntegral;
+      break;
+    case VPackValueType::UInt:
+      r.u = rhs.getUIntUnchecked();
+      rhst = Type::kUnsignedIntegral;
+      break;
+    case VPackValueType::Double:
+      r.d = rhs.getNumericValue<double>();
+      rhst = Type::kDouble;
+      break;
+    default:    // does not happen, just to please the compiler!
+      r.u = 0;  // treat anything else as 0
+      rhst = Type::kUnsignedIntegral;
+      break;
+  }
+
+  switch (lhst + rhst * Type::kNumTypes) {
+    case kUnsignedIntegral + kSignedIntegral* Type::kNumTypes:
+      return -compareInt64UInt64(r.i, l.u);
+    case kDouble + kSignedIntegral* Type::kNumTypes:
+      return -compareInt64Double(r.i, l.d);
+    case kSignedIntegral + kUnsignedIntegral* Type::kNumTypes:
+      return compareInt64UInt64(l.i, r.u);
+    case kDouble + kUnsignedIntegral* Type::kNumTypes:
+      return -compareUInt64Double(r.u, l.d);
+    case kSignedIntegral + kDouble* Type::kNumTypes:
+      return compareInt64Double(l.i, r.d);
+    case kUnsignedIntegral + kDouble* Type::kNumTypes:
+      return compareUInt64Double(l.u, r.d);
+    case kSignedIntegral + kSignedIntegral* Type::kNumTypes:
+      // Note that since we have SmallInt and Int it is
+      // indeed possible that both sides are signed integers, although
+      // we have checked before that the types are not equal!
+      return comp<int64_t>(l.i, r.i);
+    default:  // does not happen!
+      TRI_ASSERT(false);
+      return 0;
+  }
 }
 
 /// @brief compares two VelocyPack string values
@@ -463,7 +685,8 @@ void VelocyPackHelper::ensureStringValue(VPackSlice const& slice,
   }
 }
 
-/// @brief returns a string value, or the default value if it is not a string
+/// @brief returns a string value, or the default value if it is not a
+/// string
 std::string VelocyPackHelper::getStringValue(VPackSlice slice,
                                              std::string const& defaultValue) {
   if (!slice.isString()) {
@@ -636,10 +859,11 @@ bool VelocyPackHelper::velocyPackToFile(std::string const& filename,
   return true;
 }
 
-int VelocyPackHelper::compare(VPackSlice lhs, VPackSlice rhs, bool useUTF8,
-                              VPackOptions const* options,
-                              VPackSlice const* lhsBase,
-                              VPackSlice const* rhsBase) {
+template<VelocyPackHelper::SortingMethod sortingMethod>
+int VelocyPackHelper::compareInternal(VPackSlice lhs, VPackSlice rhs,
+                                      bool useUTF8, VPackOptions const* options,
+                                      VPackSlice const* lhsBase,
+                                      VPackSlice const* rhsBase) {
   {
     // will resolve externals and modify both lhs & rhs...
     int8_t lWeight = TypeWeight(lhs);
@@ -688,7 +912,19 @@ int VelocyPackHelper::compare(VPackSlice lhs, VPackSlice rhs, bool useUTF8,
     case VPackValueType::Int:
     case VPackValueType::UInt:
     case VPackValueType::SmallInt: {
-      return compareNumberValues(lhsType, lhs, rhs);
+      if (sortingMethod == SortingMethod::Correct) {
+        return compareNumberValuesCorrectly(lhsType, lhs, rhs);
+      } else {
+        return compareNumberValuesLegacy(lhsType, lhs, rhs);
+      }
+    }
+    case VPackValueType::UTCDate: {
+      // We know that the other type also has to be UTCDate, since only
+      // UTCDate has weight 3:
+      TRI_ASSERT(rhs.type() == VPackValueType::UTCDate);
+      int64_t l = lhs.getUTCDate();
+      int64_t r = rhs.getUTCDate();
+      return comp<int64_t>(l, r);
     }
     case VPackValueType::String:
     case VPackValueType::Custom: {
@@ -750,7 +986,8 @@ int VelocyPackHelper::compare(VPackSlice lhs, VPackSlice rhs, bool useUTF8,
           ar.next();
         }
 
-        int result = compare(lhsValue, rhsValue, useUTF8, options, &lhs, &rhs);
+        int result = compareInternal<sortingMethod>(lhsValue, rhsValue, useUTF8,
+                                                    options, &lhs, &rhs);
         if (result != 0) {
           return result;
         }
@@ -760,11 +997,11 @@ int VelocyPackHelper::compare(VPackSlice lhs, VPackSlice rhs, bool useUTF8,
     }
     case VPackValueType::Object: {
       if (useUTF8) {
-        return ::compareObjects<true, AttributeSorterUTF8StringView>(lhs, rhs,
-                                                                     options);
+        return compareObjects<true, AttributeSorterUTF8StringView,
+                              sortingMethod>(lhs, rhs, options);
       }
-      return ::compareObjects<false, AttributeSorterBinaryStringView>(lhs, rhs,
-                                                                      options);
+      return compareObjects<false, AttributeSorterBinaryStringView,
+                            sortingMethod>(lhs, rhs, options);
     }
     case VPackValueType::Illegal:
     case VPackValueType::MinKey:
@@ -779,6 +1016,21 @@ int VelocyPackHelper::compare(VPackSlice lhs, VPackSlice rhs, bool useUTF8,
       return 0;
   }
 }
+
+// Instantiate template functions explicitly:
+template int
+VelocyPackHelper::compareInternal<VelocyPackHelper::SortingMethod::Correct>(
+    arangodb::velocypack::Slice lhs, arangodb::velocypack::Slice rhs,
+    bool useUTF8, arangodb::velocypack::Options const* options,
+    arangodb::velocypack::Slice const* lhsBase,
+    arangodb::velocypack::Slice const* rhsBase);
+
+template int
+VelocyPackHelper::compareInternal<VelocyPackHelper::SortingMethod::Legacy>(
+    arangodb::velocypack::Slice lhs, arangodb::velocypack::Slice rhs,
+    bool useUTF8, arangodb::velocypack::Options const* options,
+    arangodb::velocypack::Slice const* lhsBase,
+    arangodb::velocypack::Slice const* rhsBase);
 
 bool VelocyPackHelper::hasNonClientTypes(VPackSlice input, bool checkExternals,
                                          bool checkCustom) {
@@ -883,3 +1135,5 @@ arangodb::LoggerStream& operator<<(arangodb::LoggerStream& logger,
   }
   return logger;
 }
+
+}  // namespace arangodb::basics

--- a/lib/Basics/VelocyPackHelper.h
+++ b/lib/Basics/VelocyPackHelper.h
@@ -88,12 +88,31 @@ struct VPackHashedSlice {
   ~VPackHashedSlice() = default;
 };
 
+// Note that the following class has some code duplication, which is
+// intentional. Unfortunately, we had a bug in the sorting functionality
+// for VelocyPack regarding numbers in their different representations.
+// Since we need to retain the old, buggy behaviour, we have the compare
+// method in a "correct" and a "legacy" version. We did not want to
+// expose internal template magic to the user of this class, therefore
+// we have methods
+//   compare       (correctly)
+//   compareLegacy (legacy)
+// We need the legacy methods only for the RocksDB comparator. There is
+// a global switch, such that at server start, we can choose about this
+// switch so that in new database directories can directly use the new
+// sorting method, whereas after an upgrade, we can at first use the old
+// sorting method for backwards compatibility (and to avoid that RocksDB
+// is corrupt).
+
 class VelocyPackHelper {
  private:
   VelocyPackHelper() = delete;
   ~VelocyPackHelper() = delete;
 
  public:
+  // For templating:
+  enum SortingMethod { Legacy = 0, Correct = 1 };
+
   /// @brief static initializer for all VPack values
   static void initialize();
 
@@ -106,6 +125,11 @@ class VelocyPackHelper {
   struct VPackStringHash {
     size_t operator()(arangodb::velocypack::Slice const&) const noexcept;
   };
+
+  /// For better readability of the traditional int comparison result:
+  static constexpr int cmp_less = -1;
+  static constexpr int cmp_equal = 0;
+  static constexpr int cmp_greater = 1;
 
   /// @brief equality comparator for VelocyPack values
   struct VPackEqual {
@@ -141,34 +165,6 @@ class VelocyPackHelper {
                                        rhsBase) < 0;
     }
 
-    arangodb::velocypack::Options const* options;
-    arangodb::velocypack::Slice const* lhsBase;
-    arangodb::velocypack::Slice const* rhsBase;
-  };
-
-  template<bool useUtf8>
-  struct VPackSorted {
-    explicit VPackSorted(bool reverse,
-                         arangodb::velocypack::Options const* options =
-                             &arangodb::velocypack::Options::Defaults,
-                         arangodb::velocypack::Slice const* lhsBase = nullptr,
-                         arangodb::velocypack::Slice const* rhsBase = nullptr)
-        : _reverse(reverse),
-          options(options),
-          lhsBase(lhsBase),
-          rhsBase(rhsBase) {}
-
-    inline bool operator()(arangodb::velocypack::Slice const& lhs,
-                           arangodb::velocypack::Slice const& rhs) const {
-      if (_reverse) {
-        return VelocyPackHelper::compare(lhs, rhs, useUtf8, options, lhsBase,
-                                         rhsBase) > 0;
-      }
-      return VelocyPackHelper::compare(lhs, rhs, useUtf8, options, lhsBase,
-                                       rhsBase) < 0;
-    }
-
-    bool _reverse;
     arangodb::velocypack::Options const* options;
     arangodb::velocypack::Slice const* lhsBase;
     arangodb::velocypack::Slice const* rhsBase;
@@ -339,26 +335,89 @@ class VelocyPackHelper {
   static bool velocyPackToFile(std::string const& filename, VPackSlice slice,
                                bool syncFile);
 
-  /// @brief compares two VelocyPack number values
-  static int compareNumberValues(arangodb::velocypack::ValueType,
-                                 arangodb::velocypack::Slice lhs,
-                                 arangodb::velocypack::Slice rhs);
+  /// @brief compares two VelocyPack number values (legacy version, this
+  /// should no longer be used, since it can lead to non-transitive
+  /// behaviour, in particular around NaN, but also for integers larger
+  /// than 2^53, which are compared with doubles or integers in a different
+  /// representation (signed/unsigned)). Use `compareNumberValuesCorrect`
+  /// instead. We keep thisi function to implement the legacy sorting
+  /// behaviour for old vpack indexes.
+  static int compareNumberValuesLegacy(arangodb::velocypack::ValueType,
+                                       arangodb::velocypack::Slice lhs,
+                                       arangodb::velocypack::Slice rhs);
+
+  /// @brief compares two VelocyPack number values, this must only be called
+  /// if the types on either side are either SmallInt, Int, UInt, UTCDate
+  /// or Double. Otherwise the behaviour is undefined.
+  /// For such values, the function implements the numerical total order
+  /// for all possible values, including Double's -Inf, +Inf, +0, -0 and Nan.
+  /// This is to be understood in the following way: First of all,
+  /// NaN is considered to be larger than any number (including +Inf),
+  /// and all NaN values are considered equal. Integers are considered
+  /// equal if they have different representations (for example many
+  /// positive numbers have an unsigned and a signed representation,
+  /// and the SmallInt values also have representations as signed or
+  /// unsigned integers). An integer of whatever representation is
+  /// considered equal to an integer in its representation as Double (if
+  /// it exists). Other than these representation issues, numbers are
+  /// compared numerically as rational numbers would be compared.
+  /// +Inf is larger than any other number of whatever representation (except
+  /// NaN), and -Inf is smaller than any number.
+  static int compareNumberValuesCorrectly(arangodb::velocypack::ValueType,
+                                          arangodb::velocypack::Slice lhs,
+                                          arangodb::velocypack::Slice rhs);
 
   /// @brief compares two VelocyPack string values
   static int compareStringValues(char const* left, VPackValueLength nl,
                                  char const* right, VPackValueLength nr,
                                  bool useUTF8);
 
+ private:
+  template<bool useUtf8, typename Comparator, SortingMethod sortingMethod>
+  static int compareObjects(VPackSlice lhs, VPackSlice rhs,
+                            VPackOptions const* options);
+
+  template<SortingMethod sortingMethod>
+  static int compareInternal(
+      arangodb::velocypack::Slice lhs, arangodb::velocypack::Slice rhs,
+      bool useUTF8,
+      arangodb::velocypack::Options const* options =
+          &arangodb::velocypack::Options::Defaults,
+      arangodb::velocypack::Slice const* lhsBase = nullptr,
+      arangodb::velocypack::Slice const* rhsBase = nullptr)
+      ADB_WARN_UNUSED_RESULT;
+
+ public:
   /// @brief Compares two VelocyPack slices
-  /// returns 0 if the two slices are equal, < 0 if lhs < rhs, and > 0 if rhs >
-  /// lhs
+  /// returns 0 if the two slices are equal, < 0 if lhs < rhs, and > 0
+  /// if rhs > lhs, there is a correct, modern method and a wrong legacy
+  /// method. The legacy method is wrong w.r.t. numeric comparisons and
+  /// NaN and in the case that numbers of different types (unsigned,
+  /// signed or double) are compared and the integers are too large to
+  /// fit in the precision of double.
+  /// This is the "correct" method!
   static int compare(arangodb::velocypack::Slice lhs,
                      arangodb::velocypack::Slice rhs, bool useUTF8,
                      arangodb::velocypack::Options const* options =
                          &arangodb::velocypack::Options::Defaults,
                      arangodb::velocypack::Slice const* lhsBase = nullptr,
                      arangodb::velocypack::Slice const* rhsBase = nullptr)
-      ADB_WARN_UNUSED_RESULT;
+      ADB_WARN_UNUSED_RESULT {
+    return compareInternal<SortingMethod::Correct>(lhs, rhs, useUTF8, options,
+                                                   lhsBase, rhsBase);
+  }
+
+  /// This is the "legacy" method!
+  static int compareLegacy(arangodb::velocypack::Slice lhs,
+                           arangodb::velocypack::Slice rhs, bool useUTF8,
+                           arangodb::velocypack::Options const* options =
+                               &arangodb::velocypack::Options::Defaults,
+                           arangodb::velocypack::Slice const* lhsBase = nullptr,
+                           arangodb::velocypack::Slice const* rhsBase = nullptr)
+      ADB_WARN_UNUSED_RESULT {
+    return compareInternal<SortingMethod::Legacy>(lhs, rhs, useUTF8, options,
+                                                  lhsBase, rhsBase);
+  }
 
   /// @brief Compares two VelocyPack slices for equality
   /// returns true if the slices are equal, false otherwise
@@ -368,7 +427,8 @@ class VelocyPackHelper {
                         &arangodb::velocypack::Options::Defaults,
                     arangodb::velocypack::Slice const* lhsBase = nullptr,
                     arangodb::velocypack::Slice const* rhsBase = nullptr) {
-    return compare(lhs, rhs, useUTF8, options, lhsBase, rhsBase) == 0;
+    return compareInternal<SortingMethod::Correct>(lhs, rhs, useUTF8, options,
+                                                   lhsBase, rhsBase) == 0;
   }
 
   static bool hasNonClientTypes(arangodb::velocypack::Slice,

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -125,6 +125,7 @@ ERROR_ARANGO_COLLECTION_NOT_LOADED,1238,"collection not loaded","Will be raised 
 ERROR_ARANGO_DOCUMENT_REV_BAD,1239,"illegal document revision","Will be raised when a document revision is corrupt or is missing where needed."
 ERROR_ARANGO_INCOMPLETE_READ,1240,"incomplete read","Will be raised by the storage engine when a read cannot be completed."
 ERROR_ARANGO_OLD_ROCKSDB_FORMAT,1241,"not supported by old legacy data format","Will be raised by the storage engine when an operation cannot be performed because the old, deprecated, little endian key encoding format is still used and an operation is tried which is not supported by this format."
+ERROR_ARANGO_INDEX_HAS_LEGACY_SORTED_KEYS,1242,"an index with legacy sorted keys has been found","Will be raised if the VPackSortMigration has detected an index, which is using the old legacy sorting order and would be corrupt if the database is migrated to the new, correct sorting order."
 
 ################################################################################
 ## Checked ArangoDB storage errors

--- a/tests/Basics/VelocyPackHelperTest.cpp
+++ b/tests/Basics/VelocyPackHelperTest.cpp
@@ -41,6 +41,35 @@
   r = VPackParser::fromJson(rValue);                      \
   EXPECT_EQ(expected, func(l->slice(), r->slice(), true));
 
+struct DoubleValue {
+  double d;
+  uint8_t sign;
+  uint16_t E;
+  uint64_t M;
+
+  std::string to_string() {
+    return std::to_string(sign) + " " + std::to_string(E) + " " +
+           std::to_string(M);
+  }
+};
+
+DoubleValue makeDoubleValue(uint8_t sign, uint16_t E, uint64_t M) {
+  EXPECT_LT(sign, 2);
+  EXPECT_LT(E, 2048);
+  EXPECT_LT(M, uint64_t{1} << 52);
+  uint64_t x = (static_cast<uint64_t>(sign) << 63) |
+               (static_cast<uint64_t>(E) << 52) | static_cast<uint64_t>(M);
+  double y = std::bit_cast<double>(x);
+  return DoubleValue{.d = y, .sign = sign, .E = E, .M = M};
+}
+
+template<typename T>
+VPackBuilder makeVPack(T x) {
+  VPackBuilder b;
+  b.add(VPackValue(x));
+  return b;
+}
+
 // -----------------------------------------------------------------------------
 // --SECTION--                                                        test suite
 // -----------------------------------------------------------------------------
@@ -257,4 +286,474 @@ TEST(VPackHelperTest, velocypack_string_literals) {
     ASSERT_TRUE(obj.slice()["vertices"].isArray());
     ASSERT_TRUE(obj.slice()["edges"].isArray());
   }
+}
+
+//////////////////////////////////////////////////////////////////////////////
+/// @brief test comparison of numerical values
+//////////////////////////////////////////////////////////////////////////////
+
+constexpr uint64_t mantmax = (uint64_t(1) << 52) - 1;
+
+using VelocyPackHelper = arangodb::basics::VelocyPackHelper;
+
+TEST(VPackHelperTest, test_comparison_numerical_double) {
+  for (int n = 0; n < 2; ++n) {
+    // Do everything twice, once with +0 and once with -0
+
+    // We create a vector of numerical velocypack values which is supposed
+    // to be sorted strictly ascending. We also check transitivity by comparing
+    // all pairs:
+    std::vector<VPackBuilder> v;
+    v.push_back(makeVPack(makeDoubleValue(1, 2047, 0).d));  // -Inf
+    for (uint16_t i = 2046; i >= 1; --i) {
+      v.push_back(makeVPack(makeDoubleValue(1, i, mantmax).d));
+      v.push_back(makeVPack(makeDoubleValue(1, i, 0).d));
+    }
+    v.push_back(makeVPack(makeDoubleValue(1, 0, mantmax).d));  // - denormalized
+    v.push_back(makeVPack(makeDoubleValue(1, 0, 1).d));        // - denormalized
+    if (n == 0) {
+      v.push_back(makeVPack(makeDoubleValue(0, 0, 0).d));  // + 0
+    } else {
+      v.push_back(makeVPack(makeDoubleValue(1, 0, 0).d));  // - 0
+    }
+    v.push_back(makeVPack(makeDoubleValue(0, 0, 1).d));        // + denormalized
+    v.push_back(makeVPack(makeDoubleValue(0, 0, mantmax).d));  // + denormalized
+    for (uint16_t i = 1; i <= 2046; ++i) {
+      v.push_back(makeVPack(makeDoubleValue(0, i, 0).d));
+      v.push_back(makeVPack(makeDoubleValue(0, i, mantmax).d));
+    }
+    v.push_back(makeVPack(makeDoubleValue(0, 2047, 0).d));  // infinity
+
+    // Now check if our comparator agrees that this is strictly ascending:
+    for (std::size_t i = 0; i < v.size() - 1; ++i) {
+      auto c = VelocyPackHelper::compareNumberValuesCorrectly(
+          v[i].slice().type(), v[i].slice(), v[i + 1].slice());
+      EXPECT_EQ(-1, c) << "Not strictly increasing: " << i << " "
+                       << v[i].slice().toJson() << " "
+                       << v[i + 1].slice().toJson();
+      c = VelocyPackHelper::compareNumberValuesCorrectly(
+          v[i + 1].slice().type(), v[i + 1].slice(), v[i].slice());
+      EXPECT_EQ(1, c) << "Not strictly decreasing: " << i << " "
+                      << v[i + 1].slice().toJson() << " "
+                      << v[i].slice().toJson();
+    }
+    // Check reflexivity:
+    for (std::size_t i = 0; i < v.size(); ++i) {
+      auto c = VelocyPackHelper::compareNumberValuesCorrectly(
+          v[i].slice().type(), v[i].slice(), v[i].slice());
+      EXPECT_EQ(0, c) << "Not reflexive: " << i << " " << v[i].slice().toJson();
+    }
+    // And check transitivity by comparing all pairs:
+    for (std::size_t i = 0; i < v.size() - 1; ++i) {
+      for (std::size_t j = i + 1; j < v.size(); ++j) {
+        auto c = VelocyPackHelper::compareNumberValuesCorrectly(
+            v[i].slice().type(), v[i].slice(), v[j].slice());
+        EXPECT_EQ(-1, c) << "Not transitive: " << i << " "
+                         << v[i].slice().toJson() << " " << j << " "
+                         << v[j].slice().toJson();
+      }
+    }
+    // And the same the other way round
+    for (std::size_t i = 0; i < v.size() - 1; ++i) {
+      for (std::size_t j = i + 1; j < v.size(); ++j) {
+        auto c = VelocyPackHelper::compareNumberValuesCorrectly(
+            v[j].slice().type(), v[j].slice(), v[i].slice());
+        EXPECT_EQ(1, c) << "Not transitive: " << i << " "
+                        << v[i].slice().toJson() << " " << j << " "
+                        << v[j].slice().toJson();
+      }
+    }
+  }
+}
+
+TEST(VPackHelperTest, test_equality_zeros) {
+  std::vector<VPackBuilder> v;
+  // +0.0:
+  v.push_back(makeVPack(makeDoubleValue(0, 0, 0).d));
+  // -0.0:
+  v.push_back(makeVPack(makeDoubleValue(1, 0, 0).d));
+  // uint64_t{0}:
+  v.push_back(makeVPack(uint64_t{0}));
+  // int64_t{0}:
+  v.push_back(makeVPack(int64_t{0}));
+  // smallint{0}:
+  v.push_back(makeVPack(VPackValue(0, VPackValueType::SmallInt)));
+  for (std::size_t i = 0; i < v.size(); ++i) {
+    for (std::size_t j = 0; j < v.size(); ++j) {
+      EXPECT_EQ(0, VelocyPackHelper::compareNumberValuesCorrectly(
+                       v[i].slice().type(), v[i].slice(), v[j].slice()));
+    }
+  }
+}
+
+TEST(VPackHelperTest, test_equality_with_integers) {
+  std::vector<int64_t> vi;
+  std::vector<uint64_t> vu;
+  vi.push_back(0);
+  vi.push_back(0);
+  int64_t x = -1;
+  uint64_t y = 1;
+  for (int i = 0; i < 62; ++i) {
+    vi.push_back(x);
+    vu.push_back(y);
+    x <<= 1;
+    y <<= 1;
+  }
+  for (int64_t i : vi) {
+    VPackBuilder l = makeVPack(i);
+    VPackBuilder r = makeVPack(static_cast<double>(i));
+    EXPECT_EQ(0, VelocyPackHelper::compareNumberValuesCorrectly(
+                     l.slice().type(), l.slice(), r.slice()));
+    EXPECT_EQ(0, VelocyPackHelper::compareNumberValuesCorrectly(
+                     r.slice().type(), r.slice(), l.slice()));
+  }
+  for (uint64_t u : vu) {
+    VPackBuilder l = makeVPack(u);
+    VPackBuilder r = makeVPack(static_cast<double>(u));
+    EXPECT_EQ(0, VelocyPackHelper::compareNumberValuesCorrectly(
+                     l.slice().type(), l.slice(), r.slice()));
+    EXPECT_EQ(0, VelocyPackHelper::compareNumberValuesCorrectly(
+                     r.slice().type(), r.slice(), l.slice()));
+  }
+}
+
+TEST(VPackHelperTest, test_inequality_with_integers) {
+  int64_t x = -2;
+  uint64_t y = 2;
+  for (int i = 0; i < 61; ++i) {
+    VPackBuilder l = makeVPack(static_cast<double>(x));
+    VPackBuilder r = makeVPack(x - 1);
+    EXPECT_EQ(1, VelocyPackHelper::compareNumberValuesCorrectly(
+                     l.slice().type(), l.slice(), r.slice()))
+        << "Not less: " << i << " " << l.slice().toJson() << " "
+        << r.slice().toJson();
+    EXPECT_EQ(-1, VelocyPackHelper::compareNumberValuesCorrectly(
+                      r.slice().type(), r.slice(), l.slice()))
+        << "Not greater: " << i << " " << r.slice().toJson() << " "
+        << l.slice().toJson();
+    VPackBuilder ll = makeVPack(y + 1);
+    VPackBuilder rr = makeVPack(static_cast<double>(y));
+    EXPECT_EQ(1, VelocyPackHelper::compareNumberValuesCorrectly(
+                     ll.slice().type(), ll.slice(), rr.slice()))
+        << "Not less: " << i << " " << ll.slice().toJson() << " "
+        << rr.slice().toJson();
+    EXPECT_EQ(-1, VelocyPackHelper::compareNumberValuesCorrectly(
+                      rr.slice().type(), rr.slice(), ll.slice()))
+        << "Not greater: " << i << " " << rr.slice().toJson() << " "
+        << ll.slice().toJson();
+    x <<= 1;
+    y <<= 1;
+  }
+}
+
+TEST(VPackHelperTest, test_numbers_compare_as_doubles) {
+  VPackBuilder a = makeVPack(std::numeric_limits<int64_t>::max());
+
+  uint64_t v = std::numeric_limits<int64_t>::max();
+  VPackBuilder b = makeVPack(v);
+
+  uint64_t w = v + 1;
+  VPackBuilder c = makeVPack(w);
+
+  EXPECT_EQ(0, VelocyPackHelper::compareNumberValuesCorrectly(
+                   a.slice().type(), a.slice(), b.slice()));
+  EXPECT_EQ(-1, VelocyPackHelper::compareNumberValuesCorrectly(
+                    b.slice().type(), b.slice(), c.slice()));
+  EXPECT_EQ(-1, VelocyPackHelper::compareNumberValuesCorrectly(
+                    a.slice().type(), a.slice(), c.slice()));
+}
+
+template<typename T>
+static inline void checkNaN(T t) {
+  VPackBuilder nan = makeVPack(makeDoubleValue(0, 2047, 1).d);  // NaN
+  VPackBuilder a = makeVPack(t);
+  EXPECT_EQ(-1, VelocyPackHelper::compareNumberValuesCorrectly(
+                    (a).slice().type(), (a).slice(), nan.slice()));
+  EXPECT_EQ(1, VelocyPackHelper::compareNumberValuesCorrectly(
+                   nan.slice().type(), nan.slice(), (a).slice()));
+}
+
+TEST(VPackHelperTest, test_nan_greater_than_all) {
+  VPackBuilder a;
+  checkNaN(int64_t{0});
+  checkNaN(uint64_t{0});
+  checkNaN(int64_t{-1});
+  checkNaN(int64_t{1});
+  checkNaN(uint64_t{1});
+  checkNaN(std::numeric_limits<int64_t>::max());
+  checkNaN(std::numeric_limits<int64_t>::min());
+  checkNaN(std::numeric_limits<uint64_t>::max());
+  checkNaN(int64_t{12321222123});
+  checkNaN(int64_t{-12321222123});
+  checkNaN(uint64_t{12321222123});
+
+  checkNaN(double{0.0});                    // +0
+  checkNaN(makeDoubleValue(1, 0, 0).d);     // -0
+  checkNaN(makeDoubleValue(0, 2047, 0).d);  // +infty
+  checkNaN(makeDoubleValue(1, 2047, 0).d);  // -infty
+  checkNaN(double{1.0});
+  checkNaN(double{-1.0});
+  checkNaN(double{123456.789});
+  checkNaN(double{-123456.789});
+  checkNaN(double{1.23456e89});
+  checkNaN(double{-1.23456e89});
+  checkNaN(double{1.23456e-89});
+  checkNaN(double{-1.23456e-89});
+  checkNaN(makeDoubleValue(0, 0, 1).d);                        // denormalized
+  checkNaN(makeDoubleValue(0, 0, 123456789).d);                // denormalized
+  checkNaN(makeDoubleValue(0, 0, (uint64_t{1} << 52) - 1).d);  // denormalized
+  checkNaN(makeDoubleValue(1, 0, 1).d);                        // denormalized
+  checkNaN(makeDoubleValue(1, 0, 123456789).d);                // denormalized
+  checkNaN(makeDoubleValue(1, 0, (uint64_t{1} << 52) - 1).d);  // denormalized
+}
+
+template<typename A, typename B>
+static inline int comp(A a, B b) {
+  VPackBuilder Ba = makeVPack(a);
+  VPackBuilder Bb = makeVPack(b);
+  return VelocyPackHelper::compareNumberValuesCorrectly(Ba.slice().type(),
+                                                        Ba.slice(), Bb.slice());
+}
+
+TEST(VPackHelperTest, test_unsigned_double_comparison) {
+  // Test a large representable value:
+  double d = ldexp(1.0, 52);
+  uint64_t u = uint64_t{1} << 52;
+  EXPECT_EQ(0, comp(d, u));
+  EXPECT_EQ(0, comp(u, d));
+  EXPECT_EQ(0, comp(d + 1.0, u + 1));
+  EXPECT_EQ(0, comp(u + 1, d + 1.0));
+
+  // Test a large non-representable value:
+  d = ldexp(1.0, 53);
+  u = uint64_t{1} << 53;
+  EXPECT_EQ(0, comp(d, u));
+  EXPECT_EQ(0, comp(u, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, comp(d + 1.0, u + 1));
+  EXPECT_EQ(1, comp(u + 1, d + 1.0));
+
+  // Test another large non-representable value:
+  d = ldexp(1.0, 60);
+  u = uint64_t{1} << 60;
+  EXPECT_EQ(0, comp(d, u));
+  EXPECT_EQ(0, comp(u, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, comp(d + 1.0, u + 1));
+  EXPECT_EQ(1, comp(u + 1, d + 1.0));
+
+  // Test close to the top:
+  d = ldexp(1.0, 63);
+  u = uint64_t{1} << 63;
+  EXPECT_EQ(0, comp(d, u));
+  EXPECT_EQ(0, comp(u, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, comp(d + 1.0, u + 1));
+  EXPECT_EQ(1, comp(u + 1, d + 1.0));
+
+  // Test rounding down:
+  d = ldexp(1.0, 60);
+  u = (uint64_t{1} << 61) - 1;
+  EXPECT_EQ(-1, comp(d, u));
+  EXPECT_EQ(1, comp(u, d));
+  d = ldexp(1.0, 61);
+  EXPECT_EQ(1, comp(d, u));
+  EXPECT_EQ(-1, comp(u, d));
+
+  // Test doubles between two representable integers:
+  d = ldexp(1.0, 51) + 0.5;
+  u = uint64_t{1} << 51;
+  EXPECT_EQ(1, comp(d, u));
+  EXPECT_EQ(-1, comp(u, d));
+  EXPECT_EQ(-1, comp(d, u + 1));
+  EXPECT_EQ(1, comp(u + 1, d));
+
+  // Test when no precision is lost by a large margin:
+  d = 123456789.0;
+  u = 123456789;
+  EXPECT_EQ(0, comp(d, u));
+  EXPECT_EQ(0, comp(u, d));
+  EXPECT_EQ(1, comp(d + 0.5, u));
+  EXPECT_EQ(-1, comp(u, d + 0.5));
+  EXPECT_EQ(1, comp(d + 1.0, u));
+  EXPECT_EQ(-1, comp(u, d + 1.0));
+  EXPECT_EQ(1, comp(d, u - 1));
+  EXPECT_EQ(-1, comp(u - 1, d));
+}
+
+TEST(VPackHelperTest, test_signed_double_comparison) {
+  // Test a large representable value:
+  double d = -ldexp(1.0, 52);
+  int64_t i = -(int64_t{1} << 52);
+  EXPECT_EQ(0, comp(d, i));
+  EXPECT_EQ(0, comp(i, d));
+  EXPECT_EQ(0, comp(d + 1.0, i + 1));
+  EXPECT_EQ(0, comp(i + 1, d + 1.0));
+
+  // Test a large non-representable value:
+  d = -ldexp(1.0, 53);
+  i = -(int64_t{1} << 53);
+  EXPECT_EQ(0, comp(d, i));
+  EXPECT_EQ(0, comp(i, d));
+  // d-1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(1, comp(d - 1.0, i - 1));
+  EXPECT_EQ(-1, comp(i - 1, d - 1.0));
+
+  // Test another large non-representable value:
+  d = -ldexp(1.0, 60);
+  i = -(int64_t{1} << 60);
+  EXPECT_EQ(0, comp(d, i));
+  EXPECT_EQ(0, comp(i, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, comp(d + 1.0, i + 1));
+  EXPECT_EQ(1, comp(i + 1, d + 1.0));
+
+  // Test close to the top:
+  d = -ldexp(1.0, 62);
+  i = -(int64_t{1} << 62);
+  EXPECT_EQ(0, comp(d, i));
+  EXPECT_EQ(0, comp(i, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, comp(d + 1.0, i + 1));
+  EXPECT_EQ(1, comp(i + 1, d + 1.0));
+
+  // Test rounding down:
+  d = -ldexp(1.0, 60);
+  i = -((int64_t{1} << 61) - 1);
+  EXPECT_EQ(1, comp(d, i));
+  EXPECT_EQ(-1, comp(i, d));
+  d = -ldexp(1.0, 61);
+  EXPECT_EQ(-1, comp(d, i));
+  EXPECT_EQ(1, comp(i, d));
+
+  // Test doubles between two representable integers:
+  d = -ldexp(1.0, 51) + 0.5;
+  i = -(int64_t{1} << 51);
+  EXPECT_EQ(1, comp(d, i));
+  EXPECT_EQ(-1, comp(i, d));
+  EXPECT_EQ(-1, comp(d, i + 1));
+  EXPECT_EQ(1, comp(i + 1, d));
+
+  // Test when no precision is lost by a large margin:
+  d = -123456789.0;
+  i = -123456789;
+  EXPECT_EQ(0, comp(d, i));
+  EXPECT_EQ(0, comp(i, d));
+  EXPECT_EQ(1, comp(d + 0.5, i));
+  EXPECT_EQ(-1, comp(i, d + 0.5));
+  EXPECT_EQ(1, comp(d + 1.0, i));
+  EXPECT_EQ(-1, comp(i, d + 1.0));
+  EXPECT_EQ(1, comp(d, i - 1));
+  EXPECT_EQ(-1, comp(i - 1, d));
+
+  // Test the smallest signed integer:
+  i = std::numeric_limits<int64_t>::min();
+  d = -ldexp(1.0, 63);
+  EXPECT_EQ(0, comp(d, i));
+  EXPECT_EQ(0, comp(i, d));
+  EXPECT_EQ(-1, comp(d, i + 1));
+  EXPECT_EQ(1, comp(i + 1, d));
+}
+
+template<typename A, typename B>
+static inline int compGeneric(A a, B b) {
+  VPackBuilder Ba = makeVPack(a);
+  VPackBuilder Bb = makeVPack(b);
+  return VelocyPackHelper::compare(Ba.slice(), Bb.slice(), true);
+}
+
+TEST(VPackHelperTest, test_generic_uses_correct_numerical_comparison) {
+  // Test large non-representable value:
+  double d = ldexp(1.0, 60);
+  uint64_t u = uint64_t{1} << 60;
+  EXPECT_EQ(0, compGeneric(d, u));
+  EXPECT_EQ(0, compGeneric(u, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, compGeneric(d + 1.0, u + 1));
+  EXPECT_EQ(1, compGeneric(u + 1, d + 1.0));
+
+  // Test another large non-representable value:
+  d = -ldexp(1.0, 60);
+  int64_t i = -(int64_t{1} << 60);
+  EXPECT_EQ(0, compGeneric(d, i));
+  EXPECT_EQ(0, compGeneric(i, d));
+  // d+1.0 is equal to d here due to limited precision!
+  EXPECT_EQ(-1, compGeneric(d + 1.0, i + 1));
+  EXPECT_EQ(1, compGeneric(i + 1, d + 1.0));
+
+  // Now compare signed and unsigned:
+  u = uint64_t{1} << 60;
+  i = int64_t{1} << 60;
+  EXPECT_EQ(0, compGeneric(u, i));
+  EXPECT_EQ(0, compGeneric(i, u));
+  EXPECT_EQ(0, compGeneric(u + 1, i + 1));
+  EXPECT_EQ(0, compGeneric(i + 1, u + 1));
+  EXPECT_EQ(0, compGeneric(u - 1, i - 1));
+  EXPECT_EQ(0, compGeneric(i - 1, u - 1));
+  EXPECT_EQ(1, compGeneric(u + 1, i));
+  EXPECT_EQ(-1, compGeneric(i, u + 1));
+  EXPECT_EQ(-1, compGeneric(u - 1, i));
+  EXPECT_EQ(1, compGeneric(i, u - 1));
+  EXPECT_EQ(1, compGeneric(i + 1, u));
+  EXPECT_EQ(-1, compGeneric(u, i + 1));
+  EXPECT_EQ(-1, compGeneric(i - 1, u));
+  EXPECT_EQ(1, compGeneric(u, i - 1));
+}
+
+// So far we do not actually use UTCDate, but for the sake of completeness
+// we check if things work as expected. UTCDates are larger than any number
+// (including NaN), and smaller than any string:
+
+TEST(VPackHelperTest, test_utcdate) {
+  double d = ldexp(1.0, 60);
+  uint64_t u = uint64_t{1} << 60;
+  int64_t i = int64_t{1} << 60;
+  std::string s = "abc";
+  EXPECT_EQ(-1, compGeneric(d, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i, VPackValueType::UTCDate), d));
+  EXPECT_EQ(-1, compGeneric(u, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i, VPackValueType::UTCDate), u));
+  EXPECT_EQ(-1, compGeneric(i, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i, VPackValueType::UTCDate), i));
+  EXPECT_EQ(-1, compGeneric(d + 1.0, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i + 1, VPackValueType::UTCDate), d));
+  EXPECT_EQ(1, compGeneric(VPackValue(i - 1, VPackValueType::UTCDate), d));
+  EXPECT_EQ(-1, compGeneric(u + 1, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(-1, compGeneric(u - 1, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i + 1, VPackValueType::UTCDate), u));
+  EXPECT_EQ(1, compGeneric(VPackValue(i - 1, VPackValueType::UTCDate), u));
+  EXPECT_EQ(-1, compGeneric(i + 1, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(-1, compGeneric(i - 1, VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i + 1, VPackValueType::UTCDate), i));
+  EXPECT_EQ(1, compGeneric(VPackValue(i - 1, VPackValueType::UTCDate), i));
+  EXPECT_EQ(-1,
+            compGeneric(VPackValue(i, VPackValueType::UTCDate), VPackValue(s)));
+  EXPECT_EQ(1,
+            compGeneric(VPackValue(s), VPackValue(i, VPackValueType::UTCDate)));
+}
+
+TEST(VPackHelperTest, test_small_int_with_int) {
+  int64_t i = int64_t{5};
+  EXPECT_EQ(0, compGeneric(i, VPackValue(i, VPackValueType::SmallInt)));
+  EXPECT_EQ(0, compGeneric(VPackValue(i, VPackValueType::SmallInt), i));
+  EXPECT_EQ(1, compGeneric(i + 1, VPackValue(i, VPackValueType::SmallInt)));
+  EXPECT_EQ(-1, compGeneric(VPackValue(i, VPackValueType::SmallInt), i + 1));
+  EXPECT_EQ(-1, compGeneric(i, VPackValue(i + 1, VPackValueType::SmallInt)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i + 1, VPackValueType::SmallInt), i));
+}
+
+TEST(VPackHelperTest, test_small_int_with_utcdate) {
+  int64_t i = int64_t{5};
+  EXPECT_EQ(1, compGeneric(VPackValue(i, VPackValueType::UTCDate),
+                           VPackValue(i, VPackValueType::SmallInt)));
+  EXPECT_EQ(-1, compGeneric(VPackValue(i, VPackValueType::SmallInt),
+                            VPackValue(i, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i + 1, VPackValueType::UTCDate),
+                           VPackValue(i, VPackValueType::SmallInt)));
+  EXPECT_EQ(-1, compGeneric(VPackValue(i, VPackValueType::SmallInt),
+                            VPackValue(i + 1, VPackValueType::UTCDate)));
+  EXPECT_EQ(1, compGeneric(VPackValue(i, VPackValueType::UTCDate),
+                           VPackValue(i + 1, VPackValueType::SmallInt)));
+  EXPECT_EQ(-1, compGeneric(VPackValue(i + 1, VPackValueType::SmallInt),
+                            VPackValue(i, VPackValueType::UTCDate)));
 }

--- a/tests/RocksDBEngine/KeyTest.cpp
+++ b/tests/RocksDBEngine/KeyTest.cpp
@@ -570,7 +570,8 @@ TEST_F(RocksDBKeyBoundsTestLittleEndian, test_hash_index) {
   EXPECT_EQ(prefixEnd.data()[prefixEnd.size() - 1], '\0');
 
   // prefix is just object id
-  auto cmp = std::make_unique<RocksDBVPackComparator>();
+  auto cmp = std::make_unique<RocksDBVPackComparator<
+      arangodb::basics::VelocyPackHelper::SortingMethod::Correct>>();
   EXPECT_EQ(cmp->Compare(prefixBegin, prefixEnd), 0);
   EXPECT_LT(cmp->Compare(prefixBegin, key1.string()), 0);
   EXPECT_GT(cmp->Compare(bounds.end(), key1.string()), 0);
@@ -720,7 +721,8 @@ TEST_F(RocksDBKeyBoundsTestBigEndian, test_hash_index) {
   EXPECT_EQ(prefixEnd.data()[prefixEnd.size() - 1], '\x02');
 
   // prefix is just object id
-  auto cmp = std::make_unique<RocksDBVPackComparator>();
+  auto cmp = std::make_unique<RocksDBVPackComparator<
+      arangodb::basics::VelocyPackHelper::SortingMethod::Correct>>();
   EXPECT_LT(cmp->Compare(prefixBegin, prefixEnd), 0);
   EXPECT_LT(cmp->Compare(prefixBegin, key1.string()), 0);
   EXPECT_GT(cmp->Compare(prefixEnd, key1.string()), 0);

--- a/tests/js/client/server_parameters/legacy-sorting-cluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-cluster.js
@@ -196,8 +196,8 @@ function legacySortingTestSuite() {
           if (oneResult.result.errorCode !== 0) { return false; }
           if (!Array.isArray(oneResult.result.affected)) { return false; }
           if (oneResult.result.affected.length !== 0) { return false; }
-          return true;
         }
+        return true;
       };
       let count = 0;
       while (count < 60) {

--- a/tests/js/client/server_parameters/legacy-sorting-cluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-cluster.js
@@ -1,0 +1,204 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global getOptions, assertEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// We need the following options for this test:
+//  --rocksdb.force-legacy-comparator true
+// This means that the old rocksdb comparator is used. This is necessary
+// since we want to test that the migration check detects bad data.
+
+if (getOptions === true) {
+  return {
+    'rocksdb.force-legacy-comparator': 'true'
+  };
+}
+
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+
+// This introduces some values into a collection which will be sorted
+// incorrectly with the legacy sorting order. Note that we cannot do
+// this via JSON, since JavaScript has only double numbers. That is the
+// reason why we use the HTTP API directly and use awkward strings.
+
+function poisonCollection(databasename, collname, attrA, attrB) {
+  // 1152921504606846976 = 2^60 which does not completely fit into IEEE 754,
+  // therefore 2^60+1 and 2^60 are considered equal in the old comparator,
+  // if they are presented in different representations in vpack (int, uint,
+  // or double).
+  // Therefore, the following document with key "X" is considered smaller
+  // than the one with key "Y" in the legacy order, whereas in the
+  // correct lexicographic order document "X" is be larger.
+  let r = 
+    arango.POST_RAW(`/_db/${databasename}/_api/document/${collname}`,
+      `{"_key":"X","${attrA}":1152921504606846977,"${attrB}":"x","x":1.0,"y":1.0}`);
+  assertFalse(r.error);
+  assertEqual(202, r.code);
+  r = arango.POST_RAW(`/_db/${databasename}/_api/document/${collname}`,
+    `{"_key":"Y","${attrA}":1152921504606846976.0,"${attrB}":"y","x":1.0,"y":1.0}`);
+  assertEqual(202, r.code);
+  assertFalse(r.error);
+}
+
+function createVPackIndexes(databasename, collname, attrA, attrB) {
+  db._useDatabase(databasename);
+  let c = db._collection(collname);
+  c.ensureIndex({type:"persistent", fields: [attrA, attrB], unique: false,
+                 name:"persistent_non_unique"});
+  c.ensureIndex({type:"persistent", fields: [attrA, attrB], unique: true,
+                 name:"persistent_unique"});
+  c.ensureIndex({type:"hash", fields: [attrA, attrB], unique: false,
+                 name:"hash_non_unique"});
+  c.ensureIndex({type:"hash", fields: [attrA, attrB], unique: true,
+                 name:"hash_unique"});
+  c.ensureIndex({type:"skiplist", fields: [attrA, attrB], unique: false,
+                 name:"skiplist_non_unique"});
+  c.ensureIndex({type:"skiplist", fields: [attrA, attrB], unique: true,
+                 name:"skiplist_unique"});
+  let nr = 6;
+  try {
+    c.ensureIndex({type:"mdi-prefixed", fields: ["x", "y"], prefixFields:[attrA, attrB],
+                   name:"mdi_non_unique", fieldValueTypes: "double", unique: false});
+    c.ensureIndex({type:"mdi-prefixed", fields: ["x", "y"], prefixFields:[attrA, attrB],
+                   name:"mdi_unique", fieldValueTypes: "double", unique: true});
+    nr += 2;
+  } catch(e) {
+    // Smile it away on 3.11
+  }
+  db._useDatabase("_system");
+  return nr;
+}
+
+function legacySortingTestSuite() {
+  'use strict';
+  const dn = "UnitTestsDatabase";
+  const cn = 'UnitTestsLegacySortingBad';
+  const cn2 = 'UnitTestsLegacySortingGood';
+
+  return {
+    setUp: function() {
+      let l = [];
+      for (let i = 0; i < 1000; ++i) {
+        l.push({Hallo:i, a:i, b: i, x: i * 1.234567, y : i * 1.234567});
+      }
+      // Note: We must only use one shard, since otherwise the incriminating
+      // documents might be distributed to more than one dbserver, removing
+      // the problem!
+      let c = db._create(cn, {numberOfShards:1, replicationFactor:2});
+      c.insert(l);
+      c = db._create(cn2, {numberOfShards:1, replicationFactor:2});
+      c.insert(l);
+
+      db._createDatabase(dn);
+      db._useDatabase(dn);
+      c = db._create(cn, {numberOfShards:1, replicationFactor:2});
+      c.insert(l);
+      c = db._create(cn2, {numberOfShards:1, replicationFactor:2});
+      c.insert(l);
+      db._useDatabase("_system");
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+      db._drop(cn2);
+      db._dropDatabase(dn);
+    },
+
+    testMigrationCheck: function() {
+      let nr = createVPackIndexes("_system", cn, "a", "b");
+      createVPackIndexes(dn, cn, "a", "b");
+      createVPackIndexes("_system", cn2, "a", "b");
+      createVPackIndexes(dn, cn2, "a", "b");
+      poisonCollection("_system", cn, "a", "b");
+      poisonCollection(dn, cn, "a", "b");
+
+      let c = db._collection(cn);
+      let indexes = c.getIndexes();
+      let names = indexes.map(x => x.name);
+      let ids_system = indexes.map(x => x.id);
+      let r = arango.GET("/_admin/cluster/vpackSortMigration/check");
+
+      db._useDatabase(dn);
+      c = db._collection(cn);
+      indexes = c.getIndexes();
+      let ids_dn = indexes.map(x => x.id);
+      db._useDatabase("_system");
+
+      r = arango.GET("/_admin/cluster/vpackSortMigration/check");
+
+      // Now check that we found all the indexes and not too many.
+      // We do not check the details of the output, since we do this
+      // in the single server case and we never know which shards land
+      // on which dbserver. We do not even know
+      assertFalse(r.error);
+      assertEqual(200, r.code);
+      assertEqual("object", typeof(r.result));
+      for (let dbserver in r.result) {
+        let oneResult = r.result[dbserver];
+        assertFalse(oneResult.error);
+        assertEqual(200, oneResult.code);
+        assertTrue(oneResult.result.error);
+        assertEqual(1242, oneResult.result.errorCode);
+        assertTrue(Array.isArray(oneResult.result.affected));
+        assertTrue(oneResult.result.affected.length > 0);
+      }
+
+      // Now get rid of indexes:
+      for (let d of ["_system", dn]) {
+        db._useDatabase(d);
+        c = db._collection(cn);
+        indexes = c.getIndexes();
+        for (let i of indexes) {
+          if (i.id !== cn + "/0") {   // primary index
+            c.dropIndex(i.id);
+          }
+        }
+        db._useDatabase("_system");
+      }
+
+      // And check again:
+      r = arango.GET("/_admin/cluster/vpackSortMigration/check");
+
+      // Now check that we found all the indexes and not too many:
+      assertFalse(r.error);
+      assertEqual(200, r.code);
+      assertEqual("object", typeof(r.result));
+      for (let dbserver in r.result) {
+        let oneResult = r.result[dbserver];
+        assertFalse(oneResult.error);
+        assertEqual(200, oneResult.code);
+        assertFalse(oneResult.result.error);
+        assertEqual(0, oneResult.result.errorCode);
+        assertTrue(Array.isArray(oneResult.result.affected));
+        assertEqual(0, oneResult.result.affected.length);
+      }
+    }
+  };
+}
+
+jsunity.run(legacySortingTestSuite);
+
+return jsunity.done();

--- a/tests/js/client/server_parameters/legacy-sorting-noncluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-noncluster.js
@@ -1,0 +1,198 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global getOptions, assertEqual, assertNotEqual, assertTrue, assertFalse, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Max Neunhoeffer
+// //////////////////////////////////////////////////////////////////////////////
+
+// We need the following options for this test:
+//  --rocksdb.force-legacy-comparator true
+// This means that the old rocksdb comparator is used. This is necessary
+// since we want to test that the migration check detects bad data.
+
+if (getOptions === true) {
+  return {
+    'rocksdb.force-legacy-comparator': 'true'
+  };
+}
+
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+let db = arangodb.db;
+
+// This introduces some values into a collection which will be sorted
+// incorrectly with the legacy sorting order. Note that we cannot do
+// this via JSON, since JavaScript has only double numbers. That is the
+// reason why we use the HTTP API directly and use awkward strings.
+
+function poisonCollection(databasename, collname, attrA, attrB) {
+  // 1152921504606846976 = 2^60 which does not completely fit into IEEE 754,
+  // therefore 2^60+1 and 2^60 are considered equal in the old comparator,
+  // if they are presented in different representations in vpack (int, uint,
+  // or double).
+  // Therefore, the following document with key "X" is considered smaller
+  // than the one with key "Y" in the legacy order, whereas in the
+  // correct lexicographic order document "X" is be larger.
+  let r = 
+    arango.POST_RAW(`/_db/${databasename}/_api/document/${collname}`,
+      `{"_key":"X","${attrA}":1152921504606846977,"${attrB}":"x","x":1.0,"y":1.0}`);
+  assertFalse(r.error);
+  assertEqual(202, r.code);
+  r = arango.POST_RAW(`/_db/${databasename}/_api/document/${collname}`,
+    `{"_key":"Y","${attrA}":1152921504606846976.0,"${attrB}":"y","x":1.0,"y":1.0}`);
+  assertFalse(r.error);
+  assertEqual(202, r.code);
+}
+
+function createVPackIndexes(databasename, collname, attrA, attrB) {
+  db._useDatabase(databasename);
+  let c = db._collection(collname);
+  c.ensureIndex({type:"persistent", fields: [attrA, attrB], unique: false,
+                 name:"persistent_non_unique"});
+  c.ensureIndex({type:"persistent", fields: [attrA, attrB], unique: true,
+                 name:"persistent_unique"});
+  c.ensureIndex({type:"hash", fields: [attrA, attrB], unique: false,
+                 name:"hash_non_unique"});
+  c.ensureIndex({type:"hash", fields: [attrA, attrB], unique: true,
+                 name:"hash_unique"});
+  c.ensureIndex({type:"skiplist", fields: [attrA, attrB], unique: false,
+                 name:"skiplist_non_unique"});
+  c.ensureIndex({type:"skiplist", fields: [attrA, attrB], unique: true,
+                 name:"skiplist_unique"});
+  let nr = 6;
+  try {
+    c.ensureIndex({type:"mdi-prefixed", fields: ["x", "y"], prefixFields:[attrA, attrB],
+                   name:"mdi_non_unique", fieldValueTypes: "double", unique: false});
+    c.ensureIndex({type:"mdi-prefixed", fields: ["x", "y"], prefixFields:[attrA, attrB],
+                   name:"mdi_unique", fieldValueTypes: "double", unique: true});
+    nr += 2;
+  } catch(e) {
+    // Smile it away on 3.11
+  }
+  db._useDatabase("_system");
+  return nr;
+}
+
+function legacySortingTestSuite() {
+  'use strict';
+  const dn = "UnitTestsDatabase";
+  const cn = 'UnitTestsLegacySortingBad';
+  const cn2 = 'UnitTestsLegacySortingGood';
+
+  return {
+    setUp: function() {
+      let l = [];
+      for (let i = 0; i < 1000; ++i) {
+        l.push({Hallo:i, a:i, b: i, x: i * 1.234567, y : i * 1.234567});
+      }
+      let c = db._create(cn);
+      c.insert(l);
+      c = db._create(cn2);
+      c.insert(l);
+
+      db._createDatabase(dn);
+      db._useDatabase(dn);
+      c = db._create(cn);
+      c.insert(l);
+      c = db._create(cn2);
+      c.insert(l);
+      db._useDatabase("_system");
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+      db._drop(cn2);
+      db._dropDatabase(dn);
+    },
+
+    testMigrationCheck: function() {
+      let nr = createVPackIndexes("_system", cn, "a", "b");
+      createVPackIndexes(dn, cn, "a", "b");
+      createVPackIndexes("_system", cn2, "a", "b");
+      createVPackIndexes(dn, cn2, "a", "b");
+      poisonCollection("_system", cn, "a", "b");
+      poisonCollection(dn, cn, "a", "b");
+
+      let c = db._collection(cn);
+      let indexes = c.getIndexes();
+      let names = indexes.map(x => x.name);
+      let ids_system = indexes.map(x => x.id);
+      let r = arango.GET("/_admin/cluster/vpackSortMigration/check");
+
+      db._useDatabase(dn);
+      c = db._collection(cn);
+      indexes = c.getIndexes();
+      let ids_dn = indexes.map(x => x.id);
+      db._useDatabase("_system");
+
+      r = arango.GET("/_admin/cluster/vpackSortMigration/check");
+
+      // Now check that we found all the indexes and not too many:
+      assertFalse(r.error);
+      assertEqual(200, r.code);
+      assertTrue(r.result.error);
+      assertEqual(1242, r.result.errorCode);
+      assertTrue(Array.isArray(r.result.affected));
+      assertEqual(2*nr, r.result.affected.length);
+      for (let o of r.result.affected) {
+        assertEqual(o.collection, cn);
+        assertTrue(names.indexOf(o.indexName) >= 0);
+        assertNotEqual(0, o.indexId);   // Not the primary index!
+        if (o.database === "_system") {
+          assertTrue(ids_system.indexOf(cn + "/" + o.indexId) >= 0);
+        } else if (o.database === dn) {
+          assertTrue(ids_dn.indexOf(cn + "/" + o.indexId) >= 0);
+        } else {
+          assertTrue(false, "Wrong database name: " + o.database);
+        }
+      }
+
+      // Now get rid of indexes:
+      for (let d of ["_system", dn]) {
+        db._useDatabase(d);
+        c = db._collection(cn);
+        indexes = c.getIndexes();
+        for (let i of indexes) {
+          if (i.id !== cn + "/0") {   // primary index
+            c.dropIndex(i.id);
+          }
+        }
+        db._useDatabase("_system");
+      }
+
+      // And check again:
+      r = arango.GET("/_admin/cluster/vpackSortMigration/check");
+
+      // Now check that we found all the indexes and not too many:
+      assertFalse(r.error);
+      assertEqual(200, r.code);
+      assertFalse(r.result.error);
+      assertEqual(0, r.result.errorCode);
+      assertTrue(Array.isArray(r.result.affected));
+      assertEqual(0, r.result.affected.length);
+    }
+  };
+}
+
+jsunity.run(legacySortingTestSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This addresses vpack number comparison. Previous versions had a
comparison function, which was not transitive, which can lead to data
corruption in RocksDB keys in the VPackIndex as well as to wrong results
because numerical values were compared incorrectly.

This is a backport of https://github.com/arangodb/arangodb/pull/21179

See details there.

It should only be merged once 3.12.2 is out.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
- [*] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [*] Backports
  - [*] Backport for 3.11: this is it

#### Related Information

- [*] Enterprise PR: https://github.com/arangodb/enterprise/pull/1505
