### PR TITLE
MDI performance improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -143,6 +143,10 @@ devel
   bugs which could happen on upgrade to 3.12 because funny international
   strings are indexed in VPack indexes.
 
+* Implements a faster encoding of doubles to a memcmp format. Makes it a cmake option.
+  Makes sure that it does not produce different values as the old/slower implementation.
+  Removes unneeded db._explain in a test
+
 * Improve the observability of asynchronous operations by saving all ongoing
   asynchronous operations (associated with async<T> and Future<T>) in a registry.
   A REST call gives information about all these operations via a list of all

--- a/arangod/RocksDBEngine/RocksDBMultiDimIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBMultiDimIndex.cpp
@@ -301,11 +301,9 @@ class RocksDBMdiIndexIterator final : public IndexIterator {
 
 namespace {
 
-auto convertDouble(double x) -> zkd::byte_string {
-  zkd::BitWriter bw;
-  bw.append(zkd::Bit::ZERO);  // add zero bit for `not infinity`
-  zkd::into_bit_writer_fixed_length(bw, x);
-  return std::move(bw).str();
+auto convertDouble(double const x) -> zkd::byte_string {
+  // leading with zero to indicate `not infinity`
+  return zkd::into_zero_leading_fixed_length_byte_string(x);
 }
 
 auto accessDocumentPath(VPackSlice doc,

--- a/arangod/Zkd/CMakeLists.txt
+++ b/arangod/Zkd/CMakeLists.txt
@@ -1,4 +1,12 @@
 add_library(arango_zkd STATIC
   ZkdHelper.cpp)
 
+option(USE_FAST_DOUBLE_MEMCMP_ENCODING 
+  "Used to trigger the use for a faster double encode"
+  ON)
+
+if (USE_FAST_DOUBLE_MEMCMP_ENCODING)
+  target_compile_definitions(arango_zkd PRIVATE USE_FAST_DOUBLE_MEMCMP_ENCODING)
+endif ()
+
 target_link_libraries(arango_zkd arango)

--- a/arangod/Zkd/ZkdHelper.cpp
+++ b/arangod/Zkd/ZkdHelper.cpp
@@ -23,9 +23,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "ZkdHelper.h"
 
+#include "Basics/application-exit.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/debugging.h"
 #include "Containers/SmallVector.h"
+#include "Logger/LogMacros.h"
 
 #include <absl/strings/str_cat.h>
 
@@ -34,12 +36,59 @@
 #include <cmath>
 #include <cstddef>
 #include <iomanip>
-#include <iostream>
 #include <optional>
-#include <tuple>
 
 using namespace arangodb;
 using namespace arangodb::zkd;
+
+namespace {
+#ifdef USE_FAST_DOUBLE_MEMCMP_ENCODING
+auto encode_double_to_fast_memcmp_format(double const x) -> uint64_t {
+  static_assert(sizeof(double) == sizeof(uint64_t),
+                "size of double and uint64_t do not match");
+  // This was taken from
+  // https://yizhang82.dev/sorting-structured-data-2
+  uint64_t encoded;
+  std::memcpy(&encoded, &x, sizeof(encoded));
+  // hex 0x8000000000000000 is a 1 bit and 63 zeros
+  uint64_t constexpr SIGN_BIT_MASK = 0x8000000000000000;
+
+  // we want to have the zero pretty much in the middle of our bit-encoded
+  // distribution -0.0 and +0.0 would end up at different places so we convert
+  // -0.0 to +0.0
+  if (encoded == SIGN_BIT_MASK) {
+    encoded = 0;
+  }
+
+  // negative numbers should also be "lower" and positive numbers should be
+  // "higher"
+  if ((encoded & SIGN_BIT_MASK) > 0) {
+    // sign bit is set so we detected a negative number, we have to flip the
+    // sign bit and negate everything else by doing this we ensure that the
+    // smaller numbers are farther away from zero
+    encoded = ~encoded;
+  } else {
+    // positive numbers are already in the expected order so we only flip the
+    // sign-bit to make them bigger than negative numbers
+    encoded = encoded | SIGN_BIT_MASK;
+  }
+  return encoded;
+}
+
+std::array<std::byte, 8> uint64_to_big_endian_byte_array(uint64_t const v) {
+  std::array<std::byte, 8> arr;
+  arr[7] = static_cast<std::byte>(v & 0xff);
+  arr[6] = static_cast<std::byte>((v >> 8) & 0xff);
+  arr[3] = static_cast<std::byte>((v >> 32) & 0xff);
+  arr[5] = static_cast<std::byte>((v >> 16) & 0xff);
+  arr[4] = static_cast<std::byte>((v >> 24) & 0xff);
+  arr[2] = static_cast<std::byte>((v >> 40) & 0xff);
+  arr[1] = static_cast<std::byte>((v >> 48) & 0xff);
+  arr[0] = static_cast<std::byte>((v >> 56) & 0xff);
+  return arr;
+}
+#endif  // USE_FAST_DOUBLE_MEMCMP_ENCODING
+}  // anonymous namespace
 
 zkd::byte_string zkd::operator"" _bs(const char* const str, std::size_t len) {
   using namespace std::string_literals;
@@ -626,11 +675,68 @@ void zkd::into_bit_writer_fixed_length<double>(BitWriter& bw, double x) {
   bw.write_big_endian_bits(base, 52);
 }
 
+auto zkd::into_zero_leading_fixed_length_byte_string(double const x)
+    -> byte_string {
+#ifdef USE_FAST_DOUBLE_MEMCMP_ENCODING
+  return into_zero_leading_fixed_length_byte_string_fast(x);
+#else
+  return into_zero_leading_fixed_length_byte_string_slow(x);
+#endif  // USE_FAST_DOUBLE_MEMCMP_ENCODING
+}
+
+auto zkd::into_zero_leading_fixed_length_byte_string_slow(double const x)
+    -> byte_string {
+  zkd::BitWriter bw;
+  bw.append(zkd::Bit::ZERO);  // add zero bit for `not infinity`
+  zkd::into_bit_writer_fixed_length(bw, x);
+  return std::move(bw).str();
+}
+
 template<>
 auto zkd::to_byte_string_fixed_length<double>(double x) -> byte_string {
+#ifdef USE_FAST_DOUBLE_MEMCMP_ENCODING
+  return double_to_byte_string_fixed_length_fast(x);
+#else
+  return double_to_byte_string_fixed_length_slow(x);
+#endif  // USE_FAST_DOUBLE_MEMCMP_ENCODING
+}
+
+auto zkd::double_to_byte_string_fixed_length_slow(double const x)
+    -> zkd::byte_string {
   BitWriter bw;
   zkd::into_bit_writer_fixed_length(bw, x);
   return std::move(bw).str();
+}
+
+auto zkd::into_zero_leading_fixed_length_byte_string_fast(double const x)
+    -> byte_string {
+#ifdef USE_FAST_DOUBLE_MEMCMP_ENCODING
+  uint64_t const encoded = encode_double_to_fast_memcmp_format(x);
+  uint64_t const zero_leading_part = encoded >> 1;
+
+  auto const byteArray = uint64_to_big_endian_byte_array(zero_leading_part);
+  byte_string bs{byteArray.data(), byteArray.size()};
+
+  // we are adding a zero to the front so we need 1 byte more at the end
+  std::byte const rest = static_cast<std::byte>(encoded << 7);
+  bs.push_back(rest);
+  return bs;
+#else
+  // This should never be called when the define is turned off
+  FATAL_ERROR_ABORT();
+#endif  // USE_FAST_DOUBLE_MEMCMP_ENCODING
+}
+
+auto zkd::double_to_byte_string_fixed_length_fast(double const x)
+    -> zkd::byte_string {
+#ifdef USE_FAST_DOUBLE_MEMCMP_ENCODING
+  uint64_t const encoded = encode_double_to_fast_memcmp_format(x);
+  auto const byteArray = uint64_to_big_endian_byte_array(encoded);
+  return {byteArray.data(), byteArray.size()};
+#else
+  // This should never be called when the define is turned off
+  FATAL_ERROR_ABORT();
+#endif  // USE_FAST_DOUBLE_MEMCMP_ENCODING
 }
 
 template<>

--- a/arangod/Zkd/ZkdHelper.h
+++ b/arangod/Zkd/ZkdHelper.h
@@ -76,7 +76,10 @@ auto to_byte_string_fixed_length(T) -> zkd::byte_string;
 template<typename T>
 auto from_byte_string_fixed_length(byte_string_view) -> T;
 template<>
-byte_string to_byte_string_fixed_length<double>(double x);
+auto to_byte_string_fixed_length<double>(double x) -> zkd::byte_string;
+
+auto double_to_byte_string_fixed_length_fast(double x) -> zkd::byte_string;
+auto double_to_byte_string_fixed_length_slow(double x) -> zkd::byte_string;
 
 enum class Bit { ZERO = 0, ONE = 1 };
 
@@ -157,6 +160,10 @@ template<typename T>
 void into_bit_writer_fixed_length(BitWriter&, T);
 template<typename T>
 auto from_bit_reader_fixed_length(BitReader&) -> T;
+
+auto into_zero_leading_fixed_length_byte_string(double x) -> byte_string;
+auto into_zero_leading_fixed_length_byte_string_fast(double x) -> byte_string;
+auto into_zero_leading_fixed_length_byte_string_slow(double x) -> byte_string;
 
 struct floating_point {
   bool positive : 1;

--- a/tests/Zkd/CMakeLists.txt
+++ b/tests/Zkd/CMakeLists.txt
@@ -9,6 +9,10 @@ target_include_directories(arango_tests_zkd
   PRIVATE
     ${PROJECT_SOURCE_DIR}/arangod)
 
+if (USE_FAST_DOUBLE_MEMCMP_ENCODING)
+    target_compile_definitions(arango_tests_zkd PRIVATE USE_FAST_DOUBLE_MEMCMP_ENCODING)
+endif ()
+
 add_executable(arangodbtests_zkd EXCLUDE_FROM_ALL)
 target_link_libraries(arangodbtests_zkd
   arango_tests_zkd

--- a/tests/js/client/aql/aql-mdi-prefix-fields.js
+++ b/tests/js/client/aql/aql-mdi-prefix-fields.js
@@ -374,7 +374,6 @@ function optimizerRuleMdiTraversal() {
 
       const res = db._createStatement(query).explain();
       const traversalNodes = res.plan.nodes.filter(n => n.type === "TraversalNode");
-      db._explain(query);
       traversalNodes.forEach(function (node) {
         node.indexes.base.forEach(function (idx) {
           assertEqual(idx.name, sparseIndexName, node.indexes);


### PR DESCRIPTION
Implements a faster encoding of doubles to a memcmp format.
* Makes it a cmake option
* Makes sure that it does not produce different values as the old/slower implementation
* Removes unneeded db._explain in a test
