### PR TITLE
remove duplicate string definition for _graphs collection

### DIFF
--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -1766,7 +1766,7 @@ auto ClusterInfo::loadPlan() -> consensus::index_t {
         // be old.
         if (systemDB->replicationVersion() == replication::Version::ONE) {
           // find _graphs collection in Plan
-          if (auto it2 = it->second->find(StaticStrings::GraphCollection);
+          if (auto it2 = it->second->find(StaticStrings::GraphsCollection);
               it2 != it->second->end()) {
             // found!
             if (it2->second.collection->distributeShardsLike().empty()) {

--- a/arangod/Graph/Graph.cpp
+++ b/arangod/Graph/Graph.cpp
@@ -23,13 +23,6 @@
 
 #include "Graph.h"
 
-#include <Logger/LogMacros.h>
-#include <velocypack/Buffer.h>
-#include <velocypack/Collection.h>
-#include <velocypack/Iterator.h>
-#include <array>
-#include <utility>
-
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/AstNode.h"
 #include "Aql/Query.h"
@@ -40,6 +33,7 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ServerDefaults.h"
 #include "Cluster/ServerState.h"
+#include "Logger/LogMacros.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/OperationOptions.h"
@@ -49,6 +43,14 @@
 #include "VocBase/Properties/DatabaseConfiguration.h"
 #include "VocBase/Methods/Collections.h"
 #include "VocBase/vocbase.h"
+
+#include <absl/strings/str_cat.h>
+#include <velocypack/Buffer.h>
+#include <velocypack/Collection.h>
+#include <velocypack/Iterator.h>
+
+#include <array>
+#include <utility>
 
 using namespace arangodb;
 using namespace arangodb::graph;
@@ -279,8 +281,8 @@ uint64_t Graph::replicationFactor() const { return _replicationFactor; }
 
 uint64_t Graph::writeConcern() const { return _writeConcern; }
 
-std::string const Graph::id() const {
-  return std::string(StaticStrings::GraphCollection + "/" + _graphName);
+std::string Graph::id() const {
+  return absl::StrCat(StaticStrings::GraphsCollection, "/", _graphName);
 }
 
 std::string const& Graph::rev() const { return _rev; }

--- a/arangod/Graph/Graph.h
+++ b/arangod/Graph/Graph.h
@@ -208,7 +208,7 @@ class Graph {
   uint64_t numberOfShards() const;
   uint64_t replicationFactor() const;
   uint64_t writeConcern() const;
-  std::string const id() const;
+  std::string id() const;
   std::string const& rev() const;
 
   std::string const& name() const { return _graphName; }

--- a/arangod/Graph/GraphOperations.cpp
+++ b/arangod/Graph/GraphOperations.cpp
@@ -95,7 +95,7 @@ futures::Future<OperationResult> GraphOperations::changeEdgeDefinitionForGraph(
   }
 
   // now write to database
-  return trx.update(StaticStrings::GraphCollection, builder.slice(), options);
+  return trx.update(StaticStrings::GraphsCollection, builder.slice(), options);
 }
 
 futures::Future<OperationResult> GraphOperations::eraseEdgeDefinition(
@@ -122,7 +122,7 @@ futures::Future<OperationResult> GraphOperations::eraseEdgeDefinition(
   _graph.toPersistence(builder);
   builder.close();
 
-  SingleCollectionTransaction trx(ctx(), StaticStrings::GraphCollection,
+  SingleCollectionTransaction trx(ctx(), StaticStrings::GraphsCollection,
                                   AccessMode::Type::WRITE);
   trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
@@ -133,7 +133,7 @@ futures::Future<OperationResult> GraphOperations::eraseEdgeDefinition(
     co_return OperationResult(res, options);
   }
   OperationResult result =
-      trx.update(StaticStrings::GraphCollection, builder.slice(), options);
+      trx.update(StaticStrings::GraphsCollection, builder.slice(), options);
 
   if (dropCollection) {
     std::unordered_set<std::string> collectionsToBeRemoved;
@@ -287,7 +287,7 @@ futures::Future<OperationResult> GraphOperations::editEdgeDefinition(
     co_return OperationResult{TRI_ERROR_GRAPH_INTERNAL_DATA_CORRUPT, options};
   }
 
-  SingleCollectionTransaction trx(ctx(), StaticStrings::GraphCollection,
+  SingleCollectionTransaction trx(ctx(), StaticStrings::GraphsCollection,
                                   AccessMode::Type::WRITE);
 
   res = co_await trx.beginAsync();
@@ -410,7 +410,7 @@ futures::Future<OperationResult> GraphOperations::addOrphanCollection(
   _graph.toPersistence(builder);
   builder.close();
 
-  SingleCollectionTransaction trx(ctx(), StaticStrings::GraphCollection,
+  SingleCollectionTransaction trx(ctx(), StaticStrings::GraphsCollection,
                                   AccessMode::Type::WRITE);
 
   res = co_await trx.beginAsync();
@@ -419,7 +419,7 @@ futures::Future<OperationResult> GraphOperations::addOrphanCollection(
     co_return OperationResult(res, options);
   }
 
-  result = co_await trx.updateAsync(StaticStrings::GraphCollection,
+  result = co_await trx.updateAsync(StaticStrings::GraphsCollection,
                                     builder.slice(), options);
 
   res = co_await trx.finishAsync(result.result);
@@ -485,7 +485,7 @@ futures::Future<OperationResult> GraphOperations::eraseOrphanCollection(
 
   OperationResult result(Result(), options);
   {
-    SingleCollectionTransaction trx(ctx(), StaticStrings::GraphCollection,
+    SingleCollectionTransaction trx(ctx(), StaticStrings::GraphsCollection,
                                     AccessMode::Type::WRITE);
     trx.addHint(transaction::Hints::Hint::SINGLE_OPERATION);
 
@@ -498,7 +498,7 @@ futures::Future<OperationResult> GraphOperations::eraseOrphanCollection(
     options.waitForSync = waitForSync;
 
     result =
-        trx.update(StaticStrings::GraphCollection, builder.slice(), options);
+        trx.update(StaticStrings::GraphsCollection, builder.slice(), options);
     res = co_await trx.finishAsync(result.result);
   }
 

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1475,14 +1475,14 @@ std::string const& TRI_vocbase_t::shardingPrototypeName() const {
       return StaticStrings::UsersCollection;
     case ShardingPrototype::Graphs:
       // Specifically set defaults should win
-      return StaticStrings::GraphCollection;
+      return StaticStrings::GraphsCollection;
     case ShardingPrototype::Undefined:
       if (isSystem()) {
         // The sharding Prototype for system databases is always the users
         return StaticStrings::UsersCollection;
       } else {
         // All others should follow _graphs
-        return StaticStrings::GraphCollection;
+        return StaticStrings::GraphsCollection;
       }
   }
 }

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -305,7 +305,6 @@ std::string const StaticStrings::ReplicationVersion("replicationVersion");
 std::string const StaticStrings::ReplicatedLogs("replicatedLogs");
 
 // graph attribute names
-std::string const StaticStrings::GraphCollection("_graphs");
 std::string const StaticStrings::GraphFrom("from");
 std::string const StaticStrings::GraphTo("to");
 std::string const StaticStrings::GraphOptions("options");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -285,7 +285,6 @@ class StaticStrings {
   static std::string const ReplicatedLogs;
 
   // graph attribute names
-  static std::string const GraphCollection;
   static std::string const GraphFrom;
   static std::string const GraphTo;
   static std::string const GraphOptions;


### PR DESCRIPTION
### Scope & Purpose

Remove duplicate string definition for `_graphs` collection.
We previously had `StaticStrings::GraphsCollection` and `StaticString::GraphCollection`.
We now go only with the former definition for simplicity.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 