### PR TITLE
Tune shortest path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ devel
 * Speed up shortest path computations by choosing more diligently which
   side to expand next. This brings back 3.10 performance.
 
+* Fixed a bug in (non-Yen) k-shortest-paths which could overlook some
+  paths.
+
 * Bind variables for TTL deletions should not be moved when now reused.
 
 * Removed the deprecated Batch API (`/_api/batch`).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Speed up shortest path computations by choosing more dilligently which
+  side to expand next. This brings back 3.10 performance.
+
 * Removed the deprecated Batch API (`/_api/batch`).
   The arangobench `--batch-size` startup option is ignored now.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Speed up shortest path computations by choosing more dilligently which
+* Speed up shortest path computations by choosing more diligently which
   side to expand next. This brings back 3.10 performance.
 
 * Removed the deprecated Batch API (`/_api/batch`).

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -252,6 +252,7 @@ class WeightedTwoSidedEnumerator {
     [[nodiscard]] auto peekQueue() const -> Step const&;
     [[nodiscard]] auto isQueueEmpty() const -> bool;
     [[nodiscard]] auto doneWithDepth() const -> bool;
+    [[nodiscard]] auto queueSize() const -> size_t { return _queue.size(); }
 
     auto buildPath(Step const& vertexInShell,
                    PathResult<ProviderType, Step>& path) -> void;

--- a/tests/Graph/WeightedShortestPathTest.cpp
+++ b/tests/Graph/WeightedShortestPathTest.cpp
@@ -386,7 +386,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_V4_V9) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 13U);
+    EXPECT_EQ(stats.getScannedIndex(), 14U);
   }
 
   {
@@ -435,7 +435,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_outbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 17U);
+    EXPECT_EQ(stats.getScannedIndex(), 16U);
   }
 
   {
@@ -484,7 +484,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_inbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 17U);
+    EXPECT_EQ(stats.getScannedIndex(), 16U);
   }
 
   {


### PR DESCRIPTION
Tune shortest paths to bring back 3.10 performance.

This effort comes from an investigation as to why Version 3.10 performed weighted shortest path computations (and as a consequence also Yen k-shortest-path computations) much faster than 3.12.

The finding is the following: In both implementations we use a two sided enumeration. We essentially use the same Dijkstra-like algorithm, but in 3.10 we choose differently, on which side we expand the next vertex from the priority queue. In 3.10, we always picked the side which had so far enumerated less vertices. In 3.12, we always picked the side, which had so far enumerated the smaller diameter.

Why does this matter so much?

If the search is "asymmetric" in the sense that there are a lot more paths coming out of one side than the other (quite likely in directed graphs and directed searches), the 3.10 approach concentrates on the "cheap" side first, and can therefore enumerate that one first, before expanding many vertices on the expensive side. This together with the following trick gave a tremendous advantage: Once one side has finished its search in its entirety, and some path has been found, we can prove that we can no longer find a shorter path anywhere.

This PR implements these changes and thus speeds up weighted shortest path searches considerably, not in all cases, but in many real life cases.

We also add source code comments to explain our rationale and our correctness proofs in detail.

In the process we discovered a bug in the legacy k-shortest-path algorithm which could overlook paths. This is fixed as well.

- **Tune shortest path.**
- **CHANGELOG.**

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-2091
- [*] Enterprise PR: https://github.com/arangodb/enterprise/pull/1513
