### PR TITLE
Set waiter in future functions

### DIFF
--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -105,11 +105,21 @@ struct AddToAsyncRegistry {
   ~AddToAsyncRegistry();
 
   auto set_promise_waiter(void* waiter) {
-    promise_in_registry->waiter.store(waiter);
+    if (promise_in_registry != nullptr) {
+      promise_in_registry->waiter.store(waiter);
+    }
   }
-  auto id() -> void* { return promise_in_registry->id(); }
+  auto id() -> void* {
+    if (promise_in_registry != nullptr) {
+      return promise_in_registry->id();
+    } else {
+      return nullptr;
+    }
+  }
   auto update_source_location(std::source_location loc) {
-    promise_in_registry->source_location.line.store(loc.line());
+    if (promise_in_registry != nullptr) {
+      promise_in_registry->source_location.line.store(loc.line());
+    }
   }
 
  private:

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -90,7 +90,7 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
     return awaitable{
         this, get_awaitable_object(std::forward<U>(co_awaited_expression)),
         ExecContext::currentAsShared()};
-  };
+  }
   void unhandled_exception() { _value.set_exception(std::current_exception()); }
   auto get_return_object() {
     return async<T>{std::coroutine_handle<promise_type>::from_promise(

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -309,6 +309,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
+    set_promise_waiter(future.id());
     getState().setCallback([fn = std::forward<DF>(fn),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -339,6 +340,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
+    set_promise_waiter(future.id());
     getState().setCallback([fn = std::forward<DF>(fn),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -373,6 +375,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
+    set_promise_waiter(future.id());
     getState().setCallback([fn = std::forward<DF>(func),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       pr.setTry(detail::makeTryWith([&fn, &t] {
@@ -395,6 +398,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
+    set_promise_waiter(future.id());
     getState().setCallback([fn = std::forward<F>(func),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       try {
@@ -433,6 +437,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
+    set_promise_waiter(future.id());
     getState().setCallback([fn = std::forward<DF>(func),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -466,6 +471,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
+    set_promise_waiter(future.id());
     getState().setCallback([fn = std::forward<DF>(fn),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -491,9 +497,17 @@ class [[nodiscard]] Future {
   }
 
   auto set_promise_waiter(void* waiter) {
-    return _state->set_promise_waiter(waiter);
+    if (_state != nullptr) {
+      _state->set_promise_waiter(waiter);
+    }
   }
-  auto id() -> void* { return _state->id(); }
+  auto id() -> void* {
+    if (_state != nullptr) {
+      return _state->id();
+    } else {
+      return nullptr;
+    }
+  }
 
  private:
   explicit Future(detail::EmptyConstructor) : _state(nullptr) {}

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -124,6 +124,9 @@ class Promise {
     return _state->set_promise_waiter(waiter);
   }
   auto id() -> void* { return _state->id(); }
+  auto update_source_location(std::source_location loc) {
+    _state->update_source_location(std::move(loc));
+  }
 
  private:
   explicit Promise(detail::SharedState<T>* state)

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -120,6 +120,11 @@ class Promise {
 
   arangodb::futures::Future<T> getFuture();
 
+  auto set_promise_waiter(void* waiter) {
+    return _state->set_promise_waiter(waiter);
+  }
+  auto id() -> void* { return _state->id(); }
+
  private:
   explicit Promise(detail::SharedState<T>* state)
       : _state(state), _retrieved(false) {}

--- a/tests/Futures/FutureTest.cpp
+++ b/tests/Futures/FutureTest.cpp
@@ -848,7 +848,7 @@ TEST(FutureTest, futures_are_registered_in_global_async_registry) {
   arangodb::async_registry::get_thread_registry().garbage_collect();
   {
     auto x = foo();
-    std::vector<std::string> names;
+    std::vector<std::string_view> names;
     arangodb::async_registry::registry.for_promise(
         [&](arangodb::async_registry::Promise* promise) {
           names.push_back(promise->source_location.function_name);


### PR DESCRIPTION
Async registry waiter is now set for
- future coroutines
- futures continuations (then, thenValue, thenError)
- future collections (collectAll, collect, gather)

Addtionally, the source location is now updated in future coroutines.