### PR TITLE
Make sure that async registry REST handler is running more than once at the same time

### DIFF
--- a/arangod/AsyncRegistryServer/CMakeLists.txt
+++ b/arangod/AsyncRegistryServer/CMakeLists.txt
@@ -1,6 +1,3 @@
-add_library(arango_async_registry_feature STATIC
+target_sources(arangoserver PRIVATE
   Feature.cpp
   RestHandler.cpp)
-target_link_libraries(arango_async_registry_feature 
-  PRIVATE
-  arango_metrics)

--- a/arangod/AsyncRegistryServer/Feature.cpp
+++ b/arangod/AsyncRegistryServer/Feature.cpp
@@ -26,7 +26,6 @@
 #include "Metrics/CounterBuilder.h"
 #include "Metrics/GaugeBuilder.h"
 #include "Metrics/MetricsFeature.h"
-#include "Scheduler/SchedulerFeature.h"
 #include "ProgramOptions/Parameters.h"
 
 using namespace arangodb::async_registry;
@@ -53,22 +52,10 @@ DECLARE_GAUGE(arangodb_async_registered_threads, std::uint64_t,
               "Number of threads the asynchronous registry iterates over to "
               "list all asynchronous promises");
 
-template<typename F>
-void Feature::SchedulerWrapper::queue(F&& fn) {
-  SchedulerFeature::SCHEDULER->queue(RequestLane::CLUSTER_INTERNAL,
-                                     std::forward<F>(fn));
-}
-template<typename F>
-Feature::SchedulerWrapper::WorkHandle Feature::SchedulerWrapper::queueDelayed(
-    F&& fn, std::chrono::milliseconds timeout) {
-  return SchedulerFeature::SCHEDULER->queueDelayed(
-      "rocksdb-meta-collection-lock-timeout", RequestLane::CLUSTER_INTERNAL,
-      timeout, std::forward<F>(fn));
-}
-
 Feature::Feature(Server& server)
     : ArangodFeature{server, *this}, _async_mutex{_schedulerWrapper} {
-  startsAfter<arangodb::metrics::MetricsFeature>();
+  startsAfter<metrics::MetricsFeature>();
+  startsAfter<SchedulerFeature>();
 }
 
 auto Feature::create_metrics(arangodb::metrics::MetricsFeature& metrics_feature)

--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -27,7 +27,14 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Async/Registry/promise.h"
 #include "Async/Registry/registry_variable.h"
+#include "Cluster/ClusterFeature.h"
+#include "Cluster/ClusterInfo.h"
+#include "Cluster/ServerState.h"
 #include "Inspection/VPack.h"
+#include "Network/ConnectionPool.h"
+#include "Network/Methods.h"
+#include "Network/NetworkFeature.h"
+#include "Network/RequestOptions.h"
 #include "Rest/CommonDefines.h"
 
 using namespace arangodb;
@@ -63,15 +70,8 @@ RestHandler::RestHandler(ArangodServer& server, GeneralRequest* request,
     : RestVocbaseBaseHandler(server, request, response),
       _feature(server.getFeature<Feature>()) {}
 
-auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
-  if (_request->requestType() != rest::RequestType::GET) {
-    generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
-                  TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    co_return;
-  }
-
-  auto lock_guard = co_await _feature.asyncLock();
-
+namespace {
+auto getData() -> VPackBuilder {
   auto [promises, roots] = all_undeleted_promises();
   auto awaited_promises = promises.index_by_awaitee();
 
@@ -98,7 +98,74 @@ auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
   }
   builder.close();
   builder.close();
+  return builder;
+}
+}  // namespace
 
-  generateResult(rest::ResponseCode::OK, builder.slice());
+auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
+  if (!ExecContext::current().isSuperuser()) {
+    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
+                  "you need super user rights for log operations");
+  }
+
+  if (_request->requestType() != rest::RequestType::GET) {
+    generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
+                  TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
+    co_return;
+  }
+
+  bool foundServerIdParameter;
+  std::string const& serverId =
+      _request->value("serverId", foundServerIdParameter);
+
+  if (ServerState::instance()->isCoordinator() && foundServerIdParameter) {
+    if (serverId != ServerState::instance()->getId()) {
+      // not ourselves! - need to pass through the request
+      auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
+
+      bool found = false;
+      for (auto const& srv : ci.getServers()) {
+        // validate if server id exists
+        if (srv.first == serverId) {
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        generateError(rest::ResponseCode::NOT_FOUND,
+                      TRI_ERROR_HTTP_BAD_PARAMETER,
+                      "unknown serverId supplied.");
+        co_return;
+      }
+
+      NetworkFeature const& nf = server().getFeature<NetworkFeature>();
+      network::ConnectionPool* pool = nf.pool();
+      if (pool == nullptr) {
+        THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+      }
+      network::RequestOptions options;
+      options.timeout = network::Timeout(30.0);
+      options.database = _request->databaseName();
+      options.parameters = _request->parameters();
+
+      auto f = network::sendRequestRetry(
+          pool, "server:" + serverId, fuerte::RestVerb::Get,
+          _request->requestPath(), VPackBuffer<uint8_t>{}, options);
+      co_await std::move(f).thenValue(
+          [self = std::dynamic_pointer_cast<RestHandler>(shared_from_this())](
+              network::Response const& r) {
+            if (r.fail()) {
+              self->generateError(r.combinedResult());
+            } else {
+              self->generateResult(rest::ResponseCode::OK, r.slice());
+            }
+          });
+      co_return;
+    }
+  }
+
+  auto lock_guard = co_await _feature.asyncLock();
+  generateResult(rest::ResponseCode::OK, getData().slice());
   co_return;
 }

--- a/arangod/AsyncRegistryServer/RestHandler.h
+++ b/arangod/AsyncRegistryServer/RestHandler.h
@@ -34,7 +34,7 @@ class RestHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   char const* name() const override final { return "AsyncRegistryRestHandler"; }
   RequestLane lane() const override final { return RequestLane::CLUSTER_ADMIN; }
-  RestStatus execute() override;
+  futures::Future<futures::Unit> executeAsync() override;
 
   Feature& _feature;
 };

--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -207,7 +207,6 @@ endif()
 target_link_libraries(arangoserver
   arango_agency
   arango_aql
-  arango_async_registry_feature
   arango_cluster_engine
   arango_cluster_methods
   arango_common_rest_handler


### PR DESCRIPTION
Uses an async mutex (FutureSharedLock) to achieve that.

Additionally, adds authentication and forwarding from coordinator to other other instances.