### PR TITLE
we may receive an undefined body and later on struggle over that.

### DIFF
--- a/tests/js/client/load-balancing/load-balancing-foxx-installation-noauth-cluster.js
+++ b/tests/js/client/load-balancing/load-balancing-foxx-installation-noauth-cluster.js
@@ -76,6 +76,7 @@ function sendRequest(method, endpoint, body, usePrimary) {
     return {};
   }
   assertTrue(res.hasOwnProperty('body'), JSON.stringify(res));
+  assertTrue(res.body !== undefined, JSON.stringify(res));
   let resultBody = res.body;
   if (typeof resultBody === "string") {
     resultBody = JSON.parse(resultBody);


### PR DESCRIPTION
### Scope & Purpose

fix test error handling: 
```

=== cl_load_balancing ===
* Test "load_balancing"
    [FAILED]  tests/js/client/load-balancing/load-balancing-foxx-installation-noauth-cluster.js

      "testFoxxZipUploadWithRedirect" failed: TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')
    at installFoxxZipFile (/work/ArangoDB/tests/js/client/load-balancing/load-balancing-foxx-installation-noauth-cluster.js:111:28)
    at Object.testFoxxZipUploadWithRedirect (/work/ArangoDB/tests/js/client/load-balancing/load-balancing-foxx-installation-noauth-cluster.js:194:7)
    at /work/ArangoDB/tests/js/client/load-balancing/load-balancing-foxx-installation-noauth-cluster.js:239:9
...    at Function.forEach (/work/ArangoDB/js/node/node_modules/lodash/lodash.js:9410:14)
```

- [x] :hankey: Bugfix
