### PR TITLE
Use shared_ptr for thread_registry ref counting.

### DIFF
--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -3,7 +3,7 @@
 #include <iostream>
 #include <source_location>
 #include <string>
-#include <atomic>
+#include <memory>
 
 namespace arangodb::async_registry {
 
@@ -22,7 +22,7 @@ struct PromiseInList : Observables {
   virtual ~PromiseInList() = default;
 
   // identifies the promise list it belongs to
-  ThreadRegistry* registry = nullptr;
+  std::shared_ptr<ThreadRegistry> registry = nullptr;
   PromiseInList* next = nullptr;
   // only needed to remove an item
   PromiseInList* previous = nullptr;

--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -19,21 +19,18 @@ struct Registry {
      Each thread needs to call this once to be able to add promises to the
      coroutine registry.
    */
-  auto add_thread() -> ThreadRegistry* {
+  auto add_thread() -> std::shared_ptr<ThreadRegistry> {
     auto guard = std::lock_guard(mutex);
-    registries.push_back(ThreadRegistry::make());
-    auto registry = registries.back();
-    registry->increment_ref_count();
-    return registry;
+    registries.push_back(std::make_shared<ThreadRegistry>());
+    return registries.back();
   }
 
   /**
      Removes a coroutine thread registry from this registry.
    */
-  auto remove_thread(ThreadRegistry* registry) -> void {
+  auto remove_thread(std::shared_ptr<ThreadRegistry> registry) -> void {
     auto guard = std::lock_guard(mutex);
     std::erase(registries, registry);
-    registry->decrement_ref_count();
   }
 
   /**
@@ -56,7 +53,7 @@ struct Registry {
   }
 
  private:
-  std::vector<ThreadRegistry*> registries;
+  std::vector<std::shared_ptr<ThreadRegistry>> registries;
   std::mutex mutex;
 };
 

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -7,9 +7,11 @@ Registry coroutine_registry;
 auto get_thread_registry() noexcept -> ThreadRegistry& {
   struct ThreadRegistryGuard {
     ThreadRegistryGuard() : _registry{coroutine_registry.add_thread()} {}
-    ~ThreadRegistryGuard() { coroutine_registry.remove_thread(_registry); }
+    ~ThreadRegistryGuard() {
+      coroutine_registry.remove_thread(std::move(_registry));
+    }
 
-    ThreadRegistry* _registry;
+    std::shared_ptr<ThreadRegistry> _registry;
   };
   static thread_local auto registry_guard = ThreadRegistryGuard{};
   return *registry_guard._registry;


### PR DESCRIPTION
### Scope & Purpose
We missed some ref-counting in `for_promise` when copying the vector of thread registries. To circumvent any further mistakes, I replaced everything with `shared_ptr`. 