### PR TITLE
Refactor shortest path

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,9 @@ devel
 * Speed up shortest path computations by choosing more diligently which
   side to expand next. This brings back 3.10 performance.
 
+* Fixed a bug in (non-Yen) k-shortest-paths which could overlook some
+  paths.
+
 * Bind variables for TTL deletions should not be moved when now reused.
 
 * Removed the deprecated Batch API (`/_api/batch`).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Speed up shortest path computations by choosing more dilligently which
+  side to expand next. This brings back 3.10 performance.
+
 * Removed the deprecated Batch API (`/_api/batch`).
   The arangobench `--batch-size` startup option is ignored now.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Speed up shortest path computations by choosing more dilligently which
+* Speed up shortest path computations by choosing more diligently which
   side to expand next. This brings back 3.10 performance.
 
 * Removed the deprecated Batch API (`/_api/batch`).

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -195,11 +195,12 @@ using ShortestPathTracer = arangodb::graph::TracedShortestPathEnumerator<
     arangodb::graph::SingleServerProvider<
         arangodb::graph::SingleServerProviderStep>>;
 
-using WeightedShortestPath = arangodb::graph::WeightedShortestPathEnumerator<
-    arangodb::graph::SingleServerProvider<
-        arangodb::graph::SingleServerProviderStep>>;
+using WeightedShortestPath =
+    arangodb::graph::WeightedShortestPathEnumeratorAlias<
+        arangodb::graph::SingleServerProvider<
+            arangodb::graph::SingleServerProviderStep>>;
 using WeightedShortestPathTracer =
-    arangodb::graph::TracedWeightedShortestPathEnumerator<
+    arangodb::graph::TracedWeightedShortestPathEnumeratorAlias<
         arangodb::graph::SingleServerProvider<
             arangodb::graph::SingleServerProviderStep>>;
 
@@ -237,10 +238,10 @@ using ShortestPathClusterTracer = arangodb::graph::TracedShortestPathEnumerator<
     arangodb::graph::ClusterProvider<arangodb::graph::ClusterProviderStep>>;
 
 using WeightedShortestPathCluster =
-    arangodb::graph::WeightedShortestPathEnumerator<
+    arangodb::graph::WeightedShortestPathEnumeratorAlias<
         arangodb::graph::ClusterProvider<arangodb::graph::ClusterProviderStep>>;
 using WeightedShortestPathClusterTracer =
-    arangodb::graph::TracedWeightedShortestPathEnumerator<
+    arangodb::graph::TracedWeightedShortestPathEnumeratorAlias<
         arangodb::graph::ClusterProvider<arangodb::graph::ClusterProviderStep>>;
 
 namespace arangodb::aql {

--- a/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
@@ -509,7 +509,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
 
           if (!opts->useWeight()) {
             // Non-Weighted Variant
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   YenEnumeratorWithProvider<Provider>, Provider,
                   SingleServerBaseProviderOptions>(
@@ -556,7 +556,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                   return previousWeight + weight;
                 });
 
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   WeightedYenEnumeratorWithProvider<Provider>, Provider,
                   SingleServerBaseProviderOptions>(
@@ -605,7 +605,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
 
           if (!opts->useWeight()) {
             // Non-Weighted Variant
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   TracedYenEnumeratorWithProvider<Provider>,
                   ProviderTracer<Provider>, SingleServerBaseProviderOptions>(
@@ -652,7 +652,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                   return previousWeight + weight;
                 });
 
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   TracedWeightedYenEnumeratorWithProvider<Provider>,
                   ProviderTracer<Provider>, SingleServerBaseProviderOptions>(
@@ -723,7 +723,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
 
           if (!opts->useWeight()) {
             // Non-Weighted Variant
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   YenEnumeratorWithProvider<ClusterProvider>, ClusterProvider,
                   ClusterBaseProviderOptions>(
@@ -770,7 +770,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                   return previousWeight + weight;
                 });
 
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   WeightedYenEnumeratorWithProvider<ClusterProvider>,
                   ClusterProvider, ClusterBaseProviderOptions>(
@@ -818,7 +818,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
 
           if (!opts->useWeight()) {
             // Non-Weighted Variant
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   TracedYenEnumeratorWithProvider<ClusterProvider>,
                   ProviderTracer<ClusterProvider>, ClusterBaseProviderOptions>(
@@ -865,7 +865,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                   return previousWeight + weight;
                 });
 
-            if (opts->getAlgorithm() == StaticStrings::Yen) {
+            if (opts->getAlgorithm() != StaticStrings::Legacy) {
               return _makeExecutionBlockImpl<
                   TracedWeightedYenEnumeratorWithProvider<ClusterProvider>,
                   ProviderTracer<ClusterProvider>, ClusterBaseProviderOptions>(

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
@@ -457,9 +457,9 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
             _buildOutputRegisters<WeightedShortestPath>();
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
-        return makeExecutionBlockImpl<WeightedShortestPathEnumerator<Provider>,
-                                      Provider,
-                                      SingleServerBaseProviderOptions>(
+        return makeExecutionBlockImpl<
+            WeightedShortestPathEnumeratorAlias<Provider>, Provider,
+            SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
@@ -485,7 +485,7 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
         return makeExecutionBlockImpl<
-            TracedWeightedShortestPathEnumerator<Provider>,
+            TracedWeightedShortestPathEnumeratorAlias<Provider>,
             ProviderTracer<Provider>, SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
@@ -527,8 +527,8 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
         auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                                  std::move(outputRegisters));
         return makeExecutionBlockImpl<
-            WeightedShortestPathEnumerator<ClusterProvider>, ClusterProvider,
-            ClusterBaseProviderOptions>(
+            WeightedShortestPathEnumeratorAlias<ClusterProvider>,
+            ClusterProvider, ClusterBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
             validatorOptions, std::move(outputRegisterMapping), engine,
@@ -554,7 +554,7 @@ std::unique_ptr<ExecutionBlock> ShortestPathNode::createBlock(
                                                  std::move(outputRegisters));
 
         return makeExecutionBlockImpl<
-            TracedWeightedShortestPathEnumerator<ClusterProvider>,
+            TracedWeightedShortestPathEnumeratorAlias<ClusterProvider>,
             ProviderTracer<ClusterProvider>, ClusterBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,

--- a/arangod/Aql/Executor/ShortestPathExecutor.cpp
+++ b/arangod/Aql/Executor/ShortestPathExecutor.cpp
@@ -49,13 +49,13 @@ template class ::arangodb::aql::ShortestPathExecutorInfos<
     TracedShortestPathEnumerator<Cluster>>;
 
 template class ::arangodb::aql::ShortestPathExecutorInfos<
-    WeightedShortestPathEnumerator<SingleServer>>;
+    WeightedShortestPathEnumeratorAlias<SingleServer>>;
 template class ::arangodb::aql::ShortestPathExecutorInfos<
-    TracedWeightedShortestPathEnumerator<SingleServer>>;
+    TracedWeightedShortestPathEnumeratorAlias<SingleServer>>;
 template class ::arangodb::aql::ShortestPathExecutorInfos<
-    WeightedShortestPathEnumerator<Cluster>>;
+    WeightedShortestPathEnumeratorAlias<Cluster>>;
 template class ::arangodb::aql::ShortestPathExecutorInfos<
-    TracedWeightedShortestPathEnumerator<Cluster>>;
+    TracedWeightedShortestPathEnumeratorAlias<Cluster>>;
 
 // Executor
 template class ::arangodb::aql::ShortestPathExecutor<
@@ -68,10 +68,10 @@ template class ::arangodb::aql::ShortestPathExecutor<
     TracedShortestPathEnumerator<Cluster>>;
 
 template class ::arangodb::aql::ShortestPathExecutor<
-    WeightedShortestPathEnumerator<SingleServer>>;
+    WeightedShortestPathEnumeratorAlias<SingleServer>>;
 template class ::arangodb::aql::ShortestPathExecutor<
-    WeightedShortestPathEnumerator<Cluster>>;
+    WeightedShortestPathEnumeratorAlias<Cluster>>;
 template class ::arangodb::aql::ShortestPathExecutor<
-    TracedWeightedShortestPathEnumerator<SingleServer>>;
+    TracedWeightedShortestPathEnumeratorAlias<SingleServer>>;
 template class ::arangodb::aql::ShortestPathExecutor<
-    TracedWeightedShortestPathEnumerator<Cluster>>;
+    TracedWeightedShortestPathEnumeratorAlias<Cluster>>;

--- a/arangod/Graph/EdgeDocumentToken.h
+++ b/arangod/Graph/EdgeDocumentToken.h
@@ -195,6 +195,14 @@ struct EdgeDocumentToken {
            (_data.document.cid.id() << 1);
   }
 
+  std::string toString() const {
+    if (ServerState::instance()->isCoordinator()) {
+      return arangodb::velocypack::Slice(vpack()).toString();
+    }
+    return std::to_string(_data.document.cid.id()) + ":" +
+           std::to_string(_data.document.localDocumentId.id());
+  }
+
  private:
   /// Identifying information for an edge documents valid on one server
   /// only used on a dbserver or single server

--- a/arangod/Graph/Enumerators/CMakeLists.txt
+++ b/arangod/Graph/Enumerators/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(arango_graph PRIVATE
   OneSidedEnumerator.cpp
   OneSidedEnumeratorInterface.cpp
+  WeightedShortestPathEnumerator.cpp
   WeightedTwoSidedEnumerator.cpp
   TwoSidedEnumerator.cpp
   YenEnumerator.cpp)

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
@@ -81,6 +81,7 @@ void WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
                                                                     center,
                                                                 size_t depth) {
   clear();
+  _center = center;
   auto firstStep = _provider.startVertex(center, depth);
   _queue.append(std::move(firstStep));
 }
@@ -272,7 +273,8 @@ auto WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
     _visitedNodes[step.getVertex().getID()].emplace_back(posPrevious);
   }
 
-  if (!res.isPruned()) {
+  if (!res.isPruned() && step.getVertex().getID() != other.getCenter()) {
+    // We do not want to go further than the center of the other side!
     _provider.expand(step, posPrevious, [&](Step n) -> void {
       // TODO: maybe the pathStore could be asked whether a vertex has been
       // visited?
@@ -668,7 +670,7 @@ void WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
       // expanded by the right hand side. Since w' < d1+d2, there is no
       // "gap" between the two sides: There cannot be a vertex on the path,
       // which is both at least d1 from the start and at least d2 from the
-      // target. It might even be that some vertex on the PATH has been
+      // target. It might even be that some vertex on the path P has been
       // expanded by both sides. In any case, there must be an edge on the
       // path, so that the source of the edge has been expanded by the
       // left hand side and the target of the edge has been expanded

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
@@ -71,7 +71,10 @@ WeightedShortestPathEnumerator<
 template<class QueueType, class PathStoreType, class ProviderType,
          class PathValidator>
 WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
-                               PathValidator>::Ball::~Ball() = default;
+                               PathValidator>::Ball::~Ball() {
+  clear();
+  clearProvider();
+}
 
 template<class QueueType, class PathStoreType, class ProviderType,
          class PathValidator>
@@ -97,9 +100,9 @@ void WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
   _interior.reset();  // PathStore
   _diameter = -std::numeric_limits<double>::infinity();
   _validator.reset();
-
-  // Provider - Must be last one to be cleared(!)
-  clearProvider();
+  // We do not clear the provider here, or else it would immediately
+  // clear all its caches. For repeated calls we want to retain the caches.
+  // The provider is only cleared in the destructor.
 }
 
 template<class QueueType, class PathStoreType, class ProviderType,

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
@@ -268,7 +268,7 @@ auto WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
   if (!res.isPruned() && step.getVertex().getID() != other.getCenter()) {
     auto it = _foundVertices.find(step.getVertex().getID());
     TRI_ASSERT(it != _foundVertices.end());
-    if (it->second.cancelled) {
+    if (it->second.expanded) {
       // This happens if we have later found a shorter path to the vertex
       // and have still not queued the cheaper Step, for example, because
       // the other side has already expanded the vertex. This is a performance
@@ -331,9 +331,9 @@ auto WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
         // later:
         _queue.append(std::move(n));
         _queued++;
-        reachedIt->second.cancelled = false;  // Make sure we expand the vertex
+        reachedIt->second.expanded = false;  // Make sure we expand the vertex
       } else if (weightReduced) {
-        reachedIt->second.cancelled = true;
+        reachedIt->second.expanded = true;
       }
     });
   }

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
@@ -268,7 +268,7 @@ auto WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
   if (!res.isPruned() && step.getVertex().getID() != other.getCenter()) {
     auto it = _foundVertices.find(step.getVertex().getID());
     TRI_ASSERT(it != _foundVertices.end());
-    if (it->second.expanded) {
+    if (it->second.cancelled) {
       // This happens if we have later found a shorter path to the vertex
       // and have still not queued the cheaper Step, for example, because
       // the other side has already expanded the vertex. This is a performance
@@ -331,9 +331,9 @@ auto WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
         // later:
         _queue.append(std::move(n));
         _queued++;
-        reachedIt->second.expanded = false;  // Make sure we expand the vertex
+        reachedIt->second.cancelled = false;  // Make sure we expand the vertex
       } else if (weightReduced) {
-        reachedIt->second.expanded = true;
+        reachedIt->second.cancelled = true;
       }
     });
   }

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
@@ -545,9 +545,10 @@ bool WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
   };
 
   auto report = [&]() {
-    LOG_DEVEL << "Left: expanded " << _left.getExpanded()
-              << " queued: " << _left.getQueued() << " Right: expanded "
-              << _right.getExpanded() << " queued: " << _right.getQueued();
+    LOG_TOPIC("47010", TRACE, Logger::GRAPHS)
+        << "Yen: Left: expanded " << _left.getExpanded()
+        << " queued: " << _left.getQueued() << " Right: expanded "
+        << _right.getExpanded() << " queued: " << _right.getQueued();
   };
 
   while (!isDone()) {
@@ -577,14 +578,6 @@ void WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
                                     PathValidator>::searchMoreResults() {
   while (!searchDone()) {
     _resultsFetched = false;
-
-    auto report = [&]() {
-      LOG_DEVEL << "Left: expanded " << _left.getExpanded()
-                << " queued: " << _left.getQueued() << " Right: expanded "
-                << _right.getExpanded() << " queued: " << _right.getQueued()
-                << " have candidate: " << _bestPath.has_value();
-    };
-    report();
 
     if (_singleton) {
       _left.validateSingletonPath(_bestPath);
@@ -692,9 +685,10 @@ WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
     return BallSearchLocation::FINISH;
   }
 
-  LOG_DEVEL << "Pondering left/right: " << _left.queueSize() << " vs. "
-            << _right.queueSize() << " ==> "
-            << (_left.queueSize() < _right.queueSize() ? "LEFT" : "RIGHT");
+  LOG_TOPIC("47011", TRACE, Logger::GRAPHS)
+      << "Pondering left/right: " << _left.queueSize() << " vs. "
+      << _right.queueSize() << " ==> "
+      << (_left.queueSize() < _right.queueSize() ? "LEFT" : "RIGHT");
 
   if (_left.getDiameter() < 0.0) {
     return BallSearchLocation::LEFT;

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.cpp
@@ -640,7 +640,11 @@ void WeightedShortestPathEnumerator<QueueType, PathStoreType, ProviderType,
       // have actually found some path, then we are done. Why is that?
       // Assume wlog that the left side is finished and we have found
       // a path. Then the left hand side has found everything that is
-      // reachable from the source and has expanded it.
+      // reachable from the source, unless it has already been expanded
+      // by the other side. The left hand side has expanded everything it
+      // has found. If the right hand side has expanded a vertex, it "knows"
+      // the distance of this vertex from the target and knows a shortest
+      // path. Therefore, we do not have to go there any more.
       if (_left.isQueueEmpty() || _right.isQueueEmpty()) {
         // Note that we might have already found a path with the above
         // criteria, so we should then not report a second one:

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -1,0 +1,474 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Michael Hackstein
+/// @author Heiko Kernbach
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Assertions/Assert.h"
+#include "Basics/ResourceUsage.h"
+#include "Containers/HashSet.h"
+#include "Graph/Options/TwoSidedEnumeratorOptions.h"
+#include "Graph/PathManagement/PathResult.h"
+#include "Graph/Types/ForbiddenVertices.h"
+#include "Containers/FlatHashMap.h"
+
+#include <limits>
+#include <set>
+#include <deque>
+
+namespace arangodb {
+
+using VertexRef = arangodb::velocypack::HashedStringRef;
+using VertexSet = arangodb::containers::HashSet<VertexRef, std::hash<VertexRef>,
+                                                std::equal_to<VertexRef>>;
+
+namespace aql {
+class TraversalStats;
+}
+
+namespace velocypack {
+class Builder;
+class HashedStringRef;
+}  // namespace velocypack
+
+namespace graph {
+
+class PathValidatorOptions;
+struct TwoSidedEnumeratorOptions;
+
+template<class ProviderType, class Step>
+class PathResult;
+
+// This class `WeightedTwoSidedEnumerator` is used for shortest path searches,
+// as well as for k-shortest-path searches, for all-shortest-path searches
+// and for k-paths (finding all paths from source to target), whenever the
+// length is measured by an edge weight.
+// It works by doing a Dijkstra-like graph traversal from both sides and
+// then matching findings. As work queue it uses a priority queue, always
+// processing the next unprocessed step according to the queue.
+// This class is used in very different situations (single server, cluster,
+// various different types of smart and not so smart graphs, with tracing
+// and without, etc.). Therefore we need many template parameters. Let me
+// here give an overview over what they do:
+//  - QueueType: This is the queue being used to track which steps to visit
+//    next. It is always `WeightedQueue`, but it needs to be a template
+//    argument since there is a wrapper template for tracing `QueueTracer`,
+//    so it is sometimes QueueTracer<WeightedQueue>.
+//  - PathStoreType: This is a class to store paths. Its type depends on
+//    the type ProviderType::Step (see below) and on the presence of a
+//    tracing wrapper type.
+//  - ProviderType: This is a class which delivers the actual graph data,
+//    essentially to answer the question as to what the neighbours of a
+//    vertex are. This can be `SingleServerProvider` or `ClusterProvider`.
+//    Again, there is a tracing wrapper.
+//  - PathValidatorType: Finally, this is a class which is used to validate
+//    if paths are valid. Various filtering conditions can be handed in,
+//    but the most important one is to specify the uniqueness conditions
+//    on edges and vertices. Again, there is a tracing wrapper.
+// A few words on uniqueness conditions are in order, since they are
+// specified in the PathValidator, but have very strong interferences with
+// the actual algorithm. For edges, there is either "no uniqueness"
+// or "path uniqueness" (which means no edge may appear more than once
+// on a single path), or "global uniqueness" (which means no edge may
+// appear more than once in the whole traversal. For vertices, there is
+// either "no uniqueness" or "path uniqueness" (no vertex may appear
+// more than once on a single path), or "global uniqueness", which says
+// that no vertex may occur more than once in the whole traversal.
+// The great variety is only used for normal graph traversals, and so in
+// particular not here in the `WeightedTwoSidedEnumerator`. Here, only two
+// combinations are in use:
+//   vertex path uniqueness / edge path uniqueness
+//   vertex global uniqueness / edge path uniqueness
+// The first is for finding all possible loopless paths and edge uniqueness
+// follows from vertex uniqueness. This is used for k-paths and the versions
+// of all-shortest-paths and k-shortest-paths which do not use Yen's
+// algorithm. The second combination is used for (two-sided) Dijkstra-type
+// computations, where we are only interested in the shortest path. This
+// is also what Yen's algorithm does, just computing various shortest paths
+// one after another.
+// Please note the following subtle issue: When enumerating paths (first
+// combination above), the item on the queue is a "Step" (which encodes
+// the path so far plus one more edge). In particular, there can and will
+// be multiple Steps on the queue, which have arrived at the same vertex
+// (with different edges or indeed different paths). This is necessary,
+// since we have to enumerate all possible paths.
+// When we are only looking for a shortest path, we use global vertex
+// uniqueness. However, the implementation is slightly different from a
+// standard Dijkstra algorithm as can be found in the literature. Namely,
+// some vertex V can indeed be found in different ways, and in this case
+// multiple Steps to reach it will in this case be put on the queue. This
+// is to get the accounting of the weight of the different ways to reach
+// this vertex right. Therefore, we must not check the validity of the path
+// **when we explore a new step and put it on the queue**. Rather, we check
+// path validity only when we **visit** a step to explore all next steps!
+// That is, we have no "reduce weight" operation when we find a new path
+// to a vertex which has already been visited, but we administrate both
+// Steps (the shorter and the longer path), the shorter path's Step will
+// be earlier in the WeightedQueue and thus will be visited earlier.
+// The other Step will then be later in the queue and when we would otherwise
+// visit it, we will check validity of the path and will then not visit it,
+// since global vertex uniqueness is violated.
+
+template<class QueueType, class PathStoreType, class ProviderType,
+         class PathValidatorType>
+class WeightedShortestPathEnumerator {
+ public:
+  using Step = typename ProviderType::Step;  // public due to tracer access
+
+  // A meeting point with calculated path weight
+  using CalculatedCandidate = std::tuple<double, Step, Step>;
+
+ private:
+  enum Direction { FORWARD, BACKWARD };
+
+  using VertexRef = arangodb::velocypack::HashedStringRef;
+
+  using Edge = ProviderType::Step::EdgeType;
+  using EdgeSet =
+      arangodb::containers::HashSet<Edge, std::hash<Edge>, std::equal_to<Edge>>;
+
+  using Shell = std::multiset<Step>;
+  using ResultList = std::deque<CalculatedCandidate>;
+  using GraphOptions = arangodb::graph::TwoSidedEnumeratorOptions;
+
+  /*
+   * Weighted candidate store for handling path-match candidates in the order
+   * from the lowest weight to the highest weight.
+   */
+  class CandidatesStore {
+   public:
+    void clear() {
+      if (!_queue.empty()) {
+        _queue.clear();
+      }
+    }
+
+    void append(CalculatedCandidate candidate) {
+      // if emplace() throws, no harm is done, and the memory usage increase
+      // will be rolled back
+      _queue.emplace_back(std::move(candidate));
+      // std::push_heap takes the last element in the queue, assumes that all
+      // other elements are in heap structure, and moves the last element into
+      // the correct position in the heap (incl. rebalancing of other elements)
+      // The heap structure guarantees that the first element in the queue
+      // is the "largest" element (in our case it is the smallest, as we
+      // inverted the comparator)
+      std::push_heap(_queue.begin(), _queue.end(), _cmpHeap);
+    }
+
+    [[nodiscard]] size_t size() const { return _queue.size(); }
+
+    [[nodiscard]] bool isEmpty() const { return _queue.empty(); }
+
+    [[nodiscard]] std::vector<Step*> getLeftLooseEnds() {
+      std::vector<Step*> steps;
+
+      for (auto& [_, step, __] : _queue) {
+        if (!step.isProcessable()) {
+          steps.emplace_back(&step);
+        }
+      }
+
+      return steps;
+    }
+
+    [[nodiscard]] std::vector<Step*> getRightLooseEnds() {
+      std::vector<Step*> steps;
+
+      for (auto& [_, __, step] : _queue) {
+        if (!step.isProcessable()) {
+          steps.emplace_back(&step);
+        }
+      }
+
+      return steps;
+    }
+
+    [[nodiscard]] CalculatedCandidate& peek() {
+      TRI_ASSERT(!_queue.empty());
+      // will return a pointer to the step with the lowest weight amount
+      // possible. The heap structure guarantees that the first element in the
+      // queue is the "largest" element (in our case it is the smallest, as we
+      // inverted the comparator)
+      return _queue.front();
+    }
+
+    [[nodiscard]] CalculatedCandidate pop() {
+      TRI_ASSERT(!isEmpty());
+      // std::pop_heap will move the front element (the one we would like to
+      // steal) to the back of the vector, keeping the tree intact otherwise.
+      // Now we steal the last element.
+      std::pop_heap(_queue.begin(), _queue.end(), _cmpHeap);
+      CalculatedCandidate first = std::move(_queue.back());
+      _queue.pop_back();
+      return first;
+    }
+
+   private:
+    struct WeightedComparator {
+      bool operator()(CalculatedCandidate const& a,
+                      CalculatedCandidate const& b) {
+        auto const& [weightA, candAA, candAB] = a;
+        auto const& [weightB, candBA, candBB] = b;
+        return weightA > weightB;
+      }
+    };
+
+    WeightedComparator _cmpHeap{};
+
+    /// @brief queue datastore
+    std::vector<CalculatedCandidate> _queue;
+  };
+
+  class Ball {
+   public:
+    Ball(Direction dir, ProviderType&& provider, GraphOptions const& options,
+         PathValidatorOptions validatorOptions,
+         arangodb::ResourceMonitor& resourceMonitor);
+    ~Ball();
+    auto clear() -> void;
+    auto reset(VertexRef center, size_t depth = 0) -> void;
+    [[nodiscard]] auto noPathLeft() const -> bool;
+    [[nodiscard]] auto peekQueue() const -> Step const&;
+    [[nodiscard]] auto isQueueEmpty() const -> bool;
+    [[nodiscard]] auto doneWithDepth() const -> bool;
+    [[nodiscard]] auto queueSize() const -> size_t { return _queue.size(); }
+
+    auto buildPath(Step const& vertexInShell,
+                   PathResult<ProviderType, Step>& path) -> void;
+
+    auto matchResultsInShell(Step const& match, CandidatesStore& results,
+                             PathValidatorType const& otherSideValidator)
+        -> void;
+
+    auto computeNeighbourhoodOfNextVertex(Ball& other, CandidatesStore& results)
+        -> void;
+
+    [[nodiscard]] auto hasBeenVisited(Step const& step) -> bool;
+    auto validateSingletonPath(CandidatesStore& candidates) -> void;
+
+    auto ensureQueueHasProcessableElement() -> void;
+
+    // Ensure that we have fetched all vertices in the _results list.
+    // Otherwise, we will not be able to generate the resulting path
+    auto fetchResults(CandidatesStore& candidates) -> void;
+    auto fetchResult(CalculatedCandidate& candidate) -> void;
+
+    auto provider() -> ProviderType&;
+
+    auto getDiameter() const noexcept -> double { return _diameter; }
+
+    auto haveSeenOtherSide() const noexcept -> bool {
+      return _haveSeenOtherSide;
+    }
+
+    auto setForbiddenVertices(std::shared_ptr<VertexSet> forbidden)
+        -> void requires HasForbidden<PathValidatorType> {
+      _validator.setForbiddenVertices(std::move(forbidden));
+    };
+
+    auto setForbiddenEdges(std::shared_ptr<EdgeSet> forbidden)
+        -> void requires HasForbidden<PathValidatorType> {
+      _validator.setForbiddenEdges(std::move(forbidden));
+    };
+
+   private : auto clearProvider() -> void;
+   private:
+    // TODO: Double check if we really need the monitor here. Currently unused.
+    arangodb::ResourceMonitor& _resourceMonitor;
+
+    // This stores all paths processed by this ball
+    PathStoreType _interior;
+
+    // The next elements to process
+    QueueType _queue;
+
+    ProviderType _provider;
+
+    PathValidatorType _validator;
+    containers::FlatHashMap<typename Step::VertexType, std::vector<size_t>>
+        _visitedNodes;
+    Direction _direction;
+    GraphOptions _graphOptions;
+    double _diameter = -std::numeric_limits<double>::infinity();
+    bool _haveSeenOtherSide;
+  };
+  enum BallSearchLocation { LEFT, RIGHT, FINISH };
+
+  /*
+   * A class that is able to store valid shortest paths results.
+   * This is required to be able to check for duplicate paths, as those can be
+   * found during a KShortestPaths graphs search.
+   */
+  class ResultCache {
+   public:
+    ResultCache(Ball& left, Ball& right);
+    ~ResultCache();
+
+    // @brief: returns whether a path could be inserted or not.
+    // True: It will be inserted if this specific path has not been added yet.
+    // False: Could not insert as this path has already been found.
+    [[nodiscard]] auto tryAddResult(CalculatedCandidate const& candidate)
+        -> bool;
+    auto clear() -> void;
+
+   private:
+    Ball& _internalLeft;
+    Ball& _internalRight;
+    std::vector<PathResult<ProviderType, Step>> _internalResultsCache{};
+  };
+
+ public:
+  WeightedShortestPathEnumerator(ProviderType&& forwardProvider,
+                                 ProviderType&& backwardProvider,
+                                 TwoSidedEnumeratorOptions&& options,
+                                 PathValidatorOptions validatorOptions,
+                                 arangodb::ResourceMonitor& resourceMonitor);
+  WeightedShortestPathEnumerator(WeightedShortestPathEnumerator const& other) =
+      delete;
+  WeightedShortestPathEnumerator& operator=(
+      WeightedShortestPathEnumerator const& other) = delete;
+  WeightedShortestPathEnumerator(WeightedShortestPathEnumerator&& other) =
+      delete;
+  WeightedShortestPathEnumerator& operator=(
+      WeightedShortestPathEnumerator&& other) = delete;
+
+  ~WeightedShortestPathEnumerator();
+
+  auto clear() -> void;
+
+  /**
+   * @brief Quick test if the finder can prove there is no more data available.
+   *        It can respond with false, even though there is no path left.
+   * @return true There will be no further path.
+   * @return false There is a chance that there is more data available.
+   */
+  [[nodiscard]] bool isDone() const;
+
+  /**
+   * @brief Reset to new source and target vertices.
+   * This API uses string references, this class will not take responsibility
+   * for the referenced data. It is caller's responsibility to retain the
+   * underlying data and make sure the strings stay valid until next
+   * call of reset.
+   *
+   * @param source The source vertex to start the paths
+   * @param target The target vertex to end the paths
+   */
+  void reset(VertexRef source, VertexRef target, size_t depth = 0);
+
+  /**
+   * @brief Get the next path, if available written into the result build.
+   * The given builder will be not be cleared, this function requires a
+   * prepared builder to write into.
+   *
+   * @param result Input and output, this needs to be an open builder,
+   * where the path can be placed into.
+   * Can be empty, or an openArray, or the value of an object.
+   * Guarantee: Every returned path matches the conditions handed in via
+   * options. No path is returned twice, it is intended that paths overlap.
+   * @return true Found and written a path, result is modified.
+   * @return false No path found, result has not been changed.
+   */
+  bool getNextPath(arangodb::velocypack::Builder& result);
+
+  // The reference returned by the following call is only valid until
+  // getNextPath is called again or until the WeightedShortestPathEnumerator
+  // is destroyed or otherwise modified!
+  PathResult<ProviderType, typename ProviderType::Step> const&
+  getLastPathResult() const {
+    return _resultPath;
+  }
+
+  /**
+   * @brief Skip the next Path, like getNextPath, but does not return the path.
+   *
+   * @return true Found and skipped a path.
+   * @return false No path found.
+   */
+
+  bool skipPath();
+  auto destroyEngines() -> void;
+
+  /**
+   * @brief Return statistics generated since
+   * the last time this method was called.
+   */
+  auto stealStats() -> aql::TraversalStats;
+
+  auto setForbiddenVertices(std::shared_ptr<VertexSet> forbidden)
+      -> void requires HasForbidden<PathValidatorType> {
+    _left.setForbiddenVertices(forbidden);
+    _right.setForbiddenVertices(std::move(forbidden));
+  };
+
+  auto setForbiddenEdges(std::shared_ptr<EdgeSet> forbidden)
+      -> void requires HasForbidden<PathValidatorType> {
+    _left.setForbiddenEdges(forbidden);
+    _right.setForbiddenEdges(std::move(forbidden));
+  };
+
+  auto setEmitWeight(bool flag) -> void { _emitWeight = flag; }
+
+ private:
+  [[nodiscard]] auto searchDone() const -> bool;
+  // Ensure that we have fetched all vertices in the _results list. Otherwise,
+  // we will not be able to generate the resulting path
+  auto fetchResults() -> void;
+  auto fetchResult() -> void;
+
+  // Ensure that we have more valid paths in the _result stock.
+  // May be a noop if _result is not empty.
+  auto searchMoreResults() -> void;
+
+  // Check where we want to continue our search
+  // (Left or right ball)
+  auto getBallToContinueSearch() const -> BallSearchLocation;
+
+  // In case we call this method, we know that we've already produced
+  // enough results. This flag will be checked within the "isDone" method
+  // and will provide a quick exit. Currently, this is only being used for
+  // graph searches of type "Shortest Path".
+  auto setAlgorithmFinished() -> void;
+  auto setAlgorithmUnfinished() -> void;
+  [[nodiscard]] auto isAlgorithmFinished() const -> bool;
+
+ private:
+  GraphOptions _options;
+  Ball _left;
+  Ball _right;
+
+  // Templated result list, where only valid result(s) are stored in
+  CandidatesStore _candidatesStore{};
+  ResultCache _resultsCache;
+  ResultList _results{};
+
+  bool _resultsFetched{false};
+  bool _algorithmFinished{false};
+  bool _singleton{false};
+  bool _emitWeight{false};
+
+  PathResult<ProviderType, Step> _resultPath;
+};
+}  // namespace graph
+}  // namespace arangodb

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -298,14 +298,13 @@ class WeightedShortestPathEnumerator {
 
     PathValidatorType _validator;
     struct VertexWeight {
-      VertexWeight(double w)
-          : weight(w), position(0), expanded(false), cancelled(false) {}
+      VertexWeight(double w) : weight(w), position(0), expanded(false) {}
       double weight;
       size_t position;  // this is only set once `expanded` is true
                         // it refers to the position in _interior
                         // once the vertex has been expanded.
       bool expanded;    // This is set to true if a vertex has been expanded.
-      bool cancelled;   // This is set to true if a vertex has been found
+                        // This is set also to true if a vertex has been found
                         // with a lower weight than the current one and
                         // yet no new Step has been queued for it. We can
                         // then prevent further expansion of this vertex

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -276,6 +276,9 @@ class WeightedShortestPathEnumerator {
 
     auto getCenter() const noexcept -> VertexRef { return _center; }
 
+    auto getQueued() const noexcept -> size_t { return _queued; }
+    auto getExpanded() const noexcept -> size_t { return _expanded; }
+
    private:
     auto clearProvider() -> void;
 
@@ -291,6 +294,9 @@ class WeightedShortestPathEnumerator {
 
     // The next elements to process
     QueueType _queue;
+
+    size_t _queued = 0;
+    size_t _expanded = 0;
 
     ProviderType _provider;
 
@@ -424,7 +430,7 @@ class WeightedShortestPathEnumerator {
 
   // Check where we want to continue our search
   // (Left or right ball)
-  auto getBallToContinueSearch() const -> BallSearchLocation;
+  auto getBallToContinueSearch() -> BallSearchLocation;
 
   // In case we call this method, we know that we've already produced
   // enough results. This flag will be checked within the "isDone" method

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -29,7 +29,6 @@
 #include "Containers/HashSet.h"
 #include "Graph/Options/TwoSidedEnumeratorOptions.h"
 #include "Graph/PathManagement/PathResult.h"
-#include "Graph/Types/ForbiddenVertices.h"
 #include "Containers/FlatHashMap.h"
 
 #include <limits>
@@ -167,13 +166,11 @@ class WeightedShortestPathEnumerator {
 
     auto getDiameter() const noexcept -> double { return _diameter; }
 
-    auto setForbiddenVertices(std::shared_ptr<VertexSet> forbidden)
-        -> void requires HasForbidden<PathValidatorType> {
+    auto setForbiddenVertices(std::shared_ptr<VertexSet> forbidden) -> void {
       _forbiddenVertices = std::move(forbidden);
     };
 
-    auto setForbiddenEdges(std::shared_ptr<EdgeSet> forbidden)
-        -> void requires HasForbidden<PathValidatorType> {
+    auto setForbiddenEdges(std::shared_ptr<EdgeSet> forbidden) -> void {
       _forbiddenEdges = std::move(forbidden);
     };
 
@@ -228,29 +225,6 @@ class WeightedShortestPathEnumerator {
     std::shared_ptr<EdgeSet> _forbiddenEdges;
   };
   enum BallSearchLocation { LEFT, RIGHT, FINISH };
-
-  /*
-   * A class that is able to store valid shortest paths results.
-   * This is required to be able to check for duplicate paths, as those can be
-   * found during a KShortestPaths graphs search.
-   */
-  class ResultCache {
-   public:
-    ResultCache(Ball& left, Ball& right);
-    ~ResultCache();
-
-    // @brief: returns whether a path could be inserted or not.
-    // True: It will be inserted if this specific path has not been added yet.
-    // False: Could not insert as this path has already been found.
-    [[nodiscard]] auto tryAddResult(CalculatedCandidate const& candidate)
-        -> bool;
-    auto clear() -> void;
-
-   private:
-    Ball& _internalLeft;
-    Ball& _internalRight;
-    std::vector<PathResult<ProviderType, Step>> _internalResultsCache{};
-  };
 
  public:
   WeightedShortestPathEnumerator(ProviderType&& forwardProvider,
@@ -322,14 +296,12 @@ class WeightedShortestPathEnumerator {
    */
   auto stealStats() -> aql::TraversalStats;
 
-  auto setForbiddenVertices(std::shared_ptr<VertexSet> forbidden)
-      -> void requires HasForbidden<PathValidatorType> {
+  auto setForbiddenVertices(std::shared_ptr<VertexSet> forbidden) -> void {
     _left.setForbiddenVertices(forbidden);
     _right.setForbiddenVertices(std::move(forbidden));
   };
 
-  auto setForbiddenEdges(std::shared_ptr<EdgeSet> forbidden)
-      -> void requires HasForbidden<PathValidatorType> {
+  auto setForbiddenEdges(std::shared_ptr<EdgeSet> forbidden) -> void {
     _left.setForbiddenEdges(forbidden);
     _right.setForbiddenEdges(std::move(forbidden));
   };

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -274,13 +274,20 @@ class WeightedShortestPathEnumerator {
       _validator.setForbiddenEdges(std::move(forbidden));
     };
 
-   private : auto clearProvider() -> void;
+    auto getCenter() const noexcept -> VertexRef { return _center; }
+
+   private:
+    auto clearProvider() -> void;
+
    private:
     // TODO: Double check if we really need the monitor here. Currently unused.
     arangodb::ResourceMonitor& _resourceMonitor;
 
     // This stores all paths processed by this ball
     PathStoreType _interior;
+
+    // The center:
+    VertexRef _center;
 
     // The next elements to process
     QueueType _queue;

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -400,14 +400,6 @@ class WeightedShortestPathEnumerator {
     return _resultPath;
   }
 
-  /**
-   * @brief Skip the next Path, like getNextPath, but does not return the path.
-   *
-   * @return true Found and skipped a path.
-   * @return false No path found.
-   */
-
-  bool skipPath();
   auto destroyEngines() -> void;
 
   /**

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -298,13 +298,14 @@ class WeightedShortestPathEnumerator {
 
     PathValidatorType _validator;
     struct VertexWeight {
-      VertexWeight(double w) : weight(w), position(0), expanded(false) {}
+      VertexWeight(double w)
+          : weight(w), position(0), expanded(false), cancelled(false) {}
       double weight;
       size_t position;  // this is only set once `expanded` is true
                         // it refers to the position in _interior
                         // once the vertex has been expanded.
       bool expanded;    // This is set to true if a vertex has been expanded.
-                        // This is set also to true if a vertex has been found
+      bool cancelled;   // This is set to true if a vertex has been found
                         // with a lower weight than the current one and
                         // yet no new Step has been queued for it. We can
                         // then prevent further expansion of this vertex

--- a/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedShortestPathEnumerator.h
@@ -60,9 +60,7 @@ template<class ProviderType, class Step>
 class PathResult;
 
 // This class `WeightedTwoSidedEnumerator` is used for shortest path searches,
-// as well as for k-shortest-path searches, for all-shortest-path searches
-// and for k-paths (finding all paths from source to target), whenever the
-// length is measured by an edge weight.
+// whenever the // length is measured by an edge weight.
 // It works by doing a Dijkstra-like graph traversal from both sides and
 // then matching findings. As work queue it uses a priority queue, always
 // processing the next unprocessed step according to the queue.
@@ -85,34 +83,15 @@ class PathResult;
 //    if paths are valid. Various filtering conditions can be handed in,
 //    but the most important one is to specify the uniqueness conditions
 //    on edges and vertices. Again, there is a tracing wrapper.
-// A few words on uniqueness conditions are in order, since they are
-// specified in the PathValidator, but have very strong interferences with
-// the actual algorithm. For edges, there is either "no uniqueness"
-// or "path uniqueness" (which means no edge may appear more than once
-// on a single path), or "global uniqueness" (which means no edge may
-// appear more than once in the whole traversal. For vertices, there is
-// either "no uniqueness" or "path uniqueness" (no vertex may appear
-// more than once on a single path), or "global uniqueness", which says
-// that no vertex may occur more than once in the whole traversal.
-// The great variety is only used for normal graph traversals, and so in
-// particular not here in the `WeightedTwoSidedEnumerator`. Here, only two
-// combinations are in use:
-//   vertex path uniqueness / edge path uniqueness
-//   vertex global uniqueness / edge path uniqueness
-// The first is for finding all possible loopless paths and edge uniqueness
-// follows from vertex uniqueness. This is used for k-paths and the versions
-// of all-shortest-paths and k-shortest-paths which do not use Yen's
-// algorithm. The second combination is used for (two-sided) Dijkstra-type
-// computations, where we are only interested in the shortest path. This
-// is also what Yen's algorithm does, just computing various shortest paths
-// one after another.
+//    For this class, the vertex uniqueness condition must be GLOBAL and
+//    the edge uniqueness condition must be PATH.
 // Please note the following subtle issue: When enumerating paths (first
 // combination above), the item on the queue is a "Step" (which encodes
 // the path so far plus one more edge). In particular, there can and will
 // be multiple Steps on the queue, which have arrived at the same vertex
 // (with different edges or indeed different paths). This is necessary,
 // since we have to enumerate all possible paths.
-// When we are only looking for a shortest path, we use global vertex
+// Since we are only looking for a shortest path, we use global vertex
 // uniqueness. However, the implementation is slightly different from a
 // standard Dijkstra algorithm as can be found in the literature. Namely,
 // some vertex V can indeed be found in different ways, and in this case
@@ -128,6 +107,9 @@ class PathResult;
 // The other Step will then be later in the queue and when we would otherwise
 // visit it, we will check validity of the path and will then not visit it,
 // since global vertex uniqueness is violated.
+// This could eventually be improved but for now we run with it.
+// Note that the path type in the TwoSidedEnumeratorOptions must always
+// be "ShortestPath" for this class here to work.
 
 template<class QueueType, class PathStoreType, class ProviderType,
          class PathValidatorType>

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
@@ -545,13 +545,9 @@ bool WeightedTwoSidedEnumerator<QueueType, PathStoreType, ProviderType,
       _right.buildPath(rightVertex, _resultPath);
       TRI_ASSERT(!_resultPath.isEmpty());
 
-      if (_emitWeight) {
-        // Add weight attribute to edges
-        _resultPath.toVelocyPack(
-            result, PathResult<ProviderType, Step>::WeightType::ACTUAL_WEIGHT);
-      } else {
-        _resultPath.toVelocyPack(result);
-      }
+      // Add weight attribute to edges
+      _resultPath.toVelocyPack(
+          result, PathResult<ProviderType, Step>::WeightType::ACTUAL_WEIGHT);
       // remove handled result
       _results.pop_front();
 
@@ -569,13 +565,9 @@ bool WeightedTwoSidedEnumerator<QueueType, PathStoreType, ProviderType,
     _right.buildPath(rightVertex, _resultPath);
     TRI_ASSERT(!_resultPath.isEmpty());
 
-    if (_emitWeight) {
-      // Add weight attribute to edges
-      _resultPath.toVelocyPack(
-          result, PathResult<ProviderType, Step>::WeightType::ACTUAL_WEIGHT);
-    } else {
-      _resultPath.toVelocyPack(result);
-    }
+    // Add weight attribute to edges
+    _resultPath.toVelocyPack(
+        result, PathResult<ProviderType, Step>::WeightType::ACTUAL_WEIGHT);
   };
 
   auto checkCandidates = [&]() {

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.cpp
@@ -660,22 +660,24 @@ void WeightedTwoSidedEnumerator<QueueType, PathStoreType, ProviderType,
       // find a shorter one.
       // Proof:
       // Assume that there is a shortest path P with weight w' < w. Then
-      // w' < d1+d2 in particular. The weights of the vertices on the path
-      // might not be the the shortest path to these vertices, but if a
-      // vertex V on the path is reached by some weight d on this path, then
-      // its smallest weight by which it can be reached is at most d.
-      // This means that all vertices on P which are on this path less than
-      // d1 away from the start vertex have already been found and expanded
-      // by the left hand side. Likewise, all vertices on P which are - on
-      // P - less than d2 away from the end vertex have already been found
-      // and expanded by the right hand side. Since w' < d1 + d2, there is no
-      // "gap" between the two sides: There cannot be a vertex on the path,
-      // which is both at least d1 from the start and at least d2 from the
-      // target. It might even be that some vertex on the path P has been
-      // expanded by both sides. In any case, there must be an edge on the
-      // path, so that the source of the edge has been expanded by the left
-      // hand side and the target of the edge has been expanded by the right
-      // hand side. Then one of these expansions has to have happened first
+      // w' < d1+d2 in particular. The weights of the vertices on the
+      // path might not be the the shortest path to these vertices, but
+      // if a vertex V on the path is reached by some weight d on this
+      // path, then its smallest weight by which it can be reached is
+      // at most d. This means that all vertices on P which are on this
+      // path less than d1 away from the start vertex have already been
+      // found and expanded by the left hand side (or by the right hand
+      // side). Likewise, all vertices on P which are - on P - less
+      // than d2 away from the end vertex have already been found and
+      // expanded by the right hand side (or by the left hand side).
+      // Since w' < d1 + d2, there is no "gap" between the two sides:
+      // There cannot be a vertex on the path, which is both at least d1
+      // from the start and at least d2 from the target. It might even
+      // be that some vertex on the path P has been expanded by both
+      // sides. In any case, there must be an edge on the path, so that
+      // the source of the edge has been expanded by the left hand side
+      // and the target of the edge has been expanded by the right hand
+      // side. Then one of these expansions has to have happened first
       // and the other must have seen this path.
       // For a K-SHORTEST-PATH search all candidates that have lower
       // weight than the sum of the two diameters are valid shortest

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -410,8 +410,6 @@ class WeightedTwoSidedEnumerator {
     _right.setForbiddenEdges(std::move(forbidden));
   };
 
-  auto setEmitWeight(bool) -> void {}
-
  private:
   [[nodiscard]] auto searchDone() const -> bool;
   // Ensure that we have fetched all vertices in the _results list. Otherwise,

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -59,10 +59,8 @@ struct TwoSidedEnumeratorOptions;
 template<class ProviderType, class Step>
 class PathResult;
 
-// This class `WeightedTwoSidedEnumerator` is used for k-shortest-path
-// searches, for all-shortest-path searches and for k-paths (finding all
-// paths from source to target), whenever the length is measured by an
-// edge weight.
+// This class `WeightedTwoSidedEnumerator` is used for legacy k-shortest-path
+// searches, whenever the length is measured by an edge weight.
 // It works by doing a Dijkstra-like graph traversal from both sides and
 // then matching findings. As work queue it uses a priority queue, always
 // processing the next unprocessed step according to the queue.
@@ -99,9 +97,8 @@ class PathResult;
 // combination is in use:
 //   vertex path uniqueness / edge path uniqueness
 // It is for finding all possible loopless paths and edge uniqueness
-// follows from vertex uniqueness. This is used for k-paths and the versions
-// of all-shortest-paths and k-shortest-paths which do not use Yen's
-// algorithm.
+// follows from vertex uniqueness. This is used for k-shortest-paths
+// which do not use Yen's algorithm.
 // Please note the following subtle issue: When enumerating paths (first
 // combination above), the item on the queue is a "Step" (which encodes
 // the path so far plus one more edge). In particular, there can and will

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -252,6 +252,7 @@ class WeightedTwoSidedEnumerator {
     [[nodiscard]] auto peekQueue() const -> Step const&;
     [[nodiscard]] auto isQueueEmpty() const -> bool;
     [[nodiscard]] auto doneWithDepth() const -> bool;
+    [[nodiscard]] auto queueSize() const -> size_t { return _queue.size(); }
 
     auto buildPath(Step const& vertexInShell,
                    PathResult<ProviderType, Step>& path) -> void;

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -410,8 +410,7 @@ class WeightedTwoSidedEnumerator {
     _right.setForbiddenEdges(std::move(forbidden));
   };
 
- private:
-  [[nodiscard]] auto searchDone() const -> bool;
+ private : [[nodiscard]] auto searchDone() const -> bool;
   // Ensure that we have fetched all vertices in the _results list. Otherwise,
   // we will not be able to generate the resulting path
   auto fetchResults() -> void;

--- a/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/WeightedTwoSidedEnumerator.h
@@ -410,7 +410,7 @@ class WeightedTwoSidedEnumerator {
     _right.setForbiddenEdges(std::move(forbidden));
   };
 
-  auto setEmitWeight(bool flag) -> void { _emitWeight = flag; }
+  auto setEmitWeight(bool) -> void {}
 
  private:
   [[nodiscard]] auto searchDone() const -> bool;
@@ -448,7 +448,6 @@ class WeightedTwoSidedEnumerator {
   bool _resultsFetched{false};
   bool _algorithmFinished{false};
   bool _singleton{false};
-  bool _emitWeight{false};
 
   PathResult<ProviderType, Step> _resultPath;
 };

--- a/arangod/Graph/Enumerators/YenEnumerator.cpp
+++ b/arangod/Graph/Enumerators/YenEnumerator.cpp
@@ -185,6 +185,10 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
       return false;
     }
     auto const& path = _shortestPathEnumerator->getLastPathResult();
+    for (size_t i = 0; i < path.getLength(); ++i) {
+      LOG_DEVEL << "Vertex: " << path.getVertex(i).getID();
+    }
+    LOG_DEVEL << "Weight: " << path.getWeight();
     auto owned = toOwned(path);
     owned.setBranchPoint(0);
     _shortestPaths.emplace_back(std::move(owned));  // Copy the path with all
@@ -211,6 +215,7 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
     // previous path:
     auto forbiddenVertices = std::make_shared<VertexSet>();
     for (size_t i = 0; i < prefixLen; ++i) {
+      LOG_DEVEL << "Forbidden vertex: " << prevPath.getVertex(i).getID();
       forbiddenVertices->insert(prevPath.getVertex(i).getID());
     }
     // To avoid finding old shortest paths again, we must forbid every edge,
@@ -218,6 +223,8 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
     // same prefix:
     auto forbiddenEdges = std::make_shared<EdgeSet>();
     forbiddenEdges->insert(prevPath.getEdge(prefixLen).getID());
+    LOG_DEVEL << "Forbidden edge from " << prevPath.getVertex(prefixLen).getID()
+              << " to " << prevPath.getVertex(prefixLen + 1).getID();
     // This handles the previous one, now do the ones before:
     for (size_t i = 0; i + 1 < _shortestPaths.size(); ++i) {
       // Check if that shortest path has the same prefix:
@@ -232,6 +239,9 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
         }
         if (samePrefix) {
           forbiddenEdges->insert(_shortestPaths[i].getEdge(prefixLen).getID());
+          LOG_DEVEL << "Forbidden edge from "
+                    << _shortestPaths[i].getVertex(prefixLen).getID() << " to "
+                    << _shortestPaths[i].getVertex(prefixLen + 1).getID();
         }
       }
     }
@@ -255,6 +265,10 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
     if (found) {
       PathResult<ProviderType, typename ProviderType::Step> const& path =
           _shortestPathEnumerator->getLastPathResult();
+      for (size_t i = 0; i < path.getLength(); ++i) {
+        LOG_DEVEL << "Vertex: " << path.getVertex(i).getID();
+      }
+      LOG_DEVEL << "Weight: " << path.getWeight();
       auto newPath = std::make_unique<
           PathResult<ProviderType, typename ProviderType::Step>>(
           path.getSourceProvider(), path.getTargetProvider());  // empty path

--- a/arangod/Graph/Enumerators/YenEnumerator.cpp
+++ b/arangod/Graph/Enumerators/YenEnumerator.cpp
@@ -335,11 +335,12 @@ template class ::arangodb::graph::YenEnumerator<
     TracedShortestPathEnumeratorForYen<SingleProvider>, false>;
 
 template class ::arangodb::graph::YenEnumerator<
-    SingleProvider, WeightedShortestPathEnumeratorForYen<SingleProvider>, true>;
+    SingleProvider, WeightedShortestPathEnumeratorForYenAlias<SingleProvider>,
+    true>;
 
 template class ::arangodb::graph::YenEnumerator<
     ProviderTracer<SingleProvider>,
-    TracedWeightedShortestPathEnumeratorForYen<SingleProvider>, true>;
+    TracedWeightedShortestPathEnumeratorForYenAlias<SingleProvider>, true>;
 
 // ClusterProvider Section:
 
@@ -353,8 +354,9 @@ template class ::arangodb::graph::YenEnumerator<
     TracedShortestPathEnumeratorForYen<ClustProvider>, false>;
 
 template class ::arangodb::graph::YenEnumerator<
-    ClustProvider, WeightedShortestPathEnumeratorForYen<ClustProvider>, true>;
+    ClustProvider, WeightedShortestPathEnumeratorForYenAlias<ClustProvider>,
+    true>;
 
 template class ::arangodb::graph::YenEnumerator<
     ProviderTracer<ClustProvider>,
-    TracedWeightedShortestPathEnumeratorForYen<ClustProvider>, true>;
+    TracedWeightedShortestPathEnumeratorForYenAlias<ClustProvider>, true>;

--- a/arangod/Graph/Enumerators/YenEnumerator.cpp
+++ b/arangod/Graph/Enumerators/YenEnumerator.cpp
@@ -60,7 +60,7 @@ YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::YenEnumerator(
       _totalMemoryUsageHere(0),
       _isDone(true),
       _isInitialized(false) {
-  // Yen's algorithm only ever uses the TwoSidedEnumerator here to find
+  // Yen's algorithm only ever uses the ShortestPathEnumerator here to find
   // exactly one shortest path:
   options.setOnlyProduceOnePath(true);
   options.setPathType(PathType::Type::ShortestPath);

--- a/arangod/Graph/Enumerators/YenEnumerator.cpp
+++ b/arangod/Graph/Enumerators/YenEnumerator.cpp
@@ -382,12 +382,11 @@ template class ::arangodb::graph::YenEnumerator<
     TracedShortestPathEnumeratorForYen<SingleProvider>, false>;
 
 template class ::arangodb::graph::YenEnumerator<
-    SingleProvider, WeightedShortestPathEnumeratorForYenAlias<SingleProvider>,
-    true>;
+    SingleProvider, WeightedShortestPathEnumeratorAlias<SingleProvider>, true>;
 
 template class ::arangodb::graph::YenEnumerator<
     ProviderTracer<SingleProvider>,
-    TracedWeightedShortestPathEnumeratorForYenAlias<SingleProvider>, true>;
+    TracedWeightedShortestPathEnumeratorAlias<SingleProvider>, true>;
 
 // ClusterProvider Section:
 
@@ -401,9 +400,8 @@ template class ::arangodb::graph::YenEnumerator<
     TracedShortestPathEnumeratorForYen<ClustProvider>, false>;
 
 template class ::arangodb::graph::YenEnumerator<
-    ClustProvider, WeightedShortestPathEnumeratorForYenAlias<ClustProvider>,
-    true>;
+    ClustProvider, WeightedShortestPathEnumeratorAlias<ClustProvider>, true>;
 
 template class ::arangodb::graph::YenEnumerator<
     ProviderTracer<ClustProvider>,
-    TracedWeightedShortestPathEnumeratorForYenAlias<ClustProvider>, true>;
+    TracedWeightedShortestPathEnumeratorAlias<ClustProvider>, true>;

--- a/arangod/Graph/Enumerators/YenEnumerator.cpp
+++ b/arangod/Graph/Enumerators/YenEnumerator.cpp
@@ -173,22 +173,30 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
   if (_isDone) {
     return false;
   }
-  LOG_DEVEL << "YenEnumerator::getNextPath()";
+  LOG_TOPIC("47000", TRACE, Logger::GRAPHS) << "YenEnumerator::getNextPath()";
   if (_shortestPaths.empty()) {
     // First find the shortest path using the _shortestPathEnumerator:
+    auto start = std::chrono::steady_clock::now();
     _shortestPathEnumerator->reset(_source, _target);
-    LOG_DEVEL << "Shortest path from " << _source << " to " << _target;
     bool found = _shortestPathEnumerator->getNextPath(result);
-    LOG_DEVEL << "done.";
+    LOG_TOPIC("47001", TRACE, Logger::GRAPHS)
+        << "Yen: shortest path from " << _source << " to " << _target
+        << " done in "
+        << std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::steady_clock::now() - start)
+               .count()
+        << " microseconds.";
     if (!found) {
       _isDone = true;
       return false;
     }
     auto const& path = _shortestPathEnumerator->getLastPathResult();
+    LOG_TOPIC("47002", TRACE, Logger::GRAPHS)
+        << "Path found, weight: " << path.getWeight();
     for (size_t i = 0; i < path.getLength(); ++i) {
-      LOG_DEVEL << "Vertex: " << path.getVertex(i).getID();
+      LOG_TOPIC("47003", TRACE, Logger::GRAPHS)
+          << "Vertex: " << path.getVertex(i).getID();
     }
-    LOG_DEVEL << "Weight: " << path.getWeight();
     auto owned = toOwned(path);
     owned.setBranchPoint(0);
     _shortestPaths.emplace_back(std::move(owned));  // Copy the path with all
@@ -215,7 +223,8 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
     // previous path:
     auto forbiddenVertices = std::make_shared<VertexSet>();
     for (size_t i = 0; i < prefixLen; ++i) {
-      LOG_DEVEL << "Forbidden vertex: " << prevPath.getVertex(i).getID();
+      LOG_TOPIC("47004", TRACE, Logger::GRAPHS)
+          << "Yen: forbidden vertex: " << prevPath.getVertex(i).getID();
       forbiddenVertices->insert(prevPath.getVertex(i).getID());
     }
     // To avoid finding old shortest paths again, we must forbid every edge,
@@ -223,8 +232,9 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
     // same prefix:
     auto forbiddenEdges = std::make_shared<EdgeSet>();
     forbiddenEdges->insert(prevPath.getEdge(prefixLen).getID());
-    LOG_DEVEL << "Forbidden edge from " << prevPath.getVertex(prefixLen).getID()
-              << " to " << prevPath.getVertex(prefixLen + 1).getID();
+    LOG_TOPIC("47005", TRACE, Logger::GRAPHS)
+        << "Yen: forbidden edge from " << prevPath.getVertex(prefixLen).getID()
+        << " to " << prevPath.getVertex(prefixLen + 1).getID();
     // This handles the previous one, now do the ones before:
     for (size_t i = 0; i + 1 < _shortestPaths.size(); ++i) {
       // Check if that shortest path has the same prefix:
@@ -239,9 +249,10 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
         }
         if (samePrefix) {
           forbiddenEdges->insert(_shortestPaths[i].getEdge(prefixLen).getID());
-          LOG_DEVEL << "Forbidden edge from "
-                    << _shortestPaths[i].getVertex(prefixLen).getID() << " to "
-                    << _shortestPaths[i].getVertex(prefixLen + 1).getID();
+          LOG_TOPIC("47006", TRACE, Logger::GRAPHS)
+              << "Yen: forbidden edge from "
+              << _shortestPaths[i].getVertex(prefixLen).getID() << " to "
+              << _shortestPaths[i].getVertex(prefixLen + 1).getID();
         }
       }
     }
@@ -254,21 +265,24 @@ bool YenEnumerator<ProviderType, EnumeratorType, IsWeighted>::getNextPath(
     _shortestPathEnumerator->setForbiddenEdges(std::move(forbiddenEdges));
 
     VPackBuilder temp;
-    LOG_DEVEL << "Another shortest path from " << spurVertex.getID() << " to "
-              << _target;
     auto start = std::chrono::steady_clock::now();
     bool found = _shortestPathEnumerator->getNextPath(temp);
-    LOG_DEVEL << "Finished in "
-              << std::chrono::duration_cast<std::chrono::microseconds>(
-                     std::chrono::steady_clock::now() - start)
-                     .count();
+    LOG_TOPIC("47007", TRACE, Logger::GRAPHS)
+        << "Yen: another shortest path from " << spurVertex.getID() << " to "
+        << _target << ", finished in "
+        << std::chrono::duration_cast<std::chrono::microseconds>(
+               std::chrono::steady_clock::now() - start)
+               .count()
+        << " microseconds.";
     if (found) {
       PathResult<ProviderType, typename ProviderType::Step> const& path =
           _shortestPathEnumerator->getLastPathResult();
+      LOG_TOPIC("47008", TRACE, Logger::GRAPHS)
+          << "Yen: Path found, weight: " << path.getWeight();
       for (size_t i = 0; i < path.getLength(); ++i) {
-        LOG_DEVEL << "Vertex: " << path.getVertex(i).getID();
+        LOG_TOPIC("47009", TRACE, Logger::GRAPHS)
+            << "Vertex: " << path.getVertex(i).getID();
       }
-      LOG_DEVEL << "Weight: " << path.getWeight();
       auto newPath = std::make_unique<
           PathResult<ProviderType, typename ProviderType::Step>>(
           path.getSourceProvider(), path.getTargetProvider());  // empty path

--- a/arangod/Graph/PathManagement/PathResult.h
+++ b/arangod/Graph/PathManagement/PathResult.h
@@ -83,6 +83,11 @@ class PathResult {
   auto compare(PathResult<ProviderType, Step> const& other)
       -> std::strong_ordering;
 
+  auto getBranchPoint() const noexcept -> size_t { return _branchPoint; }
+  auto setBranchPoint(size_t branchPoint) noexcept -> void {
+    _branchPoint = branchPoint;
+  }
+
  private:
   std::vector<typename Step::Vertex> _vertices;
   std::vector<typename Step::Edge> _edges;
@@ -94,6 +99,7 @@ class PathResult {
   size_t _numVerticesFromSourceProvider;
   size_t _numEdgesFromSourceProvider;
   double _pathWeight;
+  size_t _branchPoint = 0;  // only used in Yen's algorithm
 
   // Provider for the beginning of the path (source)
   ProviderType& _sourceProvider;

--- a/arangod/Graph/Providers/SingleServerProvider.cpp
+++ b/arangod/Graph/Providers/SingleServerProvider.cpp
@@ -150,7 +150,7 @@ auto SingleServerProvider<Step>::expand(
       *this, _stats, step.getDepth(),
       [&](EdgeDocumentToken&& eid, VPackSlice edge, size_t cursorID) -> void {
         ++_readSomething;
-        VertexType id = _cache.persistString(([&]() -> auto{
+        VertexType id = _cache.persistString(([&]() -> auto {
           if (edge.isString()) {
             return VertexType(edge);
           } else {

--- a/arangod/Graph/Providers/SingleServerProvider.cpp
+++ b/arangod/Graph/Providers/SingleServerProvider.cpp
@@ -145,10 +145,12 @@ auto SingleServerProvider<Step>::expand(
   LOG_TOPIC("c9169", TRACE, Logger::GRAPHS)
       << "<SingleServerProvider> Expanding " << vertex.getID();
   _cursor->rearm(vertex.getID(), step.getDepth(), _stats);
+  ++_rearmed;
   _cursor->readAll(
       *this, _stats, step.getDepth(),
       [&](EdgeDocumentToken&& eid, VPackSlice edge, size_t cursorID) -> void {
-        VertexType id = _cache.persistString(([&]() -> auto {
+        ++_readSomething;
+        VertexType id = _cache.persistString(([&]() -> auto{
           if (edge.isString()) {
             return VertexType(edge);
           } else {
@@ -187,6 +189,11 @@ auto SingleServerProvider<Step>::clear() -> void {
   // Clear the cache - this cache does contain StringRefs
   // We need to make sure that no one holds references to the cache (!)
   _cache.clear();
+  LOG_TOPIC("65261", TRACE, Logger::GRAPHS)
+      << "Rearmed edge index cursor: " << _rearmed
+      << " Read callback called: " << _readSomething;
+  _rearmed = 0;
+  _readSomething = 0;
 }
 
 template<class Step>

--- a/arangod/Graph/Providers/SingleServerProvider.h
+++ b/arangod/Graph/Providers/SingleServerProvider.h
@@ -149,6 +149,9 @@ class SingleServerProvider {
   RefactoredTraverserCache _cache;
 
   arangodb::aql::TraversalStats _stats;
+
+  size_t _rearmed = 0;
+  size_t _readSomething = 0;
 };
 }  // namespace graph
 }  // namespace arangodb

--- a/arangod/Graph/algorithm-aliases.h
+++ b/arangod/Graph/algorithm-aliases.h
@@ -26,6 +26,7 @@
 #include "Graph/Enumerators/OneSidedEnumerator.h"
 #include "Graph/Enumerators/TwoSidedEnumerator.h"
 #include "Graph/Enumerators/WeightedTwoSidedEnumerator.h"
+#include "Graph/Enumerators/WeightedShortestPathEnumerator.h"
 #include "Graph/Enumerators/YenEnumerator.h"
 
 #include "Graph/Queues/FifoQueue.h"
@@ -86,7 +87,7 @@ using ShortestPathEnumerator = TwoSidedEnumerator<
                   VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>;
 
 template<class Provider>
-using WeightedShortestPathEnumerator = WeightedTwoSidedEnumerator<
+using WeightedShortestPathEnumeratorAlias = WeightedShortestPathEnumerator<
     WeightedQueue<typename Provider::Step>, PathStore<typename Provider::Step>,
     Provider,
     PathValidator<Provider, PathStore<typename Provider::Step>,
@@ -104,14 +105,15 @@ using TracedShortestPathEnumerator = TwoSidedEnumerator<
         VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
 
 template<class Provider>
-using TracedWeightedShortestPathEnumerator = WeightedTwoSidedEnumerator<
-    QueueTracer<WeightedQueue<typename Provider::Step>>,
-    PathStoreTracer<PathStore<typename Provider::Step>>,
-    ProviderTracer<Provider>,
-    PathValidatorTracer<PathValidator<
-        ProviderTracer<Provider>,
+using TracedWeightedShortestPathEnumeratorAlias =
+    WeightedShortestPathEnumerator<
+        QueueTracer<WeightedQueue<typename Provider::Step>>,
         PathStoreTracer<PathStore<typename Provider::Step>>,
-        VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
+        ProviderTracer<Provider>,
+        PathValidatorTracer<PathValidator<
+            ProviderTracer<Provider>,
+            PathStoreTracer<PathStore<typename Provider::Step>>,
+            VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
 
 // SHORTEST_PATH for Yen:
 template<class Provider>
@@ -123,12 +125,13 @@ using ShortestPathEnumeratorForYen = TwoSidedEnumerator<
         VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
 
 template<class Provider>
-using WeightedShortestPathEnumeratorForYen = WeightedTwoSidedEnumerator<
-    WeightedQueue<typename Provider::Step>, PathStore<typename Provider::Step>,
-    Provider,
-    PathValidatorTabooWrapper<PathValidator<
-        Provider, PathStore<typename Provider::Step>,
-        VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
+using WeightedShortestPathEnumeratorForYenAlias =
+    WeightedShortestPathEnumerator<
+        WeightedQueue<typename Provider::Step>,
+        PathStore<typename Provider::Step>, Provider,
+        PathValidatorTabooWrapper<PathValidator<
+            Provider, PathStore<typename Provider::Step>,
+            VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
 
 // SHORTEST_PATH for Yen with tracing:
 
@@ -143,14 +146,15 @@ using TracedShortestPathEnumeratorForYen = TwoSidedEnumerator<
         VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>>;
 
 template<class Provider>
-using TracedWeightedShortestPathEnumeratorForYen = WeightedTwoSidedEnumerator<
-    QueueTracer<WeightedQueue<typename Provider::Step>>,
-    PathStoreTracer<PathStore<typename Provider::Step>>,
-    ProviderTracer<Provider>,
-    PathValidatorTracer<PathValidatorTabooWrapper<PathValidator<
-        ProviderTracer<Provider>,
+using TracedWeightedShortestPathEnumeratorForYenAlias =
+    WeightedShortestPathEnumerator<
+        QueueTracer<WeightedQueue<typename Provider::Step>>,
         PathStoreTracer<PathStore<typename Provider::Step>>,
-        VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>>;
+        ProviderTracer<Provider>,
+        PathValidatorTracer<PathValidatorTabooWrapper<PathValidator<
+            ProviderTracer<Provider>,
+            PathStoreTracer<PathStore<typename Provider::Step>>,
+            VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>>;
 
 // K_PATH implementation
 template<class Provider>
@@ -189,14 +193,14 @@ using TracedYenEnumeratorWithProvider =
 // Yen's algorithm implementation with weights:
 template<class Provider>
 using WeightedYenEnumeratorWithProvider =
-    YenEnumerator<Provider, WeightedShortestPathEnumeratorForYen<Provider>,
+    YenEnumerator<Provider, WeightedShortestPathEnumeratorForYenAlias<Provider>,
                   true /* IsWeighted */>;
 
 // Yen's algorithm implementation with weights using tracing:
 template<class Provider>
 using TracedWeightedYenEnumeratorWithProvider =
     YenEnumerator<ProviderTracer<Provider>,
-                  TracedWeightedShortestPathEnumeratorForYen<Provider>,
+                  TracedWeightedShortestPathEnumeratorForYenAlias<Provider>,
                   true /* IsWeighted */>;
 
 // WEIGHTED_K_SHORTEST_PATHS implementation

--- a/arangod/Graph/algorithm-aliases.h
+++ b/arangod/Graph/algorithm-aliases.h
@@ -91,7 +91,7 @@ using WeightedShortestPathEnumeratorAlias = WeightedShortestPathEnumerator<
     WeightedQueue<typename Provider::Step>, PathStore<typename Provider::Step>,
     Provider,
     PathValidator<Provider, PathStore<typename Provider::Step>,
-                  VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>;
+                  VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>;
 
 // SHORTEST_PATH implementation using Tracing
 template<class Provider>
@@ -113,7 +113,7 @@ using TracedWeightedShortestPathEnumeratorAlias =
         PathValidatorTracer<PathValidator<
             ProviderTracer<Provider>,
             PathStoreTracer<PathStore<typename Provider::Step>>,
-            VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
+            VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>>;
 
 // SHORTEST_PATH for Yen:
 template<class Provider>
@@ -129,9 +129,8 @@ using WeightedShortestPathEnumeratorForYenAlias =
     WeightedShortestPathEnumerator<
         WeightedQueue<typename Provider::Step>,
         PathStore<typename Provider::Step>, Provider,
-        PathValidatorTabooWrapper<PathValidator<
-            Provider, PathStore<typename Provider::Step>,
-            VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
+        PathValidator<Provider, PathStore<typename Provider::Step>,
+                      VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>;
 
 // SHORTEST_PATH for Yen with tracing:
 
@@ -151,10 +150,10 @@ using TracedWeightedShortestPathEnumeratorForYenAlias =
         QueueTracer<WeightedQueue<typename Provider::Step>>,
         PathStoreTracer<PathStore<typename Provider::Step>>,
         ProviderTracer<Provider>,
-        PathValidatorTracer<PathValidatorTabooWrapper<PathValidator<
+        PathValidatorTracer<PathValidator<
             ProviderTracer<Provider>,
             PathStoreTracer<PathStore<typename Provider::Step>>,
-            VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>>;
+            VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>>;
 
 // K_PATH implementation
 template<class Provider>

--- a/arangod/Graph/algorithm-aliases.h
+++ b/arangod/Graph/algorithm-aliases.h
@@ -124,14 +124,6 @@ using ShortestPathEnumeratorForYen = TwoSidedEnumerator<
         Provider, PathStore<typename Provider::Step>,
         VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>;
 
-template<class Provider>
-using WeightedShortestPathEnumeratorForYenAlias =
-    WeightedShortestPathEnumerator<
-        WeightedQueue<typename Provider::Step>,
-        PathStore<typename Provider::Step>, Provider,
-        PathValidator<Provider, PathStore<typename Provider::Step>,
-                      VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>;
-
 // SHORTEST_PATH for Yen with tracing:
 
 template<class Provider>
@@ -143,17 +135,6 @@ using TracedShortestPathEnumeratorForYen = TwoSidedEnumerator<
         ProviderTracer<Provider>,
         PathStoreTracer<PathStore<typename Provider::Step>>,
         VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>>>;
-
-template<class Provider>
-using TracedWeightedShortestPathEnumeratorForYenAlias =
-    WeightedShortestPathEnumerator<
-        QueueTracer<WeightedQueue<typename Provider::Step>>,
-        PathStoreTracer<PathStore<typename Provider::Step>>,
-        ProviderTracer<Provider>,
-        PathValidatorTracer<PathValidator<
-            ProviderTracer<Provider>,
-            PathStoreTracer<PathStore<typename Provider::Step>>,
-            VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>>;
 
 // K_PATH implementation
 template<class Provider>
@@ -192,14 +173,14 @@ using TracedYenEnumeratorWithProvider =
 // Yen's algorithm implementation with weights:
 template<class Provider>
 using WeightedYenEnumeratorWithProvider =
-    YenEnumerator<Provider, WeightedShortestPathEnumeratorForYenAlias<Provider>,
+    YenEnumerator<Provider, WeightedShortestPathEnumeratorAlias<Provider>,
                   true /* IsWeighted */>;
 
 // Yen's algorithm implementation with weights using tracing:
 template<class Provider>
 using TracedWeightedYenEnumeratorWithProvider =
     YenEnumerator<ProviderTracer<Provider>,
-                  TracedWeightedShortestPathEnumeratorForYenAlias<Provider>,
+                  TracedWeightedShortestPathEnumeratorAlias<Provider>,
                   true /* IsWeighted */>;
 
 // WEIGHTED_K_SHORTEST_PATHS implementation

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -175,7 +175,7 @@ std::string const StaticStrings::ForceOneShardAttributeValue(
     "forceOneShardAttributeValue");
 std::string const StaticStrings::JoinStrategyType("joinStrategyType");
 std::string const StaticStrings::Algorithm("algorithm");
-std::string const StaticStrings::Yen("yen");
+std::string const StaticStrings::Legacy("legacy");
 
 // HTTP headers
 std::string const StaticStrings::Accept("accept");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -173,7 +173,7 @@ class StaticStrings {
   static std::string const ForceOneShardAttributeValue;
   static std::string const JoinStrategyType;
   static std::string const Algorithm;
-  static std::string const Yen;
+  static std::string const Legacy;
 
   // HTTP headers
   static std::string const Accept;

--- a/tests/Graph/GraphMockProviderInstances.cpp
+++ b/tests/Graph/GraphMockProviderInstances.cpp
@@ -26,6 +26,7 @@
 #include "Graph/Enumerators/OneSidedEnumerator.cpp"
 #include "Graph/Enumerators/TwoSidedEnumerator.cpp"
 #include "Graph/Enumerators/WeightedTwoSidedEnumerator.cpp"
+#include "Graph/Enumerators/WeightedShortestPathEnumerator.cpp"
 #include "Graph/PathManagement/PathResult.cpp"
 #include "Graph/PathManagement/PathStore.cpp"
 #include "Graph/PathManagement/SingleProviderPathResult.cpp"
@@ -86,7 +87,7 @@ template class ::arangodb::graph::WeightedTwoSidedEnumerator<
     PathValidator<MockGraphProvider, PathStore<MockGraphProvider::Step>,
                   VertexUniquenessLevel::PATH, EdgeUniquenessLevel::PATH>>;
 
-template class ::arangodb::graph::WeightedTwoSidedEnumerator<
+template class ::arangodb::graph::WeightedShortestPathEnumerator<
     WeightedQueue<MockGraphProvider::Step>, PathStore<MockGraphProvider::Step>,
     MockGraphProvider,
     PathValidator<MockGraphProvider, PathStore<MockGraphProvider::Step>,

--- a/tests/Graph/GraphMockProviderInstances.cpp
+++ b/tests/Graph/GraphMockProviderInstances.cpp
@@ -91,7 +91,7 @@ template class ::arangodb::graph::WeightedShortestPathEnumerator<
     WeightedQueue<MockGraphProvider::Step>, PathStore<MockGraphProvider::Step>,
     MockGraphProvider,
     PathValidator<MockGraphProvider, PathStore<MockGraphProvider::Step>,
-                  VertexUniquenessLevel::GLOBAL, EdgeUniquenessLevel::PATH>>;
+                  VertexUniquenessLevel::NONE, EdgeUniquenessLevel::NONE>>;
 
 template class arangodb::graph::PathValidatorTracer<
     arangodb::graph::PathValidator<

--- a/tests/Graph/WeightedShortestPathTest.cpp
+++ b/tests/Graph/WeightedShortestPathTest.cpp
@@ -60,7 +60,7 @@ namespace graph {
 class WeightedShortestPathTest
     : public ::testing::TestWithParam<MockGraphProvider::LooseEndBehaviour> {
   using WeightedShortestPathFinder =
-      WeightedShortestPathEnumerator<MockGraphProvider>;
+      WeightedShortestPathEnumeratorAlias<MockGraphProvider>;
 
   static constexpr size_t minDepth = 0;
   static constexpr size_t maxDepth = std::numeric_limits<size_t>::max();

--- a/tests/Graph/WeightedShortestPathTest.cpp
+++ b/tests/Graph/WeightedShortestPathTest.cpp
@@ -435,7 +435,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_outbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 16U);
+    EXPECT_EQ(stats.getScannedIndex(), 17U);
   }
 
   {
@@ -484,7 +484,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_inbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 16U);
+    EXPECT_EQ(stats.getScannedIndex(), 17U);
   }
 
   {

--- a/tests/Graph/WeightedShortestPathTest.cpp
+++ b/tests/Graph/WeightedShortestPathTest.cpp
@@ -386,7 +386,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_V4_V9) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 13U);
+    EXPECT_EQ(stats.getScannedIndex(), 14U);
   }
 
   {
@@ -435,7 +435,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_outbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 17U);
+    EXPECT_EQ(stats.getScannedIndex(), 16U);
   }
 
   {
@@ -484,7 +484,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_A_F_inbound) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 17U);
+    EXPECT_EQ(stats.getScannedIndex(), 16U);
   }
 
   {

--- a/tests/Graph/WeightedShortestPathTest.cpp
+++ b/tests/Graph/WeightedShortestPathTest.cpp
@@ -386,7 +386,7 @@ TEST_P(WeightedShortestPathTest, shortest_path_V4_V9) {
     aql::TraversalStats stats = finder.stealStats();
     // We have to lookup the vertex
     // 4x vertices, 3x edges
-    EXPECT_EQ(stats.getScannedIndex(), 14U);
+    EXPECT_EQ(stats.getScannedIndex(), 13U);
   }
 
   {

--- a/tests/js/client/aql/aql-graph-enumerate-path-filter.js
+++ b/tests/js/client/aql/aql-graph-enumerate-path-filter.js
@@ -203,7 +203,7 @@ function enumeratePathsFilter() {
       assertRuleDoesNotFire(query);
     },
     testFiresWithNesting: function() {
-      for (let o of ['', ', algorithm: "yen"']) {
+      for (let o of ['', ', algorithm: "legacy"']) {
         const query = `
           FOR path2 IN ANY K_SHORTEST_PATHS "${vName}/19" TO "${vName}/22" GRAPH "${graphName}"  
             FOR path IN ANY K_PATHS "${vName}/0" TO "${vName}/2" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
@@ -215,7 +215,7 @@ function enumeratePathsFilter() {
       }
     },
     testExpectedPathFound: function() {
-      for (let o of ['', ' OPTIONS { algorithm: "yen" } ']) {
+      for (let o of ['', ' OPTIONS { algorithm: "legacy" } ']) {
         const unrestrictedQuery = `
           FOR path IN ANY K_SHORTEST_PATHS "${vName}/19" TO "${vName}/23" GRAPH "${graphName}" ${o}
               LIMIT 1

--- a/tests/js/client/aql/aql-graph-k-shortest-path-0-weight-regression.js
+++ b/tests/js/client/aql/aql-graph-k-shortest-path-0-weight-regression.js
@@ -94,7 +94,7 @@ function kZeroWeightRegressionTest() {
     tearDownAll,
 
     testPathsExists: function () {
-      for (let o of ['', ', algorithm: "yen"']) {
+      for (let o of ['', ', algorithm: "legacy"']) {
         const query = `
           FOR path IN ANY K_SHORTEST_PATHS "${vName}/0" TO "${vName}/2" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             RETURN path`;
@@ -109,7 +109,7 @@ function kZeroWeightRegressionTest() {
     },
 
     testPathsExists2: function () {
-      for (let o of ['', ', algorithm: "yen"']) {
+      for (let o of ['', ', algorithm: "legacy"']) {
         const query = `
           FOR path IN ANY K_SHORTEST_PATHS "${vName}/4" TO "${vName}/7" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             RETURN path`;
@@ -125,7 +125,7 @@ function kZeroWeightRegressionTest() {
     },
 
     testPathsExists3: function () {
-      for (let o of ['', ', algorithm: "yen"']) {
+      for (let o of ['', ', algorithm: "legacy"']) {
         const query = `
           FOR path IN ANY K_SHORTEST_PATHS "${vName}/8" TO "${vName}/18" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             RETURN path`;

--- a/tests/js/client/aql/aql-graph-k-shortest-path-early-abort-regression.js
+++ b/tests/js/client/aql/aql-graph-k-shortest-path-early-abort-regression.js
@@ -83,7 +83,7 @@ function kEarlyAbortRegressionTest() {
     testPathsExists: function () {
       const query = `
         FOR path IN OUTBOUND K_SHORTEST_PATHS "${vName}/0" TO "${vName}/1" GRAPH "${graphName}"
-          OPTIONS {weightAttribute: "weight"}
+          OPTIONS {weightAttribute: "weight", algorithm: "legacy"}
           LIMIT 1
           RETURN path`;
       const result = db._query(query).toArray();
@@ -103,7 +103,7 @@ function kEarlyAbortRegressionTest() {
     testPathsExistsYen: function () {
       const query = `
         FOR path IN OUTBOUND K_SHORTEST_PATHS "${vName}/0" TO "${vName}/1" GRAPH "${graphName}"
-          OPTIONS {weightAttribute: "weight", algorithm: "yen"}
+          OPTIONS {weightAttribute: "weight"}
           LIMIT 1
           RETURN path`;
       const result = db._query(query).toArray();
@@ -123,7 +123,7 @@ function kEarlyAbortRegressionTest() {
     testPaths: function () {
       const query = `
         FOR path IN OUTBOUND K_SHORTEST_PATHS "${vName}/0" TO "${vName}/1" GRAPH "${graphName}"
-          OPTIONS {weightAttribute: "weight"}
+          OPTIONS {weightAttribute: "weight", algorithm: "legacy"}
           RETURN path.weight`;
       const result = db._query(query).toArray();
       assertEqual([1000,1100], result);
@@ -132,7 +132,7 @@ function kEarlyAbortRegressionTest() {
     testPathsYen: function () {
       const query = `
         FOR path IN OUTBOUND K_SHORTEST_PATHS "${vName}/0" TO "${vName}/1" GRAPH "${graphName}"
-          OPTIONS {weightAttribute: "weight", algorithm: "yen"}
+          OPTIONS {weightAttribute: "weight"}
           RETURN path.weight`;
       const result = db._query(query).toArray();
       assertEqual([1000,1100], result);

--- a/tests/js/client/aql/aql-graph-k-shortest-path.js
+++ b/tests/js/client/aql/aql-graph-k-shortest-path.js
@@ -244,37 +244,6 @@ const createGraph = () => {
   // * 121 on loop
 };
 
-const createGraph2 = () => {
-  gm._create(graphName, [ gm._relation(e1Name, vName, vName) ], [],
-    {
-      numberOfShards: 9
-    }
-  );
-
-  const vertices = [];
-  const es = [];
-  vertices.push({_key:"S"});
-  vertices.push({_key:"V"});
-  vertices.push({_key:"W"});
-  vertices.push({_key:"Z"});
-  es.push({_from:`${vName}/S`,_to:`${vName}/W`,weight:9});
-  es.push({_from:`${vName}/S`,_to:`${vName}/V`,weight:10});
-  es.push({_from:`${vName}/W`,_to:`${vName}/Z`,weight:10});
-  es.push({_from:`${vName}/V`,_to:`${vName}/Z`,weight:9});
-  es.push({_from:`${vName}/V`,_to:`${vName}/W`,weight:1});
-
-  // S ------- 9 ------> W 
-  // |                 -/|
-  // |         /-------/||
-  // 10       1         10 
-  // |  -----/           |
-  // v /                 v
-  // V ------- 9 ------> Z
-
-  db[vName].save(vertices);
-  db[e1Name].save(es);
-};
-
 function kConstantWeightShortestPathTestSuite() {
   return {
     setUpAll: function () {
@@ -583,11 +552,42 @@ function kAttributeWeightShortestPathTestSuite() {
   };
 }
 
+const createSmallGraphWithAwkwardEdge = () => {
+  gm._create(graphName, [ gm._relation(e1Name, vName, vName) ], [],
+    {
+      numberOfShards: 9
+    }
+  );
+
+  const vertices = [];
+  const es = [];
+  vertices.push({_key:"S"});
+  vertices.push({_key:"V"});
+  vertices.push({_key:"W"});
+  vertices.push({_key:"Z"});
+  es.push({_from:`${vName}/S`,_to:`${vName}/W`,weight:9});
+  es.push({_from:`${vName}/S`,_to:`${vName}/V`,weight:10});
+  es.push({_from:`${vName}/W`,_to:`${vName}/Z`,weight:10});
+  es.push({_from:`${vName}/V`,_to:`${vName}/Z`,weight:9});
+  es.push({_from:`${vName}/V`,_to:`${vName}/W`,weight:1});
+
+  // S ------- 9 ------> W 
+  // |                 -/|
+  // |         /-------/||
+  // 10       1         10 
+  // |  -----/           |
+  // v /                 v
+  // V ------- 9 ------> Z
+
+  db[vName].save(vertices);
+  db[e1Name].save(es);
+};
+
 function kAttributeWeightShortestPathRegressionSuite() {
   return {
     setUpAll: function () {
       tearDownAll();
-      createGraph2();
+      createSmallGraphWithAwkwardEdge();
     },
     tearDownAll,
 

--- a/tests/js/client/aql/aql-graph-k-shortest-path.js
+++ b/tests/js/client/aql/aql-graph-k-shortest-path.js
@@ -256,7 +256,7 @@ const createGraph2 = () => {
   vertices.push({_key:"S"});
   vertices.push({_key:"V"});
   vertices.push({_key:"W"});
-  vertices.push({_key:"U"});
+  vertices.push({_key:"Z"});
   es.push({_from:`${vName}/S`,_to:`${vName}/W`,weight:9});
   es.push({_from:`${vName}/S`,_to:`${vName}/V`,weight:10});
   es.push({_from:`${vName}/W`,_to:`${vName}/Z`,weight:10});

--- a/tests/js/client/aql/aql-graph-k-shortest-path.js
+++ b/tests/js/client/aql/aql-graph-k-shortest-path.js
@@ -284,7 +284,7 @@ function kConstantWeightShortestPathTestSuite() {
     tearDownAll,
 
     testPathsExistsLimit: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" ${o}
             LIMIT 6
@@ -304,7 +304,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testNoPathExistsLimit: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${badTarget}" GRAPH "${graphName}" ${o}
             LIMIT 6
@@ -316,7 +316,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testFewerPathsThanLimit: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" ${o}
             LIMIT 1000
@@ -337,7 +337,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testPathsExistsNoLimit: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR source IN ${vName}
             FILTER source._id == "${source}"
@@ -361,7 +361,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testNoPathsExistsNoLimit: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR source IN ${vName}
             FILTER source._id == "${source}"
@@ -376,7 +376,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testPathsSkip: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" ${o}
             LIMIT 3, 3
@@ -397,7 +397,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testPathsSkipMoreThanExists: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" ${o}
             LIMIT 1000, 2
@@ -409,7 +409,7 @@ function kConstantWeightShortestPathTestSuite() {
     },
 
     testMultiDirections: function () {
-      for (let o of ['', 'OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', 'OPTIONS { algorithm: "legacy" }']) {
         const query = `
           WITH ${vName}
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" ${e1Name}, INBOUND ${e2Name} ${o}
@@ -439,7 +439,7 @@ function kAttributeWeightShortestPathTestSuite() {
     tearDownAll,
 
     testWeightPathsExistsLimit: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             LIMIT 6
@@ -459,7 +459,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightNoPathExistsLimit: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${badTarget}" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             LIMIT 6
@@ -471,7 +471,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightFewerPathsThanLimit: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             LIMIT 1000
@@ -494,7 +494,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightPathsExistsNoLimit: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR source IN ${vName}
             FILTER source._id == "${source}"
@@ -520,7 +520,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightNoPathsExistsNoLimit: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR source IN ${vName}
             FILTER source._id == "${source}"
@@ -535,7 +535,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightPathsSkip: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             LIMIT 3, 3
@@ -552,7 +552,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightPathsSkipMoreThanExists: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" GRAPH "${graphName}" OPTIONS {weightAttribute: "weight" ${o}}
             LIMIT 1000, 2
@@ -564,7 +564,7 @@ function kAttributeWeightShortestPathTestSuite() {
     },
 
     testWeightMultiDirections: function () {
-      for (let o of ['', ' ,algorithm: "yen"']) {
+      for (let o of ['', ' ,algorithm: "legacy"']) {
         const query = `
           WITH ${vName}
           FOR path IN OUTBOUND K_SHORTEST_PATHS "${source}" TO "${target}" ${e1Name}, INBOUND ${e2Name} OPTIONS {weightAttribute: "weight" ${o}}
@@ -602,7 +602,7 @@ function kAttributeWeightShortestPathRegressionSuite() {
       res = db._query(
         `FOR p IN OUTBOUND K_SHORTEST_PATHS "${vName}/S" TO "${vName}/Z" 
            GRAPH ${graphName} 
-           OPTIONS { weightAttribute: "weight", algorithm: "yen"}
+           OPTIONS { weightAttribute: "weight", algorithm: "legacy"}
            RETURN p`).toArray();
       assertEqual(res.length, 3);
       assertEqual(res.map((x) => x.weight), [19, 19, 21], res);

--- a/tests/js/client/aql/aql-graph-k-shortest-path.js
+++ b/tests/js/client/aql/aql-graph-k-shortest-path.js
@@ -606,7 +606,6 @@ function kAttributeWeightShortestPathRegressionSuite() {
            RETURN p`).toArray();
       assertEqual(res.length, 3);
       assertEqual(res.map((x) => x.weight), [19, 19, 21], res);
-      require("internal").wait(3600);
     },
   };
 

--- a/tests/js/client/aql/aql-memory-limit.js
+++ b/tests/js/client/aql/aql-memory-limit.js
@@ -238,7 +238,7 @@ function ahuacatlMemoryLimitGraphQueriesTestSuite () {
     },
     
     testKShortestPaths : function () {
-      for (let o of ['', ' OPTIONS { algorithm: "yen" }']) {
+      for (let o of ['', ' OPTIONS { algorithm: "legacy" }']) {
         const query = "WITH " + vn + " FOR p IN OUTBOUND K_SHORTEST_PATHS '" + vn + "/test0' TO '" + vn + "/test11' " + en + o + " RETURN p";
 
         if (isCluster) {


### PR DESCRIPTION
Tune shortest paths to bring back 3.10 performance. This PR does not quite achieve this, but it brings the YenEnumerator and the WeightedShortestPathEnumerator in a state that they perform the same search as in 3.10.
The performance is still not on 3.10 level, since the underlying infrastructure has been weakened, too. In particular the `SingleServerProvider` does less caching than the corresponding code in 3.10 did. This will be addressed by a separate PR.

This effort comes from an investigation as to why Version 3.10 performed weighted shortest path computations (and as a consequence also Yen k-shortest-path computations) much faster than 3.12.

The finding is the following: In both implementations we use a two sided enumeration. We essentially use the same Dijkstra-like algorithm, but in 3.10 we choose differently, on which side we expand the next vertex from the priority queue. In 3.10, we always picked the side which less vertices on its queue.. In 3.12, we always picked the side, which had so far enumerated the smaller diameter.

Why does this matter so much?

If the search is "asymmetric" in the sense that there are a lot more paths coming out of one side than the other (quite likely in directed graphs and directed searches), the 3.10 approach concentrates on the "cheap" side first, and can therefore enumerate that one first, before expanding many vertices on the expensive side. This together with the following trick gave a tremendous advantage: Once one side has finished its search in its entirety, and some path has been found, we can prove that we can no longer find a shorter path anywhere.

This PR implements these changes and thus speeds up weighted shortest path searches considerably, not in all cases, but in many real life cases.

We also add source code comments to explain our rationale and our correctness proofs in detail.

In the process we discovered a bug in the legacy k-shortest-path algorithm which could overlook paths. This is fixed as well.

Finally, the class WeightedTwoSidedEnumerator did too many things at the
same time. It has been split integration
  WeightedTwoSidedEnumerator
and
  WeightedShortestPathEnumerator

The latter is responsible for shortest paths (ShortestPathNode and
Yen's algorithm), the former is responsible for legacy K-shortest-path
and AllShortestPaths and K-Paths.

This lead to a massive simplification of the `WeightedShortestPathEnumerator`. For example, it now only has to remember a single "best path" and various complex data structures become unnecessary.

Furthermore, we get a new tuning opportunity: Since we know that we are only ever looking for the shortest path, we can improve the stop criterium and quite often stop earlier, for example, if either side has finished its enumeration.

Furthermore, since we are no longer enumerating all paths, we can implement the proper Dijkstra-behaviour: If a vertex is first found via a longer/heavier path and then via a shorter/lighter path, we only have to continue our search from the path with the lower weight. We achieve this with an additional data structure to keep track of vertices found and not only of the queue of "Step"s. This also improves the decision as to which side we expand next, since the queue on the cheap side remains shorter in many cases.

We also add additional performance accounting and optional logging/tracing for debugging purposes.

### Scope & Purpose

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-2091
- [*] Enterprise PR: https://github.com/arangodb/enterprise/pull/1513

