### PR TITLE
Allow log levels to be configured for each appender individually (#21…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,54 @@
 v3.11.12 (XXXX-XX-XX)
 ---------------------
 
+* We already had the concept of individual log appenders (e.g., stdout, stderr,
+  files, syslog). but log levels could only be configured globally. That is,
+  all appenders always used the same log levels for all topics.
+
+  This PR introduces appender specific log levels. For example, it is now
+  possible to set the log levels for all topics to `error`, but leave the log
+  levels for the log file unchanged. This is particularly useful for test runs
+  because we avoid flooding the console with log messages, but still have all
+  the information in the log files in case of test failures.
+
+  The log level can be specified per appender via the command line by adding a
+  comma separated list of topics with their respective level after the output
+  definition, separated by a semicolon:
+    `--log.output file:///path/to/file;queries=trace,requests=info`
+    `--log.output -;all=error`
+
+  The `_admin/log/level` endpoint has also been extended to with an optional
+  parameter `withAppenders`. If that parameter is set to `true`, the response
+  has the following form:
+  ```
+  {
+    "global": {
+      <topic>: <level>,
+      ...
+    },
+    "appenders": {
+      <appender>: {
+        <topic>: <level>,
+        ...
+      },
+      ...
+    }
+  }
+  ```
+  A `PUT` request to `_admin/log/level` with `withAppenders` set to true
+  requires an input of the same format.
+
+  Previously, requests to the `_admin/log/level` endpoint where not fully
+  validated. A `PUT`' request that specified invalid topics or log levels
+  would silently ignore those. This has been improved, so that invalid input
+  is now always rejected with a proper error message - in that case _no_
+  changes are applied at all.
+
+  The global level for some topic is always identical to the highest log level
+  for that topic of all appenders. Thus, changing the log level for an appender
+  will implicitly also adjust the global level accordingly. When a global level
+  is set explicitly, this change is also applied to all appenders.
+
 * Change dumping of VPack to JSON for large double values with absolute
   value between 2^53 and 2^64. This ensures that dumps to JSON followed
   by parsing of the JSON back to VPack retain the right numerical values.

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -34,6 +34,8 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "GeneralServer/ServerSecurityFeature.h"
+#include "Inspection/VPack.h"
+#include "Logger/LogLevel.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerFeature.h"
 #include "Logger/LogTopic.h"
@@ -45,9 +47,9 @@
 
 #include <absl/strings/str_cat.h>
 
-using namespace arangodb;
-using namespace arangodb::basics;
-using namespace arangodb::rest;
+namespace arangodb {
+
+using namespace basics;
 
 RestAdminLogHandler::RestAdminLogHandler(arangodb::ArangodServer& server,
                                          GeneralRequest* request,
@@ -510,19 +512,26 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     }
   }
 
-  auto const type = _request->requestType();
+  auto withAppenders =
+      basics::StringUtils::tolower(_request->value("withAppenders")) == "true";
 
+  auto getLogLevels = [withAppenders]() {
+    auto buildResult = [](auto const& config) {
+      VPackBuilder builder;
+      velocypack::serialize(builder, config);
+      return builder;
+    };
+    if (withAppenders) {
+      return buildResult(Logger::getAppendersConfig());
+    } else {
+      return buildResult(Logger::getLogLevels());
+    }
+  };
+
+  auto const type = _request->requestType();
   if (type == rest::RequestType::GET) {
     // report log level
-    VPackBuilder builder;
-    builder.openObject();
-    auto const& levels = Logger::logLevelTopics();
-    for (auto const& level : levels) {
-      builder.add(level.first,
-                  VPackValue(Logger::translateLogLevel(level.second)));
-    }
-    builder.close();
-
+    VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else if (type == rest::RequestType::PUT) {
     // set log level
@@ -535,51 +544,50 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     if (slice.isString()) {
       Logger::setLogLevel(slice.copyString());
     } else if (slice.isObject()) {
-      if (VPackSlice all = slice.get("all"); all.isString()) {
-        // handle "all" first, so we can do
-        // {"all":"info","requests":"debug"} or such
-        std::string l = absl::StrCat("all=", all.stringView());
-        Logger::setLogLevel(l);
-      }
-      // now process all log topics except "all"
-      for (auto it : VPackObjectIterator(slice)) {
-        if (it.value.isString() && !it.key.isEqualString(LogTopic::ALL)) {
-          std::string l =
-              absl::StrCat(it.key.stringView(), "=", it.value.stringView());
-          Logger::setLogLevel(l);
+      auto parseConfig = [&](auto& config) {
+        if (auto res = velocypack::deserializeWithStatus(slice, config);
+            !res.ok()) {
+          auto msg = absl::StrCat("Failed to update log levels: ", res.error());
+          if (!res.path().empty()) {
+            msg = absl::StrCat(msg, " at path ", res.path());
+          }
+          generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                        msg);
+          return false;
         }
+        return true;
+      };
+
+      if (withAppenders) {
+        AppendersLogLevelConfig config;
+        if (!parseConfig(config)) {
+          return RestStatus::DONE;
+        }
+
+        auto res = Logger::setLogLevel(config);
+        if (res.fail()) {
+          generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                        absl::StrCat("Failed to update log levels: ",
+                                     res.errorMessage()));
+          return RestStatus::DONE;
+        }
+      } else {
+        LogLevels config;
+        if (!parseConfig(config)) {
+          return RestStatus::DONE;
+        }
+        Logger::setLogLevel(config);
       }
     }
 
     // now report current log levels
-    VPackBuilder builder;
-    builder.openObject();
-    auto const& levels = Logger::logLevelTopics();
-    for (auto const& level : levels) {
-      builder.add(level.first,
-                  VPackValue(Logger::translateLogLevel(level.second)));
-    }
-    builder.close();
-
+    VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else if (type == rest::RequestType::DELETE_REQ) {
-    // reset log levels to defaults
-    for (auto const& it : Logger::defaultLogLevelTopics()) {
-      std::string l =
-          absl::StrCat(it.first, "=", Logger::translateLogLevel(it.second));
-      Logger::setLogLevel(l);
-    }
+    Logger::resetLevelsToDefault();
 
     // now report resetted log levels
-    VPackBuilder builder;
-    builder.openObject();
-    auto const& levels = Logger::logLevelTopics();
-    for (auto const& level : levels) {
-      builder.add(level.first,
-                  VPackValue(Logger::translateLogLevel(level.second)));
-    }
-    builder.close();
-
+    VPackBuilder builder = getLogLevels();
     generateResult(rest::ResponseCode::OK, builder.slice());
   } else {
     // invalid method
@@ -637,3 +645,5 @@ void RestAdminLogHandler::handleLogStructuredParams() {
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
   }
 }
+
+}  // namespace arangodb

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -380,7 +380,14 @@ class instance {
       output.push('-'); // make sure we always have a stdout appender
     } else if (this.options.noStartStopLogs) {
       // set the stdout appender to error only
-      // output.push('-;all=error');
+      let output = this.args['log.output'];
+      if (output === undefined) {
+        output = [];
+      } else if (typeof output === 'string') {
+        output = [output];
+      }
+      output.push('-;all=error');
+      this.args['log.output'] = output;
       let logs = ['crash=info'];
       if (this.args['log.level'] !== undefined) {
         if (Array.isArray(this.args['log.level'])) {

--- a/lib/Inspection/include/Inspection/InspectorBase.h
+++ b/lib/Inspection/include/Inspection/InspectorBase.h
@@ -50,6 +50,13 @@ namespace arangodb::inspection {
 struct NoContext {};
 
 namespace detail {
+struct NoOp {
+  template<class T>
+  constexpr void operator()(T& v) const noexcept {}
+};
+}  // namespace detail
+
+namespace detail {
 template<class ContextT>
 struct ContextContainer {
   static constexpr bool hasContext = true;
@@ -248,8 +255,9 @@ struct InspectorBase : detail::ContextContainer<Context> {
 
   template<class T>
   struct Enum {
-    template<class... Args>
-    [[nodiscard]] Status values(Args&&... args) {
+    template<class Transformer, class... Args>
+    [[nodiscard]] Status transformedValues(Transformer transformer,
+                                           Args&&... args) {
       if constexpr (Derived::isLoading) {
         constexpr bool hasStringValues =
             (std::is_constructible_v<std::string, Args> || ...);
@@ -261,15 +269,17 @@ struct InspectorBase : detail::ContextContainer<Context> {
         Status res;
         bool retryDifferentType = false;
         if constexpr (hasStringValues) {
+          static_assert(std::is_invocable_v<Transformer, std::string&>);
           // TODO - read std::string_view
-          res = load<std::string>(retryDifferentType,
+          res = load<std::string>(transformer, retryDifferentType,
                                   std::forward<Args>(args)...);
           assert(retryDifferentType == false || !res.ok());
         }
         if constexpr (hasIntValues) {
+          static_assert(std::is_invocable_v<Transformer, std::uint64_t&>);
           if (!hasStringValues || retryDifferentType) {
             retryDifferentType = false;
-            res = load<std::uint64_t>(retryDifferentType,
+            res = load<std::uint64_t>(transformer, retryDifferentType,
                                       std::forward<Args>(args)...);
             if (hasStringValues && retryDifferentType) {
               return Status{"Expecting type String or Int"};
@@ -280,6 +290,11 @@ struct InspectorBase : detail::ContextContainer<Context> {
       } else {
         return store(std::forward<Args>(args)...);
       }
+    }
+
+    template<class... Args>
+    [[nodiscard]] Status values(Args&&... args) {
+      return transformedValues(detail::NoOp{}, std::forward<Args>(args)...);
     }
 
    private:
@@ -293,14 +308,17 @@ struct InspectorBase : detail::ContextContainer<Context> {
           "Enum values can only be mapped to string or unsigned values");
     }
 
-    template<class ValueType, class... Args>
-    Status load(bool& retryDifferentType, Args&&... args) {
+    template<class ValueType, class Transformer, class... Args>
+    Status load(Transformer transformer, bool& retryDifferentType,
+                Args&&... args) {
       ValueType read{};
       auto result = _inspector.apply(read);
       if (!result.ok()) {
         retryDifferentType = true;
         return result;
       }
+
+      transformer(read);
       if (loadValue(read, std::forward<Args>(args)...)) {
         return Status{};
       } else if constexpr (std::is_integral_v<ValueType>) {

--- a/lib/Logger/Appenders.cpp
+++ b/lib/Logger/Appenders.cpp
@@ -1,0 +1,398 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Appenders.h"
+
+#include "Assertions/Assert.h"
+#include "Basics/Result.h"
+#include "Basics/StringUtils.h"
+#include "Basics/ReadLocker.h"
+#include "Basics/WriteLocker.h"
+#include "Logger/LogAppender.h"
+#include "Logger/LogAppenderFile.h"
+#include "Logger/LogAppenderStdStream.h"
+#include "Logger/LogAppenderSyslog.h"
+#include "Logger/LogLevel.h"
+#include "Logger/LogMacros.h"
+#include "Logger/LogMessage.h"
+#include "Logger/LogTopic.h"
+#include "Logger/Logger.h"
+#include "Logger/Topics.h"
+
+#include <absl/strings/str_cat.h>
+#include <vector>
+
+namespace arangodb::logger {
+
+namespace {
+constexpr std::string_view filePrefix("file://");
+constexpr std::string_view syslogPrefix("syslog://");
+}  // namespace
+
+void Appenders::addGlobalAppender(LogGroup const& group,
+                                  std::shared_ptr<LogAppender> appender) {
+  WRITE_LOCKER(guard, _appendersLock);
+  _groups[group.id()].globalAppenders.emplace_back(std::move(appender));
+}
+
+void Appenders::addAppender(LogGroup const& logGroup,
+                            std::string const& definition) {
+  auto res = parseDefinition(definition);
+  if (res.fail()) {
+    LOG_TOPIC("658e0", ERR, Logger::FIXME)
+        << "Failed to configure log appender " << definition << " - "
+        << res.errorMessage();
+    return;
+  }
+
+  auto& config = res.get();
+  TRI_ASSERT(res->type != Type::kUnknown);
+
+  auto key =
+      config.type == Type::kSyslog ? std::string(syslogPrefix) : config.output;
+
+  std::shared_ptr<LogAppender> appender;
+
+  WRITE_LOCKER(guard, _appendersLock);
+
+  auto& group = _groups[logGroup.id()];
+
+  auto& definitionsMap = group.definition2appenders;
+  if (auto it = definitionsMap.find(key); it != definitionsMap.end()) {
+    // found an existing appender
+    appender = it->second;
+  } else {
+    // build a new appender from the definition
+    appender = buildAppender(logGroup, config);
+    if (appender == nullptr) {
+      // cannot create appender, for whatever reason
+      return;
+    }
+    definitionsMap.emplace(key, appender);
+    for (auto& [topic, level] : config.levels) {
+      appender->setLogLevel(*topic, level);
+    }
+  }
+
+  TRI_ASSERT(appender != nullptr);
+
+  auto& topicsMap = group.topics2appenders;
+  size_t n = (config.topic == nullptr) ? LogTopic::GLOBAL_LOG_TOPIC
+                                       : config.topic->id();
+  if (std::find(topicsMap[n].begin(), topicsMap[n].end(), appender) ==
+      topicsMap[n].end()) {
+    topicsMap[n].emplace_back(appender);
+  }
+}
+
+std::shared_ptr<LogAppender> Appenders::buildAppender(
+    LogGroup const& group, AppenderConfig const& config) {
+  switch (config.type) {
+    case Type::kFile:
+      return LogAppenderFileFactory::getFileAppender(
+          config.output.substr(filePrefix.size()));
+    case Type::kStderr:
+      TRI_ASSERT(config.output == "+");
+      if (!_groups[group.id()].definition2appenders.contains("+")) {
+        return std::make_shared<LogAppenderStderr>();
+      }
+      // already got a logger for stderr
+      break;
+    case Type::kStdout:
+      TRI_ASSERT(config.output == "-");
+      if (!_groups[group.id()].definition2appenders.contains("-")) {
+        return std::make_shared<LogAppenderStdout>();
+      }
+      // already got a logger for stdout
+      break;
+    case Type::kSyslog:
+#ifdef ARANGODB_ENABLE_SYSLOG
+    {
+      auto s = basics::StringUtils::split(
+          config.output.substr(syslogPrefix.size()), '/');
+      TRI_ASSERT(s.size() == 1 || s.size() == 2);
+
+      std::string identifier;
+      if (s.size() == 2) {
+        identifier = s[1];
+      }
+
+      return std::make_shared<LogAppenderSyslog>(s[0], identifier);
+    }
+#endif
+    case Type::kUnknown:
+      TRI_ASSERT(false);
+  }
+  return nullptr;
+}
+
+void Appenders::logGlobal(LogGroup const& group, LogMessage const& message) {
+  READ_LOCKER(guard, _appendersLock);
+
+  try {
+    auto& appenders = _groups.at(group.id()).globalAppenders;
+
+    // append to global appenders first
+    for (auto const& appender : appenders) {
+      appender->logMessageGuarded(message);
+    }
+  } catch (std::out_of_range const&) {
+    // no global appender for this group
+    TRI_ASSERT(false) << "no global appender for group " << group.id();
+    // This should never happen, however if it does we should not crash
+    // but we also cannot log anything, as we are the logger.
+  }
+}
+
+void Appenders::log(LogGroup const& group, LogMessage const& message) {
+  // output to appenders
+  READ_LOCKER(guard, _appendersLock);
+  try {
+    auto& topicsMap = _groups.at(group.id()).topics2appenders;
+    auto output = [&topicsMap](LogGroup const& group, LogMessage const& message,
+                               size_t n) -> bool {
+      bool shown = false;
+
+      auto const& it = topicsMap.find(n);
+      if (it != topicsMap.end() && !it->second.empty()) {
+        auto const& appenders = it->second;
+
+        for (auto const& appender : appenders) {
+          appender->logMessageGuarded(message);
+        }
+        shown = true;
+      }
+
+      return shown;
+    };
+
+    bool shown = false;
+
+    // try to find a topic-specific appender
+    size_t topicId = message._topicId;
+
+    if (topicId < LogTopic::GLOBAL_LOG_TOPIC) {
+      shown = output(group, message, topicId);
+    }
+
+    // otherwise use the general topic appender
+    if (!shown) {
+      output(group, message, LogTopic::GLOBAL_LOG_TOPIC);
+    }
+  } catch (std::out_of_range const&) {
+    // no topic 2 appenders entry for this group.
+    TRI_ASSERT(false) << "no topic 2 appender match for group " << group.id();
+    // This should never happen, however if it does we should not crash
+    // but we also cannot log anything, as we are the logger.
+  }
+}
+
+void Appenders::shutdown() {
+  WRITE_LOCKER(guard, _appendersLock);
+
+#ifdef ARANGODB_ENABLE_SYSLOG
+  LogAppenderSyslog::close();
+#endif
+  LogAppenderFileFactory::closeAll();
+
+  for (auto& g : _groups) {
+    g.globalAppenders.clear();
+    g.topics2appenders.clear();
+    g.definition2appenders.clear();
+  }
+}
+
+void Appenders::reopen() {
+  WRITE_LOCKER(guard, _appendersLock);
+
+  LogAppenderFileFactory::reopenAll();
+}
+
+auto Appenders::parseDefinition(std::string definition)
+    -> ResultT<Appenders::AppenderConfig> {
+  AppenderConfig result;
+
+  std::vector<std::string> v = basics::StringUtils::split(definition, ';');
+  if (v.size() == 2) {
+    definition = v[0];
+    auto res = parseLogLevels(v[1]);
+    if (res.fail()) {
+      return res.result();
+    }
+    result.levels = res.get();
+  } else if (v.size() > 2) {
+    return Result(
+        TRI_ERROR_BAD_PARAMETER,
+        absl::StrCat("strange definition '", definition, "' ignored"));
+  }
+
+  // split into parts and do some basic validation
+  v = basics::StringUtils::split(definition, '=');
+  std::string topicName;
+
+  if (v.size() == 1) {
+    result.output = v[0];
+  } else if (v.size() == 2) {
+    topicName = basics::StringUtils::tolower(v[0]);
+
+    if (topicName.empty()) {
+      result.output = v[0];
+    } else {
+      result.output = v[1];
+    }
+  } else {
+    return Result(
+        TRI_ERROR_BAD_PARAMETER,
+        absl::StrCat("strange output definition '", definition, "' ignored"));
+  }
+
+  if (!topicName.empty()) {
+    result.topic = LogTopic::lookup(topicName);
+
+    if (result.topic == nullptr) {
+      return Result(TRI_ERROR_BAD_PARAMETER,
+                    absl::StrCat("strange topic '", topicName,
+                                 "', ignoring whole defintion"));
+    }
+  }
+
+  if (result.output == "+") {
+    result.type = Type::kStderr;
+  } else if (result.output == "-") {
+    result.type = Type::kStdout;
+#ifdef ARANGODB_ENABLE_SYSLOG
+  } else if (result.output.starts_with(syslogPrefix)) {
+    auto s = basics::StringUtils::split(
+        result.output.substr(syslogPrefix.size()), '/');
+
+    if (s.size() < 1 || s.size() > 2) {
+      return Result(
+          TRI_ERROR_BAD_PARAMETER,
+          absl::StrCat("unknown syslog definition '", result.output,
+                       "', expecting 'syslog://facility/identifier'"));
+    }
+    result.type = Type::kSyslog;
+#endif
+  } else if (result.output.starts_with(filePrefix)) {
+    result.type = Type::kFile;
+  } else {
+    return Result(
+        TRI_ERROR_BAD_PARAMETER,
+        absl::StrCat("unknown output definition '", result.output, "'"));
+  }
+
+  return result;
+}
+
+auto Appenders::parseLogLevels(std::string const& levels)
+    -> ResultT<std::unordered_map<LogTopic*, LogLevel>> {
+  std::unordered_map<LogTopic*, LogLevel> result;
+  auto v = basics::StringUtils::split(levels, ',');
+  for (auto const& s : v) {
+    auto p = basics::StringUtils::split(s, '=');
+    if (p.size() != 2) {
+      return Result(TRI_ERROR_BAD_PARAMETER,
+                    absl::StrCat("strange level definition '", s, "'"));
+    }
+    LogLevel level;
+    bool isValid = Logger::translateLogLevel(p[1], false, level);
+    if (!isValid) {
+      return Result(TRI_ERROR_BAD_PARAMETER,
+                    absl::StrCat("strange log level '", p[1], "'"));
+    }
+
+    if (p[0] == LogTopic::ALL) {
+      for (std::size_t i = 0; i < kNumTopics; ++i) {
+        auto* topic = LogTopic::topicForId(i);
+        if (topic != nullptr) {
+          result[topic] = level;
+        }
+      }
+    } else {
+      auto* topic = LogTopic::lookup(p[0]);
+      if (topic == nullptr) {
+        return Result(TRI_ERROR_BAD_PARAMETER,
+                      absl::StrCat("unknown topic '", p[0], "'"));
+      }
+      result[topic] = level;
+    }
+  }
+  return result;
+}
+
+bool Appenders::haveAppenders(LogGroup const& logGroup, size_t topicId) {
+  // It might be preferable if we could avoid the lock here, but ATM this is
+  // not possible. If this actually causes performance issues we have to think
+  // about other solutions.
+  READ_LOCKER(guard, _appendersLock);
+  auto& group = _groups.at(logGroup.id());
+  try {
+    auto const& appenders = group.topics2appenders;
+    auto haveTopicAppenders = [&appenders](size_t topicId) {
+      auto it = appenders.find(topicId);
+      return it != appenders.end() && !it->second.empty();
+    };
+    return haveTopicAppenders(topicId) ||
+           haveTopicAppenders(LogTopic::GLOBAL_LOG_TOPIC) ||
+           !group.globalAppenders.empty();
+  } catch (std::out_of_range const&) {
+    // no topic 2 appenders entry for this group.
+    TRI_ASSERT(false) << "no topic 2 appender match for group "
+                      << logGroup.id();
+    // This should never happen, however if it does we should not crash
+    // but we also cannot log anything, as we are the logger.
+    return false;
+  }
+}
+
+auto Appenders::getAppender(LogGroup const& logGroup,
+                            std::string const& definition)
+    -> std::shared_ptr<LogAppender> {
+  READ_LOCKER(guard, _appendersLock);
+  auto& group = _groups.at(logGroup.id());
+  auto it = group.definition2appenders.find(definition);
+  if (it != group.definition2appenders.end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+auto Appenders::getAppenders(LogGroup const& logGroup)
+    -> std::unordered_map<std::string, std::shared_ptr<LogAppender>> {
+  READ_LOCKER(guard, _appendersLock);
+  auto& group = _groups.at(logGroup.id());
+  return group.definition2appenders;
+}
+
+void Appenders::foreach (std::function<void(LogAppender&)> const& f) {
+  READ_LOCKER(guard, _appendersLock);
+  for (auto& group : _groups) {
+    for (auto& v : group.globalAppenders) {
+      f(*v);
+    }
+    for (auto& v : group.definition2appenders) {
+      f(*v.second);
+    }
+  }
+}
+
+}  // namespace arangodb::logger

--- a/lib/Logger/Appenders.h
+++ b/lib/Logger/Appenders.h
@@ -1,0 +1,98 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "Basics/ReadWriteLock.h"
+#include "Basics/ResultT.h"
+#include "Logger/LogGroup.h"
+#include "Logger/LogLevel.h"
+
+namespace arangodb {
+class LogAppender;
+struct LogMessage;
+class LogTopic;
+}  // namespace arangodb
+
+namespace arangodb::logger {
+
+struct Appenders {
+  void addAppender(LogGroup const&, std::string const& definition);
+
+  void addGlobalAppender(LogGroup const&, std::shared_ptr<LogAppender>);
+
+  void logGlobal(LogGroup const&, LogMessage const&);
+  void log(LogGroup const&, LogMessage const&);
+
+  void reopen();
+  void shutdown();
+
+  bool haveAppenders(LogGroup const& group, size_t topicId);
+
+  auto getAppender(LogGroup const& group, std::string const& definition)
+      -> std::shared_ptr<LogAppender>;
+  auto getAppenders(LogGroup const& group)
+      -> std::unordered_map<std::string, std::shared_ptr<LogAppender>>;
+
+  void foreach (std::function<void(LogAppender&)> const& f);
+
+ private:
+  enum class Type {
+    kUnknown,
+    kFile,
+    kStderr,
+    kStdout,
+    kSyslog,
+  };
+
+  struct AppenderConfig {
+    std::string output;
+    LogTopic* topic = nullptr;
+    Type type = Type::kUnknown;
+    std::unordered_map<LogTopic*, LogLevel> levels;
+  };
+  auto parseDefinition(std::string definition) -> ResultT<AppenderConfig>;
+  auto parseLogLevels(std::string const& definition)
+      -> ResultT<std::unordered_map<LogTopic*, LogLevel>>;
+
+  std::shared_ptr<LogAppender> buildAppender(LogGroup const&,
+                                             AppenderConfig const& config);
+
+  struct Group {
+    std::vector<std::shared_ptr<LogAppender>> globalAppenders;
+    std::unordered_map<size_t, std::vector<std::shared_ptr<LogAppender>>>
+        topics2appenders;
+    std::unordered_map<std::string, std::shared_ptr<LogAppender>>
+        definition2appenders;
+  };
+
+  arangodb::basics::ReadWriteLock _appendersLock;
+  std::array<Group, LogGroup::Count> _groups;
+};
+}  // namespace arangodb::logger

--- a/lib/Logger/LogLevel.h
+++ b/lib/Logger/LogLevel.h
@@ -24,7 +24,9 @@
 
 #pragma once
 
+#include <algorithm>
 #include <iosfwd>
+#include <string>
 
 #include "Basics/operating-system.h"
 
@@ -42,6 +44,24 @@ enum class LogLevel {
   DEBUG = 5,
   TRACE = 6
 };
+
+template<typename Inspector>
+auto inspect(Inspector& f, LogLevel& l) {
+  return f.enumeration(l).transformedValues(
+      [](std::string& s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return std::toupper(c); });
+      },
+      LogLevel::DEFAULT, "DEFAULT",  //
+      LogLevel::FATAL, "FATAL",      //
+      LogLevel::ERR, "ERROR",        //
+      LogLevel::ERR, "ERR",          //
+      LogLevel::WARN, "WARNING",     //
+      LogLevel::WARN, "WARN",        //
+      LogLevel::INFO, "INFO",        //
+      LogLevel::DEBUG, "DEBUG",      //
+      LogLevel::TRACE, "TRACE");
 }
+}  // namespace arangodb
 
 std::ostream& operator<<(std::ostream&, arangodb::LogLevel);

--- a/lib/Logger/LogTopic.cpp
+++ b/lib/Logger/LogTopic.cpp
@@ -21,28 +21,32 @@
 /// @author Dr. Frank Celler
 ////////////////////////////////////////////////////////////////////////////////
 
+#include "LogTopic.h"
+
+#include <array>
 #include <cstdint>
 #include <map>
 #include <string>
 #include <type_traits>
+#include <utility>
 #include <vector>
 
-#include "LogTopic.h"
+#include <absl/strings/str_cat.h>
 
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
-#include "Logger/LoggerStream.h"
+#include "Logger/Topics.h"
 
 #ifdef USE_ENTERPRISE
 #include "Enterprise/Audit/AuditFeature.h"
 #include "Enterprise/Ldap/LdapFeature.h"
 #endif
 
-using namespace arangodb;
+namespace arangodb {
+
+static_assert(logger::kNumTopics < LogTopic::GLOBAL_LOG_TOPIC);
 
 namespace {
-
-std::atomic<uint16_t> NEXT_TOPIC_ID(0);
 
 class Topics {
  public:
@@ -54,10 +58,8 @@ class Topics {
 
   template<typename Visitor>
   bool visit(Visitor const& visitor) const {
-    std::lock_guard guard{_namesLock};
-
-    for (auto const& topic : _names) {
-      if (!visitor(topic.first, topic.second)) {
+    for (auto const& [name, idx] : _nameToIndex) {
+      if (!visitor(name, _topics[idx])) {
         return false;
       }
     }
@@ -65,18 +67,11 @@ class Topics {
     return true;
   }
 
-  bool setLogLevel(std::string const& name, LogLevel level) {
-    std::lock_guard guard{_namesLock};
+  bool setLogLevel(TopicName name, LogLevel level) {
+    auto* topic = find(name);
 
-    auto const it = _names.find(name);
-
-    if (it == _names.end()) {
-      return false;
-    }
-
-    auto* topic = it->second;
-
-    if (!topic) {
+    if (topic == nullptr) {
+      TRI_ASSERT(false) << "topic '" << name << "' not initialized";
       return false;
     }
 
@@ -84,23 +79,27 @@ class Topics {
     return true;
   }
 
-  LogTopic* find(std::string const& name) const noexcept {
-    std::lock_guard guard{_namesLock};
-    auto const it = _names.find(name);
-    return it == _names.end() ? nullptr : it->second;
+  LogTopic* get(size_t idx) const noexcept { return _topics[idx]; }
+
+  LogTopic* find(TopicName name) const noexcept {
+    auto const it = _nameToIndex.find(name);
+    return it == _nameToIndex.end() ? nullptr : _topics[it->second];
   }
 
-  void emplace(std::string const& name, LogTopic* topic) noexcept {
-    try {
-      std::lock_guard guard{_namesLock};
-      _names[name] = topic;
-    } catch (...) {
-    }
+  void emplace(TopicName name, LogTopic* topic) noexcept {
+    auto const it = _nameToIndex.find(name);
+    ADB_PROD_ASSERT(it != _nameToIndex.end() && _topics[it->second] == nullptr);
+    _topics[it->second] = topic;
   }
 
  private:
-  mutable std::mutex _namesLock;
-  std::map<std::string, LogTopic*> _names;
+  Topics() {
+    logger::TopicList::foreach ([this]<typename Topic>() {
+      _nameToIndex[Topic::name] = logger::TopicList::index<Topic>();
+    });
+  }
+  std::array<LogTopic*, logger::kNumTopics> _topics{};
+  std::map<TopicName, size_t> _nameToIndex;
 
   Topics() = default;
   Topics(const Topics&) = delete;
@@ -109,117 +108,109 @@ class Topics {
 
 }  // namespace
 
-// pseudo-topic to address all log topics
-std::string const LogTopic::ALL("all");
-
-LogTopic Logger::AGENCY("agency", LogLevel::INFO);
-LogTopic Logger::AGENCYCOMM("agencycomm", LogLevel::INFO);
-LogTopic Logger::AGENCYSTORE("agencystore", LogLevel::WARN);
-LogTopic Logger::AQL("aql", LogLevel::INFO);
-LogTopic Logger::AUTHENTICATION("authentication", LogLevel::WARN);
-LogTopic Logger::AUTHORIZATION("authorization");
-LogTopic Logger::BACKUP("backup");
-LogTopic Logger::BENCH("bench");
-LogTopic Logger::CACHE("cache", LogLevel::INFO);
-LogTopic Logger::CLUSTER("cluster", LogLevel::INFO);
-LogTopic Logger::COMMUNICATION("communication", LogLevel::INFO);
-LogTopic Logger::CONFIG("config");
-LogTopic Logger::CRASH("crash");
-LogTopic Logger::DEVEL("development", LogLevel::FATAL);
-LogTopic Logger::DUMP("dump", LogLevel::INFO);
-LogTopic Logger::ENGINES("engines", LogLevel::INFO);
-LogTopic Logger::FIXME("general", LogLevel::INFO);
-LogTopic Logger::FLUSH("flush", LogLevel::INFO);
-LogTopic Logger::GRAPHS("graphs", LogLevel::INFO);
-LogTopic Logger::HEARTBEAT("heartbeat", LogLevel::INFO);
-LogTopic Logger::HTTPCLIENT("httpclient", LogLevel::WARN);
-LogTopic Logger::LICENSE("license", LogLevel::INFO);
-LogTopic Logger::MAINTENANCE("maintenance", LogLevel::INFO);
-LogTopic Logger::MEMORY("memory", LogLevel::INFO);
-LogTopic Logger::MMAP("mmap");
-LogTopic Logger::PREGEL("pregel", LogLevel::INFO);
-LogTopic Logger::QUERIES("queries", LogLevel::INFO);
-LogTopic Logger::REPLICATION("replication", LogLevel::INFO);
-LogTopic Logger::REPLICATION2("replication2", LogLevel::WARN);
-LogTopic Logger::REPLICATED_STATE("rep-state", LogLevel::WARN);
-LogTopic Logger::REQUESTS("requests", LogLevel::FATAL);  // suppress
-LogTopic Logger::RESTORE("restore", LogLevel::INFO);
-LogTopic Logger::ROCKSDB("rocksdb", LogLevel::WARN);
-LogTopic Logger::SECURITY("security", LogLevel::INFO);
-LogTopic Logger::SSL("ssl", LogLevel::WARN);
-LogTopic Logger::STARTUP("startup", LogLevel::INFO);
-LogTopic Logger::STATISTICS("statistics", LogLevel::INFO);
-LogTopic Logger::SUPERVISION("supervision", LogLevel::INFO);
-LogTopic Logger::SYSCALL("syscall", LogLevel::INFO);
-LogTopic Logger::THREADS("threads", LogLevel::WARN);
-LogTopic Logger::TRANSACTIONS("trx", LogLevel::WARN);
-LogTopic Logger::TTL("ttl", LogLevel::WARN);
-LogTopic Logger::VALIDATION("validation", LogLevel::INFO);
-LogTopic Logger::V8("v8", LogLevel::WARN);
-LogTopic Logger::VIEWS("views", LogLevel::FATAL);
+LogTopic Logger::AGENCY(logger::topic::Agency{});
+LogTopic Logger::AGENCYCOMM(logger::topic::Agencycomm{});
+LogTopic Logger::AGENCYSTORE(logger::topic::Agencystore{});
+LogTopic Logger::AQL(logger::topic::Aql{});
+LogTopic Logger::AUTHENTICATION(logger::topic::Authentication{});
+LogTopic Logger::AUTHORIZATION(logger::topic::Authorization{});
+LogTopic Logger::BACKUP(logger::topic::Backup{});
+LogTopic Logger::BENCH(logger::topic::Bench{});
+LogTopic Logger::CACHE(logger::topic::Cache{});
+LogTopic Logger::CLUSTER(logger::topic::Cluster{});
+LogTopic Logger::COMMUNICATION(logger::topic::Communication{});
+LogTopic Logger::CONFIG(logger::topic::Config{});
+LogTopic Logger::CRASH(logger::topic::Crash{});
+LogTopic Logger::DEVEL(logger::topic::Development{});
+LogTopic Logger::DUMP(logger::topic::Dump{});
+LogTopic Logger::ENGINES(logger::topic::Engines{});
+LogTopic Logger::FIXME(logger::topic::Fixme{});
+LogTopic Logger::FLUSH(logger::topic::Flush{});
+LogTopic Logger::GRAPHS(logger::topic::Graphs{});
+LogTopic Logger::HEARTBEAT(logger::topic::Heartbeat{});
+LogTopic Logger::HTTPCLIENT(logger::topic::Httpclient{});
+LogTopic Logger::LICENSE(logger::topic::License{});
+LogTopic Logger::MAINTENANCE(logger::topic::Maintenance{});
+LogTopic Logger::MEMORY(logger::topic::Memory{});
+LogTopic Logger::QUERIES(logger::topic::Queries{});
+LogTopic Logger::REPLICATION(logger::topic::Replication{});
+LogTopic Logger::REPLICATION2(logger::topic::Replication2{});
+LogTopic Logger::REPLICATED_STATE(logger::topic::ReplicatedState{});
+LogTopic Logger::REPLICATED_WAL(logger::topic::ReplicatedWal{});
+LogTopic Logger::REQUESTS(logger::topic::Requests{});
+LogTopic Logger::RESTORE(logger::topic::Restore{});
+LogTopic Logger::ROCKSDB(logger::topic::Rocksdb{});
+LogTopic Logger::SECURITY(logger::topic::Security{});
+LogTopic Logger::SSL(logger::topic::Ssl{});
+LogTopic Logger::STARTUP(logger::topic::Startup{});
+LogTopic Logger::STATISTICS(logger::topic::Statistics{});
+LogTopic Logger::SUPERVISION(logger::topic::Supervision{});
+LogTopic Logger::SYSCALL(logger::topic::Syscall{});
+LogTopic Logger::THREADS(logger::topic::Threads{});
+LogTopic Logger::TRANSACTIONS(logger::topic::Trx{});
+LogTopic Logger::TTL(logger::topic::Ttl{});
+LogTopic Logger::VALIDATION(logger::topic::Validation{});
+LogTopic Logger::V8(logger::topic::V8{});
+LogTopic Logger::VIEWS(logger::topic::Views{});
+LogTopic Logger::DEPRECATION(logger::topic::Deprecation{});
 
 #ifdef USE_ENTERPRISE
-LogTopic LdapAuthProvider::LDAP_TOPIC("ldap", LogLevel::INFO);
-
-LogTopic AuditFeature::AUDIT_AUTHENTICATION("audit-authentication",
-                                            LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_AUTHORIZATION("audit-authorization",
-                                           LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_DATABASE("audit-database", LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_COLLECTION("audit-collection", LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_VIEW("audit-view", LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_DOCUMENT("audit-document", LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_SERVICE("audit-service", LogLevel::INFO);
-LogTopic AuditFeature::AUDIT_HOTBACKUP("audit-hotbackup", LogLevel::INFO);
+LogTopic AuditFeature::AUDIT_AUTHENTICATION(logger::audit::Authentication{});
+LogTopic AuditFeature::AUDIT_AUTHORIZATION(logger::audit::Authorization{});
+LogTopic AuditFeature::AUDIT_DATABASE(logger::audit::Database{});
+LogTopic AuditFeature::AUDIT_COLLECTION(logger::audit::Collection{});
+LogTopic AuditFeature::AUDIT_VIEW(logger::audit::View{});
+LogTopic AuditFeature::AUDIT_DOCUMENT(logger::audit::Document{});
+LogTopic AuditFeature::AUDIT_SERVICE(logger::audit::Service{});
+LogTopic AuditFeature::AUDIT_HOTBACKUP(logger::audit::HotBackup{});
 #endif
 
-std::vector<std::pair<std::string, LogLevel>> LogTopic::logLevelTopics() {
-  std::vector<std::pair<std::string, LogLevel>> levels;
+auto LogTopic::logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel> {
+  std::unordered_map<LogTopic*, LogLevel> levels;
+  levels.reserve(logger::kNumTopics);
 
-  auto visitor = [&levels](std::string const& name, LogTopic const* topic) {
-    levels.emplace_back(name, topic->level());
-    return true;
-  };
-
-  Topics::instance().visit(visitor);
+  for (std::size_t i = 0; i < logger::kNumTopics; ++i) {
+    auto* topic = Topics::instance().get(i);
+    if (topic) {
+      levels.emplace(topic, topic->level());
+    }
+  }
 
   return levels;
 }
 
-void LogTopic::setLogLevel(std::string const& name, LogLevel level) {
+void LogTopic::setLogLevel(TopicName name, LogLevel level) {
   if (!Topics::instance().setLogLevel(name, level)) {
     LOG_TOPIC("5363d", WARN, arangodb::Logger::FIXME)
         << "strange topic '" << name << "'";
   }
 }
 
-LogTopic* LogTopic::lookup(std::string const& name) {
+LogTopic* LogTopic::topicForId(size_t topicId) {
+  TRI_ASSERT(topicId < logger::kNumTopics);
+  return Topics::instance().get(topicId);
+}
+
+LogTopic* LogTopic::lookup(TopicName name) {
   return Topics::instance().find(name);
 }
 
-std::string LogTopic::lookup(size_t topicId) {
-  std::string name("UNKNOWN");
-
-  auto visitor = [&name, topicId](std::string const&, LogTopic const* topic) {
-    if (topic->_id == topicId) {
-      name = topic->_name;
-      return false;  // break the loop
-    }
-    return true;
-  };
-
-  Topics::instance().visit(visitor);
-
-  return name;
+TopicName LogTopic::lookup(size_t topicId) {
+  auto* topic = Topics::instance().get(topicId);
+  return topic->name();
 }
 
-LogTopic::LogTopic(std::string const& name)
-    : LogTopic(name, LogLevel::DEFAULT) {}
+template<typename Topic>
+LogTopic::LogTopic(Topic) requires requires(Topic) {
+  Topic::name;
+} : LogTopic(Topic::name, Topic::defaultLevel,
+             logger::TopicList::index<Topic>()) {
+  static_assert(logger::TopicList::contains<Topic>(),
+                "Topic not found in TopicList");
+}
 
-LogTopic::LogTopic(std::string const& name, LogLevel level)
-    : _id(NEXT_TOPIC_ID.fetch_add(1, std::memory_order_seq_cst)),
-      _name(name),
-      _level(level) {
+LogTopic::LogTopic(TopicName name, LogLevel level, size_t id)
+    : _id(id), _name(name), _level(level) {
   // "all" is only a pseudo-topic.
   TRI_ASSERT(name != "all");
 
@@ -228,9 +219,20 @@ LogTopic::LogTopic(std::string const& name, LogLevel level)
     // allowed to log messages without a topic. From 3.2 onwards,
     // logging is always topic-based, and all previously topicless
     // log invocations now use the log topic "fixme".
-    _displayName = std::string("{") + name + "} ";
+    _displayName = absl::StrCat("{", name, "} ");
   }
 
   Topics::instance().emplace(name, this);
-  TRI_ASSERT(_id < MAX_LOG_TOPICS);
+  TRI_ASSERT(_id < GLOBAL_LOG_TOPIC);
 }
+
+void LogTopic::setLogLevel(LogLevel level) {
+  _level.store(level, std::memory_order_relaxed);
+}
+
+// those two log topics are created in other files, so we have to explicitly
+// instantiate them here
+template LogTopic::LogTopic(logger::topic::ArangoSearch);
+template LogTopic::LogTopic(logger::topic::LibIResearch);
+
+}  // namespace arangodb

--- a/lib/Logger/LogTopic.h
+++ b/lib/Logger/LogTopic.h
@@ -27,29 +27,36 @@
 #include <atomic>
 #include <string>
 #include <utility>
-#include <vector>
+#include <unordered_map>
 
 #include "Logger/LogLevel.h"
 
 namespace arangodb {
+
+using TopicName = std::string_view;
+
 class LogTopic {
   LogTopic& operator=(LogTopic const&) = delete;
 
  public:
-  static constexpr size_t MAX_LOG_TOPICS = 64;
+  static constexpr size_t GLOBAL_LOG_TOPIC = 64;
 
   // pseudo topic to address all log topics
-  static const std::string ALL;
+  static constexpr TopicName ALL = "all";
 
-  static std::vector<std::pair<std::string, LogLevel>> logLevelTopics();
-  static void setLogLevel(std::string const&, LogLevel);
-  static LogTopic* lookup(std::string const&);
-  static std::string lookup(size_t topicId);
+  static auto logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel>;
+  static void setLogLevel(TopicName, LogLevel);
+  static LogTopic* topicForId(size_t topicId);
+  static LogTopic* lookup(TopicName);
+  static TopicName lookup(size_t topicId);
 
   explicit LogTopic(std::string const& name);
   virtual ~LogTopic() = default;
 
-  LogTopic(std::string const& name, LogLevel level);
+  template<typename Topic>
+  LogTopic(Topic) requires requires(Topic) {
+    Topic::name;
+  };
 
   LogTopic(LogTopic const& that)
       : _id(that._id), _name(that._name), _displayName(that._displayName) {
@@ -64,17 +71,17 @@ class LogTopic {
   }
 
   size_t id() const { return _id; }
-  std::string const& name() const { return _name; }
+  TopicName name() const { return _name; }
   std::string const& displayName() const { return _displayName; }
   LogLevel level() const { return _level.load(std::memory_order_relaxed); }
 
-  virtual void setLogLevel(LogLevel level) {
-    _level.store(level, std::memory_order_relaxed);
-  }
+  virtual void setLogLevel(LogLevel level);
 
  private:
+  LogTopic(TopicName name, LogLevel level, size_t id);
+
   size_t const _id;
-  std::string const _name;
+  TopicName _name;
   std::string _displayName;
   std::atomic<LogLevel> _level;
 };

--- a/lib/Logger/Logger.cpp
+++ b/lib/Logger/Logger.cpp
@@ -45,47 +45,64 @@
 #include "Logger/Escaper.h"
 #include "Logger/LogAppender.h"
 #include "Logger/LogAppenderFile.h"
+#include "Logger/LogAppenderStdStream.h"
 #include "Logger/LogContext.h"
 #include "Logger/LogGroup.h"
+#include "Logger/LogLevel.h"
 #include "Logger/LogMacros.h"
+#include "Logger/LogMessage.h"
 #include "Logger/LogStructuredParamsAllowList.h"
 #include "Logger/LogThread.h"
+#include "Logger/LogTopic.h"
+#include "Logger/Topics.h"
 
 #ifdef _WIN32
 #include "Basics/win-utils.h"
 #endif
 
+#include <absl/strings/str_cat.h>
+
+#include <velocypack/Dumper.h>
+#include <velocypack/Sink.h>
+#include <mutex>
+
 #ifdef TRI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
 
-#include <velocypack/Dumper.h>
-#include <velocypack/Sink.h>
+#include <chrono>
+#include <cstring>
+#include <iosfwd>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <type_traits>
 
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::structuredParams;
 
 namespace {
-static std::string const DEFAULT = "DEFAULT";
-static std::string const FATAL = "FATAL";
-static std::string const ERR = "ERROR";
-static std::string const WARN = "WARNING";
-static std::string const INFO = "INFO";
-static std::string const DEBUG = "DEBUG";
-static std::string const TRACE = "TRACE";
-static std::string const UNKNOWN = "UNKNOWN";
+static constexpr std::string_view DEFAULT = "DEFAULT";
+static constexpr std::string_view FATAL = "FATAL";
+static constexpr std::string_view ERR = "ERROR";
+static constexpr std::string_view WARN = "WARNING";
+static constexpr std::string_view INFO = "INFO";
+static constexpr std::string_view DEBUG = "DEBUG";
+static constexpr std::string_view TRACE = "TRACE";
+static constexpr std::string_view UNKNOWN = "UNKNOWN";
 
-class DefaultLogGroup final : public LogGroup {
-  std::size_t id() const override { return 0; }
+struct DefaultLogGroup final : LogGroup {
+  DefaultLogGroup() : LogGroup(0) {}
 };
 DefaultLogGroup defaultLogGroupInstance;
 
 }  // namespace
 
-LogMessage::LogMessage(char const* function, char const* file, int line,
-                       LogLevel level, size_t topicId, std::string&& message,
-                       uint32_t offset, bool shrunk) noexcept
+LogMessage::LogMessage(std::string_view function, std::string_view file,
+                       int line, LogLevel level, size_t topicId,
+                       std::string&& message, uint32_t offset,
+                       bool shrunk) noexcept
     : _function(function),
       _file(file),
       _line(line),
@@ -115,10 +132,11 @@ void LogMessage::shrink(std::size_t maxLength) {
 
 std::atomic<bool> Logger::_active(false);
 std::atomic<LogLevel> Logger::_level(LogLevel::INFO);
+std::mutex Logger::_appenderModificationMutex;
+logger::Appenders Logger::_appenders;
+bool Logger::_allowStdLogging = true;
 
-// default log levels, captured once at startup. these can be used
-// to reset the log levels back to defaults.
-std::vector<std::pair<std::string, LogLevel>> Logger::_defaultLogLevelTopics{};
+std::function<void()> Logger::_onDroppedMessage;
 
 std::unordered_set<std::string> Logger::_structuredLogParams({});
 arangodb::basics::ReadWriteLock Logger::_structuredParamsLock;
@@ -169,13 +187,29 @@ std::unordered_set<std::string> Logger::structuredLogParams() {
   return _structuredLogParams;
 }
 
-std::vector<std::pair<std::string, LogLevel>> Logger::logLevelTopics() {
+auto Logger::logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel> {
   return LogTopic::logLevelTopics();
 }
 
-std::vector<std::pair<std::string, LogLevel>> const&
-Logger::defaultLogLevelTopics() {
-  return _defaultLogLevelTopics;
+auto Logger::getLogLevels() -> LogLevels {
+  return {.topics = LogTopic::logLevelTopics()};
+}
+
+auto Logger::getAppendersConfig() -> AppendersLogLevelConfig {
+  AppendersLogLevelConfig result;
+  result.global = getLogLevels();
+  for (auto& [definition, appender] :
+       _appenders.getAppenders(defaultLogGroup())) {
+    result.appenders[definition].topics = appender->getLogLevels();
+  }
+  return result;
+}
+
+void Logger::resetLevelsToDefault() {
+  std::lock_guard guard(_appenderModificationMutex);
+  _appenders.foreach (
+      [](LogAppender& appender) { appender.resetLevelsToDefault(); });
+  calculateEffectiveLogLevels();
 }
 
 void Logger::setShowIds(bool show) { _showIds = show; }
@@ -222,20 +256,138 @@ void Logger::setLogLevel(std::string const& levelName) {
     // set the log level globally (e.g. `--log.level info`). note that
     // this does not set the log level for all log topics, but only the
     // log level for the "general" log topic.
-    Logger::setLogLevel(level);
+    setLogLevel(level);
     // setting the log level for topic "general" is required here, too,
     // as "fixme" is the previous general log topic...
-    LogTopic::setLogLevel(std::string("general"), level);
-  } else if (v[0] == LogTopic::ALL) {
+    setLogLevel(std::string("general"), level);
+  } else {
+    setLogLevel(v[0], level);
+  }
+}
+
+void Logger::setLogLevel(TopicName topic, LogLevel level) {
+  if (topic == LogTopic::ALL) {
+    std::lock_guard guard(_appenderModificationMutex);
     // handle pseudo log-topic "all": this will set the log level for
     // all existing topics
-    for (auto const& it : logLevelTopics()) {
-      LogTopic::setLogLevel(it.first, level);
-    }
+    doSetAllLevels(level);
   } else {
     // handle a topic-specific request (e.g. `--log.level requests=info`).
-    LogTopic::setLogLevel(v[0], level);
+    auto* logTopic = LogTopic::lookup(topic);
+    if (logTopic != nullptr) {
+      setLogLevel(*logTopic, level);
+    }
   }
+}
+
+void Logger::setLogLevel(LogTopic& topic, LogLevel level) {
+  std::lock_guard guard(_appenderModificationMutex);
+  doSetGlobalLevel(topic, level);
+}
+
+void Logger::setLogLevel(std::vector<std::string> const& levels) {
+  for (auto const& level : levels) {
+    setLogLevel(level);
+  }
+}
+
+void Logger::setLogLevel(LogLevels const& levels) {
+  std::lock_guard guard(_appenderModificationMutex);
+  // handle "all" first, so we can do
+  // {"all":"info","requests":"debug"} or such
+  if (levels.all.has_value()) {
+    doSetAllLevels(levels.all.value());
+  }
+  for (auto& [topic, level] : levels.topics) {
+    doSetGlobalLevel(*topic, level);
+  }
+}
+
+Result Logger::setLogLevel(AppendersLogLevelConfig const& config) {
+  std::lock_guard guard(_appenderModificationMutex);
+
+  // we want this function to be all or nothing, so we first check if all
+  // appenders from the input are valid - if not we bail out without changing
+  // anything
+  auto appenders = _appenders.getAppenders(defaultLogGroup());
+  for (auto& [definition, levels] : config.appenders) {
+    if (!appenders.contains(definition)) {
+      return Result(TRI_ERROR_BAD_PARAMETER,
+                    absl::StrCat("Unknown appender ", definition));
+    }
+  }
+
+  // all good, so now actually apply the changes.
+  // we first apply the global settings (these will be applied to _all_
+  // appenders) then we change the settings for the individual appenders. That
+  // will in turn also adjust the global settings again, but without affecting
+  // the other appenders.
+  if (config.global.all.has_value()) {
+    doSetAllLevels(config.global.all.value());
+  }
+  for (auto& [topic, level] : config.global.topics) {
+    doSetGlobalLevel(*topic, level);
+  }
+
+  auto setAppenderTopicLevel = [](LogAppender& appender, LogTopic& topic,
+                                  LogLevel level) {
+    // the appender specific levels must be less or equal to the global
+    // level, so if we change the level for an appender, we might also have to
+    // adjust the global level.
+    appender.setLogLevel(topic, level);
+    auto currentLevel = topic.level();
+    if (level > currentLevel) {
+      // if the new level is higher than the current level, we can simply
+      // update the global topic to the new level
+      topic.setLogLevel(level);
+    } else if (level < currentLevel) {
+      // we have to go through all appenders and check if there are other
+      // appenders with a higher level
+      _appenders.foreach ([&level, &topic](LogAppender& appender) {
+        auto l = appender.getLogLevel(topic);
+        if (l > level) {
+          level = l;
+        }
+      });
+      topic.setLogLevel(level);
+    }
+  };
+
+  for (auto& [definition, levels] : config.appenders) {
+    auto& appender = *appenders[definition];
+    if (levels.all.has_value()) {
+      auto level = levels.all.value();
+      for (size_t i = 0; i < logger::kNumTopics; ++i) {
+        auto* topic = LogTopic::topicForId(i);
+        if (topic != nullptr) {
+          setAppenderTopicLevel(appender, *topic, level);
+        }
+      }
+    }
+    for (auto& [topic, level] : levels.topics) {
+      setAppenderTopicLevel(appender, *topic, level);
+    }
+  }
+  return {};
+}
+
+void Logger::doSetAllLevels(LogLevel level) {
+  for (size_t i = 0; i < logger::kNumTopics; ++i) {
+    auto* topic = LogTopic::topicForId(i);
+    if (topic != nullptr) {
+      topic->setLogLevel(level);
+      _appenders.foreach ([level, topic](LogAppender& appender) {
+        appender.setLogLevel(*topic, level);
+      });
+    }
+  }
+}
+
+void Logger::doSetGlobalLevel(LogTopic& topic, LogLevel level) {
+  topic.setLogLevel(level);
+  _appenders.foreach ([level, &topic](LogAppender& appender) {
+    appender.setLogLevel(topic, level);
+  });
 }
 
 void Logger::setLogStructuredParams(
@@ -251,12 +403,6 @@ void Logger::setLogStructuredParams(
     } else {
       _structuredLogParams.erase(paramName);
     }
-  }
-}
-
-void Logger::setLogLevel(std::vector<std::string> const& levels) {
-  for (auto const& level : levels) {
-    setLogLevel(level);
   }
 }
 
@@ -474,6 +620,25 @@ void Logger::setUseJson(bool value) {
   _useJson = value;
 }
 
+void Logger::reopen() { _appenders.reopen(); }
+
+void Logger::addAppender(LogGroup const& group, std::string const& definition) {
+  _appenders.addAppender(group, definition);
+}
+
+void Logger::addGlobalAppender(LogGroup const& group,
+                               std::shared_ptr<LogAppender> appender) {
+  _appenders.addGlobalAppender(group, std::move(appender));
+}
+
+bool Logger::haveAppenders(LogGroup const& group, size_t topicId) {
+  return _appenders.haveAppenders(group, topicId);
+}
+
+void Logger::log(LogGroup const& group, LogMessage const& message) {
+  _appenders.log(group, message);
+}
+
 bool Logger::translateLogLevel(std::string const& l, bool isGeneral,
                                LogLevel& level) noexcept {
   if (l == "fatal") {
@@ -497,7 +662,7 @@ bool Logger::translateLogLevel(std::string const& l, bool isGeneral,
   return true;
 }
 
-std::string const& Logger::translateLogLevel(LogLevel level) noexcept {
+std::string_view Logger::translateLogLevel(LogLevel level) noexcept {
   switch (level) {
     case LogLevel::ERR:
       return ERR;
@@ -518,17 +683,13 @@ std::string const& Logger::translateLogLevel(LogLevel level) noexcept {
   return UNKNOWN;
 }
 
-void Logger::log(char const* logid, char const* function, char const* file,
-                 int line, LogLevel level, size_t topicId,
-                 std::string_view message) try {
-  TRI_ASSERT(logid != nullptr);
-  LogContext& logContext = LogContext::current();
+void Logger::log(std::string_view logid, std::string_view function,
+                 std::string_view file, int line, LogLevel level,
+                 size_t topicId, std::string_view message) try {
+  TRI_ASSERT(!logid.empty());
 
   // we only determine our pid once, as currentProcessId() will
   // likely do a syscall.
-  // this read-check-update sequence is not thread-safe, but this
-  // should not matter, as the pid value is only changed from 0 to the
-  // actual pid and never changes afterwards
   if (_cachedPid.load(std::memory_order_relaxed) == 0) {
     _cachedPid.store(Thread::currentProcessId(), std::memory_order_relaxed);
   }
@@ -539,294 +700,19 @@ void Logger::log(char const* logid, char const* function, char const* file,
   uint32_t offset = 0;
   bool shrunk = false;
 
+  if (_showLineNumber && !file.empty() && _shortenFilenames) {
+    auto pos = file.find_last_of(TRI_DIR_SEPARATOR_CHAR);
+    if (pos != std::string_view::npos) {
+      file = file.substr(pos + 1);
+    }
+  }
+
   if (Logger::_useJson) {
-    // construct JSON output
-    arangodb::velocypack::StringSink sink(&out);
-    arangodb::velocypack::Options options;
-    options.escapeControl = _useControlEscaped;
-    options.escapeUnicode = _useUnicodeEscaped;
-    arangodb::velocypack::Dumper dumper(&sink, &options);
-
-    out.push_back('{');
-
-    // current date/time
-    {
-      out.append("\"time\":");
-      if (LogTimeFormats::isStringFormat(_timeFormat)) {
-        out.push_back('"');
-      }
-      // value of date/time is always safe to print
-      LogTimeFormats::writeTime(out, _timeFormat,
-                                std::chrono::system_clock::now());
-      if (LogTimeFormats::isStringFormat(_timeFormat)) {
-        out.push_back('"');
-      }
-    }
-
-    // prefix
-    if (!_outputPrefix.empty()) {
-      out.append(",\"prefix\":");
-      dumper.appendString(_outputPrefix.data(), _outputPrefix.size());
-    }
-
-    // pid
-    if (_showProcessIdentifier) {
-      out.append(",\"pid\":");
-      StringUtils::itoa(uint64_t(_cachedPid.load(std::memory_order_relaxed)),
-                        out);
-    }
-
-    // tid
-    if (_showThreadIdentifier) {
-      out.append(",\"tid\":");
-      StringUtils::itoa(uint64_t(Thread::currentThreadNumber()), out);
-    }
-
-    // thread name
-    if (_showThreadName) {
-      ThreadNameFetcher nameFetcher;
-      std::string_view threadName = nameFetcher.get();
-      out.append(",\"thread\":");
-      dumper.appendString(threadName.data(), threadName.size());
-    }
-
-    // role
-    if (_showRole) {
-      out.append(",\"role\":\"");
-      if (_role != '\0') {
-        // value of _role is always safe to print
-        out.push_back(_role);
-      }
-      out.push_back('"');
-    }
-
-    // log level
-    {
-      out.append(",\"level\":");
-      auto const& ll = Logger::translateLogLevel(level);
-      // value of level is always safe to print
-      dumper.appendString(ll.data(), ll.size());
-    }
-
-    // file and line
-    if (_showLineNumber && file != nullptr) {
-      char const* filename = file;
-      if (_shortenFilenames) {
-        char const* shortened = strrchr(filename, TRI_DIR_SEPARATOR_CHAR);
-        if (shortened != nullptr) {
-          filename = shortened + 1;
-        }
-      }
-      out.append(",\"file\":");
-      dumper.appendString(filename, strlen(filename));
-    }
-
-    if (_showLineNumber) {
-      out.append(",\"line\":");
-      StringUtils::itoa(uint64_t(line), out);
-    }
-
-    if (_showLineNumber && function != nullptr) {
-      out.append(",\"function\":");
-      dumper.appendString(function, strlen(function));
-    }
-
-    // the topic
-    {
-      out.append(",\"topic\":");
-      std::string topic = LogTopic::lookup(topicId);
-      // value of topic is always safe to print
-      dumper.appendString(topic.data(), topic.size());
-    }
-
-    // the logid
-    if (::arangodb::Logger::getShowIds()) {
-      out.append(",\"id\":");
-      // value of id is always safe to print
-      dumper.appendString(logid, strlen(logid));
-    }
-
-    // hostname
-    if (!_hostname.empty()) {
-      out.append(",\"hostname\":");
-      dumper.appendString(_hostname.data(), _hostname.size());
-    }
-
-    {
-      READ_LOCKER(guard, _structuredParamsLock);
-      // meta data from log context
-      LogContext::OverloadVisitor visitor([&out, &dumper](
-                                              std::string_view const& key,
-                                              auto&& value) {
-        if (!_structuredLogParams.contains({key.data(), key.size()})) {
-          return;
-        }
-        out.push_back(',');
-        dumper.appendString(key.data(), key.size());
-        out.push_back(':');
-        if constexpr (std::is_same_v<std::string_view,
-                                     std::remove_cv_t<std::remove_reference_t<
-                                         decltype(value)>>>) {
-          dumper.appendString(value.data(), value.size());
-        } else {
-          out.append(std::to_string(value));
-        }
-      });
-      logContext.visit(visitor);
-    }
-
-    // the message itself
-    {
-      out.append(",\"message\":");
-
-      // the log message can be really large, and it can lead to
-      // truncation of the log message further down the road.
-      // however, as we are supposed to produce valid JSON log
-      // entries even with the truncation in place, we need to make
-      // sure that the dynamic text part is truncated and not the
-      // entries JSON thing
-      size_t maxMessageLength = defaultLogGroup().maxLogEntryLength();
-      // cut of prologue, the quotes ('"' --- ' '") and the final '}'
-      if (maxMessageLength >= out.size() + 3) {
-        maxMessageLength -= out.size() + 3;
-      }
-      if (maxMessageLength > message.size()) {
-        maxMessageLength = message.size();
-      }
-      dumper.appendString(message.data(), maxMessageLength);
-
-      // this tells the logger to not shrink our (potentially already
-      // shrunk) message once more - if it would shrink the message again,
-      // it may produce invalid JSON
-      shrunk = true;
-    }
-
-    out.push_back('}');
-
-    TRI_ASSERT(offset == 0);
+    buildJsonLogMessage(out, logid, function, file, line, level, topicId,
+                        message, shrunk);
   } else {
-    // hostname
-    if (!_hostname.empty()) {
-      out.append(_hostname);
-      out.push_back(' ');
-    }
-
-    // human readable format
-    LogTimeFormats::writeTime(out, _timeFormat,
-                              std::chrono::system_clock::now());
-    out.push_back(' ');
-
-    // output prefix
-    if (!_outputPrefix.empty()) {
-      out.append(_outputPrefix);
-      out.push_back(' ');
-    }
-
-    // [pid-tid-threadname], all components are optional
-    bool haveProcessOutput = false;
-    if (_showProcessIdentifier) {
-      // append the process / thread identifier
-      TRI_ASSERT(_cachedPid.load(std::memory_order_relaxed) != 0);
-      out.push_back('[');
-      StringUtils::itoa(uint64_t(_cachedPid.load(std::memory_order_relaxed)),
-                        out);
-      haveProcessOutput = true;
-    }
-
-    if (_showThreadIdentifier) {
-      out.push_back(haveProcessOutput ? '-' : '[');
-      StringUtils::itoa(uint64_t(Thread::currentThreadNumber()), out);
-      haveProcessOutput = true;
-    }
-
-    // log thread name
-    if (_showThreadName) {
-      ThreadNameFetcher nameFetcher;
-      std::string_view threadName = nameFetcher.get();
-
-      out.push_back(haveProcessOutput ? '-' : '[');
-      out.append(threadName.data(), threadName.size());
-      haveProcessOutput = true;
-    }
-
-    if (haveProcessOutput) {
-      out.append("] ", 2);
-    }
-
-    if (_showRole && _role != '\0') {
-      out.push_back(_role);
-      out.push_back(' ');
-    }
-
-    // log level
-    out.append(Logger::translateLogLevel(level));
-    out.push_back(' ');
-
-    // check if we must display the line number
-    if (_showLineNumber && file != nullptr && function != nullptr) {
-      char const* filename = file;
-
-      if (_shortenFilenames) {
-        // shorten file names from `/home/.../file.cpp` to just `file.cpp`
-        char const* shortened = strrchr(filename, TRI_DIR_SEPARATOR_CHAR);
-        if (shortened != nullptr) {
-          filename = shortened + 1;
-        }
-      }
-      out.push_back('[');
-      out.append(function);
-      out.push_back('@');
-      out.append(filename);
-      out.push_back(':');
-      StringUtils::itoa(uint64_t(line), out);
-      out.append("] ", 2);
-    }
-
-    // the offset is used by the in-memory logger, and it cuts off everything
-    // from the start of the concatenated log string until the offset. only
-    // what's after the offset gets displayed in the web interface
-    TRI_ASSERT(out.size() < static_cast<size_t>(UINT32_MAX));
-    offset = static_cast<uint32_t>(out.size());
-
-    if (::arangodb::Logger::getShowIds()) {
-      out.push_back('[');
-      out.append(logid);
-      out.append("] ", 2);
-    }
-
-    {
-      out.push_back('{');
-      out.append(LogTopic::lookup(topicId));
-      out.append("} ", 2);
-    }
-
-    {
-      READ_LOCKER(guard, _structuredParamsLock);
-      //  meta data from log
-      LogContext::OverloadVisitor visitor([&out, writerFn = _writerFn](
-                                              std::string_view const& key,
-                                              auto&& value) {
-        if (!_structuredLogParams.contains({key.data(), key.size()})) {
-          return;
-        }
-        out.push_back('[');
-        out.append(key).append(": ", 2);
-
-        if constexpr (std::is_same_v<std::string_view,
-                                     std::remove_cv_t<std::remove_reference_t<
-                                         decltype(value)>>>) {
-          writerFn(value, out);
-        } else {
-          std::string number = std::to_string(value);
-          writerFn(number, out);
-        }
-
-        out.append("] ", 2);
-      });
-      logContext.visit(visitor);
-    }
-
-    _writerFn(message, out);
+    buildTextLogMessage(out, logid, function, file, line, level, topicId,
+                        message, offset, shrunk);
   }
 
   TRI_ASSERT(offset == 0 || !_useJson);
@@ -844,7 +730,264 @@ void Logger::log(char const* logid, char const* function, char const* file,
                                                  level, topicId, msg._message);
          });
 } catch (...) {
-  // logging itself must never cause an exeption to escape
+  // logging itself must never cause an exception to escape
+}
+
+void Logger::buildJsonLogMessage(std::string& out, std::string_view logid,
+                                 std::string_view function,
+                                 std::string_view file, int line,
+                                 LogLevel level, size_t topicId,
+                                 std::string_view message, bool& shrunk) {
+  LogContext& logContext = LogContext::current();
+  // construct JSON output
+  arangodb::velocypack::StringSink sink(&out);
+  arangodb::velocypack::Options options;
+  options.escapeControl = _useControlEscaped;
+  options.escapeUnicode = _useUnicodeEscaped;
+  arangodb::velocypack::Dumper dumper(&sink, &options);
+
+  out.push_back('{');
+
+  // current date/time
+  {
+    out.append("\"time\":");
+    if (LogTimeFormats::isStringFormat(_timeFormat)) {
+      out.push_back('"');
+    }
+    // value of date/time is always safe to print
+    LogTimeFormats::writeTime(out, _timeFormat,
+                              std::chrono::system_clock::now());
+    if (LogTimeFormats::isStringFormat(_timeFormat)) {
+      out.push_back('"');
+    }
+  }
+
+  // prefix
+  if (!_outputPrefix.empty()) {
+    out.append(",\"prefix\":");
+    dumper.appendString(_outputPrefix);
+  }
+
+  // pid
+  if (_showProcessIdentifier) {
+    absl::StrAppend(&out, ",\"pid\":",
+                    uint64_t(_cachedPid.load(std::memory_order_relaxed)));
+  }
+
+  // tid
+  if (_showThreadIdentifier) {
+    absl::StrAppend(&out, ",\"tid\":", Thread::currentThreadNumber());
+  }
+
+  // thread name
+  if (_showThreadName) {
+    ThreadNameFetcher nameFetcher;
+    std::string_view threadName = nameFetcher.get();
+    out.append(",\"thread\":");
+    dumper.appendString(threadName);
+  }
+
+  // role
+  if (_showRole) {
+    out.append(",\"role\":\"");
+    if (_role != '\0') {
+      // value of _role is always safe to print
+      out.push_back(_role);
+    }
+    out.push_back('"');
+  }
+
+  // log level
+  out.append(",\"level\":");
+  // value of level is always safe to print
+  dumper.appendString(Logger::translateLogLevel(level));
+
+  // file and line
+  if (_showLineNumber && !file.empty()) {
+    out.append(",\"file\":");
+    dumper.appendString(file);
+  }
+
+  if (_showLineNumber) {
+    absl::StrAppend(&out, ",\"line\":", line);
+  }
+
+  if (_showLineNumber && !function.empty()) {
+    out.append(",\"function\":");
+    dumper.appendString(function);
+  }
+
+  // the topic
+  out.append(",\"topic\":");
+  // value of topic is always safe to print
+  dumper.appendString(LogTopic::lookup(topicId));
+
+  // the logid
+  if (::arangodb::Logger::getShowIds()) {
+    out.append(",\"id\":");
+    // value of id is always safe to print
+    dumper.appendString(logid);
+  }
+
+  // hostname
+  if (!_hostname.empty()) {
+    out.append(",\"hostname\":");
+    dumper.appendString(_hostname);
+  }
+
+  {
+    READ_LOCKER(guard, _structuredParamsLock);
+    // meta data from log context
+    LogContext::OverloadVisitor visitor(
+        [&out, &dumper](std::string_view const& key, auto&& value) {
+          if (!_structuredLogParams.contains({key.data(), key.size()})) {
+            return;
+          }
+          out.push_back(',');
+          dumper.appendString(key);
+          out.push_back(':');
+          if constexpr (std::is_same_v<std::string_view,
+                                       std::remove_cv_t<std::remove_reference_t<
+                                           decltype(value)>>>) {
+            dumper.appendString(value);
+          } else {
+            out.append(std::to_string(value));
+          }
+        });
+    logContext.visit(visitor);
+  }
+
+  // the message itself
+  {
+    out.append(",\"message\":");
+
+    // the log message can be really large, and it can lead to
+    // truncation of the log message further down the road.
+    // however, as we are supposed to produce valid JSON log
+    // entries even with the truncation in place, we need to make
+    // sure that the dynamic text part is truncated and not the
+    // entries JSON thing
+    size_t maxMessageLength = defaultLogGroup().maxLogEntryLength();
+    // cut of prologue, the quotes ('"' --- ' '") and the final '}'
+    if (maxMessageLength >= out.size() + 3) {
+      maxMessageLength -= out.size() + 3;
+    }
+    if (maxMessageLength > message.size()) {
+      maxMessageLength = message.size();
+    }
+    dumper.appendString(message.data(), maxMessageLength);
+
+    // this tells the logger to not shrink our (potentially already
+    // shrunk) message once more - if it would shrink the message again,
+    // it may produce invalid JSON
+    shrunk = true;
+  }
+
+  out.push_back('}');
+}
+
+void Logger::buildTextLogMessage(std::string& out, std::string_view logid,
+                                 std::string_view function,
+                                 std::string_view file, int line,
+                                 LogLevel level, size_t topicId,
+                                 std::string_view message, uint32_t& offset,
+                                 bool& shrunk) {
+  LogContext& logContext = LogContext::current();
+  // hostname
+  if (!_hostname.empty()) {
+    absl::StrAppend(&out, _hostname, " ");
+  }
+
+  // human readable format
+  LogTimeFormats::writeTime(out, _timeFormat, std::chrono::system_clock::now());
+  out.push_back(' ');
+
+  // output prefix
+  if (!_outputPrefix.empty()) {
+    absl::StrAppend(&out, _outputPrefix, " ");
+  }
+
+  // [pid-tid-threadname], all components are optional
+  bool haveProcessOutput = false;
+  if (_showProcessIdentifier) {
+    // append the process / thread identifier
+    TRI_ASSERT(_cachedPid.load(std::memory_order_relaxed) != 0);
+    absl::StrAppend(&out, "[",
+                    uint64_t(_cachedPid.load(std::memory_order_relaxed)));
+    haveProcessOutput = true;
+  }
+
+  if (_showThreadIdentifier) {
+    out.push_back(haveProcessOutput ? '-' : '[');
+    absl::StrAppend(&out, Thread::currentThreadNumber());
+    haveProcessOutput = true;
+  }
+
+  // log thread name
+  if (_showThreadName) {
+    ThreadNameFetcher nameFetcher;
+    std::string_view threadName = nameFetcher.get();
+
+    out.push_back(haveProcessOutput ? '-' : '[');
+    out.append(threadName);
+    haveProcessOutput = true;
+  }
+
+  if (haveProcessOutput) {
+    out.append("] ", 2);
+  }
+
+  if (_showRole && _role != '\0') {
+    out.push_back(_role);
+    out.push_back(' ');
+  }
+
+  // log level
+  absl::StrAppend(&out, Logger::translateLogLevel(level), " ");
+
+  // check if we must display the line number
+  if (_showLineNumber && !file.empty() && !function.empty()) {
+    absl::StrAppend(&out, "[", function, "@", file, ":", line, "] ");
+  }
+
+  // the offset is used by the in-memory logger, and it cuts off everything
+  // from the start of the concatenated log string until the offset. only
+  // what's after the offset gets displayed in the web interface
+  TRI_ASSERT(out.size() < static_cast<size_t>(UINT32_MAX));
+  offset = static_cast<uint32_t>(out.size());
+
+  if (::arangodb::Logger::getShowIds()) {
+    absl::StrAppend(&out, "[", logid, "] ");
+  }
+
+  absl::StrAppend(&out, "{", LogTopic::lookup(topicId), "} ");
+
+  {
+    READ_LOCKER(guard, _structuredParamsLock);
+    //  meta data from log
+    LogContext::OverloadVisitor visitor(
+        [&out, writerFn = _writerFn](std::string_view const& key,
+                                     auto&& value) {
+          if (!_structuredLogParams.contains({key.data(), key.size()})) {
+            return;
+          }
+          absl::StrAppend(&out, "[", key, ": ");
+
+          if constexpr (std::is_same_v<std::string_view,
+                                       std::remove_cv_t<std::remove_reference_t<
+                                           decltype(value)>>>) {
+            writerFn(value, out);
+          } else {
+            std::string number = std::to_string(value);
+            writerFn(number, out);
+          }
+
+          out.append("] ", 2);
+        });
+    logContext.visit(visitor);
+  }
+
+  _writerFn(message, out);
 }
 
 void Logger::append(LogGroup& group, std::unique_ptr<LogMessage> msg,
@@ -858,10 +1001,9 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage> msg,
   }
 
   // first log to all "global" appenders, which are the in-memory ring buffer
-  // logger plus some Windows-specifc appenders for the debug output window
-  // and the Windows event log. note that these loggers do not require any
-  // configuration so we can always and safely invoke them.
-  LogAppender::logGlobal(group, *msg);
+  // logger and the metrics counter. note that these loggers do not require
+  // any configuration so we can always and safely invoke them.
+  _appenders.logGlobal(group, *msg);
 
   if (!_active.load(std::memory_order_acquire)) {
     // logging is still turned off. now use hard-coded to-stderr logging
@@ -886,7 +1028,7 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage> msg,
         return;
       }
 
-      LogAppender::log(group, *msg);
+      _appenders.log(group, *msg);
     }
   }
 }
@@ -895,19 +1037,18 @@ void Logger::append(LogGroup& group, std::unique_ptr<LogMessage> msg,
 /// @brief initializes the logging component
 ////////////////////////////////////////////////////////////////////////////////
 
-void Logger::initialize(application_features::ApplicationServer& server,
-                        bool threaded, uint32_t maxQueuedLogMessages) {
+void Logger::initialize(bool threaded, uint32_t maxQueuedLogMessages) {
   if (_active.exchange(true, std::memory_order_acquire)) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                    "Logger already initialized");
   }
 
-  _defaultLogLevelTopics = logLevelTopics();
+  calculateEffectiveLogLevels();
 
   // logging is now active
   if (threaded) {
-    auto loggingThread = std::make_unique<LogThread>(
-        server, std::string(logThreadName), maxQueuedLogMessages);
+    auto loggingThread = std::make_unique<LogThread>(std::string(logThreadName),
+                                                     maxQueuedLogMessages);
     if (!loggingThread->start()) {
       LOG_TOPIC("28bd9", FATAL, arangodb::Logger::FIXME)
           << "could not start logging thread";
@@ -916,6 +1057,27 @@ void Logger::initialize(application_features::ApplicationServer& server,
 
     // (4) - this release-store synchronizes with the acquire-load (2)
     _loggingThread.store(loggingThread.release(), std::memory_order_release);
+  }
+}
+
+void Logger::calculateEffectiveLogLevels() {
+  // for each topic we have to go through all appenders and find the highest
+  // configured log level
+  for (size_t i = 0; i < logger::kNumTopics; ++i) {
+    auto* topic = LogTopic::topicForId(i);
+    if (topic != nullptr) {
+      auto maxLevel = LogLevel::DEFAULT;
+      auto curLevel = topic->level();
+      _appenders.foreach ([&maxLevel, &topic](LogAppender& appender) {
+        auto l = appender.getLogLevel(*topic);
+        if (l > maxLevel) {
+          maxLevel = l;
+        }
+      });
+      if (curLevel != maxLevel) {
+        topic->setLogLevel(maxLevel);
+      }
+    }
   }
 }
 
@@ -973,7 +1135,7 @@ void Logger::shutdown() {
   }
 
   // cleanup appenders
-  LogAppender::shutdown();
+  _appenders.shutdown();
 
   _cachedPid.store(0, std::memory_order_relaxed);
 }
@@ -991,5 +1153,15 @@ void Logger::flush() noexcept {
   ThreadRef loggingThread;
   if (loggingThread) {
     loggingThread->flush();
+  }
+}
+
+void Logger::setOnDroppedMessage(std::function<void()> cb) {
+  _onDroppedMessage = std::move(cb);
+}
+
+void Logger::onDroppedMessage() noexcept {
+  if (_onDroppedMessage) {
+    _onDroppedMessage();
   }
 }

--- a/lib/Logger/Logger.h
+++ b/lib/Logger/Logger.h
@@ -56,6 +56,7 @@
 
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -65,12 +66,13 @@
 #include <utility>
 #include <vector>
 
-#include "Basics/Common.h"
+#include "Basics/ReadWriteLock.h"
 #include "Basics/threads.h"
+#include "Inspection/Status.h"
+#include "Logger/Appenders.h"
 #include "Logger/LogLevel.h"
 #include "Logger/LogTimeFormat.h"
 #include "Logger/LogTopic.h"
-#include "Basics/ReadWriteLock.h"
 
 namespace arangodb {
 namespace application_features {
@@ -79,47 +81,55 @@ class ApplicationServer;
 class LogGroup;
 class LogThread;
 
-////////////////////////////////////////////////////////////////////////////////
-/// @brief message container
-////////////////////////////////////////////////////////////////////////////////
+struct LogLevels {
+  std::optional<LogLevel> all;
+  std::unordered_map<LogTopic*, LogLevel> topics;
 
-struct LogMessage {
-  LogMessage(LogMessage const&) = delete;
-  LogMessage& operator=(LogMessage const&) = delete;
+  template<class Inspector>
+  inline friend auto inspect(Inspector& f, LogLevels& levels)
+      -> inspection::Status {
+    if constexpr (Inspector::isLoading) {
+      std::unordered_map<std::string_view, LogLevel> map;
+      auto res = f.apply(map);
+      if (!res.ok()) {
+        return res;
+      }
 
-  LogMessage(char const* function, char const* file, int line, LogLevel level,
-             size_t topicId, std::string&& message, uint32_t offset,
-             bool shrunk) noexcept;
+      for (auto const& [topicName, value] : map) {
+        if (topicName == "all") {
+          levels.all = value;
+        } else {
+          auto topic = LogTopic::lookup(topicName);
+          if (topic == nullptr) {
+            return inspection::Status("Unknown log topic " +
+                                      std::string(topicName));
+          }
+          levels.topics[topic] = value;
+        }
+      }
+      return {};
+    } else {
+      TRI_ASSERT(!levels.all.has_value());
+      std::unordered_map<std::string_view, LogLevel> map;
+      for (auto& v : levels.topics) {
+        map.emplace(v.first->name(), v.second);
+      }
+      return f.apply(map);
+    }
+  }
+};
 
-  /// @brief whether or no the message was already shrunk
-  bool shrunk() const noexcept { return _shrunk; }
+struct AppendersLogLevelConfig {
+  LogLevels global;
+  std::unordered_map<std::string, LogLevels> appenders;
 
-  /// @brief shrink log message to at most maxLength bytes (plus "..." appended)
-  void shrink(std::size_t maxLength);
-
-  /// @brief all details about the log message. we need to
-  /// keep all this data around and not just the big log
-  /// message string, because some LogAppenders will refer
-  /// to individual components such as file, line etc.
-
-  /// @brief function name of log message source code location
-  char const* _function;
-  /// @brief file of log message source code location
-  char const* _file;
-  /// @brief line of log message source code location
-  int const _line;
-  /// @brief log level
-  LogLevel const _level;
-
-  /// @brief id of log topic
-  size_t const _topicId;
-  /// @biref the actual log message
-  std::string _message;
-  /// @brief byte offset where actual message starts (i.e. excluding prologue)
-  uint32_t _offset;
-  /// @brief whether or not the log message was already shrunk (used to
-  /// prevent duplicate shrinking of message)
-  bool _shrunk;
+  template<class Inspector>
+  inline friend auto inspect(Inspector& f, AppendersLogLevelConfig& value) {
+    return f.object(value).fields(
+        f.field("global", value.global).fallback(decltype(value.global){}),
+        f.field("appenders", value.appenders)
+            .fallback(decltype(value.appenders){}));
+  }
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -188,6 +198,7 @@ class Logger {
   static LogTopic REPLICATION;
   static LogTopic REPLICATION2;
   static LogTopic REPLICATED_STATE;
+  static LogTopic REPLICATED_WAL;
   static LogTopic REQUESTS;
   static LogTopic RESTORE;
   static LogTopic ROCKSDB;
@@ -203,6 +214,7 @@ class Logger {
   static LogTopic VALIDATION;
   static LogTopic V8;
   static LogTopic VIEWS;
+  static LogTopic DEPRECATION;
 
  public:
   struct FIXED {
@@ -218,18 +230,19 @@ class Logger {
   };
 
   struct FILE {
-    explicit FILE(char const* file) noexcept : _file(file) {}
-    char const* _file;
+    explicit FILE(std::string_view file) noexcept : _file(file) {}
+    std::string_view _file;
   };
 
   struct FUNCTION {
-    explicit FUNCTION(char const* function) noexcept : _function(function) {}
-    char const* _function;
+    explicit FUNCTION(std::string_view function) noexcept
+        : _function(function) {}
+    std::string_view _function;
   };
 
   struct LOGID {
-    explicit LOGID(char const* logid) noexcept : _logid(logid) {}
-    char const* _logid;
+    explicit LOGID(std::string_view logid) noexcept : _logid(logid) {}
+    std::string_view _logid;
   };
 
  public:
@@ -238,12 +251,19 @@ class Logger {
   static LogGroup& defaultLogGroup();
   static LogLevel logLevel();
   static std::unordered_set<std::string> structuredLogParams();
-  static std::vector<std::pair<std::string, LogLevel>> logLevelTopics();
-  static std::vector<std::pair<std::string, LogLevel>> const&
-  defaultLogLevelTopics();
+  static auto logLevelTopics() -> std::unordered_map<LogTopic*, LogLevel>;
+  static auto getLogLevels() -> LogLevels;
+  static auto getAppendersConfig() -> AppendersLogLevelConfig;
+
+  static void resetLevelsToDefault();
   static void setLogLevel(LogLevel);
   static void setLogLevel(std::string const&);
+  static void setLogLevel(TopicName topic, LogLevel level);
+  static void setLogLevel(LogTopic&, LogLevel level);
   static void setLogLevel(std::vector<std::string> const&);
+  static void setLogLevel(LogLevels const&);
+  [[nodiscard]] static Result setLogLevel(AppendersLogLevelConfig const&);
+
   static std::unordered_map<std::string, bool> parseStringParams(
       std::vector<std::string> const&);
   static void setLogStructuredParamsOnServerStart(
@@ -278,6 +298,16 @@ class Logger {
   static void setUseJson(bool);
   static LogTimeFormats::TimeFormat timeFormat() { return _timeFormat; }
 
+  static void reopen();
+  static void addAppender(LogGroup const& group, std::string const& definition);
+  static void addGlobalAppender(LogGroup const& group,
+                                std::shared_ptr<LogAppender> appender);
+  static bool haveAppenders(LogGroup const& group, size_t topicId);
+  static void log(LogGroup const& group, LogMessage const& message);
+
+  static bool allowStdLogging() { return _allowStdLogging; }
+  static void allowStdLogging(bool value) { _allowStdLogging = value; }
+
   // can be called after fork()
   static void clearCachedPid() {
     _cachedPid.store(0, std::memory_order_relaxed);
@@ -286,11 +316,11 @@ class Logger {
   static bool translateLogLevel(std::string const& l, bool isGeneral,
                                 LogLevel& level) noexcept;
 
-  static std::string const& translateLogLevel(LogLevel) noexcept;
+  static std::string_view translateLogLevel(LogLevel) noexcept;
 
-  static void log(char const* logid, char const* function, char const* file,
-                  int line, LogLevel level, size_t topicId,
-                  std::string_view message);
+  static void log(std::string_view logid, std::string_view function,
+                  std::string_view file, int line, LogLevel level,
+                  size_t topicId, std::string_view message);
 
   static void append(
       LogGroup&, std::unique_ptr<LogMessage> msg, bool forceDirect,
@@ -306,19 +336,38 @@ class Logger {
                                    : topic.level());
   }
 
-  static void initialize(application_features::ApplicationServer& server,
-                         bool threaded, uint32_t maxQueuedLogMessages);
+  static void initialize(bool threaded, uint32_t maxQueuedLogMessages);
   static void shutdown();
   static void flush() noexcept;
 
+  static void setOnDroppedMessage(std::function<void()> cb);
+  static void onDroppedMessage() noexcept;
+
  private:
+  static void doSetAllLevels(LogLevel);
+  static void doSetGlobalLevel(LogTopic&, LogLevel);
+
+  static void calculateEffectiveLogLevels();
+  static void buildJsonLogMessage(std::string& out, std::string_view logid,
+                                  std::string_view function,
+                                  std::string_view file, int line,
+                                  LogLevel level, size_t topicId,
+                                  std::string_view message, bool& shrunk);
+
+  static void buildTextLogMessage(std::string& out, std::string_view logid,
+                                  std::string_view function,
+                                  std::string_view file, int line,
+                                  LogLevel level, size_t topicId,
+                                  std::string_view message, uint32_t& offset,
+                                  bool& shrunk);
+
   // these variables might be changed asynchronously
   static std::atomic<bool> _active;
   static std::atomic<LogLevel> _level;
 
-  // default log levels, captured once at startup. these can be used
-  // to reset the log levels back to defaults.
-  static std::vector<std::pair<std::string, LogLevel>> _defaultLogLevelTopics;
+  static std::mutex _appenderModificationMutex;
+  static logger::Appenders _appenders;
+  static bool _allowStdLogging;
 
   // these variables must be set before calling initialized
   static std::unordered_set<std::string>
@@ -349,9 +398,9 @@ class Logger {
     ThreadRef();
     ~ThreadRef();
 
-    ThreadRef(const ThreadRef&) = delete;
+    ThreadRef(ThreadRef const&) = delete;
     ThreadRef(ThreadRef&&) = delete;
-    ThreadRef& operator=(const ThreadRef&) = delete;
+    ThreadRef& operator=(ThreadRef const&) = delete;
     ThreadRef& operator=(ThreadRef&&) = delete;
 
     LogThread* operator->() const noexcept { return _thread; }
@@ -363,8 +412,10 @@ class Logger {
 
   // logger thread. only populated when threaded logging is selected.
   // the pointer must only be used with atomic accessors after the ref counter
-  // has been increased. Best to usethe ThreadRef class for this!
+  // has been increased. Best to use the ThreadRef class for this!
   static std::atomic<std::size_t> _loggingThreadRefs;
   static std::atomic<LogThread*> _loggingThread;
+
+  static std::function<void()> _onDroppedMessage;
 };
 }  // namespace arangodb

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -191,7 +191,7 @@ You can adjust the parameter settings at runtime using the
 per-topic log messages to different outputs. The output definition can be one
 of the following:
 
-- `-` for stdin
+- `-` for stdout
 - `+` for stderr
 - `syslog://<syslog-facility>`
 - `syslog://<syslog-facility>/<application-name>`
@@ -234,12 +234,18 @@ The old `--log.file` option is still available for convenience. It is a
 shortcut for the more general option `--log.output file://filename`.
 
 The old `--log.requests-file` option is still available. It is a shortcut for
-the more general option `--log.output requests=file://...`.)");
+the more general option `--log.output requests=file://...`.
+
+To change the log levels for the specified output you can add a comma separated
+list of topics with their respective level after the output definition, separated
+by a semicolon:
+`--log.output file:///path/to/file;queries=trace,requests=info`
+`--log.output -;all=error`)");
 
   std::vector<std::string> topicsVector;
   auto const& levels = Logger::logLevelTopics();
   for (auto const& level : levels) {
-    topicsVector.emplace_back(level.first);
+    topicsVector.emplace_back(level.first->name());
   }
   std::string topicsJoined = StringUtils::join(topicsVector, ", ");
 

--- a/lib/V8/v8-utils.cpp
+++ b/lib/V8/v8-utils.cpp
@@ -2271,8 +2271,8 @@ static void JS_LogLevel(v8::FunctionCallbackInfo<v8::Value> const& args) {
       uint32_t pos = 0;
 
       for (auto const& level : levels) {
-        std::string output =
-            level.first + "=" + Logger::translateLogLevel(level.second);
+        std::string output = absl::StrCat(
+            level.first->name(), "=", Logger::translateLogLevel(level.second));
         v8::Handle<v8::String> val = TRI_V8_STD_STRING(isolate, output);
 
         object->Set(context, pos++, val).FromMaybe(false);

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -1457,6 +1457,21 @@ TEST_F(VPackLoadInspectorTest, load_string_enum) {
   EXPECT_EQ(MyStringEnum::kValue2, enums[1]);
 }
 
+TEST_F(VPackLoadInspectorTest, load_transformed_string_enum) {
+  builder.openArray();
+  builder.add(VPackValue("Value1"));
+  builder.add(VPackValue("value2"));
+  builder.close();
+  arangodb::inspection::VPackLoadInspector<> inspector{builder};
+
+  std::vector<MyTransformedStringEnum> enums;
+  auto result = inspector.apply(enums);
+  ASSERT_TRUE(result.ok());
+  ASSERT_EQ(2u, enums.size());
+  EXPECT_EQ(MyTransformedStringEnum::kValue1, enums[0]);
+  EXPECT_EQ(MyTransformedStringEnum::kValue2, enums[1]);
+}
+
 TEST_F(VPackLoadInspectorTest, load_int_enum) {
   builder.openArray();
   builder.add(VPackValue(1));

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -21,10 +21,12 @@
 /// @author Manuel Pöter
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <cctype>
 #include <list>
 #include <map>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <variant>
 #include <vector>
 #include <set>
@@ -561,6 +563,22 @@ template<class Inspector>
 auto inspect(Inspector& f, MyStringEnum& x) {
   return f.enumeration(x).values(MyStringEnum::kValue1, "value1",  //
                                  MyStringEnum::kValue2, "value2");
+}
+
+enum class MyTransformedStringEnum {
+  kValue1,
+  kValue2,
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, MyTransformedStringEnum& x) {
+  return f.enumeration(x).transformedValues(
+      [](std::string& s) {
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return std::toupper(c); });
+      },
+      MyTransformedStringEnum::kValue1, "VALUE1",  //
+      MyTransformedStringEnum::kValue2, "VALUE2");
 }
 }  // namespace
 

--- a/tests/js/client/server_parameters/log-pid-replacement.js
+++ b/tests/js/client/server_parameters/log-pid-replacement.js
@@ -48,6 +48,7 @@ return require('internal').options()["log.output"];
 `);
 
       assertTrue(Array.isArray(res));
+      res = res.filter((x) => x.startsWith('file://'));
       assertTrue(res.length > 0);
 
       let logfile = res[0].replace(/^file:\/\//, '');

--- a/tests/js/client/shell/multi/shell-admin-log.js
+++ b/tests/js/client/shell/multi/shell-admin-log.js
@@ -45,10 +45,11 @@ function adminLogSuite() {
 
   return {
     setUpAll: function () {
-      oldLogLevels = arango.GET("/_admin/log/level");
+      oldLogLevels = arango.GET("/_admin/log/level?withAppenders=true");
+      
       // set all log levels to "fatal" except for topic general
       let adjusted = {};
-      Object.keys(oldLogLevels).forEach((k) => {
+      Object.keys(oldLogLevels.global).forEach((k) => {
         adjusted[k] = "fatal";
       });
       adjusted.general = "info";
@@ -57,13 +58,70 @@ function adminLogSuite() {
 
     tearDownAll: function () {
       // restore previous log level for "general" topic;
-      arango.PUT("/_admin/log/level", oldLogLevels);
+      arango.PUT("/_admin/log/level?withAppenders=true", oldLogLevels);
     },
 
     setUp: function () {
       arango.DELETE("/_admin/log");
     },
+
+    testPutInvalidLevelReturnsError: function () {
+      let old = arango.GET("/_admin/log/level");
+      let res = arango.PUT("/_admin/log/level", {all: "error", general: "invalidLevel"});
+      assertEqual(res.error, true);
+      assertEqual(res.code, 400);
+      assertEqual(res.errorMessage, "Failed to update log levels: Unknown enum value INVALIDLEVEL at path ['general']");
+
+      assertEqual(old, arango.GET("/_admin/log/level"), "log levels should not have changed");
+    },
     
+    testPutInvalidTopicReturnsError: function () {
+      let old = arango.GET("/_admin/log/level");
+      let res = arango.PUT("/_admin/log/level", {all: "error", invalidTopic: "error"});
+      assertEqual(res.error, true);
+      assertEqual(res.code, 400);
+      assertEqual(res.errorMessage, "Failed to update log levels: Unknown log topic invalidTopic");
+
+      assertEqual(old, arango.GET("/_admin/log/level"), "log levels should not have changed");
+    },
+    
+    testPutInvalidAppenderReturnsError: function () {
+      let old = arango.GET("/_admin/log/level?withAppenders=true");
+      let res = arango.PUT("/_admin/log/level?withAppenders=true", { global: { all: "error" }, appenders: { invalidAppender: { all: "debug" } } });
+      assertEqual(res.error, true);
+      assertEqual(res.code, 400);
+      assertEqual(res.errorMessage, "Failed to update log levels: Unknown appender invalidAppender");
+
+      assertEqual(old, arango.GET("/_admin/log/level?withAppenders=true"), "log levels should not have changed");
+    },
+    
+    testIncreaseLogLevelForAppenderAdjustsGlobalLevel: function () {
+      let old = arango.GET("/_admin/log/level?withAppenders=true");
+      let res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "trace" } } });
+      assertEqual(res.appenders["-"].queries, "TRACE");
+      assertEqual(res.global.queries, "TRACE");
+
+      // restore old levels
+      arango.PUT("/_admin/log/level?withAppenders=true", old);
+    },
+
+
+    testDecreaseLogLevelForAppenderAdjustsGlobalLevel: function () {
+      let old = arango.GET("/_admin/log/level?withAppenders=true");
+
+      // we first set queries globally to debug (i.e., all appenders), but for the stdout appender we set it to trace.
+      // This implicitly also sets the global level to trace.
+      let res = arango.PUT("/_admin/log/level?withAppenders=true", { global: { queries: "debug" }, appenders: { "-": { queries: "trace" } } });
+      assertEqual(res.appenders["-"].queries, "TRACE");
+      assertEqual(res.global.queries, "TRACE");
+      res = arango.PUT("/_admin/log/level?withAppenders=true", { appenders: { "-": { queries: "error" } } });
+      assertEqual(res.appenders["-"].queries, "ERROR");
+      assertEqual(res.global.queries, "DEBUG");
+
+      // restore old levels
+      arango.PUT("/_admin/log/level?withAppenders=true", old);
+    },
+
     testPutAdminSetAllLevels: function () {
       let previous = arango.GET("/_admin/log/level");
       try {
@@ -423,12 +481,12 @@ function adminLogSuite() {
       assertEqual(newValue.requests, "DEBUG");
       // restore old values
       const restored = arango.DELETE("/_admin/log/level");
-      assertEqual(oldLogLevels.trx, restored.trx);
-      assertEqual(oldLogLevels.requests, restored.requests);
+      assertEqual(oldLogLevels.global.trx, restored.trx);
+      assertEqual(oldLogLevels.global.requests, restored.requests);
       // now read the restored value
       const newOld = arango.GET("/_admin/log/level");
-      assertEqual(oldLogLevels.trx, newOld.trx);
-      assertEqual(oldLogLevels.requests, newOld.requests);
+      assertEqual(oldLogLevels.global.trx, newOld.trx);
+      assertEqual(oldLogLevels.global.requests, newOld.requests);
     },
     
     testResetLogLevelsOtherServer: function () {


### PR DESCRIPTION
…235)

* Add infrastructure to track log levels per appender

* Refactoring

* Parse appender specific log levels from command line parameter

* Support pseudo log topic "all" when configuring appender

* Set the stdout appender to error only in testing.js

* Fix arangosh crash

* Fix tests

* Refactoring

* Refactor and store default log levels per appender

* Add support for transformation functions for enum inspection.

* Refactor processing of /_admin/log/level requests and validate input

* Refactoring

* Extend /_admin/log/level endpoint to optionally work appender specific

* Extend documentation for command line parameter and update CHANGELOG

* Fix typo

* Fix tests

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
