### PR TITLE
[Async Registry] Iterate over promise snapshot instead of promise ptr

### DIFF
--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -23,6 +23,7 @@
 #include "RestHandler.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Async/Registry/promise.h"
 #include "Async/Registry/registry_variable.h"
 #include "Inspection/VPack.h"
 #include "Rest/CommonDefines.h"
@@ -43,8 +44,9 @@ auto RestHandler::execute() -> RestStatus {
 
   VPackBuilder builder;
   builder.openArray();
-  registry.for_promise(
-      [&](Promise* promise) { velocypack::serialize(builder, *promise); });
+  registry.for_promise([&](PromiseSnapshot promise) {
+    velocypack::serialize(builder, promise);
+  });
   builder.close();
 
   generateResult(rest::ResponseCode::OK, builder.slice());

--- a/lib/Async/Registry/registry.h
+++ b/lib/Async/Registry/registry.h
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
 
+#include "Async/Registry/promise.h"
 #include "Async/Registry/thread_registry.h"
 
 #include <cstdint>
@@ -61,7 +62,7 @@ struct Registry {
      items stay valid during iteration (i.e. are not deleted in the meantime).
    */
   template<typename F>
-  requires std::invocable<F, Promise*>
+  requires std::invocable<F, PromiseSnapshot>
   auto for_promise(F&& function) -> void {
     auto regs = [&] {
       auto guard = std::lock_guard(mutex);

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -78,13 +78,13 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      items stay valid during iteration (i.e. are not deleted in the meantime).
    */
   template<typename F>
-  requires std::invocable<F, Promise*>
+  requires std::invocable<F, PromiseSnapshot>
   auto for_promise(F&& function) noexcept -> void {
     auto guard = std::lock_guard(mutex);
     // (2) - this load synchronizes with store in (1) and (3)
     for (auto current = promise_head.load(std::memory_order_acquire);
          current != nullptr; current = current->next) {
-      function(current);
+      function(current->snapshot());
     }
   }
 

--- a/tests/Async/AsyncTestLineNumbers.tpp
+++ b/tests/Async/AsyncTestLineNumbers.tpp
@@ -36,9 +36,9 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
 
     uint count = 0;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::Promise* promise) {
+        [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise->source_location.line.load(), 34);
+          EXPECT_EQ(promise.source_location.line, 34);
         });
     EXPECT_EQ(count, 1);
   }
@@ -54,18 +54,18 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
 
     uint count = 0;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::Promise* promise) {
+        [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise->source_location.line.load(), 50);
+          EXPECT_EQ(promise.source_location.line, 50);
         });
     EXPECT_EQ(count, 1);
     wait.resume();
 
     count = 0;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::Promise* promise) {
+        [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise->source_location.line.load(), 52);
+          EXPECT_EQ(promise.source_location.line, 52);
         });
     EXPECT_EQ(count, 1);
   }
@@ -81,18 +81,18 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
 
     uint count = 0;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::Promise* promise) {
+        [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise->source_location.line.load(), 77);
+          EXPECT_EQ(promise.source_location.line, 77);
         });
     EXPECT_EQ(count, 1);
     wait.await();
 
     count = 0;
     arangodb::async_registry::registry.for_promise(
-        [&](arangodb::async_registry::Promise* promise) {
+        [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise->source_location.line.load(), 79);
+          EXPECT_EQ(promise.source_location.line, 79);
         });
     EXPECT_EQ(count, 1);
   }


### PR DESCRIPTION
When iterating over all promises in the async registry, we now iterate over a new snapshot object and not a ptr to the object itself. This makes the iteration easier to use.