### PR TITLE
Error out if usePlanCache=true and query not eligible for plan caching

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Make it an error if usePlanCache is set to true but the query is not 
+  eligible for query plan caching. This is better for debugging.
+
 * Upgraded OpenSSL to 3.4.0.
 
 * Rebuilt included rclone v1.65.2 with go1.22.8 and non-vulnerable dependencies.

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -352,7 +352,10 @@ void Query::ensureExecutionTime() noexcept {
 }
 
 bool Query::tryLoadPlanFromCache() {
-  if (_queryOptions.usePlanCache && canUsePlanCache()) {
+  if (_queryOptions.usePlanCache) {
+    if (!canUsePlanCache()) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_NOT_ELLIGIBLE_FOR_PLAN_CACHING);
+    }
     // construct plan cache key
     TRI_ASSERT(!_planCacheKey.has_value());
     _planCacheKey.emplace(_vocbase.queryPlanCache().createCacheKey(
@@ -571,9 +574,7 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
        _ast->containsGraphNameValueBindParameters() ||
        _ast->containsTraversalDepthValueBindParameters() ||
        _ast->containsUpsertLookupValueBindParameters() || !_warnings.empty())) {
-    _queryOptions.optimizePlanForCaching = false;
-    _queryOptions.usePlanCache = false;
-    _planCacheKey.reset();
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_NOT_ELLIGIBLE_FOR_PLAN_CACHING);
   }
 
   // put in collection and attribute name bind parameters (e.g. @@collection or

--- a/arangod/Aql/QueryOptions.h
+++ b/arangod/Aql/QueryOptions.h
@@ -117,7 +117,8 @@ struct QueryOptions {
   bool count;
   // skips audit logging - used only internally
   bool skipAudit;
-  // whether or not the optimizer result should be cached
+  // whether or not the plan is optimized in a way such that the optimizer
+  // result can be cached
   bool optimizePlanForCaching;
   // whether or not the optimizer plan cache should be used, note that
   // if usePlanCache is set then optimizePlanForCaching is also automatically

--- a/js/common/bootstrap/errors.js
+++ b/js/common/bootstrap/errors.js
@@ -223,6 +223,7 @@
     "ERROR_QUERY_FUNCTION_INVALID_CODE" : { "code" : 1581, "message" : "invalid user function code" },
     "ERROR_QUERY_FUNCTION_NOT_FOUND" : { "code" : 1582, "message" : "user function '%s()' not found" },
     "ERROR_QUERY_FUNCTION_RUNTIME_ERROR" : { "code" : 1583, "message" : "user function runtime error: %s" },
+    "ERROR_QUERY_NOT_ELLIGIBLE_FOR_PLAN_CACHING" : { "code" : 1584, "message" : "query is not eligible for plan caching" },
     "ERROR_QUERY_BAD_JSON_PLAN"    : { "code" : 1590, "message" : "bad execution plan JSON" },
     "ERROR_QUERY_NOT_FOUND"        : { "code" : 1591, "message" : "query ID not found" },
     "ERROR_QUERY_USER_ASSERT"      : { "code" : 1593, "message" : "%s" },

--- a/lib/Basics/errors.dat
+++ b/lib/Basics/errors.dat
@@ -272,6 +272,7 @@ ERROR_QUERY_FUNCTION_INVALID_NAME,1580,"invalid user function name","Will be rai
 ERROR_QUERY_FUNCTION_INVALID_CODE,1581,"invalid user function code","Will be raised when a user function is registered with invalid code."
 ERROR_QUERY_FUNCTION_NOT_FOUND,1582,"user function '%s()' not found","Will be raised when a user function is accessed but not found."
 ERROR_QUERY_FUNCTION_RUNTIME_ERROR,1583,"user function runtime error: %s","Will be raised when a user function throws a runtime exception."
+ERROR_QUERY_NOT_ELLIGIBLE_FOR_PLAN_CACHING,1584,"query is not eligible for plan caching","Will be raised when a query is not eligible for plan caching and yet, the usePlanCache option was set to true."
 
 ################################################################################
 ## AQL query registry errors

--- a/tests/js/client/aql/aql-query-plan-cache.js
+++ b/tests/js/client/aql/aql-query-plan-cache.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertTrue, assertFalse, assertNotEqual, assertUndefined, assertNotUndefined, assertMatch, assertNotMatch  */
+/*global assertEqual, assertTrue, assertFalse, assertNotEqual, assertUndefined, assertNotUndefined, assertMatch, assertNotMatch, fail  */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER

--- a/tests/js/client/aql/aql-query-plan-cache.js
+++ b/tests/js/client/aql/aql-query-plan-cache.js
@@ -48,6 +48,18 @@ const assertNotCached = (query, bindVars = {}, options = {}) => {
   assertFalse(res.hasOwnProperty("planCacheKey"));
 };
 
+const assertErrorsOut = (query, bindVars = {}, options = {}) => {
+  options.optimizePlanForCaching = true;
+  options.usePlanCache = true;
+  // execute query once
+  try {
+    let res = db._query(query, bindVars, options);
+    fail();
+  } catch (e) {
+    assertEqual(1584, e.errorNum);
+  }
+};
+
 const assertCached = (query, bindVars = {}, options = {}) => {
   options.optimizePlanForCaching = true;
   options.usePlanCache = true;
@@ -125,14 +137,14 @@ function QueryPlanCacheTestSuite () {
       const query = `${uniqid()} FOR doc IN ${cn1} FILTER doc.@attr == 25 RETURN doc`;
 
       // attribute name bind parameters are not supported
-      assertNotCached(query, { attr: "foo" });
+      assertErrorsOut(query, { attr: "foo" });
     },
     
     testUpsert : function () {
       const query = `${uniqid()} UPSERT {foo: "bar"} INSERT {} UPDATE {} IN ${cn1}`;
 
       // value bind parameters are not supported when defining the lookup values for UPSERT
-      assertNotCached(query, {});
+      assertErrorsOut(query, {});
     },
     
     testCollectionBindParameter : function () {
@@ -213,16 +225,13 @@ function QueryPlanCacheTestSuite () {
       const bindVars = {};
       const options = { optimizePlanForCaching: true, usePlanCache: true, allPlans: true };
 
-      let stmt = db._createStatement({ query, bindVars, options });
-      let res = stmt.explain();
-      assertFalse(res.hasOwnProperty("planCacheKey"));
-      assertNotUndefined(res.plans, res);
-      
       // allPlans is not supported with plan caching
-      stmt = db._createStatement({ query, bindVars, options });
-      res = stmt.explain();
-      assertFalse(res.hasOwnProperty("planCacheKey"));
-      assertNotUndefined(res.plans, res);
+      let stmt = db._createStatement({ query, bindVars, options });
+      try {
+        let res = stmt.explain();
+      } catch (e) {
+        assertEqual(1584, e.errorNum);
+      }
     },
     
     testProfiling : function () {
@@ -272,9 +281,9 @@ function QueryPlanCacheTestSuite () {
       const query = `${uniqid()} RETURN 1`;
 
       assertCached(query);
-      assertNotCached(query, null, { optimizer: { rules: ["-all"] } });
-      assertNotCached(query, null, { optimizer: { rules: ["+async-prefetch"] } });
-      assertNotCached(query, null, { optimizer: { rules: ["-async-prefetch"] } });
+      assertErrorsOut(query, null, { optimizer: { rules: ["-all"] } });
+      assertErrorsOut(query, null, { optimizer: { rules: ["+async-prefetch"] } });
+      assertErrorsOut(query, null, { optimizer: { rules: ["-async-prefetch"] } });
     },
     
     testFullCount : function () {
@@ -536,11 +545,7 @@ function QueryPlanCacheTestSuite () {
         const query = `${uniqid()} FOR v, e, p IN 1..4 OUTBOUND '${vn}/test0' GRAPH @g RETURN {v, e, p}`;
         const options = { optimizePlanForCaching: true, usePlanCache: true };
 
-        let res = db._query(query, {g: gn}, options);
-        assertFalse(res.hasOwnProperty("planCacheKey"));
-      
-        res = db._query(query, {g: gn}, options);
-        assertFalse(res.hasOwnProperty("planCacheKey"));
+        assertErrorsOut(query, {g: gn}, options);
       } finally {
         graphs._drop(gn, true);
       }
@@ -556,11 +561,7 @@ function QueryPlanCacheTestSuite () {
         const query = `${uniqid()} FOR v, e, p IN @min..@max OUTBOUND '${vn}/test0' GRAPH '${gn}' RETURN {v, e, p}`;
         const options = { optimizePlanForCaching: true, usePlanCache: true };
 
-        let res = db._query(query, {min: 1, max: 2}, options);
-        assertFalse(res.hasOwnProperty("planCacheKey"));
-      
-        res = db._query(query, {min: 1, max: 2}, options);
-        assertFalse(res.hasOwnProperty("planCacheKey"));
+        assertErrorsOut(query, {min: 1, max: 2}, options);
       } finally {
         graphs._drop(gn, true);
       }


### PR DESCRIPTION
### Scope & Purpose

This strives to make the behaviour of the query plan cache more
coherent. In cases in which the user has requested query plan caching
with the option usePlanCache set to true, but the query is not eligible
for caching, error out.

Also check these conditions on `explain`, so that explain behaves the same as normal query execution.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] :books: documentation written (release notes, API changes, ...)
- [*] Backports: no backports necessary

#### Related Information

none
