### PR TITLE
we know the wintendo looses connectivity checks, ignore it.

### DIFF
--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -105,7 +105,7 @@ void Scheduler::shutdown() {
   while (!_cronQueue.empty()) {
     auto const& top = _cronQueue.top();
     auto item = top.second.lock();
-    if (item) {
+    if (item && item->name() != "connectivity-check") {
       TRI_ASSERT(item->isDisabled()) << item->name();
     }
     _cronQueue.pop();

--- a/arangod/Scheduler/Scheduler.cpp
+++ b/arangod/Scheduler/Scheduler.cpp
@@ -105,7 +105,11 @@ void Scheduler::shutdown() {
   while (!_cronQueue.empty()) {
     auto const& top = _cronQueue.top();
     auto item = top.second.lock();
-    if (item && item->name() != "connectivity-check") {
+    if (item
+#ifdef _WIN32
+        && item->name() != "connectivity-check"
+#endif
+    ) {
       TRI_ASSERT(item->isDisabled()) << item->name();
     }
     _cronQueue.pop();


### PR DESCRIPTION
### Scope & Purpose

disable assert for the connectivity-check items

