### PR TITLE
QA-553: model tests after java tests  (#21310)

### DIFF
--- a/js/client/modules/@arangodb/arango-transaction.js
+++ b/js/client/modules/@arangodb/arango-transaction.js
@@ -198,18 +198,24 @@ ArangoTransaction.prototype.query = function(query, bindVars, cursorOptions, opt
   if (!this.running()) {
     throwNotRunning();
   }
-  if (typeof query !== 'string' || query === undefined || query === '') {
-    throw 'need a valid query string';
-  }
-  if (options === undefined && cursorOptions !== undefined) {
-    options = cursorOptions;
-  }
-
   let body = {
     query: query,
     count: (cursorOptions && cursorOptions.count) || false,
     bindVars: bindVars || undefined,
   };
+  if (query && typeof query === 'object' && typeof query.toAQL !== 'function') {
+    body.query = query.query;
+    body.options = query.cursorOptions || undefined;
+    body.bindVars = query.bindVars || undefined;
+  }
+  else {
+    if (typeof query !== 'string' || query === undefined || query === '') {
+    throw 'need a valid query string';
+    }
+    if (options === undefined && cursorOptions !== undefined) {
+      options = cursorOptions;
+    }
+  }
 
   if (cursorOptions && cursorOptions.batchSize) {
     body.batchSize = cursorOptions.batchSize;

--- a/js/client/modules/@arangodb/testsuites/server_permissions.js
+++ b/js/client/modules/@arangodb/testsuites/server_permissions.js
@@ -100,6 +100,11 @@ class permissionsRunner extends trs.runLocalInArangoshRunner {
         let paramsSecondRun = executeScript(content, true, te);
         let rootDir = fs.join(fs.getTempPath(), count.toString());
         let runSetup = paramsSecondRun.hasOwnProperty('runSetup');
+        if (paramsSecondRun.hasOwnProperty('opts')) {
+          _.defaults(paramsSecondRun.opts, clonedOpts);
+          clonedOpts = _.clone(paramsSecondRun.opts);
+          delete paramsSecondRun.opts;
+        }
         clonedOpts['startupMaxCount'] = 600; // Slow startups may occur on slower machines.
         if (paramsSecondRun.hasOwnProperty('server.jwt-secret')) {
           clonedOpts['server.jwt-secret'] = paramsSecondRun['server.jwt-secret'];

--- a/tests/js/client/communication/test-cluster-multi-shard-transaction.js
+++ b/tests/js/client/communication/test-cluster-multi-shard-transaction.js
@@ -1,0 +1,243 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global fail, assertTrue, assertFalse, assertEqual, assertNotEqual, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Wilfried Goesgens
+// //////////////////////////////////////////////////////////////////////////////
+const _ = require('lodash');
+let jsunity = require('jsunity');
+let internal = require('internal');
+let arangodb = require('@arangodb');
+const isEnterprise = require("internal").isEnterprise();
+let fs = require('fs');
+let pu = require('@arangodb/testutils/process-utils');
+let db = arangodb.db;
+
+let { debugCanUseFailAt,
+      debugSetFailAt,
+      debugResetRaceControl,
+      debugRemoveFailAt,
+      debugClearFailAt,
+      versionHas
+    } = require('@arangodb/test-helper');
+
+const isCov = versionHas('coverage');
+const {
+  launchSnippetInBG,
+  joinBGShells,
+  cleanupBGShells
+} = require('@arangodb/testutils/client-tools').run;
+
+let IM = global.instanceManager;
+
+let waitFor = 60; //isCov ? 60 * 4 : 60;
+if (versionHas('asan') || versionHas('tsan') || versionHas('coverage')) {
+  waitFor *= 10;
+}
+
+function getRandomString() {
+  return require("@arangodb/crypto").md5(internal.genRandomAlphaNumbers(32));
+}
+function MultiShardTransactionSuite () {
+  'use strict';
+  // generate a random collection name
+  const cn = "UnitTests" + getRandomString();
+  const testCol = "UnitTestTemp";
+
+  let debug = function(text) {
+    console.warn(text);
+  };
+  let runTests = function (tests, duration) {
+    assertFalse(db[cn].exists("stop"));
+    let clients = [];
+    debug("starting " + tests.length + " test clients");
+    try {
+      tests.forEach(function (test) {
+        let key = test[0];
+        let code = test[1];
+        let client = launchSnippetInBG(IM.options, code, key, cn);
+        client.done = false;
+        client.failed = true; // assume the worst
+        clients.push(client);
+      });
+
+      debug("running test for " + duration + " s...");
+
+      internal.sleep(duration);
+
+      debug("stopping all test clients");
+
+      // broad cast stop signal
+      assertFalse(db[cn].exists("stop"));
+      db[cn].insert({ _key: "stop" }, { overwriteMode: "ignore" });
+      joinBGShells(IM.options, clients, waitFor, cn);
+
+      assertEqual(1 + clients.length, db[cn].count());
+      let stats = {};
+      clients.forEach(function (client) {
+        let doc = db[cn].document(client.key);
+        assertEqual(client.key, doc._key);
+        assertTrue(doc.done);
+
+        stats[client.key] = doc.iterations;
+      });
+
+      debug("test run iterations: " + JSON.stringify(stats));
+    } finally {
+      cleanupBGShells(clients, cn);
+    }
+  };
+
+  return {
+    setUp: function () {
+      db._drop(cn);
+      db._create(cn);
+
+      db._drop(testCol);
+      let c = db._create(testCol, { numberOfShards: 2 });
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+      db._drop(testCol);
+    },
+
+    testQueryInParallel: function () {
+      let assocShard = {};
+      function getAssocShard(shardId) {
+        // print(assocShard)
+        if (!assocShard.hasOwnProperty(shardId)) {
+          assocShard[shardId] = Object.keys(assocShard).length;
+        }
+        return assocShard[shardId];
+      }
+      let c = db[testCol];
+      let shardIds = [[],[]];
+      const maxLength = 1000;
+      while (shardIds[0].length + shardIds[1].length < maxLength * 2) {
+        let id = getRandomString();
+        let shardNo = getAssocShard(c.getResponsibleShard(id));
+        if (shardIds[shardNo].length < maxLength) {
+          shardIds[shardNo].push(id);
+        }
+      }
+      let tests = [];
+      for(let count = 0; count < 2; count++) {
+        tests.push([
+          `TransactionInsertTest_${count}`,
+          `
+let myKeys = ${JSON.stringify(shardIds[count])};
+let cn = "${testCol}";
+let lastCount = 0;
+myKeys.forEach(oneKey => {
+  let trx = db._createTransaction({ collections: { write: [cn] } });
+  let c = trx.collection(cn);
+  c.insert({_key: oneKey});
+  trx.commit();
+  let count = db[cn].count();
+  if (count <= lastCount) {
+    print(oneKey + " - Was expecting to have " + count + " > " + lastCoun)
+    throw new Error("Was expecting to have " + count + " > " + lastCoun);
+  }
+  lastCount = count;
+})
+
+return false;`
+        ]);
+      }
+      // print(JSON.stringify(tests))
+      // run the suite for a while...
+      runTests(tests, 30);
+      assertEqual(c.count(), maxLength*2);
+    },
+    testQueryCountInParallel: function () {
+      let assocShard = {};
+      function getAssocShard(shardId) {
+        // print(assocShard)
+        if (!assocShard.hasOwnProperty(shardId)) {
+          assocShard[shardId] = Object.keys(assocShard).length;
+        }
+        return assocShard[shardId];
+      }
+      let c = db[testCol];
+      let shardIds = [[],[]];
+      const maxLength = 1000;
+      while (shardIds[0].length + shardIds[1].length < maxLength * 2) {
+        let id = getRandomString();
+        let shardNo = getAssocShard(c.getResponsibleShard(id));
+        if (shardIds[shardNo].length < maxLength) {
+          shardIds[shardNo].push(id);
+        }
+      }
+      let tests = [];
+      for(let count = 0; count < 2; count++) {
+        tests.push([
+          `TransactionInsertTest_${count}`,
+          `
+let myKeys = ${JSON.stringify(shardIds[count])};
+let cn = "${testCol}";
+let lastCount = 0;
+let loopCount = 0;
+const stepWidth = 10;
+myKeys.forEach(oneKey => {
+  let trx = db._createTransaction({ collections: { write: [cn], exclusive: [cn] } });
+  let c = trx.collection(cn);
+  c.insert({_key: oneKey});
+  let count = c.count();
+  if (count <= lastCount) {
+    print(oneKey + " - Was expecting to have " + count + " > " + lastCoun)
+    trx.abort();
+    throw new Error("Was expecting to have " + count + " > " + lastCoun);
+  }
+  trx.commit();
+  loopCount += 1;
+  count = db[cn].count();
+  if (count <= lastCount) {
+    print(oneKey + " - Was expecting to have " + count + " > " + lastCoun)
+    throw new Error("Was expecting to have " + count + " > " + lastCoun);
+  }
+  let tries = 0;
+  while ((loopCount % stepWidth === 0) && (count % stepWidth !== 0)) {
+    tries ++;
+    if (tries > 10) {
+      throw new Error("failed to get to the next step in 5s");
+    }
+    require('internal').sleep(0.5);
+    count = db[cn].count();
+  }
+  lastCount = count;
+})
+
+return false;`
+        ]);
+      }
+      // print(JSON.stringify(tests))
+      // run the suite for a while...
+      runTests(tests, 30);
+      assertEqual(c.count(), maxLength*2);
+    },
+  };
+}
+
+jsunity.run(MultiShardTransactionSuite);
+
+return jsunity.done();

--- a/tests/js/client/server_parameters/test-streaming-max-transaction-size.js
+++ b/tests/js/client/server_parameters/test-streaming-max-transaction-size.js
@@ -1,0 +1,192 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, fail, arango, aql */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Jan Steemann
+/// @author Copyright 2019, ArangoDB Inc, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'transaction.streaming-max-transaction-size': "16MB",
+    'opts': {
+      coordinators: 2
+    }
+  };
+}
+const jsunity = require('jsunity');
+const errors = require('@arangodb').errors;
+const cn = "UnitTestsCollection";
+const db = require('internal').db;
+const ArangoError = require('@arangodb').ArangoError;
+
+function testSuite() {
+  return {
+    setUp: function () {
+      db._create(cn);
+    },
+
+    tearDown: function () {
+      db._drop(cn);
+    },
+
+    testTransactionBelowLimit: function() {
+      let trx = db._createTransaction({ collections: { write: [cn] } });
+      try {
+        let c = trx.collection(cn);
+        for (let i = 0; i < 1000; ++i) {
+          c.insert({ value1: i, value2: "testmann " + i });
+        }
+        assertEqual(1000, c.count());
+        trx.commit();
+        trx = null;
+        assertEqual(1000, db[cn].count());
+      } finally {
+        if (trx) {
+          trx.abort();
+        }
+      }
+    },
+    
+    testAQLTransactionBelowLimit: function() {
+      let trx = db._createTransaction({ collections: { write: [cn] } });
+      try {
+        let res = trx.query("FOR i IN 1..1000 INSERT { value1: i, value2: CONCAT('testmann', i) } INTO " + cn).getExtra();
+        assertTrue(res.stats.peakMemoryUsage <= 16 * 1024 * 1024, res);
+        let c = trx.collection(cn);
+        assertEqual(1000, c.count());
+        assertEqual(1000, c.count());
+        trx.commit();
+        trx = null;
+        assertEqual(1000, db[cn].count());
+      } finally {
+        if (trx) {
+          trx.abort();
+        }
+      }
+    },
+    
+    testTransactionAboveLimit: function() {
+      const payload = { value1: Array(256).join("rip"), value2: Array(256).join("crap") };
+      let trx = db._createTransaction({ collections: { write: [cn] } });
+      try {
+        let c = trx.collection(cn);
+        try {
+          let docs = [];
+          for (let i = 0; i < 100; ++i) {
+            docs.push({ payload });
+          }
+          while (true) {
+            let res = c.insert(docs);
+            res.forEach((r) => {
+              if (r.error) {
+                throw new ArangoError(r);
+              }
+            });
+          }
+          fail();
+        } catch (err) {
+          assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+        }
+      } finally {
+        trx.abort();
+      }
+    },
+
+    testTransactionAboveLimitCommit: function(testName) {
+      // 1KB limit is quite low
+      // We're testing that the transaction is not aborted when the limit is reached.
+      // Rather, the commit should succeed.
+      let trx = db._createTransaction({ collections: { write: [cn] }, maxTransactionSize: 1024 });
+      let c = trx.collection(cn);
+      let docCount = 0;
+      const maxDocs = 10;
+      while (docCount < maxDocs) {
+        try {
+          // The insertion takes place inside a loop, because we are particularly interested in
+          // the iteration where the limit is reached. We are expecting a failure after a certain document count.
+          c.insert({_key: `${testName}-${docCount}`, value: docCount});
+        } catch (err) {
+          assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+          break;
+        }
+        ++docCount;
+      }
+      assertTrue(docCount > 0, "We didn't insert anything, better check maxTransactionSize!");
+      assertTrue(docCount < maxDocs, "We actually inserted everything, better check maxTransactionSize!");
+      trx.commit();
+      c = db._collection(cn);
+      assertEqual(docCount, c.count(), `expected ${docCount} documents in collection ${cn} but got ${c.count()}`);
+    },
+    
+    testAQLTransactionAboveLimit: function() {
+      let trx = db._createTransaction({ collections: { write: [cn] } });
+      try {
+        try {
+          trx.query("FOR i IN 1..1000000 INSERT { value1: i, value2: CONCAT('testmann', i) } INTO " + cn);
+          fail();
+        } catch (err) {
+          assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum);
+        }
+      } finally {
+        trx.abort();
+      }
+    },
+    testUpdateWithDocumentStatement: function () {
+      // ConcurrentStreamTransactionsTest.java
+      let docs = [];
+      let c = db[cn];
+      for (let i = 0; i < 1000; ++i) {
+        docs.push({ _key: `${i}`, value2: "testmann " + i });
+      }
+      c.insert(docs);
+      let docid = `${cn}/500`;
+      let trx = db._createTransaction({ collections: { write: [c] } });
+      trx.query(aql`LET d = DOCUMENT(${docid})
+                        UPDATE d WITH { "aaa": "aaa" } IN ${c}
+                        RETURN true`);
+      trx.commit();
+      let doc = c.byExample({_key: '500'}).toArray()[0];
+      assertTrue(doc.hasOwnProperty('aaa'), JSON.stringify(doc));
+    },
+    testStreamTransactionCluster: function () {
+      let IM = global.instanceManager;
+      if (IM.options.cluster) {
+        let coordinators = IM.arangods.filter(arangod => { return arangod.isFrontend();});
+        let count = 0;
+        let trx = db._createTransaction({ collections: { write: [cn], exclusive: [cn] } });
+        let c = trx.collection(cn);
+        while (count < 50){
+          coordinators[count %2].connect();
+          c.insert({count: count});
+          count ++;
+        }
+        trx.abort();
+        coordinators[0].connect();
+        assertEqual(db[cn].count(), 0);
+      }
+    }
+  };
+}
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/shell/api/cursor.js
+++ b/tests/js/client/shell/api/cursor.js
@@ -1804,6 +1804,32 @@ function dealing_with_cursorsSuite_retriable_request_last_batch() {
       cursor.dispose();
     },
 
+    test_cursor_non_stream_pull_partly: function () {
+      const stmt = db._createStatement({
+        query: `FOR u IN ${cn} RETURN u`,
+        options: {stream: false, allowRetry: true},
+        batchSize: 100
+      });
+      let cursor = stmt.execute();
+      IM.debugSetFailAt("MakeConnectionErrorForRetry");
+
+      // the batches in between will also be retrieved with `/_api/cursor/<cursorId>/<latestBatchId>` because
+      // the failure point is located in a place in which the server would return an error, hence not returning
+      // the batch response object to the user, but it would have been constructed, so the latest batch would be cached
+      for (let i = 0; i < 21; ++i) {
+        const nextValue = cursor.next();
+        // last batch not returning will close the cursor, won't be able to fetch the latest batch
+        if (i === 1900) {
+          IM.debugClearFailAt();
+        }
+        assertEqual("test" + i, nextValue._key);
+        assertEqual(i !== 2000, cursor.hasNext());
+      }
+      IM.debugClearFailAt();
+      assertTrue(cursor.hasNext());
+      cursor.dispose();
+    },
+
     test_cursor_stream_retriable: function () {
       const stmt = db._createStatement({
         query: `FOR u IN ${cn} RETURN u`,

--- a/tests/js/client/shell/api/multi/document-read.js
+++ b/tests/js/client/shell/api/multi/document-read.js
@@ -604,6 +604,11 @@ function checking_a_documentSuite () {
       doc = arango.HEAD_RAW(cmd, hdr);
 
       assertEqual(doc.code, 412);
+      hdr = { "if-match": "nonMatching" };
+      doc = arango.HEAD_RAW(cmd, hdr);
+
+      assertEqual(doc.body, undefined);
+      assertEqual(doc.code, 412);
     },
 
     test_use_empty_array_for_documents_read: function () {


### PR DESCRIPTION
Backport of https://github.com/arangodb/arangodb/pull/21310
* add support for the aql string processor

* add test for updating a document from streaming transactions in from java

* from Java: add check for nonMatch HEAD-requests

* implement massiv parallel two load generators transaction to two shards insert test

* reduce idle time, add second test.

* add test that doesn't pull the full cursor

* assure we reach synchronicity within a threshhold

* mark collections as exclusive - as advised by @raschtao

* add possibility to modify global options

* demand 2 coordinators, switch between them while running a transaction

