### PR TITLE
FE-459: fix failing foxx service download

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* FE-459: fix failing foxx service download.
+
 * Fixed BTS-1742: `IN_RANGE` function now uses MDI index if possible.
 
 * FE-456: upgrade web UI to React 18.

--- a/js/apps/system/_admin/aardvark/APP/foxxes.js
+++ b/js/apps/system/_admin/aardvark/APP/foxxes.js
@@ -29,7 +29,6 @@ const arangodb = require('@arangodb');
 const fs = require('fs');
 const joi = require('joi');
 const dd = require('dedent');
-const crypto = require('@arangodb/crypto');
 const errors = require('@arangodb').errors;
 const FoxxManager = require('@arangodb/foxx/manager');
 const store = require('@arangodb/foxx/store');

--- a/js/apps/system/_admin/aardvark/APP/foxxes.js
+++ b/js/apps/system/_admin/aardvark/APP/foxxes.js
@@ -472,16 +472,6 @@ router.get('/fishbowl', function (req, res) {
   This function contacts the fishbowl and reports which services are available for install.
 `);
 
-router.post('/download/nonce', function (req, res) {
-  const nonce = crypto.createNonce();
-  res.status('created');
-  res.json({nonce});
-})
-.response('created', joi.object({nonce: joi.string().required()}).required(), 'The created nonce.')
-.summary('Creates a nonce for downloading the service')
-.description(dd`
-  Creates a cryptographic nonce that can be used to download the service without authentication.
-`);
 
 anonymousRouter.use('/docs/standalone', module.context.createDocumentationRouter((req, res) => {
   if (req.suffix === 'swagger.json' && !req.authorized && internal.authenticationEnabled()) {

--- a/js/apps/system/_admin/aardvark/APP/foxxes.js
+++ b/js/apps/system/_admin/aardvark/APP/foxxes.js
@@ -483,25 +483,6 @@ router.post('/download/nonce', function (req, res) {
   Creates a cryptographic nonce that can be used to download the service without authentication.
 `);
 
-anonymousRouter.get('/download/zip', function (req, res) {
-  const nonce = decodeURIComponent(req.queryParams.nonce);
-  const checked = nonce && crypto.checkAndMarkNonce(nonce);
-  if (!checked) {
-    res.throw(403, 'Nonce missing or invalid');
-  }
-  const mount = decodeURIComponent(req.queryParams.mount);
-  const service = FoxxManager.lookupService(mount);
-  const dir = fs.join(fs.makeAbsolute(service.root), service.path);
-  const zipPath = fmu.zipDirectory(dir);
-  const name = mount.replace(/^\/|\/$/g, '').replace(/\//g, '_');
-  res.download(zipPath, `${name}_${service.manifest.version}.zip`);
-})
-.queryParam('nonce', joi.string().required(), 'Cryptographic nonce that authorizes the download.')
-.summary('Download a service as zip archive')
-.description(dd`
-  Download a Foxx service packed in a zip archive.
-`);
-
 anonymousRouter.use('/docs/standalone', module.context.createDocumentationRouter((req, res) => {
   if (req.suffix === 'swagger.json' && !req.authorized && internal.authenticationEnabled()) {
     res.throw('unauthorized');

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/models/foxx.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/models/foxx.js
@@ -144,13 +144,39 @@
     },
 
     download: function () {
-      sendRequest(this, function (err, data) {
-        if (err) {
-          console.error(err.responseJSON);
-          return;
-        }
-        window.location.href = arangoHelper.databaseUrl('/_admin/aardvark/foxxes/download/zip?mount=' + this.encodedMount() + '&nonce=' + data.nonce);
-      }.bind(this), 'POST', 'download/nonce');
+      var downloadUrl = arangoHelper.databaseUrl(
+        "/_api/foxx/download?mount=" + this.encodedMount()
+      );
+      window
+        .fetch(downloadUrl, {
+          method: "POST",
+          headers: {
+            Authorization: "bearer " + window.arangoHelper.getCurrentJwt(),
+          },
+        })
+        .then((response) => {
+          if (response.ok) {
+            return response.blob();
+          }
+          return response.json();
+        })
+        .then((blob) => {
+          if (blob.error) {
+            console.error("Failed to download Foxx service");
+            return console.error(blob.error);
+          }
+          var url = window.URL.createObjectURL(blob);
+          var a = document.createElement("a");
+          a.href = url;
+          var fileName =
+            this.get("mount").slice(1) + "_" + this.attributes.version + ".zip";
+          a.download = fileName;
+          a.click();
+          window.URL.revokeObjectURL(url);
+        })
+        .catch((err) => {
+          console.error("Failed to download Foxx service");
+        });
     },
 
     fetchThumbnail: function (cb) {

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/models/foxx.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/models/foxx.js
@@ -147,13 +147,12 @@
       var downloadUrl = arangoHelper.databaseUrl(
         "/_api/foxx/download?mount=" + this.encodedMount()
       );
-      window
-        .fetch(downloadUrl, {
-          method: "POST",
-          headers: {
-            Authorization: "bearer " + window.arangoHelper.getCurrentJwt(),
-          },
-        })
+      fetch(downloadUrl, {
+        method: "POST",
+        headers: {
+          Authorization: "bearer " + window.arangoHelper.getCurrentJwt(),
+        },
+      })
         .then((response) => {
           if (response.ok) {
             return response.blob();

--- a/tests/js/client/server_permissions/test-foxx-apis-off.js
+++ b/tests/js/client/server_permissions/test-foxx-apis-off.js
@@ -95,7 +95,7 @@ function testSuite() {
         arango.reconnect(endpoint, db._name(), user, "testi");
 
         let routes = [
-          "tests", "download/nonce"
+          "tests"
         ];
 
         routes.forEach(function(route) {

--- a/tests/js/client/server_permissions/test-foxx-apis-off.js
+++ b/tests/js/client/server_permissions/test-foxx-apis-off.js
@@ -112,7 +112,7 @@ function testSuite() {
         arango.reconnect(endpoint, db._name(), user, "testi");
 
         let routes = [
-          "", "thumbnail", "config", "deps", "fishbowl", "download/zip" 
+          "", "thumbnail", "config", "deps", "fishbowl"
         ];
 
         routes.forEach(function(route) {

--- a/tests/js/client/server_permissions/test-foxx-apis-on.js
+++ b/tests/js/client/server_permissions/test-foxx-apis-on.js
@@ -97,7 +97,7 @@ function testSuite() {
         arango.reconnect(endpoint, db._name(), user, "testi");
 
         let routes = [
-          "tests", "download/nonce"
+          "tests"
         ];
 
         routes.forEach(function(route) {

--- a/tests/js/client/server_permissions/test-foxx-apis-on.js
+++ b/tests/js/client/server_permissions/test-foxx-apis-on.js
@@ -114,7 +114,7 @@ function testSuite() {
         arango.reconnect(endpoint, db._name(), user, "testi");
 
         let routes = [
-          "", "thumbnail", "config", "deps", "fishbowl", "download/zip" 
+          "", "thumbnail", "config", "deps", "fishbowl"
         ];
 
         routes.forEach(function(route) {


### PR DESCRIPTION
### Scope & Purpose

Foxx service download fails sometimes with a 500, this fixes the issue by using a different endpoint for downloading

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Manually tested
- [x] :book: CHANGELOG entry made

#### Related Information

- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-459