### PR TITLE
Add promise state to registry

### DIFF
--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -58,6 +58,14 @@ auto inspect(Inspector& f, SourceLocation& x) {
   }
 }
 
+enum class State { Running = 0, Suspended, Resolved, Deleted };
+template<typename Inspector>
+auto inspect(Inspector& f, State& x) {
+  return f.enumeration(x).values(State::Running, "Running", State::Suspended,
+                                 "Suspended", State::Resolved, "Resolved",
+                                 State::Deleted, "Deleted");
+}
+
 struct Promise {
   Promise(Promise* next, std::shared_ptr<ThreadRegistry> registry,
           std::source_location location);
@@ -70,6 +78,7 @@ struct Promise {
 
   SourceLocation source_location;
   std::atomic<void*> waiter = nullptr;
+  std::atomic<State> state = State::Running;
   // identifies the promise list it belongs to
   std::shared_ptr<ThreadRegistry> registry;
   Promise* next = nullptr;
@@ -88,10 +97,11 @@ template<typename Inspector>
 auto inspect(Inspector& f, Promise& x) {
   if constexpr (!Inspector::isLoading) {  // only serialize
     return f.object(x).fields(
-        f.field("thread", x.thread),
+        f.field("owning_thread", x.thread),
         f.field("source_location", x.source_location),
         f.field("id", reinterpret_cast<intptr_t>(x.id())),
-        f.field("waiter", reinterpret_cast<intptr_t>(x.waiter.load())));
+        f.field("waiter", reinterpret_cast<intptr_t>(x.waiter.load())),
+        f.field("state", x.state.load()));
   }
 }
 
@@ -121,11 +131,18 @@ struct AddToAsyncRegistry {
       promise_in_registry->source_location.line.store(loc.line());
     }
   }
+  auto update_state(State state) {
+    if (promise_in_registry != nullptr) {
+      promise_in_registry->state.store(state);
+    }
+  }
 
  private:
   struct noop {
     void operator()(void*) {}
   };
+
+ public:
   std::unique_ptr<Promise, noop> promise_in_registry = nullptr;
 };
 

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -99,6 +99,9 @@ auto ThreadRegistry::add_promise(std::source_location location) noexcept
 auto ThreadRegistry::mark_for_deletion(Promise* promise) noexcept -> void {
   // makes sure that promise is really in this list
   ADB_PROD_ASSERT(promise->registry.get() == this);
+
+  promise->state.store(State::Deleted);
+
   // keep a local copy of the shared pointer. This promise might be the
   // last of the registry.
   auto self = std::move(promise->registry);

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -127,6 +127,9 @@ class Promise {
   auto update_source_location(std::source_location loc) {
     _state->update_source_location(std::move(loc));
   }
+  auto update_state(async_registry::State state) {
+    _state->update_state(std::move(state));
+  }
 
  private:
   explicit Promise(detail::SharedState<T>* state)

--- a/lib/Futures/include/Futures/SharedState.h
+++ b/lib/Futures/include/Futures/SharedState.h
@@ -202,6 +202,7 @@ class SharedState : public async_registry::AddToAsyncRegistry {
       case State::Start:
         if (_state.compare_exchange_strong(state, State::OnlyResult,
                                            std::memory_order_release)) {
+          update_state(async_registry::State::Resolved);
           return;
         }
         TRI_ASSERT(state == State::OnlyCallback);  // race with setCallback
@@ -238,7 +239,9 @@ class SharedState : public async_registry::AddToAsyncRegistry {
   SharedState(std::source_location loc)
       : async_registry::AddToAsyncRegistry(std::move(loc)),
         _state(State::Start),
-        _attached(2) {}
+        _attached(2) {
+    update_state(async_registry::State::Suspended);
+  }
 
   /// use to construct a ready future
   explicit SharedState(Try<T>&& t)
@@ -278,10 +281,14 @@ class SharedState : public async_registry::AddToAsyncRegistry {
     TRI_ASSERT(_state == State::Done);
     TRI_ASSERT(_callback);
 
+    update_state(async_registry::State::Running);
+
     _attached.fetch_add(1);
     // SharedStateScope makes this exception safe
     SharedStateScope scope(this);  // will call detachOne()
     _callback(std::move(_result));
+
+    update_state(async_registry::State::Resolved);
   }
 
  private:

--- a/tests/Futures/CMakeLists.txt
+++ b/tests/Futures/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(arango_tests_futures OBJECT
   FutureTest.cpp
+  FutureCoroutineTest.cpp
   PromiseTest.cpp
   TryTest.cpp)
 target_link_libraries(arango_tests_futures

--- a/tests/Futures/FutureCoroutineTest.cpp
+++ b/tests/Futures/FutureCoroutineTest.cpp
@@ -1,0 +1,150 @@
+#include "Async/Registry/registry_variable.h"
+#include "Futures/Future.h"
+
+#include <condition_variable>
+#include <coroutine>
+#include <mutex>
+#include <thread>
+#include <deque>
+
+#include <gtest/gtest.h>
+
+using namespace arangodb::futures;
+
+struct WaitSlot {
+  void resume() {
+    ready = true;
+    _continuation.resume();
+  }
+
+  void await() {}
+
+  std::coroutine_handle<> _continuation;
+
+  bool await_ready() { return ready; }
+  void await_resume() {}
+  void await_suspend(std::coroutine_handle<> continuation) {
+    _continuation = continuation;
+  }
+
+  void stop() {}
+
+  bool ready = false;
+};
+
+struct NoWait {
+  void resume() {}
+  void await() {}
+
+  auto operator co_await() { return std::suspend_never{}; }
+  void stop() {}
+};
+
+struct ConcurrentNoWait {
+  void resume() {}
+  void await() {
+    await_suspend(std::noop_coroutine());
+    _thread.join();
+  }
+
+  bool await_ready() { return false; }
+  void await_resume() {}
+  void await_suspend(std::coroutine_handle<> handle) {
+    {
+      std::unique_lock guard(_mutex);
+      _coro.emplace_back(handle);
+    }
+    _cv.notify_one();
+  }
+  ConcurrentNoWait()
+      : _thread([&] {
+          bool stopping = false;
+          while (true) {
+            std::coroutine_handle<> handle;
+            {
+              std::unique_lock guard(_mutex);
+              if (_coro.empty() && stopping) {
+                break;
+              }
+              _cv.wait(guard, [&] { return !_coro.empty(); });
+              handle = _coro.front();
+              _coro.pop_front();
+            }
+            if (handle == std::noop_coroutine()) {
+              stopping = true;
+            }
+            handle.resume();
+          }
+        }) {}
+
+  auto stop() -> void {
+    if (_thread.joinable()) {
+      await_suspend(std::noop_coroutine());
+      _thread.join();
+    }
+  }
+
+  std::mutex _mutex;
+  std::condition_variable_any _cv;
+  std::deque<std::coroutine_handle<>> _coro;
+
+  std::jthread _thread;
+};
+
+template<typename WaitType>
+struct FutureCoroutineTest : ::testing::Test {
+  void SetUp() override {
+    arangodb::async_registry::get_thread_registry().garbage_collect();
+  }
+
+  void TearDown() override {
+    arangodb::async_registry::get_thread_registry().garbage_collect();
+    wait.stop();
+  }
+
+  WaitType wait;
+};
+
+using MyTypes = ::testing::Types<NoWait, WaitSlot, ConcurrentNoWait>;
+TYPED_TEST_SUITE(FutureCoroutineTest, MyTypes);
+
+TYPED_TEST(FutureCoroutineTest, promises_in_async_registry_know_their_state) {
+  {
+    auto coro = [&]() -> Future<int> {
+      co_await this->wait;
+      co_return 12;
+    }();
+
+    if (std::is_same<decltype(this->wait), WaitSlot>()) {
+      uint count = 0;
+      arangodb::async_registry::registry.for_promise(
+          [&](arangodb::async_registry::Promise* promise) {
+            count++;
+            EXPECT_EQ(promise->state.load(),
+                      arangodb::async_registry::State::Suspended);
+          });
+      EXPECT_EQ(count, 1);
+    }
+
+    this->wait.resume();
+    this->wait.await();
+
+    uint count = 0;
+    arangodb::async_registry::registry.for_promise(
+        [&](arangodb::async_registry::Promise* promise) {
+          count++;
+          EXPECT_EQ(promise->state.load(),
+                    arangodb::async_registry::State::Resolved);
+        });
+    EXPECT_EQ(count, 1);
+  }
+
+  uint count = 0;
+  arangodb::async_registry::registry.for_promise(
+      [&](arangodb::async_registry::Promise* promise) {
+        count++;
+        EXPECT_EQ(promise->state.load(),
+                  arangodb::async_registry::State::Deleted);
+      });
+  EXPECT_EQ(count, 1);
+}


### PR DESCRIPTION
Adds a state to the async registry promise, which can be either Running, Suspended, Resolved or MarkedForDeletion.
The object that creates the promise is responsible for updating this state:

async<T> coroutine:
- Is Running when created and resumed
- Is Suspended when it suspends
- Is Resolved when it hits co_return
- Is Deleted when the coroutine is destroyed

Future<T> coroutine:
same as for async<T> coroutine

plain Future<T> which is not resolved on creation:
- Is Suspended when created
- Is Resolved when its Promise<T> is resolved or its callback is finished running
- Is Running when its callback is running
- Is Deleted when the future is destroyed