### PR TITLE
Fix JSON dumping of large numbers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.11.12 (XXXX-XX-XX)
 ---------------------
 
+* Change dumping of VPack to JSON for large double values with absolute
+  value between 2^53 and 2^64. This ensures that dumps to JSON followed
+  by parsing of the JSON back to VPack retain the right numerical values.
+  This fixes a problem in arangodump/arangorestore as well as in replication.
+  Furthermore, JSON output from the API now shows numbers in this area
+  with their correct numerical value.
+
 * Updated ArangoDB Starter to v0.18.10.
 
 * Allow an `arangod` server to startup, even if the option 

--- a/tests/js/client/shell/aql-string-conversion.js
+++ b/tests/js/client/shell/aql-string-conversion.js
@@ -1,0 +1,122 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual, assertTrue, db, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Max Neunhöffer
+// //////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var helper = require("@arangodb/aql-helper");
+var getQueryResults = helper.getQueryResults;
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function ahuacatlStringConversionTestSuite () {
+
+  let cn = "UnitTestsAhuacatlDocument";
+
+  return {
+
+    setUp : function () {
+      db._drop(cn);
+      db._create(cn);
+    },
+
+    tearDown : function () {
+      db._drop(cn);
+    },
+
+    testToStringLargeNumbers : function() {
+      let actual = getQueryResults("RETURN TO_STRING(1152921504606846976)");
+      assertEqual([ "1152921504606846976" ], actual);
+      actual = getQueryResults("RETURN TO_STRING(1152921504606846977)");
+      assertEqual([ "1152921504606846977" ], actual);
+      actual = getQueryResults("RETURN TO_STRING(1152921504606846976.0)");
+      assertEqual([ "1152921504606846976.0" ], actual);
+      actual = getQueryResults("RETURN TO_STRING(-1152921504606846976)");
+      assertEqual([ "-1152921504606846976" ], actual);
+      actual = getQueryResults("RETURN TO_STRING(-1152921504606846977)");
+      assertEqual([ "-1152921504606846977" ], actual);
+      actual = getQueryResults("RETURN TO_STRING(-1152921504606846976.0)");
+      assertEqual([ "-1152921504606846976.0" ], actual);
+      actual = getQueryResults("RETURN TO_STRING(4503599627370496.0)");
+      assertEqual([ "4503599627370496" ], actual);   // 2^52 too small for .0
+      actual = getQueryResults("RETURN TO_STRING(9007199254740992.0)");
+      assertEqual([ "9007199254740992.0" ], actual);   // 2^53 large enough
+      actual = getQueryResults("RETURN TO_STRING(9223372036854775808.0)");
+      assertEqual([ "9223372036854775808.0" ], actual);   // 2^63
+      actual = getQueryResults("RETURN TO_STRING(18446744073709551616.0)");
+      assertEqual([ "18446744073709552000" ], actual);   // 2^64 too large
+      // Note that 2^64 cannot be represented in 64 bits, therefore, we 
+      // fall back to the fast behaviour which produces a number, which is
+      // not numerically correct, but will be parsed back to the same
+      // double value by the JSON parser!
+    },
+
+    testLargeDoublesInJSON : function() {
+      db._query(`INSERT {v: 1152921504606846976, _key: "1"} INTO ${cn}`);
+      db._query(`INSERT {v: 1152921504606846977, _key: "2"} INTO ${cn}`);
+      db._query(`INSERT {v: 1152921504606846976.0, _key: "3"} INTO ${cn}`);
+
+      let res = db._query(`FOR d IN ${cn} FILTER d.v == 1152921504606846976 RETURN d._key`).toArray();
+      assertEqual(2, res.length, res);
+      assertTrue(res.indexOf("1") >= 0, res);
+      assertTrue(res.indexOf("3") >= 0, res);
+
+      res = db._query(`FOR d IN ${cn} FILTER d.v == 1152921504606846977 RETURN d._key`).toArray();
+      assertEqual(1, res.length, res);
+      assertTrue(res.indexOf("2") >= 0, res);
+
+      res = db._query(`FOR d IN ${cn} FILTER d.v == 1152921504606846976.0 RETURN d._key`).toArray();
+      assertEqual(2, res.length, res);
+      assertTrue(res.indexOf("1") >= 0, res);
+      assertTrue(res.indexOf("3") >= 0, res);
+
+      // Note that 1152921504606846976.0 is the same as 1152921504606846977.0!
+      res = db._query(`FOR d IN ${cn} FILTER d.v == 1152921504606846977.0 RETURN d._key`).toArray();
+      assertEqual(2, res.length, res);
+      assertTrue(res.indexOf("1") >= 0, res);
+      assertTrue(res.indexOf("3") >= 0, res);
+
+      res = arango.GET_RAW(`/_api/document/${cn}/1`, {accept: "application/json"});
+      assertTrue(res.body.toString().indexOf('"v":1152921504606846976}') >= 0, res);
+
+      res = arango.GET_RAW(`/_api/document/${cn}/2`, {accept: "application/json"});
+      assertTrue(res.body.toString().indexOf('"v":1152921504606846977}') >= 0, res);
+
+      res = arango.GET_RAW(`/_api/document/${cn}/3`, {accept: "application/json"});
+      assertTrue(res.body.toString().indexOf('"v":1152921504606846976.0}') >= 0, res);
+    },
+  };
+
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(ahuacatlStringConversionTestSuite);
+
+return jsunity.done();
+

--- a/tests/js/client/shell/aql-string-conversion.js
+++ b/tests/js/client/shell/aql-string-conversion.js
@@ -25,8 +25,6 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 var jsunity = require("jsunity");
-var helper = require("@arangodb/aql-helper");
-var getQueryResults = helper.getQueryResults;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
@@ -48,25 +46,25 @@ function ahuacatlStringConversionTestSuite () {
     },
 
     testToStringLargeNumbers : function() {
-      let actual = getQueryResults("RETURN TO_STRING(1152921504606846976)");
+      let actual = db._query("RETURN TO_STRING(1152921504606846976)").toArray();
       assertEqual([ "1152921504606846976" ], actual);
-      actual = getQueryResults("RETURN TO_STRING(1152921504606846977)");
+      actual = db._query("RETURN TO_STRING(1152921504606846977)").toArray();
       assertEqual([ "1152921504606846977" ], actual);
-      actual = getQueryResults("RETURN TO_STRING(1152921504606846976.0)");
+      actual = db._query("RETURN TO_STRING(1152921504606846976.0)").toArray();
       assertEqual([ "1152921504606846976.0" ], actual);
-      actual = getQueryResults("RETURN TO_STRING(-1152921504606846976)");
+      actual = db._query("RETURN TO_STRING(-1152921504606846976)").toArray();
       assertEqual([ "-1152921504606846976" ], actual);
-      actual = getQueryResults("RETURN TO_STRING(-1152921504606846977)");
+      actual = db._query("RETURN TO_STRING(-1152921504606846977)").toArray();
       assertEqual([ "-1152921504606846977" ], actual);
-      actual = getQueryResults("RETURN TO_STRING(-1152921504606846976.0)");
+      actual = db._query("RETURN TO_STRING(-1152921504606846976.0)").toArray();
       assertEqual([ "-1152921504606846976.0" ], actual);
-      actual = getQueryResults("RETURN TO_STRING(4503599627370496.0)");
+      actual = db._query("RETURN TO_STRING(4503599627370496.0)").toArray();
       assertEqual([ "4503599627370496" ], actual);   // 2^52 too small for .0
-      actual = getQueryResults("RETURN TO_STRING(9007199254740992.0)");
+      actual = db._query("RETURN TO_STRING(9007199254740992.0)").toArray();
       assertEqual([ "9007199254740992.0" ], actual);   // 2^53 large enough
-      actual = getQueryResults("RETURN TO_STRING(9223372036854775808.0)");
+      actual = db._query("RETURN TO_STRING(9223372036854775808.0)").toArray();
       assertEqual([ "9223372036854775808.0" ], actual);   // 2^63
-      actual = getQueryResults("RETURN TO_STRING(18446744073709551616.0)");
+      actual = db._query("RETURN TO_STRING(18446744073709551616.0)").toArray();
       assertEqual([ "18446744073709552000" ], actual);   // 2^64 too large
       // Note that 2^64 cannot be represented in 64 bits, therefore, we 
       // fall back to the fast behaviour which produces a number, which is


### PR DESCRIPTION
This is a backport of https://github.com/arangodb/arangodb/pull/21332

This addresses https://arangodb.atlassian.net/browse/BTS-1969
in a different way than previously planned.

This PR "fixes" JSON dumping for large double values.

 - Our normal API uses JSON as input and output format. In most APIs,
   however, it is nowadays also possible to use VelocyPack (ContentType:
   application/x-velocypack).

 - Internally, we only store VelocyPack.

 - VelocyPack has essentially three different number types: Unsigned
   Integers (0 <= x < 2^64), Signed Integers (-2^63 <= x < 2^63) and
   Doubles (IEEE-754), but JSON has only one number type.

 - Our JSON parser (to VPack) tries its best to parse any JSON number to
   "something sensible", if the number does not contain a "." or an "e" it 
   uses integer types as much as possible and otherwise falls back to
   Double. This all seems pretty sensible with the given limitations of
   JSON.

 - When we dump VPack to JSON, we try to be smart, too. We faithfully
   dump integers (unsigned or signed) and use a very fast algorithm for
   Doubles, which was published in 2010 and which guarantees that every
   Double converted to a string is parsed back to the same double, when
   parsed as a Double, and excluding stuff like -0, +Inf, -Inf or the
   various other NaN values.

 - Unfortunately, when we parse JSON back, we do not always parse
   numbers as doubles, so we have a problem when we convert VPack to JSON
   and back. For example, the Double value 1152921504606846976.0 (which
   is 2^60) is currently written out as 1152921504606847000 in JSON and
   then parsed back to *the unsigned integer 1152921504606847000*, which
   is of course a genuinely different number.

 - This has wide ramifications, for example, it means that
   arangodump/arangorestore does not properly backup large numbers! Also,
   our replication code uses JSON and thus does not replicate large numbers
   correctly! And so it becomes a problem...

 - By the way, V8 does the very same thing, it always works with
   doubles, and you will always see 1152921504606847000 when you mess with
   2^60 there.

In this PR, we propose to do the following when dumping double values to
JSON:

    If the absolute value of the number is >= 2^53 and less than 2^64
    (in which case it always represents an integer), then we cast it
    to an integer, use the integer conversion routine, and then append
    ".0" to the resulting string. All other values are dumped as before.

This has the following consequences:

 - Nearly all double values are dumped as before.
 - In particular, smaller integral values are correctly dumped out and
   no ".0" is appended. They will be parsed back to an integer, but
   resulting in the same numerical value. Very little test and other
   code is affected.
 - Numbers in the above range are dumped numerically correctly, but due
   to the suffix ".0" will be parsed back to the exact same double value
   when parsing the JSON back to VPack.
 - This fixes `arangodump/arangorestore` for large numbers.
 - It fixes replication APIs, when used with JSON.
 - It fixes our JSON output of documents for large numbers.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
- [x] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1969
- [*] Original PR: https://github.com/arangodb/arangodb/pull/21332

