### PR TITLE
Add execution context to async

### DIFF
--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -134,6 +134,13 @@ class ExecContext : public RequestContext {
     return requested <= collectionAuthLevel(db, coll);
   }
 
+  static std::shared_ptr<ExecContext const> set(
+      std::shared_ptr<ExecContext const> ctx) {
+    auto tmp = CURRENT;
+    CURRENT = ctx;
+    return tmp;
+  }
+
 #ifdef USE_ENTERPRISE
   virtual std::string clientAddress() const { return ""; }
   virtual std::string requestUrl() const { return ""; }

--- a/lib/Async/CMakeLists.txt
+++ b/lib/Async/CMakeLists.txt
@@ -4,6 +4,7 @@ target_include_directories(arango_async
   include)
 target_link_libraries(arango_async
   INTERFACE
+  arango_utils
   arango_async_registry)
 
 add_subdirectory(Registry)

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -70,15 +70,16 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
           promise->_callerExecContext = ExecContext::currentAsShared();
           promise->isSuspended = false;
         }
-        ExecContext::set(promise->_myExecContext);
+        ExecContext::set(_myExecContext);
         return inner_awaitable.await_resume();
       }
       async_promise_base<T>* promise;
       inner_awaitable_type inner_awaitable;
+      std::shared_ptr<ExecContext const> _myExecContext;
     };
-    _myExecContext = ExecContext::currentAsShared();
     return awaitable{this,
-                     get_awaitable_object(std::forward<U>(other_awaitable))};
+                     get_awaitable_object(std::forward<U>(other_awaitable)),
+                     ExecContext::currentAsShared()};
   };
   void unhandled_exception() { _value.set_exception(std::current_exception()); }
   auto get_return_object() {
@@ -88,7 +89,6 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
 
   std::atomic<void*> _continuation = nullptr;
   expected<T> _value;
-  std::shared_ptr<ExecContext const> _myExecContext;
   std::shared_ptr<ExecContext const> _callerExecContext;
   bool isSuspended = false;
 };

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "Async/Registry/promise.h"
+#include "Async/coro-utils.h"
 #include "Async/expected.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "Utils/ExecContext.h"
 
 #include <coroutine>
 #include <atomic>
@@ -26,7 +28,10 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
   async_promise_base(std::source_location loc)
       : async_registry::AddToAsyncRegistry{std::move(loc)} {}
 
-  std::suspend_never initial_suspend() noexcept { return {}; }
+  std::suspend_never initial_suspend() noexcept {
+    _callerExecContext = ExecContext::currentAsShared();
+    return {};
+  }
   auto final_suspend() noexcept {
     struct awaitable {
       bool await_ready() noexcept { return false; }
@@ -46,8 +51,35 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
       void await_resume() noexcept {}
       async_promise_base* _promise;
     };
+    ExecContext::set(_callerExecContext);
     return awaitable{this};
   }
+  template<typename U>
+  auto await_transform(U&& other_awaitable) noexcept {
+    using inner_awaitable_type =
+        decltype(get_awaitable_object(std::forward<U>(other_awaitable)));
+    struct awaitable {
+      bool await_ready() { return inner_awaitable.await_ready(); }
+      auto await_suspend(std::coroutine_handle<> handle) {
+        promise->isSuspended = true;
+        ExecContext::set(promise->_callerExecContext);
+        return inner_awaitable.await_suspend(handle);
+      }
+      auto await_resume() {
+        if (promise->isSuspended) {
+          promise->_callerExecContext = ExecContext::currentAsShared();
+          promise->isSuspended = false;
+        }
+        ExecContext::set(promise->_myExecContext);
+        return inner_awaitable.await_resume();
+      }
+      async_promise_base<T>* promise;
+      inner_awaitable_type inner_awaitable;
+    };
+    _myExecContext = ExecContext::currentAsShared();
+    return awaitable{this,
+                     get_awaitable_object(std::forward<U>(other_awaitable))};
+  };
   void unhandled_exception() { _value.set_exception(std::current_exception()); }
   auto get_return_object() {
     return async<T>{std::coroutine_handle<promise_type>::from_promise(
@@ -56,6 +88,9 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
 
   std::atomic<void*> _continuation = nullptr;
   expected<T> _value;
+  std::shared_ptr<ExecContext const> _myExecContext;
+  std::shared_ptr<ExecContext const> _callerExecContext;
+  bool isSuspended = false;
 };
 
 template<typename T>

--- a/lib/Async/include/Async/coro-utils.h
+++ b/lib/Async/include/Async/coro-utils.h
@@ -1,7 +1,31 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
 #include <coroutine>
 #include <utility>
+
+namespace arangodb {
 
 template<typename T>
 concept HasOperatorCoAwait = requires(T t) {
@@ -24,3 +48,5 @@ template<HasMemberOperatorCoAwait T>
 auto get_awaitable_object(T&& t) {
   return std::forward<T>(t).operator co_await();
 }
+
+}  // namespace arangodb

--- a/lib/Async/include/Async/coro-utils.h
+++ b/lib/Async/include/Async/coro-utils.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <coroutine>
+#include <utility>
+
+template<typename T>
+concept HasOperatorCoAwait = requires(T t) {
+  operator co_await(std::forward<T>(t));
+};
+template<typename T>
+concept HasMemberOperatorCoAwait = requires(T t) {
+  std::forward<T>(t).operator co_await();
+};
+
+template<typename T>
+auto get_awaitable_object(T&& t) -> T&& {
+  return std::forward<T>(t);
+}
+template<HasOperatorCoAwait T>
+auto get_awaitable_object(T&& t) {
+  return operator co_await(std::forward<T>(t));
+}
+template<HasMemberOperatorCoAwait T>
+auto get_awaitable_object(T&& t) {
+  return std::forward<T>(t).operator co_await();
+}

--- a/lib/Futures/CMakeLists.txt
+++ b/lib/Futures/CMakeLists.txt
@@ -12,4 +12,5 @@ target_link_libraries(arango_futures
   arango_inspection
   arango_assertions
   arango_async_registry
+  arango_utils
   velocypack)


### PR DESCRIPTION
Saves execution context in async-coroutine, such that when such a coroutine is resumed, the previous execution context of the coroutine is loaded. And when a coroutine is suspended, the execution context is changed back to the one of the caller.
This is achieved by the `await_transform` function of the coroutine promise, which is called on `expr` in  `co_await expr` before the co_await operator is applied. This function is now written in such a way that it can be called on any coroutine-type that defines how co_await is handled:
- On types that define the co_await operator as a member function, 
- on types that have a co_await operator defined on them and
-  on types that just define the co_await-functions (`await_ready`, `await_suspend` and `await_resume`) as member functions.