### PR TITLE
ttl deletions are now retried. bind vars should not be moved anymore.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Bind variables for TTL deletions should not be moved when now reused.
+
 * Removed the deprecated Batch API (`/_api/batch`).
   The arangobench `--batch-size` startup option is ignored now.
 

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -402,6 +402,7 @@ class TtlThread final : public ServerThread<ArangodServer> {
             // every time we do a potential TTL index purge
             options.skipAudit = true;
 
+            TRI_ASSERT(bindVars->slice().hasKey("@collection"));
             auto query = aql::Query::create(
                 transaction::StandaloneContext::create(*vocbase, origin),
                 aql::QueryString(::lookupQuery), bindVars, options);

--- a/arangod/RestServer/TtlFeature.cpp
+++ b/arangod/RestServer/TtlFeature.cpp
@@ -404,7 +404,7 @@ class TtlThread final : public ServerThread<ArangodServer> {
 
             auto query = aql::Query::create(
                 transaction::StandaloneContext::create(*vocbase, origin),
-                aql::QueryString(::lookupQuery), std::move(bindVars), options);
+                aql::QueryString(::lookupQuery), bindVars, options);
             query->collections().add(collection->name(), AccessMode::Type::READ,
                                      aql::Collection::Hint::Shard);
             aql::QueryResult queryResult = query->executeSync();


### PR DESCRIPTION
### Scope & Purpose

*Bind vars for TTL deletions shouold not be moved when reused*
No need to backport: In 3.11 the bindVars are not moved
`scripts/unittest shell_client --test ttl` triggers the added assertion with old code version

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
