### PR TITLE
Link async<T> that call each other via their ids

### DIFF
--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -39,9 +39,9 @@ auto Promise::mark_for_deletion() noexcept -> void {
 }
 
 AddToAsyncRegistry::AddToAsyncRegistry(std::source_location loc)
-    : promise{get_thread_registry().add_promise(std::move(loc))} {}
+    : promise_in_registry{get_thread_registry().add_promise(std::move(loc))} {}
 AddToAsyncRegistry::~AddToAsyncRegistry() {
-  if (promise != nullptr) {
-    promise->mark_for_deletion();
+  if (promise_in_registry != nullptr) {
+    promise_in_registry->mark_for_deletion();
   }
 }

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -90,7 +90,7 @@ struct AddToAsyncRegistry {
   struct noop {
     void operator()(void*) {}
   };
-  std::unique_ptr<Promise, noop> promise = nullptr;
+  std::unique_ptr<Promise, noop> promise_in_registry = nullptr;
 };
 
 }  // namespace arangodb::async_registry

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -77,6 +77,9 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
       inner_awaitable_type inner_awaitable;
       std::shared_ptr<ExecContext const> _myExecContext;
     };
+    if constexpr (CanSetPromiseWaiter<U>) {
+      co_awaited_expression.set_promise_waiter(this->id());
+    }
     return awaitable{
         this, get_awaitable_object(std::forward<U>(co_awaited_expression)),
         ExecContext::currentAsShared()};
@@ -155,6 +158,11 @@ struct async {
 
   bool valid() const noexcept { return _handle != nullptr; }
   operator bool() const noexcept { return valid(); }
+
+  auto set_promise_waiter(void* waiter) {
+    _handle.promise().set_promise_waiter(waiter);
+  }
+  auto id() -> void* { return _handle.promise()->id(); }
 
   ~async() { reset(); }
 

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -55,31 +55,31 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
     return awaitable{this};
   }
   template<typename U>
-  auto await_transform(U&& other_awaitable) noexcept {
+  auto await_transform(U&& co_awaited_expression) noexcept {
     using inner_awaitable_type =
-        decltype(get_awaitable_object(std::forward<U>(other_awaitable)));
+        decltype(get_awaitable_object(std::forward<U>(co_awaited_expression)));
     struct awaitable {
       bool await_ready() { return inner_awaitable.await_ready(); }
       auto await_suspend(std::coroutine_handle<> handle) {
-        promise->isSuspended = true;
-        ExecContext::set(promise->_callerExecContext);
+        outer_promise->isSuspended = true;
+        ExecContext::set(outer_promise->_callerExecContext);
         return inner_awaitable.await_suspend(handle);
       }
       auto await_resume() {
-        if (promise->isSuspended) {
-          promise->_callerExecContext = ExecContext::currentAsShared();
-          promise->isSuspended = false;
+        if (outer_promise->isSuspended) {
+          outer_promise->_callerExecContext = ExecContext::currentAsShared();
+          outer_promise->isSuspended = false;
         }
         ExecContext::set(_myExecContext);
         return inner_awaitable.await_resume();
       }
-      async_promise_base<T>* promise;
+      async_promise_base<T>* outer_promise;
       inner_awaitable_type inner_awaitable;
       std::shared_ptr<ExecContext const> _myExecContext;
     };
-    return awaitable{this,
-                     get_awaitable_object(std::forward<U>(other_awaitable)),
-                     ExecContext::currentAsShared()};
+    return awaitable{
+        this, get_awaitable_object(std::forward<U>(co_awaited_expression)),
+        ExecContext::currentAsShared()};
   };
   void unhandled_exception() { _value.set_exception(std::current_exception()); }
   auto get_return_object() {

--- a/lib/Async/include/Async/coro-utils.h
+++ b/lib/Async/include/Async/coro-utils.h
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include <concepts>
 #include <coroutine>
 #include <utility>
 
@@ -48,5 +49,14 @@ template<HasMemberOperatorCoAwait T>
 auto get_awaitable_object(T&& t) {
   return std::forward<T>(t).operator co_await();
 }
+
+template<typename T>
+concept CanSetPromiseWaiter = requires(T t, void* waiter) {
+  t.set_promise_waiter(waiter);
+};
+template<typename T>
+concept HasId = requires(T t) {
+  { t.id() } -> std::convertible_to<void*>;
+};
 
 }  // namespace arangodb

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -490,6 +490,11 @@ class [[nodiscard]] Future {
     return future;
   }
 
+  auto set_promise_waiter(void* waiter) {
+    return _state->set_promise_waiter(waiter);
+  }
+  auto id() -> void* { return _state->id(); }
+
  private:
   explicit Future(detail::EmptyConstructor) : _state(nullptr) {}
   explicit Future(detail::SharedState<T>* state) : _state(state) {}

--- a/lib/Futures/include/Futures/SharedState.h
+++ b/lib/Futures/include/Futures/SharedState.h
@@ -51,7 +51,7 @@ namespace detail {
 ///   |                    ---> OnlyCallback ---                    |
 ///   +-------------------------------------------------------------+
 template<typename T>
-class SharedState : async_registry::AddToAsyncRegistry {
+class SharedState : public async_registry::AddToAsyncRegistry {
   enum class State : uint8_t {
     Start = 1 << 0,
     OnlyResult = 1 << 1,

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -380,10 +380,12 @@ TYPED_TEST(AsyncTest, coroutine_is_removed_before_registry_entry) {
   }
 }
 
-auto foo() -> async<CopyOnlyValue> { co_return 1; }
-auto bar() -> async<CopyOnlyValue> { co_return 4; }
-auto baz() -> async<CopyOnlyValue> { co_return 2; }
-TEST(AsyncTest, promises_are_registered_in_global_registry) {
+namespace {
+auto foo() -> async<void> { co_return; }
+auto bar() -> async<void> { co_return; }
+auto baz() -> async<void> { co_return; }
+}  // namespace
+TYPED_TEST(AsyncTest, promises_are_registered_in_global_async_registry) {
   auto coro_foo = foo();
   EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()), 1);
 
@@ -471,4 +473,42 @@ TYPED_TEST(AsyncTest, execution_context_is_local_to_coroutine) {
   this->wait.resume();
   this->wait.await();
   EXPECT_EQ(ExecContext::current().user(), "End");
+}
+
+namespace {
+auto awaited_fn() -> async<void> { co_return; };
+auto waiter_fn(async<void>&& fn) -> async<void> {
+  co_await std::move(fn);
+  co_return;
+};
+}  // namespace
+TYPED_TEST(AsyncTest, async_promises_in_async_registry_know_their_waiter) {
+  auto awaited_coro = awaited_fn();
+  auto waiter_coro = waiter_fn(std::move(awaited_coro));
+
+  struct PromiseIds {
+    bool set = false;
+    void* id;
+    void* waiter;
+  };
+  PromiseIds awaited_promise;
+  PromiseIds waiter_promise;
+  uint count = 0;
+  arangodb::async_registry::registry.for_promise(
+      [&](arangodb::async_registry::Promise* promise) {
+        count++;
+        if (std::string(promise->entry_point.function_name())
+                .find("awaited_fn") != std::string::npos) {
+          awaited_promise = PromiseIds{true, promise->id(), promise->waiter};
+        }
+        if (std::string(promise->entry_point.function_name())
+                .find("waiter_fn") != std::string::npos) {
+          waiter_promise = PromiseIds{true, promise->id(), promise->waiter};
+        }
+      });
+  EXPECT_EQ(count, 2);
+  EXPECT_TRUE(awaited_promise.set);
+  EXPECT_TRUE(waiter_promise.set);
+  EXPECT_EQ(awaited_promise.waiter, waiter_promise.id);
+  EXPECT_EQ(waiter_promise.waiter, nullptr);
 }


### PR DESCRIPTION
An async function inside the async registry does now have a unique id and a waiter id which is the id of the async function that is waiting for this function.
For async<T> this waiter id is set when another coroutine is co_awaited.
The implementation for Future<T> still needs to be done.