### PR TITLE
add suffix option, so we can differenciate the testresults

### DIFF
--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -417,7 +417,7 @@ function iterateTests(cases, options) {
     let printTestName = currentTest;
     let resultTestName = currentTest;
     if (localOptions.suffix && localOptions.suffix !== "") {
-      resultTestName += "_" + localOptions.suffix;
+      resultTestName += "-" + localOptions.suffix;
     }
     if (options.testBuckets) {
       printTestName += " - " + options.testBuckets;

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -415,7 +415,10 @@ function iterateTests(cases, options) {
       localOptions = _.defaults(optionsList[n], localOptions);
     }
     let printTestName = currentTest;
-    let resultTestName = currentTest + localOptions.suffix;
+    let resultTestName = currentTest;
+    if (localOptions.suffix && localOptions.suffix !== "") {
+      resultTestName += localOptions.suffix;
+    }
     if (options.testBuckets) {
       printTestName += " - " + options.testBuckets;
     }

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -73,6 +73,7 @@ let optionsDocumentation = [
   '   - `failed`: if set to true, re-runs only those tests that failed in the',
   '     previous test run. The information which tests previously failed is taken',
   '     from the "UNITTEST_RESULT.json" (if available).',
+  '   - `suffix` append to the representation name',
   '   - `optionsJson`: all of the above, as json list for mutliple suite launches',
   ''
 ];
@@ -95,6 +96,7 @@ const optionsDefaults = {
   'vst': false,
   'http2': false,
   'failed': false,
+  'suffix': '',
   'optionsJson': null,
 };
 
@@ -413,6 +415,7 @@ function iterateTests(cases, options) {
       localOptions = _.defaults(optionsList[n], localOptions);
     }
     let printTestName = currentTest;
+    let resultTestName = currentTest + localOptions.suffix;
     if (options.testBuckets) {
       printTestName += " - " + options.testBuckets;
     }
@@ -445,7 +448,7 @@ function iterateTests(cases, options) {
     }
     result.failed = failed;
     result.status = status;
-    results[currentTest] = result;
+    results[resultTestName] = result;
   }
 
   results.status = globalStatus;

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -417,7 +417,7 @@ function iterateTests(cases, options) {
     let printTestName = currentTest;
     let resultTestName = currentTest;
     if (localOptions.suffix && localOptions.suffix !== "") {
-      resultTestName += localOptions.suffix;
+      resultTestName += "_" + localOptions.suffix;
     }
     if (options.testBuckets) {
       printTestName += " - " + options.testBuckets;

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -47,9 +47,9 @@ shell_client priority=250 parallelity=2 buckets=4 single size=medium -- $Encrypt
 shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
 shell_client_multi priority=1500 parallelity=2 single suffix=http -- --http true
 
-shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}] 
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
+shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix":"http2"}]
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix":"http2"}] 
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix":"http2"}]
 
 shell_client_aql buckets=17 priority=250  single
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -47,9 +47,9 @@ shell_client priority=250 parallelity=2 buckets=4 single size=medium -- $Encrypt
 shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
 shell_client_multi priority=1500 parallelity=2 single suffix=http -- --http true
 
-shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"_http"},{"http2":true,"suffix","_http2"}]
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"_http"},{"http2":true,"suffix","_http2"}] 
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"_http"},{"http2":true,"suffix","_http2"}]
+shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}] 
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
 
 shell_client_aql buckets=17 priority=250  single
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -47,9 +47,9 @@ shell_client priority=250 parallelity=2 buckets=4 single size=medium -- $Encrypt
 shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
 shell_client_multi priority=1500 parallelity=2 single suffix=http -- --http true
 
-shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- --optionsJson [{"http":true},{"http2":true}] $EncryptionAtRest
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true},{"http2":true}]
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl -- --optionsJson [{"http":true},{"http2":true}] --protocol ssl
+shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}] 
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
 
 shell_client_aql buckets=17 priority=250  single
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -47,9 +47,9 @@ shell_client priority=250 parallelity=2 buckets=4 single size=medium -- $Encrypt
 shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
 shell_client_multi priority=1500 parallelity=2 single suffix=http -- --http true
 
-shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}] 
-shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix","http2"}]
+shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"_http"},{"http2":true,"suffix","_http2"}]
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"_http"},{"http2":true,"suffix","_http2"}] 
+shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single suffix=ssl --  --protocol ssl --optionsJson [{"http":true,"suffix":"_http"},{"http2":true,"suffix","_http2"}]
 
 shell_client_aql buckets=17 priority=250  single
 


### PR DESCRIPTION
### Scope & Purpose

tests in optionsJson need to be able to specify their result namespace. 

- [x] :hankey: Bugfix
