### PR TITLE
Fix `IN_RANGE` on MDI index

### DIFF
--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1722,7 +1722,7 @@ void Condition::optimize(ExecutionPlan* plan, bool multivalued) {
           ++l;
         }
       }  // cross compare sub-and-nodes
-    }  // foreach sub-and-node
+    }    // foreach sub-and-node
 
   fastForwardToNextOrItem:
     if (!retry) {

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1010,6 +1010,7 @@ bool canInRangeBeRemoved(auto const* inRangeNode, auto const* otherAndNode,
       continue;
     }
 
+    // since we know that this is IN_RANGE node, it must contain 5 members
     auto const* operandArrayNode = operand->getMember(0);
     TRI_ASSERT(operandArrayNode->numMembers() == 5);
 

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -415,7 +415,9 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertTrue(appliedRules.includes(useIndexes));
         assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
 
-        const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
+        const indexNodes = explainRes.plan.nodes.filter(function (n) {
+          return n.type === "IndexNode";
+        });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
@@ -453,7 +455,9 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
         assertTrue(appliedRules.includes(useIndexes));
 
-        const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
+        const indexNodes = explainRes.plan.nodes.filter(function (n) {
+          return n.type === "IndexNode";
+        });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
@@ -492,7 +496,9 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
         assertTrue(appliedRules.includes(useIndexes));
 
-        const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
+        const indexNodes = explainRes.plan.nodes.filter(function (n) {
+          return n.type === "IndexNode";
+        });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
@@ -526,7 +532,9 @@ function optimizerRuleMdi2dIndexTestSuite() {
         const executeRes = db._query(query.query, query.bindVars);
         const res = executeRes.toArray();
 
-        const indexNodes = explainRes.plan.nodes.filter(function(n) { return n.type === 'IndexNode'; });
+        const indexNodes = explainRes.plan.nodes.filter(function (n) {
+          return n.type === "IndexNode";
+        });
         assertEqual(indexNodes.length, 1);
 
         const indexNode = indexNodes[0];
@@ -534,6 +542,43 @@ function optimizerRuleMdi2dIndexTestSuite() {
 
         res.sort();
         assertEqual([0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], res);
+      }
+    },
+
+    testInRangeMixed: function () {
+      const queries = [
+        aql`FOR d IN ${col} FILTER IN_RANGE(d.x, 0, 1, false, true) AND 0 <= d.y AND d.y <= 5 RETURN d.x`,
+        aql`FOR d IN ${col} FILTER 0 <= d.y AND d.y <= 5 AND IN_RANGE(d.x, 0, 1, false, true) RETURN d.x`,
+      ];
+
+      for (let i = 0; i < queries.length; ++i) {
+        const query = queries[i];
+
+        db._explain({ query: query.query, bindVars: query.bindVars });
+        const explainRes = db
+          ._createStatement({ query: query.query, bindVars: query.bindVars })
+          .explain();
+        const appliedRules = explainRes.plan.rules;
+        const nodeTypes = explainRes.plan.nodes
+          .map((n) => n.type)
+          .filter((n) => !["GatherNode", "RemoteNode"].includes(n));
+        assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
+
+        assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+        assertTrue(appliedRules.includes(useIndexes));
+
+        const indexNodes = explainRes.plan.nodes.filter(function (n) {
+          return n.type === "IndexNode";
+        });
+        assertEqual(indexNodes.length, 1);
+
+        const indexNode = indexNodes[0];
+        assertEqual(indexNode.filter, undefined);
+
+        const executeRes = db._query(query.query, query.bindVars);
+        const res = executeRes.toArray();
+        res.sort();
+        assertEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], res);
       }
     },
   };

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -470,7 +470,7 @@ function optimizerRuleMdi2dIndexTestSuite() {
       }
     },
 
-    testInRangeLefttStrict: function () {
+    testInRangeLeftStrict: function () {
       const queries = [
         {
           q: aql`FOR d IN ${col} FILTER 0 < d.x && d.x <= 1 RETURN d.x`,
@@ -581,6 +581,44 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], res);
       }
     },
+
+    testInRangeMultipleInRangeFunctions: function () {
+      const queries = [
+        aql`FOR d IN ${col} FILTER IN_RANGE(d.x, 0, 1, false, true) AND IN_RANGE(d.y, 0, 5, true, true) RETURN d.x`,
+        aql`FOR d IN ${col} FILTER 0 < d.x AND d.x <= 1 AND 0 <= d.y AND d.y <= 5 RETURN d.x`,
+      ];
+
+      for (let i = 0; i < queries.length; ++i) {
+        const query = queries[i];
+
+        db._explain({ query: query.query, bindVars: query.bindVars });
+        const explainRes = db
+          ._createStatement({ query: query.query, bindVars: query.bindVars })
+          .explain();
+        const appliedRules = explainRes.plan.rules;
+        const nodeTypes = explainRes.plan.nodes
+          .map((n) => n.type)
+          .filter((n) => !["GatherNode", "RemoteNode"].includes(n));
+        assertEqual(["SingletonNode", "IndexNode", "ReturnNode"], nodeTypes);
+
+        assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
+        assertTrue(appliedRules.includes(useIndexes));
+
+        const indexNodes = explainRes.plan.nodes.filter(function (n) {
+          return n.type === "IndexNode";
+        });
+        assertEqual(indexNodes.length, 1);
+
+        const indexNode = indexNodes[0];
+        assertEqual(indexNode.filter, undefined);
+
+        const executeRes = db._query(query.query, query.bindVars);
+        const res = executeRes.toArray();
+        res.sort();
+        assertEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], res);
+      }
+    },
+
   };
 }
 

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -549,6 +549,8 @@ function optimizerRuleMdi2dIndexTestSuite() {
       const queries = [
         aql`FOR d IN ${col} FILTER IN_RANGE(d.x, 0, 1, false, true) AND 0 <= d.y AND d.y <= 5 RETURN d.x`,
         aql`FOR d IN ${col} FILTER 0 <= d.y AND d.y <= 5 AND IN_RANGE(d.x, 0, 1, false, true) RETURN d.x`,
+        aql`FOR d IN ${col} FILTER IN_RANGE(d.y, 0, 5, true, true) AND 0 < d.x AND d.x <= 1 RETURN d.x`,
+        aql`FOR d IN ${col} FILTER 0 < d.x AND d.x <= 1 AND IN_RANGE(d.y, 0, 5, true, true) RETURN d.x`,
       ];
 
       for (let i = 0; i < queries.length; ++i) {

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -618,7 +618,6 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertEqual([0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1], res);
       }
     },
-
   };
 }
 

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -568,12 +568,7 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
         assertTrue(appliedRules.includes(useIndexes));
 
-        const indexNodes = explainRes.plan.nodes.filter(function (n) {
-          return n.type === "IndexNode";
-        });
-        assertEqual(indexNodes.length, 1);
-
-        const indexNode = indexNodes[0];
+        const indexNode = explainRes.plan.nodes.find((n) => n.type === "IndexNode");
         assertEqual(indexNode.filter, undefined);
 
         const executeRes = db._query(query.query, query.bindVars);
@@ -604,12 +599,7 @@ function optimizerRuleMdi2dIndexTestSuite() {
         assertTrue(appliedRules.includes(removeFilterCoveredByIndex));
         assertTrue(appliedRules.includes(useIndexes));
 
-        const indexNodes = explainRes.plan.nodes.filter(function (n) {
-          return n.type === "IndexNode";
-        });
-        assertEqual(indexNodes.length, 1);
-
-        const indexNode = indexNodes[0];
+        const indexNode = explainRes.plan.nodes.find((n) => n.type === "IndexNode");
         assertEqual(indexNode.filter, undefined);
 
         const executeRes = db._query(query.query, query.bindVars);

--- a/tests/js/client/aql/aql-mdi.js
+++ b/tests/js/client/aql/aql-mdi.js
@@ -554,7 +554,6 @@ function optimizerRuleMdi2dIndexTestSuite() {
       for (let i = 0; i < queries.length; ++i) {
         const query = queries[i];
 
-        db._explain({ query: query.query, bindVars: query.bindVars });
         const explainRes = db
           ._createStatement({ query: query.query, bindVars: query.bindVars })
           .explain();
@@ -591,7 +590,6 @@ function optimizerRuleMdi2dIndexTestSuite() {
       for (let i = 0; i < queries.length; ++i) {
         const query = queries[i];
 
-        db._explain({ query: query.query, bindVars: query.bindVars });
         const explainRes = db
           ._createStatement({ query: query.query, bindVars: query.bindVars })
           .explain();


### PR DESCRIPTION
### Scope & Purpose

Fix an issue with the `IN_RANGE` function call on MDI index when there are multiple IN_RANGE function calls and when the IN_RANGE is on non-first indexed field.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
