### PR TITLE
Allow log levels to be configured for each appender individually

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,54 @@
 devel
 -----
 
+* We already had the concept of individual log appenders (e.g., stdout, stderr,
+  files, syslog). but log levels could only be configured globally. That is,
+  all appenders always used the same log levels for all topics.
+
+  This PR introduces appender specific log levels. For example, it is now
+  possible to set the log levels for all topics to `error`, but leave the log
+  levels for the log file unchanged. This is particularly useful for test runs
+  because we avoid flooding the console with log messages, but still have all
+  the information in the log files in case of test failures.
+
+  The log level can be specified per appender via the command line by adding a
+  comma separated list of topics with their respective level after the output
+  definition, separated by a semicolon:
+    `--log.output file:///path/to/file;queries=trace,requests=info`
+    `--log.output -;all=error`
+
+  The `_admin/log/level` endpoint has also been extended to with an optional
+  parameter `withAppenders`. If that parameter is set to `true`, the response
+  has the following form:
+  ```
+  {
+    "global": {
+      <topic>: <level>,
+      ...
+    },
+    "appenders": {
+      <appender>: {
+        <topic>: <level>,
+        ...
+      },
+      ...
+    }
+  }
+  ```
+  A `PUT` request to `_admin/log/level` with `withAppenders` set to true
+  requires an input of the same format.
+
+  Previously, requests to the `_admin/log/level` endpoint where not fully
+  validated. A `PUT`' request that specified invalid topics or log levels
+  would silently ignore those. This has been improved, so that invalid input
+  is now always rejected with a proper error message - in that case _no_
+  changes are applied at all.
+
+  The global level for some topic is always identical to the highest log level
+  for that topic of all appenders. Thus, changing the log level for an appender
+  will implicitly also adjust the global level accordingly. When a global level
+  is set explicitly, this change is also applied to all appenders.
+
 * Fixed BTS-1742: `IN_RANGE` function now uses MDI index if possible.
 
 * FE-456: upgrade web UI to React 18.

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -47,9 +47,9 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
-using namespace arangodb;
-using namespace arangodb::basics;
-using namespace arangodb::rest;
+namespace arangodb {
+
+using namespace basics;
 
 RestAdminLogHandler::RestAdminLogHandler(arangodb::ArangodServer& server,
                                          GeneralRequest* request,
@@ -510,20 +510,23 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     }
   }
 
-  auto const type = _request->requestType();
+  auto withAppenders =
+      basics::StringUtils::tolower(_request->value("withAppenders")) == "true";
 
-  auto getLogLevels = []() {
-    VPackBuilder builder;
-    builder.openObject();
-    auto const& levels = Logger::logLevelTopics();
-    for (auto const& level : levels) {
-      builder.add(level.first.name(),
-                  VPackValue(Logger::translateLogLevel(level.second)));
+  auto getLogLevels = [withAppenders]() {
+    auto buildResult = [](auto const& config) {
+      VPackBuilder builder;
+      velocypack::serialize(builder, config);
+      return builder;
+    };
+    if (withAppenders) {
+      return buildResult(Logger::getAppendersConfig());
+    } else {
+      return buildResult(Logger::getLogLevels());
     }
-    builder.close();
-    return builder;
   };
 
+  auto const type = _request->requestType();
   if (type == rest::RequestType::GET) {
     // report log level
     VPackBuilder builder = getLogLevels();
@@ -539,41 +542,39 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     if (slice.isString()) {
       Logger::setLogLevel(slice.copyString());
     } else if (slice.isObject()) {
-      std::unordered_map<std::string_view, LogLevel> parsedLevels;
-      auto res = velocypack::deserializeWithStatus(slice, parsedLevels);
-      if (!res.ok()) {
-        generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                      absl::StrCat("Failed to parse log levels: ", res.error(),
-                                   " at path ", res.path()));
-        return RestStatus::DONE;
-      }
-
-      std::unordered_map<LogTopic*, LogLevel> logLevels;
-      bool containsAll = false;
-      LogLevel allLevel;
-      for (auto& [topicName, level] : parsedLevels) {
-        if (topicName == LogTopic::ALL) {
-          containsAll = true;
-          allLevel = level;
-        } else {
-          auto topic = LogTopic::lookup(topicName);
-          if (topic == nullptr) {
-            generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                          absl::StrCat("Unknown log topic ", topicName));
-            return RestStatus::DONE;
+      auto parseConfig = [&](auto& config) {
+        if (auto res = velocypack::deserializeWithStatus(slice, config);
+            !res.ok()) {
+          auto msg = absl::StrCat("Failed to update log levels: ", res.error());
+          if (!res.path().empty()) {
+            msg = absl::StrCat(msg, " at path ", res.path());
           }
-          logLevels[topic] = level;
+          generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                        msg);
+          return false;
         }
-      }
+        return true;
+      };
 
-      if (containsAll) {
-        // handle "all" first, so we can do
-        // {"all":"info","requests":"debug"} or such
-        Logger::setLogLevel(LogTopic::ALL, allLevel);
-      }
-      // now process all log topics except "all"
-      for (auto& [topic, level] : logLevels) {
-        Logger::setLogLevel(*topic, level);
+      if (withAppenders) {
+        AppendersLogLevelConfig config;
+        if (!parseConfig(config)) {
+          return RestStatus::DONE;
+        }
+
+        auto res = Logger::setLogLevel(config);
+        if (res.fail()) {
+          generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                        absl::StrCat("Failed to update log levels: ",
+                                     res.errorMessage()));
+          return RestStatus::DONE;
+        }
+      } else {
+        LogLevels config;
+        if (!parseConfig(config)) {
+          return RestStatus::DONE;
+        }
+        Logger::setLogLevel(config);
       }
     }
 
@@ -581,7 +582,6 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else if (type == rest::RequestType::DELETE_REQ) {
-    std::cout << "Resetting to default log levels" << std::endl;
     Logger::resetLevelsToDefault();
 
     // now report resetted log levels
@@ -643,3 +643,5 @@ void RestAdminLogHandler::handleLogStructuredParams() {
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
   }
 }
+
+}  // namespace arangodb

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -557,10 +557,7 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else if (type == rest::RequestType::DELETE_REQ) {
-    // reset log levels to defaults
-    for (auto const& [topic, level] : Logger::defaultLogLevelTopics()) {
-      Logger::setLogLevel(topic, level);
-    }
+    Logger::resetLevelsToDefault();
 
     // now report resetted log levels
     VPackBuilder builder = getLogLevels();

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -510,7 +510,8 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
 
   auto const type = _request->requestType();
 
-  auto getLogLevels = [](VPackBuilder& builder) {
+  auto getLogLevels = []() {
+    VPackBuilder builder;
     builder.openObject();
     auto const& levels = Logger::logLevelTopics();
     for (auto const& level : levels) {
@@ -518,12 +519,12 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
                   VPackValue(Logger::translateLogLevel(level.second)));
     }
     builder.close();
+    return builder;
   };
 
   if (type == rest::RequestType::GET) {
     // report log level
-    VPackBuilder builder;
-    getLogLevels(builder);
+    VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else if (type == rest::RequestType::PUT) {
     // set log level
@@ -553,20 +554,16 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     }
 
     // now report current log levels
-    VPackBuilder builder;
-    getLogLevels(builder);
+    VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else if (type == rest::RequestType::DELETE_REQ) {
     // reset log levels to defaults
-    for (auto const& it : Logger::defaultLogLevelTopics()) {
-      std::string l = absl::StrCat(it.first.name(), "=",
-                                   Logger::translateLogLevel(it.second));
-      Logger::setLogLevel(l);
+    for (auto const& [topic, level] : Logger::defaultLogLevelTopics()) {
+      Logger::setLogLevel(topic, level);
     }
 
     // now report resetted log levels
-    VPackBuilder builder;
-    getLogLevels(builder);
+    VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else {
     // invalid method

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -378,7 +378,9 @@ class instance {
     if (this.options.verbose) {
       this.args['log.level'] = 'debug';
     } else if (this.options.noStartStopLogs) {
-      let logs = ['all=error', 'crash=info'];
+      // set the stdout appender to error only
+      this.args['log.output'] = '-;all=error';
+      let logs = ['crash=info'];
       if (this.args['log.level'] !== undefined) {
         if (Array.isArray(this.args['log.level'])) {
           logs = logs.concat(this.args['log.level']);

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -379,7 +379,14 @@ class instance {
       this.args['log.level'] = 'debug';
     } else if (this.options.noStartStopLogs) {
       // set the stdout appender to error only
-      this.args['log.output'] = '-;all=error';
+      let output = this.args['log.output'];
+      if (output === undefined) {
+        output = [];
+      } else if (typeof output === 'string') {
+        output = [output];
+      }
+      output.push('-;all=error');
+      this.args['log.output'] = output;
       let logs = ['crash=info'];
       if (this.args['log.level'] !== undefined) {
         if (Array.isArray(this.args['log.level'])) {

--- a/lib/Inspection/include/Inspection/InspectorBase.h
+++ b/lib/Inspection/include/Inspection/InspectorBase.h
@@ -44,6 +44,13 @@ namespace arangodb::inspection {
 struct NoContext {};
 
 namespace detail {
+struct NoOpt {
+  template<class T>
+  constexpr void operator()(T& v) const noexcept {}
+};
+}  // namespace detail
+
+namespace detail {
 template<class ContextT>
 struct ContextContainer {
   static constexpr bool hasContext = true;
@@ -244,8 +251,9 @@ struct InspectorBase : detail::ContextContainer<Context> {
 
   template<class T>
   struct Enum {
-    template<class... Args>
-    [[nodiscard]] Status values(Args&&... args) {
+    template<class Transformer, class... Args>
+    [[nodiscard]] Status transformedValues(Transformer transformer,
+                                           Args&&... args) {
       if constexpr (Derived::isLoading) {
         constexpr bool hasStringValues =
             (std::is_constructible_v<std::string, Args> || ...);
@@ -257,15 +265,17 @@ struct InspectorBase : detail::ContextContainer<Context> {
         Status res;
         bool retryDifferentType = false;
         if constexpr (hasStringValues) {
+          static_assert(std::is_invocable_v<Transformer, std::string&>);
           // TODO - read std::string_view
-          res = load<std::string>(retryDifferentType,
+          res = load<std::string>(transformer, retryDifferentType,
                                   std::forward<Args>(args)...);
           assert(retryDifferentType == false || !res.ok());
         }
         if constexpr (hasIntValues) {
+          static_assert(std::is_invocable_v<Transformer, std::uint64_t&>);
           if (!hasStringValues || retryDifferentType) {
             retryDifferentType = false;
-            res = load<std::uint64_t>(retryDifferentType,
+            res = load<std::uint64_t>(transformer, retryDifferentType,
                                       std::forward<Args>(args)...);
             if (hasStringValues && retryDifferentType) {
               return Status{"Expecting type String or Int"};
@@ -276,6 +286,11 @@ struct InspectorBase : detail::ContextContainer<Context> {
       } else {
         return store(std::forward<Args>(args)...);
       }
+    }
+
+    template<class... Args>
+    [[nodiscard]] Status values(Args&&... args) {
+      return transformedValues(detail::NoOpt{}, std::forward<Args>(args)...);
     }
 
    private:
@@ -289,14 +304,17 @@ struct InspectorBase : detail::ContextContainer<Context> {
           "Enum values can only be mapped to string or unsigned values");
     }
 
-    template<class ValueType, class... Args>
-    Status load(bool& retryDifferentType, Args&&... args) {
+    template<class ValueType, class Transformer, class... Args>
+    Status load(Transformer transformer, bool& retryDifferentType,
+                Args&&... args) {
       ValueType read{};
       auto result = _inspector.apply(read);
       if (!result.ok()) {
         retryDifferentType = true;
         return result;
       }
+
+      transformer(read);
       if (loadValue(read, std::forward<Args>(args)...)) {
         return Status{};
       } else if constexpr (std::is_integral_v<ValueType>) {

--- a/lib/Logger/Appenders.cpp
+++ b/lib/Logger/Appenders.cpp
@@ -376,6 +376,13 @@ auto Appenders::getAppender(LogGroup const& logGroup,
   return nullptr;
 }
 
+auto Appenders::getAppenders(LogGroup const& logGroup)
+    -> std::unordered_map<std::string, std::shared_ptr<LogAppender>> {
+  READ_LOCKER(guard, _appendersLock);
+  auto& group = _groups.at(logGroup.id());
+  return group.definition2appenders;
+}
+
 void Appenders::foreach (std::function<void(LogAppender&)> const& f) {
   READ_LOCKER(guard, _appendersLock);
   for (auto& group : _groups) {

--- a/lib/Logger/Appenders.cpp
+++ b/lib/Logger/Appenders.cpp
@@ -304,4 +304,25 @@ bool Appenders::haveAppenders(LogGroup const& logGroup, size_t topicId) {
   }
 }
 
+auto Appenders::getAppender(LogGroup const& logGroup,
+                            std::string const& definition)
+    -> std::shared_ptr<LogAppender> {
+  READ_LOCKER(guard, _appendersLock);
+  auto& group = _groups.at(logGroup.id());
+  auto it = group.definition2appenders.find(definition);
+  if (it != group.definition2appenders.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+void Appenders::foreach (LogGroup const& logGroup,
+                         std::function<void(LogAppender&)> const& f) {
+  READ_LOCKER(guard, _appendersLock);
+  auto& group = _groups.at(logGroup.id());
+  for (auto& v : group.definition2appenders) {
+    f(*v.second);
+  }
+}
+
 }  // namespace arangodb::logger

--- a/lib/Logger/Appenders.cpp
+++ b/lib/Logger/Appenders.cpp
@@ -380,6 +380,9 @@ void Appenders::foreach (LogGroup const& logGroup,
                          std::function<void(LogAppender&)> const& f) {
   READ_LOCKER(guard, _appendersLock);
   auto& group = _groups.at(logGroup.id());
+  for (auto& v : group.globalAppenders) {
+    f(*v);
+  }
   for (auto& v : group.definition2appenders) {
     f(*v.second);
   }

--- a/lib/Logger/Appenders.cpp
+++ b/lib/Logger/Appenders.cpp
@@ -376,15 +376,15 @@ auto Appenders::getAppender(LogGroup const& logGroup,
   return nullptr;
 }
 
-void Appenders::foreach (LogGroup const& logGroup,
-                         std::function<void(LogAppender&)> const& f) {
+void Appenders::foreach (std::function<void(LogAppender&)> const& f) {
   READ_LOCKER(guard, _appendersLock);
-  auto& group = _groups.at(logGroup.id());
-  for (auto& v : group.globalAppenders) {
-    f(*v);
-  }
-  for (auto& v : group.definition2appenders) {
-    f(*v.second);
+  for (auto& group : _groups) {
+    for (auto& v : group.globalAppenders) {
+      f(*v);
+    }
+    for (auto& v : group.definition2appenders) {
+      f(*v.second);
+    }
   }
 }
 

--- a/lib/Logger/Appenders.h
+++ b/lib/Logger/Appenders.h
@@ -57,6 +57,8 @@ struct Appenders {
 
   auto getAppender(LogGroup const& group, std::string const& definition)
       -> std::shared_ptr<LogAppender>;
+  auto getAppenders(LogGroup const& group)
+      -> std::unordered_map<std::string, std::shared_ptr<LogAppender>>;
 
   void foreach (std::function<void(LogAppender&)> const& f);
 

--- a/lib/Logger/Appenders.h
+++ b/lib/Logger/Appenders.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -51,7 +52,13 @@ struct Appenders {
   void reopen();
   void shutdown();
 
-  bool haveAppenders(LogGroup const&, size_t topicId);
+  bool haveAppenders(LogGroup const& group, size_t topicId);
+
+  auto getAppender(LogGroup const& group, std::string const& definition)
+      -> std::shared_ptr<LogAppender>;
+
+  void foreach (LogGroup const& logGroup,
+                std::function<void(LogAppender&)> const& f);
 
  private:
   enum class Type {

--- a/lib/Logger/Appenders.h
+++ b/lib/Logger/Appenders.h
@@ -32,6 +32,7 @@
 #include "Basics/ReadWriteLock.h"
 #include "Basics/ResultT.h"
 #include "Logger/LogGroup.h"
+#include "Logger/LogLevel.h"
 
 namespace arangodb {
 class LogAppender;
@@ -73,8 +74,11 @@ struct Appenders {
     std::string output;
     LogTopic* topic = nullptr;
     Type type = Type::kUnknown;
+    std::vector<std::pair<LogTopic*, LogLevel>> levels;
   };
-  ResultT<AppenderConfig> parseDefinition(std::string const& definition);
+  auto parseDefinition(std::string definition) -> ResultT<AppenderConfig>;
+  auto parseLogLevels(std::string const& definition)
+      -> ResultT<std::vector<std::pair<LogTopic*, LogLevel>>>;
 
   std::shared_ptr<LogAppender> buildAppender(LogGroup const&,
                                              AppenderConfig const& config);

--- a/lib/Logger/Appenders.h
+++ b/lib/Logger/Appenders.h
@@ -74,11 +74,11 @@ struct Appenders {
     std::string output;
     LogTopic* topic = nullptr;
     Type type = Type::kUnknown;
-    std::vector<std::pair<LogTopic*, LogLevel>> levels;
+    std::unordered_map<LogTopic*, LogLevel> levels;
   };
   auto parseDefinition(std::string definition) -> ResultT<AppenderConfig>;
   auto parseLogLevels(std::string const& definition)
-      -> ResultT<std::vector<std::pair<LogTopic*, LogLevel>>>;
+      -> ResultT<std::unordered_map<LogTopic*, LogLevel>>;
 
   std::shared_ptr<LogAppender> buildAppender(LogGroup const&,
                                              AppenderConfig const& config);

--- a/lib/Logger/Appenders.h
+++ b/lib/Logger/Appenders.h
@@ -58,8 +58,7 @@ struct Appenders {
   auto getAppender(LogGroup const& group, std::string const& definition)
       -> std::shared_ptr<LogAppender>;
 
-  void foreach (LogGroup const& logGroup,
-                std::function<void(LogAppender&)> const& f);
+  void foreach (std::function<void(LogAppender&)> const& f);
 
  private:
   enum class Type {

--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -37,8 +37,11 @@ namespace arangodb {
 LogAppender::LogAppender() {
   for (std::size_t i = 0; i < logger::kNumTopics; ++i) {
     auto* topic = LogTopic::topicForId(i);
-    TRI_ASSERT(topic != nullptr);
-    _topicLevels[i].store(topic->level(), std::memory_order_relaxed);
+    if (topic != nullptr) {
+      _topicLevels[i].store(topic->level(), std::memory_order_relaxed);
+    } else {
+      _topicLevels[i].store(LogLevel::DEFAULT, std::memory_order_relaxed);
+    }
   }
 }
 void LogAppender::logMessageGuarded(LogMessage const& message) {

--- a/lib/Logger/LogAppender.cpp
+++ b/lib/Logger/LogAppender.cpp
@@ -82,4 +82,16 @@ void LogAppender::setLogLevel(LogTopic const& topic, LogLevel level) {
   _topicLevels[topic.id()].store(level, std::memory_order_relaxed);
 }
 
+auto LogAppender::getLogLevels() -> std::unordered_map<LogTopic*, LogLevel> {
+  std::unordered_map<LogTopic*, LogLevel> result;
+  result.reserve(logger::kNumTopics);
+  for (std::size_t i = 0; i < logger::kNumTopics; ++i) {
+    auto* topic = LogTopic::topicForId(i);
+    if (topic != nullptr) {
+      result.emplace(topic, _topicLevels[i].load(std::memory_order_relaxed));
+    }
+  }
+  return result;
+}
+
 }  // namespace arangodb

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -44,6 +44,8 @@ class LogAppender {
   LogAppender(LogAppender const&) = delete;
   LogAppender& operator=(LogAppender const&) = delete;
 
+  void setCurrentLevelsAsDefault();
+  void resetLevelsToDefault();
   auto getLogLevel(LogTopic const& topic) -> LogLevel;
   void setLogLevel(LogTopic const& topic, LogLevel level);
 
@@ -58,5 +60,6 @@ class LogAppender {
   basics::ReadWriteLock _logOutputMutex;
   std::atomic<std::thread::id> _logOutputMutexOwner;
   std::array<std::atomic<LogLevel>, logger::kNumTopics> _topicLevels;
+  std::array<LogLevel, logger::kNumTopics> _defaultLevels;
 };
 }  // namespace arangodb

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -27,6 +27,7 @@
 #include <atomic>
 #include <string>
 #include <thread>
+#include <unordered_map>
 
 #include "Basics/ReadWriteLock.h"
 #include "Logger/LogLevel.h"
@@ -48,6 +49,7 @@ class LogAppender {
   void resetLevelsToDefault();
   auto getLogLevel(LogTopic const& topic) -> LogLevel;
   void setLogLevel(LogTopic const& topic, LogLevel level);
+  auto getLogLevels() -> std::unordered_map<LogTopic*, LogLevel>;
 
   void logMessageGuarded(LogMessage const&);
 

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -38,7 +38,7 @@ struct LogMessage;
 
 class LogAppender {
  public:
-  LogAppender() = default;
+  LogAppender();
   virtual ~LogAppender() = default;
 
   LogAppender(LogAppender const&) = delete;

--- a/lib/Logger/LogAppender.h
+++ b/lib/Logger/LogAppender.h
@@ -23,11 +23,14 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <string>
 #include <thread>
 
 #include "Basics/ReadWriteLock.h"
+#include "Logger/LogLevel.h"
+#include "Logger/Topics.h"
 
 namespace arangodb {
 class LogTopic;
@@ -41,7 +44,9 @@ class LogAppender {
   LogAppender(LogAppender const&) = delete;
   LogAppender& operator=(LogAppender const&) = delete;
 
- public:
+  auto getLogLevel(LogTopic const& topic) -> LogLevel;
+  void setLogLevel(LogTopic const& topic, LogLevel level);
+
   void logMessageGuarded(LogMessage const&);
 
   virtual std::string details() const = 0;
@@ -52,5 +57,6 @@ class LogAppender {
  private:
   basics::ReadWriteLock _logOutputMutex;
   std::atomic<std::thread::id> _logOutputMutexOwner;
+  std::array<std::atomic<LogLevel>, logger::kNumTopics> _topicLevels;
 };
 }  // namespace arangodb

--- a/lib/Logger/LogLevel.h
+++ b/lib/Logger/LogLevel.h
@@ -44,17 +44,17 @@ auto inspect(Inspector& f, LogLevel& l) {
   return f.enumeration(l).transformedValues(
       [](std::string& s) {
         std::transform(s.begin(), s.end(), s.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
+                       [](unsigned char c) { return std::toupper(c); });
       },
-      LogLevel::DEFAULT, "default",  //
-      LogLevel::FATAL, "fatal",      //
-      LogLevel::ERR, "err",          //
-      LogLevel::ERR, "error",        //
-      LogLevel::WARN, "warn",        //
-      LogLevel::WARN, "warning",     //
-      LogLevel::INFO, "info",        //
-      LogLevel::DEBUG, "debug",      //
-      LogLevel::TRACE, "trace");
+      LogLevel::DEFAULT, "DEFAULT",  //
+      LogLevel::FATAL, "FATAL",      //
+      LogLevel::ERR, "ERR",          //
+      LogLevel::ERR, "ERROR",        //
+      LogLevel::WARN, "WARN",        //
+      LogLevel::WARN, "WARNING",     //
+      LogLevel::INFO, "INFO",        //
+      LogLevel::DEBUG, "DEBUG",      //
+      LogLevel::TRACE, "TRACE");
 }
 }  // namespace arangodb
 

--- a/lib/Logger/LogLevel.h
+++ b/lib/Logger/LogLevel.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <iosfwd>
+#include <string>
 
 namespace arangodb {
 enum class LogLevel {
@@ -36,6 +38,24 @@ enum class LogLevel {
   DEBUG = 5,
   TRACE = 6
 };
+
+template<typename Inspector>
+auto inspect(Inspector& f, LogLevel& l) {
+  return f.enumeration(l).transformedValues(
+      [](std::string& s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return std::tolower(c); });
+      },
+      LogLevel::DEFAULT, "default",  //
+      LogLevel::FATAL, "fatal",      //
+      LogLevel::ERR, "err",          //
+      LogLevel::ERR, "error",        //
+      LogLevel::WARN, "warn",        //
+      LogLevel::WARN, "warning",     //
+      LogLevel::INFO, "info",        //
+      LogLevel::DEBUG, "debug",      //
+      LogLevel::TRACE, "trace");
 }
+}  // namespace arangodb
 
 std::ostream& operator<<(std::ostream&, arangodb::LogLevel);

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -186,6 +186,11 @@ void LogTopic::setLogLevel(TopicName name, LogLevel level) {
   }
 }
 
+LogTopic* LogTopic::topicForId(size_t topicId) {
+  TRI_ASSERT(topicId < logger::kNumTopics);
+  return Topics::instance().get(topicId);
+}
+
 LogTopic* LogTopic::lookup(TopicName name) {
   return Topics::instance().find(name);
 }

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -163,14 +163,14 @@ LogTopic AuditFeature::AUDIT_SERVICE(logger::audit::Service{});
 LogTopic AuditFeature::AUDIT_HOTBACKUP(logger::audit::HotBackup{});
 #endif
 
-auto LogTopic::logLevelTopics() -> std::vector<std::pair<LogTopic&, LogLevel>> {
-  std::vector<std::pair<LogTopic&, LogLevel>> levels;
+auto LogTopic::logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel> {
+  std::unordered_map<LogTopic*, LogLevel> levels;
   levels.reserve(logger::kNumTopics);
 
   for (std::size_t i = 0; i < logger::kNumTopics; ++i) {
     auto* topic = Topics::instance().get(i);
     if (topic) {
-      levels.emplace_back(*topic, topic->level());
+      levels.emplace(topic, topic->level());
     }
   }
 

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -224,6 +224,10 @@ LogTopic::LogTopic(TopicName name, LogLevel level, size_t id)
   TRI_ASSERT(_id < GLOBAL_LOG_TOPIC);
 }
 
+void LogTopic::setLogLevel(LogLevel level) {
+  _level.store(level, std::memory_order_relaxed);
+}
+
 // those two log topics are created in other files, so we have to explicitly
 // instantiate them here
 template LogTopic::LogTopic(logger::topic::ArangoSearch);

--- a/lib/Logger/LogTopic.h
+++ b/lib/Logger/LogTopic.h
@@ -44,7 +44,7 @@ class LogTopic {
   // pseudo topic to address all log topics
   static constexpr TopicName ALL = "all";
 
-  static std::vector<std::pair<TopicName, LogLevel>> logLevelTopics();
+  static auto logLevelTopics() -> std::vector<std::pair<LogTopic&, LogLevel>>;
   static void setLogLevel(TopicName, LogLevel);
   static LogTopic* topicForId(size_t topicId);
   static LogTopic* lookup(TopicName);
@@ -53,7 +53,9 @@ class LogTopic {
   virtual ~LogTopic() = default;
 
   template<typename Topic>
-  LogTopic(Topic);
+  LogTopic(Topic) requires requires(Topic) {
+    Topic::name;
+  };
 
   LogTopic(LogTopic const& that)
       : _id(that._id), _name(that._name), _displayName(that._displayName) {

--- a/lib/Logger/LogTopic.h
+++ b/lib/Logger/LogTopic.h
@@ -27,7 +27,7 @@
 #include <atomic>
 #include <string>
 #include <utility>
-#include <vector>
+#include <unordered_map>
 
 #include "Logger/LogLevel.h"
 
@@ -44,7 +44,7 @@ class LogTopic {
   // pseudo topic to address all log topics
   static constexpr TopicName ALL = "all";
 
-  static auto logLevelTopics() -> std::vector<std::pair<LogTopic&, LogLevel>>;
+  static auto logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel>;
   static void setLogLevel(TopicName, LogLevel);
   static LogTopic* topicForId(size_t topicId);
   static LogTopic* lookup(TopicName);

--- a/lib/Logger/LogTopic.h
+++ b/lib/Logger/LogTopic.h
@@ -46,6 +46,7 @@ class LogTopic {
 
   static std::vector<std::pair<TopicName, LogLevel>> logLevelTopics();
   static void setLogLevel(TopicName, LogLevel);
+  static LogTopic* topicForId(size_t topicId);
   static LogTopic* lookup(TopicName);
   static TopicName lookup(size_t topicId);
 

--- a/lib/Logger/LogTopic.h
+++ b/lib/Logger/LogTopic.h
@@ -74,9 +74,7 @@ class LogTopic {
   std::string const& displayName() const { return _displayName; }
   LogLevel level() const { return _level.load(std::memory_order_relaxed); }
 
-  virtual void setLogLevel(LogLevel level) {
-    _level.store(level, std::memory_order_relaxed);
-  }
+  virtual void setLogLevel(LogLevel level);
 
  private:
   LogTopic(TopicName name, LogLevel level, size_t id);

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -953,8 +953,8 @@ void Logger::initialize(bool threaded, uint32_t maxQueuedLogMessages) {
                                    "Logger already initialized");
   }
 
-  _defaultLogLevelTopics = logLevelTopics();
   calculateEffectiveLogLevels();
+  _defaultLogLevelTopics = logLevelTopics();
 
   // logging is now active
   if (threaded) {

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -976,15 +976,17 @@ void Logger::calculateEffectiveLogLevels() {
   // configured log level
   for (size_t i = 0; i < logger::kNumTopics; ++i) {
     auto* topic = LogTopic::topicForId(i);
-    auto level = topic->level();
-    _appenders.foreach (Logger::defaultLogGroup(),
-                        [&level, &topic](LogAppender& appender) {
-                          auto l = appender.getLogLevel(*topic);
-                          if (l > level) {
-                            level = l;
-                          }
-                        });
-    topic->setLogLevel(level);
+    if (topic != nullptr) {
+      auto level = topic->level();
+      _appenders.foreach (Logger::defaultLogGroup(),
+                          [&level, &topic](LogAppender& appender) {
+                            auto l = appender.getLogLevel(*topic);
+                            if (l > level) {
+                              level = l;
+                            }
+                          });
+      topic->setLogLevel(level);
+    }
   }
 }
 

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -197,13 +197,13 @@ class Logger {
   static LogGroup& defaultLogGroup();
   static LogLevel logLevel();
   static std::unordered_set<std::string> structuredLogParams();
-  static std::vector<std::pair<TopicName, LogLevel>> logLevelTopics();
-  static std::vector<std::pair<TopicName, LogLevel>> const&
-  defaultLogLevelTopics();
+  static auto logLevelTopics() -> std::vector<std::pair<LogTopic&, LogLevel>>;
+  static auto defaultLogLevelTopics()
+      -> std::vector<std::pair<LogTopic&, LogLevel>> const&;
   static void setLogLevel(LogLevel);
   static void setLogLevel(std::string const&);
-  static void setLogLevel(std::string const& topic, LogLevel level);
-  static void setLogLevel(std::string const& appender, std::string const& topic,
+  static void setLogLevel(TopicName topic, LogLevel level);
+  static void setLogLevel(std::string const& appender, TopicName topic,
                           LogLevel level);
   static void setLogLevel(std::vector<std::string> const&);
   static std::unordered_map<std::string, bool> parseStringParams(
@@ -309,7 +309,7 @@ class Logger {
 
   // default log levels, captured once at startup. these can be used
   // to reset the log levels back to defaults.
-  static std::vector<std::pair<TopicName, LogLevel>> _defaultLogLevelTopics;
+  static std::vector<std::pair<LogTopic&, LogLevel>> _defaultLogLevelTopics;
 
   // these variables must be set before calling initialized
   static std::unordered_set<std::string>

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -198,8 +198,7 @@ class Logger {
   static LogLevel logLevel();
   static std::unordered_set<std::string> structuredLogParams();
   static auto logLevelTopics() -> std::vector<std::pair<LogTopic&, LogLevel>>;
-  static auto defaultLogLevelTopics()
-      -> std::vector<std::pair<LogTopic&, LogLevel>> const&;
+  static void resetLevelsToDefault();
   static void setLogLevel(LogLevel);
   static void setLogLevel(std::string const&);
   static void setLogLevel(TopicName topic, LogLevel level);
@@ -308,10 +307,6 @@ class Logger {
   static std::mutex _appenderModificationMutex;
   static logger::Appenders _appenders;
   static bool _allowStdLogging;
-
-  // default log levels, captured once at startup. these can be used
-  // to reset the log levels back to defaults.
-  static std::vector<std::pair<LogTopic&, LogLevel>> _defaultLogLevelTopics;
 
   // these variables must be set before calling initialized
   static std::unordered_set<std::string>

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -202,6 +202,9 @@ class Logger {
   defaultLogLevelTopics();
   static void setLogLevel(LogLevel);
   static void setLogLevel(std::string const&);
+  static void setLogLevel(std::string const& topic, LogLevel level);
+  static void setLogLevel(std::string const& appender, std::string const& topic,
+                          LogLevel level);
   static void setLogLevel(std::vector<std::string> const&);
   static std::unordered_map<std::string, bool> parseStringParams(
       std::vector<std::string> const&);
@@ -300,6 +303,7 @@ class Logger {
   static std::atomic<bool> _active;
   static std::atomic<LogLevel> _level;
 
+  static std::mutex _appenderModificationMutex;
   static logger::Appenders _appenders;
   static bool _allowStdLogging;
 

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -286,6 +286,7 @@ class Logger {
   static void onDroppedMessage() noexcept;
 
  private:
+  static void calculateEffectiveLogLevels();
   static void buildJsonLogMessage(std::string& out, std::string_view logid,
                                   std::string_view function,
                                   std::string_view file, int line,

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -197,7 +197,7 @@ class Logger {
   static LogGroup& defaultLogGroup();
   static LogLevel logLevel();
   static std::unordered_set<std::string> structuredLogParams();
-  static auto logLevelTopics() -> std::vector<std::pair<LogTopic&, LogLevel>>;
+  static auto logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel>;
   static void resetLevelsToDefault();
   static void setLogLevel(LogLevel);
   static void setLogLevel(std::string const&);
@@ -286,6 +286,9 @@ class Logger {
   static void onDroppedMessage() noexcept;
 
  private:
+  static void doSetAllLevels(LogLevel);
+  static void doSetGlobalLevel(LogTopic&, LogLevel);
+
   static void calculateEffectiveLogLevels();
   static void buildJsonLogMessage(std::string& out, std::string_view logid,
                                   std::string_view function,

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -203,6 +203,7 @@ class Logger {
   static void setLogLevel(LogLevel);
   static void setLogLevel(std::string const&);
   static void setLogLevel(TopicName topic, LogLevel level);
+  static void setLogLevel(LogTopic&, LogLevel level);
   static void setLogLevel(std::string const& appender, TopicName topic,
                           LogLevel level);
   static void setLogLevel(std::vector<std::string> const&);

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -183,7 +183,7 @@ You can adjust the parameter settings at runtime using the
 per-topic log messages to different outputs. The output definition can be one
 of the following:
 
-- `-` for stdin
+- `-` for stdout
 - `+` for stderr
 - `syslog://<syslog-facility>`
 - `syslog://<syslog-facility>/<application-name>`
@@ -225,7 +225,13 @@ The old `--log.file` option is still available for convenience. It is a
 shortcut for the more general option `--log.output file://filename`.
 
 The old `--log.requests-file` option is still available. It is a shortcut for
-the more general option `--log.output requests=file://...`.)");
+the more general option `--log.output requests=file://...`.
+
+To change the log levels for the specified output you can add a comma separated
+list of topics with their respective level after the output definition, separated
+by a semicolon:
+`--log.output file:///path/to/file;queries=trace,requests=info`
+`--log.output -;all=error`)");
 
   std::vector<std::string> topicsVector;
   auto const& levels = Logger::logLevelTopics();

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -230,7 +230,7 @@ the more general option `--log.output requests=file://...`.)");
   std::vector<std::string> topicsVector;
   auto const& levels = Logger::logLevelTopics();
   for (auto const& level : levels) {
-    topicsVector.emplace_back(level.first);
+    topicsVector.emplace_back(level.first.name());
   }
   std::string topicsJoined = StringUtils::join(topicsVector, ", ");
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -230,7 +230,7 @@ the more general option `--log.output requests=file://...`.)");
   std::vector<std::string> topicsVector;
   auto const& levels = Logger::logLevelTopics();
   for (auto const& level : levels) {
-    topicsVector.emplace_back(level.first.name());
+    topicsVector.emplace_back(level.first->name());
   }
   std::string topicsJoined = StringUtils::join(topicsVector, ", ");
 

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -2273,7 +2273,7 @@ static void JS_LogLevel(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
       for (auto const& level : levels) {
         std::string output = absl::StrCat(
-            level.first, "=", Logger::translateLogLevel(level.second));
+            level.first.name(), "=", Logger::translateLogLevel(level.second));
         v8::Handle<v8::String> val = TRI_V8_STD_STRING(isolate, output);
 
         object->Set(context, pos++, val).FromMaybe(false);

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -2273,7 +2273,7 @@ static void JS_LogLevel(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
       for (auto const& level : levels) {
         std::string output = absl::StrCat(
-            level.first.name(), "=", Logger::translateLogLevel(level.second));
+            level.first->name(), "=", Logger::translateLogLevel(level.second));
         v8::Handle<v8::String> val = TRI_V8_STD_STRING(isolate, output);
 
         object->Set(context, pos++, val).FromMaybe(false);

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -1579,6 +1579,21 @@ TEST_F(VPackLoadInspectorTest, load_string_enum) {
   EXPECT_EQ(MyStringEnum::kValue2, enums[1]);
 }
 
+TEST_F(VPackLoadInspectorTest, load_transformed_string_enum) {
+  builder.openArray();
+  builder.add(VPackValue("Value1"));
+  builder.add(VPackValue("value2"));
+  builder.close();
+  arangodb::inspection::VPackLoadInspector<> inspector{builder};
+
+  std::vector<MyTransformedStringEnum> enums;
+  auto result = inspector.apply(enums);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(2u, enums.size());
+  EXPECT_EQ(MyTransformedStringEnum::kValue1, enums[0]);
+  EXPECT_EQ(MyTransformedStringEnum::kValue2, enums[1]);
+}
+
 TEST_F(VPackLoadInspectorTest, load_int_enum) {
   builder.openArray();
   builder.add(VPackValue(1));

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -21,10 +21,12 @@
 /// @author Manuel Pöter
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <cctype>
 #include <list>
 #include <map>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <variant>
 #include <vector>
 #include <set>
@@ -617,6 +619,22 @@ template<class Inspector>
 auto inspect(Inspector& f, MyStringEnum& x) {
   return f.enumeration(x).values(MyStringEnum::kValue1, "value1",  //
                                  MyStringEnum::kValue2, "value2");
+}
+
+enum class MyTransformedStringEnum {
+  kValue1,
+  kValue2,
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, MyTransformedStringEnum& x) {
+  return f.enumeration(x).transformedValues(
+      [](std::string& s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return std::toupper(c); });
+      },
+      MyTransformedStringEnum::kValue1, "VALUE1",  //
+      MyTransformedStringEnum::kValue2, "VALUE2");
 }
 }  // namespace
 

--- a/tests/js/client/server_parameters/log-pid-replacement.js
+++ b/tests/js/client/server_parameters/log-pid-replacement.js
@@ -47,6 +47,7 @@ return require('internal').options()["log.output"];
 `);
 
       assertTrue(Array.isArray(res));
+      res = res.filter((x) => x.startsWith('file://'));
       assertTrue(res.length > 0);
 
       let logfile = res[0].replace(/^file:\/\//, '');

--- a/tests/js/client/shell/multi/shell-admin-log.js
+++ b/tests/js/client/shell/multi/shell-admin-log.js
@@ -64,6 +64,20 @@ function adminLogSuite() {
     setUp: function () {
       arango.DELETE("/_admin/log");
     },
+
+    testPutInvalidLevelReturnsError: function () {        
+      let res = arango.PUT("/_admin/log/level", {all: "invalidLevel"});
+      assertEqual(res.error, true);
+      assertEqual(res.code, 400);
+      assertEqual(res.errorMessage, "Failed to parse log levels: Unknown enum value invalidlevel at path ['all']");
+    },
+    
+    testPutInvalidTopicReturnsError: function () {        
+      let res = arango.PUT("/_admin/log/level", {invalidTopic: "error"});
+      assertEqual(res.error, true);
+      assertEqual(res.code, 400);
+      assertEqual(res.errorMessage, "Unknown log topic invalidTopic");
+    },
     
     testPutAdminSetAllLevels: function () {
       let previous = arango.GET("/_admin/log/level");


### PR DESCRIPTION
### Scope & Purpose

We already had the concept of individual log appenders (e.g., stdout, stderr, files, syslog). but log levels could only be configured globally. That is, all appenders always used the same log levels for all topics.

This PR introduces appender specific log levels. For example, it is now possible to set the log levels for all topics to `error`, but leave the log levels for the log file unchanged. This is particularly useful for test runs because we avoid flooding the console with log messages, but still have all the information in the log files in case of test failures.

The log level can be specified per appender via the command line by adding a comma separated list of topics with their respective level after the output definition, separated by a semicolon:
  `--log.output file:///path/to/file;queries=trace,requests=info`
  `--log.output -;all=error`

The `_admin/log/level` endpoint has also been extended to with an optional parameter `withAppenders`. If that parameter is set to `true`, the response has the following form:
```
{
  "global": {
    <topic>: <level>,
     ...
  },
  "appenders": {
    <appender>: {
      <topic>: <level>,
       ...
    },
    ...
  }
}
```
A `PUT` request to `_admin/log/level` with `withAppenders` set to true requires an input of the same format.

Previously, requests to the `_admin/log/level` endpoint where not fully validated. A PUT request that specified invalid topics or log levels would silently ignore those. This has been improved, so that invalid input is now always rejected with a proper error message - in that case _no_ changes are applied at all.

The global level for some topic is always identical to the highest log level for that topic of all appenders. Thus, changing the log level for an appender will implicitly also adjust the global level accordingly. When a global level is set explicitly, this change is also applied to all appenders.

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] **integration tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
