### PR TITLE
fix a potential race when killing queries

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -301,6 +301,10 @@ void Query::kill() {
   }
 }
 
+void Query::setKillFlag() {
+  _queryKilled.store(true, std::memory_order_acq_rel);
+}
+
 /// @brief return the start time of the query (steady clock value)
 double Query::startTime() const noexcept { return _startTime; }
 

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -126,6 +126,8 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   /// @brief set the query to killed
   void kill();
 
+  void setKillFlag();
+
   /// @brief setter and getter methods for the query lockTimeout.
   void setLockTimeout(double timeout) noexcept final;
   double getLockTimeout() const noexcept final;

--- a/arangod/GeneralServer/AsyncJobManager.cpp
+++ b/arangod/GeneralServer/AsyncJobManager.cpp
@@ -34,6 +34,8 @@
 #include "RestServer/SoftShutdownFeature.h"
 #include "Utils/ExecContext.h"
 
+#include <absl/strings/str_cat.h>
+
 namespace {
 bool authorized(
     std::pair<std::string, arangodb::rest::AsyncJobResult> const& job) {
@@ -183,8 +185,8 @@ Result AsyncJobManager::cancelJob(AsyncJobResult::IdType jobId) {
 
   if (it == _jobs.end() || !::authorized(it->second)) {
     rv.reset(TRI_ERROR_HTTP_NOT_FOUND,
-             "could not find job (" + std::to_string(jobId) +
-                 ") in AsyncJobManager during cancel operation");
+             absl::StrCat("could not find job (", jobId,
+                          ") in AsyncJobManager during cancel operation"));
     return rv;
   }
 

--- a/arangod/RestHandler/RestCursorHandler.cpp
+++ b/arangod/RestHandler/RestCursorHandler.cpp
@@ -40,7 +40,9 @@
 #include "Utils/CursorRepository.h"
 #include "Utils/Events.h"
 
+#include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
+#include <velocypack/Slice.h>
 #include <velocypack/Value.h>
 
 using namespace arangodb;
@@ -51,10 +53,9 @@ RestCursorHandler::RestCursorHandler(
     ArangodServer& server, GeneralRequest* request, GeneralResponse* response,
     arangodb::aql::QueryRegistry* queryRegistry)
     : RestVocbaseBaseHandler(server, request, response),
+      _queryKilled(false),
       _queryRegistry(queryRegistry),
-      _cursor(nullptr),
-      _hasStarted(false),
-      _queryKilled(false) {}
+      _cursor(nullptr) {}
 
 RestCursorHandler::~RestCursorHandler() { releaseCursor(); }
 
@@ -255,18 +256,23 @@ RestStatus RestCursorHandler::registerQueryOrCursor(VPackSlice const& slice) {
 /// The function is repeatable, so whenever we need to WAIT
 /// in AQL we can post a handler calling this function again.
 RestStatus RestCursorHandler::processQuery() {
-  if (_query == nullptr) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_INTERNAL,
-        "Illegal state in RestCursorHandler, query not found.");
-  }
+  auto query = [this]() {
+    std::unique_lock<std::mutex> mutexLocker{_queryLock};
+
+    if (_query == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          "Illegal state in RestCursorHandler, query not found.");
+    }
+    return _query;
+  }();
 
   {
     // always clean up
     auto guard = scopeGuard([this]() noexcept { unregisterQuery(); });
 
     // continue handler is registered earlier
-    auto state = _query->execute(_queryResult);
+    auto state = query->execute(_queryResult);
 
     if (state == aql::ExecutionState::WAITING) {
       guard.cancel();
@@ -460,16 +466,12 @@ void RestCursorHandler::cancelQuery() {
       _query->sharedState()->resetWakeupHandler();
     }
 
-    _query->kill();
-    _queryKilled = true;
-    _hasStarted = true;
-  } else if (!_hasStarted) {
-    _queryKilled = true;
+    _query->setKillFlag();
   }
+  _queryKilled = true;
 }
 
-/// @brief whether or not the query was canceled
-bool RestCursorHandler::wasCanceled() {
+bool RestCursorHandler::wasCanceled() const {
   std::lock_guard mutexLocker{_queryLock};
   return _queryKilled;
 }


### PR DESCRIPTION
### Scope & Purpose

Backport for #21075

Canceling an async job that executes an AQL query via the RestJobHandler's `cancel` operation could lead to a race between the RestJobHandler calling `cancel` on the RestCursorHandler which owns the query, and the RestCursorHandler object that currently executed the query.
the cancel operation could lead to the query being shut down while it was operating, which was not race-free. instead of trying to attempt a full shutdown during a cancel operation, we are now only setting the kill flag on the coordinator in a soft way, which avoids all potential races, but may lead to a later shutdown of the query. this is potentially a good tradeoff, as the RestJobHandler's cancel operation should be used only very rarely in practice.

- [x] :hankey: Bugfix

