### PR TITLE
Rename async registry route

### DIFF
--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -74,6 +74,8 @@ auto RestHandler::execute() -> RestStatus {
   auto awaited_promises = promises.index_by_awaitee();
 
   VPackBuilder builder;
+  builder.openObject();
+  builder.add(VPackValue("promise_stacktraces"));
   builder.openArray();
   for (auto root : roots) {
     builder.openArray();
@@ -92,6 +94,7 @@ auto RestHandler::execute() -> RestStatus {
     } while (true);
     builder.close();
   }
+  builder.close();
   builder.close();
 
   generateResult(rest::ResponseCode::OK, builder.slice());

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -753,10 +753,6 @@ void GeneralServerFeature::defineRemainingHandlers(
 #endif
 
   f.addPrefixHandler(
-      "/_api/async_registry",
-      RestHandlerCreator<arangodb::async_registry::RestHandler>::createNoData);
-
-  f.addPrefixHandler(
       "/_api/dump",
       RestHandlerCreator<arangodb::RestDumpHandler>::createNoData);
 
@@ -845,6 +841,10 @@ void GeneralServerFeature::defineRemainingHandlers(
   // ...........................................................................
   // /_admin
   // ...........................................................................
+
+  f.addPrefixHandler(
+      "/_admin/async-registry",
+      RestHandlerCreator<arangodb::async_registry::RestHandler>::createNoData);
 
   f.addPrefixHandler(
       "/_admin/cluster",


### PR DESCRIPTION
Rename async registry route to be more intuitive

Wrap REST output in object to make clearer what is returned and be able to later add more stuff without breaking backwards compatibility.