### PR TITLE
Bug fix/join late materialize doc lookup counter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Add missing accounting for document lookups in JOIN nodes when in late
+  materialize mode.
+
 * Speed up shortest path further by using a neighbour cache in the 
   SingleServerProvider.
 

--- a/arangod/Aql/Executor/JoinExecutor.cpp
+++ b/arangod/Aql/Executor/JoinExecutor.cpp
@@ -498,6 +498,9 @@ auto JoinExecutor::produceRows(AqlItemBlockInputRange& inputRange,
               AqlValueGuard guard{v, false};
               output.moveValueInto(idx.docIdOutputRegister, _currentRow,
                                    &guard);
+              // account for later document lookups here, because the
+              // MaterializeExecutor has NoStats.
+              stats.incrDocumentLookups(1);
             }
 
             if (idx.filter && idx.filter->projections.usesCoveringIndex()) {

--- a/tests/js/client/aql/aql-index-join.js
+++ b/tests/js/client/aql/aql-index-join.js
@@ -1138,12 +1138,14 @@ const IndexJoinTestSuite = function () {
       assertEqual(join.indexInfos[1].producesOutput, true);
       assertEqual(join.indexInfos[1].indexCoversProjections, true);
 
-
-      const result = db._createStatement(query).execute().toArray();
+      const cursor = db._createStatement(query).execute();
+      const result = cursor.toArray();
       assertEqual(result.length, 20);
       for (const [a, b] of result) {
         assertEqual(a, b.x);
       }
+
+      assertEqual(cursor.getExtra().stats.documentLookups, 100);
     },
 
     testLateMaterializedPushPastJoin: function () {


### PR DESCRIPTION
### Scope & Purpose
Add missing accounting for document look ups in JOIN nodes when late materialization is enabled. Although the documents are lookup up in the materialize node, we account for it in the Join node, because the Materialize Node is pass through and thus only supports `NoStats`.