### PR TITLE
Don't instantiate query during explain

### DIFF
--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -207,9 +207,9 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
                              velocypack::Slice collections,
                              velocypack::Slice views,
                              velocypack::Slice variables,
-                             velocypack::Slice snippets,
-                             bool simpleSnippetFormat,
-                             QueryAnalyzerRevisions const& analyzersRevision);
+                             velocypack::Slice snippets);
+
+  void instantiatePlan(velocypack::Slice snippets);
 
   /// @brief whether or not a query is a modification query
   bool isModificationQuery() const noexcept final;
@@ -411,7 +411,7 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   std::vector<std::unique_ptr<ExecutionPlan>> _plans;
 
   /// plan serialized before instantiation, used for query profiling
-  std::shared_ptr<velocypack::UInt8Buffer> _planSliceCopy;
+  velocypack::SharedSlice _planSliceCopy;
 
   /// @brief the transaction object, in a distributed query every part of
   /// the query has its own transaction object. The transaction object is

--- a/arangod/Aql/QueryPlanCache.cpp
+++ b/arangod/Aql/QueryPlanCache.cpp
@@ -99,7 +99,7 @@ size_t QueryPlanCache::Value::memoryUsage() const noexcept {
   for (auto const& it : dataSources) {
     total += 32 + it.first.size() + it.second.name.size();
   }
-  total += serializedPlan->size();
+  total += serializedPlan.byteSize();
   return total;
 }
 
@@ -175,7 +175,7 @@ std::shared_ptr<QueryPlanCache::Value const> QueryPlanCache::lookup(
 bool QueryPlanCache::store(
     QueryPlanCache::Key&& key,
     std::unordered_map<std::string, DataSourceEntry>&& dataSources,
-    std::shared_ptr<velocypack::UInt8Buffer> serializedPlan) {
+    velocypack::SharedSlice serializedPlan) {
   auto value = std::make_shared<Value>(
       std::move(dataSources), std::move(serializedPlan), TRI_microtime(), 0);
   size_t memoryUsage = key.memoryUsage() + value->memoryUsage();

--- a/arangod/Aql/QueryPlanCache.h
+++ b/arangod/Aql/QueryPlanCache.h
@@ -28,6 +28,7 @@
 #include "Metrics/Fwd.h"
 
 #include <velocypack/Buffer.h>
+#include <velocypack/SharedSlice.h>
 
 #include <atomic>
 #include <functional>
@@ -121,7 +122,7 @@ class QueryPlanCache {
     std::unordered_map<std::string, DataSourceEntry> dataSources;
 
     // The query plan velocypack. guaranteed to be a non-nullptr.
-    std::shared_ptr<velocypack::UInt8Buffer> serializedPlan;
+    velocypack::SharedSlice serializedPlan;
 
     // Timestamp when this plan was cached. currently not used, but
     // could be used when analyzing/exposing the contents of the query
@@ -151,7 +152,7 @@ class QueryPlanCache {
   // could not be stored (e.g. due to sizing constraints).
   bool store(Key&& key,
              std::unordered_map<std::string, DataSourceEntry>&& dataSources,
-             std::shared_ptr<velocypack::UInt8Buffer> serializedPlan);
+             velocypack::SharedSlice serializedPlan);
 
   Key createCacheKey(QueryString const& queryString,
                      std::shared_ptr<velocypack::Builder> const& bindVars,

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -785,18 +785,13 @@ static void JS_ExecuteAqlJson(v8::FunctionCallbackInfo<v8::Value> const& args) {
   VPackSlice collections = queryBuilder.slice().get("collections");
   VPackSlice variables = queryBuilder.slice().get("variables");
 
-  QueryAnalyzerRevisions analyzersRevision;
-  auto revisionRes = analyzersRevision.fromVelocyPack(queryBuilder.slice());
-  if (ADB_UNLIKELY(revisionRes.fail())) {
-    TRI_V8_THROW_EXCEPTION(revisionRes);
-  }
-
   TRI_ASSERT(!ServerState::instance()->isDBServer());
-  query->prepareFromVelocyPack(
-      /*querySlice*/ VPackSlice::emptyObjectSlice(), collections,
-      VPackSlice::noneSlice(), variables,
-      /*snippets*/ queryBuilder.slice().get("nodes"), /*simple*/ true,
-      analyzersRevision);
+  auto const snippets = queryBuilder.slice().get("nodes");
+  auto const querySlice = velocypack::Slice::emptyObjectSlice();
+  auto const viewsSlice = velocypack::Slice::noneSlice();
+  query->prepareFromVelocyPack(querySlice, collections, viewsSlice, variables,
+                               snippets);
+  query->instantiatePlan(snippets);
 
   aql::QueryResult queryResult = query->executeSync();
 

--- a/tests/js/client/aql/aql-optimizer-rule-late-document-materialization-arangosearch.inc
+++ b/tests/js/client/aql/aql-optimizer-rule-late-document-materialization-arangosearch.inc
@@ -24,7 +24,7 @@
 /// @author Andrei Lobov
 /// @author Copyright 2020, ArangoDB GmbH, Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
-let IM = global.instanceManager;
+var IM = global.instanceManager;
 
 (function() {
   var db = require("@arangodb").db;


### PR DESCRIPTION
### Scope & Purpose

If a query explain was loaded from the query plan cache, the query was instantiated (e.g., snippets created on the dbservers etc.). This PR changes that, so instantiation no longer happens during explain.

- [X] :hankey: Bugfix
- [X] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification
