### PR TITLE
Make minimal debug info configurable for CircleCI

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -8,6 +8,9 @@ parameters:
   enterprise-commit:
     type: string
     default: ""
+  use-minimal-debug-info:
+    type: boolean
+    default: true
   build-docker-image:
     type: string
     default: "arangodb/ubuntubuildarangodb-devel:6"
@@ -306,6 +309,10 @@ jobs:
       - run:
           name: Configure
           command: |
+            MINIMAL_DEBUGINFO="OFF"
+            if [ << pipeline.parameters.use-minimal-debug-info >> = true ]; then
+              MINIMAL_DEBUGINFO="ON"
+            fi
             cmake --preset << parameters.preset >> \
               -DCMAKE_C_COMPILER=<< pipeline.parameters.c-compiler >> \
               -DCMAKE_CXX_COMPILER=<< pipeline.parameters.cxx-compiler >> \
@@ -314,6 +321,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=sccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
               -DOPENSSL_ROOT_DIR=/opt \
+              -DUSE_MINIMAL_DEBUGINFO=$MINIMAL_DEBUGINFO \
               -DCMAKE_INSTALL_PREFIX=/
       - run:
           name: Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ parameters:
     # contains a branch with the same name as the arangodb repo. If this is the case
     # we use it, otherwise we fall back to "devel".
     default: ""
+  use-minimal-debug-info:
+    type: boolean
+    default: true
   create-docker-images:
     type: boolean
     default: false


### PR DESCRIPTION
### Scope & Purpose

Introduce a new pipeline parameter to enable/disable minimal debug info and default it to true. This results in much smaller executables (~650MB vs ~1.8GB) which improves CI turnaround times a bit (reduces build times somewhat, but mainly reduces the time required to persist/attach workspaces).
