### PR TITLE
Call setLocale earlier in LanguageFeature [BTS-1792]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Call `setLocale` earlier during startup to prevent crashes.
+
 * BTS-1975: Fix the output of dumped data in VPack format.
 
 * Add file descriptors to tele metrics

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 devel
 -----
 
-* Call `setLocale` earlier during startup to prevent crashes.
+* BTS_1792: Call `setLocale` earlier during startup to prevent crashes.
 
 * BTS-1975: Fix the output of dumped data in VPack format.
 

--- a/lib/ApplicationFeatures/LanguageFeature.cpp
+++ b/lib/ApplicationFeatures/LanguageFeature.cpp
@@ -179,9 +179,8 @@ void LanguageFeature::prepare() {
   ::setCollator(
       _langType == LanguageType::ICU ? _icuLanguage : _defaultLanguage,
       _langType);
+  ::setLocale(_locale);
 }
-
-void LanguageFeature::start() { ::setLocale(_locale); }
 
 icu_64_64::Locale& LanguageFeature::getLocale() { return _locale; }
 

--- a/lib/ApplicationFeatures/LanguageFeature.h
+++ b/lib/ApplicationFeatures/LanguageFeature.h
@@ -58,7 +58,6 @@ class LanguageFeature final : public application_features::ApplicationFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override final;
-  void start() override final;
 
   icu_64_64::Locale& getLocale();
   std::tuple<std::string_view, basics::LanguageType> getLanguage() const;


### PR DESCRIPTION
This tries to address https://arangodb.atlassian.net/browse/BTS-1792

There it was found that the ICU library does not seem to be initialized
when the AgencyCache tries to use it.

We move the call to `setLocale` from the start method into the prepare
method of the LanguageFeature.

- **Move setLocale into prepare in LanguageFeature.**
- **CHANGELOG.**

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21385

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1792
