### PR TITLE
Backport finishing touches for vpack sorting

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 v3.11.11 (XXXX-XX-XX)
 ---------------------
 
+* Add API GET /_admin/cluster/vpackSortMigration/status to query the status
+  of the vpack sorting migration on dbservers, single servers and
+  coordinators.
+
 * Updated ArangoDB Starter to v0.18.8 and arangosync to v2.19.8.
 
 * FE-378: fix fields containing spaces during index creation on web UI.

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -300,6 +300,7 @@ std::string const RestAdminClusterHandler::VPackSortMigration =
 std::string const RestAdminClusterHandler::VPackSortMigrationCheck = "check";
 std::string const RestAdminClusterHandler::VPackSortMigrationMigrate =
     "migrate";
+std::string const RestAdminClusterHandler::VPackSortMigrationStatus = "status";
 std::string const RestAdminClusterHandler::FailureOracle = "failureOracle";
 
 RestStatus RestAdminClusterHandler::execute() {
@@ -2993,7 +2994,9 @@ RestStatus RestAdminClusterHandler::handleVPackSortMigration(
   if (!((request()->requestType() == rest::RequestType::GET &&
          subCommand == VPackSortMigrationCheck) ||
         (request()->requestType() == rest::RequestType::PUT &&
-         subCommand == VPackSortMigrationMigrate))) {
+         subCommand == VPackSortMigrationMigrate) ||
+        (request()->requestType() == rest::RequestType::GET &&
+         subCommand == VPackSortMigrationStatus))) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     return RestStatus::DONE;
@@ -3009,17 +3012,20 @@ RestStatus RestAdminClusterHandler::handleVPackSortMigration(
   Result res;
   if (!ServerState::instance()->isCoordinator()) {
     if (request()->requestType() == rest::RequestType::GET) {
-      res = ::analyzeVPackIndexSorting(_vocbase, result);
+      if (subCommand == VPackSortMigrationCheck) {
+        res = ::analyzeVPackIndexSorting(_vocbase, result);
+      } else {
+        res = ::statusVPackIndexSorting(_vocbase, result);
+      }
     } else {  // PUT
       res = ::migrateVPackIndexSorting(_vocbase, result);
     }
   } else {
     // Coordinators from here:
-    if (request()->requestType() == rest::RequestType::GET) {
-      res = handleVPackSortMigrationTest(_vocbase, result);
-    } else {  // PUT
-      res = handleVPackSortMigrationAction(_vocbase, result);
-    }
+    fuerte::RestVerb verb = request()->requestType() == rest::RequestType::GET +
+                                ? fuerte::RestVerb::Get +
+                                : fuerte::RestVerb::Put;
+    res = ::fanOutRequests(_vocbase, verb, subCommand, result);
   }
   if (res.fail()) {
     generateError(rest::ResponseCode::SERVER_ERROR, res.errorNumber(),

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -69,6 +69,7 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   static std::string const VPackSortMigration;
   static std::string const VPackSortMigrationCheck;
   static std::string const VPackSortMigrationMigrate;
+  static std::string const VPackSortMigrationStatus;
   static std::string const FailureOracle;
 
   RestStatus handleHealth();

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -543,11 +543,15 @@ class RocksDBEngine final : public StorageEngine {
   Result writeSortingFile(
       arangodb::basics::VelocyPackHelper::SortingMethod sortingMethod);
 
- private:
   // The following method returns what is detected for the sorting method.
   // If no SORTING file is detected, a new one with "LEGACY" will be created.
   arangodb::basics::VelocyPackHelper::SortingMethod readSortingFile();
+  arangodb::basics::VelocyPackHelper::SortingMethod currentSortingMethod()
+      const {
+    return _sortingMethod;
+  }
 
+ private:
   RocksDBOptionsProvider const& _optionsProvider;
 
   /// single rocksdb database used in this storage engine

--- a/arangod/StorageEngine/VPackSortMigration.h
+++ b/arangod/StorageEngine/VPackSortMigration.h
@@ -21,6 +21,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "Basics/Result.h"
+#include "Network/Methods.h"
 #include "VocBase/vocbase.h"
 
 namespace arangodb {
@@ -28,11 +29,10 @@ namespace arangodb {
 // On dbservers, agents and single servers:
 Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
 Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
+Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
 
 // On coordinators:
-Result handleVPackSortMigrationTest(TRI_vocbase_t& vocbase,
-                                    VPackBuilder& result);
-Result handleVPackSortMigrationAction(TRI_vocbase_t& vocbase,
-                                      VPackBuilder& result);
+Result fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,
+                      std::string_view subCommand, VPackBuilder& result);
 
 }  // namespace arangodb

--- a/tests/js/client/server_parameters/legacy-sorting-cluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-cluster.js
@@ -135,6 +135,19 @@ function legacySortingTestSuite() {
       poisonCollection("_system", cn, "a", "b");
       poisonCollection(dn, cn, "a", "b");
 
+      // Check info API:
+      let res = arango.GET("/_admin/cluster/vpackSortMigration/status");
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+      assertEqual("object", typeof(res.result));
+      for (let dbserver in res.result) {
+        let oneResult = res.result[dbserver];
+        assertFalse(oneResult.error);
+        assertEqual(200, oneResult.code);
+        assertEqual("LEGACY", oneResult.result.next);
+        assertEqual("LEGACY", oneResult.result.current);
+      }
+
       let c = db._collection(cn);
       let indexes = c.getIndexes();
       let names = indexes.map(x => x.name);
@@ -200,17 +213,37 @@ function legacySortingTestSuite() {
         return true;
       };
       let count = 0;
-      while (count < 60) {
+      while (true) {
         r = arango.GET("/_admin/cluster/vpackSortMigration/check");
         let res = tester(r);
         if (res === true) {
-          return;
+          break;
         }
         console.error("Bad result:", JSON.stringify(r));
         require("internal").wait(1.0);
         count += 1;
+        if (count > 60) {
+          assertTrue(false, "Test not good after 60s.");
+        }
       }
-      assertTrue(false, "Test not good after 60s.");
+
+      // Migrate:
+      res = arango.PUT("/_admin/cluster/vpackSortMigration/migrate", {});
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+
+      // Check info API:
+      res = arango.GET("/_admin/cluster/vpackSortMigration/status");
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+      assertEqual("object", typeof(res.result));
+      for (let dbserver in res.result) {
+        let oneResult = res.result[dbserver];
+        assertFalse(oneResult.error);
+        assertEqual(200, oneResult.code);
+        assertEqual("CORRECT", oneResult.result.next);
+        assertEqual("LEGACY", oneResult.result.current);
+      }
     }
   };
 }

--- a/tests/js/client/server_parameters/legacy-sorting-noncluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-noncluster.js
@@ -132,6 +132,13 @@ function legacySortingTestSuite() {
       poisonCollection("_system", cn, "a", "b");
       poisonCollection(dn, cn, "a", "b");
 
+      // Check info API:
+      let res = arango.GET("/_admin/cluster/vpackSortMigration/status");
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+      assertEqual("LEGACY", res.result.next);
+      assertEqual("LEGACY", res.result.current);
+
       let c = db._collection(cn);
       let indexes = c.getIndexes();
       let names = indexes.map(x => x.name);
@@ -189,6 +196,18 @@ function legacySortingTestSuite() {
       assertEqual(0, r.result.errorCode);
       assertTrue(Array.isArray(r.result.affected));
       assertEqual(0, r.result.affected.length);
+
+      // Migrate:
+      res = arango.PUT("/_admin/cluster/vpackSortMigration/migrate", {});
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+
+      // Check info API:
+      res = arango.GET("/_admin/cluster/vpackSortMigration/status");
+      assertFalse(res.error);
+      assertEqual(200, res.code);
+      assertEqual("CORRECT", res.result.next);
+      assertEqual("LEGACY", res.result.current);
     }
   };
 }


### PR DESCRIPTION
This adds an API to check the status of the migration for vpack sorting.
The API is available on dbservers and indicates the status of the
SORTING file on disk (migration status after next restart) as well as
the current status in the running process. The API is also available on
coordinators to fan out to dbservers and query all of them at once.

 - Implement new API call.
 - Add tests.
 - CHANGELOG

This is a backport of https://github.com/arangodb/arangodb/pull/21249

### Scope & Purpose

 *(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

 - [*] :hankey: Bugfix
 - [*] :pizza: New feature

### Checklist

 - [*] Tests
 - [*] **integration tests**
 - [*] :book: CHANGELOG entry made
 - [*] Backports
   - [*] Backport for 3.11: this is it 
