### PR TITLE
Bugfix: Enable async tests

### DIFF
--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -21,7 +21,7 @@ struct Registry {
    */
   auto add_thread() -> std::shared_ptr<ThreadRegistry> {
     auto guard = std::lock_guard(mutex);
-    registries.push_back(std::make_shared<ThreadRegistry>());
+    registries.push_back(ThreadRegistry::make());
     return registries.back();
   }
 

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -23,9 +23,7 @@ namespace arangodb::async_registry {
    This registry destroys itself when its ref counter is decremented to 0.
  */
 struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
-  static auto make() -> std::shared_ptr<ThreadRegistry> {
-    return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{});
-  }
+  static auto make() -> std::shared_ptr<ThreadRegistry> { return {}; }
 
   ~ThreadRegistry() noexcept { garbage_collect(); }
 

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -23,7 +23,9 @@ namespace arangodb::async_registry {
    This registry destroys itself when its ref counter is decremented to 0.
  */
 struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
-  static auto make() -> std::shared_ptr<ThreadRegistry> { return {}; }
+  static auto make() -> std::shared_ptr<ThreadRegistry> {
+    return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{});
+  }
 
   ~ThreadRegistry() noexcept { garbage_collect(); }
 

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -23,7 +23,9 @@ namespace arangodb::async_registry {
    This registry destroys itself when its ref counter is decremented to 0.
  */
 struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
-  ThreadRegistry() = default;
+  static auto make() -> std::shared_ptr<ThreadRegistry> {
+    return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{});
+  }
 
   ~ThreadRegistry() noexcept { garbage_collect(); }
 
@@ -109,6 +111,8 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   std::atomic<PromiseInList*> free_head = nullptr;
   std::atomic<PromiseInList*> promise_head = nullptr;
   std::mutex mutex;
+
+  ThreadRegistry() = default;
 
   /**
      Removes the promise from the registry.

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -72,7 +72,7 @@ struct ConcurrentNoWait {
             }
             handle.resume();
           }
-          arangodb::coroutine::get_thread_registry().garbage_collect();
+          arangodb::async_registry::get_thread_registry().garbage_collect();
         }) {}
 
   auto stop() -> void {
@@ -136,7 +136,7 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
   void SetUp() override { InstanceCounterValue::instanceCounter = 0; }
 
   void TearDown() override {
-    arangodb::coroutine::get_thread_registry().garbage_collect();
+    arangodb::async_registry::get_thread_registry().garbage_collect();
     wait.stop();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
   }

--- a/tests/Async/CMakeLists.txt
+++ b/tests/Async/CMakeLists.txt
@@ -2,3 +2,5 @@ target_sources(arangodbtests
   PRIVATE
   AsyncTest.cpp
   ExpectedTest.cpp)
+
+add_subdirectory(Registry)

--- a/tests/Async/ExpectedTest.cpp
+++ b/tests/Async/ExpectedTest.cpp
@@ -1,4 +1,4 @@
-#include "Basics/expected.h"
+#include "Async/expected.h"
 #include <gtest/gtest.h>
 
 namespace {

--- a/tests/Async/Registry/ThreadRegistryTest.cpp
+++ b/tests/Async/Registry/ThreadRegistryTest.cpp
@@ -19,7 +19,8 @@ struct MyTestPromise : PromiseInList {
   uint64_t id;
 };
 
-auto all_ids(ThreadRegistry* registry) -> std::vector<uint64_t> {
+auto all_ids(std::shared_ptr<ThreadRegistry> registry)
+    -> std::vector<uint64_t> {
   std::vector<uint64_t> ids;
   registry->for_promise([&](PromiseInList* promise) {
     ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
@@ -32,11 +33,10 @@ struct CoroutineThreadRegistryTest : ::testing::Test {};
 using CoroutineThreadRegistryDeathTest = CoroutineThreadRegistryTest;
 
 TEST_F(CoroutineThreadRegistryTest, adds_a_promise) {
+  auto promise = MyTestPromise{1};
   auto registry = ThreadRegistry::make();
 
-  auto promise = MyTestPromise{1};
   registry->add(&promise);
-
   EXPECT_EQ(all_ids(registry), std::vector<uint64_t>{promise.id});
 
   // make sure registry is cleaned up
@@ -56,19 +56,18 @@ TEST_F(CoroutineThreadRegistryTest, adds_a_promise) {
 // }
 
 TEST_F(CoroutineThreadRegistryTest, iterates_over_all_promises) {
-  auto registry = ThreadRegistry::make();
   auto first_promise = MyTestPromise{1};
-  registry->add(&first_promise);
   auto second_promise = MyTestPromise{2};
-  registry->add(&second_promise);
   auto third_promise = MyTestPromise{3};
-  registry->add(&third_promise);
+  auto registry = ThreadRegistry::make();
 
+  registry->add(&first_promise);
+  registry->add(&second_promise);
+  registry->add(&third_promise);
   std::vector<uint64_t> promise_ids;
   registry->for_promise([&](PromiseInList* promise) {
     promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
-
   EXPECT_EQ(promise_ids,
             (std::vector<uint64_t>{third_promise.id, second_promise.id,
                                    first_promise.id}));
@@ -81,15 +80,16 @@ TEST_F(CoroutineThreadRegistryTest, iterates_over_all_promises) {
 
 TEST_F(CoroutineThreadRegistryTest,
        iterates_in_another_thread_over_all_promises) {
-  auto registry = ThreadRegistry::make();
   auto first_promise = MyTestPromise{1};
-  registry->add(&first_promise);
   auto second_promise = MyTestPromise{2};
-  registry->add(&second_promise);
   auto third_promise = MyTestPromise{3};
+  auto registry = ThreadRegistry::make();
+
+  registry->add(&first_promise);
+  registry->add(&second_promise);
   registry->add(&third_promise);
 
-  std::jthread([&]() {
+  std::thread([&]() {
     std::vector<uint64_t> promise_ids;
     registry->for_promise([&](PromiseInList* promise) {
       promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
@@ -97,7 +97,7 @@ TEST_F(CoroutineThreadRegistryTest,
     EXPECT_EQ(promise_ids,
               (std::vector<uint64_t>{third_promise.id, second_promise.id,
                                      first_promise.id}));
-  });
+  }).join();
 
   // make sure registry is cleaned up
   registry->mark_for_deletion(&first_promise);
@@ -107,14 +107,13 @@ TEST_F(CoroutineThreadRegistryTest,
 
 TEST_F(CoroutineThreadRegistryTest,
        marked_promises_are_deleted_in_garbage_collection) {
-  auto registry = ThreadRegistry::make();
   auto promise_to_delete = MyTestPromise{1};
-  registry->add(&promise_to_delete);
   auto another_promise = MyTestPromise{2};
+  auto registry = ThreadRegistry::make();
+
+  registry->add(&promise_to_delete);
   registry->add(&another_promise);
-
   registry->mark_for_deletion(&promise_to_delete);
-
   EXPECT_FALSE(promise_to_delete.destroyed);
   EXPECT_EQ(all_ids(registry),
             (std::vector<uint64_t>{another_promise.id, promise_to_delete.id}));
@@ -127,28 +126,26 @@ TEST_F(CoroutineThreadRegistryTest,
   registry->mark_for_deletion(&another_promise);
 }
 
-TEST_F(CoroutineThreadRegistryTest,
-       last_marked_promise_runs_garbage_collection_and_deletes_registry) {
-  auto registry = ThreadRegistry::make();
+TEST_F(CoroutineThreadRegistryTest, garbage_collection_runs_on_destruction) {
   auto promise = MyTestPromise{1};
-  registry->add(&promise);
-
-  registry->mark_for_deletion(&promise);
-
+  {
+    auto registry = ThreadRegistry::make();
+    registry->add(&promise);
+    registry->mark_for_deletion(&promise);
+  }
   EXPECT_TRUE(promise.destroyed);
-
-  // now registry is deleted
 }
 
 TEST_F(CoroutineThreadRegistryTest,
        garbage_collection_deletes_marked_promises) {
   {
-    auto registry = ThreadRegistry::make();
     auto first_promise = MyTestPromise{1};
-    registry->add(&first_promise);
     auto second_promise = MyTestPromise{2};
-    registry->add(&second_promise);
     auto third_promise = MyTestPromise{3};
+    auto registry = ThreadRegistry::make();
+
+    registry->add(&first_promise);
+    registry->add(&second_promise);
     registry->add(&third_promise);
     EXPECT_EQ(all_ids(registry),
               (std::vector<uint64_t>{third_promise.id, second_promise.id,
@@ -156,7 +153,6 @@ TEST_F(CoroutineThreadRegistryTest,
 
     registry->mark_for_deletion(&first_promise);
     registry->garbage_collect();
-
     EXPECT_EQ(all_ids(registry),
               (std::vector<uint64_t>{third_promise.id, second_promise.id}));
 
@@ -165,12 +161,13 @@ TEST_F(CoroutineThreadRegistryTest,
     registry->mark_for_deletion(&third_promise);
   }
   {
-    auto registry = ThreadRegistry::make();
     auto first_promise = MyTestPromise{1};
-    registry->add(&first_promise);
     auto second_promise = MyTestPromise{2};
-    registry->add(&second_promise);
     auto third_promise = MyTestPromise{3};
+    auto registry = ThreadRegistry::make();
+
+    registry->add(&first_promise);
+    registry->add(&second_promise);
     registry->add(&third_promise);
     EXPECT_EQ(all_ids(registry),
               (std::vector<uint64_t>{third_promise.id, second_promise.id,
@@ -178,7 +175,6 @@ TEST_F(CoroutineThreadRegistryTest,
 
     registry->mark_for_deletion(&second_promise);
     registry->garbage_collect();
-
     EXPECT_EQ(all_ids(registry),
               (std::vector<uint64_t>{third_promise.id, first_promise.id}));
 
@@ -187,12 +183,13 @@ TEST_F(CoroutineThreadRegistryTest,
     registry->mark_for_deletion(&third_promise);
   }
   {
-    auto registry = ThreadRegistry::make();
     auto first_promise = MyTestPromise{1};
-    registry->add(&first_promise);
     auto second_promise = MyTestPromise{2};
-    registry->add(&second_promise);
     auto third_promise = MyTestPromise{3};
+    auto registry = ThreadRegistry::make();
+
+    registry->add(&first_promise);
+    registry->add(&second_promise);
     registry->add(&third_promise);
     EXPECT_EQ(all_ids(registry),
               (std::vector<uint64_t>{third_promise.id, second_promise.id,
@@ -200,7 +197,6 @@ TEST_F(CoroutineThreadRegistryTest,
 
     registry->mark_for_deletion(&third_promise);
     registry->garbage_collect();
-
     EXPECT_EQ(all_ids(registry),
               (std::vector<uint64_t>{second_promise.id, first_promise.id}));
 
@@ -214,29 +210,31 @@ TEST_F(CoroutineThreadRegistryTest,
 //        unrelated_promise_cannot_be_marked_for_deletion) {
 //   GTEST_FLAG_SET(death_test_style, "threadsafe");
 
-//   auto registry = ThreadRegistry::make();
 //   auto promise = MyTestPromise{1};
+//   auto registry = ThreadRegistry::make();
 
 //   EXPECT_DEATH(registry->mark_for_deletion(&promise), "Assertion failed");
 // }
 
 TEST_F(CoroutineThreadRegistryTest,
        another_thread_can_mark_a_promise_for_deletion) {
-  auto registry = ThreadRegistry::make();
   auto promise_to_delete = MyTestPromise{1};
-  registry->add(&promise_to_delete);
   auto another_promise = MyTestPromise{2};
+  auto registry = ThreadRegistry::make();
+
+  registry->add(&promise_to_delete);
   registry->add(&another_promise);
 
-  std::jthread([&]() {
+  std::thread([&]() {
     registry->mark_for_deletion(&promise_to_delete);
   }).join();
-  registry->garbage_collect();
 
+  registry->garbage_collect();
   EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{another_promise.id}));
 
   // clean up
   registry->mark_for_deletion(&another_promise);
+  registry->garbage_collect();
 }
 
 // TEST_F(CoroutineThreadRegistryDeathTest,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -413,5 +413,6 @@ foreach(ELEMENT ${IRESEARCH_LIB_RESOURCES})
 endforeach()
 
 add_subdirectory(Actor)
+add_subdirectory(Async)
 add_subdirectory(sepp)
 add_subdirectory(VocBase/Properties)


### PR DESCRIPTION
Enables the execution of the async tests in arangodbtests. They were not executed before because of a missing cmake subdirectory command.
The test included some small errors which were not seen because they did not run, these are fixed now.