### PR TITLE
Extend specializeCollecRule to consider existing SORT nodes that cover all group variables

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,26 @@
 devel
 -----
 
+* Extend COLLECT optimizer rule to to consider existing SORT nodes that cover
+  all group variables. Previously the following query would use a hash collect
+  instead of a sorted collect:
+  ```
+  FOR d IN docs
+    SORT d.value DESC
+    COLLECT v = d.value
+    RETURN v
+  ```
+  The reason is that previously the rule unconditionally created a SORT node
+  with all group variables sorted in ascending order, but because that
+  resulted in a plan with two different SORT nodes which obviously is more
+  expensive than the hash collect, which was thus preferred.
+  The sorted collect doesn't need the values to be sorted in a particular
+  order, it just needs the values to be grouped correctly. So the new version
+  now checks if there are existing SORT nodes that already cover all the group
+  values, and in that case does not create an additional SORT node. That way
+  we can also utilize descending SORTs as in the example above, and perhaps
+  even utilize an index if we have one.
+
 3.12.2 (XXXX-XX-XX)
 -------------------
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Extend COLLECT optimizer rule to to consider existing SORT nodes that cover
+* Extend COLLECT optimizer rule to consider existing SORT nodes that cover
   all group variables. Previously the following query would use a hash collect
   instead of a sorted collect:
   ```

--- a/tests/js/client/aql/aql-explain-cluster.js
+++ b/tests/js/client/aql/aql-explain-cluster.js
@@ -127,14 +127,6 @@ function explainSuite () {
       prev = node.id;
       
       node = nodes[n++];
-      assertEqual("SortNode", node.type);
-      assertEqual([ prev ], node.dependencies);
-      assertEqual(1, node.elements.length);
-      assertEqual("a", node.elements[0].inVariable.name);
-      assertTrue(node.stable);
-      prev = node.id;
-      
-      node = nodes[n++];
       assertEqual("CollectNode", node.type);
       assertEqual([ prev ], node.dependencies);
       assertEqual(1, node.groups.length);

--- a/tests/js/client/aql/aql-explain-noncluster.js
+++ b/tests/js/client/aql/aql-explain-noncluster.js
@@ -99,23 +99,15 @@ function explainSuite () {
       assertFalse(node.stable);
 
       node = nodes[6];
-      assertEqual("SortNode", node.type);
-      assertEqual([ 6 ], node.dependencies);
-      assertEqual(9, node.id);
-      assertEqual(1, node.elements.length);
-      assertEqual("a", node.elements[0].inVariable.name);
-      assertTrue(node.stable);
-      
-      node = nodes[7];
       assertEqual("CollectNode", node.type);
-      assertEqual([ 9 ], node.dependencies);
+      assertEqual([ 6 ], node.dependencies);
       assertEqual(7, node.id);
       assertEqual(1, node.groups.length);
       assertEqual("a", node.groups[0].inVariable.name);
       assertEqual("x", node.groups[0].outVariable.name);
       assertEqual("g", node.outVariable.name);
       
-      node = nodes[8];
+      node = nodes[7];
       assertEqual("ReturnNode", node.type);
       assertEqual([ 7 ], node.dependencies);
       assertEqual(8, node.id);


### PR DESCRIPTION
### Scope & Purpose

Extend COLLECT optimizer rule to to consider existing SORT nodes that cover all group variables. Previously the following query would use a hash collect instead of a sorted collect:
  ```
  FOR d IN docs
    SORT d.value DESC
    COLLECT v = d.value
    RETURN v
  ```
The reason is that previously the rule unconditionally created a SORT node with all group variables sorted in ascending order, but because that resulted in a plan with two different SORT nodes which obviously is more expensive than the hash collect, which was thus preferred.

The sorted collect doesn't need the values to be sorted in a particular order, it just needs the values to be grouped correctly. So the new version now checks if there are existing SORT nodes that already cover all the group values, and in that case does not create an additional SORT node. That way we can also utilize descending SORTs as in the example above, and perhaps even utilize an index if we have one.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **integration tests**
- [x] :book: CHANGELOG entry made
