### PR TITLE
JS API: Use collection.indexes() instead of .getIndexes()

### DIFF
--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -236,17 +236,15 @@ let helpArangoCollection = arangosh.createHelpHeadline('ArangoCollection help') 
   '  properties()                          show collection properties        ' + '\n' +
   '  properties(<data>)                    change collection properties      ' + '\n' +
   '  drop()                                delete a collection               ' + '\n' +
-  '  load()                                load a collection                 ' + '\n' +
-  '  unload()                              unload a collection               ' + '\n' +
   '  rename(<new-name>)                    renames a collection              ' + '\n' +
-  '  getIndexes()                          return defined indexes            ' + '\n' +
+  '  indexes()                             return defined indexes            ' + '\n' +
   '  refresh()                             refresh the status and name       ' + '\n' +
   '  _help()                               this help                         ' + '\n' +
   '                                                                          ' + '\n' +
   'Document Functions:                                                       ' + '\n' +
   '  count()                               return number of documents        ' + '\n' +
-  '  save(<data>)                          create document and return handle ' + '\n' +
-  '  document(<id>)                        get document by handle (_id or _key)' + '\n' +
+  '  save(<data>) / insert(<data>)         create document, return metadata  ' + '\n' +
+  '  document(<id>)                        get document by _key or _id       ' + '\n' +
   '  replace(<id>, <data>, <overwrite>)    overwrite document                ' + '\n' +
   '  update(<id>, <data>, <overwrite>,     partially update document         ' + '\n' +
   '         <keepNull>)                                                      ' + '\n' +

--- a/js/client/modules/@arangodb/inspector.js
+++ b/js/client/modules/@arangodb/inspector.js
@@ -608,7 +608,7 @@ function getServerData(arango) {
                 Object.keys(localCol.properties()).forEach( function(property) {
                   local[localDB][colName][property] = localCol.properties()[property];
                 });
-                local[localDB][colName].index = localCol.getIndexes();
+                local[localDB][colName].index = localCol.indexes();
                 local[localDB][colName].count = localCol.count();
               });});
             db._useDatabase('_system');

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -2541,7 +2541,7 @@ function debug(query, bindVars, options) {
         name: collection.name,
         type: c.type(),
         properties: c.properties(),
-        indexes: c.getIndexes(true),
+        indexes: c.indexes(true),
         count: c.count(),
         counts: c.count(true),
         examples

--- a/js/common/modules/@arangodb/arango-collection-common.js
+++ b/js/common/modules/@arangodb/arango-collection-common.js
@@ -190,7 +190,7 @@ ArangoCollection.prototype.geo = function (loc, order) {
   var idx;
 
   var locateGeoIndex1 = function (collection, loc, order) {
-    var inds = collection.getIndexes();
+    var inds = collection.indexes();
     var i;
 
     for (i = 0;  i < inds.length;  ++i) {
@@ -207,7 +207,7 @@ ArangoCollection.prototype.geo = function (loc, order) {
   };
 
   var locateGeoIndex2 = function (collection, lat, lon) {
-    var inds = collection.getIndexes();
+    var inds = collection.indexes();
     var i;
 
     for (i = 0;  i < inds.length;  ++i) {

--- a/js/common/modules/@arangodb/simple-query-common.js
+++ b/js/common/modules/@arangodb/simple-query-common.js
@@ -530,7 +530,7 @@ SimpleQueryNear = function (collection, latitude, longitude, iid) {
   this._distance = null;
 
   if (iid === undefined) {
-    idx = collection.getIndexes();
+    idx = collection.indexes();
 
     for (i = 0;  i < idx.length;  ++i) {
       var index = idx[i];
@@ -636,7 +636,7 @@ SimpleQueryWithin = function (collection, latitude, longitude, radius, iid) {
   this._distance = null;
 
   if (iid === undefined) {
-    idx = collection.getIndexes();
+    idx = collection.indexes();
 
     for (i = 0;  i < idx.length;  ++i) {
       var index = idx[i];
@@ -746,7 +746,7 @@ SimpleQueryWithinRectangle = function (collection, latitude1, longitude1, latitu
   this._index = (iid === undefined ? null : iid);
 
   if (iid === undefined) {
-    idx = collection.getIndexes();
+    idx = collection.indexes();
 
     for (i = 0;  i < idx.length;  ++i) {
       var index = idx[i];
@@ -835,7 +835,7 @@ function SimpleQueryFulltext (collection, attribute, query, iid) {
   this._index = (iid === undefined ? null : iid);
 
   if (iid === undefined) {
-    var idx = collection.getIndexes();
+    var idx = collection.indexes();
     var i;
 
     for (i = 0;  i < idx.length;  ++i) {

--- a/js/server/modules/@arangodb/arango-collection.js
+++ b/js/server/modules/@arangodb/arango-collection.js
@@ -110,7 +110,7 @@ ArangoCollection.prototype.toArray = function () {
 // / *Examples*
 // /
 // / @code
-// / arango> db.example.getIndexes().map(function(x) { return x.id; })
+// / arango> db.example.indexes().map(function(x) { return x.id; })
 // / ["example/0"]
 // / arango> db.example.index("93013/0")
 // / { "id" : "example/0", "type" : "primary", "fields" : ["_id"] }
@@ -118,7 +118,7 @@ ArangoCollection.prototype.toArray = function () {
 // //////////////////////////////////////////////////////////////////////////////
 
 ArangoCollection.prototype.index = function (id) {
-  var indexes = this.getIndexes();
+  var indexes = this.indexes();
   var i;
 
   if (typeof id === 'object' && id.hasOwnProperty('id')) {

--- a/js/server/modules/@arangodb/arango-database.js
+++ b/js/server/modules/@arangodb/arango-database.js
@@ -246,7 +246,7 @@ ArangoDatabase.prototype._index = function (id) {
     throw err;
   }
 
-  var indexes = col.getIndexes();
+  var indexes = col.indexes();
   var i;
 
   for (i = 0;  i < indexes.length;  ++i) {

--- a/tests/js/client/aql/aql-arangosearch-inverted-index-search-alias-community.js
+++ b/tests/js/client/aql/aql-arangosearch-inverted-index-search-alias-community.js
@@ -765,7 +765,7 @@ function IResearchInvertedIndexSearchAliasAqlTestSuiteCommunity() {
                     triggerMetrics();
                 }
                 checkIndexMetrics( function () {
-                    let stats = testColl.getIndexes(true, true);
+                    let stats = testColl.indexes(true, true);
                     for (let i = 0; i < stats.length; i++) {
                         let index = stats[i];
                         if (index["type"] === "primary") {

--- a/tests/js/client/aql/aql-graph-traverser-optimizeNonVertexCentricIndexes-noncluster.js
+++ b/tests/js/client/aql/aql-graph-traverser-optimizeNonVertexCentricIndexes-noncluster.js
@@ -85,7 +85,7 @@ function optimizeNonVertexCentricIndexesSuite() {
 
     tearDown: () => {
       // After each test get rid of all superflous indexes.
-      var idxs = db[en].getIndexes();
+      var idxs = db[en].indexes();
       for (let i = 2; i < idxs.length; ++i) {
         db[en].dropIndex(idxs[i].id);
       }

--- a/tests/js/client/aql/aql-inverted-index-ddl.js
+++ b/tests/js/client/aql/aql-inverted-index-ddl.js
@@ -64,7 +64,7 @@ function testSuite() {
           "includeAllFields": true,
           "analyzer": "identity"
       });
-      let properties = db.c0.getIndexes().find(function (idx) { return idx.name === "c0_cached";});
+      let properties = db.c0.indexes().find(function (idx) { return idx.name === "c0_cached";});
       if (isEnterprise) {
         assertTrue(properties.fields[0].cache);
         assertTrue(properties.primaryKeyCache);

--- a/tests/js/client/aql/aql-optimizer-indexes.js
+++ b/tests/js/client/aql/aql-optimizer-indexes.js
@@ -2605,7 +2605,7 @@ function optimizerIndexesModifyTestSuite () {
 
     testIndexAndHashIndexedNonIndexed : function () {
       // drop the skiplist index
-      c.dropIndex(c.getIndexes()[1]);
+      c.dropIndex(c.indexes()[1]);
       c.ensureIndex({ type: "hash", fields: ["value"] });
       // value2 is not indexed
       db._query("FOR i IN " + c.name() + " UPDATE i WITH { value2: i.value } IN " + c.name());
@@ -2681,7 +2681,7 @@ function optimizerIndexesModifyTestSuite () {
 
     testIndexAndSkiplistPartialIndexedNonIndexed : function () {
       // drop the skiplist index
-      c.dropIndex(c.getIndexes()[1]);
+      c.dropIndex(c.indexes()[1]);
 
       // create an alternative index
       c.ensureIndex({ type: "skiplist", fields: ["value", "value3"] });

--- a/tests/js/client/aql/aql-queries-array-nested.js
+++ b/tests/js/client/aql/aql-queries-array-nested.js
@@ -51,40 +51,40 @@ function nestedArraySimpleSuite () {
 
     // try with hash index on value
     var idx = c.ensureIndex({ type: "hash", fields: [ "value" ] });
-    assertEqual(2, c.getIndexes().length);
+    assertEqual(2, c.indexes().length);
     
     result = db._query(q).toArray().sort();
     assertEqual(expected, result);
     assertEqual(useIndexForSimple, indexUsed(q));
 
     c.dropIndex(idx);
-    assertEqual(1, c.getIndexes().length);
+    assertEqual(1, c.indexes().length);
     
     // try with hash index on value[*]
     idx = c.ensureIndex({ type: "hash", fields: [ "value[*]" ] });
-    assertEqual(2, c.getIndexes().length);
+    assertEqual(2, c.indexes().length);
     
     result = db._query(q).toArray().sort();
     assertEqual(expected, result);
     assertEqual(useIndexForArray, indexUsed(q));
     
     c.dropIndex(idx);
-    assertEqual(1, c.getIndexes().length);
+    assertEqual(1, c.indexes().length);
     
     // try with skiplist ndex on value
     idx = c.ensureIndex({ type: "skiplist", fields: [ "value" ] });
-    assertEqual(2, c.getIndexes().length);
+    assertEqual(2, c.indexes().length);
     
     result = db._query(q).toArray().sort();
     assertEqual(expected, result);
     assertEqual(useIndexForSimple, indexUsed(q));
     
     c.dropIndex(idx);
-    assertEqual(1, c.getIndexes().length);
+    assertEqual(1, c.indexes().length);
     
     // try with skiplist index on value[*]
     c.ensureIndex({ type: "skiplist", fields: [ "value[*]" ] });
-    assertEqual(2, c.getIndexes().length);
+    assertEqual(2, c.indexes().length);
     
     result = db._query(q).toArray().sort();
     assertEqual(expected, result);

--- a/tests/js/client/aql/aql-queries-array.js
+++ b/tests/js/client/aql/aql-queries-array.js
@@ -410,7 +410,7 @@ function ArrayIndexNonArraySuite () {
   let col;
 
   const checkElementsInIndex = function (count) {
-    var allIndexes = col.getIndexes(true);
+    var allIndexes = col.indexes(true);
     assertEqual(allIndexes.length, 2, "We have more than one index!");
   };
 

--- a/tests/js/client/aql/aql-shardids-cluster.js
+++ b/tests/js/client/aql/aql-shardids-cluster.js
@@ -147,7 +147,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
   };
 
   const dropIndexes = (col) => {
-    let indexes = col.getIndexes();
+    let indexes = col.indexes();
     for (const idx of indexes) {
       if (idx.type !== "primary" && idx.type !== "edge") {
         col.dropIndex(idx.id);

--- a/tests/js/client/aql/aql-view-arangosearch-ddl-combined.js
+++ b/tests/js/client/aql/aql-view-arangosearch-ddl-combined.js
@@ -231,10 +231,10 @@ function IResearchFeatureDDLTestSuite1() {
         let properties = view.properties();
         assertTrue(Object === properties.links.constructor);
         assertEqual(2, Object.keys(properties.links).length);
-        var indexes = db.TestCollection0.getIndexes(false);
+        var indexes = db.TestCollection0.indexes(false);
         assertEqual(2, indexes.length);
         assertEqual("primary", indexes[0].type);
-        indexes = db.TestCollection0.getIndexes(false, true);
+        indexes = db.TestCollection0.indexes(false, true);
         assertEqual(3, indexes.length);
         var ii = indexes[1];
         assertEqual("primary", indexes[0].type);
@@ -246,7 +246,7 @@ function IResearchFeatureDDLTestSuite1() {
         assertEqual("arangosearch", link.type);
         db._dropView("TestView");
         assertEqual(null, db._view("TestView"));
-        assertEqual(2, db.TestCollection0.getIndexes(false, true).length);
+        assertEqual(2, db.TestCollection0.indexes(false, true).length);
       }
       let result = db._query("FOR doc IN TestCollection0 OPTIONS {indexHint: 'inverted', forceIndexHint: true, waitForSync: true} FILTER doc.name_1 != 'wrong' RETURN doc").toArray();
       assertEqual(100, result.length);
@@ -275,7 +275,7 @@ function IResearchFeatureDDLTestSuite1() {
         let properties = view.properties();
         assertTrue(Object === properties.links.constructor);
         assertEqual(2, Object.keys(properties.links).length);
-        var indexes = db.TestCollection0.getIndexes(false, true);
+        var indexes = db.TestCollection0.indexes(false, true);
         assertEqual(3, indexes.length);
         var ii = indexes[1];
         assertNotEqual(null, ii);
@@ -288,7 +288,7 @@ function IResearchFeatureDDLTestSuite1() {
         properties = view.properties();
         assertTrue(Object === properties.links.constructor);
         assertEqual(0, Object.keys(properties.links).length);
-        assertEqual(2, db.TestCollection0.getIndexes(false, true).length);
+        assertEqual(2, db.TestCollection0.indexes(false, true).length);
       }
       let result = db._query("FOR doc IN TestCollection0 OPTIONS {indexHint: 'inverted', forceIndexHint: true, waitForSync: true} FILTER doc.name_1 != 'wrong' RETURN doc").toArray();
       assertEqual(100, result.length);
@@ -1761,7 +1761,7 @@ function IResearchFeatureDDLTestSuite1() {
       // check link stats
       checkIndexMetrics(function () {
         for (const type of types) {
-          let figures = db.TestCollection.getIndexes(true, true)
+          let figures = db.TestCollection.indexes(true, true)
             .find(e => e.type === type)
             .figures;
           assertNotEqual(null, figures);
@@ -1793,7 +1793,7 @@ function IResearchFeatureDDLTestSuite1() {
       // check link stats
       checkIndexMetrics(function () {
         for (const type of types) {
-          let figures = db.TestCollection.getIndexes(true, true)
+          let figures = db.TestCollection.indexes(true, true)
             .find(e => e.type === type)
             .figures;
           assertNotEqual(null, figures);
@@ -1832,7 +1832,7 @@ function IResearchFeatureDDLTestSuite1() {
       // check link stats
       checkIndexMetrics(function () {
         for (const type of types) {
-          let figures = db.TestCollection.getIndexes(true, true)
+          let figures = db.TestCollection.indexes(true, true)
             .find(e => e.type === type)
             .figures;
           assertNotEqual(null, figures);
@@ -1872,7 +1872,7 @@ function IResearchFeatureDDLTestSuite1() {
       // check link stats
       checkIndexMetrics(function () {
         for (const type of types) {
-          let figures = db.TestCollection.getIndexes(true, true)
+          let figures = db.TestCollection.indexes(true, true)
             .find(e => e.type === type)
             .figures;
           assertNotEqual(null, figures);
@@ -1907,7 +1907,7 @@ function IResearchFeatureDDLTestSuite1() {
       // check link stats
       checkIndexMetrics(function () {
         for (const type of types) {
-          let figures = db.TestCollection.getIndexes(true, true)
+          let figures = db.TestCollection.indexes(true, true)
             .find(e => e.type === type)
             .figures;
           assertNotEqual(null, figures);
@@ -2310,7 +2310,7 @@ function IResearchFeatureDDLTestSuite2() {
       assertEqual(initialCount + inTransCount, docs.length);
 
       // inBackground should not be returned as part of index definition
-      let indexes = col.getIndexes(false, true);
+      let indexes = col.indexes(false, true);
       assertEqual(3, indexes.length);
       var index = indexes[1];
       assertEqual("inverted", index.type);

--- a/tests/js/client/authentication/user-access-right-collection-properties-spec.js
+++ b/tests/js/client/authentication/user-access-right-collection-properties-spec.js
@@ -100,12 +100,12 @@ describe('User Rights Management', () => {
                 expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
                 if (dbLevel['rw'].has(name) && colLevel['rw'].has(name)) {
                   let col = db._collection(colName);
-                  let origIdxCount = col.getIndexes().length;
+                  let origIdxCount = col.indexes().length;
                   expect(origIdxCount).to.equal(1); // Only primary index
                   let idx = col.ensureIndex({ type: "hash", fields: ["foo"] });
-                  expect(col.getIndexes().length).to.equal(origIdxCount + 1, 'Ensure Index reported success, but collection does not show it.');
+                  expect(col.indexes().length).to.equal(origIdxCount + 1, 'Ensure Index reported success, but collection does not show it.');
                   col.dropIndex(idx);
-                  expect(col.getIndexes().length).to.equal(origIdxCount, 'Drop Index reported success, but collection does still show it.');
+                  expect(col.indexes().length).to.equal(origIdxCount, 'Drop Index reported success, but collection does still show it.');
                 } else {
                   let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                     (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
@@ -117,8 +117,8 @@ describe('User Rights Management', () => {
                   }
                   if (hasReadAccess) {
                     let col = db._collection(colName);
-                    let origIdxCount = col.getIndexes().length;
-                    expect(col.getIndexes().length).to.equal(origIdxCount, `${name} was able to create a new index on the collection, with insufficent rights.`);
+                    let origIdxCount = col.indexes().length;
+                    expect(col.indexes().length).to.equal(origIdxCount, `${name} was able to create a new index on the collection, with insufficent rights.`);
                   }
                 }
               });

--- a/tests/js/client/dump/check-graph-multiple.js
+++ b/tests/js/client/dump/check-graph-multiple.js
@@ -65,13 +65,13 @@ function dumpTestSuite () {
       assertEqual(1, g.count());
 
       assertEqual(3, e.type()); // edge
-      assertEqual(2, e.getIndexes().length);
-      assertEqual('edge', e.getIndexes()[1].type);
+      assertEqual(2, e.indexes().length);
+      assertEqual('edge', e.indexes()[1].type);
       assertEqual(5, e.count());
 
       assertEqual(2, v.type()); // document
-      assertEqual(1, v.getIndexes().length); // just primary index
-      assertEqual('primary', v.getIndexes()[0].type);
+      assertEqual(1, v.indexes().length); // just primary index
+      assertEqual('primary', v.indexes()[0].type);
       assertEqual(5, v.count());
     }
   };

--- a/tests/js/client/dump/check-graph.js
+++ b/tests/js/client/dump/check-graph.js
@@ -64,13 +64,13 @@ function dumpTestSuite () {
       assertTrue(!!g.exists('knows_graph'));
 
       assertEqual(3, e.type()); // edge
-      assertEqual(2, e.getIndexes().length);
-      assertEqual('edge', e.getIndexes()[1].type);
+      assertEqual(2, e.indexes().length);
+      assertEqual('edge', e.indexes()[1].type);
       assertEqual(5, e.count());
 
       assertEqual(2, v.type()); // document
-      assertEqual(1, v.getIndexes().length); // just primary index
-      assertEqual('primary', v.getIndexes()[0].type);
+      assertEqual(1, v.indexes().length); // just primary index
+      assertEqual('primary', v.indexes()[0].type);
       assertEqual(5, v.count());
     }
   };

--- a/tests/js/client/dump/dump-modify.js
+++ b/tests/js/client/dump/dump-modify.js
@@ -60,8 +60,8 @@ function dumpTestSuite() {
       assertEqual(2, c.type()); // document
       assertFalse(p.waitForSync);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
 
       c.ensureIndex({type: "hash", fields: ["abc"]});
 
@@ -123,9 +123,9 @@ function dumpTestSuite() {
       assertEqual(3, c.type()); // edges
       assertFalse(p.waitForSync);
 
-      assertEqual(2, c.getIndexes().length); // primary index + edges index
-      assertEqual("primary", c.getIndexes()[0].type);
-      assertEqual("edge", c.getIndexes()[1].type);
+      assertEqual(2, c.indexes().length); // primary index + edges index
+      assertEqual("primary", c.indexes()[0].type);
+      assertEqual("edge", c.indexes()[1].type);
       assertEqual(10, c.count());
       c.ensureIndex({type: "hash", fields: ["abc"]});
 
@@ -160,8 +160,8 @@ function dumpTestSuite() {
       assertEqual(2, c.type()); // document
       assertFalse(p.waitForSync);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(3, c.count());
     },
 
@@ -176,8 +176,8 @@ function dumpTestSuite() {
       assertEqual(2, c.type()); // document
       assertFalse(p.waitForSync);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(9000, c.count());
 
       c.ensureIndex({type: "hash", fields: ["abc"]});
@@ -200,46 +200,46 @@ function dumpTestSuite() {
       assertEqual(2, c.type()); // document
       assertFalse(p.waitForSync);
 
-      assertEqual(9, c.getIndexes().length);
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(9, c.indexes().length);
+      assertEqual("primary", c.indexes()[0].type);
 
-      assertEqual("hash", c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
-      assertFalse(c.getIndexes()[1].sparse);
-      assertEqual(["a_uc"], c.getIndexes()[1].fields);
+      assertEqual("hash", c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
+      assertFalse(c.indexes()[1].sparse);
+      assertEqual(["a_uc"], c.indexes()[1].fields);
 
-      assertEqual("skiplist", c.getIndexes()[2].type);
-      assertFalse(c.getIndexes()[2].unique);
-      assertFalse(c.getIndexes()[2].sparse);
-      assertEqual(["a_s1", "a_s2"], c.getIndexes()[2].fields);
+      assertEqual("skiplist", c.indexes()[2].type);
+      assertFalse(c.indexes()[2].unique);
+      assertFalse(c.indexes()[2].sparse);
+      assertEqual(["a_s1", "a_s2"], c.indexes()[2].fields);
 
-      assertEqual("hash", c.getIndexes()[3].type);
-      assertFalse(c.getIndexes()[3].unique);
-      assertFalse(c.getIndexes()[3].sparse);
-      assertEqual(["a_h1", "a_h2"], c.getIndexes()[3].fields);
+      assertEqual("hash", c.indexes()[3].type);
+      assertFalse(c.indexes()[3].unique);
+      assertFalse(c.indexes()[3].sparse);
+      assertEqual(["a_h1", "a_h2"], c.indexes()[3].fields);
 
-      assertEqual("skiplist", c.getIndexes()[4].type);
-      assertTrue(c.getIndexes()[4].unique);
-      assertFalse(c.getIndexes()[4].sparse);
-      assertEqual(["a_su"], c.getIndexes()[4].fields);
+      assertEqual("skiplist", c.indexes()[4].type);
+      assertTrue(c.indexes()[4].unique);
+      assertFalse(c.indexes()[4].sparse);
+      assertEqual(["a_su"], c.indexes()[4].fields);
 
-      assertEqual("hash", c.getIndexes()[5].type);
-      assertFalse(c.getIndexes()[5].unique);
-      assertTrue(c.getIndexes()[5].sparse);
-      assertEqual(["a_hs1", "a_hs2"], c.getIndexes()[5].fields);
+      assertEqual("hash", c.indexes()[5].type);
+      assertFalse(c.indexes()[5].unique);
+      assertTrue(c.indexes()[5].sparse);
+      assertEqual(["a_hs1", "a_hs2"], c.indexes()[5].fields);
 
-      assertEqual("skiplist", c.getIndexes()[6].type);
-      assertFalse(c.getIndexes()[6].unique);
-      assertTrue(c.getIndexes()[6].sparse);
-      assertEqual(["a_ss1", "a_ss2"], c.getIndexes()[6].fields);
+      assertEqual("skiplist", c.indexes()[6].type);
+      assertFalse(c.indexes()[6].unique);
+      assertTrue(c.indexes()[6].sparse);
+      assertEqual(["a_ss1", "a_ss2"], c.indexes()[6].fields);
 
-      assertFalse(c.getIndexes()[7].unique);
-      assertEqual("fulltext", c.getIndexes()[7].type);
-      assertEqual(["a_f"], c.getIndexes()[7].fields);
+      assertFalse(c.indexes()[7].unique);
+      assertEqual("fulltext", c.indexes()[7].type);
+      assertEqual(["a_f"], c.indexes()[7].fields);
 
-      assertEqual("geo", c.getIndexes()[8].type);
-      assertEqual(["a_la", "a_lo"], c.getIndexes()[8].fields);
-      assertFalse(c.getIndexes()[8].unique);
+      assertEqual("geo", c.indexes()[8].type);
+      assertEqual(["a_la", "a_lo"], c.indexes()[8].fields);
+      assertFalse(c.indexes()[8].unique);
 
       assertEqual(0, c.count());
       c.ensureIndex({type: "hash", fields: ["abc"]});
@@ -256,8 +256,8 @@ function dumpTestSuite() {
       assertEqual(2, c.type()); // document
       assertFalse(p.waitForSync);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(0, c.count());
     },
 
@@ -276,8 +276,8 @@ function dumpTestSuite() {
       assertEqual(7, p.keyOptions.offset);
       assertEqual(42, p.keyOptions.increment);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(1001, c.count());
 
       for (let i = 0; i < 1000; ++i) {
@@ -306,8 +306,8 @@ function dumpTestSuite() {
       assertEqual("padded", p.keyOptions.type);
       assertFalse(p.keyOptions.allowUserKeys);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(1001, c.count());
 
       let allDocs = {};
@@ -340,8 +340,8 @@ function dumpTestSuite() {
       assertEqual("uuid", p.keyOptions.type);
       assertFalse(p.keyOptions.allowUserKeys);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(1001, c.count());
 
       let allDocs = {};
@@ -368,8 +368,8 @@ function dumpTestSuite() {
       assertEqual(2, c.type()); // document
       assertFalse(p.waitForSync);
 
-      assertEqual(1, c.getIndexes().length); // just primary index
-      assertEqual("primary", c.getIndexes()[0].type);
+      assertEqual(1, c.indexes().length); // just primary index
+      assertEqual("primary", c.indexes()[0].type);
       assertEqual(8, c.count());
 
       var texts = [
@@ -467,9 +467,9 @@ function dumpTestSuite() {
       var c = db._collection("UnitTestsDumpPersistent");
       var p = c.properties();
 
-      assertEqual(2, c.getIndexes().length);
-      assertEqual("primary", c.getIndexes()[0].type);
-      assertEqual("persistent", c.getIndexes()[1].type);
+      assertEqual(2, c.indexes().length);
+      assertEqual("primary", c.indexes()[0].type);
+      assertEqual("persistent", c.indexes()[1].type);
       assertEqual(10000, c.count());
 
       var res = db._query("FOR doc IN " + c.name() + " FILTER doc.value >= 0 RETURN doc").toArray();

--- a/tests/js/client/dump/dump-test.inc
+++ b/tests/js/client/dump/dump-test.inc
@@ -360,7 +360,7 @@
         assertEqual(2, c.type()); // document
         assertTrue(p.waitForSync);
 
-        const indexes = c.getIndexes();
+        const indexes = c.indexes();
 
         assertEqual(args.emptyIndexes, indexes.length, `Found indexes: ${JSON.stringify(indexes)}`); // just primary index
         assertEqual("primary", indexes[0].type);
@@ -378,8 +378,8 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(args.manyIndexes, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(args.manyIndexes, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(100000, c.count());
 
         // test all documents
@@ -414,12 +414,12 @@
         assertEqual(3, c.type()); // edges
         assertFalse(p.waitForSync);
 
-        assertEqual(args.edgesIndexCount, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // primary index + edges index
-        assertEqual("primary", c.getIndexes()[0].type);
-        assertEqual("edge", c.getIndexes()[1].type);
+        assertEqual(args.edgesIndexCount, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // primary index + edges index
+        assertEqual("primary", c.indexes()[0].type);
+        assertEqual("edge", c.indexes()[1].type);
         if (args.edgesIndexCount > 2) {
           // Backup and restore:
-          assertEqual("hash", c.getIndexes()[2].type);
+          assertEqual("hash", c.indexes()[2].type);
         }
         assertEqual(10, c.count());
 
@@ -446,8 +446,8 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(3, c.count());
       },
 
@@ -462,8 +462,8 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(args.removedSingleIndices, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(args.removedSingleIndices, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(args.removedCount, c.count());
 
         for (let i = 0; i < 10000; ++i) {
@@ -491,8 +491,8 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(10000, c.count());
 
         for (let i = 0; i < 10000; ++i) {
@@ -512,51 +512,51 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(args.indexesCount, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`);
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(args.indexesCount, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`);
+        assertEqual("primary", c.indexes()[0].type);
 
-        assertEqual("hash", c.getIndexes()[1].type);
-        assertTrue(c.getIndexes()[1].unique);
-        assertFalse(c.getIndexes()[1].sparse);
-        assertEqual(["a_uc"], c.getIndexes()[1].fields);
+        assertEqual("hash", c.indexes()[1].type);
+        assertTrue(c.indexes()[1].unique);
+        assertFalse(c.indexes()[1].sparse);
+        assertEqual(["a_uc"], c.indexes()[1].fields);
 
-        assertEqual("skiplist", c.getIndexes()[2].type);
-        assertFalse(c.getIndexes()[2].unique);
-        assertFalse(c.getIndexes()[2].sparse);
-        assertEqual(["a_s1", "a_s2"], c.getIndexes()[2].fields);
+        assertEqual("skiplist", c.indexes()[2].type);
+        assertFalse(c.indexes()[2].unique);
+        assertFalse(c.indexes()[2].sparse);
+        assertEqual(["a_s1", "a_s2"], c.indexes()[2].fields);
 
-        assertEqual("hash", c.getIndexes()[3].type);
-        assertFalse(c.getIndexes()[3].unique);
-        assertFalse(c.getIndexes()[3].sparse);
-        assertEqual(["a_h1", "a_h2"], c.getIndexes()[3].fields);
+        assertEqual("hash", c.indexes()[3].type);
+        assertFalse(c.indexes()[3].unique);
+        assertFalse(c.indexes()[3].sparse);
+        assertEqual(["a_h1", "a_h2"], c.indexes()[3].fields);
 
-        assertEqual("skiplist", c.getIndexes()[4].type);
-        assertTrue(c.getIndexes()[4].unique);
-        assertFalse(c.getIndexes()[4].sparse);
-        assertEqual(["a_su"], c.getIndexes()[4].fields);
+        assertEqual("skiplist", c.indexes()[4].type);
+        assertTrue(c.indexes()[4].unique);
+        assertFalse(c.indexes()[4].sparse);
+        assertEqual(["a_su"], c.indexes()[4].fields);
 
-        assertEqual("hash", c.getIndexes()[5].type);
-        assertFalse(c.getIndexes()[5].unique);
-        assertTrue(c.getIndexes()[5].sparse);
-        assertEqual(["a_hs1", "a_hs2"], c.getIndexes()[5].fields);
+        assertEqual("hash", c.indexes()[5].type);
+        assertFalse(c.indexes()[5].unique);
+        assertTrue(c.indexes()[5].sparse);
+        assertEqual(["a_hs1", "a_hs2"], c.indexes()[5].fields);
 
-        assertEqual("skiplist", c.getIndexes()[6].type);
-        assertFalse(c.getIndexes()[6].unique);
-        assertTrue(c.getIndexes()[6].sparse);
-        assertEqual(["a_ss1", "a_ss2"], c.getIndexes()[6].fields);
+        assertEqual("skiplist", c.indexes()[6].type);
+        assertFalse(c.indexes()[6].unique);
+        assertTrue(c.indexes()[6].sparse);
+        assertEqual(["a_ss1", "a_ss2"], c.indexes()[6].fields);
 
-        assertFalse(c.getIndexes()[7].unique);
-        assertEqual("fulltext", c.getIndexes()[7].type);
-        assertEqual(["a_f"], c.getIndexes()[7].fields);
+        assertFalse(c.indexes()[7].unique);
+        assertEqual("fulltext", c.indexes()[7].type);
+        assertEqual(["a_f"], c.indexes()[7].fields);
 
-        assertEqual("geo", c.getIndexes()[8].type);
-        assertEqual(["a_la", "a_lo"], c.getIndexes()[8].fields);
-        assertFalse(c.getIndexes()[8].unique);
+        assertEqual("geo", c.indexes()[8].type);
+        assertEqual(["a_la", "a_lo"], c.indexes()[8].fields);
+        assertFalse(c.indexes()[8].unique);
 
         if (args.indexesCount > 9) {
-          assertEqual("hash", c.getIndexes()[9].type);
-          assertEqual(["abc"], c.getIndexes()[9].fields);
-          assertFalse(c.getIndexes()[9].unique);
+          assertEqual("hash", c.indexes()[9].type);
+          assertEqual(["abc"], c.indexes()[9].fields);
+          assertFalse(c.indexes()[9].unique);
         }
         assertEqual(0, c.count());
       },
@@ -572,8 +572,8 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(0, c.count());
       },
 
@@ -589,8 +589,8 @@
         assertFalse(p.waitForSync);
         assertEqual(getNoShards(9), p.numberOfShards);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(1000, c.count());
 
         for (let i = 0; i < 1000; ++i) {
@@ -642,8 +642,8 @@
         assertEqual(7, p.keyOptions.offset);
         assertEqual(42, p.keyOptions.increment);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(args.autoIncDocCount, c.count());
 
         for (var i = 0; i < 1000; ++i) {
@@ -683,8 +683,8 @@
         assertFalse(p.waitForSync);
         assertEqual("padded", p.keyOptions.type);
         assertFalse(p.keyOptions.allowUserKeys);
-        assertEqual(1,  c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1,  c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(args.paddedDocCount, c.count());
 
         let allDocs = {};
@@ -734,8 +734,8 @@
         assertEqual("uuid", p.keyOptions.type);
         assertFalse(p.keyOptions.allowUserKeys);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(args.uuidDocCount, c.count());
 
         let allDocs = {};
@@ -766,8 +766,8 @@
         assertEqual(2, c.type()); // document
         assertFalse(p.waitForSync);
 
-        assertEqual(1, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`); // just primary index
-        assertEqual("primary", c.getIndexes()[0].type);
+        assertEqual(1, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`); // just primary index
+        assertEqual("primary", c.indexes()[0].type);
         assertEqual(8, c.count());
 
         var texts = [
@@ -849,9 +849,9 @@
         var c = getCollection("UnitTestsDumpPersistent");
         var p = c.properties();
 
-        assertEqual(2, c.getIndexes().length, `We found following indexes: ${JSON.stringify(c.getIndexes())}`);
-        assertEqual("primary", c.getIndexes()[0].type);
-        assertEqual("persistent", c.getIndexes()[1].type);
+        assertEqual(2, c.indexes().length, `We found following indexes: ${JSON.stringify(c.indexes())}`);
+        assertEqual("primary", c.indexes()[0].type);
+        assertEqual("persistent", c.indexes()[1].type);
         assertEqual(10000, c.count());
 
         var res = db._query("FOR doc IN " + c.name() + " FILTER doc.value >= 0 RETURN doc").toArray();
@@ -962,7 +962,7 @@
         let figures;
         for (let i = 0; i < 100; ++i) {
           require("internal").sleep(0.5);
-          figures = collection.getIndexes(true, true)
+          figures = collection.indexes(true, true)
             .find(e => e.name === "searchIndex")
             .figures;
           if (figures.numDocs > 5000) {

--- a/tests/js/client/recovery/create-collections.js
+++ b/tests/js/client/recovery/create-collections.js
@@ -99,7 +99,7 @@ function recoverySuite () {
       assertTrue(prop.waitForSync);
       assertEqual(2, c.type());
       assertFalse(prop.isSystem);
-      idx = c.getIndexes();
+      idx = c.indexes();
       assertEqual(3, idx.length);
 
       c = db._collection('UnitTestsRecovery2');
@@ -108,7 +108,7 @@ function recoverySuite () {
       assertFalse(prop.waitForSync);
       assertEqual(2, c.type());
       assertFalse(prop.isSystem);
-      idx = c.getIndexes();
+      idx = c.indexes();
       assertEqual(2, idx.length);
       assertEqual('skiplist', idx[1].type);
       assertFalse(idx[1].unique);
@@ -120,7 +120,7 @@ function recoverySuite () {
       assertFalse(prop.waitForSync);
       assertEqual(3, c.type());
       assertFalse(prop.isSystem);
-      idx = c.getIndexes();
+      idx = c.indexes();
       assertEqual(3, idx.length);
       assertEqual('edge', idx[1].type);
       assertEqual('skiplist', idx[2].type);
@@ -131,7 +131,7 @@ function recoverySuite () {
       prop = c.properties();
       assertEqual(2, c.type());
       assertTrue(prop.isSystem);
-      idx = c.getIndexes();
+      idx = c.indexes();
       assertEqual(2, idx.length);
       assertEqual('hash', idx[1].type);
       assertTrue(idx[1].unique);

--- a/tests/js/client/recovery/create-indexes.js
+++ b/tests/js/client/recovery/create-indexes.js
@@ -74,7 +74,7 @@ function recoverySuite () {
       for (i = 0; i < 5; ++i) {
         c = db._collection('UnitTestsRecovery' + i);
         assertEqual(100, c.count());
-        idx = c.getIndexes();
+        idx = c.indexes();
         assertEqual(3, idx.length);
 
         for (j = 1; j < 3; ++j) {

--- a/tests/js/client/recovery/drop-index-shutdown-exitzero.js
+++ b/tests/js/client/recovery/drop-index-shutdown-exitzero.js
@@ -56,7 +56,7 @@ function recoverySuite () {
 
     testDropIndexShutdown: function () {
       var c = db._collection('UnitTestsRecovery');
-      var idx = c.getIndexes();
+      var idx = c.indexes();
       assertEqual(1, idx.length);
       assertEqual('primary', idx[0].type);
     }

--- a/tests/js/client/recovery/drop-index.js
+++ b/tests/js/client/recovery/drop-index.js
@@ -59,7 +59,7 @@ function recoverySuite () {
 
     testDropIndex: function () {
       var c = db._collection('UnitTestsRecovery');
-      var idx = c.getIndexes();
+      var idx = c.indexes();
       assertEqual(1, idx.length);
       assertEqual('primary', idx[0].type);
     }

--- a/tests/js/client/recovery/drop-indexes.js
+++ b/tests/js/client/recovery/drop-indexes.js
@@ -45,7 +45,7 @@ if (runSetup === true) {
   let c;
   for (let i = 0; i < 4; ++i) {
     c = db._collection('UnitTestsRecovery' + i);
-    let idx = c.getIndexes();
+    let idx = c.indexes();
     for (let j = 1; j < idx.length; ++j) {
       c.dropIndex(idx[j].id);
     }
@@ -76,13 +76,13 @@ function recoverySuite () {
 
       for (i = 0; i < 4; ++i) {
         c = db._collection('UnitTestsRecovery' + i);
-        idx = c.getIndexes();
+        idx = c.indexes();
         assertEqual(1, idx.length);
         assertEqual('primary', idx[0].type);
       }
 
       c = db._collection('UnitTestsRecovery4');
-      idx = c.getIndexes();
+      idx = c.indexes();
       assertEqual(3, idx.length);
     }
 

--- a/tests/js/client/recovery/indexes-after-flush.js
+++ b/tests/js/client/recovery/indexes-after-flush.js
@@ -61,17 +61,17 @@ function recoverySuite () {
     testIndexesAfterFlush: function () {
       var c = db._collection('UnitTestsRecovery'), idx;
 
-      assertEqual(3, c.getIndexes().length);
-      idx = c.getIndexes()[0];
+      assertEqual(3, c.indexes().length);
+      idx = c.indexes()[0];
       assertEqual('primary', idx.type);
 
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value1' ], idx.fields);
       assertEqual('skiplist', idx.type);
       
-      idx = c.getIndexes()[2];
+      idx = c.indexes()[2];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value2' ], idx.fields);

--- a/tests/js/client/recovery/indexes-geo.js
+++ b/tests/js/client/recovery/indexes-geo.js
@@ -95,7 +95,7 @@ function recoverySuite () {
     testIndexesGeo: function () {
       var c = db._collection('UnitTestsRecovery1'), idx, i;
       var geo1 = null, geo2 = null;
-      idx = c.getIndexes();
+      idx = c.indexes();
 
       for (i = 1; i < idx.length; ++i) {
         if (idx[i].type === 'geo1' || (idx[i].type === 'geo' && idx[i].fields.length === 1)) {
@@ -119,7 +119,7 @@ function recoverySuite () {
       assertEqual(100, new simple.SimpleQueryNear(c, 0, 0, geo2.id).limit(100).toArray().length);
 
       c = db._collection('UnitTestsRecovery2');
-      geo1 = c.getIndexes()[1];
+      geo1 = c.indexes()[1];
       assertFalse(geo1.unique);
       assertTrue(geo1.sparse);
       assertTrue(geo1.geoJson);
@@ -128,7 +128,7 @@ function recoverySuite () {
       assertEqual(100, new simple.SimpleQueryNear(c, 0, 0, geo1.id).limit(100).toArray().length);
 
       c = db._collection('UnitTestsRecovery3');
-      geo1 = c.getIndexes()[1];
+      geo1 = c.indexes()[1];
       assertFalse(geo1.unique);
       assertTrue(geo1.sparse);
       assertFalse(geo1.geoJson);

--- a/tests/js/client/recovery/indexes-hash.js
+++ b/tests/js/client/recovery/indexes-hash.js
@@ -96,7 +96,7 @@ function recoverySuite () {
 
     testSingleAttributeHashIndexInfo: function() {
       let c = db._collection(colName1);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value' ], idx.fields);
@@ -115,13 +115,13 @@ function recoverySuite () {
 
     testSingleAttributeHashIndexEstimate: function () {
       let c = db._collection(colName1);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertEqual(est1, idx.selectivityEstimate);
     },
 
     testNestedAttributeHashIndexInfo: function() {
       let c = db._collection(colName2);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertTrue(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a.value' ], idx.fields);
@@ -140,13 +140,13 @@ function recoverySuite () {
 
     testNestedAttributeHashIndexEstimate: function () {
       let c = db._collection(colName2);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertEqual(est2, idx.selectivityEstimate);
     },
 
     testManyAttributesHashIndexInfo: function() {
       let c = db._collection(colName3);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a', 'b' ], idx.fields);
@@ -166,7 +166,7 @@ function recoverySuite () {
 
     testManyAttributesHashIndexEstimate: function () {
       let c = db._collection(colName3);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertEqual(est3, idx.selectivityEstimate);
     },
 

--- a/tests/js/client/recovery/indexes-persistent-nosync.js
+++ b/tests/js/client/recovery/indexes-persistent-nosync.js
@@ -70,7 +70,7 @@ function recoverySuite () {
 
     testIndexesRocksDBNoSync: function () {
       const c = db._collection('UnitTestsRecovery');
-      const idxs = c.getIndexes();
+      const idxs = c.indexes();
       assertEqual(idxs.length, 2);
       let idx = idxs[1];
       assertFalse(idx.unique);

--- a/tests/js/client/recovery/indexes-persistent-restore.js
+++ b/tests/js/client/recovery/indexes-persistent-restore.js
@@ -65,7 +65,7 @@ function recoverySuite () {
 
     testIndexesRocksDBRestore: function () {
       var c = db._collection('UnitTestsRecovery1'), idx, i;
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value' ], idx.fields);

--- a/tests/js/client/recovery/indexes-persistent.js
+++ b/tests/js/client/recovery/indexes-persistent.js
@@ -81,7 +81,7 @@ function recoverySuite () {
 
     testIndexesRocksDB: function () {
       var c = db._collection('UnitTestsRecovery1'), idx, i;
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value' ], idx.fields);
@@ -90,7 +90,7 @@ function recoverySuite () {
       }
 
       c = db._collection('UnitTestsRecovery2');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertTrue(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a.value' ], idx.fields);
@@ -99,7 +99,7 @@ function recoverySuite () {
       }
 
       c = db._collection('UnitTestsRecovery3');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a', 'b' ], idx.fields);

--- a/tests/js/client/recovery/indexes-skiplist.js
+++ b/tests/js/client/recovery/indexes-skiplist.js
@@ -88,7 +88,7 @@ function recoverySuite () {
 
     testIndexesSkiplist: function () {
       var c = db._collection('UnitTestsRecovery1'), idx, i;
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value' ], idx.fields);
@@ -98,7 +98,7 @@ function recoverySuite () {
       assertEqual(1, db._query("FOR doc IN UnitTestsRecovery1 FILTER doc.value == 1 RETURN doc").toArray().length);
 
       c = db._collection('UnitTestsRecovery2');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertTrue(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a.value' ], idx.fields);
@@ -108,7 +108,7 @@ function recoverySuite () {
       assertEqual(1, db._query("FOR doc IN UnitTestsRecovery2 FILTER doc.a.value == 1 RETURN doc").toArray().length);
 
       c = db._collection('UnitTestsRecovery3');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a', 'b' ], idx.fields);

--- a/tests/js/client/recovery/indexes-sparse-hash.js
+++ b/tests/js/client/recovery/indexes-sparse-hash.js
@@ -88,7 +88,7 @@ function recoverySuite () {
 
     testIndexesSparseHash: function () {
       var c = db._collection('UnitTestsRecovery1'), idx, i;
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertTrue(idx.sparse);
       assertEqual([ 'value' ], idx.fields);
@@ -97,7 +97,7 @@ function recoverySuite () {
       }
 
       c = db._collection('UnitTestsRecovery2');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertTrue(idx.unique);
       assertTrue(idx.sparse);
       assertEqual([ 'a.value' ], idx.fields);
@@ -106,7 +106,7 @@ function recoverySuite () {
       }
 
       c = db._collection('UnitTestsRecovery3');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertTrue(idx.sparse);
       assertEqual([ 'a', 'b' ], idx.fields);

--- a/tests/js/client/recovery/indexes-sparse-skiplist.js
+++ b/tests/js/client/recovery/indexes-sparse-skiplist.js
@@ -88,7 +88,7 @@ function recoverySuite () {
 
     testIndexesSparseSkiplist: function () {
       var c = db._collection('UnitTestsRecovery1'), idx, i;
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertTrue(idx.sparse);
       assertEqual([ 'value' ], idx.fields);
@@ -97,7 +97,7 @@ function recoverySuite () {
       }
 
       c = db._collection('UnitTestsRecovery2');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertTrue(idx.unique);
       assertTrue(idx.sparse);
       assertEqual([ 'a.value' ], idx.fields);
@@ -106,7 +106,7 @@ function recoverySuite () {
       }
 
       c = db._collection('UnitTestsRecovery3');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertTrue(idx.sparse);
       assertEqual([ 'a', 'b' ], idx.fields);

--- a/tests/js/client/recovery/indexes-ttl.js
+++ b/tests/js/client/recovery/indexes-ttl.js
@@ -54,7 +54,7 @@ function recoverySuite () {
   return {
     testIndexesTtl: function () {
       let c = db._collection('UnitTestsRecovery1');
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
 
       assertEqual("ttl", idx.type);
       assertEqual(["value"], idx.fields);
@@ -62,7 +62,7 @@ function recoverySuite () {
       assertFalse(idx.estimates);
       
       c = db._collection('UnitTestsRecovery2');
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
 
       assertEqual("ttl", idx.type);
       assertEqual(["value"], idx.fields);

--- a/tests/js/client/recovery/indexes.js
+++ b/tests/js/client/recovery/indexes.js
@@ -66,7 +66,7 @@ function recoverySuite () {
     testIndexes: function () {
       var docs;
       var c = db._collection('UnitTestsRecovery'), i;
-      var idx = c.getIndexes().sort(function (l, r) {
+      var idx = c.indexes().sort(function (l, r) {
         if (l.id.length !== r.id.length) {
           return l.id.length - r.id.length < 0 ? -1 : 1;
         }

--- a/tests/js/client/recovery/nosync-indexes-hash.js
+++ b/tests/js/client/recovery/nosync-indexes-hash.js
@@ -98,7 +98,7 @@ function recoverySuite () {
     testNoSyncSingleAttributeHashIndexInfo: function() {
       let c = db._collection(colName1);
       assertEqual(c.count(), 1000);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value' ], idx.fields);
@@ -117,14 +117,14 @@ function recoverySuite () {
 
     testNoSyncSingleAttributeHashIndexEstimate: function () {
       let c = db._collection(colName1);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertEqual(est1, idx.selectivityEstimate);
     },
 
     testNoSyncNestedAttributeHashIndexInfo: function() {
       let c = db._collection(colName2);
       assertEqual(c.count(), 1000);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertTrue(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a.value' ], idx.fields);
@@ -143,13 +143,13 @@ function recoverySuite () {
 
     testNoSyncNestedAttributeHashIndexEstimate: function () {
       let c = db._collection(colName2);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertEqual(est2, idx.selectivityEstimate);
     },
 
     testNoSyncManyAttributesHashIndexInfo: function() {
       let c = db._collection(colName3);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'a', 'b' ], idx.fields);
@@ -170,7 +170,7 @@ function recoverySuite () {
     testNoSyncManyAttributesHashIndexEstimate: function () {
       let c = db._collection(colName3);
       assertEqual(c.count(), 1000);
-      let idx = c.getIndexes()[1];
+      let idx = c.indexes()[1];
       assertEqual(est3, idx.selectivityEstimate);
     },
 

--- a/tests/js/client/recovery/search/view-search-alias-index-create-no-flushthread.js
+++ b/tests/js/client/recovery/search/view-search-alias-index-create-no-flushthread.js
@@ -72,7 +72,7 @@ function recoverySuite () {
 
       let checkIndex = function(indexName, analyzer, includeAllFields) {
         let c = db._collection("UnitTestsRecoveryDummy");
-        let indexes = c.getIndexes().filter(i => i.type === "inverted" && i.name === indexName);
+        let indexes = c.indexes().filter(i => i.type === "inverted" && i.name === indexName);
         assertEqual(1, indexes.length);
 
         let i = indexes[0];

--- a/tests/js/client/recovery/search/view-search-alias-index-create.js
+++ b/tests/js/client/recovery/search/view-search-alias-index-create.js
@@ -68,7 +68,7 @@ function recoverySuite () {
 
       let checkIndex = function(indexName, analyzer, includeAllFields) {
         let c = db._collection("UnitTestsRecoveryDummy");
-        let indexes = c.getIndexes().filter(i => i.type === "inverted" && i.name === indexName);
+        let indexes = c.indexes().filter(i => i.type === "inverted" && i.name === indexName);
         assertEqual(1, indexes.length);
 
         let i = indexes[0];

--- a/tests/js/client/recovery/search/view-search-alias-populate-cluster.js
+++ b/tests/js/client/recovery/search/view-search-alias-populate-cluster.js
@@ -104,7 +104,7 @@ function recoverySuite() {
 
       let checkIndex = function (indexName, analyzer, includeAllFields, hasFields) {
         let c = db._collection("UnitTestsRecoveryDummy");
-        let indexes = c.getIndexes().filter(i => i.type === "inverted" && i.name === indexName);
+        let indexes = c.indexes().filter(i => i.type === "inverted" && i.name === indexName);
         assertEqual(1, indexes.length);
 
         let i = indexes[0];
@@ -147,7 +147,7 @@ function recoverySuite() {
       }
       let figures;
       for (let i = 0; i < 100; ++i) {
-        figures = db._collection('UnitTestsRecoveryDummy').getIndexes(true, true)
+        figures = db._collection('UnitTestsRecoveryDummy').indexes(true, true)
           .find(e => e.name === "i1")
           .figures;
         if (figures.numDocs > 500) {

--- a/tests/js/client/recovery/search/view-search-alias-populate-drop-view-no-flushthread.js
+++ b/tests/js/client/recovery/search/view-search-alias-populate-drop-view-no-flushthread.js
@@ -65,7 +65,7 @@ function recoverySuite () {
 
       let checkIndex = function(indexName) {
         let c = db._collection("UnitTestsRecoveryDummy");
-        let indexes = c.getIndexes().filter(i => i.type === "inverted" && i.name === indexName);
+        let indexes = c.indexes().filter(i => i.type === "inverted" && i.name === indexName);
         assertEqual(0, indexes.length);
       };
       checkIndex("i1");

--- a/tests/js/client/recovery/search/view-search-alias-populate-transaction-abort.js
+++ b/tests/js/client/recovery/search/view-search-alias-populate-transaction-abort.js
@@ -85,7 +85,7 @@ function recoverySuite () {
 
       let checkIndex = function(indexName, analyzer, includeAllFields, hasFields) {
         let c = db._collection("UnitTestsRecoveryDummy");
-        let indexes = c.getIndexes().filter(i => i.type === "inverted" && i.name === indexName);
+        let indexes = c.indexes().filter(i => i.type === "inverted" && i.name === indexName);
         assertEqual(1, indexes.length);
 
         let i = indexes[0];

--- a/tests/js/client/recovery/search/view-search-alias-populate.js
+++ b/tests/js/client/recovery/search/view-search-alias-populate.js
@@ -91,7 +91,7 @@ function recoverySuite () {
 
       let checkIndex = function(indexName, analyzer, includeAllFields, hasFields) {
         let c = db._collection("UnitTestsRecoveryDummy");
-        let indexes = c.getIndexes().filter(i => i.type === "inverted" && i.name === indexName);
+        let indexes = c.indexes().filter(i => i.type === "inverted" && i.name === indexName);
         assertEqual(1, indexes.length);
 
         let i = indexes[0];

--- a/tests/js/client/replication/fuzz/replication-fuzz-global.js
+++ b/tests/js/client/replication/fuzz/replication-fuzz-global.js
@@ -439,7 +439,7 @@ function ReplicationSuite() {
 
           let dropIndex = function () {
             let collection = pickCollection();
-            let indexes = collection.getIndexes();
+            let indexes = collection.indexes();
             if (indexes.length > 1) {
               collection.dropIndex(indexes[1]);
             }

--- a/tests/js/client/replication/fuzz/replication-fuzz.js
+++ b/tests/js/client/replication/fuzz/replication-fuzz.js
@@ -458,7 +458,7 @@ function ReplicationSuite() {
 
           let dropIndex = function () {
             let collection = pickCollection();
-            let indexes = collection.getIndexes();
+            let indexes = collection.indexes();
             if (indexes.length > 1) {
               emit("dropIndex " + db._name() + " " + collection.name());
               collection.dropIndex(indexes[1]);

--- a/tests/js/client/replication/ongoing/global/replication-ongoing-global.js
+++ b/tests/js/client/replication/ongoing/global/replication-ongoing-global.js
@@ -314,7 +314,7 @@ function BaseTestConfig () {
         function (state) {
           let col = db._collection(cn);
           assertNotNull(col, 'collection does not exist');
-          let idx = col.getIndexes();
+          let idx = col.indexes();
           assertEqual(2, idx.length);
           assertEqual('primary', idx[0].type);
           assertEqual('persistent', idx[1].type);
@@ -347,7 +347,7 @@ function BaseTestConfig () {
         },
 
         function (state) {
-          let idx = db._collection(cn).getIndexes();
+          let idx = db._collection(cn).indexes();
           assertEqual(1, idx.length);
           assertEqual('primary', idx[0].type);
         }

--- a/tests/js/client/replication/ongoing/global/spec/replication-ongoing-global-spec.js
+++ b/tests/js/client/replication/ongoing/global/spec/replication-ongoing-global-spec.js
@@ -242,7 +242,7 @@ describe('Global Replication on a fresh boot', function () {
       // First Part Create Collection
       let mcol = db._create(docColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       // Validate it is created properly
       waitForReplication();
@@ -252,7 +252,7 @@ describe('Global Replication on a fresh boot', function () {
       let scol = db._collection(docColName);
       expect(scol.type()).to.equal(2);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
 
       connectToLeader();
       // Second Part Drop it again
@@ -270,7 +270,7 @@ describe('Global Replication on a fresh boot', function () {
       // First Part Create Collection
       let mcol = db._createEdgeCollection(edgeColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       connectToFollower();
       // Validate it is created properly
@@ -279,7 +279,7 @@ describe('Global Replication on a fresh boot', function () {
       let scol = db._collection(edgeColName);
       expect(scol.type()).to.equal(3);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
 
       connectToLeader();
       // Second Part Drop it again
@@ -428,17 +428,17 @@ describe('Global Replication on a fresh boot', function () {
       it("should replicate index creation", function () {
         connectToLeader();
 
-        let oIdx = db._collection(docColName).getIndexes();
+        let oIdx = db._collection(docColName).indexes();
 
         db._collection(docColName).ensureIndex({ type: "hash", fields: ["value"] });
 
-        let mIdx = db._collection(docColName).getIndexes();
+        let mIdx = db._collection(docColName).indexes();
 
         waitForReplication();
         connectToFollower();
 
         internal.sleep(5); // makes test more reliable
-        let sIdx = db._collection(docColName).getIndexes();
+        let sIdx = db._collection(docColName).indexes();
         compareIndexes(sIdx, mIdx, true);
         compareIndexes(sIdx, oIdx, false);
       });
@@ -447,7 +447,7 @@ describe('Global Replication on a fresh boot', function () {
         connectToLeader();
 
         let c = db._collection(docColName);
-        let oIdx = c.getIndexes();
+        let oIdx = c.indexes();
 
         c.truncate({ compact: false });
         let docs = [];
@@ -460,13 +460,13 @@ describe('Global Replication on a fresh boot', function () {
         }
 
         c.ensureIndex({ type: "hash", fields: ["value2"] });
-        let mIdx = c.getIndexes();
+        let mIdx = c.indexes();
 
         waitForReplication();
         connectToFollower();
 
         internal.sleep(5); // makes test more reliable
-        let sIdx = db._collection(docColName).getIndexes();
+        let sIdx = db._collection(docColName).indexes();
         expect(db._collection(docColName).count()).to.eq(10000);
 
         compareIndexes(sIdx, mIdx, true);
@@ -511,7 +511,7 @@ describe('Global Replication on a fresh boot', function () {
       // First Part Create Collection
       let mcol = db._create(docColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
       testCollectionExists(docColName); 
 
       connectToFollower();
@@ -522,7 +522,7 @@ describe('Global Replication on a fresh boot', function () {
       let scol = db._collection(docColName);
       expect(scol.type()).to.equal(2);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
 
       connectToLeader();
       db._useDatabase(dbName);
@@ -543,7 +543,7 @@ describe('Global Replication on a fresh boot', function () {
       // First Part Create Collection
       let mcol = db._createEdgeCollection(edgeColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       connectToFollower();
       // Validate it is created properly
@@ -553,7 +553,7 @@ describe('Global Replication on a fresh boot', function () {
       let scol = db._collection(edgeColName);
       expect(scol.type()).to.equal(3);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
 
       connectToLeader();
       db._useDatabase(dbName);
@@ -689,18 +689,18 @@ describe('Global Replication on a fresh boot', function () {
       it("should replicate index creation", function () {
         connectToLeader();
         db._useDatabase(dbName);
-        let oIdx = db._collection(docColName).getIndexes();
+        let oIdx = db._collection(docColName).indexes();
 
         db._collection(docColName).ensureIndex({ type: "hash", fields: ["value"] });
 
-        let mIdx = db._collection(docColName).getIndexes();
+        let mIdx = db._collection(docColName).indexes();
 
         waitForReplication();
         connectToFollower();
         db._useDatabase(dbName);
 
         internal.sleep(5); // makes test more reliable
-        let sIdx = db._collection(docColName).getIndexes();
+        let sIdx = db._collection(docColName).indexes();
         
         compareIndexes(sIdx, mIdx, true);
         compareIndexes(sIdx, oIdx, false);
@@ -711,7 +711,7 @@ describe('Global Replication on a fresh boot', function () {
         db._useDatabase(dbName);
 
         let c = db._collection(docColName);
-        let oIdx = c.getIndexes();
+        let oIdx = c.indexes();
 
         c.truncate();
         let docs = [];
@@ -724,14 +724,14 @@ describe('Global Replication on a fresh boot', function () {
         }
 
         c.ensureIndex({ type: "hash", fields: ["value2"] });
-        let mIdx = c.getIndexes();
+        let mIdx = c.indexes();
 
         waitForReplication();
         connectToFollower();
         db._useDatabase(dbName);
 
         internal.sleep(5); // makes test more reliable
-        let sIdx = db._collection(docColName).getIndexes();
+        let sIdx = db._collection(docColName).indexes();
         expect(db._collection(docColName).count()).to.eq(10000);
 
         compareIndexes(sIdx, mIdx, true);
@@ -801,14 +801,14 @@ describe('Setup global replication on empty follower and leader has some data', 
       // First Part Create Collection
       let mcol = db._collection(docColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       connectToFollower();
       testCollectionExists(docColName);
       let scol = db._collection(docColName);
       expect(scol.type()).to.equal(2);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
     });
 
     it("should have synced the edge collection", function () {
@@ -816,7 +816,7 @@ describe('Setup global replication on empty follower and leader has some data', 
       // First Part Create Collection
       let mcol = db._collection(edgeColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       connectToFollower();
 
@@ -825,7 +825,7 @@ describe('Setup global replication on empty follower and leader has some data', 
       let scol = db._collection(edgeColName);
       expect(scol.type()).to.equal(3);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
     });
 
     it("should have synced the database", function () {
@@ -852,7 +852,7 @@ describe('Setup global replication on empty follower and leader has some data', 
       // First Part Create Collection
       let mcol = db._collection(docColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       connectToFollower();
       db._useDatabase(dbName);
@@ -860,7 +860,7 @@ describe('Setup global replication on empty follower and leader has some data', 
       let scol = db._collection(docColName);
       expect(scol.type()).to.equal(2);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
     });
 
     it("should have synced the edge collection", function () {
@@ -870,7 +870,7 @@ describe('Setup global replication on empty follower and leader has some data', 
       // First Part Create Collection
       let mcol = db._collection(edgeColName);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       connectToFollower();
       db._useDatabase(dbName);
@@ -880,7 +880,7 @@ describe('Setup global replication on empty follower and leader has some data', 
       let scol = db._collection(edgeColName);
       expect(scol.type()).to.equal(3);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
     });
 
     describe("content of an existing collection", function () {
@@ -947,7 +947,7 @@ describe('Test switch off and restart replication', function() {
 
       let mcol = db._create(col);
       let mProps = mcol.properties();
-      let mIdxs = mcol.getIndexes();
+      let mIdxs = mcol.indexes();
 
       startReplication();
 
@@ -956,7 +956,7 @@ describe('Test switch off and restart replication', function() {
       let scol = db._collection(col);
       expect(scol.type()).to.equal(2);
       expect(scol.properties()).to.deep.equal(mProps);
-      compareIndexes(scol.getIndexes(), mIdxs, true);
+      compareIndexes(scol.indexes(), mIdxs, true);
 
       // Second part. Delete collection
 
@@ -984,16 +984,16 @@ describe('Test switch off and restart replication', function() {
 
       connectToLeader();
       let mcol = db._collection(col);
-      let omidx = mcol.getIndexes();
+      let omidx = mcol.indexes();
       mcol.ensureIndex({ type: "hash", fields: ["value"] });
 
-      let midxs = mcol.getIndexes();
+      let midxs = mcol.indexes();
 
       startReplication();
 
       connectToFollower();
       let scol = db._collection(col);
-      let sidxs = scol.getIndexes();
+      let sidxs = scol.indexes();
       compareIndexes(sidxs, midxs, true);
       compareIndexes(sidxs, omidx, false);
 

--- a/tests/js/client/replication/ongoing/replication-ongoing.js
+++ b/tests/js/client/replication/ongoing/replication-ongoing.js
@@ -666,7 +666,7 @@ function BaseTestConfig () {
         function (state) {
           let col = db._collection(cn);
           assertNotNull(col, 'collection does not exist');
-          let idx = col.getIndexes();
+          let idx = col.indexes();
           assertEqual(2, idx.length);
           assertEqual('primary', idx[0].type);
           assertEqual('persistent', idx[1].type);
@@ -699,7 +699,7 @@ function BaseTestConfig () {
         },
 
         function (state) {
-          let idx = db._collection(cn).getIndexes();
+          let idx = db._collection(cn).indexes();
           assertEqual(1, idx.length);
           assertEqual('primary', idx[0].type);
         }
@@ -1300,7 +1300,7 @@ function BaseTestConfig () {
         function () { // followerFuncOngoing
         }, // followerFuncOngoing
         function (state) { // followerFuncFinal
-          let idx = db._collection(cn).getIndexes();
+          let idx = db._collection(cn).indexes();
           assertEqual(1, idx.length); // primary
 
           let view = db._view(cn + 'View');
@@ -1390,7 +1390,7 @@ function BaseTestConfig () {
         function (state) { // followerFuncFinal
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
-          let idx = db._collection(cn).getIndexes();
+          let idx = db._collection(cn).indexes();
           assertEqual(1, idx.length); // primary
 
           let view = db._view(cn + 'View');
@@ -1459,7 +1459,7 @@ function BaseTestConfig () {
         function (state) { // followerFuncFinal
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
-          let idx = db._collection(cn).getIndexes();
+          let idx = db._collection(cn).indexes();
           assertEqual(1, idx.length); // primary
 
           let view = db._view(cn + 'View');

--- a/tests/js/client/replication/static/replication-static.js
+++ b/tests/js/client/replication/static/replication-static.js
@@ -1477,13 +1477,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(1001, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('hash', state.idx.type);
           assertFalse(state.idx.unique);
@@ -1518,13 +1518,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(1001, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('hash', state.idx.type);
           assertFalse(state.idx.unique);
@@ -1559,13 +1559,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(501, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('hash', state.idx.type);
           assertTrue(state.idx.unique);
@@ -1600,13 +1600,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(501, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('hash', state.idx.type);
           assertTrue(state.idx.unique);
@@ -1641,13 +1641,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(1001, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('skiplist', state.idx.type);
           assertFalse(state.idx.unique);
@@ -1682,13 +1682,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(1001, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('skiplist', state.idx.type);
           assertFalse(state.idx.unique);
@@ -1723,13 +1723,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(501, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('skiplist', state.idx.type);
           assertTrue(state.idx.unique);
@@ -1764,13 +1764,13 @@ function BaseTestConfig() {
           state.count = collectionCount(cn);
           assertEqual(501, state.count);
 
-          state.idx = c.getIndexes()[1];
+          state.idx = c.indexes()[1];
         },
         function(state) {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes()[1];
+          var idx = db._collection(cn).indexes()[1];
           assertEqual(state.idx.id, idx.id);
           assertEqual('skiplist', state.idx.type);
           assertTrue(state.idx.unique);

--- a/tests/js/client/replication/sync/replication-sync.js
+++ b/tests/js/client/replication/sync/replication-sync.js
@@ -1283,7 +1283,7 @@ function BaseTestConfig () {
           assertEqual(state.count, collectionCount(cn));
           assertEqual(state.checksum, collectionChecksum(cn));
 
-          var idx = db._collection(cn).getIndexes();
+          var idx = db._collection(cn).indexes();
           assertEqual(3, idx.length); // primary + hash + skiplist
           for (var i = 1; i < idx.length; ++i) {
             assertFalse(idx[i].unique);
@@ -2588,8 +2588,8 @@ function ReplicationIncrementalKeyConflict () {
       db._flushCache();
       c = db._collection(cn);
       
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       assertEqual(3, c.count());
       assertEqual(1, c.document('x').value);
@@ -2620,8 +2620,8 @@ function ReplicationIncrementalKeyConflict () {
 
       db._flushCache();
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       c = db._collection(cn);
       assertEqual(3, c.count());
@@ -2718,8 +2718,8 @@ function ReplicationIncrementalKeyConflict () {
 
       db._flushCache();
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       c = db._collection(cn);
       assertEqual(1000, c.count());
@@ -2769,8 +2769,8 @@ function ReplicationIncrementalKeyConflict () {
 
       db._flushCache();
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       c = db._collection(cn);
       assertEqual(1000, c.count());
@@ -2805,8 +2805,8 @@ function ReplicationIncrementalKeyConflict () {
 
       assertEqual(10000, c.count());
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       connectToLeader();
       c = db._collection(cn);
@@ -2849,8 +2849,8 @@ function ReplicationIncrementalKeyConflict () {
       c = db._collection(cn);
       assertEqual(10000, c.count());
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
     }
   };
 }
@@ -2925,8 +2925,8 @@ function ReplicationNonIncrementalKeyConflict () {
       assertEqual(2, c.document('y').value);
       assertEqual(3, c.document('z').value);
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       connectToLeader();
       c = db._collection(cn);
@@ -2959,8 +2959,8 @@ function ReplicationNonIncrementalKeyConflict () {
       assertEqual(1, c.document('x').value);
       assertEqual(2, c.document('y').value);
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
     },
     
     testKeyConflictsNonIncrementalManyDocuments: function () {
@@ -2991,8 +2991,8 @@ function ReplicationNonIncrementalKeyConflict () {
 
       assertEqual(10000, c.count());
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
 
       connectToLeader();
       c = db._collection(cn);
@@ -3036,8 +3036,8 @@ function ReplicationNonIncrementalKeyConflict () {
       c = db._collection(cn);
       assertEqual(10000, c.count());
 
-      assertEqual('hash', c.getIndexes()[1].type);
-      assertTrue(c.getIndexes()[1].unique);
+      assertEqual('hash', c.indexes()[1].type);
+      assertTrue(c.indexes()[1].unique);
     }
   };
 }

--- a/tests/js/client/server_parameters/legacy-sorting-cluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-cluster.js
@@ -149,14 +149,14 @@ function legacySortingTestSuite() {
       }
 
       let c = db._collection(cn);
-      let indexes = c.getIndexes();
+      let indexes = c.indexes();
       let names = indexes.map(x => x.name);
       let ids_system = indexes.map(x => x.id);
       let r = arango.GET("/_admin/cluster/vpackSortMigration/check");
 
       db._useDatabase(dn);
       c = db._collection(cn);
-      indexes = c.getIndexes();
+      indexes = c.indexes();
       let ids_dn = indexes.map(x => x.id);
       db._useDatabase("_system");
 
@@ -183,7 +183,7 @@ function legacySortingTestSuite() {
       for (let d of ["_system", dn]) {
         db._useDatabase(d);
         c = db._collection(cn);
-        indexes = c.getIndexes();
+        indexes = c.indexes();
         for (let i of indexes) {
           if (i.id !== cn + "/0") {   // primary index
             c.dropIndex(i.id);

--- a/tests/js/client/server_parameters/legacy-sorting-noncluster.js
+++ b/tests/js/client/server_parameters/legacy-sorting-noncluster.js
@@ -140,14 +140,14 @@ function legacySortingTestSuite() {
       assertEqual("LEGACY", res.result.current);
 
       let c = db._collection(cn);
-      let indexes = c.getIndexes();
+      let indexes = c.indexes();
       let names = indexes.map(x => x.name);
       let ids_system = indexes.map(x => x.id);
       let r = arango.GET("/_admin/cluster/vpackSortMigration/check");
 
       db._useDatabase(dn);
       c = db._collection(cn);
-      indexes = c.getIndexes();
+      indexes = c.indexes();
       let ids_dn = indexes.map(x => x.id);
       db._useDatabase("_system");
 
@@ -177,7 +177,7 @@ function legacySortingTestSuite() {
       for (let d of ["_system", dn]) {
         db._useDatabase(d);
         c = db._collection(cn);
-        indexes = c.getIndexes();
+        indexes = c.indexes();
         for (let i of indexes) {
           if (i.id !== cn + "/0") {   // primary index
             c.dropIndex(i.id);

--- a/tests/js/client/shell/multi/shell-fulltext.js
+++ b/tests/js/client/shell/multi/shell-fulltext.js
@@ -129,7 +129,7 @@ function fulltextCreateSuite () {
       var result = internal.db._query("RETURN FULLTEXT(" + c.name() + ", 'text', 'foo')").toArray()[0];
       assertEqual(0, result.length);
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -152,7 +152,7 @@ function fulltextCreateSuite () {
     testCreateIndexExisting : function () {
       var idx = c.ensureIndex({ type: "fulltext", fields: ["textattr"] });
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -181,7 +181,7 @@ function fulltextCreateSuite () {
       var result = internal.db._query("RETURN FULLTEXT(" + c.name() + ", 'iam-an-indexed-ATTRIBUTE', 'foo')").toArray()[0];
       assertEqual(0, result.length);
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -204,7 +204,7 @@ function fulltextCreateSuite () {
     testCreateIndexSubstringsExisting : function () {
       var idx = c.ensureIndex({ type: "fulltext", fields: ["iam-an-indexed-ATTRIBUTE"] });
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -233,7 +233,7 @@ function fulltextCreateSuite () {
       var result = internal.db._query("RETURN FULLTEXT(" + c.name() + ", 'a.b.c', 'foo')").toArray()[0];
       assertEqual(0, result.length);
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -258,7 +258,7 @@ function fulltextCreateSuite () {
       var idx2 = c.ensureIndex({ type: "fulltext", fields: ["attr1"] });
       var idx3 = c.ensureIndex({ type: "fulltext", fields: ["attr2"] });
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -290,7 +290,7 @@ function fulltextCreateSuite () {
     testCreateIndexMinLength1 : function () {
       var idx = c.ensureIndex({ type: "fulltext", fields: ["test"], minLength: 5 });
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {
@@ -314,7 +314,7 @@ function fulltextCreateSuite () {
     testCreateIndexMinLength2 : function () {
       var idx = c.ensureIndex({ type: "fulltext", fields: ["test"], minLength: 1 });
 
-      var indexes = c.getIndexes();
+      var indexes = c.indexes();
       for (var i = 0; i < indexes.length; ++i) {
         var index = indexes[i];
         if (index.type !== "fulltext") {

--- a/tests/js/client/shell/shell-arangosearch-dangling-link-cluster-fp.js
+++ b/tests/js/client/shell/shell-arangosearch-dangling-link-cluster-fp.js
@@ -55,7 +55,7 @@ function ArangoSearchDanglingLinkSuite () {
       db._createView("dangle", "arangosearch", {links:{foo:{includeAllFields:true}}});
       db._dropView("dangle");
       let nCount = 0;
-      while(db.foo.getIndexes(true, true).length > 1) {
+      while(db.foo.indexes(true, true).length > 1) {
         internal.sleep(1);
         nCount++;
         // 30 secs should be more than enough to kick in cleanup
@@ -69,13 +69,13 @@ function ArangoSearchDanglingLinkSuite () {
       db._createView("dangle", "arangosearch", {links:{foo:{includeAllFields:true}}});
       db._dropView("dangle");
       let nCount = 0;
-      while(db.foo.getIndexes(true, true).length > 1 && nCount < 10) {
+      while(db.foo.indexes(true, true).length > 1 && nCount < 10) {
         internal.sleep(1);
         nCount++;
       }
       assertEqual(10, nCount);
       IM.debugClearFailAt("IResearchLink::failDropDangling");
-      while(db.foo.getIndexes(true, true).length > 1) {
+      while(db.foo.indexes(true, true).length > 1) {
         internal.sleep(1);
         nCount++;
         // 30 secs should be more than enough to kick in cleanup

--- a/tests/js/client/shell/shell-array-index.js
+++ b/tests/js/client/shell/shell-array-index.js
@@ -50,14 +50,14 @@ function arrayIndexSuite () {
 ////////////////////////////////////////////////////////////////////////////////
 
     testCreateIndex : function () {
-      var indexes = collection.getIndexes();
+      var indexes = collection.indexes();
       
       assertEqual(1, indexes.length);
 
       collection.ensureIndex({ type: "persistent", fields: ["a[*]"] });
       collection.ensureIndex({ type: "persistent", fields: ["b[*]"], unique: true });
 
-      indexes = collection.getIndexes();
+      indexes = collection.indexes();
 
       assertEqual(3, indexes.length);
     },
@@ -157,7 +157,7 @@ function arrayIndexSuite () {
       collection.ensureIndex({ type: "persistent", fields: ["a[*]", "b[*]"] });
 
       assertEqual(n, collection.count());
-      assertEqual(3, collection.getIndexes().length);
+      assertEqual(3, collection.indexes().length);
     },
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/shell/shell-cluster-collection-selectivity.js
+++ b/tests/js/client/shell/shell-cluster-collection-selectivity.js
@@ -75,7 +75,7 @@ function ClusterCollectionSuite () {
       let indexes;
       let tries = 0;
       while (++tries < 60) {
-        indexes = c.getIndexes(true);
+        indexes = c.indexes(true);
         // if this fails, increase wait-time in ClusterEngine::waitForEstimatorSync
         if (indexes[1].selectivityEstimate >= 0.999) {
           break;
@@ -92,7 +92,7 @@ function ClusterCollectionSuite () {
      
       tries = 0; 
       while (++tries < 60) {
-        indexes = c.getIndexes(true);
+        indexes = c.indexes(true);
         // if this fails, increase wait-time in ClusterEngine::waitForEstimatorSync
         if (indexes[1].selectivityEstimate <= 0.501) {
           break;

--- a/tests/js/client/shell/shell-collection-cache-noncluster.js
+++ b/tests/js/client/shell/shell-collection-cache-noncluster.js
@@ -58,7 +58,7 @@ function CollectionCacheSuite () {
       assertEqual(f.cacheUsage, 0);
       assertEqual(f.cacheLifeTimeHitRate, 0);
 
-      let idxs = c.getIndexes(true);
+      let idxs = c.indexes(true);
       idxs.forEach(function(idx) {
         if (idx.type === 'primary') {
           assertTrue(idx.figures.cacheInUse, idx);
@@ -74,7 +74,7 @@ function CollectionCacheSuite () {
       assertFalse(p.cacheEnabled, p);
       let f = c.figures();
       assertFalse(f.cacheInUse, f);
-      let idxs = c.getIndexes(true);
+      let idxs = c.indexes(true);
       idxs.forEach(function(idx) {
         if (idx.type === 'primary') {
           assertFalse(idx.figures.cacheInUse);
@@ -89,7 +89,7 @@ function CollectionCacheSuite () {
       f = c.figures();
       assertTrue(f.cacheInUse, f);
       assertEqual(f.cacheLifeTimeHitRate, 0);
-      idxs = c.getIndexes(true);
+      idxs = c.indexes(true);
       idxs.forEach(function(idx) {
         if (idx.type === 'primary') {
           assertTrue(idx.figures.cacheInUse);
@@ -103,7 +103,7 @@ function CollectionCacheSuite () {
       assertFalse(p.cacheEnabled, p);
       f = c.figures();
       assertFalse(f.cacheInUse, f);
-      idxs = c.getIndexes(true);
+      idxs = c.indexes(true);
       idxs.forEach(function(idx) {
         if (idx.type === 'primary') {
           assertFalse(idx.figures.cacheInUse);
@@ -132,7 +132,7 @@ function CollectionCacheSuite () {
       assertEqual(f.cacheUsage, 0);
       assertEqual(f.cacheLifeTimeHitRate, 0);
 
-      let idxs = c.getIndexes(true);
+      let idxs = c.indexes(true);
       idxs.forEach(function(idx, i) {
         if (idx.figures.cacheInUse) {
           assertTrue(idx.figures.cacheSize > 0);

--- a/tests/js/client/shell/shell-collection-failures-noncluster-fp.js
+++ b/tests/js/client/shell/shell-collection-failures-noncluster-fp.js
@@ -361,7 +361,7 @@ function CollectionTruncateFailuresSuite() {
       // Test Selectivity Estimates
       {
         waitForEstimatorSync();  // make sure estimates are consistent
-        let indexes = c.getIndexes(true);
+        let indexes = c.indexes(true);
         for (let i of indexes) {
           switch (i.type) {
             case 'primary':
@@ -433,7 +433,7 @@ function CollectionTruncateFailuresSuite() {
       // Test Selectivity Estimates
       {
         waitForEstimatorSync();  // make sure estimates are consistent
-        let indexes = c.getIndexes(true);
+        let indexes = c.indexes(true);
         for (let i of indexes) {
           switch (i.type) {
             case 'primary':
@@ -514,7 +514,7 @@ function CollectionTruncateFailuresSuite() {
       // This may be fuzzy...
       {
         waitForEstimatorSync();  // make sure estimates are consistent
-        let indexes = c.getIndexes(true);
+        let indexes = c.indexes(true);
         for (let i of indexes) {
           switch (i.type) {
             case 'primary':

--- a/tests/js/client/shell/shell-collection-noncluster.js
+++ b/tests/js/client/shell/shell-collection-noncluster.js
@@ -123,7 +123,7 @@ function CollectionSuite () {
       // Test Selectivity Estimates
       {
         waitForEstimatorSync();  // make sure estimates are consistent
-        let indexes = c.getIndexes(true);
+        let indexes = c.indexes(true);
         for (let i of indexes) {
           switch (i.type) {
             case 'primary':
@@ -295,7 +295,7 @@ function CollectionSuite () {
           }
 
           // check if edge cache is present
-          let idxs = c.getIndexes(true);
+          let idxs = c.indexes(true);
           assertEqual("edge", idxs[1].type, idxs);
 
           let initial = [];
@@ -312,7 +312,7 @@ function CollectionSuite () {
           internal.wait(3);
 
           // checking if edge cache grew
-          idxs = c.getIndexes(true);
+          idxs = c.indexes(true);
           idxs.forEach(function(idx, i) {
             if (idx.figures.cacheInUse) {
               assertTrue(idx.figures.cacheSize >= initial[i].cacheSize, idx);
@@ -325,7 +325,7 @@ function CollectionSuite () {
             c.outEdges("c/v" + (i / 100));
             c.inEdges("c/v" + (i / 100));
           }
-          idxs = c.getIndexes(true);
+          idxs = c.indexes(true);
           // cache was filled with same queries, hit rate must now increase
           idxs.forEach(function(idx, i) {
             if (idx.figures.cacheInUse) {
@@ -340,7 +340,7 @@ function CollectionSuite () {
             c.outEdges("c/v" + (i / 100));
             c.inEdges("c/v" + (i / 100));
           }
-          idxs = c.getIndexes(true);
+          idxs = c.indexes(true);
           // cache was filled with same queries, hit rate must be higher
           idxs.forEach(function(idx, i) {
             if (idx.figures.cacheInUse) {

--- a/tests/js/client/shell/shell-edge-index-noncluster.js
+++ b/tests/js/client/shell/shell-edge-index-noncluster.js
@@ -262,7 +262,7 @@ function EdgeIndexSuite () {
     // //////////////////////////////////////////////////////////////////////////////
 
     testIndexPresence: function () {
-      var indexes = edge.getIndexes();
+      var indexes = edge.indexes();
       assertEqual(2, indexes.length);
       assertEqual('edge', indexes[1].type);
       assertEqual([ '_from', '_to' ], indexes[1].fields);

--- a/tests/js/client/shell/shell-edge-index-selectivity-noncluster.js
+++ b/tests/js/client/shell/shell-edge-index-selectivity-noncluster.js
@@ -77,7 +77,7 @@ function EdgeIndexSuite () {
 
     testIndexSelectivityEmpty: function () {
       waitForEstimatorSync();  // make sure estimates are consistent
-      var edgeIndex = edge.getIndexes()[1];
+      var edgeIndex = edge.indexes()[1];
       assertTrue(edgeIndex.hasOwnProperty('selectivityEstimate'));
       assertEqual(1, edgeIndex.selectivityEstimate);
     },
@@ -89,7 +89,7 @@ function EdgeIndexSuite () {
     testIndexSelectivityOneDoc: function () {
       edge.save(v1, v2, { });
       waitForEstimatorSync();  // make sure estimates are consistent
-      var edgeIndex = edge.getIndexes()[1];
+      var edgeIndex = edge.indexes()[1];
       assertTrue(edgeIndex.hasOwnProperty('selectivityEstimate'));
       assertEqual(1, edgeIndex.selectivityEstimate);
     },
@@ -105,7 +105,7 @@ function EdgeIndexSuite () {
         edge.save(v1, v2, { });
       }
       waitForEstimatorSync();  // make sure estimates are consistent
-      edgeIndex = edge.getIndexes()[1];
+      edgeIndex = edge.indexes()[1];
       expectedSelectivity = 1 / 1000;
       // allow for some floating-point deviations
       assertTrue(Math.abs(expectedSelectivity - edgeIndex.selectivityEstimate) <= 0.001);
@@ -120,7 +120,7 @@ function EdgeIndexSuite () {
       }
 
       waitForEstimatorSync();  // make sure estimates are consistent
-      edgeIndex = edge.getIndexes()[1];
+      edgeIndex = edge.indexes()[1];
       expectedSelectivity = 1.0;
       // allow for some floating-point deviations
       assertTrue(Math.abs(expectedSelectivity - edgeIndex.selectivityEstimate) <= 0.001);
@@ -135,7 +135,7 @@ function EdgeIndexSuite () {
         edge.save(vn + '/from' + i, vn + '/to' + i, { });
       }
       waitForEstimatorSync();  // make sure estimates are consistent
-      var edgeIndex = edge.getIndexes()[1];
+      var edgeIndex = edge.indexes()[1];
       assertTrue(1, edgeIndex.selectivityEstimate);
     },
 
@@ -148,7 +148,7 @@ function EdgeIndexSuite () {
         edge.save(vn + '/from' + i, vn + '/1', { });
       }
       waitForEstimatorSync();  // make sure estimates are consistent
-      var edgeIndex = edge.getIndexes()[1];
+      var edgeIndex = edge.indexes()[1];
       var expectedSelectivity = (1 + (1 / 1000)) * 0.5;
       assertTrue(Math.abs(expectedSelectivity - edgeIndex.selectivityEstimate) <= 0.001);
     },
@@ -162,7 +162,7 @@ function EdgeIndexSuite () {
         edge.save(vn + '/from' + (i % 20), vn + '/to' + i, { });
       }
       waitForEstimatorSync();  // make sure estimates are consistent
-      var edgeIndex = edge.getIndexes()[1];
+      var edgeIndex = edge.indexes()[1];
       var expectedSelectivity = (1 + (20 / 1000)) * 0.5;
       assertTrue(Math.abs(expectedSelectivity - edgeIndex.selectivityEstimate) <= 0.001);
     },
@@ -174,7 +174,7 @@ function EdgeIndexSuite () {
       }
       edge.save(docs);
       waitForEstimatorSync();  // make sure estimates are consistent
-      let idx = edge.getIndexes()[1];
+      let idx = edge.indexes()[1];
       let estimateBefore = idx.selectivityEstimate;
       try {
         internal.db._executeTransaction({
@@ -198,7 +198,7 @@ function EdgeIndexSuite () {
         // Insert failed.
         // Validate that estimate is non modified
         waitForEstimatorSync();  // make sure estimates are consistent
-        idx = edge.getIndexes()[1];
+        idx = edge.indexes()[1];
         assertEqual(idx.selectivityEstimate, estimateBefore);
       }
 

--- a/tests/js/client/shell/shell-ensure-inverted-index.js
+++ b/tests/js/client/shell/shell-ensure-inverted-index.js
@@ -54,7 +54,7 @@ function testEnsureInvertedIndex() {
       delete r["inBackground"];  // TODO Why do we need to return inBackground?
 
       let was = false;
-      let indexes = db.c.getIndexes();
+      let indexes = db.c.indexes();
       indexes.forEach(function (index) {
         if (index["name"] === "i") {
           assertEqual(index, r);

--- a/tests/js/client/shell/shell-index-background-nocov.js
+++ b/tests/js/client/shell/shell-index-background-nocov.js
@@ -183,7 +183,7 @@ function backgroundIndexSuite() {
       }
 
       waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':
@@ -241,7 +241,7 @@ function backgroundIndexSuite() {
       }
 
       waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':
@@ -307,7 +307,7 @@ function backgroundIndexSuite() {
         assertEqual(cursor.count(), 1);
       }
 
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':
@@ -433,7 +433,7 @@ function backgroundIndexSuite() {
       }
 
       waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':
@@ -505,7 +505,7 @@ function backgroundIndexSuite() {
       assertEqual(oldCursor.count(), 0);
 
       waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':
@@ -537,15 +537,15 @@ function backgroundIndexSuite() {
       const idxDef = {type: 'persistent', fields: ['value'], unique: false, inBackground: true};
       let idx = c.ensureIndex(idxDef);
 
-      assertEqual(c.getIndexes().length, 2);
+      assertEqual(c.indexes().length, 2);
 
       c.dropIndex(idx.id);
 
-      assertEqual(c.getIndexes().length, 1);
+      assertEqual(c.indexes().length, 1);
 
       idx = c.ensureIndex(idxDef);
 
-      assertEqual(c.getIndexes().length, 2);
+      assertEqual(c.indexes().length, 2);
 
       // check for entries via index
       const newCursor = db._query("FOR doc IN @@coll FILTER doc.value >= @val RETURN 1", 
@@ -553,7 +553,7 @@ function backgroundIndexSuite() {
       assertEqual(newCursor.count(), 12500);
 
       waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/client/shell/shell-index-correctness.js
+++ b/tests/js/client/shell/shell-index-correctness.js
@@ -292,7 +292,7 @@ function IndexCorrectnessSuite() {
       coll.insert(arr);
       assertEqual(30000, coll.count());
 
-      assertEqual(coll.getIndexes().length, 1);
+      assertEqual(coll.indexes().length, 1);
 
       try {
         coll.ensureIndex({ type: "persistent", fields: ["v"], unique: true });
@@ -301,7 +301,7 @@ function IndexCorrectnessSuite() {
         assertEqual(internal.errors.ERROR_ARANGO_UNIQUE_CONSTRAINT_VIOLATED.code, e.errorNum);
       }
 
-      let idx = coll.getIndexes();
+      let idx = coll.indexes();
     
       // should not have created an index
       assertEqual(idx.length, 1, idx);

--- a/tests/js/client/shell/shell-index-ensure.js
+++ b/tests/js/client/shell/shell-index-ensure.js
@@ -80,7 +80,7 @@ function ensureIndexSuite() {
       assertEqual([ "a" ], idx.fields);
       assertEqual(collection.name() + "/" + id, idx.id);
 
-      var res = collection.getIndexes()[collection.getIndexes().length - 1];
+      var res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -96,7 +96,7 @@ function ensureIndexSuite() {
       assertEqual([ "b", "d" ], idx.fields);
       assertEqual(collection.name() + "/" + id, idx.id);
 
-      var res = collection.getIndexes()[collection.getIndexes().length - 1];
+      var res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -145,19 +145,19 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureNamePrimary : function () {
-      var res = collection.getIndexes()[0];
+      var res = collection.indexes()[0];
 
       assertEqual("primary", res.type);
       assertEqual("primary", res.name);
     },
 
     testEnsureNameEdge : function () {
-      var res = edgeCollection.getIndexes()[0];
+      var res = edgeCollection.indexes()[0];
 
       assertEqual("primary", res.type);
       assertEqual("primary", res.name);
 
-      res = edgeCollection.getIndexes()[1];
+      res = edgeCollection.indexes()[1];
 
       assertEqual("edge", res.type);
       assertEqual("edge", res.name);
@@ -171,7 +171,7 @@ function ensureIndexSuite() {
       assertEqual([ "b", "d" ], idx.fields);
       assertEqual(name, idx.name);
 
-      var res = collection.getIndexes()[collection.getIndexes().length - 1];
+      var res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -203,7 +203,7 @@ function ensureIndexSuite() {
       assertEqual([ "b", "d" ], idx.fields);
       assertEqual("idx_", idx.name.substr(0,4));
 
-      var res = collection.getIndexes()[collection.getIndexes().length - 1];
+      var res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", idx.type);
       assertFalse(idx.unique);
@@ -333,7 +333,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureHash : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -343,7 +343,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "a" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -358,7 +358,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSparseHash : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -368,7 +368,7 @@ function ensureIndexSuite() {
       assertTrue(idx.sparse);
       assertEqual([ "a" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -383,7 +383,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureUniqueConstraint : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -393,7 +393,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "b", "c" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertTrue(res.unique);
@@ -408,7 +408,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSparseUniqueConstraint : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -418,7 +418,7 @@ function ensureIndexSuite() {
       assertTrue(idx.sparse);
       assertEqual([ "b", "c" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertTrue(res.unique);
@@ -433,7 +433,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSparseMultipleHashIndexes : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -455,21 +455,21 @@ function ensureIndexSuite() {
       assertFalse(idx3.sparse);
       assertEqual([ "b", "c" ], idx3.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 3];
+      res = collection.indexes()[collection.indexes().length - 3];
       assertEqual("hash", res.type);
       assertTrue(res.unique);
       assertTrue(idx1.sparse);
       assertEqual([ "b", "c" ], res.fields);
       assertEqual(idx1.id, res.id);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 2];
+      res = collection.indexes()[collection.indexes().length - 2];
       assertEqual("hash", res.type);
       assertTrue(res.unique);
       assertFalse(idx2.sparse);
       assertEqual([ "b", "c" ], res.fields);
       assertEqual(idx2.id, res.id);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
       assertEqual("hash", res.type);
       assertFalse(res.unique);
       assertFalse(idx3.sparse);
@@ -482,7 +482,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureHashOnRev : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -492,7 +492,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_rev" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -507,7 +507,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureHashOnKey : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -517,7 +517,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_key" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -542,7 +542,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureHashOnKeyCombined : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -552,7 +552,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_key", "value" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -603,7 +603,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplist : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -613,7 +613,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "a" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -628,7 +628,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSparseSkiplist : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -638,7 +638,7 @@ function ensureIndexSuite() {
       assertTrue(idx.sparse);
       assertEqual([ "a" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -653,7 +653,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureUniqueSkiplist : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -663,7 +663,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "b", "c" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertTrue(res.unique);
@@ -678,7 +678,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSparseUniqueSkiplist : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -688,7 +688,7 @@ function ensureIndexSuite() {
       assertTrue(idx.sparse);
       assertEqual([ "b", "c" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertTrue(res.unique);
@@ -703,7 +703,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSparseMultipleSkiplists : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -725,21 +725,21 @@ function ensureIndexSuite() {
       assertFalse(idx3.sparse);
       assertEqual([ "b", "c" ], idx3.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 3];
+      res = collection.indexes()[collection.indexes().length - 3];
       assertEqual("skiplist", res.type);
       assertTrue(res.unique);
       assertTrue(idx1.sparse);
       assertEqual([ "b", "c" ], res.fields);
       assertEqual(idx1.id, res.id);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 2];
+      res = collection.indexes()[collection.indexes().length - 2];
       assertEqual("skiplist", res.type);
       assertTrue(res.unique);
       assertFalse(idx2.sparse);
       assertEqual([ "b", "c" ], res.fields);
       assertEqual(idx2.id, res.id);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
       assertFalse(idx3.sparse);
@@ -752,7 +752,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnRev : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -762,7 +762,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_rev" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -789,7 +789,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnKey : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -799,7 +799,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_key" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -836,7 +836,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnKeyCombined : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -846,7 +846,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_key", "value" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -886,7 +886,7 @@ function ensureIndexSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureUniqueHashOnArray : function () {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
 
@@ -896,7 +896,7 @@ function ensureIndexSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "value[*]" ], idx.fields);
 
-      res = collection.getIndexes()[collection.getIndexes().length - 1];
+      res = collection.indexes()[collection.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertTrue(res.unique);
@@ -1113,7 +1113,7 @@ function ensureIndexSuite() {
         assertEqual("object", typeof r);
         assertTrue(r.hasOwnProperty("legacyPolygons"));
         assertEqual(expected, r.legacyPolygons);
-        let i = collection.getIndexes();
+        let i = collection.indexes();
         let found = false;
         for (let j = 0; j < i.length; ++j) {
           if (i[j].id === r.id) {
@@ -1141,7 +1141,7 @@ function ensureIndexSuite() {
         assertEqual("object", typeof r);
         assertTrue(r.hasOwnProperty("legacyPolygons"));
         assertEqual(expected, r.legacyPolygons);
-        let i = collection.getIndexes();
+        let i = collection.indexes();
         let found = false;
         for (let j = 0; j < i.length; ++j) {
           if (i[j].id === r.id) {
@@ -1169,7 +1169,7 @@ function ensureIndexSuite() {
         assertEqual("object", typeof r);
         assertTrue(r.hasOwnProperty("legacyPolygons"));
         assertEqual(expected, r.legacyPolygons);
-        let i = collection.getIndexes();
+        let i = collection.indexes();
         let found = false;
         for (let j = 0; j < i.length; ++j) {
           if (i[j].id === r.id) {
@@ -1230,7 +1230,7 @@ function ensureIndexEdgesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnFrom : function () {
-      var res = edge.getIndexes();
+      var res = edge.indexes();
 
       assertEqual(1, res.length);
 
@@ -1240,7 +1240,7 @@ function ensureIndexEdgesSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_from" ], idx.fields);
 
-      res = edge.getIndexes()[edge.getIndexes().length - 1];
+      res = edge.indexes()[edge.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -1267,7 +1267,7 @@ function ensureIndexEdgesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnTo : function () {
-      var res = edge.getIndexes();
+      var res = edge.indexes();
 
       assertEqual(1, res.length);
 
@@ -1277,7 +1277,7 @@ function ensureIndexEdgesSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_to" ], idx.fields);
 
-      res = edge.getIndexes()[edge.getIndexes().length - 1];
+      res = edge.indexes()[edge.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);
@@ -1304,7 +1304,7 @@ function ensureIndexEdgesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnFromToCombinedHash : function () {
-      var res = edge.getIndexes();
+      var res = edge.indexes();
 
       assertEqual(1, res.length);
 
@@ -1314,7 +1314,7 @@ function ensureIndexEdgesSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_from", "_to" ], idx.fields);
 
-      res = edge.getIndexes()[edge.getIndexes().length - 1];
+      res = edge.indexes()[edge.indexes().length - 1];
 
       assertEqual("hash", res.type);
       assertFalse(res.unique);
@@ -1343,7 +1343,7 @@ function ensureIndexEdgesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEnsureSkiplistOnFromToCombinedSkiplist : function () {
-      var res = edge.getIndexes();
+      var res = edge.indexes();
 
       assertEqual(1, res.length);
 
@@ -1353,7 +1353,7 @@ function ensureIndexEdgesSuite() {
       assertFalse(idx.sparse);
       assertEqual([ "_from", "_to" ], idx.fields);
 
-      res = edge.getIndexes()[edge.getIndexes().length - 1];
+      res = edge.indexes()[edge.indexes().length - 1];
 
       assertEqual("skiplist", res.type);
       assertFalse(res.unique);

--- a/tests/js/client/shell/shell-index-figures-noncluster-spec.js
+++ b/tests/js/client/shell/shell-index-figures-noncluster-spec.js
@@ -85,21 +85,21 @@ describe('Index figures', function () {
       });
 
       it('index types', function() {
-        var indexes = col.getIndexes(true);
+        var indexes = col.indexes(true);
         expect(indexes.length).to.be.equal(2);
         expect(indexes[0].type).to.be.equal("primary");
         expect(indexes[1].type).to.be.equal("edge");
       });
 
       it('index - memory', function() {
-        var indexes = col.getIndexes(true);
+        var indexes = col.indexes(true);
         indexes.forEach((i) => {
             verifyMemory(i);
         });
       });
 
       it('figures - cache', function() {
-        var indexes = col.getIndexes(true);
+        var indexes = col.indexes(true);
         indexes.forEach((i) => {
           verifyCache(i);
         });
@@ -120,7 +120,7 @@ describe('Index figures', function () {
       it('should fill the cache', function() {
         // The cache does not expose fillgrades an such.
         // We can only check memory consumption...
-        let indexes = col.getIndexes(true);
+        let indexes = col.indexes(true);
         let edgeIndex = indexes[1];
         expect(edgeIndex.type).to.be.equal('edge');
 
@@ -131,7 +131,7 @@ describe('Index figures', function () {
         col.loadIndexesIntoMemory();
 
         // Test if the memory consumption goes up
-        let indexes2 = col.getIndexes(true);
+        let indexes2 = col.indexes(true);
         let edgeIndex2 = indexes2[1];
         expect(edgeIndex2.type).to.be.equal('edge');
         expect(edgeIndex2.figures.cacheSize).to.be.at.least(oldSize);
@@ -157,20 +157,20 @@ describe('Index figures', function () {
       db._drop(colName);
     });
     it('verify index types', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       expect(indexes.length).to.be.equal(2);
       expect(indexes[0].type).to.be.equal("primary");
       expect(indexes[1].type).to.be.equal("hash");
     });
     it('verify index - memory', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyMemory(i);
       });
     });
     // FIXME not implemented
     it.skip('verify figures - cache', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyCache(i);
       });
@@ -196,20 +196,20 @@ describe('Index figures', function () {
       db._drop(colName);
     });
     it('verify index types', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       expect(indexes.length).to.be.equal(2);
       expect(indexes[0].type).to.be.equal("primary");
       expect(indexes[1].type).to.be.equal("skiplist");
     });
     it('verify index - memory', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyMemory(i);
       });
     });
     // FIXME not implemented
     it.skip('verify figures - cache', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyCache(i);
       });
@@ -235,20 +235,20 @@ describe('Index figures', function () {
       db._drop(colName);
     });
     it('verify index types', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       expect(indexes.length).to.be.equal(2);
       expect(indexes[0].type).to.be.equal("primary");
       expect(indexes[1].type).to.be.equal("fulltext");
     });
     it('verify index - memory', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyMemory(i);
       });
     });
     // FIXME not implemented
     it.skip('verify figures - cache', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyCache(i);
       });
@@ -278,20 +278,20 @@ describe('Index figures', function () {
       db._drop(colName);
     });
     it('verify index types', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       expect(indexes.length).to.be.equal(2);
       expect(indexes[0].type).to.be.equal("primary");
       expect(indexes[1].type).to.be.equal("geo");
     });
     it('verify index - memory', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyMemory(i);
       });
     });
     // FIXME not implemented
     it.skip('verify figures - cache', function() {
-      var indexes = col.getIndexes(true);
+      var indexes = col.indexes(true);
       indexes.forEach((i) => {
         verifyCache(i);
       });

--- a/tests/js/client/shell/shell-index-vertex-centric.js
+++ b/tests/js/client/shell/shell-index-vertex-centric.js
@@ -53,11 +53,11 @@ function vertexCentricIndexSuite() {
     },
 
     testCreateDefault : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", {direction: "outbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("hash", idx.type);
@@ -70,16 +70,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "hash", fields: ["_from", "label"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreateHash : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", {type: "hash", direction: "outbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("hash", idx.type);
@@ -92,16 +92,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "hash", fields: ["_from", "label"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreateSkiplist : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", {type: "skiplist", direction: "outbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("skiplist", idx.type);
@@ -114,16 +114,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "skiplist", fields: ["_from", "label"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreatePersistent : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", {type: "persistent", direction: "outbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("persistent", idx.type);
@@ -136,16 +136,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({type: "persistent", fields:["_from", "label"]});
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreateMultiFields : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", "type", {direction: "outbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("hash", idx.type);
@@ -158,16 +158,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "hash", fields: ["_from", "label", "type"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreateOnlyOptions : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex({fields: ["label", "type"], direction: "outbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("hash", idx.type);
@@ -180,16 +180,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "hash", fields: ["_from", "label", "type"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreateInbound : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", {direction: "inbound"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("hash", idx.type);
@@ -202,16 +202,16 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "hash", fields: ["_to", "label"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
 
     testCreateWrongTyping : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       let idx = collection.ensureVertexCentricIndex("label", {direction: "oUtBoUnD"});
 
       // creation
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length + 1, after.length);
 
       assertEqual("hash", idx.type);
@@ -224,12 +224,12 @@ function vertexCentricIndexSuite() {
       let idx2 = collection.ensureIndex({ type: "hash", fields: ["_from", "label"] });
       assertFalse(idx2.isNewlyCreated);
 
-      let after2 = collection.getIndexes();
+      let after2 = collection.indexes();
       assertEqual(after.length, after2.length);
     },
  
     testErrorDirection : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       try {
         let idx = collection.ensureVertexCentricIndex("label", {direction: "any"});
         fail();
@@ -237,12 +237,12 @@ function vertexCentricIndexSuite() {
         assertEqual(arangodb.errors.ERROR_BAD_PARAMETER.code, e.errorNum);
       }
       // Nothing happend
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length, after.length);
     },
 
     testErrorType : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       try {
         let idx = collection.ensureVertexCentricIndex("label", {direction: "outbound", type: "circus"});
         fail();
@@ -250,12 +250,12 @@ function vertexCentricIndexSuite() {
         assertEqual(arangodb.errors.ERROR_BAD_PARAMETER.code, e.errorNum);
       }
       // Nothing happend
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length, after.length);
     },
  
     testErrorFields : () => {
-      let before = collection.getIndexes();
+      let before = collection.indexes();
       try {
         let idx = collection.ensureVertexCentricIndex({direction: "outbound"});
         fail();
@@ -263,7 +263,7 @@ function vertexCentricIndexSuite() {
         assertEqual(arangodb.errors.ERROR_BAD_PARAMETER.code, e.errorNum);
       }
       // Nothing happend
-      let after = collection.getIndexes();
+      let after = collection.indexes();
       assertEqual(before.length, after.length);
     }
   };

--- a/tests/js/client/shell/shell-index.js
+++ b/tests/js/client/shell/shell-index.js
@@ -273,7 +273,7 @@ function IndexSuite() {
       helper.waitUnload(collection);
 
       assertEqual(idx.id, collection.index(idx.id).id);
-      assertEqual(idx.id, collection.getIndexes()[1].id);
+      assertEqual(idx.id, collection.indexes()[1].id);
     },
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -296,7 +296,7 @@ function IndexSuite() {
       }
 
       try {
-        collection.getIndexes();
+        collection.indexes();
         fail();
       } catch (e2) {
         assertEqual(errors.ERROR_ARANGO_DATA_SOURCE_NOT_FOUND.code, e2.errorNum);
@@ -336,10 +336,10 @@ function IndexSuite() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite: return value of getIndexes
+/// @brief test suite: return value of indexes
 ////////////////////////////////////////////////////////////////////////////////
 
-function GetIndexesSuite() {
+function IndexesSuite() {
   'use strict';
 
   let collection = null;
@@ -361,7 +361,7 @@ function GetIndexesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testGetPrimary: function() {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(1, res.length);
       var idx = res[0];
@@ -377,7 +377,7 @@ function GetIndexesSuite() {
 
     testGetPersistentUnique1: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], unique: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -394,7 +394,7 @@ function GetIndexesSuite() {
 
     testGetPersistentUnique2: function() {
       collection.ensureIndex({type: "persistent", fields: ["value1", "value2"], unique: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -411,7 +411,7 @@ function GetIndexesSuite() {
 
     testGetSparsePersistentUnique1: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], unique: true, sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -428,7 +428,7 @@ function GetIndexesSuite() {
 
     testGetSparsePersistentUnique2: function() {
       collection.ensureIndex({type: "persistent", fields: ["value1", "value2"], unique: true, sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -445,7 +445,7 @@ function GetIndexesSuite() {
 
     testGetPersistentNonUnique1: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -462,7 +462,7 @@ function GetIndexesSuite() {
 
     testGetPersistentNonUnique2: function() {
       collection.ensureIndex({type: "persistent", fields: ["value1", "value2"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -479,7 +479,7 @@ function GetIndexesSuite() {
 
     testGetSparsePersistentNonUnique1: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -496,7 +496,7 @@ function GetIndexesSuite() {
 
     testGetSparsePersistentNonUnique2: function() {
       collection.ensureIndex({type: "persistent", fields: ["value1", "value2"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -573,7 +573,7 @@ function GetIndexesSuite() {
 
     testGetFulltext: function() {
       collection.ensureIndex({type: "fulltext", fields: ["value"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -589,7 +589,7 @@ function GetIndexesSuite() {
 
     testGetRocksDBUnique1: function() {
       collection.ensureIndex({type: "persistent", unique: true, fields: ["value"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -606,7 +606,7 @@ function GetIndexesSuite() {
 
     testGetRocksDBUnique2: function() {
       collection.ensureIndex({type: "persistent", unique: true, fields: ["value1", "value2"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -623,7 +623,7 @@ function GetIndexesSuite() {
 
     testGetSparseRocksDBUnique1: function() {
       collection.ensureIndex({type: "persistent", unique: true, fields: ["value"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -640,7 +640,7 @@ function GetIndexesSuite() {
 
     testGetSparseRocksDBUnique2: function() {
       collection.ensureIndex({type: "persistent", unique: true, fields: ["value1", "value2"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -657,7 +657,7 @@ function GetIndexesSuite() {
 
     testGetRocksDBNonUnique1: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -674,7 +674,7 @@ function GetIndexesSuite() {
 
     testGetRocksDBNonUnique2: function() {
       collection.ensureIndex({type: "persistent", fields: ["value1", "value2"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -691,7 +691,7 @@ function GetIndexesSuite() {
 
     testGetSparseRocksDBNonUnique1: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -708,7 +708,7 @@ function GetIndexesSuite() {
 
     testGetSparseRocksDBNonUnique2: function() {
       collection.ensureIndex({type: "persistent", fields: ["value1", "value2"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -723,10 +723,10 @@ function GetIndexesSuite() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief test suite: return value of getIndexes for an edge collection
+/// @brief test suite: return value of indexes for an edge collection
 ////////////////////////////////////////////////////////////////////////////////
 
-function GetIndexesEdgesSuite() {
+function IndexesEdgesSuite() {
   'use strict';
 
   let collection = null;
@@ -748,7 +748,7 @@ function GetIndexesEdgesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testEdgeGetPrimary: function() {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[0];
@@ -765,7 +765,7 @@ function GetIndexesEdgesSuite() {
 ////////////////////////////////////////////////////////////////////////////////
 
     testGetEdge: function() {
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(2, res.length);
       var idx = res[1];
@@ -784,7 +784,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetGeoConstraint1: function() {
       collection.ensureIndex({type: "geo", fields: ["lat", "lon"], geoJson: false});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -804,7 +804,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetGeoConstraint2: function() {
       collection.ensureIndex({type: "geo", fields: ["lat", "lon"], geoJson: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -824,7 +824,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetGeoConstraint3: function() {
       collection.ensureIndex({type: "geo", fields: ["lat"], geoJson: true, sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -845,7 +845,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetGeoIndex1: function() {
       collection.ensureIndex({type: "geo", fields: ["lat"], geoJson: true, sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -866,7 +866,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetGeoIndex2: function() {
       collection.ensureIndex({type: "geo", fields: ["lat", "lon"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -886,7 +886,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetPersistentUnique: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], unique: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -906,7 +906,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetSparsePersistentUnique: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], unique: true, sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -926,7 +926,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetPersistent: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -946,7 +946,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetSparsePersistent: function() {
       collection.ensureIndex({type: "persistent", fields: ["value"], sparse: true});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -966,7 +966,7 @@ function GetIndexesEdgesSuite() {
 
     testEdgeGetFulltext: function() {
       collection.ensureIndex({type: "fulltext", fields: ["value"]});
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(3, res.length);
       var idx = res[2];
@@ -1572,7 +1572,7 @@ function MultiIndexRollbackSuite() {
       collection.ensureIndex({type: "persistent", fields: ["_from", "_to", "link"], unique: true});
       collection.ensureIndex({type: "persistent", fields: ["_to", "ext"], unique: true, sparse: true});
 
-      var res = collection.getIndexes();
+      var res = collection.indexes();
 
       assertEqual(4, res.length);
       assertEqual("primary", res[0].type);
@@ -1641,7 +1641,7 @@ function ParallelIndexSuite() {
       let time = require("internal").time;
       let start = time();
       while (true) {
-        let indexes = require("internal").db._collection(cn).getIndexes();
+        let indexes = require("internal").db._collection(cn).indexes();
         assertTrue(indexes.length >= 1, indexes);
         if (indexes.length === noIndexes + 1) {
           // primary index + user-defined indexes
@@ -1658,7 +1658,7 @@ function ParallelIndexSuite() {
         require("internal").wait(0.5, false);
       }
 
-      let indexes = require("internal").db._collection(cn).getIndexes();
+      let indexes = require("internal").db._collection(cn).indexes();
       assertEqual(noIndexes + 1, indexes.length);
     },
 
@@ -1672,7 +1672,7 @@ function ParallelIndexSuite() {
       let time = require("internal").time;
       let start = time();
       while (true) {
-        let indexes = require("internal").db._collection(cn).getIndexes();
+        let indexes = require("internal").db._collection(cn).indexes();
         if (indexes.length === 4 + 1) {
           // primary index + user-defined indexes
           break;
@@ -1694,7 +1694,7 @@ function ParallelIndexSuite() {
       // will not do anything because the target indexes already exist)
       require("internal").wait(5, false);
 
-      let indexes = require("internal").db._collection(cn).getIndexes();
+      let indexes = require("internal").db._collection(cn).indexes();
       assertEqual(4 + 1, indexes.length);
     }
   };
@@ -1745,8 +1745,8 @@ function IndexUpdateSuite() {
 }
 
 jsunity.run(IndexSuite);
-jsunity.run(GetIndexesSuite);
-jsunity.run(GetIndexesEdgesSuite);
+jsunity.run(IndexesSuite);
+jsunity.run(IndexesEdgesSuite);
 jsunity.run(DuplicateValuesSuite);
 jsunity.run(MultiIndexRollbackSuite);
 jsunity.run(ParallelIndexSuite);

--- a/tests/js/client/shell/shell-quickie.js
+++ b/tests/js/client/shell/shell-quickie.js
@@ -81,10 +81,10 @@ function QuickieSuite () {
       var aql = db._query("FOR x IN UnitTestCollection RETURN x._key").toArray();
       assertEqual(1, aql.length);
       assertEqual(r._key, aql[0]);
-      var i = c.getIndexes();
+      var i = c.indexes();
       assertEqual(1, i.length); // We have a primary index
       c.ensureIndex({type: "hash", fields: ["Hallo"]});
-      i = c.getIndexes();
+      i = c.indexes();
       assertEqual(2, i.length); // We have a primary index and a hash Index
       aql = db._query("FOR x IN UnitTestCollection FILTER x.Hallo == 14 RETURN x._key").toArray();
       assertEqual(1, aql.length);
@@ -130,10 +130,10 @@ function QuickieSuite () {
       var aql = db._query("FOR x IN UnitTestCollection RETURN x._key").toArray();
       assertEqual(1, aql.length);
       assertEqual(r._key, aql[0]);
-      var i = c.getIndexes();
+      var i = c.indexes();
       assertEqual(1, i.length); // We have a primary index
       c.ensureIndex({type: "hash", fields: ["Hallo"]});
-      i = c.getIndexes();
+      i = c.indexes();
       assertEqual(2, i.length); // We have a primary index and a hash Index
       aql = db._query("FOR x IN UnitTestCollection FILTER x.Hallo == 14RETURN x._key").toArray();
       assertEqual(1, aql.length);

--- a/tests/js/client/shell/transaction/shell-transaction.inc
+++ b/tests/js/client/shell/transaction/shell-transaction.inc
@@ -4557,7 +4557,7 @@ function transactionIteratorSuite(dbParams) {
     testIteratorBoundsForward: function () {
       c.ensureIndex({ type: "persistent", fields: ["value1"] });
       c.ensureIndex({ type: "persistent", fields: ["value2"] });
-      let res = c.getIndexes();
+      let res = c.indexes();
       assertEqual(3, res.length);
 
       const opts = {
@@ -4599,7 +4599,7 @@ function transactionIteratorSuite(dbParams) {
     testIteratorBoundsReverse: function () {
       c.ensureIndex({ type: "persistent", fields: ["value1"] });
       c.ensureIndex({ type: "persistent", fields: ["value2"] });
-      let res = c.getIndexes();
+      let res = c.indexes();
       assertEqual(3, res.length);
 
       const opts = {

--- a/tests/js/common/replication/replication.js
+++ b/tests/js/common/replication/replication.js
@@ -564,7 +564,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "hash", fields: ["a", "b"], unique: true });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
 
       var entry = getLogEntries(tick, 2100)[0];
       assertTrue(2100, entry.type);
@@ -586,7 +586,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "hash", fields: ["a"] });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
 
       var entry = getLogEntries(tick, 2100)[0];
       assertEqual(c._id, entry.cid);
@@ -608,7 +608,7 @@ function ReplicationLoggerSuite () {
 
       c.ensureIndex({ type: "hash", fields: ["a", "b"], unique: true, sparse: true });
 
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
 
       var entry = getLogEntries(tick, 2100)[0];
       assertTrue(2100, entry.type);
@@ -631,7 +631,7 @@ function ReplicationLoggerSuite () {
 
       c.ensureIndex({ type: "hash", fields: ["a"], sparse: true });
 
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
 
       var entry = getLogEntries(tick, 2100)[0];
       assertEqual(c._id, entry.cid);
@@ -653,7 +653,7 @@ function ReplicationLoggerSuite () {
 
       c.ensureIndex({ type: "skiplist", fields: ["a", "b", "c"] });
 
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -676,7 +676,7 @@ function ReplicationLoggerSuite () {
 
       c.ensureIndex({ type: "skiplist", fields: ["a"], unique: true });
 
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertEqual(c._id, entry.cid);
@@ -698,7 +698,7 @@ function ReplicationLoggerSuite () {
 
       c.ensureIndex({ type: "skiplist", fields: ["a", "b", "c"], sparse: true });
 
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -721,7 +721,7 @@ function ReplicationLoggerSuite () {
 
       c.ensureIndex({ type: "skiplist", fields: ["a"], unique: true, sparse: true });
 
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertEqual(c._id, entry.cid);
@@ -741,7 +741,7 @@ function ReplicationLoggerSuite () {
 
       var tick = getLastLogTick();
       c.ensureIndex({ type: "fulltext", fields: ["a"], minLength: 5 });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
 
       var entry = getLogEntries(tick, 2100)[0];
       assertTrue(2100, entry.type);
@@ -763,7 +763,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "geo", fields: ["a", "b"] });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -784,7 +784,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "geo", fields: ["a"], geoJson: true });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -806,7 +806,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "geo", fields: ["a", "b"], geoJson: false });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -829,7 +829,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "geo", fields: ["a", "b"], geoJson: false });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -852,7 +852,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       c.ensureIndex({ type: "geo", fields: ["a"], geoJson: true });
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       var entry = getLogEntries(tick, 2100)[0];
 
       assertTrue(2100, entry.type);
@@ -876,7 +876,7 @@ function ReplicationLoggerSuite () {
       var tick = getLastLogTick();
 
       // use index at #1 (#0 is primary index)
-      var idx = c.getIndexes()[1];
+      var idx = c.indexes()[1];
       c.dropIndex(idx);
       var entry = getLogEntries(tick, 2101)[0];
 

--- a/tests/js/server/recovery/index-estimator.js
+++ b/tests/js/server/recovery/index-estimator.js
@@ -57,11 +57,11 @@ function recoverySuite () {
     testIndexEstimators: function () {
       let c = db._collection('UnitTestsRecovery');
 
-      assertEqual(3, c.getIndexes().length);
-      let idx = c.getIndexes()[0];
+      assertEqual(3, c.indexes().length);
+      let idx = c.indexes()[0];
       assertEqual('primary', idx.type);
 
-      idx = c.getIndexes()[1];
+      idx = c.indexes()[1];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value1' ], idx.fields);
@@ -70,7 +70,7 @@ function recoverySuite () {
       // so leave some leeway.
       assertTrue(idx.selectivityEstimate >= 0.90, idx); 
       
-      idx = c.getIndexes()[2];
+      idx = c.indexes()[2];
       assertFalse(idx.unique);
       assertFalse(idx.sparse);
       assertEqual([ 'value2' ], idx.fields);

--- a/tests/js/server/recovery/indexes-inbackground-exitone.js
+++ b/tests/js/server/recovery/indexes-inbackground-exitone.js
@@ -64,7 +64,7 @@ function recoverySuite () {
 
     testBrokenIndex: function () {
       const c = db._collection('UnitTestsRecovery1');
-      const indexes = c.getIndexes();
+      const indexes = c.indexes();
       assertEqual(indexes.length, 1);
       assertEqual(indexes[0].type, 'primary');
       assertEqual(indexes[0].id, 'UnitTestsRecovery1/0');

--- a/tests/js/server/recovery/nosync-rangedelete-truncate-indexes.js
+++ b/tests/js/server/recovery/nosync-rangedelete-truncate-indexes.js
@@ -86,7 +86,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       assertEqual(indexes.length, 4);
       for (let i of indexes) {
         switch (i.type) {

--- a/tests/js/server/recovery/nosync-rangedelete-truncate-indexes2.js
+++ b/tests/js/server/recovery/nosync-rangedelete-truncate-indexes2.js
@@ -86,7 +86,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       assertEqual(indexes.length, 4);
       for (let i of indexes) {
         switch (i.type) {

--- a/tests/js/server/recovery/nosync-rangedelete-truncate-indexes3.js
+++ b/tests/js/server/recovery/nosync-rangedelete-truncate-indexes3.js
@@ -86,7 +86,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/recovery/nosync-rangedelete-truncate-multi4.js
+++ b/tests/js/server/recovery/nosync-rangedelete-truncate-multi4.js
@@ -91,7 +91,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/recovery/nosync-rangedelete-truncate-multi5.js
+++ b/tests/js/server/recovery/nosync-rangedelete-truncate-multi5.js
@@ -91,7 +91,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/recovery/nosync-rangedelete-truncate-multi6.js
+++ b/tests/js/server/recovery/nosync-rangedelete-truncate-multi6.js
@@ -91,7 +91,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/recovery/rangedelete-truncate-indexes.js
+++ b/tests/js/server/recovery/rangedelete-truncate-indexes.js
@@ -80,7 +80,7 @@ function recoverySuite () {
       }
 
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       assertEqual(indexes.length, 4);
       for (let i of indexes) {
         switch (i.type) {

--- a/tests/js/server/recovery/truncate-collection-failures-after-commits-fp.js
+++ b/tests/js/server/recovery/truncate-collection-failures-after-commits-fp.js
@@ -111,7 +111,7 @@ const recoverySuite = function () {
 
     testIndexEstimates: () => {
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/recovery/truncate-collection-failures-before-commit-fp.js
+++ b/tests/js/server/recovery/truncate-collection-failures-before-commit-fp.js
@@ -105,7 +105,7 @@ const recoverySuite = function () {
 
     testSelectivityEstimates: () => {
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/recovery/truncate-collection-failures-between-commits-fp.js
+++ b/tests/js/server/recovery/truncate-collection-failures-between-commits-fp.js
@@ -113,7 +113,7 @@ const recoverySuite = function () {
 
     testSelectivityEstimates: () => {
       internal.waitForEstimatorSync(); // make sure estimates are consistent
-      let indexes = c.getIndexes(true);
+      let indexes = c.indexes(true);
       for (let i of indexes) {
         switch (i.type) {
           case 'primary':

--- a/tests/js/server/shell/shell-foxx-queues.js
+++ b/tests/js/server/shell/shell-foxx-queues.js
@@ -75,7 +75,7 @@ function BaseTestConfig () {
     },
 
     testCheckJobIndexes : function () {
-      let indexes = db._jobs.getIndexes();
+      let indexes = db._jobs.indexes();
       assertEqual(indexes.length, 3);
       indexes.forEach(idx => {
         switch(idx.type) {


### PR DESCRIPTION
### Scope & Purpose

We added `.indexes()` as an alias for `.getIndexes()` in v3.4.
`.indexes()` is more consistent with the rest of the JavaScript API, so this is a preparation for deprecating `.getIndexes()`.

- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made - no, removal TBD e.g. in v3.13
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
