### PR TITLE
Fix view usage if query plan comes from cache

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix view usage in cached query plans.
+
 * Make it an error if usePlanCache is set to true but the query is not 
   eligible for query plan caching. This is better for debugging.
 

--- a/tests/js/client/aql/aql-query-plan-cache.js
+++ b/tests/js/client/aql/aql-query-plan-cache.js
@@ -595,6 +595,11 @@ function QueryPlanCacheTestSuite () {
         }
         assertTrue(res.hasOwnProperty("planCacheKey"));
         assertEqual([2], res.toArray());
+        // Now try to run the same query again to see if it works when the plan
+        // comes from the cache:
+        res = db._query(query, {value: 2}, options);
+        assertTrue(res.hasOwnProperty("planCacheKey"),
+          "planCacheKey missing, view query not cached");
       } finally {
         db._dropView(vn);
       }


### PR DESCRIPTION
We found that a query plan which came from the query plan cache
and which was using views did not work in execution. The reason was
that when storing the original plan in the cache we were not taking
care of listing the used views. Therefore, instantiation later when
the plan came from the cache did not work.

Furthermore, the behaviour of actual query execution and explaining
a query was made more consistent. There are a few more conditions
on when a plan can be cached, which are now also enforced in explain.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: no backports necessary

