### PR TITLE
Fix migration for vpack sorting

### DIFF
--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -4239,6 +4239,13 @@ SortingMethod RocksDBEngine::readSortingFile() {
     sortingMethod =
         (value == "LEGACY") ? SortingMethod::Legacy : SortingMethod::Correct;
   } catch (std::exception const& ex) {
+    // To find out if we are an agent, we need to check if the AgencyFeature
+    // is activated! Note that we cannot use ServerState::isAgent here for
+    // the following reason: When we run an upgraded version for the first
+    // time, we almost certainly run with --database.auto-upgrade=true .
+    // But in this case, the AgencyFeature and the ClusterFeature are
+    // disabled! Therefore, the role of the server is not correctly
+    // reported to the ServerState class!
     auto& agencyFeature = server().getFeature<AgencyFeature>();
     // When we see a database directory without SORTING file, we fall back
     // to legacy mode, except for agents. Since agents have never used

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -23,6 +23,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "RocksDBEngine.h"
+#include "Agency/AgencyFeature.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/LanguageFeature.h"
 #include "Basics/Exceptions.h"
@@ -4238,12 +4239,13 @@ SortingMethod RocksDBEngine::readSortingFile() {
     sortingMethod =
         (value == "LEGACY") ? SortingMethod::Legacy : SortingMethod::Correct;
   } catch (std::exception const& ex) {
+    auto& agencyFeature = server().getFeature<AgencyFeature>();
     // When we see a database directory without SORTING file, we fall back
     // to legacy mode, except for agents. Since agents have never used
     // VPackIndexes before we fixed the sorting order, we might as well
     // directly consider them to be migrated to the CORRECT sorting order:
-    sortingMethod = ServerState::instance()->isAgent() ? SortingMethod::Correct
-                                                       : SortingMethod::Legacy;
+    sortingMethod = agencyFeature.activated() ? SortingMethod::Correct
+                                              : SortingMethod::Legacy;
     LOG_TOPIC("8ff0e", WARN, Logger::STARTUP)
         << "unable to read 'SORTING' file '" << path << "': " << ex.what()
         << ". This is expected directly after an upgrade and will then be "


### PR DESCRIPTION
This fixes two small problems with the vpack sorting migration, which
were spotted during tests:

 1. The timeout for the cluster internal communication was too low for
    large databases.
 2. On database upgrade, an agent did not correctly detect that it is an
    agent and did not do auto-migration.


### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

- [*] Backports
  - [*] Backport for 3.11: unnecessary, since backport PR already fixed

