### PR TITLE
Make sure testing.js always configures an stdout appender

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -375,18 +375,17 @@ class instance {
       }
     }
 
+    let output = this.args.hasOwnProperty('log.output') ? this.args['log.output'] : [];
+    if (typeof output === 'string') {
+      output = [output];
+    }
+
     if (this.options.verbose) {
       this.args['log.level'] = 'debug';
+      output.push('-'); // make sure we always have a stdout appender
     } else if (this.options.noStartStopLogs) {
       // set the stdout appender to error only
-      let output = this.args['log.output'];
-      if (output === undefined) {
-        output = [];
-      } else if (typeof output === 'string') {
-        output = [output];
-      }
       output.push('-;all=error');
-      this.args['log.output'] = output;
       let logs = ['crash=info'];
       if (this.args['log.level'] !== undefined) {
         if (Array.isArray(this.args['log.level'])) {
@@ -396,7 +395,10 @@ class instance {
         }
       }
       this.args['log.level'] = logs;
+    } else {
+      output.push('-'); // make sure we always have a stdout appender
     }
+    this.args['log.output'] = output;
     if (this.isAgent()) {
       this.args = Object.assign(this.args, {
         'agency.activate': 'true',


### PR DESCRIPTION
### Scope & Purpose

By default we only add a stdout appender if we have a TTY, but some tests depend on the existence of a stdout appender, so make sure we always configure one.

- [x] :hankey: Bugfix
