### PR TITLE
Expire idle connections [BTS-2041] [BTS-2011]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,12 @@
 devel
 -----
 
-* Change expiry time for idle TCP/IP connections in the ConnectionPool
-  and the ConnectionCache to 30s. This is to prevent errors in replication
-  caused by cloud environments terminating connections. Also increase the 
-  timeout in initial sync to transfer up to 5000 documents from 25s to 900s.
-  This addresses BTS-2011 and BTS-2041.
+* Introduce expiry time for idle TCP/IP connections in the ConnectionCache
+  (for `SimpleHttpClient`) with a default of 120s. This is to prevent
+  errors in replication caused by cloud environments terminating
+  connections. Also add retries in a few places. Also increase the
+  timeout in initial sync to transfer up to 5000 documents from 25s to
+  900s. This addresses BTS-2011 and BTS-2041.
 
 * If a coordinator cannot send a heartbeat to the agency, it will shut down
   itself after 30 mins (configurable by the startup option

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 devel
 -----
 
+* Change expiry time for idle TCP/IP connections in the ConnectionPool
+  and the ConnectionCache to 30s. This is to prevent errors in replication
+  caused by cloud environments terminating connections. Also increase the 
+  timeout in initial sync to transfer up to 5000 documents from 25s to 900s.
+  This addresses BTS-2011 and BTS-2041.
+
 * If a coordinator cannot send a heartbeat to the agency, it will shut down
   itself after 30 mins (configurable by the startup option
   `--cluster.no-heartbeat-delay-before-shutdown` whose default is 1800.

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -697,19 +697,6 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
 
     {
       VPackObjectBuilder o(&sy);
-      sy.add(LAST_LOG_TICK, VPackValue(lastLogTick));
-      sy.add(VPackValue(COLLECTIONS));
-      {
-        VPackArrayBuilder a(&sy);
-        for (auto const& i : syncer->getProcessedCollections()) {
-          VPackObjectBuilder e(&sy);
-          sy.add(ID, VPackValue(i.first.id()));
-          sy.add(NAME, VPackValue(i.second));
-        }
-      }
-    }
-    {
-      VPackObjectBuilder o(&sy);
       sy.add(LAST_LOG_TICK, VPackValue(syncer->getLastLogTick()));
       sy.add(VPackValue(COLLECTIONS));
       {

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -602,8 +602,8 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     SynchronizeShard& job,
     std::chrono::time_point<std::chrono::steady_clock> endTime,
     std::shared_ptr<arangodb::LogicalCollection> const& col, VPackSlice config,
-    std::shared_ptr<DatabaseTailingSyncer> tailingSyncer, VPackBuilder& sy,
-    bool syncByRevision, AgencyCache& agencyCache) {
+    VPackBuilder& sy, bool syncByRevision, AgencyCache& agencyCache,
+    replutils::LeaderInfo& leaderInfo, TRI_voc_tick_t& lastLogTick) {
   auto& vocbase = col->vocbase();
   auto database = vocbase.name();
 
@@ -625,14 +625,6 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     // In this phase we use the normal leader ID without following term id:
     syncer->setLeaderId(leaderId);
   }
-
-  syncer->setOnSuccessCallback(
-      [tailingSyncer](DatabaseInitialSyncer& syncer) -> Result {
-        // store leader info for later, so that the next phases don't need to
-        // acquire it again. this saves an HTTP roundtrip to the leader when
-        // initializing the WAL tailing.
-        return tailingSyncer->inheritFromInitialSyncer(syncer);
-      });
 
   ReplicationTimeoutFeature& timeouts =
       job.feature().server().getFeature<ReplicationTimeoutFeature>();
@@ -700,6 +692,22 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
       return r;
     }
 
+    leaderInfo = syncer->leaderInfo();
+    lastLogTick = syncer->getLastLogTick();
+
+    {
+      VPackObjectBuilder o(&sy);
+      sy.add(LAST_LOG_TICK, VPackValue(lastLogTick));
+      sy.add(VPackValue(COLLECTIONS));
+      {
+        VPackArrayBuilder a(&sy);
+        for (auto const& i : syncer->getProcessedCollections()) {
+          VPackObjectBuilder e(&sy);
+          sy.add(ID, VPackValue(i.first.id()));
+          sy.add(NAME, VPackValue(i.second));
+        }
+      }
+    }
     {
       VPackObjectBuilder o(&sy);
       sy.add(LAST_LOG_TICK, VPackValue(syncer->getLastLogTick()));
@@ -1120,18 +1128,6 @@ bool SynchronizeShard::first() {
         << shardNameForLogging() << " for central "
         << ::shardNameForLogging(database, planId);
 
-    // the destructor of the tailingSyncer will automatically unregister itself
-    // from the leader in case it still has to do so (it will do it at most once
-    // per tailingSyncer object, and only if the tailingSyncer registered itself
-    // on the leader)
-    std::shared_ptr<DatabaseTailingSyncer> tailingSyncer =
-        buildTailingSyncer(guard.database(), ep);
-
-    // tailingSyncer cannot be a nullptr here, because
-    // DatabaseTailingSyncer::create() returns the result of a make_shared
-    // operation.
-    TRI_ASSERT(tailingSyncer != nullptr);
-
     try {
       // From here on we perform a number of steps, each of which can
       // fail. If it fails with an exception, it is caught, but this
@@ -1197,9 +1193,12 @@ bool SynchronizeShard::first() {
       startTime = std::chrono::system_clock::now();
 
       VPackBuilder builder;
+      auto leaderInfo = replutils::LeaderInfo::createEmpty();
+      TRI_voc_tick_t lastLogTick = 0;
       ResultT<SyncerId> syncRes = replicationSynchronize(
-          *this, _endTimeForAttempt, collection, config.slice(), tailingSyncer,
-          builder, syncByRevision, _clusterFeature.agencyCache());
+          *this, _endTimeForAttempt, collection, config.slice(), builder,
+          syncByRevision, _clusterFeature.agencyCache(), leaderInfo,
+          lastLogTick);
 
       auto const endTime = std::chrono::system_clock::now();
 
@@ -1264,6 +1263,18 @@ bool SynchronizeShard::first() {
       ReplicationTimeoutFeature& timeouts =
           _feature.server().getFeature<ReplicationTimeoutFeature>();
 
+      // the destructor of the tailingSyncer will automatically unregister
+      // itself from the leader in case it still has to do so (it will do it at
+      // most once per tailingSyncer object, and only if the tailingSyncer
+      // registered itself on the leader)
+      std::shared_ptr<DatabaseTailingSyncer> tailingSyncer =
+          buildTailingSyncer(guard.database(), ep);
+
+      // tailingSyncer cannot be a nullptr here, because
+      // DatabaseTailingSyncer::create() returns the result of a make_shared
+      // operation.
+      TRI_ASSERT(tailingSyncer != nullptr);
+      tailingSyncer->inheritFromInitialSyncer(leaderInfo, lastLogTick);
       tailingSyncer->setCancellationCheckCallback(
           [=, endTime = _endTimeForAttempt, shardName = shardNameForLogging(),
            &timeouts]() -> bool {

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -68,9 +68,9 @@ class ConnectionPool final {
     Metrics metrics;
     // note: clusterInfo can remain a nullptr in unit tests
     ClusterInfo* clusterInfo = nullptr;
-    uint64_t maxOpenConnections = 1024;     /// max number of connections
-    uint64_t idleConnectionMilli = 120000;  /// unused connection lifetime
-    unsigned int numIOThreads = 1;          /// number of IO threads
+    uint64_t maxOpenConnections = 1024;    /// max number of connections
+    uint64_t idleConnectionMilli = 30000;  /// unused connection lifetime
+    unsigned int numIOThreads = 1;         /// number of IO threads
     bool verifyHosts = false;
     fuerte::ProtocolType protocol = fuerte::ProtocolType::Http;
     // name must remain valid for the lifetime of the Config object.

--- a/arangod/Network/ConnectionPool.h
+++ b/arangod/Network/ConnectionPool.h
@@ -68,9 +68,9 @@ class ConnectionPool final {
     Metrics metrics;
     // note: clusterInfo can remain a nullptr in unit tests
     ClusterInfo* clusterInfo = nullptr;
-    uint64_t maxOpenConnections = 1024;    /// max number of connections
-    uint64_t idleConnectionMilli = 30000;  /// unused connection lifetime
-    unsigned int numIOThreads = 1;         /// number of IO threads
+    uint64_t maxOpenConnections = 1024;     /// max number of connections
+    uint64_t idleConnectionMilli = 120000;  /// unused connection lifetime
+    unsigned int numIOThreads = 1;          /// number of IO threads
     bool verifyHosts = false;
     fuerte::ProtocolType protocol = fuerte::ProtocolType::Http;
     // name must remain valid for the lifetime of the Config object.

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -303,7 +303,11 @@ Result fetchRevisions(NetworkFeature& netFeature, transaction::Methods& trx,
           .param("batchId", std::to_string(config.batch.id))
           .param("encodeAsHLC", encodeAsHLC ? "true" : "false");
       reqOptions.database = config.vocbase.name();
-      reqOptions.timeout = network::Timeout(25.0);
+      // We take a relatively generous timeout here, because we have seen
+      // cases in which the leader was under heavy load or RocksDB had
+      // a compaction debt or the user has relatively large documents,
+      // in which case a batch of 5000 can be relatively large.
+      reqOptions.timeout = network::Timeout(900.0);
       auto buffer = requestBuilder.steal();
       auto f = network::sendRequestRetry(
           pool, config.leader.endpoint, fuerte::RestVerb::Put, path,
@@ -458,7 +462,11 @@ Result fetchRevisions(NetworkFeature& netFeature, transaction::Methods& trx,
             .param("serverId", state.localServerIdString)
             .param("batchId", std::to_string(config.batch.id))
             .param("encodeAsHLC", encodeAsHLC ? "true" : "false");
-        reqOptions.timeout = network::Timeout(25.0);
+        // We take a relatively generous timeout here, because we have seen
+        // cases in which the leader was under heavy load or RocksDB had
+        // a compaction debt or the user has relatively large documents,
+        // in which case a batch of 5000 can be relatively large.
+        reqOptions.timeout = network::Timeout(900.0);
         reqOptions.database = config.vocbase.name();
         auto buffer = requestBuilder.steal();
         auto f = network::sendRequestRetry(

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -180,9 +180,7 @@ Result DatabaseTailingSyncer::syncCollectionFinalize(
 }
 
 Result DatabaseTailingSyncer::inheritFromInitialSyncer(
-    DatabaseInitialSyncer const& syncer) {
-  replutils::LeaderInfo const& leaderInfo = syncer.leaderInfo();
-
+    replutils::LeaderInfo const& leaderInfo, TRI_voc_tick_t lastLogTick) {
   TRI_ASSERT(!leaderInfo.endpoint.empty());
   TRI_ASSERT(leaderInfo.endpoint == _state.leader.endpoint);
   TRI_ASSERT(leaderInfo.serverId.isSet());
@@ -194,7 +192,7 @@ Result DatabaseTailingSyncer::inheritFromInitialSyncer(
   _state.leader.majorVersion = leaderInfo.majorVersion;
   _state.leader.minorVersion = leaderInfo.minorVersion;
 
-  _initialTick = syncer.getLastLogTick();
+  _initialTick = lastLogTick;
 
   return registerOnLeader();
 }

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -82,7 +82,8 @@ class DatabaseTailingSyncer : public TailingSyncer {
                                TRI_voc_tick_t& until, bool& didTimeout,
                                std::string const& context);
 
-  Result inheritFromInitialSyncer(DatabaseInitialSyncer const& syncer);
+  Result inheritFromInitialSyncer(replutils::LeaderInfo const& leaderInfo,
+                                  TRI_voc_tick_t initialTick);
   Result registerOnLeader();
   void unregisterFromLeader(bool hardLocked);
 

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -66,7 +66,7 @@ ReplicationFeature::ReplicationFeature(Server& server)
       _autoRepairRevisionTrees(true),
       _connectionCache{
           server.getFeature<application_features::CommunicationFeaturePhase>(),
-          httpclient::ConnectionCache::Options{5}},
+          httpclient::ConnectionCache::Options{5, 30}},
       _parallelTailingInvocations(0),
       _maxParallelTailingInvocations(0),
       _quickKeysLimit(1000000),

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -66,7 +66,7 @@ ReplicationFeature::ReplicationFeature(Server& server)
       _autoRepairRevisionTrees(true),
       _connectionCache{
           server.getFeature<application_features::CommunicationFeaturePhase>(),
-          httpclient::ConnectionCache::Options{5, 30}},
+          httpclient::ConnectionCache::Options{5, 120}},
       _parallelTailingInvocations(0),
       _maxParallelTailingInvocations(0),
       _quickKeysLimit(1000000),

--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -73,7 +73,8 @@ class ConnectionCache {
   struct Options {
     explicit Options(size_t maxConnectionsPerEndpoint,
                      uint32_t idleConnectionTimeout)
-        : maxConnectionsPerEndpoint(maxConnectionsPerEndpoint) {}
+        : maxConnectionsPerEndpoint(maxConnectionsPerEndpoint),
+          idleConnectionTimeout(idleConnectionTimeout) {}
 
     size_t maxConnectionsPerEndpoint;
     uint32_t idleConnectionTimeout = 120;  // seconds

--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -76,7 +76,7 @@ class ConnectionCache {
         : maxConnectionsPerEndpoint(maxConnectionsPerEndpoint) {}
 
     size_t maxConnectionsPerEndpoint;
-    uint32_t idleConnectionTimeout = 30;  // seconds
+    uint32_t idleConnectionTimeout = 120;  // seconds
   };
 
   ConnectionCache(application_features::CommunicationFeaturePhase& comm,

--- a/tests/SimpleHttpClient/ConnectionCacheTest.cpp
+++ b/tests/SimpleHttpClient/ConnectionCacheTest.cpp
@@ -40,7 +40,7 @@ TEST(ConnectionCacheTest, testEmpty) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   auto const& connections = cache.connections();
   EXPECT_EQ(0, connections.size());
@@ -52,7 +52,7 @@ TEST(ConnectionCacheTest, testAcquireInvalidEndpoint) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   ConnectionLease lease;
   EXPECT_EQ(nullptr, lease._connection);
@@ -76,7 +76,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnection) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -103,7 +103,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnectionForce) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -133,7 +133,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseRepeat) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -193,7 +193,7 @@ TEST(ConnectionCacheTest, testSameEndpointMultipleLeases) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -220,7 +220,7 @@ TEST(ConnectionCacheTest, testSameEndpointMultipleLeases) {
 
     EXPECT_NE(connections.find(endpoint), connections.end());
     EXPECT_EQ(1, connections.find(endpoint)->second.size());
-    EXPECT_EQ(gc1, connections.find(endpoint)->second[0].get());
+    EXPECT_EQ(gc1, connections.find(endpoint)->second[0].connection.get());
   }
 
   cache.release(std::move(lease2._connection), true);
@@ -231,8 +231,8 @@ TEST(ConnectionCacheTest, testSameEndpointMultipleLeases) {
 
     EXPECT_NE(connections.find(endpoint), connections.end());
     EXPECT_EQ(2, connections.find(endpoint)->second.size());
-    EXPECT_EQ(gc1, connections.find(endpoint)->second[0].get());
-    EXPECT_EQ(gc2, connections.find(endpoint)->second[1].get());
+    EXPECT_EQ(gc1, connections.find(endpoint)->second[0].connection.get());
+    EXPECT_EQ(gc2, connections.find(endpoint)->second[1].connection.get());
   }
 }
 
@@ -242,7 +242,7 @@ TEST(ConnectionCacheTest, testDifferentEndpoints) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   std::string endpoint1 = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
   std::string endpoint2 = Endpoint::unifiedForm("tcp://127.0.0.1:12345");
@@ -281,7 +281,7 @@ TEST(ConnectionCacheTest, testSameEndpointDifferentProtocols) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5});
+      ConnectionCache::Options{5, 30});
 
   std::string endpoint1 = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
   std::string endpoint2 = Endpoint::unifiedForm("ssl://127.0.0.1:9999");
@@ -320,7 +320,7 @@ TEST(ConnectionCacheTest, testDropSuperfluous) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{3});
+      ConnectionCache::Options{3, 30});
 
   std::string endpoint1 = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
   std::string endpoint2 = Endpoint::unifiedForm("tcp://127.0.0.1:12345");

--- a/tests/SimpleHttpClient/ConnectionCacheTest.cpp
+++ b/tests/SimpleHttpClient/ConnectionCacheTest.cpp
@@ -40,7 +40,7 @@ TEST(ConnectionCacheTest, testEmpty) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   auto const& connections = cache.connections();
   EXPECT_EQ(0, connections.size());
@@ -52,7 +52,7 @@ TEST(ConnectionCacheTest, testAcquireInvalidEndpoint) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   ConnectionLease lease;
   EXPECT_EQ(nullptr, lease._connection);
@@ -76,7 +76,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnection) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -103,7 +103,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnectionForce) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -133,7 +133,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseRepeat) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -193,7 +193,7 @@ TEST(ConnectionCacheTest, testSameEndpointMultipleLeases) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   std::string endpoint = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
 
@@ -242,7 +242,7 @@ TEST(ConnectionCacheTest, testDifferentEndpoints) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   std::string endpoint1 = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
   std::string endpoint2 = Endpoint::unifiedForm("tcp://127.0.0.1:12345");
@@ -281,7 +281,7 @@ TEST(ConnectionCacheTest, testSameEndpointDifferentProtocols) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{5, 30});
+      ConnectionCache::Options{5, 120});
 
   std::string endpoint1 = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
   std::string endpoint2 = Endpoint::unifiedForm("ssl://127.0.0.1:9999");
@@ -320,7 +320,7 @@ TEST(ConnectionCacheTest, testDropSuperfluous) {
 
   ConnectionCache cache(
       server.getFeature<application_features::CommunicationFeaturePhase>(),
-      ConnectionCache::Options{3, 30});
+      ConnectionCache::Options{3, 120});
 
   std::string endpoint1 = Endpoint::unifiedForm("tcp://127.0.0.1:9999");
   std::string endpoint2 = Endpoint::unifiedForm("tcp://127.0.0.1:12345");

--- a/tests/SimpleHttpClient/ConnectionCacheTest.cpp
+++ b/tests/SimpleHttpClient/ConnectionCacheTest.cpp
@@ -400,4 +400,3 @@ TEST(ConnectionCacheTest, testSameEndpointMultipleLeasesOverExpiry) {
     EXPECT_EQ(0, connections.find(endpoint)->second.size());
   }
 }
-


### PR DESCRIPTION
### Scope & Purpose

This addresses
  https://arangodb.atlassian.net/browse/BTS-2011
and 
  https://arangodb.atlassian.net/browse/BTS-2042

The common theme is TCP/IP connections within the cluster, which are sometimes broken by external actors in the cloud, or indeed by our own `arangod`. This PR adds a timeout for idle TCP/IP connections in the `ConnectionCache` of 120s. Furthermore, there is a fix for `SynchronizeShard`, which leased a connection for the `DatabaseTailingSyncer` too early in the process, so that it could be stale until the `DatabaseTailingSyncer` was actually used.

Finally, it increases a few timeouts in replication for larger or slower
cases.

- [*] :hankey: Bugfix

### Checklist

- [x] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11:  https://github.com/arangodb/arangodb/pull/21529

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2011
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2042
