### PR TITLE
Fixed MDS-1225

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fixed MDS-1225: reloading of AQL user-defined functions inside AQL queries 
+  could cause trouble if the `_aqlfunctions` collection is located on different
+  DB server than the leader shards of other collections used in the same query.
+
 * Fix comparison of numeric values in AQL to bring it in line with the 
   now correct VPack numerical sorting.
 


### PR DESCRIPTION
### Scope & Purpose

https://arangodb.atlassian.net/browse/MDS-1225

* Fixed MDS-1225: reloading of AQL user-defined functions inside AQL queries could cause trouble if the `_aqlfunctions` collection is located on different DB server than the leader shards of other collections used in the same query.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21209
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 