### PR TITLE
Fix delay in maintenance if write hots directly after hotbackup restore [BTS-2014]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v3.11.13 (XXXX-XX-XX) 
+---------------------
+
+* BTS-2014: Fix delay if write hits early after a hotbackup restore.
+
+
 v3.11.12 (2024-10-31)
 ---------------------
 

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -561,7 +561,6 @@ Result FollowerInfo::persistInAgency(bool isRemove,
   std::string curPath = ::currentShardPath(*_docColl);
   std::string planPath = ::planShardPath(*_docColl);
   AgencyComm ac(_docColl->vocbase().server());
-  int badCurrentCount = 0;
   using namespace std::chrono_literals;
   auto wait(50ms), waitMore(wait);
   do {

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -587,16 +587,23 @@ Result FollowerInfo::persistInAgency(bool isRemove,
           LOG_TOPIC("57c84", ERR, Logger::CLUSTER)
               << "Found: " << currentEntry.toJson();
         }
-        // We have to prevent an endless loop in this case, if the collection
-        // has been dropped in the agency in the meantime
-        ++badCurrentCount;
-        if (badCurrentCount > 30) {
-          // this retries for 15s, if current is bad for such a long time, we
-          // assume that the collection has been dropped in the meantime:
-          LOG_TOPIC("8972b", INFO, Logger::CLUSTER)
-              << "giving up persisting follower info for dropped collection";
-          return TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;
-        }
+        // If we get here and the Current/Collections entry for this
+        // collection is not an object, then our task here is obviously
+        // meaningless. Since our task in life is to update the Current
+        // entry, there is nothing to do. Note that this can happen if
+        // the collection has been dropped in the meantime, or if we are
+        // directly after a hotbackup restore and this collection has
+        // existed before and after the restore. In particular, we do want
+        // to delay things unduly, if we are coming from
+        //   updateFailoverCandidates
+        //   allowedToWrite
+        // which can happen any time even directly after a hotbackup restore.
+        // For this particular case it is also OK to return
+        //   TRI_ERROR_ARANGO_DATABASE_NOT_FOUND
+        // since the actual error code is not checked in this case.
+        LOG_TOPIC("8972b", INFO, Logger::CLUSTER)
+            << "giving up persisting follower info for dropped collection";
+        return TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND;
       } else {
         if (!planEntry.isArray() || planEntry.length() == 0 ||
             !planEntry[0].isString() ||


### PR DESCRIPTION
### Scope & Purpose

Fix delay if write hits directly after a hotbackup restore.

Analysis see: https://arangodb.atlassian.net/browse/BTS-2014

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] Tests
  - [*] RTA
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: BTS-2014
- [*] Corresponding devel PR: https://github.com/arangodb/arangodb/pull/21445
