### PR TITLE
set size of cluster machine to medium

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -405,7 +405,7 @@ class instance {
         'agency.my-address': this.protocol + '://127.0.0.1:' + this.port,
         // Sometimes for unknown reason the agency startup is too slow.
         // With this log level we might have a chance to see what is going on.
-        'log.level': "agency=info",
+        'log.level': ["agency=info", "startup=trace"],
       });
       if (!this.args.hasOwnProperty("agency.supervision-grace-period")) {
         this.args['agency.supervision-grace-period'] = '10.0';

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -405,7 +405,7 @@ class instance {
         'agency.my-address': this.protocol + '://127.0.0.1:' + this.port,
         // Sometimes for unknown reason the agency startup is too slow.
         // With this log level we might have a chance to see what is going on.
-        'log.level': ["agency=info", "startup=trace"],
+        'log.level': "agency=info",
       });
       if (!this.args.hasOwnProperty("agency.supervision-grace-period")) {
         this.args['agency.supervision-grace-period'] = '10.0';

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -29,7 +29,7 @@ endpoints priority=250 single -- --skipEndpointsIpv6 true
 
 recovery priority=2000 buckets=8 parallelity=3 size=small single
 # cluster
-recovery_cluster priority=2000 size=small cluster buckets=8 --
+recovery_cluster priority=2000 size=medium cluster buckets=8 --
 
 recovery_server priority=2000 buckets=3 parallelity=3 size=small single
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -29,7 +29,7 @@ endpoints priority=250 single -- --skipEndpointsIpv6 true
 
 recovery priority=2000 buckets=8 parallelity=3 size=small single
 # cluster
-recovery_cluster priority=2000 size=medium cluster buckets=8 --
+recovery_cluster priority=2000 cluster buckets=8 --
 
 recovery_server priority=2000 buckets=3 parallelity=3 size=small single
 


### PR DESCRIPTION
### Scope & Purpose

default for clusters is medium. we need this size here as well hence delete the desperate choice of small. 