### PR TITLE
ignore warning

### DIFF
--- a/tests/js/client/recovery/check-warnings-exitzero.js
+++ b/tests/js/client/recovery/check-warnings-exitzero.js
@@ -95,6 +95,11 @@ function recoverySuite () {
           // experimental feature
           return false;
         }
+        if (line.match(/\[a1690\].*Scheduler/)) {
+          // intentionally ignore shutdown warning
+          // experimental feature
+          return false;
+        }
         return true;
       });
 


### PR DESCRIPTION
### Scope & Purpose

It seems we can't avoid this warning hence ignore it as well:

  "2024-10-14T11:44:13.934702Z [103-1] S WARNING [a1690] {threads} Scheduler received shutdown, but there are still tasks on the queue: jobsSubmitted=15 jobsDone=14" 

- [x] :hankey: Bugfix
