### PR TITLE
Do not clean up failed jobs before their parent is finished [BTS-2022]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Don't cleanup failed agency jobs if they are subjobs of pending jobs.
+  This avoids a bug in CleanOutServer jobs, where such a job could complete
+  seemingly successfully despite the fact that some MoveShard jobs had 
+  actually failed. This fixes BTS-2022.
+
 * Put in more diagnostics and avoid a crash in follower on commit of a
   transaction in case a collection is already gone (BTS-2033).
 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1769,11 +1769,16 @@ void Supervision::cleanupFinishedAndFailedJobs() {
   // /Target/Failed. We can be rather generous here since old
   // snapshots and log entries are kept for much longer.
   // We only keep up to 500 finished jobs and 1000 failed jobs.
+  // Note that we must not throw away failed jobs which are subjobs
+  // of a larger job (e.g. MoveShard jobs in the context of a
+  // CleanOutServer job), or else the larger job can no longer
+  // detect any failures!
 
   constexpr size_t maximalFinishedJobs = 500;
   constexpr size_t maximalFailedJobs = 1000;
 
   auto cleanup = [&](std::string const& prefix, size_t limit) {
+    auto const& pendingJobs = *snapshot().hasAsChildren(pendingPrefix);
     auto const& jobs = *snapshot().hasAsChildren(prefix);
     if (jobs.size() <= 2 * limit) {
       return;
@@ -1782,6 +1787,18 @@ void Supervision::cleanupFinishedAndFailedJobs() {
     std::vector<keyDate> v;
     v.reserve(jobs.size());
     for (auto const& p : jobs) {
+      // Let's first see if this is a subjob of a larger job:
+      auto pos = p.first.find('-');
+      if (pos != std::string::npos) {
+        auto const& parent = p.first.substr(0, pos);
+        if (pendingJobs.find(parent) != nullptr) {
+          LOG_TOPIC("99887", TRACE, Logger::SUPERVISION)
+              << "Skipping removal of subjob " << p.first << " of parent "
+              << parent << " since the parent is still pending.";
+          continue;  // this is a subjob, and its parent is still pending, let's
+                     // keep it
+        }
+      }
       auto created = p.second->hasAsString("timeCreated");
       if (created) {
         v.emplace_back(p.first, *created);

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1811,7 +1811,10 @@ bool arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
               [](keyDate const& a, keyDate const& b) -> bool {
                 return a.second < b.second;
               });
-    size_t toBeDeleted = v.size() - limit;  // known to be positive
+    if (v.size() < limit) {
+      return false;
+    }
+    size_t toBeDeleted = v.size() - limit;
     LOG_TOPIC("98451", INFO, Logger::AGENCY) << "Deleting " << toBeDeleted
                                              << " old jobs"
                                                 " in "
@@ -1866,7 +1869,7 @@ void Supervision::cleanupFinishedAndFailedJobs() {
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
-      LOG_TOPIC("1232b", INFO, Logger::SUPERVISION)
+      LOG_TOPIC("1232e", INFO, Logger::SUPERVISION)
           << "Failed to remove old transfer jobs or locks: "
           << envelope->toJson();
     }
@@ -2073,7 +2076,7 @@ void Supervision::cleanupHotbackupTransferJobs() {
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
-      LOG_TOPIC("1232b", INFO, Logger::SUPERVISION)
+      LOG_TOPIC("1232d", INFO, Logger::SUPERVISION)
           << "Failed to remove old transfer jobs or locks: "
           << envelope->toJson();
     }

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -77,6 +77,13 @@ void cleanupHotbackupTransferJobsFunctional(
 void failBrokenHotbackupTransferJobsFunctional(
     Node const& snapshot, std::shared_ptr<VPackBuilder> envelope);
 
+// This is the functional version which actually does the work, it is
+// called by the private method Supervision::cleanupFinishedAndFailedJobs
+// and the unit tests:
+bool cleanupFinishedOrFailedJobsFunctional(
+    Node const& snapshot, std::shared_ptr<VPackBuilder> envelope,
+    bool doFinished);
+
 class Supervision : public ServerThread<ArangodServer> {
  public:
   typedef std::chrono::system_clock::time_point TimePoint;

--- a/tests/Agency/SupervisionTest.cpp
+++ b/tests/Agency/SupervisionTest.cpp
@@ -459,6 +459,13 @@ static void makeHotbackupTransferJob(NodePtr& snapshot, size_t year, size_t id,
                         createNode(st.c_str()));
 }
 
+static void makeFailedMoveShardJob(NodePtr& snapshot, size_t year,
+                                   std::string const& id, char const* job) {
+  std::string st = std::string(job) + "\"timeCreated\": \"" +
+                   std::to_string(year) + "-02-25T12:38:29Z\"\n}";
+  snapshot = snapshot->placeAt("/Target/Failed/" + id, createNode(st.c_str()));
+}
+
 TEST_F(SupervisionTestClass, cleanup_hotback_transfer_jobs) {
   for (size_t i = 0; i < 200; ++i) {
     makeHotbackupTransferJob(_snapshot, 1900 + i, 1000000 + i,
@@ -995,4 +1002,83 @@ TEST_F(SupervisionTestClass, fail_hotbackup_transfer_jobs) {
       "/Target/HotBackup/TransferJobs/1234567/DBServers/"
       "PRMR-a0b13c71-2472-4985-bc48-ffa091d26e03/Status");
   EXPECT_EQ(guck.copyString(), "RUNNING");
+}
+
+TEST_F(SupervisionTestClass, cleanup_failed_jobs) {
+  for (size_t i = 0; i < 2001; ++i) {
+    makeFailedMoveShardJob(_snapshot, 1970 + i, std::to_string(1000000 + i),
+                           R"=(
+{
+  "timeFinished": "2024-12-09T10:22:22Z",
+  "collection": "45",
+  "creator": "16020029",
+  "database": "d",
+  "fromServer": "PRMR-5e5faae8-6955-4cc9-88d6-d483486d6374",
+  "isLeader": true,
+  "jobId": "0",
+  "remainsFollower": false,
+  "shard": "s46",
+  "timeStarted": "2024-12-09T10:22:22Z",
+  "toServer": "PRMR-9dd10e6b-c8d6-4007-b449-54c2e355e340",
+  "tryUndo": false,
+  "type": "moveShard",
+)=");
+  };
+
+  auto envelope = std::make_shared<VPackBuilder>();
+  bool sthTodo = arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
+      *_snapshot, envelope, false);
+  EXPECT_TRUE(sthTodo);
+  VPackSlice content = envelope->slice();
+  EXPECT_TRUE(content.isArray());
+  EXPECT_EQ(content.length(), 1);
+  content = content[0];
+  EXPECT_EQ(content.length(), 1001);
+  // We expect the first 1001 jobs to be deleted:
+  for (size_t i = 0; i < 1001; ++i) {
+    std::string jobId = "/Target/Failed/" + std::to_string(1000000 + i);
+    VPackSlice guck = content.get(jobId);
+    EXPECT_TRUE(guck.isObject());
+    EXPECT_TRUE(guck.hasKey("op"));
+    EXPECT_EQ(guck.get("op").copyString(), "delete");
+  }
+}
+
+TEST_F(SupervisionTestClass, not_cleanup_failed_sub_jobs) {
+  for (size_t i = 0; i < 2001; ++i) {
+    makeFailedMoveShardJob(_snapshot, 1970 + i, "1234567-" + std::to_string(i),
+                           R"=(
+{
+  "timeFinished": "2024-12-09T10:22:22Z",
+  "collection": "45",
+  "creator": "16020029",
+  "database": "d",
+  "fromServer": "PRMR-5e5faae8-6955-4cc9-88d6-d483486d6374",
+  "isLeader": true,
+  "jobId": "0",
+  "parentJob": "1234567",
+  "remainsFollower": false,
+  "shard": "s46",
+  "timeStarted": "2024-12-09T10:22:22Z",
+  "toServer": "PRMR-9dd10e6b-c8d6-4007-b449-54c2e355e340",
+  "tryUndo": false,
+  "type": "moveShard",
+)=");
+  };
+
+  _snapshot = _snapshot->placeAt("/Target/Pending/1234567", createNode(R"=(
+{
+  "creator": "16020029",
+  "server": "PRMR-5e5faae8-6955-4cc9-88d6-d483486d6374",
+  "jobId": "1234567",
+  "timeCreated": "2024-12-09T10:22:21Z",
+  "timeStarted": "2024-12-09T10:22:22Z",
+  "type": "cleanOutServer"
+}
+)="));
+
+  auto envelope = std::make_shared<VPackBuilder>();
+  bool sthTodo = arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
+      *_snapshot, envelope, false);
+  EXPECT_FALSE(sthTodo);
 }


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-2022.

The issue is the following: Our regular cleanup of failed jobs in the
agency can clean up failed MoveShard jobs which are part of a
CleanOutServer job which is still Pending. This means that the
CleanOutServer job at the end might not detect that it has in fact
failed, and some data remains on the to be cleaned out server.

The bugfix is simple: Do not clean up jobs which are subjobs of a Pending
superjob.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21488

#### Related Information

- [*] GitHub issue / Jira ticket: *(Please reference tickets / specification / other PRs etc)*
