### PR TITLE
Reset Locale in Tests

### DIFF
--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -132,9 +132,10 @@ constexpr std::string_view kGerman = "de";
 constexpr std::string_view kRussian = "ru";
 
 std::string_view getNonSysLang() {
+  auto currentLocale = std::string{setlocale(LC_ALL, NULL)};
   setlocale(LC_ALL, "");
-  const std::string_view currSysLang =
-      std::string_view(setlocale(LC_ALL, NULL)).substr(0, 2);
+  auto currSysLang = std::string(setlocale(LC_ALL, NULL)).substr(0, 2);
+  setlocale(LC_ALL, currentLocale.c_str());
   if (currSysLang == "de") {
     return kRussian;
   } else {


### PR DESCRIPTION
The locale was changed but not reset. This can lead to test failures on systems with non-default locale.
