### PR TITLE
Fix thread registry beeing removed too early

### DIFF
--- a/arangod/AsyncRegistryServer/Feature.h
+++ b/arangod/AsyncRegistryServer/Feature.h
@@ -47,6 +47,8 @@ class Feature final : public application_features::ApplicationFeature {
     // startsAfter<Bla, Server>();
   }
 
+  ~Feature() { registry.set_metrics(std::make_shared<Metrics>()); }
+
  private:
   std::shared_ptr<const Metrics> metrics;
 };

--- a/arangod/AsyncRegistryServer/Feature.h
+++ b/arangod/AsyncRegistryServer/Feature.h
@@ -47,8 +47,6 @@ class Feature final : public application_features::ApplicationFeature {
     // startsAfter<Bla, Server>();
   }
 
-  ~Feature() { registry.set_metrics(std::make_shared<Metrics>()); }
-
  private:
   std::shared_ptr<const Metrics> metrics;
 };

--- a/lib/Async/Registry/registry.cpp
+++ b/lib/Async/Registry/registry.cpp
@@ -22,8 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "registry.h"
 
-#include "Assertions/ProdAssert.h"
 #include "Async/Registry/Metrics.h"
+#include "Metrics/Gauge.h"
 
 using namespace arangodb::async_registry;
 
@@ -31,17 +31,19 @@ Registry::Registry() : _metrics{std::make_shared<Metrics>()} {}
 
 auto Registry::add_thread() -> std::shared_ptr<ThreadRegistry> {
   auto guard = std::lock_guard(mutex);
-  auto registry = registries.emplace_back(ThreadRegistry::make(_metrics));
+  auto thread_registry = ThreadRegistry::make(_metrics, this);
+  registries.emplace_back(thread_registry.get());
   if (_metrics->registered_threads != nullptr) {
     _metrics->registered_threads->fetch_add(1);
   }
-  return registry;
+  return thread_registry;
 }
 
-auto Registry::remove_thread(std::shared_ptr<ThreadRegistry> registry) -> void {
+auto Registry::remove_thread(ThreadRegistry* registry) -> void {
   auto guard = std::lock_guard(mutex);
   if (_metrics->registered_threads != nullptr) {
     _metrics->registered_threads->fetch_sub(1);
   }
+  // delete last reference to registry
   std::erase(registries, registry);
 }

--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -52,7 +52,7 @@ struct Registry {
   /**
      Removes a coroutine thread registry from this registry.
    */
-  auto remove_thread(std::shared_ptr<ThreadRegistry> registry) -> void;
+  auto remove_thread(ThreadRegistry* registry) -> void;
 
   /**
      Executes a function on each coroutine in the registry.
@@ -83,7 +83,7 @@ struct Registry {
   }
 
  private:
-  std::vector<std::shared_ptr<ThreadRegistry>> registries;
+  std::vector<ThreadRegistry*> registries;
   std::mutex mutex;
   std::shared_ptr<const Metrics> _metrics;
 };

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -29,7 +29,11 @@ Registry registry;
 auto get_thread_registry() noexcept -> ThreadRegistry& {
   struct ThreadRegistryGuard {
     ThreadRegistryGuard() : _registry{registry.add_thread()} {}
-    ~ThreadRegistryGuard() { registry.remove_thread(std::move(_registry)); }
+
+    /**
+       Runs when the current thread is deleted
+     */
+    ~ThreadRegistryGuard() {}
 
     std::shared_ptr<ThreadRegistry> _registry;
   };

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -24,23 +24,26 @@
 
 #include "Assertions/ProdAssert.h"
 #include "Async/Registry/Metrics.h"
+#include "Async/Registry/promise.h"
+#include "Async/Registry/registry.h"
 #include "Basics/Thread.h"
 #include "Inspection/Format.h"
-#include "Logger/LogMacros.h"
-#include "Logger/Logger.h"
-#include "Logger/LoggerStream.h"
 #include "Metrics/Counter.h"
 #include "Metrics/Gauge.h"
 
 using namespace arangodb::async_registry;
 
-auto ThreadRegistry::make(std::shared_ptr<const Metrics> metrics)
+auto ThreadRegistry::make(std::shared_ptr<const Metrics> metrics,
+                          Registry* registry)
     -> std::shared_ptr<ThreadRegistry> {
-  return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{metrics});
+  return std::shared_ptr<ThreadRegistry>(new ThreadRegistry{metrics, registry});
 }
 
-ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics)
-    : thread_name{ThreadNameFetcher{}.get()}, metrics{metrics} {
+ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics,
+                               Registry* registry)
+    : thread_name{ThreadNameFetcher{}.get()},
+      registry{registry},
+      metrics{metrics} {
   if (metrics->total_threads != nullptr) {
     metrics->total_threads->count();
   }
@@ -52,6 +55,9 @@ ThreadRegistry::ThreadRegistry(std::shared_ptr<const Metrics> metrics)
 ThreadRegistry::~ThreadRegistry() noexcept {
   if (metrics->running_threads != nullptr) {
     metrics->running_threads->fetch_sub(1);
+  }
+  if (registry != nullptr) {
+    registry->remove_thread(this);
   }
   cleanup();
 }

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #include "Async/Registry/promise.h"
-#include "Metrics/GaugeCounterGuard.h"
 
 #include <atomic>
 #include <cstdint>
@@ -57,7 +56,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   static auto make(std::shared_ptr<const Metrics> metrics)
       -> std::shared_ptr<ThreadRegistry>;
 
-  ~ThreadRegistry() noexcept { cleanup(); }
+  ~ThreadRegistry() noexcept;
 
   /**
      Adds a promise on the registry's thread to the registry.
@@ -107,7 +106,6 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
   std::atomic<Promise*> free_head = nullptr;
   std::atomic<Promise*> promise_head = nullptr;
   std::mutex mutex;
-  metrics::GaugeCounterGuard<uint64_t> running_threads;
   std::shared_ptr<const Metrics> metrics;
 
   ThreadRegistry(std::shared_ptr<const Metrics> metrics);

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -67,7 +67,7 @@ TEST_F(CoroutineRegistryTest, registers_promise_on_same_thread) {
 
   thread_registry->mark_for_deletion(&promise);
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(CoroutineRegistryTest, registers_promise_on_different_threads) {
@@ -83,7 +83,7 @@ TEST_F(CoroutineRegistryTest, registers_promise_on_different_threads) {
 
     thread_registry->mark_for_deletion(&promise);
     thread_registry->garbage_collect();
-    registry.remove_thread(thread_registry);
+    registry.remove_thread(thread_registry.get());
   }).join();
 }
 
@@ -101,7 +101,7 @@ TEST_F(CoroutineRegistryTest,
   thread_registry->mark_for_deletion(&first_promise);
   thread_registry->mark_for_deletion(&second_promise);
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(CoroutineRegistryTest, iterates_over_promises_on_differen_threads) {
@@ -119,12 +119,12 @@ TEST_F(CoroutineRegistryTest, iterates_over_promises_on_differen_threads) {
 
     thread_registry->mark_for_deletion(&second_promise);
     thread_registry->garbage_collect();
-    registry.remove_thread(thread_registry);
+    registry.remove_thread(thread_registry.get());
   }).join();
 
   thread_registry->mark_for_deletion(&first_promise);
   thread_registry->garbage_collect();
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(CoroutineRegistryTest,
@@ -146,7 +146,7 @@ TEST_F(CoroutineRegistryTest,
   EXPECT_TRUE(promise.destroyed);
   EXPECT_EQ(all_ids(registry).size(), 0);
 
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 }
 
 TEST_F(
@@ -159,7 +159,7 @@ TEST_F(
 
   EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{1}));
 
-  registry.remove_thread(thread_registry);
+  registry.remove_thread(thread_registry.get());
 
   EXPECT_FALSE(promise.destroyed);
   EXPECT_EQ(all_ids(registry), (std::vector<uint64_t>{}));
@@ -179,7 +179,7 @@ TEST_F(CoroutineRegistryTest,
     std::thread([&]() {
       thread_registry_on_different_thread = registry.add_thread();
       thread_registry_on_different_thread->add(&promise);
-      registry.remove_thread(thread_registry_on_different_thread);
+      registry.remove_thread(thread_registry_on_different_thread.get());
     }).join();
 
     EXPECT_EQ(all_ids(registry).size(), 0);


### PR DESCRIPTION
The global registry includes a list of all thread registries. A thread registry should only be deleted from this list after it is not used any more, aka when the corresponding thread was destroyed AND all promises inside the thread registry are marked for deletion. Before, the latter condition was ignored.