### PR TITLE
we want to check for the agency to be alive *before* any other is already running

### DIFF
--- a/js/client/modules/@arangodb/testutils/agency.js
+++ b/js/client/modules/@arangodb/testutils/agency.js
@@ -298,7 +298,7 @@ class agencyMgr {
   detectAgencyAlive(httpAuthOptions) {
     if (!this.options.agency ||
         !this.shouldBeCompleted() ||
-        !this.moreIsAlreadyRunning()) {
+        this.moreIsAlreadyRunning()) {
       print("no agency check this time.");
       return;
     }


### PR DESCRIPTION
### Scope & Purpose

In the startup of the SUT we want the agency to be healthy before we start subsequent dbserver and coordinator instances.  Fix the trigger condition so the agency alive check takes place in exactly this phase.

- [x] :hankey: Bugfix
