### PR TITLE
Move frontend build to separate job

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -383,7 +383,7 @@ jobs:
             find build/ -iname *.o.d -delete || true
             rm js/apps/system/_admin/aardvark/APP/react/node_modules -rf
       - run:
-          name: Build artifacts
+          name: List build artifacts
           command: |
             ls -Ssha build/bin/
       - run:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -51,7 +51,7 @@ parameters:
   # these are basically global constants
   build-targets:
     type: string
-    default: "arangod arangoimport arangoexport arangodump arangorestore arangobench frontend arangovpack"
+    default: "arangod arangoimport arangoexport arangodump arangorestore arangobench arangovpack"
   test-build-targets:
     type: string
     default: "arangodbtests fuertetest"
@@ -241,6 +241,25 @@ jobs:
               echo "Nothing to cancel"
             fi
 
+  build-frontend:
+    docker:
+      - image: << pipeline.parameters.build-docker-image >>
+    resource_class: large
+    steps:
+      - checkout-arangodb:
+          with-submodules: false
+          destination: "/root/project"
+      - run:
+          name: Build frontend
+          command: |
+            cd js/apps/system/_admin/aardvark/APP/react
+            yarn install
+            yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - js/apps/system/_admin/aardvark/APP/react/build
+
   compile-linux:
     parameters:
       preset:
@@ -363,6 +382,10 @@ jobs:
             find build/ -iname *.o -delete || true
             find build/ -iname *.o.d -delete || true
             rm js/apps/system/_admin/aardvark/APP/react/node_modules -rf
+      - run:
+          name: Build artifacts
+          command: |
+            ls -Ssha build/bin/
       - run:
           name: SCCache Statistics
           command: sccache -s

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -93,7 +93,7 @@ shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 
 # different number of buckets in cluster
 shell_client_aql priority=1000 size=medium+ cluster buckets=20 -- --dumpAgencyOnError true
-shell_client priority=500 cluster size=medium+ buckets=18 -- --dumpAgencyOnError true
+shell_client priority=500 cluster size=medium+ buckets=20 -- --dumpAgencyOnError true
 shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5 -- --dumpAgencyOnError true
 shell_client_replication2_recovery priority=500 size=medium cluster -- --dumpAgencyOnError true
 


### PR DESCRIPTION
### Scope & Purpose

This servers three purposes:
  - it makes issues with the frontend build better visible (e.g. when fetching the npm packages failes)
  - it slightly reduces costs, because the webpack build is largely serial and does not profit from a bigger machine, so we can use a smaller resource class
  - the frontend build now runs parallel to the C++ build. Previously the frontend was built as yet another cmake target, but since cmake targets are built serially this added ~3min to the total runtime of the build.

- [x] :hammer: Refactoring/simplification
