### PR TITLE
Fix document lookup counter in corner case.

### DIFF
--- a/arangod/Aql/DocumentProducingHelper.cpp
+++ b/arangod/Aql/DocumentProducingHelper.cpp
@@ -678,6 +678,7 @@ IndexIterator::CoveringCallback aql::getCallback(
 
           return false;
         };
+        context.incrLookups();
         context.getPhysical().lookup(
             context.getTrxPtr(), token, cb,
             {.readOwnWrites = static_cast<bool>(context.getReadOwnWrites()),


### PR DESCRIPTION
### Scope & Purpose
In case of a filter condition being partially covered by the index, but the post filter condition is also covered by stored value, but documents have to be produced, but we are not in late materialization mode, then the document lookup counter misses document look ups.