### PR TITLE
[BTS-1254] Invalid Primary Index Entry

### DIFF
--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1503,10 +1503,8 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
   key->constructDocument(objectId(), documentId);
   TRI_ASSERT(key->containsLocalDocumentId(documentId));
 
-  if (state->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED)) {
-    // banish new document to avoid caching without committing first
-    invalidateCacheEntry(key.ref());
-  }
+  // banish new document to avoid caching without committing first
+  invalidateCacheEntry(key.ref());
 
   // disable indexing in this transaction if we are allowed to
   IndexingDisabler disabler(mthds, state->isSingleOperation());
@@ -1915,10 +1913,8 @@ Result RocksDBCollection::modifyDocument(
     return res.reset(rocksutils::convertStatus(s, rocksutils::document));
   }
 
-  if (state->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED)) {
-    // banish new document to avoid caching without committing first
-    invalidateCacheEntry(key.ref());
-  }
+  // banish new document to avoid caching without committing first
+  invalidateCacheEntry(key.ref());
 
   trx->state()->trackShardUsage(
       *trx->resolver(), _logicalCollection.vocbase().name(),

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -775,12 +775,9 @@ Result RocksDBPrimaryIndex::insert(transaction::Methods& trx,
   // we do not need to perform any additional checks here since the document key
   // is already locked at the beginning of the insert operation
 
-  if (trx.state()->hasHint(transaction::Hints::Hint::GLOBAL_MANAGED)) {
-    // invalidate new index cache entry to avoid caching without committing
-    // first
-    invalidateCacheEntry(key->string().data(),
-                         static_cast<uint32_t>(key->string().size()));
-  }
+  // invalidate new index cache entry to avoid caching without committing first
+  invalidateCacheEntry(key->string().data(),
+                       static_cast<uint32_t>(key->string().size()));
 
   TRI_ASSERT(revision.isSet());
   auto value = RocksDBValue::PrimaryIndexValue(documentId, revision);

--- a/tests/js/client/shell/shell-transactions.js
+++ b/tests/js/client/shell/shell-transactions.js
@@ -1624,6 +1624,22 @@ function transactionOperationsSuite () {
       assertEqual([ 'foo' ], sortedKeys(c1));
     },
 
+    testReadWithCache: function() {
+
+      c1 = db._create(cn1, {cacheEnabled: true});
+      let trx = db._createTransaction({
+        collections: {read: [cn1]}
+      });
+
+      assertEqual(trx.collection(cn1).exists("baz"), false);
+
+      // insert and read the document
+      c1.insert({_key: "baz"});
+      c1.document("baz");
+
+      assertEqual(trx.collection(cn1).exists("baz"), false);
+    },
+
     // //////////////////////////////////////////////////////////////////////////////
     // / @brief test: trx with read operation
     // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Scope & Purpose

In some cases, cache entries were not banished, which resulted in new cache entries becoming visible in already running transactions. This can affect the primary index cache as well as the documents cache. With correct timing a read request can find a cache entry for the primary index but no such cache entry for the corresponding documents cache. Since the snapshot does not contain the document, this would result in an `Found primary index entry for which there is no actual document` error.