### PR TITLE
add ability to specify the URL if we're not able to bind it to localhost

### DIFF
--- a/utils/llvm-symbolizer-client.py
+++ b/utils/llvm-symbolizer-client.py
@@ -2,10 +2,13 @@
 
 import urllib.request
 import sys
-
+import os
 
 def run():
-    url = "http://localhost:43210"
+    if 'HOST_SYMBOLIZER_URL' in os.environ:
+        url = os.environ['HOST_SYMBOLIZER_URL']
+    else:
+        url = "http://localhost:43210"
     for line in sys.stdin:
         data = line.encode("utf8")
         headers = {"content-type": "text/plain"}


### PR DESCRIPTION
### Scope & Purpose

RTA is running inside docker container, the symbolizer can not be exposed via localhost. The hosts public IP needs to be specified instead. 

- [x] :pizza: New feature
