### PR TITLE
Refuse Sync Log Message Improvements

### DIFF
--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -2679,6 +2679,11 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
         auto currentLeader = cservers[0].stringView();
         auto planLeader = pservers[0].stringView();
 
+        // if we are considered to be in sync there is nothing to do
+        if (!needsResyncBecauseOfRestart && indexOf(cservers, serverId) > 0) {
+          continue;
+        }
+
         if (currentLeader.starts_with("_") || planLeader != currentLeader) {
           // Do not attempt to sync if the server in current is still resigned
           // or not equal to the planned leader.
@@ -2691,20 +2696,18 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
           //    (new leader hasn't confirmed leadership yet)
 
           LOG_TOPIC("2dba7", INFO, Logger::MAINTENANCE)
-              << "refuse to synchronize shard with a resigned leader in "
-                 "current - myself = "
-              << serverId << " plan servers = " << pservers.toJson()
+              << "refuse to synchronize shard " << dbname << "/" << colname
+              << "/" << shname
+              << " with a resigned leader in current - myself = " << serverId
+              << " plan servers = " << pservers.toJson()
               << " current servers = " << cservers.toJson();
           continue;
         }
 
-        // if we are considered to be in sync there is nothing to do
-        if (!needsResyncBecauseOfRestart && indexOf(cservers, serverId) > 0) {
-          continue;
-        }
-
         LOG_TOPIC("3d7a8", DEBUG, Logger::MAINTENANCE)
-            << "detected synchronize shard: myself = " << serverId
+            << "detected synchronize shard" << dbname << "/" << colname << "/"
+            << shname << ": myself = " << serverId
+            << " plan servers = " << pservers.toJson()
             << " current servers = " << cservers.toJson()
             << " local theLeader = " << theLeader.toJson();
 


### PR DESCRIPTION
### Scope & Purpose
Refuse sync only after check if sync is necessary. Add more details to the log message.
