### PR TITLE
Fixed MDS-1225

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.11 (XXXX-XX-XX)
 ---------------------
 
+* Fixed MDS-1225: reloading of AQL user-defined functions inside AQL queries 
+  could cause trouble if the `_aqlfunctions` collection is located on different
+  DB server than the leader shards of other collections used in the same query.
+
 * Fixed FE-435: drop collections checkbox in graph settings modal was not
   aligned.
 

--- a/js/server/modules/@arangodb/aql.js
+++ b/js/server/modules/@arangodb/aql.js
@@ -27,22 +27,22 @@
 // / @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
-var INTERNAL = require('internal');
-var ArangoError = require('@arangodb').ArangoError;
+const INTERNAL = require('internal');
+const ArangoError = require('@arangodb').ArangoError;
 
 // / @brief user functions cache
-var UserFunctions = { };
+let UserFunctions = { };
 
 // / @brief throw a runtime exception
 function THROW (func, error, data, moreMessage) {
   'use strict';
 
-  var prefix = '';
+  let prefix = '';
   if (func !== null && func !== '') {
     prefix = "in function '" + func + "()': ";
   }
 
-  var err = new ArangoError();
+  let err = new ArangoError();
 
   err.errorNum = error.code;
   if (typeof data === 'string') {
@@ -66,8 +66,8 @@ function DB_PREFIX () {
 function reloadUserFunctions () {
   'use strict';
 
-  var prefix = DB_PREFIX();
-  var c = INTERNAL.db._collection('_aqlfunctions');
+  const prefix = DB_PREFIX();
+  let c = INTERNAL.db._collection('_aqlfunctions');
 
   if (c === null) {
     // collection not found. now reset all user functions
@@ -76,12 +76,12 @@ function reloadUserFunctions () {
     return;
   }
 
-  var foundError = false;
-  var functions = { };
+  let foundError = false;
+  let functions = {};
 
   c.toArray().forEach(function (f) {
-    var key = f._key.replace(/:{1,}/g, '::');
-    var code;
+    let key = f._key.replace(/:{1,}/g, '::');
+    let code;
 
     if (f.code.match(/^\(?function\s+\(/)) {
       code = f.code;
@@ -90,7 +90,7 @@ function reloadUserFunctions () {
     }
 
     try {
-      var res = INTERNAL.executeScript(code, undefined, '(user function ' + key + ')');
+      let res = INTERNAL.executeScript(code, undefined, '(user function ' + key + ')');
       if (typeof res !== 'function') {
         foundError = true;
       }
@@ -119,11 +119,58 @@ function reloadUserFunctions () {
   }
 }
 
+// reload a single AQL user-defined function by name
+function reloadUserFunction (name) {
+  'use strict';
+
+  let prefix = DB_PREFIX();
+  let c = INTERNAL.db._collection('_aqlfunctions');
+
+  if (c === null) {
+    UserFunctions = {};
+    return;
+  }
+
+  if (!UserFunctions.hasOwnProperty(prefix)) {
+    UserFunctions[prefix] = {};
+  }
+
+  let key = name.replace(/:{1,}/g, '::').toUpperCase();
+
+  try {
+    // use the single-document GET operation here, which does not require a full
+    // AQL query setup and is much cheaper and less error-prone than a full AQL
+    // query.
+    let doc = c.document(key);
+    let code;
+    if (doc.code.match(/^\(?function\s+\(/)) {
+      code = doc.code;
+    } else {
+      code = '(function() { var callback = ' + doc.code + ';\n return callback; })();';
+    }
+
+    try {
+      let res = INTERNAL.executeScript(code, undefined, '(user function ' + key + ')');
+      if (typeof res !== 'function') {
+        THROW(null, INTERNAL.errors.ERROR_QUERY_FUNCTION_INVALID_CODE);
+      }
+      UserFunctions[prefix][key] = {
+        name: key,
+        func: res,
+        isDeterministic: doc.isDeterministic || false
+      };
+    } catch (err) {
+      THROW(null, INTERNAL.errors.ERROR_QUERY_FUNCTION_INVALID_CODE);
+    }
+  } catch (err) {
+  }
+}
+
 // / @brief box a value into the AQL datatype system
 function FIX_VALUE (value) {
   'use strict';
 
-  var type = typeof (value);
+  let type = typeof (value);
 
   if (value === undefined ||
     value === null ||
@@ -136,8 +183,8 @@ function FIX_VALUE (value) {
   }
 
   if (Array.isArray(value)) {
-    var i, n = value.length;
-    for (i = 0; i < n; ++i) {
+    const n = value.length;
+    for (let i = 0; i < n; ++i) {
       value[i] = FIX_VALUE(value[i]);
     }
 
@@ -145,7 +192,7 @@ function FIX_VALUE (value) {
   }
 
   if (type === 'object') {
-    var result = { };
+    let result = {};
 
     Object.keys(value).forEach(function (k) {
       if (typeof value[k] !== 'function') {
@@ -163,15 +210,17 @@ function FIX_VALUE (value) {
 exports.FCALL_USER = function (name, parameters, func) {
   'use strict';
 
-  var prefix = DB_PREFIX(), reloaded = false;
+  let prefix = DB_PREFIX(), reloaded = false;
   if (!UserFunctions.hasOwnProperty(prefix)) {
-    reloadUserFunctions();
+    // gracefully only reload the one missing function
+    reloadUserFunction(name);
     reloaded = true;
   }
 
   if (!UserFunctions[prefix].hasOwnProperty(name) && !reloaded) {
     // last chance
-    reloadUserFunctions();
+    // gracefully only reload the one missing function
+    reloadUserFunction(name);
   }
 
   if (!UserFunctions[prefix].hasOwnProperty(name)) {
@@ -194,4 +243,9 @@ exports.AQL_V8 = function (value) {
   return value;
 };
 
+// reload all AQL user-defined functions for the current database
 exports.reload = reloadUserFunctions;
+
+// flush the cache for user-defined functions for all databases.
+// not meant to be part of the public API
+exports.flush = () => { UserFunctions = {}; };

--- a/tests/js/common/shell/multi/shell-aqlfunctions.js
+++ b/tests/js/common/shell/multi/shell-aqlfunctions.js
@@ -29,17 +29,11 @@
 /// @author Copyright 2012, triAGENS GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-var jsunity = require("jsunity");
-var arangodb = require("@arangodb");
-var ERRORS = arangodb.errors;
-var db = arangodb.db;
-
-var aqlfunctions = require("@arangodb/aql/functions");
-
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite
-////////////////////////////////////////////////////////////////////////////////
+const jsunity = require("jsunity");
+const arangodb = require("@arangodb");
+const ERRORS = arangodb.errors;
+const db = arangodb.db;
+const aqlfunctions = require("@arangodb/aql/functions");
 
 function AqlFunctionsSuite () {
   'use strict';
@@ -51,7 +45,6 @@ function AqlFunctionsSuite () {
   };
 
   return {
-
     setUp : function () {
       db._useDatabase("_system");
       aqlfunctions.unregisterGroup("UnitTests::");
@@ -703,7 +696,26 @@ function AqlFunctionsSuite () {
       } finally {
         db._drop("UnitTestsFunc");
       }
-    }
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test user function reloading during query
+////////////////////////////////////////////////////////////////////////////////
+
+    testUserFunctionReloading : function () {
+      unregister("UnitTests::testFunc");
+      let testFunc = function(val) {
+        require("@arangodb/aql").flush();
+        return val;
+      };
+      aqlfunctions.register("UnitTests::testFunc", testFunc);
+
+      let actual = db._query("FOR i IN 1..100 RETURN UnitTests::testFunc(i)").toArray();
+      assertEqual(100, actual.length);
+      actual.forEach((v, i) => {
+        assertEqual(v, i + 1);
+      });
+    },
 
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/21210

https://arangodb.atlassian.net/browse/MDS-1225

* Fixed MDS-1225: reloading of AQL user-defined functions inside AQL queries could cause trouble if the `_aqlfunctions` collection is located on different DB server than the leader shards of other collections used in the same query.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: this PR
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/MDS-1225
- [ ] Design document: 