### PR TITLE
Fix changelog: No truncation of bindVars in query log

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -40,7 +40,7 @@ devel
   - `started`: date/time the query started executing
   - `runTime`: total runtime of the query, in seconds
   - `state`: the state of the query (will always be "finished")
-  - `stream` whether or not the query was a streaming AQL query
+  - `stream`: whether or not the query was a streaming AQL query
   - `modificationQuery`: whether or not the query was a modification query
   - `warnings`: number of warnings issued by the query
   - `exitCode`: exit code of the query (0 = success, any other exit code 
@@ -53,8 +53,6 @@ devel
     `--query.max-artifact-log-length` characters.
   - `bindVars` will only contain data if the startup option
     `--query.tracking-with-bindvars` is set to `true`. This is the default.
-    The stringified bind parameters representation will also be cut off after 
-    `--query.max-artifact-log-length` characters.
   - `dataSources` will only contain data if the startup option
     `--query.tracking-with-datasources` is set to `true`. This is not the 
     default.


### PR DESCRIPTION
Follow-up to https://github.com/arangodb/arangodb/pull/20834

There is no truncation here unlike Jan originally wrote:
https://arangodb.slack.com/archives/C06HYC4KBFF/p1722371457380259?thread_ts=1722355304.163519&cid=C06HYC4KBFF