### PR TITLE
Collect Performance Improvement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,10 @@ devel
 
 * Fix view usage in cached query plans.
 
+* Optimized COLLECT queries by pushing collection of INTO values onto database
+  servers and aggregate on the coordinator. This can be disabled by setting
+  the option `aggregateIntoExpressionOnDBServers` to false.
+
 * Make it an error if usePlanCache is set to true but the query is not 
   eligible for query plan caching. This is better for debugging.
 

--- a/arangod/Aql/CollectOptions.cpp
+++ b/arangod/Aql/CollectOptions.cpp
@@ -44,6 +44,10 @@ CollectOptions::CollectOptions(velocypack::Slice slice)
   if (VPackSlice v = slice.get("fixed"); v.isBoolean()) {
     fixed = v.isTrue();
   }
+  if (VPackSlice v = slice.get("aggregateIntoExpressionOnDBServers");
+      v.isBoolean()) {
+    aggregateIntoExpressionOnDBServers = v.isTrue();
+  }
 
   TRI_ASSERT(method != CollectMethod::kUndefined || !fixed);
 }
@@ -78,6 +82,8 @@ void CollectOptions::toVelocyPack(velocypack::Builder& builder) const {
   VPackObjectBuilder guard(&builder);
   builder.add("method", VPackValue(methodToString(method)));
   builder.add("fixed", VPackValue(fixed));
+  builder.add("aggregateIntoExpressionOnDBServers",
+              VPackValue(aggregateIntoExpressionOnDBServers));
 }
 
 /// @brief get the aggregation method from a string

--- a/arangod/Aql/CollectOptions.h
+++ b/arangod/Aql/CollectOptions.h
@@ -75,6 +75,10 @@ struct CollectOptions final {
   /// @brief if true, then the CollectMethod must not be changed after
   /// being set. if false, the CollectMethod can still change later.
   bool fixed;
+
+  /// @brief whether aggregation of collects output should be moved to
+  /// dbservers.
+  bool aggregateIntoExpressionOnDBServers{true};
 };
 
 struct GroupVarInfo final {

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -846,4 +846,5 @@ void CollectNode::setMergeListsAggregation(Variable const* outVariable) {
 
   // clear out variable and expression variable
   _outVariable = _expressionVariable = nullptr;
+  _keepVariables.clear();
 }

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -839,3 +839,11 @@ std::vector<Variable const*> CollectNode::getVariablesSetHere() const {
   }
   return v;
 }
+
+void CollectNode::setMergeListsAggregation(Variable const* outVariable) {
+  _aggregateVariables.emplace_back(
+      AggregateVarInfo{_outVariable, outVariable, "MERGE_LISTS"});
+
+  // clear out variable and expression variable
+  _outVariable = _expressionVariable = nullptr;
+}

--- a/arangod/Aql/ExecutionNode/CollectNode.h
+++ b/arangod/Aql/ExecutionNode/CollectNode.h
@@ -148,6 +148,9 @@ class CollectNode : public ExecutionNode {
 
   /// @brief set the expression variable
   void expressionVariable(Variable const* variable);
+  Variable const* expressionVariable() const noexcept {
+    return _expressionVariable;
+  }
 
   /// @brief return whether or not the collect has keep variables
   bool hasKeepVariables() const noexcept;
@@ -188,6 +191,8 @@ class CollectNode : public ExecutionNode {
   static void calculateAccessibleUserVariables(
       ExecutionNode const& node,
       std::vector<std::pair<Variable const*, std::string>>& userVariables);
+
+  void setMergeListsAggregation(Variable const* outVariable);
 
  protected:
   /// @brief export to VelocyPack

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -1234,6 +1234,12 @@ CollectOptions ExecutionPlan::createCollectOptions(AstNode const* node) {
               handled = true;
             }
           }
+        } else if (name == "aggregateIntoExpressionOnDBServers") {
+          auto value = member->getMember(0);
+          if (value->isBoolValue()) {
+            options.aggregateIntoExpressionOnDBServers = value->getBoolValue();
+            handled = true;
+          }
         }
         if (!handled) {
           invalidOptionAttribute(_ast->query(), "unknown", "COLLECT", name);

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -4717,6 +4717,7 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
 
             Variable const* expressionVariable = nullptr;
             Variable const* outVariable = nullptr;
+            std::vector<std::pair<Variable const*, std::string>> keepVariables;
 
             bool const aggregateOutVariablesOnDBServers =
                 collectNode->getOptions().aggregateIntoExpressionOnDBServers &&
@@ -4726,13 +4727,13 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
               outVariable =
                   plan->getAst()->variables()->createTemporaryVariable();
               expressionVariable = collectNode->expressionVariable();
+              keepVariables = collectNode->keepVariables();
             }
 
             auto dbCollectNode = plan->createNode<CollectNode>(
                 plan.get(), plan->nextId(), collectNode->getOptions(), outVars,
                 dbServerAggVars, expressionVariable, outVariable,
-                std::vector<std::pair<Variable const*, std::string>>{},
-                collectNode->variableMap());
+                std::move(keepVariables), collectNode->variableMap());
 
             dbCollectNode->addDependency(previous);
             target->replaceDependency(previous, dbCollectNode);

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -207,7 +207,7 @@ void replaceGatherNodeVariables(
       // no match. now check all our replacements and compare how
       // their sources are actually calculated (e.g. #2 may mean
       // "foo.bar")
-      cmp = it.toString();
+      cmp = it.toVarAccessString();
       for (auto const& it3 : replacements) {
         auto setter = plan->getVarSetBy(it3.first->id);
         if (setter == nullptr || setter->getType() != EN::CALCULATION) {
@@ -4677,8 +4677,9 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
             collectNode->groupVariables(copy);
 
             replaceGatherNodeVariables(plan.get(), gatherNode, replacements);
-          } else if (  //! collectNode->groupVariables().empty() &&
-              !collectNode->hasOutVariable()) {
+          } else if (!collectNode->hasOutVariable() ||
+                     collectNode->getOptions()
+                         .aggregateIntoExpressionOnDBServers) {
             // clone a COLLECT v1 = expr, v2 = expr ... operation from the
             // coordinator to the DB server(s), and leave an aggregate COLLECT
             // node on the coordinator for total aggregation
@@ -4714,9 +4715,22 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
               outVars.emplace_back(GroupVarInfo{out, it.inVar});
             }
 
+            Variable const* expressionVariable = nullptr;
+            Variable const* outVariable = nullptr;
+
+            bool const aggregateOutVariablesOnDBServers =
+                collectNode->getOptions().aggregateIntoExpressionOnDBServers &&
+                collectNode->hasOutVariable();
+
+            if (aggregateOutVariablesOnDBServers) {
+              outVariable =
+                  plan->getAst()->variables()->createTemporaryVariable();
+              expressionVariable = collectNode->expressionVariable();
+            }
+
             auto dbCollectNode = plan->createNode<CollectNode>(
                 plan.get(), plan->nextId(), collectNode->getOptions(), outVars,
-                dbServerAggVars, nullptr, nullptr,
+                dbServerAggVars, expressionVariable, outVariable,
                 std::vector<std::pair<Variable const*, std::string>>{},
                 collectNode->variableMap());
 
@@ -4740,6 +4754,11 @@ void arangodb::aql::collectInClusterRule(Optimizer* opt,
               it.inVar = dbServerAggVars[j].outVar;
               it.type = Aggregator::runOnCoordinatorAs(it.type);
               ++j;
+            }
+
+            if (aggregateOutVariablesOnDBServers) {
+              TRI_ASSERT(outVariable != nullptr);
+              collectNode->setMergeListsAggregation(outVariable);
             }
 
             removeGatherNodeSort = (dbCollectNode->aggregationMethod() !=

--- a/arangod/Aql/SortElement.cpp
+++ b/arangod/Aql/SortElement.cpp
@@ -98,11 +98,16 @@ void SortElement::replaceAttributeAccess(Variable const* searchVariable,
   var = replaceVariable;
 }
 
-std::string SortElement::toString() const {
+std::string SortElement::toVarAccessString() const {
   std::string result = absl::StrCat("$", var->id);
   for (auto const& it : attributePath) {
     absl::StrAppend(&result, ".", it);
   }
+  return result;
+}
+
+std::string SortElement::toString() const {
+  std::string result = toVarAccessString();
   absl::StrAppend(&result, ascending ? " ASC" : " DESC");
   return result;
 }
@@ -136,4 +141,11 @@ SortElement SortElement::fromVelocyPack(Ast* ast, velocypack::Slice info) {
     }
   }
   return elem;
+}
+
+std::ostream& arangodb::aql::operator<<(std::ostream& os,
+                                        SortElement const& se) noexcept {
+  using arangodb::operator<<;
+  return os << se.var->name << se.attributePath << " "
+            << (se.ascending ? "ASC" : "DESC");
 }

--- a/arangod/Aql/SortElement.h
+++ b/arangod/Aql/SortElement.h
@@ -30,6 +30,7 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
+#include <iosfwd>
 
 namespace arangodb::velocypack {
 class Builder;
@@ -56,6 +57,8 @@ struct SortElement {
   /// @brief stringify a sort element. note: the output of this should match the
   /// stringification output of an AstNode for an attribute access
   /// (e.g. foo.bar => $0.bar)
+  std::string toVarAccessString() const;
+
   std::string toString() const;
 
   /// @brief resets variable to v, and clears the attributePath
@@ -71,6 +74,8 @@ struct SortElement {
   void toVelocyPack(velocypack::Builder& builder) const;
 
   static SortElement fromVelocyPack(Ast* ast, velocypack::Slice info);
+
+  friend std::ostream& operator<<(std::ostream&, SortElement const&) noexcept;
 
   // variable to sort by
   Variable const* var;

--- a/tests/js/client/aql/aql-collect-output-aggregation-optimization-cluster.js
+++ b/tests/js/client/aql/aql-collect-output-aggregation-optimization-cluster.js
@@ -34,8 +34,9 @@ const numDocuments = 10000;
 const modulus = [1, 10, 100, 1000];
 
 const checkOptimization = function (plan) {
-
-  const [dbCollect, remote, collect] = plan.nodes.filter(x => ["RemoteNode", "CollectNode"].indexOf(x.type) !== -1);
+  const nodes = plan.nodes.filter(x => ["RemoteNode", "CollectNode"].indexOf(x.type) !== -1);
+  assertEqual(nodes.length, 3);
+  const [dbCollect, remote, collect] = nodes;
   assertEqual(dbCollect.type, "CollectNode");
   assertEqual(remote.type, "RemoteNode");
   assertEqual(collect.type, "CollectNode");
@@ -46,8 +47,9 @@ const checkOptimization = function (plan) {
 };
 
 const checkNotOptimized = function (plan) {
-
-  const [remote, collect] = plan.nodes.filter(x => ["RemoteNode", "CollectNode"].indexOf(x.type) !== -1);
+  const nodes = plan.nodes.filter(x => ["RemoteNode", "CollectNode"].indexOf(x.type) !== -1);
+  assertEqual(nodes.length, 2);
+  const [remote, collect] = nodes;
   assertEqual(remote.type, "RemoteNode");
   assertEqual(collect.type, "CollectNode");
 

--- a/tests/js/client/aql/aql-collect-output-aggregation-optimization-cluster.js
+++ b/tests/js/client/aql/aql-collect-output-aggregation-optimization-cluster.js
@@ -1,0 +1,117 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertTrue, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Lars Maier
+/// @author Copyright 2024, triAGENS GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+const jsunity = require("jsunity");
+const db = require("@arangodb").db;
+
+const database = "CollectOutputAggregationDb";
+const collection = "Collection";
+
+const numDocuments = 10000;
+const modulus = [1, 10, 100, 1000];
+
+const checkOptimization = function (plan) {
+
+  const [dbCollect, remote, collect] = plan.nodes.filter(x => ["RemoteNode", "CollectNode"].indexOf(x.type) !== -1);
+  assertEqual(dbCollect.type, "CollectNode");
+  assertEqual(remote.type, "RemoteNode");
+  assertEqual(collect.type, "CollectNode");
+
+  const [aggregate] = collect.aggregates;
+  assertEqual(aggregate.type, "MERGE_LISTS");
+  assertEqual(aggregate.inVariable.id, dbCollect.outVariable.id);
+};
+
+const checkNotOptimized = function (plan) {
+
+  const [remote, collect] = plan.nodes.filter(x => ["RemoteNode", "CollectNode"].indexOf(x.type) !== -1);
+  assertEqual(remote.type, "RemoteNode");
+  assertEqual(collect.type, "CollectNode");
+
+  assertEqual(collect.aggregates.length, 0);
+};
+
+function collectOutputAggregationSuite() {
+
+  const suite = {
+    setUpAll: function () {
+      db._createDatabase(database);
+      db._useDatabase(database);
+      const c = db._create(collection, {numberOfShards: 3});
+      for (let m of modulus) {
+        c.ensureIndex({type: "persistent", fields: [`m${m}`, "x"]});
+      }
+
+      let query = `FOR i IN 1..${numDocuments} INSERT {x: i,`
+          + modulus.map(x => `m${x}: i % ${x}`).join(",") +
+          `} INTO ${collection}`;
+      db._query(query);
+    },
+
+    tearDownAll: function () {
+      db._useDatabase("_system");
+      db._dropDatabase(database);
+    }
+  };
+
+  const testFunction = function (m) {
+    return function () {
+      const query = `
+        FOR doc IN ${collection}
+          COLLECT a = doc.@attr INTO b = doc.x OPTIONS {aggregateIntoExpressionOnDBServers: @agg}
+          RETURN [a, b]`;
+
+      let plan = db._createStatement({query, bindVars: {agg: true, attr: `m${m}`}}).explain().plan;
+      checkOptimization(plan);
+
+      plan = db._createStatement({query, bindVars: {agg: false, attr: `m${m}`}}).explain().plan;
+      checkNotOptimized(plan);
+
+      const result = db._createStatement({query, bindVars: {agg: true, attr: `m${m}`}}).execute().toArray();
+      const expectedGroups = m;
+      const expectedElementsPerGroup = numDocuments / m;
+
+      assertEqual(result.length, expectedGroups);
+
+      for (let [remainder, elements] of result) {
+        const set = new Set(elements);
+        assertEqual(set.size, expectedElementsPerGroup);
+        for (const e of elements) {
+          assertTrue(e % m === remainder);
+        }
+      }
+    };
+  };
+
+  for (const m of modulus) {
+    suite[`testCollectModulus${m}`] = testFunction(m);
+  }
+
+  return suite;
+}
+
+jsunity.run(collectOutputAggregationSuite);
+return jsunity.done();

--- a/tests/js/client/aql/aql-optimizer-collect-methods.js
+++ b/tests/js/client/aql/aql-optimizer-collect-methods.js
@@ -365,7 +365,7 @@ function optimizerCollectMethodsTestSuite () {
         }
       });
         
-      assertEqual(1, aggregateNodes);
+      assertEqual(isCluster ? 2 : 1, aggregateNodes);
       assertEqual(1, sortNodes);
 
       let result = db._query(query).toArray();
@@ -425,7 +425,7 @@ function optimizerCollectMethodsTestSuite () {
           }
         });
        
-        assertEqual((isCluster && !hasInto) ? 2 : 1, aggregateNodes);
+        assertEqual(isCluster ? 2 : 1, aggregateNodes);
         assertEqual(query[1] === 'hash' ? 1 : 0, sortNodes);
       });
     },
@@ -463,7 +463,7 @@ function optimizerCollectMethodsTestSuite () {
           }
         });
         
-        assertEqual((isCluster && !hasInto) ? 2 : 1, aggregateNodes);
+        assertEqual(isCluster ? 2 : 1, aggregateNodes);
         assertEqual(1, sortNodes);
       });
     },

--- a/tests/js/client/aql/aql-optimizer-rule-use-index-for-sort-cluster.js
+++ b/tests/js/client/aql/aql-optimizer-rule-use-index-for-sort-cluster.js
@@ -178,17 +178,20 @@ function optimizerRuleTestSuite() {
       let query = "FOR doc IN " + colName + " COLLECT value = doc.value INTO g OPTIONS { method: 'sorted' } RETURN { value, g }";
       let plan = db._createStatement(query).explain().plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'CollectNode'; });
-      assertEqual(1, nodes.length);
+      assertEqual(2, nodes.length);
       assertEqual([], nodes[0].aggregates);
+      assertEqual(1, nodes[1].aggregates.length);
+      assertEqual("MERGE_LISTS", nodes[1].aggregates[0].type);
       assertEqual("sorted", nodes[0].collectOptions.method);
-      
+      assertEqual("sorted", nodes[1].collectOptions.method);
+
       nodes = plan.nodes.filter(function(n) { return n.type === 'GatherNode'; });
       assertEqual(1, nodes.length);
       assertTrue(nodes[0].elements[0].ascending);
 
       assertNotEqual(-1, plan.rules.indexOf(ruleName));
-      assertEqual(-1, plan.rules.indexOf("collect-in-cluster"));
-    
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+
       let results = db._query(query).toArray();
       assertEqual(2000, results.length);
       let last = null;
@@ -199,7 +202,7 @@ function optimizerRuleTestSuite() {
         assertEqual(doc.value, doc.g[0].doc.value);
       });
     },
-    
+
     testCollectIntoSortedKeepGatherNonUnique : function () {
       // add the same values again
       let docs = [];
@@ -210,16 +213,19 @@ function optimizerRuleTestSuite() {
       let query = "FOR doc IN " + colName + " COLLECT value = doc.value INTO g OPTIONS { method: 'sorted' } RETURN { value, g }";
       let plan = db._createStatement(query).explain().plan;
       let nodes = plan.nodes.filter(function(n) { return n.type === 'CollectNode'; });
-      assertEqual(1, nodes.length);
+      assertEqual(2, nodes.length);
       assertEqual([], nodes[0].aggregates);
+      assertEqual(1, nodes[1].aggregates.length);
+      assertEqual("MERGE_LISTS", nodes[1].aggregates[0].type);
       assertEqual("sorted", nodes[0].collectOptions.method);
-      
+      assertEqual("sorted", nodes[1].collectOptions.method);
+
       nodes = plan.nodes.filter(function(n) { return n.type === 'GatherNode'; });
       assertEqual(1, nodes.length);
       assertTrue(nodes[0].elements[0].ascending);
 
       assertNotEqual(-1, plan.rules.indexOf(ruleName));
-      assertEqual(-1, plan.rules.indexOf("collect-in-cluster"));
+      assertNotEqual(-1, plan.rules.indexOf("collect-in-cluster"));
     
       let results = db._query(query).toArray();
       assertEqual(2000, results.length);


### PR DESCRIPTION
### Scope & Purpose
Given a query like this
```
FOR doc IN ${collection}
  COLLECT a = doc.a INTO b = doc.b
  RETURN [a, b]
```
Previously the optimizer did not push the collect statement onto the database servers. This resulted in a query like this:
```
Query String (59 chars, results cachable: true):
 FOR doc IN c COLLECT a = doc.a INTO b = doc.b RETURN [a, b]

Execution plan:
 Id   NodeType          Site  Par   Est.   Comment
  1   SingletonNode     DBS            1   * ROOT 
  9   IndexNode         DBS     ✓   1000     - FOR doc IN c   /* persistent index scan, index only (projections: `a`, `b`), 3 shard(s) */    LET #8 = doc.`a`, #9 = doc.`b`   
 12   RemoteNode        COOR        1000       - REMOTE
 13   GatherNode        COOR        1000       - GATHER #8 ASC  /* parallel, sort mode: minelement */
  5   CollectNode       COOR    ✓    800       - COLLECT a = #8 INTO b = #9   /* sorted */
  6   CalculationNode   COOR    ✓    800       - LET #5 = [ a, b ]   /* simple expression */
  7   ReturnNode        COOR         800       - RETURN #5
```
As you can see, the database servers produce a lot of rows, which are then merge sorted by the coordinator and collected into the final result. With this change however, the result will look like this:
```
Execution plan:
 Id   NodeType          Site  Par   Est.   Comment
  1   SingletonNode     DBS            1   * ROOT 
  9   IndexNode         DBS     ✓   1000     - FOR doc IN c   /* persistent index scan, index only (projections: `a`, `b`), 3 shard(s) */    LET #12 = doc.`a`, #13 = doc.`b`   
 14   CollectNode       DBS     ✓    800       - COLLECT #8 = #12 INTO #9 = #13   /* sorted */
 12   RemoteNode        COOR         800       - REMOTE
 13   GatherNode        COOR         800       - GATHER #8 ASC  /* parallel, sort mode: minelement */
  5   CollectNode       COOR    ✓    640       - COLLECT a = #8 AGGREGATE b = MERGE_LISTS(#9)   /* sorted */
  6   CalculationNode   COOR    ✓    640       - LET #5 = [ a, b ]   /* simple expression */
  7   ReturnNode        COOR         640       - RETURN #5
```
We already collect on the database servers and then use a newly introduce aggregation function on the coordinator to merge the individual result lists.

A quick performance tests showed the following speedup:
```
.----------------------------------------------------------------.
|                        #docs = 10000000                        |
|----------------------------------------------------------------|
| Modulus  | Agg. on DB | Num. Groups | Group Size | Runtime (s) |
|----------|------------|-------------|------------|-------------|
|        1 | true       |           1 |   10000000 | 1.39598654  |
|       10 | true       |          10 |    1000000 | 1.31921171  |
|      100 | true       |         100 |     100000 | 1.26165382  |
|     1000 | true       |        1000 |      10000 | 1.26326061  |
|   100000 | true       |      100000 |        100 | 3.43916125  |
|  1000000 | true       |     1000000 |         10 | 6.08275620  |
| 10000000 | true       |    10000000 |          1 | 12.37701108 |
|        1 | false      |           1 |   10000000 | 9.32352726  |
|       10 | false      |          10 |    1000000 | 9.36138735  |
|      100 | false      |         100 |     100000 | 9.47243642  |
|     1000 | false      |        1000 |      10000 | 9.77867339  |
|   100000 | false      |      100000 |        100 | 10.71115236 |
|  1000000 | false      |     1000000 |         10 | 11.26162388 |
| 10000000 | false      |    10000000 |          1 | 10.87541270 |
'----------------------------------------------------------------'
```
Here `Modulus` indicates approximately into how many different groups the documents fall. The optimization takes off pressure from the sorted gather and it has to handle far fewer rows than before.

If this optimization is for what ever reason undesirable, a new collect option was introduced to disable this behavior:  
```
FOR doc IN c
 COLLECT a = doc.a INTO b = doc.b OPTIONS {aggregateIntoExpressionOnDBServers: false} 
 RETURN [a, b]
```
Setting `aggregateIntoExpressionOnDBServers` to false restored the old behavior.

Furthermore, this PR contains a bug fix. The sorted gather used an invalidated variable after the collect operation. The logic for this replacement was already there, but it broke silently when `SortElement::toString` was patched to also contain the sort order.