### PR TITLE
QA-580: the old v8 doesn't have replaceAll

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -498,7 +498,7 @@ function unitTestPrettyPrintResults (options, results) {
               failedMessages += '\n';
               onlyFailedMessages += '\n';
             }
-            m = '      "' + one + '" failed: ' + details[one].replaceAll('\\n', '\n');
+            m = '      "' + one + '" failed: ' + details[one].replace(/\\n/g, '\n');
             failedMessages += RED + m + RESET + '\n\n';
             onlyFailedMessages += m + '\n\n';
             count++;


### PR DESCRIPTION
### Scope & Purpose

ye olde V8 doesn't have replaceAll()

- [x] :hankey: Bugfix
