### PR TITLE
Bug fix/test need stdout logging

### DIFF
--- a/tests/js/client/shell/multi/shell-admin-log.js
+++ b/tests/js/client/shell/multi/shell-admin-log.js
@@ -99,6 +99,7 @@ function adminLogSuite() {
     testIncreaseLogLevelForAppenderAdjustsGlobalLevel: function () {
       let old = arango.GET("/_admin/log/level?withAppenders=true");
       let res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "trace" } } });
+      assertTrue(res.hasOwnProperty('appenders'), JSON.stringify(res));
       assertEqual(res.appenders["-"].queries, "TRACE", JSON.stringify(res));
       assertEqual(res.global.queries, "TRACE", JSON.stringify(res));
 
@@ -113,8 +114,9 @@ function adminLogSuite() {
       // we first set queries globally to debug (i.e., all appenders), but for the stdout appender we set it to trace.
       // This implicitly also sets the global level to trace.
       let res = arango.PUT("/_admin/log/level?withAppenders=true", { global: { queries: "debug" }, appenders: { "-": { queries: "trace" } } });
-      assertEqual(res.appenders["-"].queries, "TRACE");
-      assertEqual(res.global.queries, "TRACE");
+      assertTrue(res.hasOwnProperty('appenders'), JSON.stringify(res));
+      assertEqual(res.appenders["-"].queries, "TRACE", JSON.stringify(res));
+      assertEqual(res.global.queries, "TRACE", JSON.stringify(res));
       res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "error" } } });
       assertEqual(res.appenders["-"].queries, "ERROR");
       assertEqual(res.global.queries, "DEBUG");

--- a/tests/js/client/shell/multi/shell-admin-log.js
+++ b/tests/js/client/shell/multi/shell-admin-log.js
@@ -99,10 +99,10 @@ function adminLogSuite() {
     testIncreaseLogLevelForAppenderAdjustsGlobalLevel: function () {
       let old = arango.GET("/_admin/log/level?withAppenders=true");
       let res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "trace" } } });
-      assertTrue(res.hasOwnProperty('appenders'), JSON.stringify(res));
-      assertEqual(res.appenders["-"].queries, "TRACE", JSON.stringify(res));
-      assertEqual(res.global.queries, "TRACE", JSON.stringify(res));
-
+      if (res.code !== 400 && res.hasOwnProperty('appenders')) {
+        assertEqual(res.appenders["-"].queries, "TRACE", JSON.stringify(res));
+        assertEqual(res.global.queries, "TRACE", JSON.stringify(res));
+      }
       // restore old levels
       arango.PUT("/_admin/log/level?withAppenders=true", old);
     },
@@ -114,13 +114,13 @@ function adminLogSuite() {
       // we first set queries globally to debug (i.e., all appenders), but for the stdout appender we set it to trace.
       // This implicitly also sets the global level to trace.
       let res = arango.PUT("/_admin/log/level?withAppenders=true", { global: { queries: "debug" }, appenders: { "-": { queries: "trace" } } });
-      assertTrue(res.hasOwnProperty('appenders'), JSON.stringify(res));
-      assertEqual(res.appenders["-"].queries, "TRACE", JSON.stringify(res));
-      assertEqual(res.global.queries, "TRACE", JSON.stringify(res));
-      res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "error" } } });
-      assertEqual(res.appenders["-"].queries, "ERROR");
-      assertEqual(res.global.queries, "DEBUG");
-
+      if (res.code !== 400 && res.hasOwnProperty('appenders')) {
+        assertEqual(res.appenders["-"].queries, "TRACE", JSON.stringify(res));
+        assertEqual(res.global.queries, "TRACE", JSON.stringify(res));
+        res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "error" } } });
+        assertEqual(res.appenders["-"].queries, "ERROR");
+        assertEqual(res.global.queries, "DEBUG");
+      }
       // restore old levels
       arango.PUT("/_admin/log/level?withAppenders=true", old);
     },


### PR DESCRIPTION
### Scope & Purpose

Depending on how we launch testing.js `arangod` may be enabling stdout logging, or not. 
The tests must not lean on its presence. 

- [x] :hankey: Bugfix
