### PR TITLE
Fix remove server API [BTS-2040]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Do check for replication version 2 in a safe way. This fixes BTS-2040.
+
 * Put in more diagnostics and avoid a crash in follower on commit of a
   transaction in case a collection is already gone (BTS-2033).
 

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -148,8 +148,8 @@ void removeCurrentServersReplicationTwo(
 void removePlanOrCurrentServers(std::unordered_set<std::string>& servers,
                                 VPackSlice plan, VPackSlice current) {
   for (auto const& database : VPackObjectIterator(plan.get("Databases"))) {
-    if (database.value.get(StaticStrings::ReplicationVersion)
-            .isEqualString("2")) {
+    auto replVersion = database.value.get(StaticStrings::ReplicationVersion);
+    if (replVersion.isString() && replVersion.isEqualString("2")) {
       auto planLogs = plan.get("ReplicatedLogs").get(database.key.stringView());
       auto currentLogs =
           current.get("ReplicatedLogs").get(database.key.stringView());


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-2040

The API /_admin/cluster/removeServer does not work any more if a cluster
was upgraded from 3.11 to 3.12. The reason is that the entries under
/arango/Databases do not yet have an attribute replicationVersion set to
a string. Some place in the implementation of this API assumes however
that there is a string and throws an exception if not.

The fix is simple, just ignore if the attribute is not set and treat it
as if there were a string "1" there.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports: none needed

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2040
