### PR TITLE
Use vpack for replication for document transfer throughout [BTS_1969]

### DIFF
--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -99,13 +99,6 @@ std::chrono::milliseconds sleepTimeFromWaitTime(double waitTime) {
   return std::chrono::seconds(2);
 }
 
-bool isVelocyPack(httpclient::SimpleHttpResult const& response) {
-  bool found = false;
-  std::string const& cType =
-      response.getHeaderField(StaticStrings::ContentTypeHeader, found);
-  return found && cType == StaticStrings::MimeTypeVPack;
-}
-
 std::string const kTypeString = "type";
 std::string const kDataString = "data";
 
@@ -844,7 +837,7 @@ Result DatabaseInitialSyncer::parseCollectionDump(
   char const* p = data.begin();
   char const* end = p + data.length();
 
-  if (isVelocyPack(*response)) {
+  if (replutils::isVelocyPack(*response)) {
     // received a velocypack response from the leader
 
     // intentional copy
@@ -1000,20 +993,12 @@ void DatabaseInitialSyncer::fetchDumpChunk(
     std::string url =
         absl::StrCat(baseUrl, "&from=", fromTick, "&chunkSize=", chunkSize);
 
-    bool isVPack = false;
     auto headers = replutils::createHeaders();
-    if (_config.leader.version() >= 30800) {
-      // from 3.8 onwards, it is safe and also faster to retrieve vpack-encoded
-      // dumps. in previous versions there may be vpack encoding issues for the
-      // /_api/replication/dump responses.
-      headers[StaticStrings::Accept] = StaticStrings::MimeTypeVPack;
-      isVPack = true;
-    }
 
     _config.progress.set(absl::StrCat(
         "fetching leader collection dump for collection '", coll->name(),
-        "', type: ", typeString, ", format: ", (isVPack ? "vpack" : "json"),
-        ", id: ", leaderColl, ", batch ", batch, ", url: ", url));
+        "', type: ", typeString, ", format: ", "vpack", ", id: ", leaderColl,
+        ", batch ", batch, ", url: ", url));
 
     double t = TRI_microtime();
 
@@ -1627,17 +1612,12 @@ void DatabaseInitialSyncer::fetchRevisionsChunk(
              urlEncode(requestResume.toHLC()) + "&encodeAsHLC=true";
     }
 
-    bool isVPack = false;
     auto headers = replutils::createHeaders();
-    if (_config.leader.version() >= 31000) {
-      headers[StaticStrings::Accept] = StaticStrings::MimeTypeVPack;
-      isVPack = true;
-    }
 
     _config.progress.set(absl::StrCat(
         "fetching leader collection revision ranges for collection '",
-        coll->name(), "', type: ", typeString, ", format: ",
-        (isVPack ? "vpack" : "json"), ", id: ", leaderColl, ", url: ", url));
+        coll->name(), "', type: ", typeString, ", format: ", "vpack",
+        ", id: ", leaderColl, ", url: ", url));
 
     double t = TRI_microtime();
 
@@ -1725,14 +1705,15 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
       stats.numSyncBytesReceived += response->getContentLength();
     }
 
-    auto body = response->getBodyVelocyPack();
-    if (!body) {
+    VPackBuilder body;
+    Result res = replutils::parseResponse(body, response.get());
+    if (res.fail()) {
       ++stats.numFailedConnects;
       return Result(
           TRI_ERROR_INTERNAL,
           "received improperly formed response when fetching revision tree");
     }
-    treeLeader = containers::RevisionTree::deserialize(body->slice());
+    treeLeader = containers::RevisionTree::deserialize(body.slice());
     if (!treeLeader) {
       ++stats.numFailedConnects;
       return Result(
@@ -2000,7 +1981,7 @@ Result DatabaseInitialSyncer::fetchCollectionSyncByRevisions(
 
       VPackSlice slice;
 
-      if (isVelocyPack(*chunkResponse)) {
+      if (replutils::isVelocyPack(*chunkResponse)) {
         // velocypack body...
 
         // intentional copy of options

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -273,8 +273,9 @@ void DatabaseTailingSyncer::fetchWalChunk(
     // send request
     std::unique_ptr<httpclient::SimpleHttpResult> response;
     _state.connection.lease([&](httpclient::SimpleHttpClient* client) {
-      response.reset(
-          client->retryRequest(rest::RequestType::GET, url, nullptr, 0));
+      auto headers = replutils::createHeaders();
+      response.reset(client->retryRequest(rest::RequestType::GET, url, nullptr,
+                                          0, headers));
     });
 
     t = TRI_microtime() - t;

--- a/arangod/Replication/utilities.cpp
+++ b/arangod/Replication/utilities.cpp
@@ -29,6 +29,7 @@
 
 #include <velocypack/Builder.h>
 #include <velocypack/Parser.h>
+#include <velocypack/Validator.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/StaticStrings.h"
@@ -533,7 +534,8 @@ Result LeaderInfo::getState(replutils::Connection& connection,
 }
 
 std::unordered_map<std::string, std::string> createHeaders() {
-  return {{StaticStrings::ClusterCommSource, ServerState::instance()->getId()}};
+  return {{StaticStrings::ClusterCommSource, ServerState::instance()->getId()},
+          {StaticStrings::Accept, StaticStrings::MimeTypeVPack}};
 }
 
 bool hasFailed(httpclient::SimpleHttpResult* response) {
@@ -572,9 +574,34 @@ Result buildHttpError(httpclient::SimpleHttpResult* response,
                     response->getBody().toString());
 }
 
+bool isVelocyPack(httpclient::SimpleHttpResult const& response) {
+  bool found = false;
+  std::string const& cType =
+      response.getHeaderField(StaticStrings::ContentTypeHeader, found);
+  return found && cType == StaticStrings::MimeTypeVPack;
+}
+
 /// @brief parse a velocypack response
 Result parseResponse(velocypack::Builder& builder,
                      httpclient::SimpleHttpResult const* response) {
+  if (isVelocyPack(*response)) {
+    basics::StringBuffer const& data = response->getBody();
+    VPackOptions validationOptions =
+        basics::VelocyPackHelper::strictRequestValidationOptions;
+    validationOptions.disallowCustom = false;
+    VPackValidator validator(&validationOptions);
+    try {
+      validator.validate(data.begin(), data.length());
+    } catch (VPackException const& e) {
+      return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE, e.what());
+    } catch (...) {
+      return Result(TRI_ERROR_REPLICATION_INVALID_RESPONSE);
+    }
+    // We need to copy:
+    builder.add(VPackSlice{reinterpret_cast<uint8_t const*>(data.begin())});
+    return Result();
+  }
+  // Otherwise we assume it is JSON:
   try {
     velocypack::Parser parser(builder);
     parser.parse(response->getBody().begin(), response->getBody().length());

--- a/arangod/Replication/utilities.h
+++ b/arangod/Replication/utilities.h
@@ -191,5 +191,7 @@ Result buildHttpError(httpclient::SimpleHttpResult* response,
 /// @brief parse a velocypack response
 Result parseResponse(velocypack::Builder&, httpclient::SimpleHttpResult const*);
 
+bool isVelocyPack(httpclient::SimpleHttpResult const& response);
+
 }  // namespace replutils
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

The documents needed to trigger the vpack sorting bug need numbers
which are not properly representable in JSON. Therefore, we found this
replication bug, which is essentially, that JSON is used in replication
to transfer documents in some cases. This loses precision in vpack
numbers.

This addresses https://arangodb.atlassian.net/browse/BTS-1969

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1969
