### PR TITLE
Limit error message in TransferJobs [BTS_2041]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Truncate error messages by rclone for TransferJobs to avoid excessive
+  memory use in the agency. Keep only 10 finished TransferJobs in agency.
+  This fixes BTS-2041.
+
 * Don't cleanup failed agency jobs if they are subjobs of pending jobs.
   This avoids a bug in CleanOutServer jobs, where such a job could complete
   seemingly successfully despite the fact that some MoveShard jobs had 

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1883,9 +1883,9 @@ void arangodb::consensus::cleanupHotbackupTransferJobsFunctional(
     Node const& snapshot, std::shared_ptr<VPackBuilder> envelope) {
   // This deletes old Hotbackup transfer jobs in
   // /Target/HotBackup/TransferJobs according to their time stamp.
-  // We keep at most 100 transfer jobs which are completed.
+  // We keep at most 10 transfer jobs which are completed.
   // We also delete old hotbackup transfer job locks if needed.
-  constexpr uint64_t maximalNumberTransferJobs = 100;
+  constexpr uint64_t maximalNumberTransferJobs = 10;
   constexpr char const* prefix = HOTBACKUP_TRANSFER_JOBS;
 
   auto static const noJobs = Node::Children{};


### PR DESCRIPTION
### Scope & Purpose

This is about https://arangodb.atlassian.net/browse/BTS-2041

TransferJobs (reported to the agency on hotbackup upload) can have very
long error messages, which come from rclone. We suspect that this can
happen if a hotbackup with arangosearch data is deleted during an upload
process. In this case the TransferJob can use an excessive amount of
memory in the agency which can in turn cause OOM problems elsewhere.

This PR limits the size of the error message in the TransferJob to 1kb.
Furthermore, we limit the number of transfer jobs that are done and are
kept to 10 (instead of 100).

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11: not planned so far.

#### Related Information

- [*] Enterprise PR: ???
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/ES-2273
