### PR TITLE
IO uring rocksdb file descript leak bug fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+3.12.2-1 (XXXX-XX-XX)
+---------------------
+
+* Fix bug in upstream rocksdb to not leak file descriptors when iouring 
+  is used for RocksDB.
+
+
 3.12.2 (2024-08-21)
 -------------------
 


### PR DESCRIPTION
This fixes a file descriptor leak bug in the rocksdb library we use.

- Move subproject commit for 3rdParty rocksdb.
- CHANGELOG.

Original PR for devel: https://github.com/arangodb/arangodb/pull/21273

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.12.2: This is it.

