### PR TITLE
Fix unstable tests around force-one-shard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Adjust documentation and testing of --cluster.force-one-shard option to 
+  reality.
+
 * Rebuilt included rclone v1.62.2 with go1.22.6 and non-vulnerable dependencies.
 
 * Update ArangoDB Starter to v0.19.5.

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -326,6 +326,7 @@ Coordinators.)");
                   arangodb::options::makeFlags(
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnCoordinator,
+                      arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::Enterprise))
       .setLongDescription(R"(If set to `true`, forces the cluster into creating
 all future collections with only a single shard and using the same DB-Server as
@@ -333,8 +334,7 @@ as these collections' shards leader. All collections created this way are
 eligible for specific AQL query optimizations that can improve query performance
 and provide advanced transactional guarantees.
 
-**Warning**: If you use multiple Coordinators, use the same value on all
-Coordinators.)");
+**Warning**: Use the same value on all Coordinators and all DBServers!)");
 
   options->addOption(
       "--cluster.create-waits-for-sync-replication",


### PR DESCRIPTION
This stabilizes some tests around the --cluster.force-one-shard option.

The reality is that the option has to be set the same on all dbservers 
and coordinators, since it is random which of the servers initializes
the agency and thus whose setting takes effect. This PR documents this
properly and the accompanying enterprise PR
  https://github.com/arangodb/enterprise/pull/1511
fixes the tests.

- Adjust documentation of force-one-shard option.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
- [*] :book: CHANGELOG entry made
- [*] :books: documentation written (release notes, API changes, ...)

#### Related Information

- [*] Enterprise PR: https://github.com/arangodb/enterprise/pull/1511
