### PR TITLE
Solve deadlock around SynchronizeShard

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix blockage in SynchronizeShard: We do some agency communication there,
+  this should use skipScheduler to avoid being blocked by all scheduler
+  threads being busy. This solves a problem found in RTA on upgrade
+  with resignLeadership.
+
 * Fix bug in upstream rocksdb to not leak file descriptors when iouring
   is used for RocksDB.
 

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -6236,7 +6236,8 @@ futures::Future<ResultT<T>> fetchNumberFromAgency(
   }
 
   auto fAacResult =
-      AsyncAgencyComm().sendReadTransaction(timeout, std::move(trx));
+      AsyncAgencyComm().withSkipScheduler(true).sendReadTransaction(
+          timeout, std::move(trx));
 
   auto fResult =
       std::move(fAacResult).thenValue([path = std::move(path)](auto&& result) {

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -1305,9 +1305,10 @@ namespace cluster {
 
 // Note that while a network error will just return a failed `ResultT`, there
 // are still possible exceptions.
-futures::Future<ResultT<uint64_t>> fetchPlanVersion(network::Timeout timeout);
-futures::Future<ResultT<uint64_t>> fetchCurrentVersion(
-    network::Timeout timeout);
+futures::Future<ResultT<uint64_t>> fetchPlanVersion(network::Timeout timeout,
+                                                    bool skipScheduler);
+futures::Future<ResultT<uint64_t>> fetchCurrentVersion(network::Timeout timeout,
+                                                       bool skipScheduler);
 
 }  // namespace cluster
 }  // namespace arangodb

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -1670,7 +1670,7 @@ void SynchronizeShard::setState(ActionState state) {
     auto snooze = std::chrono::milliseconds(100);
     while (!_feature.server().isStopping() &&
            std::chrono::steady_clock::now() < stoppage) {
-      cluster::fetchCurrentVersion(0.1 * timeout)
+      cluster::fetchCurrentVersion(0.1 * timeout, true /* skipScheduler */)
           .thenValue([&v](auto&& res) {
             // we need to check if res is ok() in order to not trigger a
             // bad_optional_access exception here


### PR DESCRIPTION
This solves a deadlock found in RTA on upgrade with resignLeadership.

Explanation:

In SynchronizeShard we do some agency communication using
AsyncAgencyComm. We should use `skipScheduler` there such that we
are not blocked if all scheduler threads are busy or there are queues.

This resolves a deadlock where all maintenance threads were blocked
in SynchronizeShard and therefore no TakeoverShardLeadership jobs could
be executed.

- Only use skipScheduler in SynchronizeShard.
- CHANGELOG.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1965
