### PR TITLE
 Fix delay in maintenance if write hots directly after hotbackup restore [BTS-2014]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* BTS-2014: Fix delay if write hits early after a hotbackup restore.
+
 * Fix leader resignation race in coordinator, which lead to forgotten
   collection read locks on dbservers, which in turn could lead to deadlocks
   in the cluster.

--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -577,7 +577,6 @@ Result FollowerInfo::persistInAgency(bool isRemove,
   std::string curPath = ::currentShardPath(*_docColl);
   std::string planPath = ::planShardPath(*_docColl);
   AgencyComm ac(_docColl->vocbase().server());
-  int badCurrentCount = 0;
   using namespace std::chrono_literals;
   auto wait(50ms), waitMore(wait);
   do {


### PR DESCRIPTION
### Scope & Purpose

Fix delay if write hits directly after a hotbackup restore.

Analysis see: https://arangodb.atlassian.net/browse/BTS-2014

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [*] Tests
  - [*] RTA
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21444

#### Related Information

- [*] GitHub issue / Jira ticket: BTS-2014

