### PR TITLE
Fix circleci setup w.r.t. circleci branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,9 @@ jobs:
           name: Determine enterprise branch
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            if ["<< pipeline.parameters.enterprise-branch >>" == ""]; then
+            ENTERPRISE_BRANCH=<< pipeline.parameters.enterprise-branch >>
+            echo "Found setting for ENTERPRISE_BRANCH: $ENTERPRISE_BRANCH"
+            if test -z "$ENTERPRISE_BRANCH" ; then
               set +e
               git ls-remote --exit-code --heads git@github.com:arangodb/enterprise.git "$CIRCLE_BRANCH"
               if [ "$?" == "0" ] ; then
@@ -167,8 +169,7 @@ jobs:
                 ENTERPRISE_BRANCH=devel
               fi
               set -e
-            else
-              ENTERPRISE_BRANCH=<< pipeline.parameters.enterprise-branch >>
+              echo "Actually using this for ENTERPRISE_BRANCH: $ENTERPRISE_BRANCH"
             fi
             ENTERPRISE_COMMIT=`git ls-remote --heads git@github.com:arangodb/enterprise.git $ENTERPRISE_BRANCH | cut -f1`
             echo "Using enterprise branch $ENTERPRISE_BRANCH (sha $ENTERPRISE_COMMIT)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           name: Determine enterprise branch
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            if ["" == ""]; then
+            if ["<< pipeline.parameters.enterprise-branch >>" == ""]; then
               set +e
               git ls-remote --exit-code --heads git@github.com:arangodb/enterprise.git "$CIRCLE_BRANCH"
               if [ "$?" == "0" ] ; then
@@ -168,7 +168,7 @@ jobs:
               fi
               set -e
             else
-              ENTERPRISE_BRANCH=
+              ENTERPRISE_BRANCH=<< pipeline.parameters.enterprise-branch >>
             fi
             ENTERPRISE_COMMIT=`git ls-remote --heads git@github.com:arangodb/enterprise.git $ENTERPRISE_BRANCH | cut -f1`
             echo "Using enterprise branch $ENTERPRISE_BRANCH (sha $ENTERPRISE_COMMIT)"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix circleci setup w.r.t. enterprise branch.
+
 * Adjust documentation and testing of --cluster.force-one-shard option to 
   reality.
 


### PR DESCRIPTION
### Scope & Purpose

This fixes a problem with the enterprise branch in the circleci setup,
which was accidentally introduced in 928c642590ec

Some template replacement strings were lost in translation. The effect
was that a user specified enterprise-branch setting was not always
picked up correctly. Actually, if an enterprise branch with the same
name as the community branch name existed, an explicit setting for
enterprise branch for circleci was ignored by this bug.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

