### PR TITLE
fix wrong option names in CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -65,9 +65,9 @@ devel
   should eventually become finished queries.
 
   Queries will only be logged to the `_queries` system collection if the
-  startup option `--query.collection-logger.enabled` is set to `true`.
+  startup option `--query.collection-logger-enabled` is set to `true`.
   Additionally, queries in the `_system` database are only logged if the
-  option `--query.collection-logger.include-system-database` is also set to
+  option `--query.collection-logger-include-system-database` is also set to
   `true`.
   The option `--query.collection-logger-probability` can be used to specify a
   probability for logging queries to the system collection. If set to a value


### PR DESCRIPTION
### Scope & Purpose

Fix slightly wrong option names in CHANGELOG entry.
Documentation-only bugfix.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: -
  - [ ] Backport for 3.11: -
  - [ ] Backport for 3.10: -

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
