### PR TITLE
Expire idle connections [BTS-2041] [BTS-2011]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 v3.11.13 (XXXX-XX-XX)
 ---------------------
 
+* Introduce expiry time for idle TCP/IP connections in the ConnectionCache
+  (for `SimpleHttpClient`) with a default of 120s. This is to prevent
+  errors in replication caused by cloud environments terminating
+  connections. Also add retries in a few places. Also increase the
+  timeout in initial sync to transfer up to 5000 documents from 25s to
+  900s. This addresses BTS-2011 and BTS-2041.
+
 * Don't cleanup failed agency jobs if they are subjobs of pending jobs.
   This avoids a bug in CleanOutServer jobs, where such a job could complete
   seemingly successfully despite the fact that some MoveShard jobs had 

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -597,8 +597,8 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     SynchronizeShard& job,
     std::chrono::time_point<std::chrono::steady_clock> endTime,
     std::shared_ptr<arangodb::LogicalCollection> const& col, VPackSlice config,
-    std::shared_ptr<DatabaseTailingSyncer> tailingSyncer, VPackBuilder& sy,
-    bool syncByRevision) {
+    VPackBuilder& sy, bool syncByRevision, replutils::LeaderInfo& leaderInfo,
+    TRI_voc_tick_t& lastLogTick) {
   auto& vocbase = col->vocbase();
   auto database = vocbase.name();
 
@@ -620,14 +620,6 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
     // In this phase we use the normal leader ID without following term id:
     syncer->setLeaderId(leaderId);
   }
-
-  syncer->setOnSuccessCallback(
-      [tailingSyncer](DatabaseInitialSyncer& syncer) -> Result {
-        // store leader info for later, so that the next phases don't need to
-        // acquire it again. this saves an HTTP roundtrip to the leader when
-        // initializing the WAL tailing.
-        return tailingSyncer->inheritFromInitialSyncer(syncer);
-      });
 
   auto& agencyCache =
       job.feature().server().getFeature<ClusterFeature>().agencyCache();
@@ -693,6 +685,9 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
           << ": " << r.errorMessage();
       return r;
     }
+
+    leaderInfo = syncer->leaderInfo();
+    lastLogTick = syncer->getLastLogTick();
 
     {
       VPackObjectBuilder o(&sy);
@@ -1116,18 +1111,6 @@ bool SynchronizeShard::first() {
         << database << "/" << shard << "' for central '" << database << "/"
         << planId << "'";
 
-    // the destructor of the tailingSyncer will automatically unregister itself
-    // from the leader in case it still has to do so (it will do it at most once
-    // per tailingSyncer object, and only if the tailingSyncer registered itself
-    // on the leader)
-    std::shared_ptr<DatabaseTailingSyncer> tailingSyncer =
-        buildTailingSyncer(guard.database(), ep);
-
-    // tailingSyncer cannot be a nullptr here, because
-    // DatabaseTailingSyncer::create() returns the result of a make_shared
-    // operation.
-    TRI_ASSERT(tailingSyncer != nullptr);
-
     try {
       // From here on we perform a number of steps, each of which can
       // fail. If it fails with an exception, it is caught, but this
@@ -1193,9 +1176,11 @@ bool SynchronizeShard::first() {
       startTime = std::chrono::system_clock::now();
 
       VPackBuilder builder;
+      auto leaderInfo = replutils::LeaderInfo::createEmpty();
+      TRI_voc_tick_t lastLogTick = 0;
       ResultT<SyncerId> syncRes = replicationSynchronize(
-          *this, _endTimeForAttempt, collection, config.slice(), tailingSyncer,
-          builder, syncByRevision);
+          *this, _endTimeForAttempt, collection, config.slice(), builder,
+          syncByRevision, leaderInfo, lastLogTick);
 
       auto const endTime = std::chrono::system_clock::now();
 
@@ -1261,6 +1246,18 @@ bool SynchronizeShard::first() {
       ReplicationTimeoutFeature& timeouts =
           _feature.server().getFeature<ReplicationTimeoutFeature>();
 
+      // the destructor of the tailingSyncer will automatically unregister
+      // itself from the leader in case it still has to do so (it will do it at
+      // most once per tailingSyncer object, and only if the tailingSyncer
+      // registered itself on the leader)
+      std::shared_ptr<DatabaseTailingSyncer> tailingSyncer =
+          buildTailingSyncer(guard.database(), ep);
+
+      // tailingSyncer cannot be a nullptr here, because
+      // DatabaseTailingSyncer::create() returns the result of a make_shared
+      // operation.
+      TRI_ASSERT(tailingSyncer != nullptr);
+      tailingSyncer->inheritFromInitialSyncer(leaderInfo, lastLogTick);
       tailingSyncer->setCancellationCheckCallback(
           [=, endTime = _endTimeForAttempt, &timeouts]() -> bool {
             // Will return true if the tailing syncer should be aborted.

--- a/arangod/Replication/DatabaseInitialSyncer.cpp
+++ b/arangod/Replication/DatabaseInitialSyncer.cpp
@@ -316,7 +316,11 @@ arangodb::Result fetchRevisions(
           .param("batchId", std::to_string(config.batch.id))
           .param("encodeAsHLC", encodeAsHLC ? "true" : "false");
       reqOptions.database = config.vocbase.name();
-      reqOptions.timeout = arangodb::network::Timeout(25.0);
+      // We take a relatively generous timeout here, because we have seen
+      // cases in which the leader was under heavy load or RocksDB had
+      // a compaction debt or the user has relatively large documents,
+      // in which case a batch of 5000 can be relatively large.
+      reqOptions.timeout = arangodb::network::Timeout(900.0);
       auto buffer = requestBuilder.steal();
       auto f = arangodb::network::sendRequestRetry(
           pool, config.leader.endpoint, arangodb::fuerte::RestVerb::Put, path,
@@ -472,7 +476,11 @@ arangodb::Result fetchRevisions(
             .param("serverId", state.localServerIdString)
             .param("batchId", std::to_string(config.batch.id))
             .param("encodeAsHLC", encodeAsHLC ? "true" : "false");
-        reqOptions.timeout = arangodb::network::Timeout(25.0);
+        // We take a relatively generous timeout here, because we have seen
+        // cases in which the leader was under heavy load or RocksDB had
+        // a compaction debt or the user has relatively large documents,
+        // in which case a batch of 5000 can be relatively large.
+        reqOptions.timeout = arangodb::network::Timeout(900.0);
         reqOptions.database = config.vocbase.name();
         auto buffer = requestBuilder.steal();
         auto f = arangodb::network::sendRequestRetry(

--- a/arangod/Replication/DatabaseTailingSyncer.cpp
+++ b/arangod/Replication/DatabaseTailingSyncer.cpp
@@ -178,9 +178,7 @@ Result DatabaseTailingSyncer::syncCollectionFinalize(
 }
 
 Result DatabaseTailingSyncer::inheritFromInitialSyncer(
-    DatabaseInitialSyncer const& syncer) {
-  replutils::LeaderInfo const& leaderInfo = syncer.leaderInfo();
-
+    replutils::LeaderInfo const& leaderInfo, TRI_voc_tick_t lastLogTick) {
   TRI_ASSERT(!leaderInfo.endpoint.empty());
   TRI_ASSERT(leaderInfo.endpoint == _state.leader.endpoint);
   TRI_ASSERT(leaderInfo.serverId.isSet());
@@ -192,7 +190,7 @@ Result DatabaseTailingSyncer::inheritFromInitialSyncer(
   _state.leader.majorVersion = leaderInfo.majorVersion;
   _state.leader.minorVersion = leaderInfo.minorVersion;
 
-  _initialTick = syncer.getLastLogTick();
+  _initialTick = lastLogTick;
 
   return registerOnLeader();
 }

--- a/arangod/Replication/DatabaseTailingSyncer.h
+++ b/arangod/Replication/DatabaseTailingSyncer.h
@@ -81,7 +81,8 @@ class DatabaseTailingSyncer : public TailingSyncer {
                                TRI_voc_tick_t& until, bool& didTimeout,
                                std::string const& context);
 
-  Result inheritFromInitialSyncer(DatabaseInitialSyncer const& syncer);
+  Result inheritFromInitialSyncer(replutils::LeaderInfo const& leaderInfo,
+                                  TRI_voc_tick_t initialTick);
   Result registerOnLeader();
   void unregisterFromLeader(bool hardLocked);
 

--- a/arangod/Replication/ReplicationFeature.cpp
+++ b/arangod/Replication/ReplicationFeature.cpp
@@ -99,7 +99,7 @@ ReplicationFeature::ReplicationFeature(Server& server)
       _autoRepairRevisionTrees(true),
       _connectionCache{
           server.getFeature<application_features::CommunicationFeaturePhase>(),
-          httpclient::ConnectionCache::Options{5}},
+          httpclient::ConnectionCache::Options{5, 120}},
       _parallelTailingInvocations(0),
       _maxParallelTailingInvocations(0),
       _quickKeysLimit(1000000),

--- a/lib/SimpleHttpClient/ConnectionCache.cpp
+++ b/lib/SimpleHttpClient/ConnectionCache.cpp
@@ -101,28 +101,48 @@ ConnectionLease ConnectionCache::acquire(std::string endpoint,
       auto& connectionsForEndpoint = (*it).second;
 
       for (auto it = connectionsForEndpoint.rbegin();
-           it != connectionsForEndpoint.rend(); ++it) {
+           it != connectionsForEndpoint.rend();
+           /* intentionally empty! */) {
         auto& candidate = (*it);
-        if (candidate->getEndpoint()->encryption() !=
+        if (candidate.connection->getEndpoint()->encryption() !=
                 Endpoint::EncryptionType::NONE &&
-            static_cast<SslClientConnection*>(candidate.get())->sslProtocol() !=
-                sslProtocol) {
+            static_cast<SslClientConnection*>(candidate.connection.get())
+                    ->sslProtocol() != sslProtocol) {
           // different SSL protocol
+          ++it;
           continue;
         }
 
-        TRI_ASSERT(candidate->getEndpoint()->specification() == endpoint);
+        TRI_ASSERT(candidate.connection->getEndpoint()->specification() ==
+                   endpoint);
 
-        // found a suitable candidate
-        connection = std::move(candidate);
-        TRI_ASSERT(connection != nullptr);
-
+        if (std::chrono::steady_clock::now() - candidate.lastUsed <
+            std::chrono::seconds(_options.idleConnectionTimeout)) {
+          // found a suitable candidate
+          connection = std::move(candidate.connection);
+          TRI_ASSERT(connection != nullptr);
+          // intentionally fall through here!
+        }
+        // If the connection is too old, we fell through here with
+        // `connection` still being a nullptr. In that case, we will
+        // remove the connection and move on:
         if (it != connectionsForEndpoint.rbegin()) {
           // fill the gap
           (*it) = std::move(connectionsForEndpoint.back());
+          connectionsForEndpoint.pop_back();
+          // Iterator still valid but pointing to a connection we have
+          // already looked at:
+          ++it;
+        } else {
+          connectionsForEndpoint.pop_back();
+          // `it` is now invalid, so we need to update it:
+          it = connectionsForEndpoint.rbegin();
+          // No need to ++it here, since this is the next one to look at
+          // (or indeed connectionsForEndpoint.rend()).
         }
-        connectionsForEndpoint.pop_back();
-        break;
+        if (connection != nullptr) {
+          break;
+        }
       }
     }
 
@@ -187,7 +207,9 @@ void ConnectionCache::release(
     // this may create the vector at _connections[endpoint]
     auto& connectionsForEndpoint = _connections[endpoint];
     if (connectionsForEndpoint.size() < _options.maxConnectionsPerEndpoint) {
-      connectionsForEndpoint.emplace_back(std::move(connection));
+      connectionsForEndpoint.emplace_back(
+          ConnInfo{.connection = std::move(connection),
+                   .lastUsed = std::chrono::steady_clock::now()});
     }
   }
 } catch (...) {

--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -70,10 +70,13 @@ class ConnectionCache {
 
  public:
   struct Options {
-    explicit Options(size_t maxConnectionsPerEndpoint)
-        : maxConnectionsPerEndpoint(maxConnectionsPerEndpoint) {}
+    explicit Options(size_t maxConnectionsPerEndpoint,
+                     uint32_t idleConnectionTimeout)
+        : maxConnectionsPerEndpoint(maxConnectionsPerEndpoint),
+          idleConnectionTimeout(idleConnectionTimeout) {}
 
     size_t maxConnectionsPerEndpoint;
+    uint32_t idleConnectionTimeout = 120;  // seconds
   };
 
   ConnectionCache(
@@ -89,10 +92,14 @@ class ConnectionCache {
   void release(std::unique_ptr<GeneralClientConnection> connection,
                bool force = false);
 
+  struct ConnInfo {
+    std::unique_ptr<GeneralClientConnection> connection;
+    std::chrono::steady_clock::time_point lastUsed;
+  };
+
 #ifdef ARANGODB_USE_GOOGLE_TESTS
-  std::unordered_map<
-      std::string, std::vector<std::unique_ptr<GeneralClientConnection>>> const&
-  connections() const {
+  std::unordered_map<std::string, std::vector<ConnInfo>> const& connections()
+      const {
     return _connections;
   }
 #endif
@@ -104,9 +111,7 @@ class ConnectionCache {
 
   mutable std::mutex _lock;
 
-  std::unordered_map<std::string,
-                     std::vector<std::unique_ptr<GeneralClientConnection>>>
-      _connections;
+  std::unordered_map<std::string, std::vector<ConnInfo>> _connections;
 
   uint64_t _connectionsCreated;
   uint64_t _connectionsRecycled;


### PR DESCRIPTION
### Scope & Purpose

This is a backport of https://github.com/arangodb/arangodb/pull/21518

This addresses
  https://arangodb.atlassian.net/browse/BTS-2011
and 
  https://arangodb.atlassian.net/browse/BTS-2042

The common theme is TCP/IP connections within the cluster, which are sometimes broken by external actors in the cloud, or indeed by our own `arangod`. This PR adds a timeout for idle TCP/IP connections in the `ConnectionCache` of 120s. Furthermore, there is a fix for `SynchronizeShard`, which leased a connection for the `DatabaseTailingSyncer` too early in the process, so that it could be stale until the `DatabaseTailingSyncer` was actually used.

Finally, it increases a few timeouts in replication for larger or slower
cases.

- [*] :hankey: Bugfix

### Checklist

- [x] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: this is it

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2011
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2042
- [*] Original PR: https://github.com/arangodb/arangodb/pull/21518

