### PR TITLE
Hot fix for synchronise shard race and arangodump malformed JSON with MDI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+3.12.3.1 (XXXX-XX-XX)
+---------------------
+
+* Fix shard synchronisation race where after a shard move the new
+  leader informs followers before it updates Current in the Agency. In
+  some cases the old leader fell subsequently out of sync.
+
+* Correct ClusterInfo output for MDI, which otherwise breaks
+  `arangodump` when MDI are present with "malformed JSON" error.
+
+
 3.12.3 (2024-10-25)
 -------------------
 

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -170,6 +170,7 @@ void ClusterIndex::toVelocyPack(
         !pair.key.isEqualString(StaticStrings::IndexName) &&
         !pair.key.isEqualString(StaticStrings::IndexType) &&
         !pair.key.isEqualString(StaticStrings::IndexFields) &&
+        !pair.key.isEqualString(StaticStrings::IndexPrefixFields) &&
         !pair.key.isEqualString("selectivityEstimate") &&
         !pair.key.isEqualString("figures") &&
         !pair.key.isEqualString(StaticStrings::IndexUnique) &&

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1099,7 +1099,7 @@ Result DumpFeature::runDump(httpclient::SimpleHttpClient& client,
   } catch (...) {
     return Result{TRI_ERROR_INTERNAL,
                   "got malformed JSON response from server: "
-                      "failed to parse inventory body: " +
+                  "failed to parse inventory body: " +
                       response->getBody().toString()};
   }
   VPackSlice body = parsedBody->slice();

--- a/lib/Basics/VelocyPackHelper.cpp
+++ b/lib/Basics/VelocyPackHelper.cpp
@@ -239,7 +239,7 @@ void VelocyPackHelper::initialize() {
 
   // set up options for validating requests, without UTF-8 validation
   looseRequestValidationOptions = VPackOptions::Defaults;
-  looseRequestValidationOptions.checkAttributeUniqueness = true;
+  looseRequestValidationOptions.checkAttributeUniqueness = false;
   looseRequestValidationOptions.validateUtf8Strings = false;
   looseRequestValidationOptions.disallowExternals = true;
   looseRequestValidationOptions.disallowCustom = true;


### PR DESCRIPTION
### Scope & Purpose

*Hotfix 3.12.3.1 to include race fix for synchronise shard where the old leader falls out of sync. MDI index presence breaks arangodump with malformed JSON error*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
