### PR TITLE
Make arangoimport great again [BTS-2047]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Make `RestImportHandler` asynchronous. This is to avoid some blockages
+  observed in the context of BTS-2047.
+
 * Make `arangoimport` more stable. The default batch size is lowered to 4MB
   (from 8MB) and the default maximal streaming transaction size is increased
   from 128MB to 512MB. In examples we have seen that the overhead from input
@@ -8,7 +11,7 @@ devel
   to 80x, therefore `arangoimport` could run into resource limits with the
   normal batch size. This is particularly acute for smart edge collections,
   where `arangoimport` has to use streaming transactions and where small
-  edges have to be indexed multiple times.
+  edges have to be indexed multiple times. Fixes BTS-2047.
 
 * Add optional `factory` property to `params` in vector index definition. The
   index factory enables to create composite vector indexes supported by FAISS.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,15 @@
 devel
 -----
 
+* Make `arangoimport` more stable. The default batch size is lowered to 4MB
+  (from 8MB) and the default maximal streaming transaction size is increased
+  from 128MB to 512MB. In examples we have seen that the overhead from input
+  data size to the memory usage in the actual RocksDB transaction can be up
+  to 80x, therefore `arangoimport` could run into resource limits with the
+  normal batch size. This is particularly acute for smart edge collections,
+  where `arangoimport` has to use streaming transactions and where small
+  edges have to be indexed multiple times.
+
 * Add optional `factory` property to `params` in vector index definition. The
   index factory enables to create composite vector indexes supported by FAISS.
   The factory string defines the index structure, including preprocessing,

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -460,8 +460,7 @@ futures::Future<futures::Unit> RestImportHandler::createFromJson(
     VPackSlice documents = parseVPackBody(success);
 
     if (!success) {
-      generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                    "cannot parse JSON body");
+      // JSON parsing error will be handed on!
       co_return;
     }
     if (!documents.isArray()) {
@@ -588,8 +587,7 @@ futures::Future<futures::Unit> RestImportHandler::createFromVPack(
   VPackSlice documents = parseVPackBody(success);
 
   if (!success) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  "cannot parse JSON body");
+    // JSON parsing error will be handed on!
     co_return;
   }
   if (!documents.isArray()) {

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -27,7 +27,6 @@
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cluster/ServerState.h"
-#include "Logger/Logger.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/OperationOrigin.h"
 #include "Transaction/StandaloneContext.h"
@@ -42,8 +41,6 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 #include <velocypack/Slice.h>
-
-#include "Logger/LogMacros.h"
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -102,14 +99,14 @@ RestStatus RestImportHandler::execute() {
       std::string const& documentType = _request->value("type", found);
 
       if (_request->contentType() == arangodb::ContentType::VPACK) {
-        createFromVPack(documentType);
+        return waitForFuture(createFromVPack(documentType));
       } else if (found &&
                  (documentType == "documents" || documentType == "array" ||
                   documentType == "list" || documentType == "auto")) {
-        createFromJson(documentType);
+        return waitForFuture(createFromJson(documentType));
       } else {
         // CSV
-        createFromKeyValueList();
+        return waitForFuture(createFromKeyValueList());
       }
     } break;
 
@@ -270,7 +267,8 @@ ErrorCode RestImportHandler::handleSingleDocument(
   return TRI_ERROR_NO_ERROR;
 }
 
-bool RestImportHandler::createFromJson(std::string const& type) {
+futures::Future<futures::Unit> RestImportHandler::createFromJson(
+    std::string const& type) {
   RestImportResult result;
 
   std::vector<std::string> const& suffixes = _request->suffixes();
@@ -279,7 +277,7 @@ bool RestImportHandler::createFromJson(std::string const& type) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                   "superfluous suffix, expecting " + IMPORT_PATH +
                       "?collection=<identifier>");
-    return false;
+    co_return;
   }
 
   bool const complete = _request->parsedValue("complete", false);
@@ -295,7 +293,7 @@ bool RestImportHandler::createFromJson(std::string const& type) {
                   TRI_ERROR_ARANGO_COLLECTION_PARAMETER_MISSING,
                   "'collection' is missing, expecting " + IMPORT_PATH +
                       "?collection=<identifier>");
-    return false;
+    co_return;
   }
 
   bool linewise;
@@ -334,7 +332,7 @@ bool RestImportHandler::createFromJson(std::string const& type) {
   } else {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                   "invalid value for 'type'");
-    return false;
+    co_return;
   }
 
   // find and load collection given by name or identifier
@@ -360,20 +358,19 @@ bool RestImportHandler::createFromJson(std::string const& type) {
   // inside write transaction
   // .............................................................................
 
-  Result res = trx.begin();
+  Result res = co_await trx.beginAsync();
 
   if (res.fail()) {
     generateTransactionError(collectionName, OperationResult(res, opOptions),
                              "");
-    return false;
+    co_return;
   }
 
   if (overwrite) {
     OperationOptions truncateOpts(_context);
     truncateOpts.waitForSync = false;
     // truncate collection first
-    trx.truncate(collectionName, truncateOpts);
-    // Ignore the result ...
+    std::ignore = co_await trx.truncateAsync(collectionName, truncateOpts);
   }
 
   VPackBuilder babies;
@@ -463,12 +460,14 @@ bool RestImportHandler::createFromJson(std::string const& type) {
     VPackSlice documents = parseVPackBody(success);
 
     if (!success) {
-      return false;
+      generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                    "cannot parse JSON body");
+      co_return;
     }
     if (!documents.isArray()) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     "expecting a JSON array in the request");
-      return false;
+      co_return;
     }
 
     VPackBuilder lineBuilder;
@@ -496,11 +495,11 @@ bool RestImportHandler::createFromJson(std::string const& type) {
 
   if (res.ok()) {
     // no error so far. go on and perform the actual insert
-    res =
-        performImport(trx, result, collectionName, babies, complete, opOptions);
+    res = co_await performImport(trx, result, collectionName, babies, complete,
+                                 opOptions);
   }
 
-  res = trx.finish(res);
+  res = co_await trx.finishAsync(res);
 
   if (res.fail()) {
     generateTransactionError(collectionName, OperationResult(res, opOptions),
@@ -508,10 +507,11 @@ bool RestImportHandler::createFromJson(std::string const& type) {
   } else {
     generateDocumentsCreated(result);
   }
-  return true;
+  co_return;
 }
 
-bool RestImportHandler::createFromVPack(std::string const& type) {
+futures::Future<futures::Unit> RestImportHandler::createFromVPack(
+    std::string const& type) {
   if (_request == nullptr) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid request");
   }
@@ -524,7 +524,7 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                   "superfluous suffix, expecting " + IMPORT_PATH +
                       "?collection=<identifier>");
-    return false;
+    co_return;
   }
 
   bool const complete = _request->parsedValue("complete", false);
@@ -540,7 +540,7 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
                   TRI_ERROR_ARANGO_COLLECTION_PARAMETER_MISSING,
                   "'collection' is missing, expecting " + IMPORT_PATH +
                       "?collection=<identifier>");
-    return false;
+    co_return;
   }
 
   // find and load collection given by name or identifier
@@ -565,21 +565,20 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
   // inside write transaction
   // .............................................................................
 
-  Result res = trx.begin();
+  Result res = co_await trx.beginAsync();
 
   if (res.fail()) {
     generateTransactionError(collectionName, OperationResult(res, opOptions),
                              "");
 
-    return false;
+    co_return;
   }
 
   if (overwrite) {
     OperationOptions truncateOpts;
     truncateOpts.waitForSync = false;
     // truncate collection first
-    trx.truncate(collectionName, truncateOpts);
-    // Ignore the result ...
+    std::ignore = co_await trx.truncateAsync(collectionName, truncateOpts);
   }
 
   VPackBuilder babies;
@@ -589,12 +588,14 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
   VPackSlice documents = parseVPackBody(success);
 
   if (!success) {
-    return false;
+    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                  "cannot parse JSON body");
+    co_return;
   }
   if (!documents.isArray()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting a JSON array in the request");
-    return false;
+    co_return;
   }
 
   VPackBuilder lineBuilder;
@@ -621,11 +622,11 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
 
   if (res.ok()) {
     // no error so far. go on and perform the actual insert
-    res =
-        performImport(trx, result, collectionName, babies, complete, opOptions);
+    res = co_await performImport(trx, result, collectionName, babies, complete,
+                                 opOptions);
   }
 
-  res = trx.finish(res);
+  res = co_await trx.finishAsync(res);
 
   if (res.fail()) {
     generateTransactionError(collectionName, OperationResult(res, opOptions),
@@ -633,10 +634,10 @@ bool RestImportHandler::createFromVPack(std::string const& type) {
   } else {
     generateDocumentsCreated(result);
   }
-  return true;
+  co_return;
 }
 
-bool RestImportHandler::createFromKeyValueList() {
+futures::Future<futures::Unit> RestImportHandler::createFromKeyValueList() {
   if (_request == nullptr) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid request");
   }
@@ -649,7 +650,7 @@ bool RestImportHandler::createFromKeyValueList() {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                   "superfluous suffix, expecting " + IMPORT_PATH +
                       "?collection=<identifier>");
-    return false;
+    co_return;
   }
 
   bool const complete = _request->parsedValue("complete", false);
@@ -668,7 +669,7 @@ bool RestImportHandler::createFromKeyValueList() {
                   TRI_ERROR_ARANGO_COLLECTION_PARAMETER_MISSING,
                   "'collection' is missing, expecting " + IMPORT_PATH +
                       "?collection=<identifier>");
-    return false;
+    co_return;
   }
 
   // read line number (optional)
@@ -693,7 +694,7 @@ bool RestImportHandler::createFromKeyValueList() {
   if (next == nullptr) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "no JSON array found in second line");
-    return false;
+    co_return;
   }
 
   char const* lineStart = current;
@@ -722,12 +723,12 @@ bool RestImportHandler::createFromKeyValueList() {
     // This throws if the body is not parseable
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "no JSON string array found in first line");
-    return false;
+    co_return;
   }
   if (!success) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "no JSON string array found in first line");
-    return false;
+    co_return;
   }
 
   VPackSlice const keys = parsedKeys.slice();
@@ -735,7 +736,7 @@ bool RestImportHandler::createFromKeyValueList() {
   if (!checkKeys(keys)) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "no JSON string array found in first line");
-    return false;
+    co_return;
   }
 
   current = next + 1;
@@ -763,20 +764,19 @@ bool RestImportHandler::createFromKeyValueList() {
   // inside write transaction
   // .............................................................................
 
-  Result res = trx.begin();
+  Result res = co_await trx.beginAsync();
 
   if (res.fail()) {
     generateTransactionError(collectionName, OperationResult(res, opOptions),
                              "");
-    return false;
+    co_return;
   }
 
   if (overwrite) {
     OperationOptions truncateOpts(_context);
     truncateOpts.waitForSync = false;
     // truncate collection first
-    trx.truncate(collectionName, truncateOpts);
-    // Ignore the result ...
+    std::ignore = co_await trx.truncateAsync(collectionName, truncateOpts);
   }
 
   VPackBuilder parsedValues;
@@ -862,11 +862,11 @@ bool RestImportHandler::createFromKeyValueList() {
 
   if (res.ok()) {
     // no error so far. go on and perform the actual insert
-    res =
-        performImport(trx, result, collectionName, babies, complete, opOptions);
+    res = co_await performImport(trx, result, collectionName, babies, complete,
+                                 opOptions);
   }
 
-  res = trx.finish(res);
+  res = co_await trx.finishAsync(res);
 
   if (res.fail()) {
     generateTransactionError(collectionName, OperationResult(res, opOptions),
@@ -874,19 +874,17 @@ bool RestImportHandler::createFromKeyValueList() {
   } else {
     generateDocumentsCreated(result);
   }
-  return true;
+  co_return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief perform the actual import (insert/update/replace) operations
 ////////////////////////////////////////////////////////////////////////////////
 
-Result RestImportHandler::performImport(SingleCollectionTransaction& trx,
-                                        RestImportResult& result,
-                                        std::string const& collectionName,
-                                        VPackBuilder const& babies,
-                                        bool complete,
-                                        OperationOptions const& opOptions) {
+async<Result> RestImportHandler::performImport(
+    SingleCollectionTransaction& trx, RestImportResult& result,
+    std::string const& collectionName, VPackBuilder const& babies,
+    bool complete, OperationOptions const& opOptions) {
   auto makeError = [&](size_t i, ErrorCode res, VPackSlice const& slice,
                        RestImportResult& result) {
     VPackOptions options(VPackOptions::Defaults);
@@ -907,7 +905,7 @@ Result RestImportHandler::performImport(SingleCollectionTransaction& trx,
 
   Result res;
   OperationResult opResult =
-      trx.insert(collectionName, babies.slice(), opOptions);
+      co_await trx.insertAsync(collectionName, babies.slice(), opOptions);
 
   if (!opResult.fail()) {
     VPackSlice resultSlice = opResult.slice();
@@ -959,7 +957,7 @@ Result RestImportHandler::performImport(SingleCollectionTransaction& trx,
     res = opResult.result;
   }
 
-  return res;
+  co_return res;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/RestHandler/RestImportHandler.h
+++ b/arangod/RestHandler/RestImportHandler.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include "Async/async.h"
+#include "Futures/Future.h"
 #include "Basics/Result.h"
 #include "RestHandler/RestVocbaseBaseHandler.h"
 
@@ -102,31 +104,24 @@ class RestImportHandler : public RestVocbaseBaseHandler {
   /// each line of the input stream contains an individual JSON object
   //////////////////////////////////////////////////////////////////////////////
 
-  bool createFromJson(std::string const&);
-  bool createFromVPack(std::string const&);
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief creates documents by JSON objects
-  /// the input stream is one big JSON array containing all documents
-  //////////////////////////////////////////////////////////////////////////////
-
-  bool createByDocumentsList();
+  futures::Future<futures::Unit> createFromJson(std::string const&);
+  futures::Future<futures::Unit> createFromVPack(std::string const&);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief creates a documents from key/value lists
   //////////////////////////////////////////////////////////////////////////////
 
-  bool createFromKeyValueList();
+  futures::Future<futures::Unit> createFromKeyValueList();
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief perform the actual import (insert/update/replace) operations
   //////////////////////////////////////////////////////////////////////////////
 
-  Result performImport(SingleCollectionTransaction& trx,
-                       RestImportResult& result,
-                       std::string const& collectionName,
-                       VPackBuilder const& babies, bool complete,
-                       OperationOptions const& opOptions);
+  async<Result> performImport(SingleCollectionTransaction& trx,
+                              RestImportResult& result,
+                              std::string const& collectionName,
+                              VPackBuilder const& babies, bool complete,
+                              OperationOptions const& opOptions);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief creates the result

--- a/arangod/RocksDBEngine/RocksDBMethodsMemoryTracker.cpp
+++ b/arangod/RocksDBEngine/RocksDBMethodsMemoryTracker.cpp
@@ -26,8 +26,6 @@
 #include "Basics/ResourceUsage.h"
 #include "Metrics/Gauge.h"
 #include "RocksDBEngine/RocksDBTransactionState.h"
-#include "Statistics/ServerStatistics.h"
-#include "Transaction/OperationOrigin.h"
 
 namespace arangodb {
 

--- a/arangod/Transaction/ManagerFeature.h
+++ b/arangod/Transaction/ManagerFeature.h
@@ -65,7 +65,7 @@ class ManagerFeature final : public ArangodFeature {
   void queueGarbageCollection();
 
   static constexpr size_t defaultStreamingMaxTransactionSize =
-      128 * 1024 * 1024;  // 128 MiB
+      512 * 1024 * 1024;  // 512 MiB
   static constexpr double defaultStreamingIdleTimeout = 60.0;
   static constexpr double maxStreamingIdleTimeout = 120.0;
 

--- a/client-tools/Import/ImportFeature.cpp
+++ b/client-tools/Import/ImportFeature.cpp
@@ -60,7 +60,7 @@ ImportFeature::ImportFeature(Server& server, int* result)
       _useBackslash(false),
       _convert(true),
       _autoChunkSize(false),
-      _chunkSize(1024 * 1024 * 8),
+      _chunkSize(1024 * 1024 * 4),
       _threadCount(2),
       _overwriteCollectionPrefix(false),
       _createCollection(false),


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/issues/BTS-2047 .

See explanation there. We basically decrease the default batch size and
increase the limit for streaming transactions, which are used for smart
edge collection in `arangoimport`.

Furthermore, we make the `RestImportHandler` asynchronous.

- **Remove unnecessary includes.**
- **Adjust batch size and maximal streaming transaction size.**
- **Make RestImportHandler asynchronous.**
- 
This is not relevant in 3.11, where the accounting does not cover
this memory usage.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: none planned

