### PR TITLE
Make cluster vpack sorting migration test more stable

### DIFF
--- a/tests/js/client/server_parameters/legacy-sorting-cluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-cluster.js
@@ -196,8 +196,8 @@ function legacySortingTestSuite() {
           if (oneResult.result.errorCode !== 0) { return false; }
           if (!Array.isArray(oneResult.result.affected)) { return false; }
           if (oneResult.result.affected.length !== 0) { return false; }
-          return true;
         }
+        return true;
       };
       let count = 0;
       while (count < 60) {


### PR DESCRIPTION
### Scope & Purpose

Make test more stable.

Unfortunately, it is possible that some follower still has the bad
indexes for some time. Need to repeat the test until good or abort
after 60s.

- [*] :hankey: Bugfix

### Checklist

- [*] Backports
  - [*] Backport for 3.11: done there already.

