### PR TITLE
Refactor names in async registry

### DIFF
--- a/arangod/AsyncRegistryServer/Feature.h
+++ b/arangod/AsyncRegistryServer/Feature.h
@@ -43,7 +43,7 @@ class Feature final : public application_features::ApplicationFeature {
                                                  name()},
         metrics{create_metrics(
             server.template getFeature<arangodb::metrics::MetricsFeature>())} {
-    coroutine_registry.set_metrics(metrics);
+    registry.set_metrics(metrics);
     // startsAfter<Bla, Server>();
   }
 

--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -43,7 +43,7 @@ auto RestHandler::execute() -> RestStatus {
 
   VPackBuilder builder;
   builder.openArray();
-  coroutine_registry.for_promise([&](PromiseInList* promise) {
+  registry.for_promise([&](PromiseInList* promise) {
     velocypack::serialize(builder, *promise);
   });
   builder.close();

--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -43,9 +43,8 @@ auto RestHandler::execute() -> RestStatus {
 
   VPackBuilder builder;
   builder.openArray();
-  registry.for_promise([&](PromiseInList* promise) {
-    velocypack::serialize(builder, *promise);
-  });
+  registry.for_promise(
+      [&](Promise* promise) { velocypack::serialize(builder, *promise); });
   builder.close();
 
   generateResult(rest::ResponseCode::OK, builder.slice());

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -40,11 +40,11 @@ struct Observables {
   std::source_location _where;
 };
 
-struct PromiseInList : Observables {
-  PromiseInList(std::source_location loc) : Observables(std::move(loc)) {}
+struct Promise : Observables {
+  Promise(std::source_location loc) : Observables(std::move(loc)) {}
 
   virtual auto destroy() noexcept -> void = 0;
-  virtual ~PromiseInList() = default;
+  virtual ~Promise() = default;
 
   // identifies the promise list it belongs to
   std::shared_ptr<ThreadRegistry> registry = nullptr;
@@ -52,15 +52,15 @@ struct PromiseInList : Observables {
   std::string thread_name;
   std::thread::id thread_id;
 
-  PromiseInList* next = nullptr;
+  Promise* next = nullptr;
   // only needed to remove an item
-  PromiseInList* previous = nullptr;
+  Promise* previous = nullptr;
   // only needed to garbage collect promises
-  PromiseInList* next_to_free = nullptr;
+  Promise* next_to_free = nullptr;
 };
 
 template<typename Inspector>
-auto inspect(Inspector& f, PromiseInList& x) {
+auto inspect(Inspector& f, Promise& x) {
   // perhaps just use for saving
   return f.object(x).fields(
       f.field("source_location",

--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -61,7 +61,7 @@ struct Registry {
      items stay valid during iteration (i.e. are not deleted in the meantime).
    */
   template<typename F>
-  requires std::invocable<F, PromiseInList*>
+  requires std::invocable<F, Promise*>
   auto for_promise(F&& function) -> void {
     auto regs = [&] {
       auto guard = std::lock_guard(mutex);

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -24,14 +24,12 @@
 
 namespace arangodb::async_registry {
 
-Registry coroutine_registry;
+Registry registry;
 
 auto get_thread_registry() noexcept -> ThreadRegistry& {
   struct ThreadRegistryGuard {
-    ThreadRegistryGuard() : _registry{coroutine_registry.add_thread()} {}
-    ~ThreadRegistryGuard() {
-      coroutine_registry.remove_thread(std::move(_registry));
-    }
+    ThreadRegistryGuard() : _registry{registry.add_thread()} {}
+    ~ThreadRegistryGuard() { registry.remove_thread(std::move(_registry)); }
 
     std::shared_ptr<ThreadRegistry> _registry;
   };

--- a/lib/Async/Registry/registry_variable.h
+++ b/lib/Async/Registry/registry_variable.h
@@ -30,7 +30,7 @@ namespace arangodb::async_registry {
 /**
    Global variable that holds all coroutines.
  */
-extern Registry coroutine_registry;
+extern Registry registry;
 
 /**
    Get registry of all active coroutine promises on this thread.

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -65,7 +65,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can only be called on the owning thread, crashes
      otherwise.
    */
-  auto add(PromiseInList* promise) noexcept -> void;
+  auto add(Promise* promise) noexcept -> void;
 
   /**
      Executes a function on each promise in the registry.
@@ -74,7 +74,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      items stay valid during iteration (i.e. are not deleted in the meantime).
    */
   template<typename F>
-  requires std::invocable<F, PromiseInList*>
+  requires std::invocable<F, Promise*>
   auto for_promise(F&& function) noexcept -> void {
     auto guard = std::lock_guard(mutex);
     // (2) - this load synchronizes with store in (1) and (3)
@@ -90,7 +90,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can be called from any thread. The promise needs to be included in
      the registry list, crashes otherwise.
    */
-  auto mark_for_deletion(PromiseInList* promise) noexcept -> void;
+  auto mark_for_deletion(Promise* promise) noexcept -> void;
 
   /**
      Deletes all promises that are marked for deletion.
@@ -104,8 +104,8 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   const std::string thread_name;
 
  private:
-  std::atomic<PromiseInList*> free_head = nullptr;
-  std::atomic<PromiseInList*> promise_head = nullptr;
+  std::atomic<Promise*> free_head = nullptr;
+  std::atomic<Promise*> promise_head = nullptr;
   std::mutex mutex;
   metrics::GaugeCounterGuard<uint64_t> running_threads;
   std::shared_ptr<const Metrics> metrics;
@@ -120,7 +120,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      (which also means that this function should only be called on the owning
      thread.)
    */
-  auto remove(PromiseInList* promise) -> void;
+  auto remove(Promise* promise) -> void;
 };
 
 template<typename Inspector>

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -21,11 +21,10 @@ template<typename T>
 struct async;
 
 template<typename T>
-struct async_promise_base : async_registry::PromiseInList {
+struct async_promise_base : async_registry::Promise {
   using promise_type = async_promise<T>;
 
-  async_promise_base(std::source_location loc)
-      : PromiseInList(std::move(loc)) {}
+  async_promise_base(std::source_location loc) : Promise(std::move(loc)) {}
 
   std::suspend_never initial_suspend() noexcept { return {}; }
   auto final_suspend() noexcept {

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -381,7 +381,7 @@ TEST(AsyncTest, promises_are_registered) {
     auto coro_baz = baz();
 
     std::vector<std::string> names;
-    arangodb::async_registry::coroutine_registry.for_promise(
+    arangodb::async_registry::registry.for_promise(
         [&](arangodb::async_registry::PromiseInList* promise) {
           names.push_back(promise->_where.function_name());
         });

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -382,7 +382,7 @@ TEST(AsyncTest, promises_are_registered) {
 
     std::vector<std::string> names;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::PromiseInList* promise) {
+        [&](arangodb::async_registry::Promise* promise) {
           names.push_back(promise->_where.function_name());
         });
     EXPECT_EQ(names.size(), 3);

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -31,10 +31,10 @@ using namespace arangodb::async_registry;
 
 namespace {
 
-struct MyTestPromise : PromiseInList {
+struct MyTestPromise : Promise {
   MyTestPromise(uint64_t id,
                 std::source_location loc = std::source_location::current())
-      : PromiseInList(loc), id{id} {}
+      : Promise(loc), id{id} {}
   auto destroy() noexcept -> void override { destroyed = true; }
   bool destroyed = false;
   uint64_t id;
@@ -42,7 +42,7 @@ struct MyTestPromise : PromiseInList {
 
 auto all_ids(Registry& registry) -> std::vector<uint64_t> {
   std::vector<uint64_t> ids;
-  registry.for_promise([&](PromiseInList* promise) {
+  registry.for_promise([&](Promise* promise) {
     ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
   return ids;

--- a/tests/Async/Registry/ThreadRegistryTest.cpp
+++ b/tests/Async/Registry/ThreadRegistryTest.cpp
@@ -33,10 +33,10 @@ using namespace arangodb::async_registry;
 
 namespace {
 
-struct MyTestPromise : PromiseInList {
+struct MyTestPromise : Promise {
   MyTestPromise(uint64_t id,
                 std::source_location loc = std::source_location::current())
-      : PromiseInList(loc), id{id} {}
+      : Promise(loc), id{id} {}
   auto destroy() noexcept -> void override { destroyed = true; }
   bool destroyed = false;
   uint64_t id;
@@ -45,7 +45,7 @@ struct MyTestPromise : PromiseInList {
 auto all_ids(std::shared_ptr<ThreadRegistry> registry)
     -> std::vector<uint64_t> {
   std::vector<uint64_t> ids;
-  registry->for_promise([&](PromiseInList* promise) {
+  registry->for_promise([&](Promise* promise) {
     ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
   return ids;
@@ -88,7 +88,7 @@ TEST_F(CoroutineThreadRegistryTest, iterates_over_all_promises) {
   registry->add(&second_promise);
   registry->add(&third_promise);
   std::vector<uint64_t> promise_ids;
-  registry->for_promise([&](PromiseInList* promise) {
+  registry->for_promise([&](Promise* promise) {
     promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
   });
   EXPECT_EQ(promise_ids,
@@ -114,7 +114,7 @@ TEST_F(CoroutineThreadRegistryTest,
 
   std::thread([&]() {
     std::vector<uint64_t> promise_ids;
-    registry->for_promise([&](PromiseInList* promise) {
+    registry->for_promise([&](Promise* promise) {
       promise_ids.push_back(dynamic_cast<MyTestPromise*>(promise)->id);
     });
     EXPECT_EQ(promise_ids,


### PR DESCRIPTION
This is just a pure refactoring PR, it does two renamings:
- renaming the global variable `coroutine_registry` to `registry` because it is supposed to be used not only for coroutines but also for other async constructs
- renaming `PromiseInList` to `Promise`, which is shorter and still descriptive (and unique because it is part of the namespace `async_registry`)