### PR TITLE
Improve geo index performance in the cluster [BTS_2046]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Improve geo index performance in the cluster with multiple shards. This
+  fixes BTS-2046. An unnecessary and bad SORT node is removed from the
+  query plan in the case that a geo index is used.
+
 * Rebuilt included rclone v1.65.5 with go1.22.10 and non-vulnerable
   dependencies.
 

--- a/arangod/Aql/OptimizerRules.cpp
+++ b/arangod/Aql/OptimizerRules.cpp
@@ -7281,6 +7281,21 @@ static bool optimizeSortNode(ExecutionPlan* plan, SortNode* sort,
       // establish a cross-shard sortedness by distance.
       info.exesToModify.emplace(sort, expr);
       info.nodesToRemove.emplace(expr->node());
+    } else {
+      // In the cluster case, we want to leave the SORT node in - for now!
+      // This is to achieve that the GATHER node which is introduced to
+      // distribute the query in the cluster remembers to sort things
+      // using merge sort. However, later there will be a rule which
+      // moves the sorting to the dbserver. When this rule is triggered,
+      // we do not want to reinsert the SORT node on the dbserver, since
+      // there, the items are already sorted by means of the geo index.
+      // Therefore, we tell the sort node here, not to be reinserted
+      // on the dbserver later on.
+      // This is crucial to avoid that the SORT node remains and pulls
+      // the whole collection out of the geo index, on the grounds that
+      // the SORT node wants to sort the results, which is very bad for
+      // performance.
+      sort->dontReinsertInCluster();
     }
     return true;
   }

--- a/tests/js/client/aql/aql-geo-cluster.js
+++ b/tests/js/client/aql/aql-geo-cluster.js
@@ -1,0 +1,64 @@
+/*global assertEqual, assertTrue, assertFalse, print */
+"use strict";
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2015-2025 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+/// @author Max Neunhoeffer
+/// @copyright Copyright 2025, ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+const jsunity = require("jsunity");
+const {db} = require("@arangodb");
+
+const database = "myGeoDatabase";
+const collection = "myColl";
+
+function testGeoCluster() {
+  return {
+    setUpAll: function () {
+      db._createDatabase(database);
+      db._useDatabase(database);
+      db._create(collection, {numberOfShards:3});
+      db._collection(collection).ensureIndex(
+        {type: "geo", fields: [`geo`], geoJson: true});
+    },
+    tearDownAll: function () {
+      db._useDatabase("_system");
+      db._dropDatabase(database);
+    },
+
+    testSortNodeGone: function () {
+      // For some time we had the bug that in the cluster, a sort node 
+      // was not removed in the execution plan in case of a geo query.
+      // The sort node is not needed, since the geo index delivers sorted
+      // results anyway. Its present is bad for performance, since it leads
+      // to the fact that the query execution reads **all** documents in 
+      // the collection from the geo index. Therefore we check that the
+      // sort node is removed during query optimization here:
+      let plan = db._createStatement(`
+        FOR d IN ${collection}
+          SORT GEO_DISTANCE(d.geo, [0,0])
+          RETURN d
+      `).explain();
+      let nodetypes = plan.plan.nodes.map(x => x.type);
+      assertEqual(-1, nodetypes.indexOf("SortNode"));
+    }
+  };
+}
+
+jsunity.run(testGeoCluster);
+return jsunity.done();


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/browse/BTS-2046.

Performance of geo queries like this are much worse with a geo index than without in the cluster with a collection with multiple shards:

```
FOR c IN crimes
  SORT GEO_DISTANCE(c.geo, [-118.3556633, 34.0638005]) ASC
  LIMIT 1000
  RETURN c._key
```

The reason is that an unnecessary and bad SORT node is moved to the dbserver. This node leads to the fact that the whole collection is read from the geo index, rather than just the needed documents and an additional sort step is performed.

The fix is relatively simple by just saying that this SORT node should not be inserted in the critical circumstances.

Commits:

- **Avoid a bad SORT node in the cluster when a geo index is used.**
- **CHANGELOG.**

### Scope & Purpose

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: https://github.com/arangodb/arangodb/pull/21540

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2046.
