### PR TITLE
Natively support strict ranges using MDI.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Add native support for strict ranges for MDI.
+
 * Rebuilt included rclone v1.65.2 with go1.22.6.
 
 * FE-463: Query UI view crashes for empty collections.

--- a/tests/js/client/aql/aql-mdi-stored-values.js
+++ b/tests/js/client/aql/aql-mdi-stored-values.js
@@ -68,7 +68,7 @@ function mdiIndexStoredValues() {
       const indexNodes = res.plan.nodes.filter(n => n.type === "IndexNode");
       assertEqual(indexNodes.length, 1);
       const index = indexNodes[0];
-      assertTrue(index.indexCoversProjections, true);
+      assertTrue(index.indexCoversProjections);
       assertEqual(normalize(index.projections), normalize(["z", ["w", "w"], "_id"]));
 
       const result = db._createStatement({query: query.query, bindVars: query.bindVars}).execute().toArray();
@@ -82,7 +82,7 @@ function mdiIndexStoredValues() {
     testWithPostFilter: function () {
       const query = aql`
         FOR d IN ${col}
-          FILTER d.x > 5 && d.y < 7
+          FILTER d.x > 5 && d.y < 7 && d.z[0] > 5
           RETURN [d.w.w, d.z, d._id]
       `;
 
@@ -90,10 +90,10 @@ function mdiIndexStoredValues() {
       const indexNodes = res.plan.nodes.filter(n => n.type === "IndexNode");
       assertEqual(indexNodes.length, 1);
       const index = indexNodes[0];
-      assertTrue(index.indexCoversProjections, true);
+      assertTrue(index.indexCoversProjections);
       assertEqual(normalize(index.projections), normalize(["z", ["w", "w"], "_id"]));
       assertTrue(index.indexCoversFilterProjections, true);
-      assertEqual(normalize(index.filterProjections), normalize(["x", "y"]));
+      assertEqual(normalize(index.filterProjections), normalize(["z"]));
 
       const result = db._createStatement({query: query.query, bindVars: query.bindVars}).execute().toArray();
       assertEqual(result.length, 199); // 5.1 - 6.9

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -273,7 +273,6 @@ function optimizerRuleMdi2dIndexTestSuite() {
       assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
       assertTrue(appliedRules.includes(useIndexes));
       assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
-      assertTrue(appliedRules.includes(moveFiltersIntoEnumerate));
       const executeRes = db._query(query.query, query.bindVars);
       const res = executeRes.toArray();
       res.sort();
@@ -414,13 +413,13 @@ function optimizerRuleMdi2dIndexTestSuite() {
           .filter((n) => !["GatherNode", "RemoteNode"].includes(n));
         assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
         assertTrue(appliedRules.includes(useIndexes));
-        assertFalse(appliedRules.includes(removeFilterCoveredByIndex));
+        assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
 
         const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
-        assertNotEqual(indexNode.filter, undefined);
+        assertEqual(indexNode.filter, undefined);
 
         const executeRes = db._query(query.query, query.bindVars);
         const res = executeRes.toArray();
@@ -451,18 +450,14 @@ function optimizerRuleMdi2dIndexTestSuite() {
           .map((n) => n.type)
           .filter((n) => !["GatherNode", "RemoteNode"].includes(n));
         assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
-        if (queries[i].inRange) {
-          assertFalse(appliedRules.includes(removeFilterCoveredByIndex));
-        } else {
-          assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
-        }
+        assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
         assertTrue(appliedRules.includes(useIndexes));
 
         const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
-        assertNotEqual(indexNode.filter, undefined);
+        assertEqual(indexNode.filter, undefined);
 
         const executeRes = db._query(query.query, query.bindVars);
         const res = executeRes.toArray();
@@ -493,18 +488,15 @@ function optimizerRuleMdi2dIndexTestSuite() {
           .map((n) => n.type)
           .filter((n) => !["GatherNode", "RemoteNode"].includes(n));
         assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
-        if (queries[i].inRange) {
-          assertFalse(appliedRules.includes(removeFilterCoveredByIndex));
-        } else {
-          assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
-        }
+
+        assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
         assertTrue(appliedRules.includes(useIndexes));
 
         const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
-        assertNotEqual(indexNode.filter, undefined);
+        assertEqual(indexNode.filter, undefined);
 
         const executeRes = db._query(query.query, query.bindVars);
         const res = executeRes.toArray();


### PR DESCRIPTION
### Scope & Purpose

Previously searching with the MDI only non-strict ranges were supported directly. Given a strict comparison, a post filter was inserted. This can become a bottle neck if the result set is huge. This PR adds support for non-strict ranges without a post filter. 

```
Query String (54 chars, cacheable: true):
 FOR d IN @@value0 FILTER 0 < d.x && d.x < 1 RETURN d.x

Execution plan:
 Id   NodeType        Par   Est.   Comment
  1   SingletonNode            1   * ROOT 
  7   IndexNode         ✓    715     - FOR d IN UnitTestMdiIndexCollection   /* mdi index scan, index scan + document lookup (projections: `x`) */    LET #3 = d.`x`   
  6   ReturnNode             715       - RETURN #3

Indexes used:
 By   Name       Type   Collection                   Unique   Sparse   Cache   Selectivity   Fields         Stored values   Ranges
  7   mdiIndex   mdi    UnitTestMdiIndexCollection   false    false    false           n/a   [ `x`, `y` ]   [  ]            ((d.`x` > 0) && (d.`x` < 1))

Optimization rules applied:
 Id   Rule Name                                 Id   Rule Name                                 Id   Rule Name                        
  1   move-calculations-up                       5   use-indexes                                9   optimize-projections             
  2   move-filters-up                            6   remove-filter-covered-by-index            10   remove-unnecessary-calculations-4
  3   move-calculations-up-2                     7   remove-unnecessary-calculations-2         11   async-prefetch                   
  4   move-filters-up-2                          8   reduce-extraction-to-projection  

57 rule(s) executed, 1 plan(s) created, peak mem [b]: 0, exec time [s]: 0.00161

```