### PR TITLE
Promise can have an async or sync waiter

### DIFF
--- a/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
+++ b/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
@@ -31,8 +31,8 @@ class Waiter(object):
         self.is_sync = is_sync
         self.item = item
     @classmethod
-    def from_json(cls, blob: Optional[dict]):
-        if blob is None:
+    def from_json(cls, blob: dict):
+        if not blob:
             return None
         sync = blob.get("sync")
         if sync is not None:
@@ -46,7 +46,7 @@ class Waiter(object):
             return ""
 
 class Data(object):
-    def __init__(self, owning_thread: Thread, source_location: SourceLocation, id: int, state: str, waiter: Optional[Waiter] = 0):
+    def __init__(self, owning_thread: Thread, source_location: SourceLocation, id: int, state: str, waiter: Waiter):
         self.owning_thread = owning_thread
         self.source_location = source_location
         self.id = id
@@ -54,7 +54,7 @@ class Data(object):
         self.state = state
     @classmethod
     def from_json(cls, blob: dict):
-        return cls(Thread.from_json(blob["owning_thread"]), SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Waiter.from_json(blob.get("waiter")))
+        return cls(Thread.from_json(blob["owning_thread"]), SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Waiter.from_json(blob["waiter"]))
     def __str__(self):
         waiter_str = str(self.waiter) if self.waiter != None else ""
         return str(self.source_location) + ", " + str(self.owning_thread) + ", " + self.state + waiter_str
@@ -119,6 +119,7 @@ def test_intput() -> str:
           "function_name": "arangodb::network::(anonymous namespace)::Pack::Pack(DestinationId &&, RequestLane, bool, bool)"
         },
         "id": 124252709790688,
+        "waiter": {},
         "state": "Suspended"
       }
     }

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -177,7 +177,7 @@ struct async {
   bool valid() const noexcept { return _handle != nullptr; }
   operator bool() const noexcept { return valid(); }
 
-  auto set_promise_waiter(void* waiter) {
+  auto set_promise_waiter(async_registry::AsyncWaiter waiter) {
     _handle.promise().set_promise_waiter(waiter);
   }
   auto id() -> void* { return _handle.promise()->id(); }

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "Async/Registry/promise.h"
 #include "Futures/Exceptions.h"
 #include "Futures/SharedState.h"
 #include "Futures/Unit.h"
@@ -120,7 +121,7 @@ class Promise {
 
   arangodb::futures::Future<T> getFuture();
 
-  auto set_promise_waiter(void* waiter) {
+  auto set_promise_waiter(async_registry::AsyncWaiter waiter) {
     return _state->set_promise_waiter(waiter);
   }
   auto id() -> void* { return _state->id(); }

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -506,11 +506,12 @@ TYPED_TEST(AsyncTest, async_promises_in_async_registry_know_their_waiter) {
   EXPECT_TRUE(awaited_promise.has_value());
   EXPECT_TRUE(waiter_promise.has_value());
   EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
-      awaited_promise->waiter.value()));
-  EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
-                awaited_promise->waiter.value()),
-            waiter_promise->id);
-  EXPECT_EQ(waiter_promise->waiter, std::nullopt);
+      awaited_promise->waiter));
+  EXPECT_EQ(
+      std::get<arangodb::async_registry::AsyncWaiter>(awaited_promise->waiter),
+      waiter_promise->id);
+  EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::NoWaiter>(
+      waiter_promise->waiter));
 }
 
 namespace {

--- a/tests/Futures/FutureTest.cpp
+++ b/tests/Futures/FutureTest.cpp
@@ -899,11 +899,12 @@ TEST(FutureTest,
   EXPECT_TRUE(awaited_promise.has_value());
   EXPECT_TRUE(waiter_promise.has_value());
   EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
-      awaited_promise->waiter.value()));
-  EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
-                awaited_promise->waiter.value()),
-            waiter_promise->id);
-  EXPECT_EQ(waiter_promise->waiter, std::nullopt);
+      awaited_promise->waiter));
+  EXPECT_EQ(
+      std::get<arangodb::async_registry::AsyncWaiter>(awaited_promise->waiter),
+      waiter_promise->id);
+  EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::NoWaiter>(
+      waiter_promise->waiter));
 }
 
 namespace {
@@ -971,11 +972,12 @@ TEST(FutureTest,
     EXPECT_TRUE(awaited_promise.has_value());
     EXPECT_TRUE(waiter_promise.has_value());
     EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
-        awaited_promise->waiter.value()));
+        awaited_promise->waiter));
     EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
-                  awaited_promise->waiter.value()),
+                  awaited_promise->waiter),
               waiter_promise->id);
-    EXPECT_EQ(waiter_promise->waiter, std::nullopt);
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::NoWaiter>(
+        waiter_promise->waiter));
   }
 }
 
@@ -1019,16 +1021,17 @@ TEST(FutureTest, collected_async_promises_in_async_registry_know_their_waiter) {
     EXPECT_EQ(awaited_promises.size(), 2);
     EXPECT_TRUE(waiter_promise.has_value());
     EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
-        awaited_promises[0].waiter.value()));
+        awaited_promises[0].waiter));
     EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
-                  awaited_promises[0].waiter.value()),
+                  awaited_promises[0].waiter),
               waiter_promise->id);
     EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
-        awaited_promises[1].waiter.value()));
+        awaited_promises[1].waiter));
     EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
-                  awaited_promises[1].waiter.value()),
+                  awaited_promises[1].waiter),
               waiter_promise->id);
-    EXPECT_EQ(waiter_promise->waiter, std::nullopt);
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::NoWaiter>(
+        waiter_promise->waiter));
   }
 }
 

--- a/tests/Futures/FutureTest.cpp
+++ b/tests/Futures/FutureTest.cpp
@@ -1,3 +1,5 @@
+#include <optional>
+#include <optional>
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
@@ -31,7 +33,9 @@
 #include <condition_variable>
 #include <exception>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
+#include <variant>
 
 using namespace arangodb::futures;
 
@@ -876,31 +880,30 @@ TEST(FutureTest,
   auto awaited_coro = awaited_co();
   auto waiter_coro = waiter_co(std::move(awaited_coro));
 
-  struct PromiseIds {
-    bool set = false;
-    void* id;
-    void* waiter;
-  };
-  PromiseIds awaited_promise;
-  PromiseIds waiter_promise;
+  std::optional<arangodb::async_registry::PromiseSnapshot> awaited_promise;
+  std::optional<arangodb::async_registry::PromiseSnapshot> waiter_promise;
   uint count = 0;
   arangodb::async_registry::registry.for_promise(
       [&](arangodb::async_registry::PromiseSnapshot promise) {
         count++;
         if (promise.source_location.function_name.find("awaited_co") !=
             std::string::npos) {
-          awaited_promise = PromiseIds{true, promise.id, promise.waiter};
+          awaited_promise = promise;
         }
         if (promise.source_location.function_name.find("waiter_co") !=
             std::string::npos) {
-          waiter_promise = PromiseIds{true, promise.id, promise.waiter};
+          waiter_promise = promise;
         }
       });
   EXPECT_EQ(count, 2);
-  EXPECT_TRUE(awaited_promise.set);
-  EXPECT_TRUE(waiter_promise.set);
-  EXPECT_EQ(awaited_promise.waiter, waiter_promise.id);
-  EXPECT_EQ(waiter_promise.waiter, nullptr);
+  EXPECT_TRUE(awaited_promise.has_value());
+  EXPECT_TRUE(waiter_promise.has_value());
+  EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
+      awaited_promise->waiter.value()));
+  EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
+                awaited_promise->waiter.value()),
+            waiter_promise->id);
+  EXPECT_EQ(waiter_promise->waiter, std::nullopt);
 }
 
 namespace {
@@ -911,14 +914,7 @@ auto awaited_fn() -> Future<int> {
 }  // namespace
 TEST(FutureTest,
      continued_future_promises_in_async_registry_know_their_waiter) {
-  struct PromiseIds {
-    bool set = false;
-    void* id;
-    void* waiter;
-  };
-
   std::vector<std::function<void()>> waiter{
-
       []() { auto future = awaited_fn().thenValue([](int a) { return 1; }); },
       []() {
         auto future =
@@ -956,36 +952,34 @@ TEST(FutureTest,
   for (const auto& fn : waiter) {
     arangodb::async_registry::get_thread_registry().garbage_collect();
     fn();
-    PromiseIds awaited_promise;
-    PromiseIds waiter_promise;
+    std::optional<arangodb::async_registry::PromiseSnapshot> awaited_promise;
+    std::optional<arangodb::async_registry::PromiseSnapshot> waiter_promise;
     uint count = 0;
     arangodb::async_registry::registry.for_promise(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
           if (std::string(promise.source_location.function_name)
                   .find("awaited_fn") != std::string::npos) {
-            awaited_promise = PromiseIds{true, promise.id, promise.waiter};
+            awaited_promise = promise;
           }
           if (std::string(promise.source_location.function_name)
                   .find("TestBody") != std::string::npos) {
-            waiter_promise = PromiseIds{true, promise.id, promise.waiter};
+            waiter_promise = promise;
           }
         });
     EXPECT_EQ(count, 2);
-    EXPECT_TRUE(awaited_promise.set);
-    EXPECT_TRUE(waiter_promise.set);
-    EXPECT_EQ(awaited_promise.waiter, waiter_promise.id);
-    EXPECT_EQ(waiter_promise.waiter, nullptr);
+    EXPECT_TRUE(awaited_promise.has_value());
+    EXPECT_TRUE(waiter_promise.has_value());
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
+        awaited_promise->waiter.value()));
+    EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
+                  awaited_promise->waiter.value()),
+              waiter_promise->id);
+    EXPECT_EQ(waiter_promise->waiter, std::nullopt);
   }
 }
 
 TEST(FutureTest, collected_async_promises_in_async_registry_know_their_waiter) {
-  struct PromiseIds {
-    bool set = false;
-    void* id;
-    void* waiter;
-  };
-
   std::vector<std::tuple<std::string, std::function<void()>>> waiter{
       std::make_tuple("collectAll",
                       []() {
@@ -1006,28 +1000,35 @@ TEST(FutureTest, collected_async_promises_in_async_registry_know_their_waiter) {
   for (const auto& [name, fn] : waiter) {
     arangodb::async_registry::get_thread_registry().garbage_collect();
     fn();
-    std::vector<PromiseIds> awaited_promises;
-    PromiseIds waiter_promise;
+    std::vector<arangodb::async_registry::PromiseSnapshot> awaited_promises;
+    std::optional<arangodb::async_registry::PromiseSnapshot> waiter_promise;
     uint count = 0;
     arangodb::async_registry::registry.for_promise(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
           if (std::string(promise.source_location.function_name)
                   .find("awaited_fn") != std::string::npos) {
-            awaited_promises.push_back(
-                PromiseIds{true, promise.id, promise.waiter});
+            awaited_promises.push_back(promise);
           }
           if (std::string(promise.source_location.function_name).find(name) !=
               std::string::npos) {
-            waiter_promise = PromiseIds{true, promise.id, promise.waiter};
+            waiter_promise = promise;
           }
         });
     EXPECT_EQ(count, 3);
     EXPECT_EQ(awaited_promises.size(), 2);
-    EXPECT_TRUE(waiter_promise.set);
-    EXPECT_EQ(awaited_promises[0].waiter, waiter_promise.id);
-    EXPECT_EQ(awaited_promises[1].waiter, waiter_promise.id);
-    EXPECT_EQ(waiter_promise.waiter, nullptr);
+    EXPECT_TRUE(waiter_promise.has_value());
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
+        awaited_promises[0].waiter.value()));
+    EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
+                  awaited_promises[0].waiter.value()),
+              waiter_promise->id);
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::AsyncWaiter>(
+        awaited_promises[1].waiter.value()));
+    EXPECT_EQ(std::get<arangodb::async_registry::AsyncWaiter>(
+                  awaited_promises[1].waiter.value()),
+              waiter_promise->id);
+    EXPECT_EQ(waiter_promise->waiter, std::nullopt);
   }
 }
 


### PR DESCRIPTION
You can wait synchronously on a future. The corresponding promise in the async registry does now know the thread id of the thread that does the waiting. This enables the user to connect normal and async stacktraces.

A promise does now have an optional waiter:
- If no sync or async operation awaits this promise, this promise has no waiter
- If this promise is awaited by an async operation, this promise has an async waiter (which includes the id of the waiter promise)
- If this promise is awaited by a sync operation (which happens when a thread waits on a future), this promise has a sync waiter (which includes the id of the waiting thread)
one waiter which is either 

Additionally, this PR adds garbage collection also in the new scheduler (same is already done in the old (supervised) scheduler.