### PR TITLE
Call setLocale earlier in LanguageFeature [BTS-1792]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.12 (XXXX-XX-XX)
 ---------------------
 
+* BTS_1792: Call `setLocale` earlier during startup to prevent crashes.
+
 * Change dumping of VPack to JSON for large double values with absolute
   value between 2^53 and 2^64. This ensures that dumps to JSON followed
   by parsing of the JSON back to VPack retain the right numerical values.

--- a/lib/ApplicationFeatures/LanguageFeature.cpp
+++ b/lib/ApplicationFeatures/LanguageFeature.cpp
@@ -248,9 +248,8 @@ void LanguageFeature::prepare() {
   ::setCollator(
       _langType == LanguageType::ICU ? _icuLanguage : _defaultLanguage,
       _icuData.data(), _langType);
+  ::setLocale(_locale);
 }
-
-void LanguageFeature::start() { ::setLocale(_locale); }
 
 icu::Locale& LanguageFeature::getLocale() { return _locale; }
 

--- a/lib/ApplicationFeatures/LanguageFeature.h
+++ b/lib/ApplicationFeatures/LanguageFeature.h
@@ -57,7 +57,6 @@ class LanguageFeature final : public application_features::ApplicationFeature {
 
   void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override final;
-  void start() override final;
   static std::string prepareIcu(std::string const& binaryPath,
                                 std::string const& binaryExecutionPath,
                                 std::string& path,


### PR DESCRIPTION
This tries to address https://arangodb.atlassian.net/browse/BTS-1792

There it was found that the ICU library does not seem to be initialized
when the AgencyCache tries to use it.

We move the call to `setLocale` from the start method into the prepare
method of the LanguageFeature.

- **Move setLocale into prepare in LanguageFeature.**
- **CHANGELOG.**

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-1792
- [*] Original PR: https://github.com/arangodb/arangodb/pull/21384

