### PR TITLE
Refactor `Compare` and `CompareIdentifiers` methods

### DIFF
--- a/arangod/Cluster/ClusterIndexMethods.cpp
+++ b/arangod/Cluster/ClusterIndexMethods.cpp
@@ -796,7 +796,7 @@ auto ensureIndexCoordinatorReplication2Inner(
   VPackSlice indexes = collectionFromTarget.indexes();
   for (auto const& other : VPackArrayIterator(indexes)) {
     TRI_ASSERT(other.isObject());
-    if (arangodb::Index::Compare(engine, index, other,
+    if (arangodb::Index::compare(engine, index, other,
                                  collection.vocbase().name())) {
       VPackBuilder resultBuilder;
       {  // found an existing index... Copy over all elements in slice.
@@ -807,7 +807,7 @@ auto ensureIndexCoordinatorReplication2Inner(
       return resultBuilder;
     }
 
-    if (arangodb::Index::CompareIdentifiers(index, other)) {
+    if (arangodb::Index::compareIdentifiers(index, other)) {
       // found an existing index with a same identifier (i.e. name)
       // but different definition, throw an error
       return Result(TRI_ERROR_ARANGO_DUPLICATE_IDENTIFIER,
@@ -1003,7 +1003,7 @@ Result ensureIndexCoordinatorInner(LogicalCollection const& collection,
   VPackSlice indexes = collectionFromPlan.indexes();
   for (auto const& other : VPackArrayIterator(indexes)) {
     TRI_ASSERT(other.isObject());
-    if (arangodb::Index::Compare(engine, slice, other,
+    if (arangodb::Index::compare(engine, slice, other,
                                  collection.vocbase().name())) {
       {  // found an existing index... Copy over all elements in slice.
         VPackObjectBuilder b(&resultBuilder);
@@ -1013,7 +1013,7 @@ Result ensureIndexCoordinatorInner(LogicalCollection const& collection,
       return Result(TRI_ERROR_NO_ERROR);
     }
 
-    if (arangodb::Index::CompareIdentifiers(slice, other)) {
+    if (arangodb::Index::compareIdentifiers(slice, other)) {
       // found an existing index with a same identifier (i.e. name)
       // but different definition, throw an error
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -220,7 +220,7 @@ static VPackBuilder compareIndexes(
             // should be fine. However, for robustness sake, we compare,
             // if the local index found actually has the right properties,
             // if not, we schedule a dropIndex action:
-            if (!arangodb::Index::Compare(engine, pindex, lindex, dbname)) {
+            if (!arangodb::Index::compare(engine, pindex, lindex, dbname)) {
               // To achieve this, we remove the long version of the ID
               // from the indis set. This way, the local index will be
               // dropped further down in handleLocalShard:

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -270,7 +270,7 @@ void ClusterIndex::updateProperties(velocypack::Slice slice) {
 bool ClusterIndex::matchesDefinition(VPackSlice const& info) const {
   // TODO implement faster version of this
   auto& engine = _collection.vocbase().engine();
-  return Index::Compare(engine, _info.slice(), info,
+  return Index::compare(engine, _info.slice(), info,
                         _collection.vocbase().name());
 }
 

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -545,7 +545,7 @@ bool Index::validateHandleName(bool extendedNames,
 IndexId Index::generateId() { return IndexId{TRI_NewTickServer()}; }
 
 /// @brief check if two index definitions share any identifiers (_id, name)
-bool Index::CompareIdentifiers(velocypack::Slice const& lhs,
+bool Index::compareIdentifiers(velocypack::Slice const& lhs,
                                velocypack::Slice const& rhs) {
   VPackSlice lhsId = lhs.get(arangodb::StaticStrings::IndexId);
   VPackSlice rhsId = rhs.get(arangodb::StaticStrings::IndexId);
@@ -566,7 +566,7 @@ bool Index::CompareIdentifiers(velocypack::Slice const& lhs,
 
 /// @brief index comparator, used by the coordinator to detect if two index
 /// contents are the same
-bool Index::Compare(StorageEngine& engine, VPackSlice const& lhs,
+bool Index::compare(StorageEngine& engine, VPackSlice const& lhs,
                     VPackSlice const& rhs, std::string const& dbname) {
   auto normalizeType = [](VPackSlice s) -> std::string_view {
     TRI_ASSERT(s.isString());

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -261,12 +261,12 @@ class Index {
   static IndexId generateId();
 
   /// @brief check if two index definitions share any identifiers (_id, name)
-  static bool CompareIdentifiers(velocypack::Slice const& lhs,
+  static bool compareIdentifiers(velocypack::Slice const& lhs,
                                  velocypack::Slice const& rhs);
 
   /// @brief index comparator, used by the coordinator to detect if two index
   /// contents are the same
-  static bool Compare(StorageEngine&, velocypack::Slice const& lhs,
+  static bool compare(StorageEngine&, velocypack::Slice const& lhs,
                       velocypack::Slice const& rhs, std::string const& dbname);
 
   static void normalizeFilterCosts(Index::FilterCosts& costs,


### PR DESCRIPTION
### Scope & Purpose

Small refactoring of  `Compare` and `CompareIdentifiers` methods from Index.h

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
