### PR TITLE
Dump Projection Bug

### DIFF
--- a/arangod/RocksDBEngine/RocksDBDumpContext.cpp
+++ b/arangod/RocksDBEngine/RocksDBDumpContext.cpp
@@ -473,7 +473,9 @@ void RocksDBDumpContext::handleWorkItem(WorkItem item) {
           VPackObjectBuilder ob(&projectionsBuilder);
           for (auto const& [projKey, path] : *_options.projections) {
             auto value = documentSlice.get(path);
-            projectionsBuilder.add(projKey, value);
+            if (!value.isNone()) {
+              projectionsBuilder.add(projKey, value);
+            }
           }
         }
         return projectionsBuilder.slice();

--- a/tests/js/client/shell/api/dump-cluster.js
+++ b/tests/js/client/shell/api/dump-cluster.js
@@ -215,6 +215,20 @@ function DumpAPI() {
       ctx.drop();
     },
 
+    testSimpleProjectionsNonExistentPath: function () {
+      const servers = getShardsByServer(collection);
+      const server = Object.keys(servers)[0];
+      const ctx = createContext(server, {shards: servers[server], projections: {"foo": ["value"],
+          "unknown": ["some", "non-existent", "path"]}});
+
+      for (const [doc, shard] of ctx.read()) {
+        assertEqual(Object.keys(doc), ["foo"]);
+        assertTrue(typeof doc.foo === 'number');
+        assertEqual(doc.unknown, undefined);
+      }
+      ctx.drop();
+    },
+
     testProjectionsId: function () {
       const servers = getShardsByServer(collection);
       const server = Object.keys(servers)[0];


### PR DESCRIPTION
Fix bug introduced during refactoring. If a projection access a non-existing path, it is not added to the result.