### PR TITLE
Disallow KEEP with INTO var = expr.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -26,6 +26,9 @@ devel
   seemingly successfully despite the fact that some MoveShard jobs had 
   actually failed. This fixes BTS-2022.
 
+* Disallow the KEEP keyword in conjunction with INTO var = expr when doing
+  COLLECT in an AQL query. The KEEP clause had no effect.
+
 * Do check for replication version 2 in a safe way. This fixes BTS-2040.
 
 * Put in more diagnostics and avoid a crash in follower on commit of a

--- a/arangod/Aql/grammar.y
+++ b/arangod/Aql/grammar.y
@@ -1369,6 +1369,9 @@ collect_statement:
       }
 
       if ($2 != nullptr && $2->type == NODE_TYPE_ARRAY) {
+        if ($3 != nullptr) {
+            parser->registerParseError(TRI_ERROR_QUERY_PARSE, "use of 'KEEP' with 'INTO' and projection expression", yylloc.first_line, yylloc.first_column);
+        }
         ::checkCollectVariables(parser, "INTO", $2->getMember(1), yylloc.first_line, yylloc.first_column, variablesIntroduced);
       }
         


### PR DESCRIPTION
### Scope & Purpose
In a query like
```
FOR doc IN col
  COLLECT a = doc.a INTO b = doc.b KEEP doc
  RETURN a
```
The `KEEP` statement has no effect, because `INTO` is used with a projection expression. Now a parser error is triggered.