### PR TITLE
Improve readability of async registry output

### DIFF
--- a/arangod/AsyncRegistryServer/RestHandler.cpp
+++ b/arangod/AsyncRegistryServer/RestHandler.cpp
@@ -52,16 +52,16 @@ auto all_undeleted_promises()
       // the registry
       // sync waiters point to threads that are waiting synchronously and are
       // not relevant for creating the forest
-      auto waiter = std::visit(
-          overloaded{
-              [&](AsyncRequester waiter) -> AsyncRequester { return waiter; },
-              [&](SyncRequester waiter) -> AsyncRequester { return nullptr; },
-          },
-          promise.requester);
-      forest.insert(promise.id, waiter, promise);
-      if (waiter == nullptr) {
-        roots.emplace_back(promise.id);
-      }
+      std::visit(overloaded{
+                     [&](PromiseId waiter) {
+                       forest.insert(promise.id, waiter, promise);
+                     },
+                     [&](ThreadId thread) {
+                       forest.insert(promise.id, nullptr, promise);
+                       roots.emplace_back(promise.id);
+                     },
+                 },
+                 promise.requester);
     }
   });
   return std::make_pair(forest, roots);

--- a/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
+++ b/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
@@ -11,7 +11,7 @@ class Thread(object):
         self.id = id
     @classmethod
     def from_json(cls, blob: dict):
-        return cls(blob["name"], blob["id"])
+        return cls(blob["name"], blob["LWPID"])
     def __str__(self):
         return self.name + "(" + str(self.id) + ")"
 
@@ -41,7 +41,7 @@ class Requester(object):
             return cls(False, blob["promise"])
     def __str__(self):
         if self.is_sync:
-            return "\n" + str(Thread(**self.item))
+            return "\n" + str(Thread.from_json(self.item))
         else:
             return ""
 

--- a/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
+++ b/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
@@ -34,14 +34,14 @@ class Requester(object):
     def from_json(cls, blob: dict):
         if not blob:
             return None
-        sync = blob.get("sync")
+        sync = blob.get("sync_thread")
         if sync is not None:
             return cls(True, sync)
         else:
-            return cls(False, blob["async"])
+            return cls(False, blob["async_promise"])
     def __str__(self):
         if self.is_sync:
-            return "\nsync requester thread " + str(self.item)
+            return "\n" + str(Thread(**self.item))
         else:
             return ""
 
@@ -98,140 +98,10 @@ class Stacktrace(object):
             if len(stack) == 0 or hierarchy != stack[0]:
                 stack.append(hierarchy)
 
-            # TODO now this does not work any more because waiter does not need to exist
             lines.append(ascii + str(Data.from_json(promise["data"])))
         return "\n".join(lines)
     
-        
-def test_intput() -> str:
-    return """{"promise_stacktraces": [
-  [
-    {
-      "hierarchy": 0,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Network/Methods.cpp",
-          "line": 242,
-          "function_name": "arangodb::network::(anonymous namespace)::Pack::Pack(DestinationId &&, RequestLane, bool, bool)"
-        },
-        "id": 124252709790688,
-        "requester": {},
-        "state": "Suspended"
-      }
-    }
-  ],
-  [
-    {
-      "hierarchy": 2,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Network/Methods.cpp",
-          "line": 242,
-          "function_name": "arangodb::network::(anonymous namespace)::Pack::Pack(DestinationId &&, RequestLane, bool, bool)"
-        },
-        "id": 124252709790688,
-        "requester": {"async": 124252709790368},
-        "state": "Suspended"
-      }
-    },
-    {
-      "hierarchy": 1,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Network/Methods.cpp",
-          "line": 367,
-          "function_name": "FutureRes arangodb::network::sendRequest(ConnectionPool *, DestinationId, RestVerb, std::string, velocypack::Buffer<uint8_t>, const RequestOptions &, Headers)"
-        },
-        "id": 124252709790368,
-        "requester": {"async": 124252709790848},
-        "state": "Suspended"
-      }
-    },
-    {
-      "hierarchy": 2,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Agency/AsyncAgencyComm.cpp",
-          "line": 325,
-          "function_name": "auto (anonymous namespace)::agencyAsyncSend(AsyncAgencyCommManager &, RequestMeta &&, VPackBuffer<uint8_t> &&)::(anonymous class)::operator()(auto) [auto:1 = arangodb::futures::Unit]"
-        },
-        "id": 124252709790848,
-        "requester": {"async": 124252709791008},
-        "state": "Suspended"
-      }
-    },
-    {
-      "hierarchy": 1,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Agency/AsyncAgencyComm.cpp",
-          "line": 325,
-          "function_name": "auto (anonymous namespace)::agencyAsyncSend(AsyncAgencyCommManager &, RequestMeta &&, VPackBuffer<uint8_t> &&)::(anonymous class)::operator()(auto) [auto:1 = arangodb::futures::Unit]"
-        },
-        "id": 124252709790848,
-        "requester": {"async": 124252709791008},
-        "state": "Suspended"
-      }
-    },
-    {
-      "hierarchy": 1,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Agency/AsyncAgencyComm.cpp",
-          "line": 325,
-          "function_name": "auto (anonymous namespace)::agencyAsyncSend(AsyncAgencyCommManager &, RequestMeta &&, VPackBuffer<uint8_t> &&)::(anonymous class)::operator()(auto) [auto:1 = arangodb::futures::Unit]"
-        },
-        "id": 124252709790848,
-        "requester": {"async": 124252709791008},
-        "state": "Suspended"
-      }
-    },
-    {
-      "hierarchy": 0,
-      "data": {
-        "owning_thread": {
-          "name": "AgencyCache",
-          "id": "124252722300608"
-        },
-        "source_location": {
-          "file_name": "/home/jvolmer/code/arangodb/arangod/Agency/AsyncAgencyComm.cpp",
-          "line": 325,
-          "function_name": "auto (anonymous namespace)::agencyAsyncSend(AsyncAgencyCommManager &, RequestMeta &&, VPackBuffer<uint8_t> &&)::(anonymous class)::operator()(auto) [auto:1 = arangodb::futures::Unit]"
-        },
-        "id": 124252709791008,
-        "requester": {"sync": 123},
-        "state": "Suspended"
-      }
-    }
-  ]
-    ]}"""
-
 def main():
-    # string = test_intput()
     string = sys.stdin.read()
     data = json.loads(string)["promise_stacktraces"]
     print("\n\n".join(str(Stacktrace(**{"promises": x})) for x in data))

--- a/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
+++ b/arangod/AsyncRegistryServer/pretty_printer/pretty_printer.py
@@ -34,11 +34,11 @@ class Requester(object):
     def from_json(cls, blob: dict):
         if not blob:
             return None
-        sync = blob.get("sync_thread")
+        sync = blob.get("thread")
         if sync is not None:
             return cls(True, sync)
         else:
-            return cls(False, blob["async_promise"])
+            return cls(False, blob["promise"])
     def __str__(self):
         if self.is_sync:
             return "\n" + str(Thread(**self.item))

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -34,6 +34,13 @@ Thread::Thread()
     : name{std::string{ThreadNameFetcher{}.get()}},
       id{arangodb::Thread::currentThreadId()} {}
 
+Thread::Thread(TRI_tid_t id)
+    : name{std::string{ThreadNameFetcher{id}.get()}}, id{id} {}
+
+auto Requester::sync() -> Requester {
+  return {arangodb::Thread::currentThreadId()};
+}
+
 Promise::Promise(Promise* next, std::shared_ptr<ThreadRegistry> registry,
                  Requester requester, std::source_location entry_point)
     : thread{registry->thread},

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -30,16 +30,14 @@
 
 using namespace arangodb::async_registry;
 
-Thread::Thread()
-    : name{std::string{ThreadNameFetcher{}.get()}},
-      id{arangodb::Thread::currentThreadId()} {}
-
-Thread::Thread(TRI_tid_t id)
-    : name{std::string{ThreadNameFetcher{id}.get()}}, id{id} {}
-
-auto Requester::sync() -> Requester {
-  return {arangodb::Thread::currentThreadId()};
+auto ThreadId::current() noexcept -> ThreadId {
+  return ThreadId{.id = arangodb::Thread::currentThreadId()};
 }
+auto ThreadId::name() -> std::string {
+  return std::string{ThreadNameFetcher{id}.get()};
+}
+
+auto Requester::sync() -> Requester { return {ThreadId::current()}; }
 
 Promise::Promise(Promise* next, std::shared_ptr<ThreadRegistry> registry,
                  Requester requester, std::source_location entry_point)

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -37,7 +37,7 @@ auto ThreadId::name() -> std::string {
   return std::string{ThreadNameFetcher{id}.get()};
 }
 
-auto Requester::sync() -> Requester { return {ThreadId::current()}; }
+auto Requester::current_thread() -> Requester { return {ThreadId::current()}; }
 
 Promise::Promise(Promise* next, std::shared_ptr<ThreadRegistry> registry,
                  Requester requester, std::source_location entry_point)

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -31,10 +31,11 @@
 using namespace arangodb::async_registry;
 
 auto ThreadId::current() noexcept -> ThreadId {
-  return ThreadId{.id = arangodb::Thread::currentThreadId()};
+  return ThreadId{.posix_id = arangodb::Thread::currentThreadId(),
+                  .kernel_id = arangodb::Thread::currentKernelThreadId()};
 }
 auto ThreadId::name() -> std::string {
-  return std::string{ThreadNameFetcher{id}.get()};
+  return std::string{ThreadNameFetcher{posix_id}.get()};
 }
 
 auto Requester::current_thread() -> Requester { return {ThreadId::current()}; }

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -25,9 +25,14 @@
 
 #include "Async/Registry/registry_variable.h"
 #include "Async/Registry/thread_registry.h"
+#include "Basics/Thread.h"
 #include "Inspection/Format.h"
 
 using namespace arangodb::async_registry;
+
+Thread::Thread()
+    : name{std::string{ThreadNameFetcher{}.get()}},
+      id{arangodb::Thread::currentThreadId()} {}
 
 Promise::Promise(Promise* next, std::shared_ptr<ThreadRegistry> registry,
                  Requester requester, std::source_location entry_point)

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -54,7 +54,7 @@ auto Promise::mark_for_deletion() noexcept -> void {
 
 AddToAsyncRegistry::AddToAsyncRegistry(std::source_location loc)
     : promise_in_registry{get_thread_registry().add_promise(
-          std::move(loc), *get_current_coroutine())} {}
+          *get_current_coroutine(), std::move(loc))} {}
 AddToAsyncRegistry::~AddToAsyncRegistry() {
   if (promise_in_registry != nullptr) {
     promise_in_registry->mark_for_deletion();

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -149,7 +149,7 @@ auto inspect(Inspector& f, PromiseSnapshot& x) {
   return f.object(x).fields(f.field("owning_thread", x.thread),
                             f.field("source_location", x.source_location),
                             f.field("id", fmt::format("{}", x.id)),
-                            f.field("waiter", x.requester),
+                            f.field("requester", x.requester),
                             f.field("state", x.state));
 }
 struct Promise {

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -50,12 +50,13 @@ struct ThreadRegistry;
 struct ThreadId {
   static auto current() noexcept -> ThreadId;
   auto name() -> std::string;
-  TRI_tid_t id;
+  TRI_tid_t posix_id;
+  pid_t kernel_id;
   bool operator==(ThreadId const&) const = default;
 };
 template<typename Inspector>
 auto inspect(Inspector& f, ThreadId& x) {
-  return f.object(x).fields(f.field("id", fmt::format("0x{0:x}", x.id)),
+  return f.object(x).fields(f.field("LWPID", x.kernel_id),
                             f.field("name", x.name()));
 }
 

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -55,7 +55,7 @@ struct Thread {
 template<typename Inspector>
 auto inspect(Inspector& f, Thread& x) {
   return f.object(x).fields(f.field("name", x.name),
-                            f.field("id", fmt::format("{}", x.id)));
+                            f.field("id", fmt::format("0x{0:x}", x.id)));
 }
 
 struct SourceLocationSnapshot {
@@ -97,8 +97,7 @@ struct AsyncRequesterWrapper {
 };
 template<typename Inspector>
 auto inspect(Inspector& f, AsyncRequesterWrapper& x) {
-  return f.object(x).fields(
-      f.field("async", reinterpret_cast<intptr_t>(x.item)));
+  return f.object(x).fields(f.field("async", fmt::format("{}", x.item)));
 }
 struct SyncRequesterWrapper {
   SyncRequester item;
@@ -145,7 +144,7 @@ template<typename Inspector>
 auto inspect(Inspector& f, PromiseSnapshot& x) {
   return f.object(x).fields(f.field("owning_thread", x.thread),
                             f.field("source_location", x.source_location),
-                            f.field("id", reinterpret_cast<intptr_t>(x.id)),
+                            f.field("id", fmt::format("{}", x.id)),
                             f.field("waiter", x.requester),
                             f.field("state", x.state));
 }

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -28,6 +28,7 @@
 #include <source_location>
 #include <string>
 #include <thread>
+#include "Basics/threads-posix.h"
 #include "Inspection/Types.h"
 #include "fmt/format.h"
 #include "fmt/std.h"
@@ -47,8 +48,9 @@ struct ThreadRegistry;
 
 struct Thread {
   std::string name;
-  std::thread::id id;
+  TRI_tid_t id;
   bool operator==(Thread const&) const = default;
+  Thread();
 };
 template<typename Inspector>
 auto inspect(Inspector& f, Thread& x) {

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -41,7 +41,7 @@ auto get_thread_registry() noexcept -> ThreadRegistry& {
 // get_current_coroutine_or_thread_id
 auto get_current_coroutine() noexcept -> Requester* {
   struct Guard {
-    Guard() : _identifier{{std::this_thread::get_id()}} {}
+    Guard() : _identifier{Requester::sync()} {}
 
     Requester _identifier;
   };

--- a/lib/Async/Registry/registry_variable.cpp
+++ b/lib/Async/Registry/registry_variable.cpp
@@ -41,7 +41,7 @@ auto get_thread_registry() noexcept -> ThreadRegistry& {
 // get_current_coroutine_or_thread_id
 auto get_current_coroutine() noexcept -> Requester* {
   struct Guard {
-    Guard() : _identifier{Requester::sync()} {}
+    Guard() : _identifier{Requester::current_thread()} {}
 
     Requester _identifier;
   };

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -76,7 +76,7 @@ auto ThreadRegistry::add_promise(Requester requester,
       << "ThreadRegistry::add_promise was called from thread "
       << fmt::format("{}", current_thread)
       << " but needs to be called from ThreadRegistry's owning thread "
-      << fmt::format("{}", thread.id) << ". " << this;
+      << fmt::format("{}", thread) << ". " << this;
   if (metrics->promises_total != nullptr) {
     metrics->promises_total->count();
   }
@@ -130,7 +130,7 @@ auto ThreadRegistry::garbage_collect() noexcept -> void {
       << "ThreadRegistry::garbage_collect was called from thread "
       << fmt::format("{}", current_thread)
       << " but needs to be called from ThreadRegistry's owning thread "
-      << fmt::format("{}", thread.id) << ". " << this;
+      << fmt::format("{}", thread) << ". " << this;
   auto guard = std::lock_guard(mutex);
   cleanup();
 }

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -67,8 +67,9 @@ ThreadRegistry::~ThreadRegistry() noexcept {
   cleanup();
 }
 
-auto ThreadRegistry::add_promise(std::source_location location,
-                                 Requester requester) noexcept -> Promise* {
+auto ThreadRegistry::add_promise(
+    std::source_location location = std::source_location::current(),
+    Requester requester = Requester::sync()) noexcept -> Promise* {
   // promise needs to live on the same thread as this registry
   ADB_PROD_ASSERT(arangodb::Thread::currentThreadId() == thread.id)
       << "ThreadRegistry::add was called from thread "

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -67,9 +67,9 @@ ThreadRegistry::~ThreadRegistry() noexcept {
   cleanup();
 }
 
-auto ThreadRegistry::add_promise(
-    std::source_location location = std::source_location::current(),
-    Requester requester = Requester::current_thread()) noexcept -> Promise* {
+auto ThreadRegistry::add_promise(Requester requester,
+                                 std::source_location location) noexcept
+    -> Promise* {
   // promise needs to live on the same thread as this registry
   auto current_thread = ThreadId::current();
   ADB_PROD_ASSERT(current_thread == thread)

--- a/lib/Async/Registry/thread_registry.cpp
+++ b/lib/Async/Registry/thread_registry.cpp
@@ -69,7 +69,7 @@ ThreadRegistry::~ThreadRegistry() noexcept {
 
 auto ThreadRegistry::add_promise(
     std::source_location location = std::source_location::current(),
-    Requester requester = Requester::sync()) noexcept -> Promise* {
+    Requester requester = Requester::current_thread()) noexcept -> Promise* {
   // promise needs to live on the same thread as this registry
   auto current_thread = ThreadId::current();
   ADB_PROD_ASSERT(current_thread == thread)

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -67,7 +67,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can only be called on the owning thread, crashes
      otherwise.
    */
-  auto add_promise(std::source_location location, Requester requester) noexcept
+  auto add_promise(Requester requester, std::source_location location) noexcept
       -> Promise*;
 
   /**

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -112,7 +112,7 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
    */
   auto garbage_collect_external() noexcept -> void;
 
-  Thread const thread;
+  ThreadId const thread;
 
  private:
   Registry* registry = nullptr;

--- a/lib/Async/Registry/thread_registry.h
+++ b/lib/Async/Registry/thread_registry.h
@@ -67,9 +67,8 @@ struct ThreadRegistry : std::enable_shared_from_this<ThreadRegistry> {
      Can only be called on the owning thread, crashes
      otherwise.
    */
-  auto add_promise(
-      std::source_location location = std::source_location::current(),
-      Requester requester = {std::this_thread::get_id()}) noexcept -> Promise*;
+  auto add_promise(std::source_location location, Requester requester) noexcept
+      -> Promise*;
 
   /**
      Executes a function on each promise in the registry that is not deleted yet

--- a/lib/Basics/Thread.cpp
+++ b/lib/Basics/Thread.cpp
@@ -28,6 +28,7 @@
 #include <thread>
 
 #include "Basics/operating-system.h"
+#include "Basics/threads-posix.h"
 
 #ifdef TRI_HAVE_UNISTD_H
 #include <unistd.h>
@@ -80,6 +81,10 @@ struct ThreadNumber {
 /// @brief local thread number
 static thread_local ::ThreadNumber LOCAL_THREAD_NUMBER{};
 static thread_local char const* LOCAL_THREAD_NAME = nullptr;
+
+ThreadNameFetcher::ThreadNameFetcher(TRI_tid_t id) noexcept {
+  pthread_getname_np(id, _buffer, 32);
+}
 
 // retrieve the current thread's name. the string view will
 // remain valid as long as the ThreadNameFetcher remains valid.

--- a/lib/Basics/Thread.cpp
+++ b/lib/Basics/Thread.cpp
@@ -155,6 +155,9 @@ void Thread::startThread(void* arg) {
 /// @brief returns the process id
 TRI_pid_t Thread::currentProcessId() { return getpid(); }
 
+/// @brief returns the kernel thread id
+TRI_pid_t Thread::currentKernelThreadId() { return gettid(); }
+
 /// @brief returns the thread process id
 uint64_t Thread::currentThreadNumber() noexcept {
   return LOCAL_THREAD_NUMBER.get();

--- a/lib/Basics/Thread.h
+++ b/lib/Basics/Thread.h
@@ -95,6 +95,9 @@ class Thread {
   /// @brief returns the thread id
   static TRI_tid_t currentThreadId();
 
+  /// @brief returns the kernel thread id
+  static TRI_pid_t currentKernelThreadId();
+
  public:
   [[deprecated("server argument is no longer needed")]] Thread(
       application_features::ApplicationServer&, std::string const& name,

--- a/lib/Basics/Thread.h
+++ b/lib/Basics/Thread.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <string_view>
 
+#include "Basics/threads-posix.h"
 #include "Basics/threads.h"
 #include "Basics/DownCast.h"
 
@@ -42,6 +43,7 @@ struct ConditionVariable;
 class ThreadNameFetcher {
  public:
   ThreadNameFetcher() noexcept;
+  ThreadNameFetcher(TRI_tid_t id) noexcept;
   ThreadNameFetcher(ThreadNameFetcher const&) = delete;
   ThreadNameFetcher& operator=(ThreadNameFetcher const&) = delete;
 

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -273,7 +273,7 @@ class [[nodiscard]] Future {
 
   /// Blocks until this Future is complete.
   void wait() {
-    update_requester({std::this_thread::get_id()});
+    update_requester(async_registry::Requester::sync());
     detail::waitImpl(*this);
   }
 

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -273,7 +273,7 @@ class [[nodiscard]] Future {
 
   /// Blocks until this Future is complete.
   void wait() {
-    update_requester(async_registry::Requester::sync());
+    update_requester(async_registry::Requester::current_thread());
     detail::waitImpl(*this);
   }
 

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -155,7 +155,7 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
     EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()),
               0);
-    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::SyncRequester>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
         *arangodb::async_registry::get_current_coroutine()));
   }
 
@@ -505,7 +505,7 @@ TYPED_TEST(
     static auto awaited_by_awaited_fn(TestType test) -> async<void> {
       auto promise = find_promise_by_name("awaited_by_awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::AsyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::PromiseId>(
           promise->requester));
       co_await test->wait;
 
@@ -514,7 +514,7 @@ TYPED_TEST(
     static auto awaited_fn(TestType test) -> async<void> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::AsyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::PromiseId>(
           promise->requester));
 
       auto fn = Functions::awaited_by_awaited_fn(test);
@@ -534,7 +534,7 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
@@ -554,7 +554,7 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       co_return;
@@ -576,7 +576,7 @@ TYPED_TEST(
     static auto awaited_2_fn() -> async<void> {
       auto promise = find_promise_by_name("awaited_2_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::AsyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::PromiseId>(
           promise->requester));
 
       co_return;
@@ -584,7 +584,7 @@ TYPED_TEST(
     static auto awaited_fn(TestType test) -> async<void> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::AsyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::PromiseId>(
           promise->requester));
 
       co_await test->wait;
@@ -594,7 +594,7 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
@@ -624,7 +624,7 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       co_return;
@@ -645,8 +645,8 @@ TYPED_TEST(AsyncTest,
     static auto awaited_fn(TestType test) -> async<void> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
-          promise->requester));
+      EXPECT_TRUE(
+          std::holds_alternative<async_registry::ThreadId>(promise->requester));
 
       co_await test->wait;
 
@@ -655,12 +655,12 @@ TYPED_TEST(AsyncTest,
     static auto waiter_fn(async<void>&& fn) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       co_await std::move(fn);
@@ -673,7 +673,7 @@ TYPED_TEST(AsyncTest,
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       co_return;
@@ -705,7 +705,7 @@ TYPED_TEST(
 
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<async_registry::SyncRequester>(
+      EXPECT_TRUE(std::holds_alternative<async_registry::ThreadId>(
           waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -47,7 +47,8 @@ TEST_F(AsyncRegistryTest, registers_promise_on_same_thread) {
   Registry registry;
   auto thread_registry = registry.add_thread();
 
-  auto* promise = thread_registry->add_promise();
+  auto* promise = thread_registry->add_promise(Requester::current_thread(),
+                                               std::source_location::current());
 
   EXPECT_EQ(promises_in_registry(registry),
             std::vector<PromiseSnapshot>{promise->snapshot()});
@@ -62,7 +63,8 @@ TEST_F(AsyncRegistryTest, registers_promise_on_different_threads) {
   std::thread([&]() {
     auto thread_registry = registry.add_thread();
 
-    auto* promise = thread_registry->add_promise();
+    auto* promise = thread_registry->add_promise(
+        Requester::current_thread(), std::source_location::current());
 
     EXPECT_EQ(promises_in_registry(registry),
               std::vector<PromiseSnapshot>{promise->snapshot()});
@@ -76,8 +78,10 @@ TEST_F(AsyncRegistryTest,
        iterates_over_promises_on_same_thread_in_reverse_order) {
   Registry registry;
   auto thread_registry = registry.add_thread();
-  auto* first_promise = thread_registry->add_promise();
-  auto* second_promise = thread_registry->add_promise();
+  auto* first_promise = thread_registry->add_promise(
+      Requester::current_thread(), std::source_location::current());
+  auto* second_promise = thread_registry->add_promise(
+      Requester::current_thread(), std::source_location::current());
 
   EXPECT_EQ(promises_in_registry(registry),
             (std::vector<PromiseSnapshot>{second_promise->snapshot(),
@@ -92,11 +96,13 @@ TEST_F(AsyncRegistryTest,
 TEST_F(AsyncRegistryTest, iterates_over_promises_on_differen_threads) {
   Registry registry;
   auto thread_registry = registry.add_thread();
-  auto* first_promise = thread_registry->add_promise();
+  auto* first_promise = thread_registry->add_promise(
+      Requester::current_thread(), std::source_location::current());
 
   std::thread([&]() {
     auto thread_registry = registry.add_thread();
-    auto* second_promise = thread_registry->add_promise();
+    auto* second_promise = thread_registry->add_promise(
+        Requester::current_thread(), std::source_location::current());
 
     EXPECT_EQ(promises_in_registry(registry),
               (std::vector<PromiseSnapshot>{first_promise->snapshot(),
@@ -115,7 +121,8 @@ TEST_F(AsyncRegistryTest,
   Registry registry;
   auto thread_registry = registry.add_thread();
 
-  auto* promise = thread_registry->add_promise();
+  auto* promise = thread_registry->add_promise(Requester::current_thread(),
+                                               std::source_location::current());
   EXPECT_EQ(promises_in_registry(registry),
             (std::vector<PromiseSnapshot>{promise->snapshot()}));
 
@@ -132,7 +139,8 @@ TEST_F(AsyncRegistryTest, promises_on_removed_thread_are_still_iterated_over) {
   Promise* promise;
   {
     auto thread_registry = registry.add_thread();
-    promise = thread_registry->add_promise();
+    promise = thread_registry->add_promise(Requester::current_thread(),
+                                           std::source_location::current());
   }
   EXPECT_EQ(promises_in_registry(registry),
             (std::vector<PromiseSnapshot>{promise->snapshot()}));
@@ -150,7 +158,7 @@ TEST_F(
   std::thread([&]() {
     auto thread_registry_on_different_thread = registry.add_thread();
     promise = thread_registry_on_different_thread->add_promise(
-        std::source_location::current());
+        Requester::current_thread(), std::source_location::current());
   }).join();
 
   promise->mark_for_deletion();

--- a/tests/Futures/FutureCoroutineTest.cpp
+++ b/tests/Futures/FutureCoroutineTest.cpp
@@ -110,7 +110,7 @@ template<typename WaitType>
 struct FutureCoroutineTest : ::testing::Test {
   void SetUp() override {
     arangodb::async_registry::get_thread_registry().garbage_collect();
-    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::SyncRequester>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
         *arangodb::async_registry::get_current_coroutine()));
   }
 
@@ -169,9 +169,8 @@ TYPED_TEST(
     static auto awaited_by_awaited_fn(TestType test) -> Future<Unit> {
       auto promise = find_promise_by_name("awaited_by_awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::AsyncRequester>(
-              promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::PromiseId>(
+          promise->requester));
       co_await test->wait;
 
       co_return;
@@ -179,9 +178,8 @@ TYPED_TEST(
     static auto awaited_fn(TestType test) -> Future<Unit> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::AsyncRequester>(
-              promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::PromiseId>(
+          promise->requester));
 
       auto fn = Functions::awaited_by_awaited_fn(test);
       auto awaited_promise = find_promise_by_name("awaited_by_awaited_fn");
@@ -200,9 +198,8 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> Future<Unit> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::SyncRequester>(
-              waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
+          waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
 
@@ -221,9 +218,8 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::SyncRequester>(
-              waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -242,9 +238,8 @@ TYPED_TEST(FutureCoroutineTest,
     static auto awaited_fn(TestType test) -> Future<Unit> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::SyncRequester>(
-              promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
+          promise->requester));
 
       co_await test->wait;
 
@@ -253,15 +248,13 @@ TYPED_TEST(FutureCoroutineTest,
     static auto waiter_fn(Future<Unit>&& fn) -> Future<Unit> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::SyncRequester>(
-              waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
+          waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::SyncRequester>(
-              waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
+          waiter_promise->requester));
 
       co_await std::move(fn);
 
@@ -273,9 +266,8 @@ TYPED_TEST(FutureCoroutineTest,
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<arangodb::async_registry::SyncRequester>(
-              waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
+          waiter_promise->requester));
 
       co_return;
     };

--- a/tests/Futures/FutureTest.cpp
+++ b/tests/Futures/FutureTest.cpp
@@ -933,7 +933,7 @@ TEST(FutureTest,
     EXPECT_TRUE(waiter_promise.has_value());
     EXPECT_EQ(awaited_promise->requester,
               arangodb::async_registry::Requester{waiter_promise->id});
-    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::SyncRequester>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
         waiter_promise->requester));
   }
 }
@@ -981,7 +981,7 @@ TEST(FutureTest, collected_async_promises_in_async_registry_know_their_waiter) {
               arangodb::async_registry::Requester{waiter_promise->id});
     EXPECT_EQ(awaited_promises[1].requester,
               arangodb::async_registry::Requester{waiter_promise->id});
-    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::SyncRequester>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::async_registry::ThreadId>(
         waiter_promise->requester));
   }
 }


### PR DESCRIPTION
- Prints LWPID instead of std::thread::Id (LWPID is handy because debugging tools like gdb and top directly give this number, it is only Linux-specific)
- Prints promise id in hexadecimal representation
- Prints thread name for requesting thread