### PR TITLE
[BTS-2017] Set remainsFollower=true for satellite collections.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ devel
 
 * BTS-2018: enable count cache for virtual smart edge collections.
 
+* BTS-2017: fix CleanOutServer for satellite collections.
+
 * Add metric that counts the total number of lost transaction subordinate
   states on the database servers.
 

--- a/arangod/Agency/CleanOutServer.cpp
+++ b/arangod/Agency/CleanOutServer.cpp
@@ -465,7 +465,7 @@ bool CleanOutServer::scheduleMoveShards(std::shared_ptr<Builder>& trx) {
 
             MoveShard(_snapshot, _agent, _jobId + "-" + std::to_string(sub++),
                       _jobId, database.first, collptr.first,
-                      ShardID{shard.first}, _server, toServer, isLeader, false)
+                      ShardID{shard.first}, _server, toServer, isLeader, true)
                 .withParent(_jobId)
                 .create(trx);
 

--- a/tests/Agency/CleanOutServerTest.cpp
+++ b/tests/Agency/CleanOutServerTest.cpp
@@ -615,8 +615,17 @@ TEST_F(CleanOutServerTest, cleanout_server_job_should_move_into_pending_if_ok) {
         EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-0")
                         .get("toServer")
                         .copyString() == "free");
+        EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-1")
+                        .get("toServer")
+                        .copyString() == "free");
+        EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-1")
+                        .get("remainsFollower")
+                        .getBool());
+        EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-1")
+                        .get("collection")
+                        .stringView() == "sat_collection");
         // second collection is not touched because of replicationVersion == 2
-        EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-1").isNone());
+        EXPECT_TRUE(writes.get("/arango/Target/ToDo/1-2").isNone());
 
         auto preconditions = q[0][1];
         EXPECT_TRUE(preconditions.get("/arango/Supervision/DBServers/leader")

--- a/tests/Agency/CleanOutServerTest.json
+++ b/tests/Agency/CleanOutServerTest.json
@@ -12,6 +12,14 @@ R"=(
                 "follower2"
               ]
             }
+          },
+          "sat_collection": {
+            "s1338": {
+              "servers": [
+                "leader",
+                "free"
+              ]
+            }
           }
         }
       }
@@ -26,6 +34,17 @@ R"=(
                 "leader",
                 "follower1",
                 "follower2"
+              ]
+            }
+          },
+          "sat_collection": {
+            "replicationFactor": "satellite",
+            "shards": {
+              "s1338": [
+                "leader",
+                "follower1",
+                "follower2",
+                "free"
               ]
             }
           }


### PR DESCRIPTION
### Scope & Purpose
Otherwise the MoveShardJob will fail.