### PR TITLE
Minimal sort condition for sorted gather

### DIFF
--- a/arangod/Aql/ExecutionNode/IndexNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexNode.cpp
@@ -63,7 +63,6 @@ IndexNode::IndexNode(
       CollectionAccessingNode(collection),
       _indexes(indexes),
       _condition(std::move(condition)),
-      _needsGatherNodeSort(false),
       _allCoveredByOneIndex(allCoveredByOneIndex),
       _options(opts),
       _outNonMaterializedDocId(nullptr) {
@@ -79,8 +78,6 @@ IndexNode::IndexNode(ExecutionPlan* plan,
       DocumentProducingNode(plan, base),
       CollectionAccessingNode(plan, base),
       _indexes(),
-      _needsGatherNodeSort(basics::VelocyPackHelper::getBooleanValue(
-          base, "needsGatherNodeSort", false)),
       _options(),
       _outNonMaterializedDocId(aql::Variable::varFromVPack(
           plan->getAst(), base, "outNmDocId", true)) {
@@ -220,7 +217,7 @@ void IndexNode::doToVelocyPack(VPackBuilder& builder, unsigned flags) const {
   // "strategy" is not read back by the C++ code, but it is exposed for
   // convenience and testing
   builder.add("strategy", VPackValue(strategyName(strategy())));
-  builder.add("needsGatherNodeSort", VPackValue(_needsGatherNodeSort));
+  builder.add("needsGatherNodeSort", VPackValue(needsGatherNodeSort()));
 
   // this attribute is never read back by arangod, but it is used a lot
   // in tests, so it can't be removed easily
@@ -480,7 +477,7 @@ ExecutionNode* IndexNode::clone(ExecutionPlan* plan,
                                        _indexes, _allCoveredByOneIndex,
                                        _condition->clone(), _options);
 
-  c->needsGatherNodeSort(_needsGatherNodeSort);
+  c->needsGatherNodeSort(getSortElements());
   c->_outNonMaterializedDocId = _outNonMaterializedDocId;
   CollectionAccessingNode::cloneInto(*c);
   DocumentProducingNode::cloneInto(plan, *c);
@@ -628,10 +625,10 @@ void IndexNode::setLimit(uint64_t value) noexcept { _options.limit = value; }
 
 bool IndexNode::hasLimit() const noexcept { return _options.limit != 0; }
 
-bool IndexNode::needsGatherNodeSort() const { return _needsGatherNodeSort; }
+bool IndexNode::needsGatherNodeSort() const { return !_sortElements.empty(); }
 
-void IndexNode::needsGatherNodeSort(bool value) {
-  _needsGatherNodeSort = value;
+void IndexNode::needsGatherNodeSort(SortElementVector value) {
+  _sortElements = std::move(value);
 }
 
 std::vector<Variable const*> IndexNode::getVariablesSetHere() const {

--- a/arangod/Aql/ExecutionNode/IndexNode.h
+++ b/arangod/Aql/ExecutionNode/IndexNode.h
@@ -133,7 +133,10 @@ class IndexNode : public ExecutionNode,
   /// not all queries that use an index will need to produce a sorted result
   /// (e.g. if the index is used only for filtering)
   bool needsGatherNodeSort() const;
-  void needsGatherNodeSort(bool value);
+  void needsGatherNodeSort(SortElementVector elements);
+  SortElementVector const& getSortElements() const noexcept {
+    return _sortElements;
+  }
 
   /// @brief creates corresponding ExecutionBlock
   std::unique_ptr<ExecutionBlock> createBlock(
@@ -243,7 +246,7 @@ class IndexNode : public ExecutionNode,
   std::unique_ptr<Condition> _condition;
 
   /// @brief the index sort order - this is the same order for all indexes
-  bool _needsGatherNodeSort;
+  SortElementVector _sortElements;
 
   /// @brief We have single index and this index covered whole condition
   bool _allCoveredByOneIndex;


### PR DESCRIPTION
When finding an index node, the sorted gather rule would simply sort by all index attributes instead of the original sort condition. This could even result in document lookups although no where necessary.

```
Query String (39 chars, results cachable: true):
 FOR doc IN c COLLECT a = doc.a RETURN a

Execution plan:
 Id   NodeType          Site  Par   Est.   Comment
  1   SingletonNode     DBS            1   * ROOT 
  7   IndexNode         DBS     ✓   1000     - FOR doc IN c   /* persistent index scan, index only (projections: `a`), 3 shard(s) */    LET #8 = doc.`a`   /* with late materialization */
 13   MaterializeNode   DBS         1000       - MATERIALIZE doc INTO #6
 12   CollectNode       DBS     ✓    800       - COLLECT #4 = #8   /* sorted */
 10   RemoteNode        COOR         800       - REMOTE
 11   GatherNode        COOR         800       - GATHER #6.`a` ASC, #6.`b` ASC, #6.`c` ASC, #6.`d` ASC, #6.`e` ASC, #6.`f` ASC, #6.`g` ASC  /* parallel, sort mode: minelement */
  4   CollectNode       COOR    ✓    640       - COLLECT a = #4   /* sorted */
  5   ReturnNode        COOR         640       - RETURN a

Indexes used:
 By   Name                      Type         Collection   Unique   Sparse   Cache   Selectivity   Fields                                  Stored values   Ranges
  7   idx_1818589799003455488   persistent   c            false    false    false      100.00 %   [ `a`, `b`, `c`, `d`, `e`, `f`, `g` ]   [  ]            *
  ```
There are multiple issues with this. We are materializing the document her, to sort unnecessarily in the gather node. Also in this example
```
Query String (39 chars, results cachable: true):
 FOR doc IN c COLLECT a = doc.a RETURN a

Execution plan:
 Id   NodeType        Site  Par   Est.   Comment
  1   SingletonNode   DBS            1   * ROOT 
  7   IndexNode       DBS     ✓   1000     - FOR doc IN c   /* persistent index scan, index only (projections: `a`, `b`), 3 shard(s) */    LET #6 = doc.`a`, #7 = doc.`b`   
 12   CollectNode     DBS     ✓    800       - COLLECT #4 = #6   /* sorted */
 10   RemoteNode      COOR         800       - REMOTE
 11   GatherNode      COOR         800       - GATHER #6 ASC, #7 ASC  /* parallel, sort mode: minelement */
  4   CollectNode     COOR    ✓    640       - COLLECT a = #4   /* sorted */
  5   ReturnNode      COOR         640       - RETURN a

Indexes used:
 By   Name                      Type         Collection   Unique   Sparse   Cache   Selectivity   Fields         Stored values   Ranges
  7   idx_1818587201589477376   persistent   c            false    false    false      100.00 %   [ `a`, `b` ]   [  ]            *
  ```
After the collect node (12) variable `7` no longer exists. It is however produces by the database server and contains `None`. The gather nodes then compares `none` for each row.