### PR TITLE
FE-489 - fix undefined check at disabledRules (Options tab)

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/QueryOptionsTab.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/query/editor/QueryOptionsTab.tsx
@@ -115,7 +115,7 @@ export const QueryOptionsTab = ({ mode }: { mode: "json" | "table" }) => {
           };
           if (!errors.length) {
             setQueryOptions(updatedOptions || {});
-            setDisabledRules(updatedValue.optimizer?.rules);
+            setDisabledRules(updatedValue.optimizer?.rules || []);
           }
         }}
         htmlElementProps={{
@@ -310,7 +310,7 @@ const OptimizerRules = () => {
       <MultiSelect
         options={ruleOptions}
         value={ruleOptions.filter(option => {
-          return disabledRules.includes(option.value);
+          return disabledRules?.includes(option.value);
         })}
         onChange={value => {
           const disabledRuleNames = value.map((v: any) => v.value);


### PR DESCRIPTION
### Scope & Purpose

Query view may break when toggling Bind Variables to Table after editing Options in JSON

- [X] :hankey: Bugfix

### Checklist

- [X] Tests
  - [X] Manually tested
- [ ] :book: CHANGELOG entry made

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FE-489
