### PR TITLE
Make initializer_list constexpr if possible

### DIFF
--- a/arangod/Aql/ExecutionNode/SubqueryNode.cpp
+++ b/arangod/Aql/ExecutionNode/SubqueryNode.cpp
@@ -189,7 +189,7 @@ bool SubqueryNode::mayAccessCollections() {
 
   // if the subquery contains any of these nodes, it may access data from
   // a collection
-  std::initializer_list<ExecutionNode::NodeType> const types = {
+  static constexpr std::initializer_list<ExecutionNode::NodeType> types{
       ExecutionNode::ENUMERATE_IRESEARCH_VIEW,
       ExecutionNode::ENUMERATE_COLLECTION,
       ExecutionNode::INDEX,

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -87,13 +87,14 @@ using namespace arangodb::basics;
 
 namespace {
 
-std::initializer_list<ExecutionNode::NodeType> const indexHintCheckTypes{
-    ExecutionNode::ENUMERATE_COLLECTION,
+static constexpr std::initializer_list<ExecutionNode::NodeType>
+    indexHintCheckTypes{
+        ExecutionNode::ENUMERATE_COLLECTION,
 #ifdef EXTENDED_INDEX_HINTS_FOR_GRAPH_OPERATIONS
-    ExecutionNode::TRAVERSAL,
-    ExecutionNode::ENUMERATE_PATHS,
+        ExecutionNode::TRAVERSAL,
+        ExecutionNode::ENUMERATE_PATHS,
 #endif
-};
+    };
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 /// @brief validate the counters of the plan

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -1620,7 +1620,7 @@ void arangodb::aql::removeCollectVariablesRule(
           modified = true;
         }
       }  // end - if doOptimize
-    }  // end - if collectNode has outVariable
+    }    // end - if collectNode has outVariable
 
     size_t numGroupVariables = collectNode->groupVariables().size();
     size_t numAggregateVariables = collectNode->aggregateVariables().size();
@@ -3787,9 +3787,10 @@ auto extractVocbaseFromNode(ExecutionNode* at) -> TRI_vocbase_t* {
 //
 // In an ideal world the node itself would know how to compute these parameters
 // for GatherNode (sortMode, parallelism, and elements), and we'd just ask it.
-auto insertGatherNode(ExecutionPlan& plan, ExecutionNode* node,
-                      SmallUnorderedMap<ExecutionNode*, ExecutionNode*> const&
-                          subqueries) -> GatherNode* {
+auto insertGatherNode(
+    ExecutionPlan& plan, ExecutionNode* node,
+    SmallUnorderedMap<ExecutionNode*, ExecutionNode*> const& subqueries)
+    -> GatherNode* {
   TRI_ASSERT(node);
 
   GatherNode* gatherNode{nullptr};
@@ -4088,8 +4089,9 @@ void arangodb::aql::scatterInClusterRule(Optimizer* opt,
 
 // Create a new DistributeNode for the ExecutionNode passed in node, and
 // register it with the plan
-auto arangodb::aql::createDistributeNodeFor(
-    ExecutionPlan& plan, ExecutionNode* node) -> DistributeNode* {
+auto arangodb::aql::createDistributeNodeFor(ExecutionPlan& plan,
+                                            ExecutionNode* node)
+    -> DistributeNode* {
   auto collection = static_cast<Collection const*>(nullptr);
   auto inputVariable = static_cast<Variable const*>(nullptr);
 
@@ -4220,9 +4222,10 @@ auto arangodb::aql::createGatherNodeFor(ExecutionPlan& plan,
 // and we handle this case in here as well by resetting the root to the
 // inserted GATHER node.
 //
-auto arangodb::aql::insertDistributeGatherSnippet(
-    ExecutionPlan& plan, ExecutionNode* at,
-    SubqueryNode* snode) -> DistributeNode* {
+auto arangodb::aql::insertDistributeGatherSnippet(ExecutionPlan& plan,
+                                                  ExecutionNode* at,
+                                                  SubqueryNode* snode)
+    -> DistributeNode* {
   auto const parents = at->getParents();
   auto const deps = at->getDependencies();
 
@@ -4447,7 +4450,7 @@ void arangodb::aql::distributeInClusterRule(Optimizer* opt,
         node = node->getFirstDependency();
       }
     }  // for node in subquery
-  }  // for end subquery in plan
+  }    // for end subquery in plan
   opt->addPlan(std::move(plan), rule, wasModified);
 }
 
@@ -6919,7 +6922,7 @@ static bool distanceFuncArgCheck(ExecutionPlan* plan, AstNode const* latArg,
         return true;
       }
     }  // if isGeo 1 or 2
-  }  // for index in collection
+  }    // for index in collection
   return false;
 }
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -624,15 +624,15 @@ void findShardKeysInExpression(arangodb::aql::AstNode const* root,
 // static node types used by some optimizer rules
 // having them statically available avoids having to build the lists over
 // and over for each AQL query
-std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
+static constexpr std::initializer_list<arangodb::aql::ExecutionNode::NodeType>
     removeUnnecessaryCalculationsNodeTypes{
         arangodb::aql::ExecutionNode::CALCULATION,
         arangodb::aql::ExecutionNode::SUBQUERY};
-std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
+static constexpr std::initializer_list<arangodb::aql::ExecutionNode::NodeType>
     interchangeAdjacentEnumerationsNodeTypes{
         arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION,
         arangodb::aql::ExecutionNode::ENUMERATE_LIST};
-std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
+static constexpr std::initializer_list<arangodb::aql::ExecutionNode::NodeType>
     scatterInClusterNodeTypes{
         arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION,
         arangodb::aql::ExecutionNode::INDEX,
@@ -642,19 +642,19 @@ std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
         arangodb::aql::ExecutionNode::REPLACE,
         arangodb::aql::ExecutionNode::REMOVE,
         arangodb::aql::ExecutionNode::UPSERT};
-std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
+static constexpr std::initializer_list<arangodb::aql::ExecutionNode::NodeType>
     removeDataModificationOutVariablesNodeTypes{
         arangodb::aql::ExecutionNode::REMOVE,
         arangodb::aql::ExecutionNode::INSERT,
         arangodb::aql::ExecutionNode::UPDATE,
         arangodb::aql::ExecutionNode::REPLACE,
         arangodb::aql::ExecutionNode::UPSERT};
-std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
-    moveFilterIntoEnumerateTypes{
-        arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION,
-        arangodb::aql::ExecutionNode::INDEX,
-        arangodb::aql::ExecutionNode::ENUMERATE_LIST};
-std::initializer_list<arangodb::aql::ExecutionNode::NodeType> const
+static constexpr std::initializer_list<
+    arangodb::aql::ExecutionNode::NodeType> const moveFilterIntoEnumerateTypes{
+    arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION,
+    arangodb::aql::ExecutionNode::INDEX,
+    arangodb::aql::ExecutionNode::ENUMERATE_LIST};
+static constexpr std::initializer_list<arangodb::aql::ExecutionNode::NodeType>
     undistributeNodeTypes{arangodb::aql::ExecutionNode::UPDATE,
                           arangodb::aql::ExecutionNode::REPLACE,
                           arangodb::aql::ExecutionNode::REMOVE};
@@ -1620,7 +1620,7 @@ void arangodb::aql::removeCollectVariablesRule(
           modified = true;
         }
       }  // end - if doOptimize
-    }    // end - if collectNode has outVariable
+    }  // end - if collectNode has outVariable
 
     size_t numGroupVariables = collectNode->groupVariables().size();
     size_t numAggregateVariables = collectNode->aggregateVariables().size();
@@ -3787,10 +3787,9 @@ auto extractVocbaseFromNode(ExecutionNode* at) -> TRI_vocbase_t* {
 //
 // In an ideal world the node itself would know how to compute these parameters
 // for GatherNode (sortMode, parallelism, and elements), and we'd just ask it.
-auto insertGatherNode(
-    ExecutionPlan& plan, ExecutionNode* node,
-    SmallUnorderedMap<ExecutionNode*, ExecutionNode*> const& subqueries)
-    -> GatherNode* {
+auto insertGatherNode(ExecutionPlan& plan, ExecutionNode* node,
+                      SmallUnorderedMap<ExecutionNode*, ExecutionNode*> const&
+                          subqueries) -> GatherNode* {
   TRI_ASSERT(node);
 
   GatherNode* gatherNode{nullptr};
@@ -4089,9 +4088,8 @@ void arangodb::aql::scatterInClusterRule(Optimizer* opt,
 
 // Create a new DistributeNode for the ExecutionNode passed in node, and
 // register it with the plan
-auto arangodb::aql::createDistributeNodeFor(ExecutionPlan& plan,
-                                            ExecutionNode* node)
-    -> DistributeNode* {
+auto arangodb::aql::createDistributeNodeFor(
+    ExecutionPlan& plan, ExecutionNode* node) -> DistributeNode* {
   auto collection = static_cast<Collection const*>(nullptr);
   auto inputVariable = static_cast<Variable const*>(nullptr);
 
@@ -4222,10 +4220,9 @@ auto arangodb::aql::createGatherNodeFor(ExecutionPlan& plan,
 // and we handle this case in here as well by resetting the root to the
 // inserted GATHER node.
 //
-auto arangodb::aql::insertDistributeGatherSnippet(ExecutionPlan& plan,
-                                                  ExecutionNode* at,
-                                                  SubqueryNode* snode)
-    -> DistributeNode* {
+auto arangodb::aql::insertDistributeGatherSnippet(
+    ExecutionPlan& plan, ExecutionNode* at,
+    SubqueryNode* snode) -> DistributeNode* {
   auto const parents = at->getParents();
   auto const deps = at->getDependencies();
 
@@ -4450,7 +4447,7 @@ void arangodb::aql::distributeInClusterRule(Optimizer* opt,
         node = node->getFirstDependency();
       }
     }  // for node in subquery
-  }    // for end subquery in plan
+  }  // for end subquery in plan
   opt->addPlan(std::move(plan), rule, wasModified);
 }
 
@@ -6922,7 +6919,7 @@ static bool distanceFuncArgCheck(ExecutionPlan* plan, AstNode const* latArg,
         return true;
       }
     }  // if isGeo 1 or 2
-  }    // for index in collection
+  }  // for index in collection
   return false;
 }
 

--- a/arangod/IResearch/IResearchDocument.cpp
+++ b/arangod/IResearch/IResearchDocument.cpp
@@ -93,8 +93,8 @@ irs::unbounded_object_pool<arangodb::iresearch::AnalyzerPool::Builder>
     BoolStreamPool(DEFAULT_POOL_SIZE);
 irs::unbounded_object_pool<arangodb::iresearch::AnalyzerPool::Builder>
     NumericStreamPool(DEFAULT_POOL_SIZE);
-std::initializer_list<irs::type_info::type_id> NumericStreamFeatures{
-    irs::type<irs::granularity_prefix>::id()};
+static constexpr std::initializer_list<irs::type_info::type_id>
+    NumericStreamFeatures{irs::type<irs::granularity_prefix>::id()};
 
 bool canHandleValue(std::string const& key, VPackSlice const& value,
                     arangodb::iresearch::FieldMeta const& context) noexcept {

--- a/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptimizerRules.cpp
@@ -58,9 +58,9 @@ using EN = arangodb::aql::ExecutionNode;
 
 namespace {
 
-std::initializer_list<ExecutionNode::NodeType> const
-    reduceExtractionToProjectionTypes = {ExecutionNode::ENUMERATE_COLLECTION,
-                                         ExecutionNode::INDEX};
+static constexpr std::initializer_list<ExecutionNode::NodeType>
+    reduceExtractionToProjectionTypes{ExecutionNode::ENUMERATE_COLLECTION,
+                                      ExecutionNode::INDEX};
 
 }  // namespace
 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -1748,7 +1748,8 @@ void RocksDBOptionFeature::start() {
   }
 
   LOG_TOPIC("f66e4", TRACE, Logger::ENGINES)
-      << "using RocksDB options:" << " wal_dir: '" << _walDirectory << "'"
+      << "using RocksDB options:"
+      << " wal_dir: '" << _walDirectory << "'"
       << ", compression type: " << _compressionType
       << ", write_buffer_size: " << _writeBufferSize
       << ", total_write_buffer_size: " << _totalWriteBufferSize

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -1541,17 +1541,17 @@ limited number of edge collections/shards/indexes.)");
   //////////////////////////////////////////////////////////////////////////////
   /// add column family-specific options now
   //////////////////////////////////////////////////////////////////////////////
-  std::initializer_list<RocksDBColumnFamilyManager::Family> families = {
-      RocksDBColumnFamilyManager::Family::Definitions,
-      RocksDBColumnFamilyManager::Family::Documents,
-      RocksDBColumnFamilyManager::Family::PrimaryIndex,
-      RocksDBColumnFamilyManager::Family::EdgeIndex,
-      RocksDBColumnFamilyManager::Family::VPackIndex,
-      RocksDBColumnFamilyManager::Family::GeoIndex,
-      RocksDBColumnFamilyManager::Family::FulltextIndex,
-      RocksDBColumnFamilyManager::Family::ReplicatedLogs,
-      RocksDBColumnFamilyManager::Family::MdiIndex,
-      RocksDBColumnFamilyManager::Family::MdiVPackIndex};
+  static constexpr std::initializer_list<RocksDBColumnFamilyManager::Family>
+      families{RocksDBColumnFamilyManager::Family::Definitions,
+               RocksDBColumnFamilyManager::Family::Documents,
+               RocksDBColumnFamilyManager::Family::PrimaryIndex,
+               RocksDBColumnFamilyManager::Family::EdgeIndex,
+               RocksDBColumnFamilyManager::Family::VPackIndex,
+               RocksDBColumnFamilyManager::Family::GeoIndex,
+               RocksDBColumnFamilyManager::Family::FulltextIndex,
+               RocksDBColumnFamilyManager::Family::ReplicatedLogs,
+               RocksDBColumnFamilyManager::Family::MdiIndex,
+               RocksDBColumnFamilyManager::Family::MdiVPackIndex};
 
   auto addMaxWriteBufferNumberCf =
       [this, &options](RocksDBColumnFamilyManager::Family family) {
@@ -1748,8 +1748,7 @@ void RocksDBOptionFeature::start() {
   }
 
   LOG_TOPIC("f66e4", TRACE, Logger::ENGINES)
-      << "using RocksDB options:"
-      << " wal_dir: '" << _walDirectory << "'"
+      << "using RocksDB options:" << " wal_dir: '" << _walDirectory << "'"
       << ", compression type: " << _compressionType
       << ", write_buffer_size: " << _writeBufferSize
       << ", total_write_buffer_size: " << _totalWriteBufferSize


### PR DESCRIPTION
### Scope & Purpose

Small refactoring, make initializer_list `static constexpr` where possible

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
