### PR TITLE
Backport of fix for data race in cluster selectivity estimates [BTS-1973]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.12 (XXXX-XX-XX)
 ---------------------
 
+* Fix data race in cluster selectivity estimates.
+
 * Fix blockage in SynchronizeShard: We do some agency communication there,
   this should use skipScheduler to avoid being blocked by all scheduler
   threads being busy. This solves a problem found in RTA on upgrade

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -174,11 +174,11 @@ double ClusterIndex::selectivityEstimate(std::string_view) const {
 
   // floating-point tolerance
   TRI_ASSERT(_clusterSelectivity >= 0.0 && _clusterSelectivity <= 1.00001);
-  return _clusterSelectivity;
+  return _clusterSelectivity.load(std::memory_order_relaxed);
 }
 
 void ClusterIndex::updateClusterSelectivityEstimate(double estimate) {
-  _clusterSelectivity = estimate;
+  _clusterSelectivity.store(estimate, std::memory_order_relaxed);
 }
 
 bool ClusterIndex::isSorted() const {

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -31,6 +31,8 @@
 #include "Indexes/Index.h"
 #include "VocBase/Identifiers/IndexId.h"
 
+#include <atomic>
+
 namespace arangodb {
 class LogicalCollection;
 
@@ -112,7 +114,7 @@ class ClusterIndex : public Index {
   Index::IndexType _indexType;
   velocypack::Builder _info;
   bool _estimates;
-  double _clusterSelectivity;
+  std::atomic<double> _clusterSelectivity;
 
   // Only used in RocksDB edge index.
   std::vector<std::vector<basics::AttributeName>> _coveredFields;


### PR DESCRIPTION
### Scope & Purpose

Fix data-race reported by TSan via https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/2526/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&cloud&&x86-64/artifact/testfailures.txt


- [x] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1973
- [*] Original PR: https://github.com/arangodb/arangodb/pull/21098
