### PR TITLE
Add missing CHANELOG entry for refactor vector index

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,24 @@
 devel
 -----
 
+* Add optional `factory` property to `params` in vector index definition. The
+  index factory define how to compose multiple variants of vector index via
+  factory string. More details on how to compose them can be found on FAISS
+  documentation https://github.com/facebookresearch/faiss/wiki/The-index-factory.
+  When defining the index string the number of nLists from string must match the
+  `nLists` parameter. Here is an example of using this parameter:
+  ```
+    db.<collection>.ensureIndex({
+      type: "vector",
+      fields: ["value1"],
+      params: {
+        "metric": "l2",
+        "dimension": 300,
+        "nLists": 3800,
+        "factory": "IVF3800_HNSW32,PQ480x8"
+      }
+    });
+
 * Fail queries that use `APPROX_NEAR` functions but do not apply the vector
   index.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,9 +2,11 @@ devel
 -----
 
 * Add optional `factory` property to `params` in vector index definition. The
-  index factory define how to compose multiple variants of vector index via
-  factory string. More details on how to compose them can be found on FAISS
-  documentation https://github.com/facebookresearch/faiss/wiki/The-index-factory.
+  index factory enables to create composite vector indexes supported by FAISS.
+  The factory string defines the index structure, including preprocessing,
+  inverted files, and encoding components.
+  More details on how to compose them can be found on FAISS documentation
+  https://github.com/facebookresearch/faiss/wiki/The-index-factory.
   When defining the index string the number of nLists from string must match the
   `nLists` parameter. Here is an example of using this parameter:
   ```


### PR DESCRIPTION
### Scope & Purpose

Add missing CHANGELOG entry for the https://github.com/arangodb/arangodb/pull/21503


- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
