### PR TITLE
Fix expiration of servers in agency [BTS-2039]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,12 @@
 devel
 -----
+
+* Reduce the time until an expired server is removed from the agency to 1h 
+  (from 24h). This helps with BTS-2039 and thus helps hotbackups to go
+  through in more cases when coordinators have crashed. The time is
+  configurable with the `--agency.supervision-expired-servers-grace-time`
+  command line option.
+
 * Changed the priority of WebUI request to prevent endless loading if the
   server is under load
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 devel
 -----
 
+* If a coordinator cannot send a heartbeat to the agency, it will shut down
+  itself after 30 mins (configurable by the startup option
+  `--cluster.no-heartbeat-delay-before-shutdown` whose default is 1800.
+  This is to ensure that servers which are automatically cleaned up,
+  because they are away for too long cannot disturb hotbackups by running
+  transactions.
+
 * Reduce the time until an expired server is removed from the agency to 1h 
   (from 24h). This helps with BTS-2039 and thus helps hotbackups to go
   through in more cases when coordinators have crashed. The time is

--- a/arangod/Agency/AgencyFeature.cpp
+++ b/arangod/Agency/AgencyFeature.cpp
@@ -72,6 +72,7 @@ AgencyFeature::AgencyFeature(Server& server)
       _maxAppendSize(250),
       _supervisionGracePeriod(10.0),
       _supervisionOkThreshold(5.0),
+      _supervisionExpiredServersGracePeriod(3600.0),
       _supervisionDelayAddFollower(0),
       _supervisionDelayFailedFollower(0),
       _failedLeaderAddsFollower(true) {
@@ -173,6 +174,17 @@ cluster deployments.)");
                      arangodb::options::makeFlags(
                          arangodb::options::Flags::DefaultNoComponents,
                          arangodb::options::Flags::OnAgent));
+
+  options
+      ->addOption("--agency.supervision-expired-servers-grace-period",
+                  "The supervision time after which a server is removed "
+                  "from the agency if it does no longer send heartbeats "
+                  "(in seconds).",
+                  new DoubleParameter(&_supervisionExpiredServersGracePeriod),
+                  arangodb::options::makeFlags(
+                      arangodb::options::Flags::DefaultNoComponents,
+                      arangodb::options::Flags::OnAgent))
+      .setIntroducedIn(31204);
 
   options
       ->addOption("--agency.supervision-delay-add-follower",
@@ -416,7 +428,8 @@ void AgencyFeature::prepare() {
           _waitForSync, _supervisionFrequency, _compactionStepSize,
           _compactionKeepSize, _supervisionGracePeriod, _supervisionOkThreshold,
           _supervisionDelayAddFollower, _supervisionDelayFailedFollower,
-          _failedLeaderAddsFollower, _maxAppendSize));
+          _failedLeaderAddsFollower, _maxAppendSize,
+          _supervisionExpiredServersGracePeriod));
 }
 
 void AgencyFeature::start() {

--- a/arangod/Agency/AgencyFeature.h
+++ b/arangod/Agency/AgencyFeature.h
@@ -64,6 +64,7 @@ class AgencyFeature : public ArangodFeature {
   uint64_t _maxAppendSize;
   double _supervisionGracePeriod;
   double _supervisionOkThreshold;
+  double _supervisionExpiredServersGracePeriod;
   uint64_t _supervisionDelayAddFollower;
   uint64_t _supervisionDelayFailedFollower;
   bool _failedLeaderAddsFollower;

--- a/arangod/Agency/AgentConfiguration.cpp
+++ b/arangod/Agency/AgentConfiguration.cpp
@@ -49,6 +49,8 @@ std::string const config_t::supervisionGracePeriodStr =
     "supervision grace period";
 std::string const config_t::supervisionOkThresholdStr =
     "supervision ok threshold";
+std::string const config_t::supervisionExpiredServersGracePeriodStr =
+    "supervision expired servers grace period";
 std::string const config_t::supervisionDelayAddFollowerStr =
     "supervision delay add follower job time";
 std::string const config_t::supervisionDelayFailedFollowerStr =
@@ -75,6 +77,7 @@ config_t::config_t()
       _compactionKeepSize(50000),
       _supervisionGracePeriod(15.0),
       _supervisionOkThreshold(5.0),
+      _supervisionExpiredServersGracePeriod(3600.0),
       _supervisionDelayAddFollower(0),
       _supervisionDelayFailedFollower(0),
       _supervisionFailedLeaderAddsFollower(true),
@@ -86,7 +89,8 @@ config_t::config_t()
 config_t::config_t(std::string const& rid, size_t as, double minp, double maxp,
                    std::string const& e, std::vector<std::string> const& g,
                    bool s, bool st, bool w, double f, uint64_t c, uint64_t k,
-                   double p, double o, uint64_t q, uint64_t r, bool t, size_t a)
+                   double p, double o, uint64_t q, uint64_t r, bool t, size_t a,
+                   double u)
     : _recoveryId(rid),
       _agencySize(as),
       _minPing(minp),
@@ -102,6 +106,7 @@ config_t::config_t(std::string const& rid, size_t as, double minp, double maxp,
       _compactionKeepSize(k),
       _supervisionGracePeriod(p),
       _supervisionOkThreshold(o),
+      _supervisionExpiredServersGracePeriod(u),
       _supervisionDelayAddFollower(q),
       _supervisionDelayFailedFollower(r),
       _supervisionFailedLeaderAddsFollower(t),
@@ -136,6 +141,8 @@ config_t& config_t::operator=(config_t const& other) {
   _compactionKeepSize = other._compactionKeepSize;
   _supervisionGracePeriod = other._supervisionGracePeriod;
   _supervisionOkThreshold = other._supervisionOkThreshold;
+  _supervisionExpiredServersGracePeriod =
+      other._supervisionExpiredServersGracePeriod;
   _supervisionDelayAddFollower = other._supervisionDelayAddFollower;
   _supervisionDelayFailedFollower = other._supervisionDelayFailedFollower;
   _supervisionFailedLeaderAddsFollower =
@@ -166,6 +173,8 @@ config_t& config_t::operator=(config_t&& other) {
   _compactionKeepSize = std::move(other._compactionKeepSize);
   _supervisionGracePeriod = std::move(other._supervisionGracePeriod);
   _supervisionOkThreshold = std::move(other._supervisionOkThreshold);
+  _supervisionExpiredServersGracePeriod =
+      std::move(other._supervisionExpiredServersGracePeriod);
   _supervisionDelayAddFollower = std::move(other._supervisionDelayAddFollower);
   _supervisionDelayFailedFollower =
       std::move(other._supervisionDelayFailedFollower);
@@ -190,6 +199,11 @@ double config_t::supervisionGracePeriod() const {
 double config_t::supervisionOkThreshold() const {
   READ_LOCKER(readLocker, _lock);
   return _supervisionOkThreshold;
+}
+
+double config_t::supervisionExpiredServersGracePeriod() const {
+  READ_LOCKER(readLocker, _lock);
+  return _supervisionExpiredServersGracePeriod;
 }
 
 uint64_t config_t::supervisionDelayAddFollower() const {
@@ -492,6 +506,8 @@ void config_t::toBuilder(VPackBuilder& builder) const {
     builder.add(compactionKeepSizeStr, VPackValue(_compactionKeepSize));
     builder.add(supervisionGracePeriodStr, VPackValue(_supervisionGracePeriod));
     builder.add(supervisionOkThresholdStr, VPackValue(_supervisionOkThreshold));
+    builder.add(supervisionExpiredServersGracePeriodStr,
+                VPackValue(_supervisionExpiredServersGracePeriod));
     builder.add(supervisionDelayAddFollowerStr,
                 VPackValue(_supervisionDelayAddFollower));
     builder.add(supervisionDelayFailedFollowerStr,
@@ -745,6 +761,10 @@ void config_t::updateConfiguration(velocypack::Slice other) {
   if (other.hasKey(supervisionOkThresholdStr)) {
     _supervisionOkThreshold =
         other.get(supervisionOkThresholdStr).getNumber<double>();
+  }
+  if (other.hasKey(supervisionExpiredServersGracePeriodStr)) {
+    _supervisionExpiredServersGracePeriod =
+        other.get(supervisionExpiredServersGracePeriodStr).getNumber<double>();
   }
   if (other.hasKey(supervisionDelayAddFollowerStr)) {
     _supervisionDelayAddFollower =

--- a/arangod/Agency/AgentConfiguration.h
+++ b/arangod/Agency/AgentConfiguration.h
@@ -54,6 +54,7 @@ struct config_t {
   uint64_t _compactionKeepSize;
   double _supervisionGracePeriod;
   double _supervisionOkThreshold;
+  double _supervisionExpiredServersGracePeriod;
   uint64_t _supervisionDelayAddFollower;
   uint64_t _supervisionDelayFailedFollower;
   bool _supervisionFailedLeaderAddsFollower;
@@ -80,6 +81,7 @@ struct config_t {
   static std::string const supervisionFrequencyStr;
   static std::string const supervisionGracePeriodStr;
   static std::string const supervisionOkThresholdStr;
+  static std::string const supervisionExpiredServersGracePeriodStr;
   static std::string const supervisionDelayAddFollowerStr;
   static std::string const supervisionDelayFailedFollowerStr;
   static std::string const supervisionFailedLeaderAddsFollowerStr;
@@ -98,7 +100,7 @@ struct config_t {
   config_t(std::string const& rid, size_t as, double minp, double maxp,
            std::string const& e, std::vector<std::string> const& g, bool s,
            bool st, bool w, double f, uint64_t c, uint64_t k, double p,
-           double o, uint64_t q, uint64_t r, bool t, size_t a);
+           double o, uint64_t q, uint64_t r, bool t, size_t a, double u);
 
   /// @brief copy constructor
   config_t(config_t const&);
@@ -233,6 +235,9 @@ struct config_t {
   /// @brief Supervision ok threshold
   double supervisionOkThreshold() const;
 
+  /// @brief Supervision ok expired servers grace period
+  double supervisionExpiredServersGracePeriod() const;
+
   /// @brief Supervision delay add follower
   uint64_t supervisionDelayAddFollower() const;
 
@@ -252,6 +257,12 @@ struct config_t {
   void setSupervisionOkThreshold(double d) {
     WRITE_LOCKER(writeLocker, _lock);
     _supervisionOkThreshold = d;
+  }
+
+  /// @brief set Supervision expired servers grace period
+  void setSupervisionExpiredServersGracePeriod(double d) {
+    WRITE_LOCKER(writeLocker, _lock);
+    _supervisionExpiredServersGracePeriod = d;
   }
 
   /// @brief set Supervision delay add follower

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -1363,9 +1363,11 @@ std::string Supervision::serverHealth(std::string_view serverName) const {
 //      Remove coordinator everywhere
 //      Remove DB server everywhere, if not leader of a shard
 
-std::unordered_map<ServerID, std::string> deletionCandidates(
-    Node const& snapshot, Node const& transient, std::string const& type,
-    double gracePeriod) {
+std::unordered_map<ServerID, std::string>
+arangodb::consensus::deletionCandidates(Node const& snapshot,
+                                        Node const& transient,
+                                        std::string const& type,
+                                        double gracePeriod) {
   using namespace std::chrono;
   std::unordered_map<ServerID, std::string> serverList;
   std::string const planPath = "/Plan/" + type;

--- a/arangod/Agency/Supervision.cpp
+++ b/arangod/Agency/Supervision.cpp
@@ -211,6 +211,7 @@ Supervision::Supervision(ArangodServer& server,
       _okThreshold(5.),
       _delayAddFollower(0),
       _delayFailedFollower(0),
+      _expiredServersGracePeriod(3600),
       _jobId(0),
       _jobIdMax(0),
       _lastUpdateIndex(0),
@@ -1363,7 +1364,8 @@ std::string Supervision::serverHealth(std::string_view serverName) const {
 //      Remove DB server everywhere, if not leader of a shard
 
 std::unordered_map<ServerID, std::string> deletionCandidates(
-    Node const& snapshot, Node const& transient, std::string const& type) {
+    Node const& snapshot, Node const& transient, std::string const& type,
+    double gracePeriod) {
   using namespace std::chrono;
   std::unordered_map<ServerID, std::string> serverList;
   std::string const planPath = "/Plan/" + type;
@@ -1375,22 +1377,29 @@ std::unordered_map<ServerID, std::string> deletionCandidates(
       auto const& transientHeartbeat =
           transient.get("/Supervision/Health/" + serverId.first);
       try {
-        // Do we have a transient heartbeat younger than a day?
+        // Do we have a transient heartbeat younger than the gracePeriod?
+        // Note that we take the LastAckedTime value here, since this is
+        // the time we have last seen a new heartbeat from that server
+        // here in this agency leader.
         if (transientHeartbeat) {
           auto const t = stringToTimepoint(
-              transientHeartbeat->get("Timestamp")->getString().value());
-          if (t > system_clock::now() - hours(24)) {
+              transientHeartbeat->get("LastAckedTime")->getString().value());
+          if (t > system_clock::now() -
+                      seconds(static_cast<uint64_t>(gracePeriod))) {
             continue;
           }
         }
-        // Else do we have a persistent heartbeat younger than a day?
+        // Else do we have a persistent heartbeat younger than the gracePeriod?
+        // Note that we take the Timestamp value here, since this is the
+        // time of the last persisted status change of that server.
         auto const& persistentHeartbeat =
             snapshot.get("/Supervision/Health/" + serverId.first);
         if (persistentHeartbeat) {
           persistedTimeStamp =
               persistentHeartbeat->get("Timestamp")->getString().value();
           auto const t = stringToTimepoint(persistedTimeStamp);
-          if (t > system_clock::now() - hours(24)) {
+          if (t > system_clock::now() -
+                      seconds(static_cast<uint64_t>(gracePeriod))) {
             continue;
           }
         } else {
@@ -1406,6 +1415,8 @@ std::unordered_map<ServerID, std::string> deletionCandidates(
 
       // We are still here?
       serverList.emplace(serverId.first, persistedTimeStamp);
+      LOG_TOPIC("66521", INFO, Logger::SUPERVISION)
+          << "Removing expired server: " << serverId.first;
     }
   }
 
@@ -1443,7 +1454,8 @@ std::unordered_map<ServerID, std::string> deletionCandidates(
 
 void Supervision::cleanupExpiredServers(Node const& snapshot,
                                         Node const& transient) {
-  auto servers = deletionCandidates(snapshot, transient, "DBServers");
+  auto servers = deletionCandidates(snapshot, transient, "DBServers",
+                                    _expiredServersGracePeriod);
   auto const& currentDatabases = *snapshot.get("Current/Databases");
 
   VPackBuilder del;
@@ -1493,7 +1505,8 @@ void Supervision::cleanupExpiredServers(Node const& snapshot,
   }
 
   trxs.clear();
-  servers = deletionCandidates(snapshot, transient, "Coordinators");
+  servers = deletionCandidates(snapshot, transient, "Coordinators",
+                               _expiredServersGracePeriod);
   {
     VPackArrayBuilder t(&trxs);
     for (auto const& server : servers) {
@@ -1849,7 +1862,6 @@ void Supervision::cleanupFinishedAndFailedJobs() {
   bool sthTodo = arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
       snapshot(), envelope, true);
   if (sthTodo) {
-    LOG_DEVEL << "Transaction built: " << envelope->toJson();
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
@@ -1865,7 +1877,6 @@ void Supervision::cleanupFinishedAndFailedJobs() {
   sthTodo = arangodb::consensus::cleanupFinishedOrFailedJobsFunctional(
       snapshot(), envelope, false);
   if (sthTodo) {
-    LOG_DEVEL << "Transaction 2 built: " << envelope->toJson();
     write_ret_t res = singleWriteTransaction(_agent, *envelope, false);
 
     if (!res.accepted || (res.indices.size() == 1 && res.indices[0] == 0)) {
@@ -3450,6 +3461,8 @@ bool Supervision::start(Agent* agent) {
   _delayFailedFollower = _agent->config().supervisionDelayFailedFollower();
   _failedLeaderAddsFollower =
       _agent->config().supervisionFailedLeaderAddsFollower();
+  _expiredServersGracePeriod =
+      _agent->config().supervisionExpiredServersGracePeriod();
   return start();
 }
 

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -326,6 +326,7 @@ class Supervision : public ServerThread<ArangodServer> {
   std::atomic<uint64_t> _delayAddFollower;
   std::atomic<uint64_t> _delayFailedFollower;
   std::atomic<bool> _failedLeaderAddsFollower;
+  std::atomic<double> _expiredServersGracePeriod;
   uint64_t _jobId;
   uint64_t _jobIdMax;
   uint64_t _lastUpdateIndex;

--- a/arangod/Agency/Supervision.h
+++ b/arangod/Agency/Supervision.h
@@ -84,6 +84,10 @@ bool cleanupFinishedOrFailedJobsFunctional(
     Node const& snapshot, std::shared_ptr<VPackBuilder> envelope,
     bool doFinished);
 
+std::unordered_map<ServerID, std::string> deletionCandidates(
+    Node const& snapshot, Node const& transient, std::string const& type,
+    double gracePeriod);
+
 class Supervision : public ServerThread<ArangodServer> {
  public:
   typedef std::chrono::system_clock::time_point TimePoint;

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -449,7 +449,8 @@ Setting this option to a value of zero disables these connectivity checks.")")
           "--cluster.no-heartbeat-delay-before-shutdown",
           "The delay (in seconds) before shutting down a coordinator "
           "if no heartbeat can be sent. Set to 0 to deactivate this shutdown",
-          new DoubleParameter(&_noHeartbeatDelayBeforeShutdown),
+          new DoubleParameter(&_noHeartbeatDelayBeforeShutdown, 1.0, 0.0,
+                              std::numeric_limits<double>::max(), true, true),
           arangodb::options::makeFlags(
               arangodb::options::Flags::DefaultNoComponents,
               arangodb::options::Flags::OnCoordinator,

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -445,14 +445,15 @@ Setting this option to a value of zero disables these connectivity checks.")")
       .setIntroducedIn(31104);
 
   options
-      ->addOption("--cluster.no-heartbeat-delay-before-shutdown",
-                  "The delay (in seconds) before shutting down a coordinator "
-                  "if no heartbeat can be sent.",
-                  new DoubleParameter(&_noHeartbeatDelayBeforeShutdown),
-                  arangodb::options::makeFlags(
-                      arangodb::options::Flags::DefaultNoComponents,
-                      arangodb::options::Flags::OnCoordinator,
-                      arangodb::options::Flags::OnDBServer))
+      ->addOption(
+          "--cluster.no-heartbeat-delay-before-shutdown",
+          "The delay (in seconds) before shutting down a coordinator "
+          "if no heartbeat can be sent. Set to 0 to deactivate this shutdown",
+          new DoubleParameter(&_noHeartbeatDelayBeforeShutdown),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnCoordinator,
+              arangodb::options::Flags::OnDBServer))
       .setLongDescription(
           R"(Setting this option to a value greater than zero will
 let a coordinator which cannot send a heartbeat to the agency for the specified time

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -211,6 +211,7 @@ class ClusterFeature : public ArangodFeature {
   void startHeartbeatThread(AgencyCallbackRegistry* agencyCallbackRegistry,
                             uint64_t interval_ms,
                             uint64_t maxFailsBeforeWarning,
+                            double noHeartbeatDelayBeforeShutdown,
                             std::string const& endpoints);
 
  private:
@@ -284,6 +285,8 @@ class ClusterFeature : public ArangodFeature {
   Scheduler::WorkHandle _connectivityCheck;
   metrics::Counter* _connectivityCheckFailsCoordinators = nullptr;
   metrics::Counter* _connectivityCheckFailsDBServers = nullptr;
+
+  double _noHeartbeatDelayBeforeShutdown = 1800;  // seconds
 };
 
 }  // namespace arangodb

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -804,7 +804,7 @@ void HeartbeatThread::runCoordinator() {
         break;
       }
 
-      {
+      if (_noHeartbeatDelayBeforeShutdown >= 1.0) {
         std::lock_guard<std::mutex> guard(_lastSuccessfulHeartbeatSentMutex);
         if (_lastSuccessfulHeartbeatSent.has_value()) {
           auto diff = std::chrono::steady_clock::now() -

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -24,6 +24,7 @@
 #include "HeartbeatThread.h"
 
 #include "Agency/AsyncAgencyComm.h"
+#include "ApplicationFeatures/ShutdownFeature.h"
 #include "Auth/UserManager.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/VelocyPackHelper.h"
@@ -210,7 +211,8 @@ DECLARE_HISTOGRAM(arangodb_heartbeat_send_time_msec, HeartbeatScale,
 HeartbeatThread::HeartbeatThread(Server& server,
                                  AgencyCallbackRegistry* agencyCallbackRegistry,
                                  std::chrono::microseconds interval,
-                                 uint64_t maxFailsBeforeWarning)
+                                 uint64_t maxFailsBeforeWarning,
+                                 double noHeartbeatDelayBeforeShutdown)
     : arangodb::ServerThread<Server>(server, "Heartbeat"),
       _agencyCallbackRegistry(agencyCallbackRegistry),
       _statusLock(std::make_shared<std::mutex>()),
@@ -220,6 +222,8 @@ HeartbeatThread::HeartbeatThread(Server& server,
       _interval(interval),
       _maxFailsBeforeWarning(maxFailsBeforeWarning),
       _numFails(0),
+      _doneHeartbeatShutdown(false),
+      _noHeartbeatDelayBeforeShutdown(noHeartbeatDelayBeforeShutdown),
       _lastSuccessfulVersion(0),
       _currentPlanVersion(0),
       _ready(false),
@@ -800,6 +804,27 @@ void HeartbeatThread::runCoordinator() {
         break;
       }
 
+      {
+        std::lock_guard<std::mutex> guard(_lastSuccessfulHeartbeatSentMutex);
+        if (_lastSuccessfulHeartbeatSent.has_value()) {
+          auto diff = std::chrono::steady_clock::now() -
+                      _lastSuccessfulHeartbeatSent.value();
+          if (diff > std::chrono::seconds(static_cast<uint64_t>(
+                         _noHeartbeatDelayBeforeShutdown)) &&
+              !_doneHeartbeatShutdown) {
+            LOG_TOPIC("ffffa", FATAL, Logger::HEARTBEAT)
+                << "Could not send heartbeat for too long, shutting down!";
+            _server.beginShutdown();
+            _doneHeartbeatShutdown = true;
+          } else if (diff > std::chrono::seconds(static_cast<uint64_t>(
+                                _noHeartbeatDelayBeforeShutdown / 2))) {
+            LOG_TOPIC("ffffb", ERR, Logger::HEARTBEAT)
+                << "Could not send heartbeat for a while, consider checking "
+                   "the network connection";
+          }
+        }
+      }
+
       if (getNewsRunning->load(std::memory_order_seq_cst) == 0) {
         // Schedule a getNewsFromAgency call in the Scheduler:
         auto self = shared_from_this();
@@ -820,7 +845,6 @@ void HeartbeatThread::runCoordinator() {
             locker,
             std::chrono::duration_cast<std::chrono::microseconds>(remain));
       }
-
     } catch (std::exception const& e) {
       LOG_TOPIC("27a96", ERR, Logger::HEARTBEAT)
           << "Got an exception in coordinator heartbeat: " << e.what();
@@ -846,9 +870,9 @@ bool HeartbeatThread::init() {
     // the maintenanceThread is only required by DB server instances, but we
     // deliberately initialize it here instead of in runDBServer because the
     // ClusterInfo::SyncerThread uses HeartbeatThread::notify to notify this
-    // thread, but that SyncerThread is started before runDBServer is called. So
-    // in order to prevent a data race we should initialize _maintenanceThread
-    // before that SyncerThread is started.
+    // thread, but that SyncerThread is started before runDBServer is called.
+    // So in order to prevent a data race we should initialize
+    // _maintenanceThread before that SyncerThread is started.
     _maintenanceThread =
         std::make_unique<HeartbeatBackgroundJobThread>(_server, this);
   }
@@ -1038,8 +1062,8 @@ bool HeartbeatThread::handlePlanChangeCoordinator(uint64_t currentPlanVersion) {
 /// @brief handles a plan version change, DBServer case
 /// this is triggered if the heartbeat thread finds a new plan version number,
 /// and every few heartbeats if the Current/Version has changed. Note that the
-/// latter happens not in the heartbeat thread itself but in a scheduler thread.
-/// Therefore we need to do proper locking.
+/// latter happens not in the heartbeat thread itself but in a scheduler
+/// thread. Therefore we need to do proper locking.
 ////////////////////////////////////////////////////////////////////////////////
 
 void HeartbeatThread::notify() {
@@ -1148,7 +1172,8 @@ void HeartbeatThread::sendServerStateAsync() {
   std::move(f).thenFinal(
       [self = shared_from_this(),
        start](futures::Try<AsyncAgencyCommResult> const& tryResult) noexcept {
-        auto timeDiff = std::chrono::steady_clock::now() - start;
+        auto now = std::chrono::steady_clock::now();
+        auto timeDiff = now - start;
         self->_heartbeat_send_time_ms.count(
             std::chrono::duration_cast<std::chrono::milliseconds>(timeDiff)
                 .count());
@@ -1175,6 +1200,9 @@ void HeartbeatThread::sendServerStateAsync() {
             }
           } else {
             self->_numFails = 0;
+            std::lock_guard<std::mutex> guard(
+                self->_lastSuccessfulHeartbeatSentMutex);
+            self->_lastSuccessfulHeartbeatSent = now;
           }
         } catch (std::exception const& e) {
           LOG_TOPIC("cfd83", WARN, Logger::HEARTBEAT)

--- a/arangod/Cluster/HeartbeatThread.h
+++ b/arangod/Cluster/HeartbeatThread.h
@@ -64,7 +64,8 @@ class HeartbeatThread : public ServerThread<ArangodServer>,
                         public std::enable_shared_from_this<HeartbeatThread> {
  public:
   HeartbeatThread(Server&, AgencyCallbackRegistry*, std::chrono::microseconds,
-                  uint64_t maxFailsBeforeWarning);
+                  uint64_t maxFailsBeforeWarning,
+                  double noHeartbeatDelayBeforeShutdown);
   ~HeartbeatThread();
 
   //////////////////////////////////////////////////////////////////////////////
@@ -242,6 +243,16 @@ class HeartbeatThread : public ServerThread<ArangodServer>,
   //////////////////////////////////////////////////////////////////////////////
 
   std::atomic<uint64_t> _numFails;
+
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief time of last successful heartbeat sent
+  //////////////////////////////////////////////////////////////////////////////
+
+  std::mutex _lastSuccessfulHeartbeatSentMutex;
+  std::optional<std::chrono::steady_clock::time_point>
+      _lastSuccessfulHeartbeatSent;
+  bool _doneHeartbeatShutdown;
+  double _noHeartbeatDelayBeforeShutdown;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief last successfully dispatched version


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/browse/BTS-2039

We found there that hotbacks do not work if there are old servers
configured in the agency which do no longer exist.

The root cause of this problem is that the cleanup of expired servers
in the agency did not work. This PR repairs the functionality.

The reason why the expiration did not work is the following:

 1. DBServers and Coordinators send hearbeats to `transient:/arango/Sync/ServerStates/<ID>` and send their time in the `time` attribute.
 2. The Supervision considers all servers in `agency:/arango/Plan/Coordinators` or `agency:/arango/Plan/DBServers` respectively and copies the entries in `transient:/arango/Sync/ServerStates` to `transient:/arango/Supervision/Health/<ID>`.
 3. There is a sublety here: Since servers send *their* time, the last time is compared with the last time the AgencyLeader has seen. If the time has changed, the AgencyLeader writes *its* time to `lastAckedTime` so that clock skew is ignored.
 4. In any case, the AgencyLeader writes the current time to `transient:/arango/Supervision/Health/<ID>/Timestamp`.
 5. The server expiry looked at `transient:/arango/Supervision/Health/<ID>/Timestamp` and therefore never deleted anything. This should be changed to `transient:/arango/Supervision/Health/<ID>/LastAckedTime`.
 6. There were no tests so this went unnoticed. This PR will add tests.
 7. Server expiry is done once every hour but at least 5 minutes after a leader change in the agency. This is OK.
 8. Currently, we throw away a server if it has not sent a heartbeat for 24 hours. DBServers must not have any shards in the plan (neither as leader nor as follower).

We want to change this to 1h to avoid creating problems with hotbackups.
The value is configurable via the `--agency.supervision-expired-server-grace-period`, which is given in seconds. The default is 3600 or 1h.

Furthermore, this PR will add that every coordinator which cannot send
its heartbeat to the agency for longer than 30 mins (configurable!),
will automatically shut down. This is to avoid that a coordinator which
cannot reach the agency anymore and will thus be deleted from the agency
after 1h will not haunt the cluster and potentially runs commits which
might make a hotbackup inconsistent.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
- [x] :book: CHANGELOG entry made
- [*] Backports: no backports planned

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2039
