### PR TITLE
Add futures to async registry

### DIFF
--- a/arangod/AsyncRegistryServer/Feature.h
+++ b/arangod/AsyncRegistryServer/Feature.h
@@ -43,7 +43,7 @@ class Feature final : public application_features::ApplicationFeature {
                                                  name()},
         metrics{create_metrics(
             server.template getFeature<arangodb::metrics::MetricsFeature>())} {
-    coroutine_registry.set_metrics(metrics);
+    registry.set_metrics(metrics);
     // startsAfter<Bla, Server>();
   }
 

--- a/arangod/AsyncRegistryServer/Feature.h
+++ b/arangod/AsyncRegistryServer/Feature.h
@@ -47,6 +47,8 @@ class Feature final : public application_features::ApplicationFeature {
     // startsAfter<Bla, Server>();
   }
 
+  ~Feature() { registry.set_metrics(std::make_shared<Metrics>()); }
+
  private:
   std::shared_ptr<const Metrics> metrics;
 };

--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -43,7 +43,7 @@ auto RestHandler::execute() -> RestStatus {
 
   VPackBuilder builder;
   builder.openArray();
-  coroutine_registry.for_promise([&](PromiseInList* promise) {
+  registry.for_promise([&](PromiseInList* promise) {
     velocypack::serialize(builder, *promise);
   });
   builder.close();

--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -43,9 +43,8 @@ auto RestHandler::execute() -> RestStatus {
 
   VPackBuilder builder;
   builder.openArray();
-  registry.for_promise([&](PromiseInList* promise) {
-    velocypack::serialize(builder, *promise);
-  });
+  registry.for_promise(
+      [&](Promise* promise) { velocypack::serialize(builder, *promise); });
   builder.close();
 
   generateResult(rest::ResponseCode::OK, builder.slice());

--- a/arangod/Scheduler/SupervisedScheduler.cpp
+++ b/arangod/Scheduler/SupervisedScheduler.cpp
@@ -32,6 +32,7 @@
 #include "SupervisedScheduler.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Async/Registry/registry_variable.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Thread.h"
@@ -488,6 +489,8 @@ void SupervisedScheduler::runWorker() {
       LOG_TOPIC("d4121", ERR, Logger::THREADS)
           << "scheduler loop caught unknown exception";
     }
+
+    async_registry::get_thread_registry().garbage_collect();
 
     _jobsDone.fetch_add(1, std::memory_order_release);
   }

--- a/arangod/Statistics/StatisticsWorker.cpp
+++ b/arangod/Statistics/StatisticsWorker.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Query.h"
 #include "Aql/QueryString.h"
+#include "Async/Registry/registry_variable.h"
 #include "Basics/PhysicalMemory.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/process-utils.h"
@@ -1181,6 +1182,7 @@ void StatisticsWorker::run() {
       LOG_TOPIC("9a4f9", WARN, Logger::STATISTICS)
           << "caught unknown exception in StatisticsWorker";
     }
+    async_registry::get_thread_registry().garbage_collect();
 
     std::unique_lock guard{_cv.mutex};
     _cv.cv.wait_for(guard, std::chrono::seconds{1});

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -38,6 +38,7 @@
 #include "ApplicationServer.h"
 
 #include "ApplicationFeatures/ApplicationFeature.h"
+#include "Async/Registry/registry_variable.h"
 #include "Basics/Exceptions.h"
 #include "Basics/Result.h"
 #include "Basics/ScopeGuard.h"
@@ -212,6 +213,8 @@ void ApplicationServer::run(int argc, char* argv[]) {
   // wait until we get signaled the shutdown request
   _state.store(State::IN_WAIT, std::memory_order_release);
   reportServerProgress(State::IN_WAIT);
+
+  async_registry::get_thread_registry().garbage_collect();
   wait();
 
   // beginShutdown is called asynchronously ----------

--- a/lib/Async/Registry/CMakeLists.txt
+++ b/lib/Async/Registry/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(arango_async_registry STATIC
+  promise.cpp
   registry.cpp
   registry_variable.cpp
   thread_registry.cpp)

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -1,0 +1,25 @@
+#include "promise.h"
+
+#include "Async/Registry/registry_variable.h"
+#include "Async/Registry/thread_registry.h"
+
+using namespace arangodb::async_registry;
+
+Promise::Promise(Promise* next, std::shared_ptr<ThreadRegistry> registry,
+                 std::source_location entry_point)
+    : thread{registry->thread},
+      entry_point{std::move(entry_point)},
+      registry{registry},
+      next{next} {}
+
+auto Promise::mark_for_deletion() noexcept -> void {
+  registry->mark_for_deletion(this);
+}
+
+AddToAsyncRegistry::AddToAsyncRegistry(std::source_location loc)
+    : promise{get_thread_registry().add_promise(std::move(loc))} {}
+AddToAsyncRegistry::~AddToAsyncRegistry() {
+  if (promise != nullptr) {
+    promise->mark_for_deletion();
+  }
+}

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -40,11 +40,11 @@ struct Observables {
   std::source_location _where;
 };
 
-struct PromiseInList : Observables {
-  PromiseInList(std::source_location loc) : Observables(std::move(loc)) {}
+struct Promise : Observables {
+  Promise(std::source_location loc) : Observables(std::move(loc)) {}
 
   virtual auto destroy() noexcept -> void = 0;
-  virtual ~PromiseInList() = default;
+  virtual ~Promise() = default;
 
   // identifies the promise list it belongs to
   std::shared_ptr<ThreadRegistry> registry = nullptr;
@@ -52,15 +52,15 @@ struct PromiseInList : Observables {
   std::string thread_name;
   std::thread::id thread_id;
 
-  PromiseInList* next = nullptr;
+  Promise* next = nullptr;
   // only needed to remove an item
-  PromiseInList* previous = nullptr;
+  Promise* previous = nullptr;
   // only needed to garbage collect promises
-  PromiseInList* next_to_free = nullptr;
+  Promise* next_to_free = nullptr;
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, PromiseInList& x) {
+auto inspect(Inspector& f, Promise& x) {
   // perhaps just use for saving
   return f.object(x).fields(
       f.field("source_location",

--- a/lib/Async/Registry/registry.cpp
+++ b/lib/Async/Registry/registry.cpp
@@ -22,8 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "registry.h"
 
-#include "Assertions/ProdAssert.h"
 #include "Async/Registry/Metrics.h"
+#include "Metrics/Gauge.h"
 
 using namespace arangodb::async_registry;
 
@@ -31,17 +31,19 @@ Registry::Registry() : _metrics{std::make_shared<Metrics>()} {}
 
 auto Registry::add_thread() -> std::shared_ptr<ThreadRegistry> {
   auto guard = std::lock_guard(mutex);
-  auto registry = registries.emplace_back(ThreadRegistry::make(_metrics));
+  auto thread_registry = ThreadRegistry::make(_metrics, this);
+  registries.emplace_back(thread_registry.get());
   if (_metrics->registered_threads != nullptr) {
     _metrics->registered_threads->fetch_add(1);
   }
-  return registry;
+  return thread_registry;
 }
 
-auto Registry::remove_thread(std::shared_ptr<ThreadRegistry> registry) -> void {
+auto Registry::remove_thread(ThreadRegistry* registry) -> void {
   auto guard = std::lock_guard(mutex);
   if (_metrics->registered_threads != nullptr) {
     _metrics->registered_threads->fetch_sub(1);
   }
+  // delete last reference to registry
   std::erase(registries, registry);
 }

--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -61,7 +61,7 @@ struct Registry {
      items stay valid during iteration (i.e. are not deleted in the meantime).
    */
   template<typename F>
-  requires std::invocable<F, PromiseInList*>
+  requires std::invocable<F, Promise*>
   auto for_promise(F&& function) -> void {
     auto regs = [&] {
       auto guard = std::lock_guard(mutex);

--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -52,7 +52,7 @@ struct Registry {
   /**
      Removes a coroutine thread registry from this registry.
    */
-  auto remove_thread(std::shared_ptr<ThreadRegistry> registry) -> void;
+  auto remove_thread(ThreadRegistry* registry) -> void;
 
   /**
      Executes a function on each coroutine in the registry.
@@ -83,7 +83,7 @@ struct Registry {
   }
 
  private:
-  std::vector<std::shared_ptr<ThreadRegistry>> registries;
+  std::vector<ThreadRegistry*> registries;
   std::mutex mutex;
   std::shared_ptr<const Metrics> _metrics;
 };

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -24,14 +24,12 @@
 
 namespace arangodb::async_registry {
 
-Registry coroutine_registry;
+Registry registry;
 
 auto get_thread_registry() noexcept -> ThreadRegistry& {
   struct ThreadRegistryGuard {
-    ThreadRegistryGuard() : _registry{coroutine_registry.add_thread()} {}
-    ~ThreadRegistryGuard() {
-      coroutine_registry.remove_thread(std::move(_registry));
-    }
+    ThreadRegistryGuard() : _registry{registry.add_thread()} {}
+    ~ThreadRegistryGuard() { registry.remove_thread(std::move(_registry)); }
 
     std::shared_ptr<ThreadRegistry> _registry;
   };

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -29,7 +29,11 @@ Registry registry;
 auto get_thread_registry() noexcept -> ThreadRegistry& {
   struct ThreadRegistryGuard {
     ThreadRegistryGuard() : _registry{registry.add_thread()} {}
-    ~ThreadRegistryGuard() { registry.remove_thread(std::move(_registry)); }
+
+    /**
+       Runs when the current thread is deleted
+     */
+    ~ThreadRegistryGuard() {}
 
     std::shared_ptr<ThreadRegistry> _registry;
   };

--- a/lib/Async/Registry/registry_variable.h
+++ b/lib/Async/Registry/registry_variable.h
@@ -30,7 +30,7 @@ namespace arangodb::async_registry {
 /**
    Global variable that holds all coroutines.
  */
-extern Registry coroutine_registry;
+extern Registry registry;
 
 /**
    Get registry of all active coroutine promises on this thread.

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -21,6 +21,8 @@
 /// @author Julia Volmer
 ////////////////////////////////////////////////////////////////////////////////
 #include "thread_registry.h"
+#include <source_location>
+#include <thread>
 
 #include "Assertions/ProdAssert.h"
 #include "Async/Registry/Metrics.h"
@@ -41,7 +43,8 @@ auto ThreadRegistry::make(std::shared_ptr<const Metrics> metrics,
 
 ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics,
                                Registry* registry)
-    : thread_name{ThreadNameFetcher{}.get()},
+    : thread{Thread{.name = std::string{ThreadNameFetcher{}.get()},
+                    .id = std::this_thread::get_id()}},
       registry{registry},
       metrics{metrics} {
   if (metrics->total_threads != nullptr) {
@@ -62,22 +65,20 @@ ThreadRegistry::~ThreadRegistry() noexcept {
   cleanup();
 }
 
-auto ThreadRegistry::add(Promise* promise) noexcept -> void {
-  ADB_PROD_ASSERT(promise != nullptr);
+auto ThreadRegistry::add_promise(std::source_location location) noexcept
+    -> Promise* {
   // promise needs to live on the same thread as this registry
-  ADB_PROD_ASSERT(std::this_thread::get_id() == owning_thread)
+  ADB_PROD_ASSERT(std::this_thread::get_id() == thread.id)
       << "ThreadRegistry::add was called from thread "
       << std::this_thread::get_id()
       << " but needs to be called from ThreadRegistry's owning thread "
-      << owning_thread << ".";
+      << thread.id << ".";
   if (metrics->total_functions != nullptr) {
     metrics->total_functions->count();
   }
   auto current_head = promise_head.load(std::memory_order_relaxed);
-  promise->next = current_head;
-  promise->registry = shared_from_this();
-  promise->thread_name = thread_name;
-  promise->thread_id = owning_thread;
+  auto promise =
+      new Promise{current_head, shared_from_this(), std::move(location)};
   if (current_head != nullptr) {
     current_head->previous = promise;
   }
@@ -86,6 +87,7 @@ auto ThreadRegistry::add(Promise* promise) noexcept -> void {
   if (metrics->active_functions != nullptr) {
     metrics->active_functions->fetch_add(1);
   }
+  return promise;
 }
 
 auto ThreadRegistry::mark_for_deletion(Promise* promise) noexcept -> void {
@@ -110,7 +112,7 @@ auto ThreadRegistry::mark_for_deletion(Promise* promise) noexcept -> void {
 }
 
 auto ThreadRegistry::garbage_collect() noexcept -> void {
-  ADB_PROD_ASSERT(std::this_thread::get_id() == owning_thread);
+  ADB_PROD_ASSERT(std::this_thread::get_id() == thread.id);
   auto guard = std::lock_guard(mutex);
   cleanup();
 }
@@ -126,7 +128,7 @@ auto ThreadRegistry::cleanup() noexcept -> void {
       metrics->ready_for_deletion_functions->fetch_sub(1);
     }
     remove(current);
-    current->destroy();
+    delete current;
   }
 }
 

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -24,23 +24,26 @@
 
 #include "Assertions/ProdAssert.h"
 #include "Async/Registry/Metrics.h"
+#include "Async/Registry/promise.h"
+#include "Async/Registry/registry.h"
 #include "Basics/Thread.h"
 #include "Inspection/Format.h"
-#include "Logger/LogMacros.h"
-#include "Logger/Logger.h"
-#include "Logger/LoggerStream.h"
 #include "Metrics/Counter.h"
 #include "Metrics/Gauge.h"
 
 using namespace arangodb::async_registry;
 
-auto ThreadRegistry::make(std::shared_ptr<const Metrics> metrics)
+auto ThreadRegistry::make(std::shared_ptr<const Metrics> metrics,
+                          Registry* registry)
     -> std::shared_ptr<ThreadRegistry> {
-  return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{metrics});
+  return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{metrics, registry});
 }
 
-ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics)
-    : thread_name{ThreadNameFetcher{}.get()}, metrics{metrics} {
+ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics,
+                               Registry* registry)
+    : thread_name{ThreadNameFetcher{}.get()},
+      registry{registry},
+      metrics{metrics} {
   if (metrics->total_threads != nullptr) {
     metrics->total_threads->count();
   }
@@ -52,6 +55,9 @@ ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics)
 ThreadRegistry::~ThreadRegistry() noexcept {
   if (metrics->running_threads != nullptr) {
     metrics->running_threads->fetch_sub(1);
+  }
+  if (registry != nullptr) {
+    registry->remove_thread(this);
   }
   cleanup();
 }

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -65,7 +65,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can only be called on the owning thread, crashes
      otherwise.
    */
-  auto add(PromiseInList* promise) noexcept -> void;
+  auto add(Promise* promise) noexcept -> void;
 
   /**
      Executes a function on each promise in the registry.
@@ -74,7 +74,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      items stay valid during iteration (i.e. are not deleted in the meantime).
    */
   template<typename F>
-  requires std::invocable<F, PromiseInList*>
+  requires std::invocable<F, Promise*>
   auto for_promise(F&& function) noexcept -> void {
     auto guard = std::lock_guard(mutex);
     // (2) - this load synchronizes with store in (1) and (3)
@@ -90,7 +90,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can be called from any thread. The promise needs to be included in
      the registry list, crashes otherwise.
    */
-  auto mark_for_deletion(PromiseInList* promise) noexcept -> void;
+  auto mark_for_deletion(Promise* promise) noexcept -> void;
 
   /**
      Deletes all promises that are marked for deletion.
@@ -104,8 +104,8 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   const std::string thread_name;
 
  private:
-  std::atomic<PromiseInList*> free_head = nullptr;
-  std::atomic<PromiseInList*> promise_head = nullptr;
+  std::atomic<Promise*> free_head = nullptr;
+  std::atomic<Promise*> promise_head = nullptr;
   std::mutex mutex;
   metrics::GaugeCounterGuard<uint64_t> running_threads;
   std::shared_ptr<const Metrics> metrics;
@@ -120,7 +120,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      (which also means that this function should only be called on the owning
      thread.)
    */
-  auto remove(PromiseInList* promise) -> void;
+  auto remove(Promise* promise) -> void;
 };
 
 template<typename Inspector>

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <source_location>
 #include <thread>
 #include "fmt/format.h"
 #include "fmt/std.h"
@@ -66,7 +67,8 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can only be called on the owning thread, crashes
      otherwise.
    */
-  auto add(Promise* promise) noexcept -> void;
+  auto add_promise(std::source_location location =
+                       std::source_location::current()) noexcept -> Promise*;
 
   /**
      Executes a function on each promise in the registry that is not deleted yet
@@ -101,8 +103,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
    */
   auto garbage_collect() noexcept -> void;
 
-  const std::thread::id owning_thread = std::this_thread::get_id();
-  const std::string thread_name;
+  Thread thread;
 
  private:
   Registry* registry = nullptr;
@@ -123,12 +124,5 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
    */
   auto remove(Promise* promise) -> void;
 };
-
-template<typename Inspector>
-auto inspect(Inspector& f, ThreadRegistry& x) {
-  return f.object(x).fields(
-      f.field("thread_id", fmt::format("{}", x.owning_thread)),
-      f.field("thread_name", x.thread_name));
-}
 
 }  // namespace arangodb::async_registry

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "Async/Registry/promise.h"
-#include "Metrics/GaugeCounterGuard.h"
 
 #include <atomic>
 #include <cstdint>
@@ -57,7 +56,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   static auto make(std::shared_ptr<const Metrics> metrics)
       -> std::shared_ptr<ThreadRegistry>;
 
-  ~ThreadRegistry() noexcept { cleanup(); }
+  ~ThreadRegistry() noexcept;
 
   /**
      Adds a promise on the registry's thread to the registry.
@@ -107,7 +106,6 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   std::atomic<Promise*> free_head = nullptr;
   std::atomic<Promise*> promise_head = nullptr;
   std::mutex mutex;
-  metrics::GaugeCounterGuard<uint64_t> running_threads;
   std::shared_ptr<const Metrics> metrics;
 
   ThreadRegistry(std::shared_ptr<const Metrics> metrics);

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -21,11 +21,10 @@ template<typename T>
 struct async;
 
 template<typename T>
-struct async_promise_base : async_registry::PromiseInList {
+struct async_promise_base : async_registry::Promise {
   using promise_type = async_promise<T>;
 
-  async_promise_base(std::source_location loc)
-      : PromiseInList(std::move(loc)) {}
+  async_promise_base(std::source_location loc) : Promise(std::move(loc)) {}
 
   std::suspend_never initial_suspend() noexcept { return {}; }
   auto final_suspend() noexcept {

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Async/Registry/registry_variable.h"
 #include "Async/Registry/promise.h"
 #include "Async/expected.h"
 #include "Logger/LogMacros.h"
@@ -21,10 +20,11 @@ template<typename T>
 struct async;
 
 template<typename T>
-struct async_promise_base : async_registry::Promise {
+struct async_promise_base : async_registry::AddToAsyncRegistry {
   using promise_type = async_promise<T>;
 
-  async_promise_base(std::source_location loc) : Promise(std::move(loc)) {}
+  async_promise_base(std::source_location loc)
+      : async_registry::AddToAsyncRegistry{std::move(loc)} {}
 
   std::suspend_never initial_suspend() noexcept { return {}; }
   auto final_suspend() noexcept {
@@ -37,7 +37,7 @@ struct async_promise_base : async_registry::Promise {
         if (addr == nullptr) {
           return std::noop_coroutine();
         } else if (addr == self.address()) {
-          _promise->registry->mark_for_deletion(_promise);
+          self.destroy();
           return std::noop_coroutine();
         } else {
           return std::coroutine_handle<>::from_address(addr);
@@ -50,21 +50,8 @@ struct async_promise_base : async_registry::Promise {
   }
   void unhandled_exception() { _value.set_exception(std::current_exception()); }
   auto get_return_object() {
-    async_registry::get_thread_registry().add(this);
     return async<T>{std::coroutine_handle<promise_type>::from_promise(
         *static_cast<promise_type*>(this))};
-  }
-
-  auto destroy() noexcept -> void override {
-    try {
-      std::coroutine_handle<promise_type>::from_promise(
-          *static_cast<promise_type*>(this))
-          .destroy();
-    } catch (std::exception const& ex) {
-      LOG_TOPIC("4b96e", WARN, Logger::CRASH)
-          << "caught exception when destorying coroutine promise: "
-          << ex.what();
-    }
   }
 
   std::atomic<void*> _continuation = nullptr;
@@ -105,7 +92,7 @@ struct async {
       auto await_resume() {
         auto& promise = _handle.promise();
         expected<T> r = std::move(promise._value);
-        promise.registry->mark_for_deletion(&promise);
+        _handle.destroy();
         return std::move(r).get();
       }
       explicit awaitable(std::coroutine_handle<promise_type> handle)
@@ -125,7 +112,7 @@ struct async {
       auto& promise = _handle.promise();
       if (promise._continuation.exchange(
               _handle.address(), std::memory_order_release) != nullptr) {
-        promise.registry->mark_for_deletion(&promise);
+        _handle.destroy();
       }
       _handle = nullptr;
     }

--- a/lib/Basics/FutureSharedLock.h
+++ b/lib/Basics/FutureSharedLock.h
@@ -180,8 +180,7 @@ struct FutureSharedLock {
 
     void unlock() {
       std::lock_guard lock(_mutex);
-      TRI_ASSERT(_lockCount > 0);
-      if (--_lockCount == 0 && !_queue.empty()) {
+      if (_lockCount > 0 && --_lockCount == 0 && !_queue.empty()) {
         // we were the last lock holder -> schedule the next node
         auto& node = _queue.back();
         _lockCount = 1;

--- a/lib/Futures/CMakeLists.txt
+++ b/lib/Futures/CMakeLists.txt
@@ -2,15 +2,14 @@ add_library(arango_futures STATIC
   src/Future.cpp)
 
 target_include_directories(arango_futures
-        PUBLIC
-        ${PROJECT_SOURCE_DIR}/3rdParty/iresearch/external/function2
-        include)
+  PUBLIC
+  ${PROJECT_SOURCE_DIR}/arangod
+  ${PROJECT_SOURCE_DIR}/3rdParty/iresearch/external/function2
+  include)
 
-target_link_libraries(arango_futures PUBLIC arango_inspection)
-target_link_libraries(arango_futures PUBLIC arango_assertions)
-target_link_libraries(arango_futures PUBLIC velocypack)
-
-target_include_directories(arango_futures
-        PUBLIC
-        ${PROJECT_SOURCE_DIR}/arangod
-        include)
+target_link_libraries(arango_futures
+  PUBLIC
+  arango_inspection
+  arango_assertions
+  arango_async_registry
+  velocypack)

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -46,7 +46,9 @@ class Promise {
 
   /// @brief Constructs a Promise with no shared state.
   /// After construction, valid() == true.
-  Promise() : _state(detail::SharedState<T>::make()), _retrieved(false) {}
+  Promise(std::source_location loc = std::source_location::current())
+      : _state(detail::SharedState<T>::make(std::move(loc))),
+        _retrieved(false) {}
 
   Promise(Promise const& o) = delete;
   Promise(Promise<T>&& o) noexcept

--- a/lib/Futures/include/Futures/SharedState.h
+++ b/lib/Futures/include/Futures/SharedState.h
@@ -25,9 +25,11 @@
 
 #include <atomic>
 #include <function2.hpp>
+#include <source_location>
 
 #include "Assertions/Assert.h"
-
+#include "Async/Registry/promise.h"
+#include "Async/Registry/registry_variable.h"
 #include "Futures/Try.h"
 
 namespace arangodb {
@@ -49,7 +51,7 @@ namespace detail {
 ///   |                    ---> OnlyCallback ---                    |
 ///   +-------------------------------------------------------------+
 template<typename T>
-class SharedState {
+class SharedState : async_registry::AddToAsyncRegistry {
   enum class State : uint8_t {
     Start = 1 << 0,
     OnlyResult = 1 << 1,
@@ -78,7 +80,9 @@ class SharedState {
 
  public:
   /// State will be Start
-  static SharedState* make() { return new SharedState(); }
+  static SharedState* make(std::source_location loc) {
+    return new SharedState(std::move(loc));
+  }
 
   /// State will be OnlyResult
   /// Result held will be move-constructed from `t`
@@ -231,19 +235,32 @@ class SharedState {
 
  private:
   /// empty shared state
-  SharedState() : _state(State::Start), _attached(2) {}
+  SharedState(std::source_location loc)
+      : async_registry::AddToAsyncRegistry(std::move(loc)),
+        _state(State::Start),
+        _attached(2) {}
 
   /// use to construct a ready future
   explicit SharedState(Try<T>&& t)
-      : _result(std::move(t)), _state(State::OnlyResult), _attached(1) {}
+      : async_registry::AddToAsyncRegistry(std::source_location::current()),
+        _result(std::move(t)),
+        _state(State::OnlyResult),
+        _attached(1) {
+    // is not added to async thread registry because it is immediately
+    // resolved
+  }
 
   /// use to construct a ready future
   template<typename... Args>
   explicit SharedState(std::in_place_t, Args&&... args) noexcept(
       std::is_nothrow_constructible<T, Args&&...>::value)
-      : _result(std::in_place, std::forward<Args>(args)...),
+      : async_registry::AddToAsyncRegistry(std::source_location::current()),
+        _result(std::in_place, std::forward<Args>(args)...),
         _state(State::OnlyResult),
-        _attached(1) {}
+        _attached(1) {
+    // is not added to async thread registry because it is immediately
+    // resolved
+  }
 
   ~SharedState() {
     TRI_ASSERT(_attached == 0);

--- a/lib/Futures/include/Futures/coro-helper.h
+++ b/lib/Futures/include/Futures/coro-helper.h
@@ -171,7 +171,8 @@ struct std_coro::coroutine_traits<arangodb::futures::Future<T>, Args...> {
   struct promise_type {
     // For some reason, non-maintainer compilation fails with a linker error
     // if these are missing or defaulted.
-    promise_type() {}
+    promise_type(std::source_location loc = std::source_location::current())
+        : promise{std::move(loc)} {}
     ~promise_type() {}
 
     arangodb::futures::Promise<T> promise;

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -381,7 +381,7 @@ TEST(AsyncTest, promises_are_registered) {
     auto coro_baz = baz();
 
     std::vector<std::string> names;
-    arangodb::async_registry::coroutine_registry.for_promise(
+    arangodb::async_registry::registry.for_promise(
         [&](arangodb::async_registry::PromiseInList* promise) {
           names.push_back(promise->_where.function_name());
         });

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -382,7 +382,7 @@ TEST(AsyncTest, promises_are_registered) {
 
     std::vector<std::string> names;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::PromiseInList* promise) {
+        [&](arangodb::async_registry::Promise* promise) {
           names.push_back(promise->_where.function_name());
         });
     EXPECT_EQ(names.size(), 3);

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -1,4 +1,6 @@
 #include "Async/async.h"
+#include "Async/Registry/promise.h"
+#include "Async/Registry/registry_variable.h"
 #include "Async/Registry/registry.h"
 #include "Async/Registry/thread_registry.h"
 
@@ -7,6 +9,13 @@
 #include <deque>
 
 namespace {
+
+auto promise_count(arangodb::async_registry::ThreadRegistry& registry) -> uint {
+  uint promise_count = 0;
+  registry.for_promise(
+      [&](arangodb::async_registry::Promise* promise) { promise_count++; });
+  return promise_count;
+}
 
 struct WaitSlot {
   void resume() {
@@ -139,6 +148,8 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
     arangodb::async_registry::get_thread_registry().garbage_collect();
     wait.stop();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
+    EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()),
+              0);
   }
 
   WaitType wait;
@@ -342,39 +353,38 @@ TYPED_TEST(AsyncTest, multiple_suspension_points) {
   EXPECT_EQ(awaitable.await_resume(), 0);
 }
 
-TYPED_TEST(AsyncTest, promises_are_only_removed_after_garbage_collection) {
+TYPED_TEST(AsyncTest, coroutine_is_removed_before_registry_entry) {
   using ValueType = TypeParam::second_type;
 
   auto coro = []() -> async<ValueType> { co_return 12; };
 
   {
     coro().reset();
-
-    EXPECT_EQ(InstanceCounterValue::instanceCounter, 1);
-    arangodb::async_registry::get_thread_registry().garbage_collect();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
+    EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()),
+              1);
   }
   {
     std::move(coro()).operator co_await().await_resume();
-
-    EXPECT_EQ(InstanceCounterValue::instanceCounter, 1);
-    arangodb::async_registry::get_thread_registry().garbage_collect();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
+    EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()),
+              2);
   }
   {
     { coro(); }
 
-    EXPECT_EQ(InstanceCounterValue::instanceCounter, 1);
-    arangodb::async_registry::get_thread_registry().garbage_collect();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
+    EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()),
+              3);
   }
 }
 
 auto foo() -> async<CopyOnlyValue> { co_return 1; }
 auto bar() -> async<CopyOnlyValue> { co_return 4; }
 auto baz() -> async<CopyOnlyValue> { co_return 2; }
-TEST(AsyncTest, promises_are_registered) {
+TEST(AsyncTest, promises_are_registered_in_global_registry) {
   auto coro_foo = foo();
+  EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()), 1);
 
   std::jthread([&]() {
     auto coro_bar = bar();
@@ -383,18 +393,11 @@ TEST(AsyncTest, promises_are_registered) {
     std::vector<std::string> names;
     arangodb::async_registry::registry.for_promise(
         [&](arangodb::async_registry::Promise* promise) {
-          names.push_back(promise->_where.function_name());
+          names.push_back(promise->entry_point.function_name());
         });
     EXPECT_EQ(names.size(), 3);
     EXPECT_TRUE(names[0].find("foo") != std::string::npos);
     EXPECT_TRUE(names[1].find("baz") != std::string::npos);
     EXPECT_TRUE(names[2].find("bar") != std::string::npos);
-
-    coro_bar.reset();
-    coro_baz.reset();
-    arangodb::async_registry::get_thread_registry().garbage_collect();
-  });
-
-  coro_foo.reset();
-  arangodb::async_registry::get_thread_registry().garbage_collect();
+  }).join();
 }

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -31,10 +31,10 @@ using namespace arangodb::async_registry;
 
 namespace {
 
-struct MyTestPromise : PromiseInList {
+struct MyTestPromise : Promise {
   MyTestPromise(uint64_t id,
                 std::source_location loc = std::source_location::current())
-      : PromiseInList(loc), id{id} {}
+      : Promise(loc), id{id} {}
   auto destroy() noexcept -> void override { destroyed = true; }
   bool destroyed = false;
   uint64_t id;
@@ -42,7 +42,7 @@ struct MyTestPromise : PromiseInList {
 
 auto all_ids(Registry& registry) -> std::vector<uint64_t> {
   std::vector<uint64_t> ids;
-  registry.for_promise([&](PromiseInList* promise) {
+  registry.for_promise([&](Promise* promise) {
     ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
   return ids;

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -24,6 +24,7 @@
 #include "Async/Registry/registry.h"
 
 #include <gtest/gtest.h>
+#include <source_location>
 #include <thread>
 
 using namespace arangodb;
@@ -31,161 +32,120 @@ using namespace arangodb::async_registry;
 
 namespace {
 
-struct MyTestPromise : Promise {
-  MyTestPromise(uint64_t id,
-                std::source_location loc = std::source_location::current())
-      : Promise(loc), id{id} {}
-  auto destroy() noexcept -> void override { destroyed = true; }
-  bool destroyed = false;
-  uint64_t id;
-};
-
-auto all_ids(Registry& registry) -> std::vector<uint64_t> {
-  std::vector<uint64_t> ids;
-  registry.for_promise([&](Promise* promise) {
-    ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
-  });
-  return ids;
+auto promises_in_registry(Registry& registry) -> std::vector<Promise*> {
+  std::vector<Promise*> promises;
+  registry.for_promise([&](Promise* promise) { promises.push_back(promise); });
+  return promises;
 }
 
 }  // namespace
 
-struct CoroutineRegistryTest : ::testing::Test {
-  void SetUp() override {}
+struct AsyncRegistryTest : ::testing::Test {};
 
-  void TearDown() override {}
-};
-
-TEST_F(CoroutineRegistryTest, registers_promise_on_same_thread) {
+TEST_F(AsyncRegistryTest, registers_promise_on_same_thread) {
   Registry registry;
   auto thread_registry = registry.add_thread();
 
-  auto promise = MyTestPromise{1};
-  thread_registry->add(&promise);
+  auto* promise = thread_registry->add_promise();
 
-  EXPECT_EQ(all_ids(registry), std::vector<uint64_t>{1});
+  EXPECT_EQ(promises_in_registry(registry), std::vector<Promise*>{promise});
 
-  thread_registry->mark_for_deletion(&promise);
+  promise->mark_for_deletion();
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry.get());
 }
 
-TEST_F(CoroutineRegistryTest, registers_promise_on_different_threads) {
+TEST_F(AsyncRegistryTest, registers_promise_on_different_threads) {
   Registry registry;
 
   std::thread([&]() {
     auto thread_registry = registry.add_thread();
 
-    auto promise = MyTestPromise{1};
-    thread_registry->add(&promise);
+    auto* promise = thread_registry->add_promise();
 
-    EXPECT_EQ(all_ids(registry), std::vector<uint64_t>{1});
+    EXPECT_EQ(promises_in_registry(registry), std::vector<Promise*>{promise});
 
-    thread_registry->mark_for_deletion(&promise);
+    promise->mark_for_deletion();
     thread_registry->garbage_collect();
-    registry.remove_thread(thread_registry.get());
   }).join();
 }
 
-TEST_F(CoroutineRegistryTest,
+TEST_F(AsyncRegistryTest,
        iterates_over_promises_on_same_thread_in_reverse_order) {
   Registry registry;
   auto thread_registry = registry.add_thread();
-  auto first_promise = MyTestPromise{1};
-  thread_registry->add(&first_promise);
-  auto second_promise = MyTestPromise{2};
-  thread_registry->add(&second_promise);
+  auto* first_promise = thread_registry->add_promise();
+  auto* second_promise = thread_registry->add_promise();
 
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{2, 1}));
+  EXPECT_EQ(promises_in_registry(registry),
+            (std::vector<Promise*>{second_promise, first_promise}));
 
-  thread_registry->mark_for_deletion(&first_promise);
-  thread_registry->mark_for_deletion(&second_promise);
+  first_promise->mark_for_deletion();
+  second_promise->mark_for_deletion();
   thread_registry->garbage_collect();
   registry.remove_thread(thread_registry.get());
 }
 
-TEST_F(CoroutineRegistryTest, iterates_over_promises_on_differen_threads) {
+TEST_F(AsyncRegistryTest, iterates_over_promises_on_differen_threads) {
   Registry registry;
   auto thread_registry = registry.add_thread();
-  auto first_promise = MyTestPromise{1};
-  thread_registry->add(&first_promise);
+  auto* first_promise = thread_registry->add_promise();
 
   std::thread([&]() {
     auto thread_registry = registry.add_thread();
-    auto second_promise = MyTestPromise{2};
-    thread_registry->add(&second_promise);
+    auto* second_promise = thread_registry->add_promise();
 
-    EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{1, 2}));
+    EXPECT_EQ(promises_in_registry(registry),
+              (std::vector<Promise*>{first_promise, second_promise}));
 
-    thread_registry->mark_for_deletion(&second_promise);
+    second_promise->mark_for_deletion();
     thread_registry->garbage_collect();
-    registry.remove_thread(thread_registry.get());
   }).join();
 
-  thread_registry->mark_for_deletion(&first_promise);
+  first_promise->mark_for_deletion();
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry.get());
 }
 
-TEST_F(CoroutineRegistryTest,
+TEST_F(AsyncRegistryTest,
        iteration_after_executed_garbage_collection_is_empty) {
   Registry registry;
   auto thread_registry = registry.add_thread();
-  auto promise = MyTestPromise{1};
-  thread_registry->add(&promise);
 
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{1}));
+  auto* promise = thread_registry->add_promise();
+  EXPECT_EQ(promises_in_registry(registry), (std::vector<Promise*>{promise}));
 
-  thread_registry->mark_for_deletion(&promise);
-
-  EXPECT_FALSE(promise.destroyed);
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{1}));
+  promise->mark_for_deletion();
+  EXPECT_EQ(promises_in_registry(registry), (std::vector<Promise*>{promise}));
 
   thread_registry->garbage_collect();
+  EXPECT_EQ(promises_in_registry(registry), (std::vector<Promise*>{}));
+}
 
-  EXPECT_TRUE(promise.destroyed);
-  EXPECT_EQ(all_ids(registry).size(), 0);
+TEST_F(AsyncRegistryTest, promises_on_removed_thread_are_still_iterated_over) {
+  Registry registry;
+  Promise* promise;
+  {
+    auto thread_registry = registry.add_thread();
+    promise = thread_registry->add_promise();
+  }
+  EXPECT_EQ(promises_in_registry(registry), (std::vector<Promise*>{promise}));
 
-  registry.remove_thread(thread_registry.get());
+  promise->mark_for_deletion();
 }
 
 TEST_F(
-    CoroutineRegistryTest,
-    promises_on_removed_thread_dont_show_in_iteration_but_are_not_destroyed_automatically) {
+    AsyncRegistryTest,
+    different_thread_can_mark_promise_for_deletion_after_thread_already_ended) {
   Registry registry;
   auto thread_registry = registry.add_thread();
-  auto promise = MyTestPromise{1};
-  thread_registry->add(&promise);
+  Promise* promise;
 
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{1}));
+  std::thread([&]() {
+    auto thread_registry_on_different_thread = registry.add_thread();
+    promise = thread_registry_on_different_thread->add_promise(
+        std::source_location::current());
+  }).join();
 
-  registry.remove_thread(thread_registry.get());
+  promise->mark_for_deletion();
 
-  EXPECT_FALSE(promise.destroyed);
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{}));
-
-  thread_registry->mark_for_deletion(&promise);
-  thread_registry->garbage_collect();
-  EXPECT_TRUE(promise.destroyed);
-}
-
-TEST_F(CoroutineRegistryTest,
-       different_thread_deletes_promise_after_thread_already_ended) {
-  auto promise = MyTestPromise{1};
-  {
-    Registry registry;
-    std::shared_ptr<ThreadRegistry> thread_registry_on_different_thread;
-
-    std::thread([&]() {
-      thread_registry_on_different_thread = registry.add_thread();
-      thread_registry_on_different_thread->add(&promise);
-      registry.remove_thread(thread_registry_on_different_thread.get());
-    }).join();
-
-    EXPECT_EQ(all_ids(registry).size(), 0);
-    EXPECT_FALSE(promise.destroyed);
-
-    thread_registry_on_different_thread->mark_for_deletion(&promise);
-  }
-  EXPECT_TRUE(promise.destroyed);
+  EXPECT_EQ(promises_in_registry(registry), (std::vector<Promise*>{}));
 }

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -67,7 +67,7 @@ TEST_F(CoroutineRegistryTest, registers_promise_on_same_thread) {
 
   thread_registry->mark_for_deletion(&promise);
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(CoroutineRegistryTest, registers_promise_on_different_threads) {
@@ -83,7 +83,7 @@ TEST_F(CoroutineRegistryTest, registers_promise_on_different_threads) {
 
     thread_registry->mark_for_deletion(&promise);
     thread_registry->garbage_collect();
-    registry.remove_thread(thread_registry);
+    registry.remove_thread(thread_registry.get());
   }).join();
 }
 
@@ -101,7 +101,7 @@ TEST_F(CoroutineRegistryTest,
   thread_registry->mark_for_deletion(&first_promise);
   thread_registry->mark_for_deletion(&second_promise);
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(CoroutineRegistryTest, iterates_over_promises_on_differen_threads) {
@@ -119,12 +119,12 @@ TEST_F(CoroutineRegistryTest, iterates_over_promises_on_differen_threads) {
 
     thread_registry->mark_for_deletion(&second_promise);
     thread_registry->garbage_collect();
-    registry.remove_thread(thread_registry);
+    registry.remove_thread(thread_registry.get());
   }).join();
 
   thread_registry->mark_for_deletion(&first_promise);
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(CoroutineRegistryTest,
@@ -146,7 +146,7 @@ TEST_F(CoroutineRegistryTest,
   EXPECT_TRUE(promise.destroyed);
   EXPECT_EQ(all_ids(registry).size(), 0);
 
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(
@@ -159,7 +159,7 @@ TEST_F(
 
   EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{1}));
 
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 
   EXPECT_FALSE(promise.destroyed);
   EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{}));
@@ -179,7 +179,7 @@ TEST_F(CoroutineRegistryTest,
     std::thread([&]() {
       thread_registry_on_different_thread = registry.add_thread();
       thread_registry_on_different_thread->add(&promise);
-      registry.remove_thread(thread_registry_on_different_thread);
+      registry.remove_thread(thread_registry_on_different_thread.get());
     }).join();
 
     EXPECT_EQ(all_ids(registry).size(), 0);

--- a/tests/Async/Registry/ThreadRegistryTest.cpp
+++ b/tests/Async/Registry/ThreadRegistryTest.cpp
@@ -33,10 +33,10 @@ using namespace arangodb::async_registry;
 
 namespace {
 
-struct MyTestPromise : PromiseInList {
+struct MyTestPromise : Promise {
   MyTestPromise(uint64_t id,
                 std::source_location loc = std::source_location::current())
-      : PromiseInList(loc), id{id} {}
+      : Promise(loc), id{id} {}
   auto destroy() noexcept -> void override { destroyed = true; }
   bool destroyed = false;
   uint64_t id;
@@ -45,7 +45,7 @@ struct MyTestPromise : PromiseInList {
 auto all_ids(std::shared_ptr<ThreadRegistry> registry)
     -> std::vector<uint64_t> {
   std::vector<uint64_t> ids;
-  registry->for_promise([&](PromiseInList* promise) {
+  registry->for_promise([&](Promise* promise) {
     ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
   return ids;
@@ -88,7 +88,7 @@ TEST_F(CoroutineThreadRegistryTest, iterates_over_all_promises) {
   registry->add(&second_promise);
   registry->add(&third_promise);
   std::vector<uint64_t> promise_ids;
-  registry->for_promise([&](PromiseInList* promise) {
+  registry->for_promise([&](Promise* promise) {
     promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
   EXPECT_EQ(promise_ids,
@@ -114,7 +114,7 @@ TEST_F(CoroutineThreadRegistryTest,
 
   std::thread([&]() {
     std::vector<uint64_t> promise_ids;
-    registry->for_promise([&](PromiseInList* promise) {
+    registry->for_promise([&](Promise* promise) {
       promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
     });
     EXPECT_EQ(promise_ids,

--- a/tests/Async/Registry/ThreadRegistryTest.cpp
+++ b/tests/Async/Registry/ThreadRegistryTest.cpp
@@ -33,252 +33,192 @@ using namespace arangodb::async_registry;
 
 namespace {
 
-struct MyTestPromise : Promise {
-  MyTestPromise(uint64_t id,
-                std::source_location loc = std::source_location::current())
-      : Promise(loc), id{id} {}
-  auto destroy() noexcept -> void override { destroyed = true; }
-  bool destroyed = false;
-  uint64_t id;
-};
-
-auto all_ids(std::shared_ptr<ThreadRegistry> registry)
-    -> std::vector<uint64_t> {
-  std::vector<uint64_t> ids;
-  registry->for_promise([&](Promise* promise) {
-    ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
-  });
-  return ids;
+auto promises_in_registry(std::shared_ptr<ThreadRegistry> registry)
+    -> std::vector<Promise*> {
+  std::vector<Promise*> promises;
+  registry->for_promise([&](Promise* promise) { promises.push_back(promise); });
+  return promises;
 }
+
 }  // namespace
 
-struct CoroutineThreadRegistryTest : ::testing::Test {};
-using CoroutineThreadRegistryDeathTest = CoroutineThreadRegistryTest;
+struct AsyncThreadRegistryTest : ::testing::Test {};
+using AsyncThreadRegistryDeathTest = AsyncThreadRegistryTest;
 
-TEST_F(CoroutineThreadRegistryTest, adds_a_promise) {
-  auto promise = MyTestPromise{1};
+TEST_F(AsyncThreadRegistryTest, adds_a_promise) {
   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
 
-  registry->add(&promise);
-  EXPECT_EQ(all_ids(registry), std::vector<uint64_t>{promise.id});
+  auto* promise_in = registry->add_promise();
+
+  EXPECT_EQ(promises_in_registry(registry),
+            (std::vector<Promise*>{promise_in}));
 
   // make sure registry is cleaned up
-  registry->mark_for_deletion(&promise);
+  promise_in->mark_for_deletion();
 }
 
-// TEST_F(CoroutineThreadRegistryDeathTest, another_thread_cannot_add_a_promise)
-// {
+// TEST_F(AsyncThreadRegistryDeathTest, another_thread_cannot_add_a_promise) {
 //   GTEST_FLAG_SET(death_test_style, "threadsafe");
 //   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
 
 //   std::jthread([&]() {
-//     auto promise = MyTestPromise{1};
-
-//     EXPECT_DEATH(registry->add(&promise), "Assertion failed");
+//     EXPECT_DEATH(registry->add_promise(),
+//                  "Assertion failed");
 //   });
 // }
 
-TEST_F(CoroutineThreadRegistryTest, iterates_over_all_promises) {
-  auto first_promise = MyTestPromise{1};
-  auto second_promise = MyTestPromise{2};
-  auto third_promise = MyTestPromise{3};
+TEST_F(AsyncThreadRegistryTest, iterates_over_all_promises) {
   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
 
-  registry->add(&first_promise);
-  registry->add(&second_promise);
-  registry->add(&third_promise);
-  std::vector<uint64_t> promise_ids;
-  registry->for_promise([&](Promise* promise) {
-    promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
-  });
-  EXPECT_EQ(promise_ids,
-            (std::vector<uint64_t>{third_promise.id, second_promise.id,
-                                   first_promise.id}));
+  auto* first_promise = registry->add_promise();
+  auto* second_promise = registry->add_promise();
+  auto* third_promise = registry->add_promise();
+
+  EXPECT_EQ(
+      promises_in_registry(registry),
+      (std::vector<Promise*>{third_promise, second_promise, first_promise}));
 
   // make sure registry is cleaned up
-  registry->mark_for_deletion(&first_promise);
-  registry->mark_for_deletion(&second_promise);
-  registry->mark_for_deletion(&third_promise);
+  first_promise->mark_for_deletion();
+  second_promise->mark_for_deletion();
+  third_promise->mark_for_deletion();
 }
 
-TEST_F(CoroutineThreadRegistryTest,
-       iterates_in_another_thread_over_all_promises) {
-  auto first_promise = MyTestPromise{1};
-  auto second_promise = MyTestPromise{2};
-  auto third_promise = MyTestPromise{3};
+TEST_F(AsyncThreadRegistryTest, iterates_in_another_thread_over_all_promises) {
   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
 
-  registry->add(&first_promise);
-  registry->add(&second_promise);
-  registry->add(&third_promise);
+  auto* first_promise = registry->add_promise();
+  auto* second_promise = registry->add_promise();
+  auto* third_promise = registry->add_promise();
 
   std::thread([&]() {
-    std::vector<uint64_t> promise_ids;
-    registry->for_promise([&](Promise* promise) {
-      promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
-    });
-    EXPECT_EQ(promise_ids,
-              (std::vector<uint64_t>{third_promise.id, second_promise.id,
-                                     first_promise.id}));
+    EXPECT_EQ(
+        promises_in_registry(registry),
+        (std::vector<Promise*>{third_promise, second_promise, first_promise}));
   }).join();
 
   // make sure registry is cleaned up
-  registry->mark_for_deletion(&first_promise);
-  registry->mark_for_deletion(&second_promise);
-  registry->mark_for_deletion(&third_promise);
+  first_promise->mark_for_deletion();
+  second_promise->mark_for_deletion();
+  third_promise->mark_for_deletion();
 }
 
-TEST_F(CoroutineThreadRegistryTest,
+TEST_F(AsyncThreadRegistryTest,
        marked_promises_are_deleted_in_garbage_collection) {
-  auto promise_to_delete = MyTestPromise{1};
-  auto another_promise = MyTestPromise{2};
   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
+  auto* promise_to_delete = registry->add_promise();
+  auto* another_promise = registry->add_promise();
 
-  registry->add(&promise_to_delete);
-  registry->add(&another_promise);
-  registry->mark_for_deletion(&promise_to_delete);
-  EXPECT_FALSE(promise_to_delete.destroyed);
-  EXPECT_EQ(all_ids(registry),
-            (std::vector<uint64_t>{another_promise.id, promise_to_delete.id}));
+  promise_to_delete->mark_for_deletion();
+  EXPECT_EQ(promises_in_registry(registry),
+            (std::vector<Promise*>{another_promise, promise_to_delete}));
 
   registry->garbage_collect();
-  EXPECT_TRUE(promise_to_delete.destroyed);
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{another_promise.id}));
+  EXPECT_EQ(promises_in_registry(registry),
+            (std::vector<Promise*>{another_promise}));
 
   // make sure registry is cleaned up
-  registry->mark_for_deletion(&another_promise);
+  another_promise->mark_for_deletion();
 }
 
-TEST_F(CoroutineThreadRegistryTest, garbage_collection_runs_on_destruction) {
-  auto promise = MyTestPromise{1};
+TEST_F(AsyncThreadRegistryTest, garbage_collection_deletes_marked_promises) {
   {
     auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
-    registry->add(&promise);
-    registry->mark_for_deletion(&promise);
-  }
-  EXPECT_TRUE(promise.destroyed);
-}
+    auto* first_promise = registry->add_promise();
+    auto* second_promise = registry->add_promise();
+    auto* third_promise = registry->add_promise();
 
-TEST_F(CoroutineThreadRegistryTest,
-       garbage_collection_deletes_marked_promises) {
-  {
-    auto first_promise = MyTestPromise{1};
-    auto second_promise = MyTestPromise{2};
-    auto third_promise = MyTestPromise{3};
-    auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
-
-    registry->add(&first_promise);
-    registry->add(&second_promise);
-    registry->add(&third_promise);
-    EXPECT_EQ(all_ids(registry),
-              (std::vector<uint64_t>{third_promise.id, second_promise.id,
-                                     first_promise.id}));
-
-    registry->mark_for_deletion(&first_promise);
+    first_promise->mark_for_deletion();
     registry->garbage_collect();
-    EXPECT_EQ(all_ids(registry),
-              (std::vector<uint64_t>{third_promise.id, second_promise.id}));
+
+    EXPECT_EQ(promises_in_registry(registry),
+              (std::vector<Promise*>{third_promise, second_promise}));
 
     // clean up
-    registry->mark_for_deletion(&second_promise);
-    registry->mark_for_deletion(&third_promise);
+    second_promise->mark_for_deletion();
+    third_promise->mark_for_deletion();
   }
   {
-    auto first_promise = MyTestPromise{1};
-    auto second_promise = MyTestPromise{2};
-    auto third_promise = MyTestPromise{3};
     auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
+    auto* first_promise = registry->add_promise();
+    auto* second_promise = registry->add_promise();
+    auto* third_promise = registry->add_promise();
 
-    registry->add(&first_promise);
-    registry->add(&second_promise);
-    registry->add(&third_promise);
-    EXPECT_EQ(all_ids(registry),
-              (std::vector<uint64_t>{third_promise.id, second_promise.id,
-                                     first_promise.id}));
-
-    registry->mark_for_deletion(&second_promise);
+    second_promise->mark_for_deletion();
     registry->garbage_collect();
-    EXPECT_EQ(all_ids(registry),
-              (std::vector<uint64_t>{third_promise.id, first_promise.id}));
+
+    EXPECT_EQ(promises_in_registry(registry),
+              (std::vector<Promise*>{third_promise, first_promise}));
 
     // clean up
-    registry->mark_for_deletion(&first_promise);
-    registry->mark_for_deletion(&third_promise);
+    first_promise->mark_for_deletion();
+    third_promise->mark_for_deletion();
   }
   {
-    auto first_promise = MyTestPromise{1};
-    auto second_promise = MyTestPromise{2};
-    auto third_promise = MyTestPromise{3};
     auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
+    auto* first_promise = registry->add_promise();
+    auto* second_promise = registry->add_promise();
+    auto* third_promise = registry->add_promise();
 
-    registry->add(&first_promise);
-    registry->add(&second_promise);
-    registry->add(&third_promise);
-    EXPECT_EQ(all_ids(registry),
-              (std::vector<uint64_t>{third_promise.id, second_promise.id,
-                                     first_promise.id}));
-
-    registry->mark_for_deletion(&third_promise);
+    third_promise->mark_for_deletion();
     registry->garbage_collect();
-    EXPECT_EQ(all_ids(registry),
-              (std::vector<uint64_t>{second_promise.id, first_promise.id}));
+
+    EXPECT_EQ(promises_in_registry(registry),
+              (std::vector<Promise*>{second_promise, first_promise}));
 
     // clean up
-    registry->mark_for_deletion(&first_promise);
-    registry->mark_for_deletion(&second_promise);
+    first_promise->mark_for_deletion();
+    second_promise->mark_for_deletion();
   }
 }
 
-// TEST_F(CoroutineThreadRegistryDeathTest,
+// TEST_F(AsyncThreadRegistryDeathTest,
 //        unrelated_promise_cannot_be_marked_for_deletion) {
 //   GTEST_FLAG_SET(death_test_style, "threadsafe");
-
-//   auto promise = MyTestPromise{1};
 //   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
+//   auto some_other_registry =
+//   ThreadRegistry::make(std::make_shared<Metrics>());
 
-//   EXPECT_DEATH(registry->mark_for_deletion(&promise), "Assertion failed");
+//   auto* promise =
+//       some_other_registry->add_promise();
+
+//   EXPECT_DEATH(registry->mark_for_deletion(promise), "Assertion failed");
 // }
 
-TEST_F(CoroutineThreadRegistryTest,
+TEST_F(AsyncThreadRegistryTest,
        another_thread_can_mark_a_promise_for_deletion) {
-  auto promise_to_delete = MyTestPromise{1};
-  auto another_promise = MyTestPromise{2};
   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
 
-  registry->add(&promise_to_delete);
-  registry->add(&another_promise);
+  auto* promise_to_delete = registry->add_promise();
+  auto* another_promise = registry->add_promise();
 
-  std::thread([&]() {
-    registry->mark_for_deletion(&promise_to_delete);
-  }).join();
+  std::thread([&]() { promise_to_delete->mark_for_deletion(); }).join();
 
   registry->garbage_collect();
-  EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{another_promise.id}));
+  EXPECT_EQ(promises_in_registry(registry),
+            (std::vector<Promise*>{another_promise}));
 
   // clean up
-  registry->mark_for_deletion(&another_promise);
-  registry->garbage_collect();
+  another_promise->mark_for_deletion();
 }
 
-// TEST_F(CoroutineThreadRegistryDeathTest,
+// TEST_F(AsyncThreadRegistryDeathTest,
 //        garbage_collection_for_last_promises_can_be_called_on_different_thread)
 //        {
-//   GTEST_FLAG_SET(death_test_style, "threadsafe");
-
 //   {
 //     auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
 
-//     std::jthread([&] { registry->garbage_collect(); });
+//     std::jthread(
+//         [&] { EXPECT_DEATH(registry->garbage_collect(), "Assertion failed");
+//         });
 //   }
 // }
 
-// TEST_F(CoroutineThreadRegistryDeathTest,
+// TEST_F(AsyncThreadRegistryDeathTest,
 //        garbage_collection_cannot_be_called_on_different_thread) {
 //   GTEST_FLAG_SET(death_test_style, "threadsafe");
 
 //   auto registry = ThreadRegistry::make(std::make_shared<Metrics>());
-//   auto promise = MyTestPromise{1};
-//   registry->add(&promise);
 
 //   std::jthread(
 //       [&] { EXPECT_DEATH(registry->garbage_collect(), "Assertion failed");


### PR DESCRIPTION
With this PR, the async registry includes not only async coroutines (which are at this point still very rarely used in our codebase), but also futures.
Futures that are directly resolved are not added to the registry, the future itself is responsible for its garbage collection as before. All not directly resolved futures are added to the registry and the thread is responsible for its garbage collection.

A REST handler with route `/_api/async_registry` is added that gives all currently not yet garbage collected async function that the async registry includes (including the source location and the thread where it was called from). This handler and the previously added metrics help not only to understand better what is currently going on in arangodb, but also help to debug memory leaks, i.e. on which threads the registry garbage collection was not called.