### PR TITLE
Solve deadlock around dynamic metrics [BTS-1965]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix blockage in RestMetricsHandlers if there are resigned leaders. We use 
+  getResponsibleServerNoDelay there to decide if metrics should be exposed.
+
 * Fix blockage in SynchronizeShard: We do some agency communication there,
   this should use skipScheduler to avoid being blocked by all scheduler
   threads being busy. This solves a problem found in RTA on upgrade

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -780,10 +780,17 @@ class ClusterInfo final {
   /// If it is not found in the cache, the cache is reloaded once, if
   /// it is still not there a pointer to an empty vector is returned as
   /// an error.
+  /// The "NoDelay" variant is guaranteed to not produce a noticeable delay,
+  /// however, it may return an empty result, if currently there is no
+  /// known responsible server. This is often good enough.
+  /// Note that this can happen during the transition of leadership from
+  /// one server to another.
   //////////////////////////////////////////////////////////////////////////////
 
   std::shared_ptr<ManagedVector<pmr::ServerID> const> getResponsibleServer(
       ShardID shardID);
+  std::shared_ptr<ManagedVector<pmr::ServerID> const>
+  getResponsibleServerNoDelay(ShardID shardID);
 
   futures::Future<ResultT<ServerID>> getLeaderForShard(ShardID shard);
 

--- a/arangod/IResearch/IResearchMetricStats.h
+++ b/arangod/IResearch/IResearchMetricStats.h
@@ -63,7 +63,7 @@ class MetricStats : public metrics::Guard<IResearchDataStore::Stats> {
       return true;  // This is equivalent to the code below, if we could not
                     // parse shard id, we should skip this shard
     }
-    auto r = ci.getResponsibleServer(maybeShardID.get());
+    auto r = ci.getResponsibleServerNoDelay(maybeShardID.get());
     if (r->empty()) {
       return true;  // TODO(MBkkt) We should fix cluster info :(
     }


### PR DESCRIPTION
This is solving a deadlock situation which arises with dynamic metrics.
The very high priority metrics REST handler was using
getResponsibleServer, which can block indefinitely when there is a
resigned leader. It was doing this under a lock, which can prevent
the deletion of dynamic metrics, which might become necessary during
DropCollection. Therefore, DropCollection jobs could block the whole
slow track maintenance which would prevent a server from taking over
shard leadership.

The fix is to use the new getResponsibleServerNoDelay function in the
RestMetricsHandler. This means that progress is always possible.

- Use getResponsibleServerNoDelay in metrics rest handler.
- CHANGELOG.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] Release test automation.
- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11:

#### Related Information

- [*] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1965
