### PR TITLE
Feature/async registry improvements

### DIFF
--- a/arangod/AsyncRegistryServer/Feature.cpp
+++ b/arangod/AsyncRegistryServer/Feature.cpp
@@ -51,11 +51,8 @@ DECLARE_GAUGE(arangodb_async_registered_threads, std::uint64_t,
               "Number of threads the asynchronous registry iterates over to "
               "list all asynchronous promises");
 
-Feature::Feature(Server& server)
-    : ArangodFeature{server, *this},
-      metrics{create_metrics(
-          server.template getFeature<arangodb::metrics::MetricsFeature>())} {
-  registry.set_metrics(metrics);
+Feature::Feature(Server& server) : ArangodFeature{server, *this} {
+  startsAfter<arangodb::metrics::MetricsFeature>();
 }
 
 auto Feature::create_metrics(arangodb::metrics::MetricsFeature& metrics_feature)
@@ -92,6 +89,9 @@ struct Feature::PromiseCleanupThread {
 };
 
 void Feature::start() {
+  metrics = create_metrics(
+      server().template getFeature<arangodb::metrics::MetricsFeature>());
+  registry.set_metrics(metrics);
   _cleanupThread = std::make_shared<PromiseCleanupThread>(_options.gc_timeout);
 }
 

--- a/arangod/AsyncRegistryServer/RestHandler.h
+++ b/arangod/AsyncRegistryServer/RestHandler.h
@@ -33,7 +33,7 @@ class RestHandler : public arangodb::RestVocbaseBaseHandler {
 
  public:
   char const* name() const override final { return "AsyncRegistryRestHandler"; }
-  RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
+  RequestLane lane() const override final { return RequestLane::CLUSTER_ADMIN; }
   RestStatus execute() override;
 
   Feature& _feature;


### PR DESCRIPTION
### Scope & Purpose
- Use high priority request lane for querying promises. In a high load scenario we would otherwise never get a response.
- Create metrics only at feature start and add the explicit dependency to the metrics feature.