### PR TITLE
Do not clean up failed jobs before their parent is finished [BTS-2022]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.11.13 (XXXX-XX-XX)
 ---------------------
 
+* Don't cleanup failed agency jobs if they are subjobs of pending jobs.
+  This avoids a bug in CleanOutServer jobs, where such a job could complete
+  seemingly successfully despite the fact that some MoveShard jobs had 
+  actually failed. This fixes BTS-2022.
+
 * Upgraded OpenSSL to 3.4.0.
 
 * Fix shard synchronisation race where after a shard move the new

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1837,7 +1837,7 @@ void Supervision::cleanupFinishedAndFailedJobs() {
       auto pos = p.first.find('-');
       if (pos != std::string::npos) {
         auto const& parent = p.first.substr(0, pos);
-        if (pendingJobs.find(parent) != nullptr) {
+        if (pendingJobs.find(parent) != pendingJobs.end()) {
           LOG_TOPIC("99887", TRACE, Logger::SUPERVISION)
               << "Skipping removal of subjob " << p.first << " of parent "
               << parent << " since the parent is still pending.";

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1808,26 +1808,27 @@ void Supervision::handleJobs() {
   failBrokenHotbackupTransferJobs();
 }
 
-// Guarded by caller
-void Supervision::cleanupFinishedAndFailedJobs() {
-  // This deletes old Supervision jobs in /Target/Finished and
-  // /Target/Failed. We can be rather generous here since old
-  // snapshots and log entries are kept for much longer.
-  // We only keep up to 500 finished jobs and 1000 failed jobs.
-  // Note that we must not throw away failed jobs which are subjobs
-  // of a larger job (e.g. MoveShard jobs in the context of a
-  // CleanOutServer job), or else the larger job can no longer
-  // detect any failures!
+bool arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
+    Node const& snapshot, std::shared_ptr<VPackBuilder> envelope,
+    bool doFinished) {
+  // This deletes old Supervision jobs in /Target/Finished (doFinished=true)
+  // or /Target/Failed (doFinished=false). We can be rather generous
+  // here since old snapshots and log entries are kept for much longer.
+  // We only keep up to 500 finished jobs and 1000 failed jobs. Note
+  // that we must not throw away failed jobs which are subjobs of a
+  // larger job (e.g. MoveShard jobs in the context of a CleanOutServer
+  // job), or else the larger job can no longer detect any failures!
+  // Returns true if there is something to do, false otherwise.
 
   constexpr size_t maximalFinishedJobs = 500;
   constexpr size_t maximalFailedJobs = 1000;
 
-  auto cleanup = [&](std::string const& prefix, size_t limit) {
-    auto const& jobs = snapshot().hasAsChildren(prefix).value().get();
+  auto cleanup = [&](std::string const& prefix, size_t limit) -> bool {
     auto const& pendingJobs =
-        snapshot().hasAsChildren(pendingPrefix).value().get();
+        snapshot.hasAsChildren(pendingPrefix).value().get();
+    auto const& jobs = snapshot.hasAsChildren(prefix).value().get();
     if (jobs.size() <= 2 * limit) {
-      return;
+      return false;
     }
     typedef std::pair<std::string, std::string> keyDate;
     std::vector<keyDate> v;
@@ -1861,8 +1862,8 @@ void Supervision::cleanupFinishedAndFailedJobs() {
                                              << " old jobs"
                                                 " in "
                                              << prefix;
-    VPackBuilder trx;  // We build a transaction here
-    {                  // Pair for operation, no precondition here
+    {  // Pair for operation, no precondition here
+      VPackBuilder& trx(*envelope);
       VPackArrayBuilder guard1(&trx);
       {
         VPackObjectBuilder guard2(&trx);
@@ -1875,11 +1876,49 @@ void Supervision::cleanupFinishedAndFailedJobs() {
         }
       }
     }
-    singleWriteTransaction(_agent, trx, false);  // do not care about the result
+    return true;
   };
 
-  cleanup(finishedPrefix, maximalFinishedJobs);
-  cleanup(failedPrefix, maximalFailedJobs);
+  if (doFinished) {
+    return cleanup(finishedPrefix, maximalFinishedJobs);
+  } else {
+    return cleanup(failedPrefix, maximalFailedJobs);
+  }
+}
+
+// Guarded by caller
+void Supervision::cleanupFinishedAndFailedJobs() {
+  auto envelope = std::make_shared<VPackBuilder>();
+  bool sthTodo = arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
+      snapshot(), envelope, true);
+  if (sthTodo) {
+    LOG_DEVEL << "Transaction built: " << envelope->toJson();
+    write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
+
+    if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
+      LOG_TOPIC("1232b", INFO, Logger::SUPERVISION)
+          << "Failed to remove old transfer jobs or locks: "
+          << envelope->toJson();
+    }
+    singleWriteTransaction(_agent, *envelope,
+                           false);  // do not care about the result
+  };
+
+  envelope->clear();
+  sthTodo = arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
+      snapshot(), envelope, false);
+  if (sthTodo) {
+    LOG_DEVEL << "Transaction 2 built: " << envelope->toJson();
+    write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
+
+    if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
+      LOG_TOPIC("1232b", INFO, Logger::SUPERVISION)
+          << "Failed to remove old transfer jobs or locks: "
+          << envelope->toJson();
+    }
+    singleWriteTransaction(_agent, *envelope,
+                           false);  // do not care about the result
+  };
 }
 
 // Guarded by caller
@@ -2672,8 +2711,8 @@ auto parseSomethingFromNode(Node const& n) -> T {
 }
 
 template<typename T>
-auto parseIfExists(Node const& root, std::string const& url)
-    -> std::optional<T> {
+auto parseIfExists(Node const& root,
+                   std::string const& url) -> std::optional<T> {
   if (auto node = root.get(url); node.has_value()) {
     return parseSomethingFromNode<T>(node->get());
   }
@@ -2731,11 +2770,10 @@ auto replicatedLogOwnerGone(Node const& snapshot, Node const& node,
   return true;
 }
 
-auto handleReplicatedLog(Node const& snapshot, Node const& targetNode,
-                         std::string const& dbName, std::string const& idString,
-                         ParticipantsHealth const& health,
-                         arangodb::agency::envelope envelope)
-    -> arangodb::agency::envelope try {
+auto handleReplicatedLog(
+    Node const& snapshot, Node const& targetNode, std::string const& dbName,
+    std::string const& idString, ParticipantsHealth const& health,
+    arangodb::agency::envelope envelope) -> arangodb::agency::envelope try {
   if (replicatedLogOwnerGone(snapshot, targetNode, dbName, idString)) {
     auto logId = replication2::LogId{basics::StringUtils::uint64(idString)};
     return methods::deleteReplicatedLogTrx(std::move(envelope), dbName, logId);

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1857,7 +1857,10 @@ bool arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
               [](keyDate const& a, keyDate const& b) -> bool {
                 return a.second < b.second;
               });
-    size_t toBeDeleted = v.size() - limit;  // known to be positive
+    if (v.size() < limit) {
+      return false;
+    }
+    size_t toBeDeleted = v.size() - limit;
     LOG_TOPIC("98451", INFO, Logger::AGENCY) << "Deleting " << toBeDeleted
                                              << " old jobs"
                                                 " in "
@@ -1912,7 +1915,7 @@ void Supervision::cleanupFinishedAndFailedJobs() {
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
-      LOG_TOPIC("1232b", INFO, Logger::SUPERVISION)
+      LOG_TOPIC("1232e", INFO, Logger::SUPERVISION)
           << "Failed to remove old transfer jobs or locks: "
           << envelope->toJson();
     }
@@ -2116,7 +2119,7 @@ void Supervision::cleanupHotbackupTransferJobs() {
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
-      LOG_TOPIC("1232b", INFO, Logger::SUPERVISION)
+      LOG_TOPIC("1232d", INFO, Logger::SUPERVISION)
           << "Failed to remove old transfer jobs or locks: "
           << envelope->toJson();
     }

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -2672,8 +2672,8 @@ auto parseSomethingFromNode(Node const& n) -> T {
 }
 
 template<typename T>
-auto parseIfExists(Node const& root,
-                   std::string const& url) -> std::optional<T> {
+auto parseIfExists(Node const& root, std::string const& url)
+    -> std::optional<T> {
   if (auto node = root.get(url); node.has_value()) {
     return parseSomethingFromNode<T>(node->get());
   }
@@ -2731,10 +2731,11 @@ auto replicatedLogOwnerGone(Node const& snapshot, Node const& node,
   return true;
 }
 
-auto handleReplicatedLog(
-    Node const& snapshot, Node const& targetNode, std::string const& dbName,
-    std::string const& idString, ParticipantsHealth const& health,
-    arangodb::agency::envelope envelope) -> arangodb::agency::envelope try {
+auto handleReplicatedLog(Node const& snapshot, Node const& targetNode,
+                         std::string const& dbName, std::string const& idString,
+                         ParticipantsHealth const& health,
+                         arangodb::agency::envelope envelope)
+    -> arangodb::agency::envelope try {
   if (replicatedLogOwnerGone(snapshot, targetNode, dbName, idString)) {
     auto logId = replication2::LogId{basics::StringUtils::uint64(idString)};
     return methods::deleteReplicatedLogTrx(std::move(envelope), dbName, logId);

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -74,6 +74,13 @@ void cleanupHotbackupTransferJobsFunctional(
 void failBrokenHotbackupTransferJobsFunctional(
     Node const& snapshot, std::shared_ptr<VPackBuilder> envelope);
 
+// This is the functional version which actually does the work, it is
+// called by the private method Supervision::cleanupFinishedAndFailedJobs
+// and the unit tests:
+bool cleanupFinishedOrFailedJobsFunctional(
+    Node const& snapshot, std::shared_ptr<VPackBuilder> envelope,
+    bool doFinished);
+
 class Supervision : public arangodb::Thread {
  public:
   typedef std::chrono::system_clock::time_point TimePoint;


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-2022.

The issue is the following: Our regular cleanup of failed jobs in the
agency can clean up failed MoveShard jobs which are part of a
CleanOutServer job which is still Pending. This means that the
CleanOutServer job at the end might not detect that it has in fact
failed, and some data remains on the to be cleaned out server.

The bugfix is simple: Do not clean up jobs which are subjobs of a Pending
superjob.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: this is it

#### Related Information

- [*] GitHub issue / Jira ticket: *(Please reference tickets / specification / other PRs etc)*
- [*] Original PR: https://github.com/arangodb/arangodb/pull/21487

