### PR TITLE
Solve deadlock around SynchronizeShard [BTS-1965]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+v3.11.12 (XXXX-XX-XX)
+---------------------
+
+* Fix blockage in SynchronizeShard: We do some agency communication there,
+  this should use skipScheduler to avoid being blocked by all scheduler
+  threads being busy. This solves a problem found in RTA on upgrade
+  with resignLeadership.
+
+
 v3.11.11 (2024-09-04)
 ---------------------
 

--- a/arangod/Cluster/ClusterInfo.h
+++ b/arangod/Cluster/ClusterInfo.h
@@ -1215,9 +1215,10 @@ namespace cluster {
 
 // Note that while a network error will just return a failed `ResultT`, there
 // are still possible exceptions.
-futures::Future<ResultT<uint64_t>> fetchPlanVersion(network::Timeout timeout);
-futures::Future<ResultT<uint64_t>> fetchCurrentVersion(
-    network::Timeout timeout);
+futures::Future<ResultT<uint64_t>> fetchPlanVersion(network::Timeout timeout,
+                                                    bool skipScheduler);
+futures::Future<ResultT<uint64_t>> fetchCurrentVersion(network::Timeout timeout,
+                                                       bool skipScheduler);
 
 }  // namespace cluster
 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -1754,7 +1754,7 @@ void SynchronizeShard::setState(ActionState state) {
     auto snooze = std::chrono::milliseconds(100);
     while (!_feature.server().isStopping() &&
            std::chrono::steady_clock::now() < stoppage) {
-      cluster::fetchCurrentVersion(0.1 * timeout)
+      cluster::fetchCurrentVersion(0.1 * timeout, true /* skipScheduler */)
           .thenValue([&v](auto&& res) {
             // we need to check if res is ok() in order to not trigger a
             // bad_optional_access exception here

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -107,6 +107,9 @@ function makeDataWrapper (options) {
             ct.run.rtaWaitShardsInSync(this.options, this.instanceManager);
           }
 
+          if (count === 2) {
+            this.instanceManager.upgradeCycleInstance();
+          }
           if (count === 3) {
             this.instanceManager.arangods.forEach(function (oneInstance, i) {
               if (oneInstance.isRole(inst.instanceRole.dbServer)) {
@@ -115,6 +118,7 @@ function makeDataWrapper (options) {
             });
             print('stopping dbserver ' + stoppedDbServerInstance.name +
                   ' ID: ' + stoppedDbServerInstance.id +JSON.stringify( stoppedDbServerInstance.getStructure()));
+            this.instanceManager.resignLeaderShip(stoppedDbServerInstance);
             stoppedDbServerInstance.shutDownOneInstance(counters, false, 10);
             stoppedDbServerInstance.waitForExit();
             moreargv = [ '--disabledDbserverUUID', stoppedDbServerInstance.id];

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -108,7 +108,17 @@ function makeDataWrapper (options) {
           }
 
           if (count === 2) {
-            this.instanceManager.upgradeCycleInstance();
+            try {
+              this.instanceManager.upgradeCycleInstance();
+            } catch(e) {
+              return {
+                'forceTerminate': true,
+                'message': `upgradeCycle failed by: ${e.message}\n${e.stack}`,
+                'failed': 1,
+                'status': false,
+                'duration': 0.0
+              };
+            }
           }
           if (count === 3) {
             this.instanceManager.arangods.forEach(function (oneInstance, i) {
@@ -118,7 +128,17 @@ function makeDataWrapper (options) {
             });
             print('stopping dbserver ' + stoppedDbServerInstance.name +
                   ' ID: ' + stoppedDbServerInstance.id +JSON.stringify( stoppedDbServerInstance.getStructure()));
-            this.instanceManager.resignLeaderShip(stoppedDbServerInstance);
+            try {
+              this.instanceManager.resignLeaderShip(stoppedDbServerInstance);
+            } catch(e) {
+              return {
+                'forceTerminate': true,
+                'message': `resigning leadership failed by: ${e.message}\n${e.stack}`,
+                'failed': 1,
+                'status': false,
+                'duration': 0.0
+              };
+            }
             stoppedDbServerInstance.shutDownOneInstance(counters, false, 10);
             stoppedDbServerInstance.waitForExit();
             moreargv = [ '--disabledDbserverUUID', stoppedDbServerInstance.id];

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -909,6 +909,9 @@ class instanceManager {
     do {
       sleep(1);
       jobStatus = arango.GET_RAW('/_admin/cluster/queryAgencyJob?id=' + result.parsedBody.id);
+      if (jobStatus.parsedBody.status === 'failed') {
+        throw new Error(`failed to resign ${dbServer.name} from leadership via ${frontend.name}: ${JSON.stringify(jobStatus)}`);
+      }
       print(jobStatus.parsedBody.status);
     } while (jobStatus.parsedBody.status !== 'Finished');
     print(`${Date()} DONE resigning leaderships from ${dbServer.name} via ${frontend.name}`);

--- a/js/client/modules/@arangodb/testutils/instance-manager.js
+++ b/js/client/modules/@arangodb/testutils/instance-manager.js
@@ -909,7 +909,7 @@ class instanceManager {
     do {
       sleep(1);
       jobStatus = arango.GET_RAW('/_admin/cluster/queryAgencyJob?id=' + result.parsedBody.id);
-      if (jobStatus.parsedBody.status === 'failed') {
+      if (jobStatus.parsedBody.status === 'Failed') {
         throw new Error(`failed to resign ${dbServer.name} from leadership via ${frontend.name}: ${JSON.stringify(jobStatus)}`);
       }
       print(jobStatus.parsedBody.status);

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -815,6 +815,25 @@ class instance {
     }
     print(CYAN + Date() + ' ' + this.name + ', url: ' + this.url + ', running again with PID ' + this.pid + RESET);
   }
+
+    runUpgrade() {
+    let moreArgs = {
+      '--database.auto-upgrade': 'true',
+      '--log.foreground-tty': 'true'
+    };
+    if (this.role === instanceRole.coordinator) {
+      moreArgs['--server.rest-server'] = 'false';
+    }
+    this.exitStatus = null;
+    this.pid = this._executeArangod(moreArgs).pid;
+    sleep(1);
+    while (this.isRunning()) {
+      print(".");
+      sleep(1);
+    }
+    print(`${Date()} upgrade of ${this.name} finished.`);
+  }
+
   // //////////////////////////////////////////////////////////////////////////////
   // / @brief periodic checks whether spawned arangod processes are still alive
   // //////////////////////////////////////////////////////////////////////////////
@@ -871,7 +890,7 @@ class instance {
 
   isRunning() {
     let check = () => (this.exitStatus !== null) && (this.exitStatus.status === 'RUNNING');
-    if (check()) {
+    if (this.exitStatus === null || check()) {
       this.exitStatus = this.status(false);
       return check();
     }


### PR DESCRIPTION
This solves a deadlock found in RTA on upgrade with resignLeadership.

This is a backport of https://github.com/arangodb/arangodb/pull/21302.

Explanation:

In SynchronizeShard we do some agency communication using
AsyncAgencyComm. We should use `skipScheduler` there such that we
are not blocked if all scheduler threads are busy or there are queues.

This resolves a deadlock where all maintenance threads were blocked
in SynchronizeShard and therefore no TakeoverShardLeadership jobs could
be executed.

- Only use skipScheduler in SynchronizeShard.
- CHANGELOG.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] Devel original PR: https://github.com/arangodb/arangodb/pull/21302
- [*] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1965

