### PR TITLE
Avoid crash if follower shard gone. Better diagnostics. [BTS-2033]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Put in more diagnostics and avoid a crash in follower on commit of a
+  transaction in case a collection is already gone (BTS-2033).
+
 * Fix delivery of planCacheKey attribute for batched and streaming cursors.
 
 * Fix view usage in cached query plans.


### PR DESCRIPTION
### Scope & Purpose

This avoids a crash observed in BTS-2033. The crash seems to be caused
because a shard is gone on a follower during a commit which still uses
the collection. We did not really understand the root cause of this,
so this bug fix first avoids the crash and puts out further diagnostics
in case this happens again.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports: non planned

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2033
