### PR TITLE
API to check migration status for vpack sort migration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,10 @@ devel
 3.12.2 (XXXX-XX-XX)
 -------------------
 
+* Add API GET /_admin/cluster/vpackSortMigration/status to query the status
+  of the vpack sorting migration on dbservers, single servers and
+  coordinators.
+
 * FE-461: fix JSON/table detection, disable CSV download when not a table.
 
 * FE-442: fix user avatar on user table.

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -2927,9 +2927,9 @@ RestAdminClusterHandler::handleVPackSortMigration(
   if (!((request()->requestType() == rest::RequestType::GET &&
          subCommand == VPackSortMigrationCheck) ||
         (request()->requestType() == rest::RequestType::PUT &&
-         subCommand == VPackSortMigrationMigrate)) ||
-      (request()->requestType() == rest::RequestType::GET &&
-       subCommand == VPackSortMigrationStatus)) {
+         subCommand == VPackSortMigrationMigrate) ||
+        (request()->requestType() == rest::RequestType::GET &&
+         subCommand == VPackSortMigrationStatus))) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     co_return;
@@ -2955,9 +2955,9 @@ RestAdminClusterHandler::handleVPackSortMigration(
     }
   } else {
     // Coordinators from here:
-    RestVerb verb = request()->requestType() == rest::RequestType::GET
-                        ? fuerte::RestVerb::Get
-                        : fuerte::RestVert::PUT;
+    fuerte::RestVerb verb = request()->requestType() == rest::RequestType::GET
+                                ? fuerte::RestVerb::Get
+                                : fuerte::RestVerb::Put;
     res = co_await ::fanOutRequests(_vocbase, verb, subCommand, result);
   }
   if (res.fail()) {

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -353,6 +353,7 @@ std::string const RestAdminClusterHandler::VPackSortMigration =
 std::string const RestAdminClusterHandler::VPackSortMigrationCheck = "check";
 std::string const RestAdminClusterHandler::VPackSortMigrationMigrate =
     "migrate";
+std::string const RestAdminClusterHandler::VPackSortMigrationStatus = "status";
 
 RestStatus RestAdminClusterHandler::execute() {
   // here we first do a glboal check, which is based on the setting in startup
@@ -2926,7 +2927,9 @@ RestAdminClusterHandler::handleVPackSortMigration(
   if (!((request()->requestType() == rest::RequestType::GET &&
          subCommand == VPackSortMigrationCheck) ||
         (request()->requestType() == rest::RequestType::PUT &&
-         subCommand == VPackSortMigrationMigrate))) {
+         subCommand == VPackSortMigrationMigrate)) ||
+      (request()->requestType() == rest::RequestType::GET &&
+       subCommand == VPackSortMigrationStatus)) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     co_return;
@@ -2942,17 +2945,20 @@ RestAdminClusterHandler::handleVPackSortMigration(
   Result res;
   if (!ServerState::instance()->isCoordinator()) {
     if (request()->requestType() == rest::RequestType::GET) {
-      res = ::analyzeVPackIndexSorting(_vocbase, result);
+      if (subCommand == VPackSortMigrationCheck) {
+        res = ::analyzeVPackIndexSorting(_vocbase, result);
+      } else {
+        res = ::statusVPackIndexSorting(_vocbase, result);
+      }
     } else {  // PUT
       res = ::migrateVPackIndexSorting(_vocbase, result);
     }
   } else {
     // Coordinators from here:
-    if (request()->requestType() == rest::RequestType::GET) {
-      res = co_await handleVPackSortMigrationTest(_vocbase, result);
-    } else {  // PUT
-      res = co_await handleVPackSortMigrationAction(_vocbase, result);
-    }
+    RestVerb verb = request()->requestType() == rest::RequestType::GET
+                        ? fuerte::RestVerb::Get
+                        : fuerte::RestVert::PUT;
+    res = co_await ::fanOutRequests(_vocbase, verb, subCommand, result);
   }
   if (res.fail()) {
     generateError(rest::ResponseCode::SERVER_ERROR, res.errorNumber(),

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -69,6 +69,7 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   static std::string const VPackSortMigration;
   static std::string const VPackSortMigrationCheck;
   static std::string const VPackSortMigrationMigrate;
+  static std::string const VPackSortMigrationStatus;
 
   RestStatus handleHealth();
   RestStatus handleNumberOfServers();

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -578,11 +578,15 @@ class RocksDBEngine final : public StorageEngine, public ICompactKeyRange {
   Result writeSortingFile(
       arangodb::basics::VelocyPackHelper::SortingMethod sortingMethod);
 
- private:
   // The following method returns what is detected for the sorting method.
   // If no SORTING file is detected, a new one with "LEGACY" will be created.
   arangodb::basics::VelocyPackHelper::SortingMethod readSortingFile();
+  arangodb::basics::VelocyPackHelper::SortingMethod currentSortingMethod()
+      const {
+    return _sortingMethod;
+  }
 
+ private:
   RocksDBOptionsProvider const& _optionsProvider;
 
   metrics::MetricsFeature& _metrics;

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -204,8 +204,40 @@ Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
   return res;
 }
 
-namespace {
+Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
+  // Just for the sake of completeness, restrict ourselves to the RocksDB
+  // storage engine:
+  auto& engineSelectorFeature =
+      vocbase.server().getFeature<EngineSelectorFeature>();
+  if (!engineSelectorFeature.isRocksDB()) {
+    return Result(TRI_ERROR_NOT_IMPLEMENTED,
+                  "VPack sorting migration is unnecessary for storage engines "
+                  "other than RocksDB");
+  }
+
+  auto& engine = engineSelectorFeature.engine<RocksDBEngine>();
+  auto sortingFileMethod = engine.readSortingFile();
+  {
+    VPackObjectBuilder guard(&result);
+    std::string next =
+        sortingFileMethod == basics::VelocyPackHelper::SortingMethod::Correct
+            ? "CORRECT"
+            : "LEGACY";
+    std::string current =
+        engine.currentSortingMethod() ==
+                basics::VelocyPackHelper::SortingMethod::Correct
+            ? "CORRECT"
+            : "LEGACY";
+    guard->add("next", VPackValue(next));
+    guard->add("current", VPackValue(current));
+  }
+
+  return {};
+}
+
+// On coordinators:
 async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
+                             std::string_view subCommand,
                              VPackBuilder& result) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
 
@@ -217,7 +249,7 @@ async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
   requests.reserve(dbs.size());
 
   network::RequestOptions opts;
-  if (verb == fuerte::RestVerb::Get) {
+  if (verb == fuerte::RestVerb::Get && subCommand == "check") {
     // We want to use a long timeout for the check, since going through
     // the indexes might take a while. The user is supposed to call this
     // route asynchronously anyway:
@@ -226,8 +258,7 @@ async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
   opts.database = vocbase.name();
 
   std::string path =
-      absl::StrCat("/_admin/cluster/vpackSortMigration/",
-                   verb == fuerte::RestVerb::Get ? "check" : "migrate");
+      absl::StrCat("/_admin/cluster/vpackSortMigration/", subCommand);
   for (auto const& server : dbs) {
     auto f = network::sendRequest(nf.pool(), "server:" + server, verb, path, {},
                                   opts);
@@ -267,22 +298,6 @@ async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
   }
 
   co_return {};
-}
-}  // namespace
-
-// On coordinators:
-async<Result> handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
-                                           VPackBuilder& result) {
-  TRI_ASSERT(ServerState::instance()->isCoordinator());
-
-  return fanOutRequests(vocbase, fuerte::RestVerb::Get, result);
-}
-
-async<Result> handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
-                                             VPackBuilder& result) {
-  TRI_ASSERT(ServerState::instance()->isCoordinator());
-
-  return fanOutRequests(vocbase, fuerte::RestVerb::Put, result);
 }
 
 }  // namespace arangodb

--- a/arangod/StorageEngine/VPackSortMigration.h
+++ b/arangod/StorageEngine/VPackSortMigration.h
@@ -22,6 +22,7 @@
 
 #include "Basics/Result.h"
 #include "Async/async.h"
+#include "Network/Methods.h"
 #include "VocBase/vocbase.h"
 
 namespace arangodb {
@@ -29,11 +30,10 @@ namespace arangodb {
 // On dbservers, agents and single servers:
 Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
 Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
+Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
 
 // On coordinators:
-async<Result> handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
-                                           VPackBuilder& result);
-async<Result> handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
-                                             VPackBuilder& result);
+async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
+                             std::string_view subCommand, VPackBuilder& result);
 
 }  // namespace arangodb

--- a/tests/js/client/server_parameters/legacy-sorting-cluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-cluster.js
@@ -144,8 +144,8 @@ function legacySortingTestSuite() {
         let oneResult = res.result[dbserver];
         assertFalse(oneResult.error);
         assertEqual(200, oneResult.code);
-        assertEqual("LEGACY", oneResult.next);
-        assertEqual("LEGACY", oneResult.current);
+        assertEqual("LEGACY", oneResult.result.next);
+        assertEqual("LEGACY", oneResult.result.current);
       }
 
       let c = db._collection(cn);
@@ -241,8 +241,8 @@ function legacySortingTestSuite() {
         let oneResult = res.result[dbserver];
         assertFalse(oneResult.error);
         assertEqual(200, oneResult.code);
-        assertEqual("CORRECT", oneResult.next);
-        assertEqual("LEGACY", oneResult.current);
+        assertEqual("CORRECT", oneResult.result.next);
+        assertEqual("LEGACY", oneResult.result.current);
       }
     }
   };

--- a/tests/js/client/server_parameters/legacy-sorting-noncluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-noncluster.js
@@ -132,6 +132,13 @@ function legacySortingTestSuite() {
       poisonCollection("_system", cn, "a", "b");
       poisonCollection(dn, cn, "a", "b");
 
+      // Check info API:
+      let res = arango.GET("/_admin/cluster/vpackSortMigration/status");
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+      assertEqual("LEGACY", res.result.next);
+      assertEqual("LEGACY", res.result.current);
+
       let c = db._collection(cn);
       let indexes = c.getIndexes();
       let names = indexes.map(x => x.name);
@@ -189,6 +196,18 @@ function legacySortingTestSuite() {
       assertEqual(0, r.result.errorCode);
       assertTrue(Array.isArray(r.result.affected));
       assertEqual(0, r.result.affected.length);
+
+      // Migrate:
+      res = arango.PUT("/_admin/cluster/vpackSortMigration/migrate", {});
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+
+      // Check info API:
+      res = arango.GET("/_admin/cluster/vpackSortMigration/status");
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+      assertEqual("CORRECT", res.result.next);
+      assertEqual("LEGACY", res.result.current);
     }
   };
 }


### PR DESCRIPTION
This adds an API to check the status of the migration for vpack sorting.
The API is available on dbservers and indicates the status of the
SORTING file on disk (migration status after next restart) as well as
the current status in the running process. The API is also available on
coordinators to fan out to dbservers and query all of them at once.

- Implement new API call.
- Add tests.
- CHANGELOG

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix
- [*] :pizza: New feature

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11:

