### PR TITLE
Optimize MDI Sparse Condition Matcher

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* The optimizer was very pessimistic about sparse mdi indexes and did not
+  properly react to queries that excluded null values.
+
 * Fix blockage in RestMetricsHandlers if there are resigned leaders. We use 
   getResponsibleServerNoDelay there to decide if metrics should be exposed.
 

--- a/tests/js/client/aql/aql-mdi-sparse.js
+++ b/tests/js/client/aql/aql-mdi-sparse.js
@@ -204,7 +204,7 @@ function multiDimSparseTestSuite() {
       }
     },
 
-    testSparseQuery: function () {
+    testMdiSparseQuery: function () {
       const c = db._create(collectionName);
       const idx = c.ensureIndex({
         type: 'mdi',
@@ -462,6 +462,40 @@ function multiDimPrefixedSparseTestSuite() {
         assertTrue(figures.engine.indexes.filter(x => x.type === 'mdi').every(x => x.count === 1));
       }
     },
+
+
+    testMdiPrefixedSparseQuery: function () {
+      const c = db._create(collectionName);
+      const idx = c.ensureIndex({
+        type: 'mdi-prefixed',
+        name: indexName,
+        fields: ["x", "y"],
+        storedValues: ["z"],
+        prefixFields: ["a"],
+        sparse: true,
+        fieldValueTypes: 'double',
+      });
+
+      for (let k = 0; k < 10; k++) {
+        c.insert({x: k, y: k, z: k});
+      }
+
+      // For MDI with sparse, we can only use doc.x < something if the query also includes something like doc.x != NULL
+      const queries = [
+        [`FOR doc IN ${collectionName} FILTER doc.a == 12 && doc.x < 0 && doc.y > 10 && doc.x != NULL RETURN doc.z`],
+        [`FOR doc IN ${collectionName} FILTER doc.a == 12 && doc.x > 0 && doc.y > 10 && doc.x != NULL RETURN doc.z`],
+        [`FOR doc IN ${collectionName} FILTER doc.a == 12 && doc.x > 0 && doc.y < 10 && doc.y != NULL RETURN doc.z`],
+        [`FOR doc IN ${collectionName} FILTER doc.a == 12 && doc.x > 0 && doc.y > 10 && doc.y != NULL && doc.x != NULL RETURN doc.z`],
+        [`FOR doc IN ${collectionName} FILTER doc.a == 12 && doc.x < 0 && doc.y < 10 && doc.y != NULL && doc.x != NULL RETURN doc.z`],
+      ];
+
+      for (const [query] of queries) {
+        const plan = db._createStatement({query}).explain().plan;
+
+        const [indexNode] = plan.nodes.filter(n => n.type === 'IndexNode');
+        assertTrue(indexNode.filter === undefined, query);
+      }
+    }
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose
While the optimizer correctly handled sparse MDI queries, it did not choose the best utilization available. With sparse indexes, `null` values have to explicitly excluded, otherwise range queries containing `doc.x < 5` can not be optimized. This is because `null` is smaller than all numbers and thus would have to be returned, but those documents are not stored in the index because of sparseness. Thus it does not use the index.

If you add the condition `doc.x != NULL` it will use the index, but did not optimize away the null check.

```
 FOR doc IN col 
     FILTER doc.x <= 6 
     FILTER doc.y >= 8 
     FILTER doc.created != NULL 
     FILTER doc.p == 5 
RETURN doc.foo

Execution plan:
 Id   NodeType        Par   Est.   Comment
  1   SingletonNode            1   * ROOT 
 13   IndexNode         ✓      0     - FOR doc IN col   /* mdi-prefixed index scan, index only (projections: `foo`) */    LET #6 = doc.`foo`   
 12   ReturnNode               0       - RETURN #6

Indexes used:
 By   Name                      Type           Collection   Unique   Sparse   Cache   Selectivity   Fields         Stored values   Ranges
 13   idx_1810995884608978944   mdi-prefixed   col          false    true     false      100.00 %   [ `x`, `y` ]   [ `foo` ]       ((doc.`y` >= 8) && (doc.`p` == 5) && (doc.`x` <= 6))

```