### PR TITLE
Disable HTTP2 tests

### DIFF
--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -41,11 +41,10 @@ shell_api_multi,shell_api_multi name=shell_api_multi priority=500 single -- --op
 shell_client priority=250 parallelity=2 buckets=4 single size=medium -- $EncryptionAtRest
 
 # shell_client_multi tests run quite long, so want to have a separate job for each protocol
-shell_client_multi priority=1500 parallelity=2 single suffix=http2 -- --http2 true
-shell_client_multi priority=1500 parallelity=2 single suffix=http -- --http true
+shell_client_multi priority=1500 parallelity=2 single
 
-shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix":"http2"}]
-shell_client_traffic,shell_client_traffic,shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http2":true,"suffix":"http2"},{"http":true,"ssl":true,"suffix":"http-ssl"},{"http2":true,"ssl":true,"suffix":"http2-ssl"}]
+shell_client_transaction,shell_client_transaction name=shell_client_transaction priority=750 single -- $EncryptionAtRest
+shell_client_traffic,shell_client_traffic,shell_client_traffic,shell_client_traffic name=shell_client_traffic priority=250 parallelity=1 single -- --optionsJson [{"http":true,"suffix":"http"},{"http":true,"ssl":true,"suffix":"http-ssl"}]
 
 shell_client_aql buckets=19 priority=250  single --javascript.v8-max-heap=8192
 
@@ -84,8 +83,7 @@ shell_api_multi priority=500 cluster suffix=http -- $EncryptionAtRest
 shell_api_multi priority=500 cluster suffix=https -- $EncryptionAtRest --protocol ssl
 
 # shell_client_multi tests run quite long, so want to have a separate job for each protocol
-shell_client_multi priority=1500 cluster suffix=http -- --http true
-shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
+shell_client_multi priority=1500 cluster
 
 # different number of buckets in cluster
 shell_client_aql priority=1000 size=medium+ cluster buckets=20 --javascript.v8-max-heap=8192 -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

Our http client (fuerte) is unreliable for http2, so it doesn't make much sense to test our server with it.
