### PR TITLE
Extract executeExternalAndWaitWithSanitizer function

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -943,3 +943,11 @@ exports.insertManyDocumentsIntoCollection
   }
 };
 
+exports.executeExternalAndWaitWithSanitizer = function (executable, args, tmpFileName) {
+  let sanHnd = new sanHandler(executable, global.instanceManager.options);
+  let tmpMgr = new tmpDirMngr(fs.join(tmpFileName), global.instanceManager.options);
+  sanHnd.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
+  let actualRc = internal.executeExternalAndWait(executable, args, false, 0, sanHnd.getSanOptions());
+  sanHnd.fetchSanFileAfterExit(actualRc.pid);
+  return actualRc;
+};

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -943,9 +943,9 @@ exports.insertManyDocumentsIntoCollection
   }
 };
 
-exports.executeExternalAndWaitWithSanitizer = function (executable, args, tmpFileName) {
-  let sanHnd = new sanHandler(executable, global.instanceManager.options);
-  let tmpMgr = new tmpDirMngr(fs.join(tmpFileName), global.instanceManager.options);
+exports.executeExternalAndWaitWithSanitizer = function (executable, args, tmpFileName, options = global.instanceManager.options) {
+  let sanHnd = new sanHandler(executable, options);
+  let tmpMgr = new tmpDirMngr(fs.join(tmpFileName), options);
   sanHnd.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
   let actualRc = internal.executeExternalAndWait(executable, args, false, 0, sanHnd.getSanOptions());
   sanHnd.fetchSanFileAfterExit(actualRc.pid);

--- a/js/client/modules/@arangodb/testsuites/arangosh.js
+++ b/js/client/modules/@arangodb/testsuites/arangosh.js
@@ -35,14 +35,9 @@ const tu = require('@arangodb/testutils/test-utils');
 const ct = require('@arangodb/testutils/client-tools');
 const internal = require('internal');
 const toArgv = internal.toArgv;
-const executeScript = internal.executeScript;
 const statusExternal = internal.statusExternal;
-const executeExternal = internal.executeExternal;
 const executeExternalAndWait = internal.executeExternalAndWait;
-const tmpDirMngr = require('@arangodb/testutils/tmpDirManager').tmpDirManager;
-const {sanHandler} = require('@arangodb/testutils/san-file-handler');
-
-const platform = internal.platform;
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 
 // const BLUE = require('internal').COLORS.COLOR_BLUE;
 const CYAN = require('internal').COLORS.COLOR_CYAN;
@@ -98,9 +93,6 @@ function arangosh (options) {
     print(`testcase ${section} - ${title}`);
     print('--------------------------------------------------------------------------------');
 
-    let weirdNames = ['some dog', 'ла́ять', '犬', 'Kläffer'];
-    let tmpMgr = new tmpDirMngr(fs.join('arangosh_tests_weird_names'), options);
-
     ////////////////////////////////////////////////////////////////////////////////
     // run command from a .js file
     let args = ct.makeArgs.arangosh(options);
@@ -112,10 +104,7 @@ function arangosh (options) {
     }
 
     const startTime = time();
-    let sh = new sanHandler(pu.ARANGOSH_BIN, options);
-    sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-    let rc = executeExternalAndWait(pu.ARANGOSH_BIN, toArgv(args), false, 0, sh.getSanOptions());
-    sh.fetchSanFileAfterExit(rc.pid);
+    let rc = executeExternalAndWaitWithSanitizer(pu.ARANGOSH_BIN, toArgv(args), 'arangosh_tests_weird_names', options);
     const deltaTime = time() - startTime;
     const failSuccess = (rc.hasOwnProperty('exit') && rc.exit === expectedReturnCode);
 
@@ -162,9 +151,8 @@ function arangosh (options) {
 
     const startTime2 = time();
 
-    let rc2 = executeExternalAndWait(pu.ARANGOSH_BIN, toArgv(args2), false, 0, sh.getSanOptions());
-    sh.fetchSanFileAfterExit(rc2.pid);
-    const deltaTime2 = time() - startTime;
+    let rc2 = executeExternalAndWaitWithSanitizer(pu.ARANGOSH_BIN, toArgv(args2), 'arangosh_tests_weird_names_2', options);
+    const deltaTime2 = time() - startTime2;
     const failSuccess2 = (rc2.hasOwnProperty('exit') && rc2.exit === expectedReturnCode);
 
     if (!failSuccess2) {
@@ -179,7 +167,7 @@ function arangosh (options) {
 
     ++ret[section]['total'];
     ret[section]['status'] = failSuccess2;
-    ret[section]['duration'] = deltaTime;
+    ret[section]['duration'] = deltaTime2;
     print((failSuccess2 ? GREEN : RED) + 'Status: ' + (failSuccess2 ? 'SUCCESS' : 'FAIL') + RESET);
     if (options.extremeVerbosity) {
       print(toArgv(args2));
@@ -188,7 +176,6 @@ function arangosh (options) {
       print('expect rc: ' + expectedReturnCode);
       print(`status: ${JSON.stringify(ret[section])}`);
     }
-    tmpMgr.destructor(ret[section]['status'] && options.cleanup);
   }
 
   runTest('testArangoshExitVersion',
@@ -270,10 +257,7 @@ function arangosh (options) {
   args['javascript.execute-string'] = "print(require('internal').pollStdin())";
 
   const startTime = time();
-  let tmpMgr = new tmpDirMngr('arangosh_tests_pipe', options);
-  let sh = new sanHandler(pu.ARANGOSH_BIN, options);
-  sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-  let res = executeExternal(pu.ARANGOSH_BIN, toArgv(args), true, 0, sh.getSanOptions());
+  let res = executeExternalAndWaitWithSanitizer(pu.ARANGOSH_BIN, toArgv(args), 'arangosh_tests_pipe', options);
   const deltaTime = time() - startTime;
 
   fs.writePipe(res.pid, "bla\n");
@@ -284,7 +268,6 @@ function arangosh (options) {
   let success = output === searchstring;
 
   let rc = statusExternal(res.pid, true);
-  sh.fetchSanFileAfterExit(res.pid);
   let failSuccess = (rc.hasOwnProperty('exit') && rc.exit === 0);
   failSuccess = failSuccess && success;
   if (options.extremeVerbosity) {
@@ -308,11 +291,10 @@ function arangosh (options) {
     };
   }
 
-  ret[section]['duration'] = time() - startTime;
+  ret[section]['duration'] = deltaTime;
   print((failSuccess ? GREEN : RED) + 'Status: ' + (failSuccess ? 'SUCCESS' : 'FAIL') + RESET);
 
   {
-    let tmpMgr = new tmpDirMngr('arangosh_tests_echo', options);
     var echoSuccess = true;
     var deltaTime2 = 0;
     var execFile = fs.getTempFile();
@@ -324,13 +306,10 @@ function arangosh (options) {
     fs.write(execFile,
       'echo "db._databases();" | ' + fs.makeAbsolute(pu.ARANGOSH_BIN) + ' --server.endpoint tcp://127.0.0.1:0');
 
-    let sh = new sanHandler(pu.ARANGOSH_BIN, options);
-    sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
     executeExternalAndWait('sh', ['-c', 'chmod a+x ' + execFile]);
 
     const startTime2 = time();
-    let rc = executeExternalAndWait('sh', ['-c', execFile], false, 0, sh.getSanOptions());
-    sh.fetchSanFileAfterExit(rc.pid);
+    let rc = executeExternalAndWaitWithSanitizer('sh', ['-c', execFile], 'arangosh_tests_echo', options);
     deltaTime2 = time() - startTime2;
 
     echoSuccess = (rc.hasOwnProperty('exit') && rc.exit === 1);
@@ -355,7 +334,6 @@ function arangosh (options) {
 
   // test shebang execution with arangosh
   {
-    let tmpMgr = new tmpDirMngr('arangosh_tests_shebang', options);
     var shebangSuccess = true;
     var deltaTime3 = 0;
     var shebangFile = fs.getTempFile();
@@ -375,9 +353,7 @@ function arangosh (options) {
     executeExternalAndWait('sh', ['-c', 'chmod a+x ' + shebangFile]);
 
     const startTime3 = time();
-    sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-    rc = executeExternalAndWait('sh', ['-c', shebangFile], false, sh.getSanOptions());
-    sh.fetchSanFileAfterExit(rc.pid);
+    rc = executeExternalAndWaitWithSanitizer('sh', ['-c', shebangFile], 'arangosh_tests_shebang', options);
     deltaTime3 = time() - startTime3;
 
     if (options.verbose) {

--- a/tests/js/client/shell/agency-oneshard-regression-nocluster.js
+++ b/tests/js/client/shell/agency-oneshard-regression-nocluster.js
@@ -26,9 +26,7 @@
 const jsunity = require("jsunity");
 const pu = require('@arangodb/testutils/process-utils');
 const fs = require("fs");
-const {executeExternalAndWait} = require("internal");
-const tmpDirMngr = require('@arangodb/testutils/tmpDirManager').tmpDirManager;
-const {sanHandler} = require('@arangodb/testutils/san-file-handler');
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 
 function UpgradeForceOneShardRegressionSuite() {
   'use strict';
@@ -46,8 +44,6 @@ function UpgradeForceOneShardRegressionSuite() {
       * The options we use here are the bare minimum to identify a server as
       * agent.
       */
-      let sh = new sanHandler(pu.ARANGOD_BIN, global.instanceManager.options);
-      let tmpMgr = new tmpDirMngr(fs.join('agency_oneshard_regression-noncluster'), global.instanceManager.options);
       const arangod = pu.ARANGOD_BIN;
       assertTrue(fs.isFile(arangod), "arangod not found!");
 
@@ -70,9 +66,7 @@ function UpgradeForceOneShardRegressionSuite() {
       const args = [];
       addConnectionArgs(args);
       require("console").warn(`Start arangod agency with args: ${JSON.stringify(args)}`);
-      sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-      const actualRc = executeExternalAndWait(arangod, args, false, 0, sh.getSanOptions());
-      sh.fetchSanFileAfterExit(actualRc.pid);
+      const actualRc = executeExternalAndWaitWithSanitizer(arangod, args, 'agency_oneshard_regression-noncluster');
       assertEqual(actualRc.exit, 0, `Instead process exited with ${JSON.stringify(actualRc)}`);
     }
   };

--- a/tests/js/client/shell/shell-arango-secure-installation-noncluster.js
+++ b/tests/js/client/shell/shell-arango-secure-installation-noncluster.js
@@ -28,8 +28,7 @@ let jsunity = require('jsunity');
 let internal = require('internal');
 let fs = require('fs');
 let pu = require('@arangodb/testutils/process-utils');
-const tmpDirMngr = require('@arangodb/testutils/tmpDirManager').tmpDirManager;
-const {sanHandler} = require('@arangodb/testutils/san-file-handler');
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 
 function arangoSecureInstallationSuite () {
   'use strict';
@@ -60,13 +59,8 @@ function arangoSecureInstallationSuite () {
 
       // set no password for the database
       try {
-        let args = [path];
         // invoke arango-secure-installation without password. this will fail
-        let sh = new sanHandler(pu.ARANGOD_BIN, global.instanceManager.options);
-        let tmpMgr = new tmpDirMngr(fs.join('shell-arango-secure-installation-noncluster-1'), global.instanceManager.options);
-        sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-        let actualRc = internal.executeExternalAndWait(arangoSecureInstallation, args, false, 0, sh.getSanOptions());
-        sh.fetchSanFileAfterExit(actualRc.pid);
+        const actualRc = executeExternalAndWaitWithSanitizer(arangoSecureInstallation, [path], 'shell-arango-secure-installation-noncluster-1');
         assertTrue(actualRc.hasOwnProperty("exit"), actualRc);
         assertEqual(1, actualRc.exit, actualRc);
       } finally {
@@ -84,13 +78,8 @@ function arangoSecureInstallationSuite () {
       // set an initial password for the database
       internal.env['ARANGODB_DEFAULT_ROOT_PASSWORD'] = 'haxxmann';
       try {
-        let args = [path];
         // invoke arango-secure-installation with password. this must succeed
-        let sh = new sanHandler(pu.ARANGOD_BIN, global.instanceManager.options);
-        let tmpMgr = new tmpDirMngr(fs.join('shell-arango-secure-installation-noncluster-2'), global.instanceManager.options);
-        sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-        let actualRc = internal.executeExternalAndWait(arangoSecureInstallation, args, false, 0, sh.getSanOptions());
-        sh.fetchSanFileAfterExit(actualRc.pid);
+        const actualRc = executeExternalAndWaitWithSanitizer(arangoSecureInstallation, [path], 'shell-arango-secure-installation-noncluster-2');
         assertTrue(actualRc.hasOwnProperty("exit"), actualRc);
         assertEqual(0, actualRc.exit, actualRc);
       } finally {

--- a/tests/js/client/shell/shell-dump-integration.js
+++ b/tests/js/client/shell/shell-dump-integration.js
@@ -34,8 +34,7 @@ const isCluster = require("internal").isCluster();
 const dbs = ["_system", "maçã", "😀", "ﻚﻠﺑ ﻞﻄﻴﻓ", "testName"];
 const extendedName = "Десятую Международную Конференцию по 💩🍺🌧t⛈c🌩_⚡🔥💥🌨";
 const collectionToBeIgnored = ["UnitTestCollectionNoNoDumpA", "UnitTestCollectionNoNoDumpB"];
-const tmpDirMngr = require('@arangodb/testutils/tmpDirManager').tmpDirManager;
-const {sanHandler} = require('@arangodb/testutils/san-file-handler');
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 
 const validatorJson = {
   "message": "",
@@ -92,10 +91,7 @@ function dumpIntegrationSuite() {
     args.push(path);
     addConnectionArgs(args);
 
-    let sh = new sanHandler(arangodump, global.instanceManager.options);
-    let tmpMgr = new tmpDirMngr(fs.join('shell-dump-integration'), global.instanceManager.options);
-    let actualRc = internal.executeExternalAndWait(arangodump, args, false, 0, sh.getSanOptions());
-    sh.fetchSanFileAfterExit(actualRc.pid);
+    const actualRc = executeExternalAndWaitWithSanitizer(arangodump, args, 'shell-dump-integration');
     assertTrue(actualRc.hasOwnProperty("exit"));
     assertEqual(expectRc, actualRc.exit);
     return fs.listTree(path);

--- a/tests/js/client/shell/shell-restore-integration.js
+++ b/tests/js/client/shell/shell-restore-integration.js
@@ -32,8 +32,7 @@ const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const db = arangodb.db;
 const isCluster = require("internal").isCluster();
-const tmpDirMngr = require('@arangodb/testutils/tmpDirManager').tmpDirManager;
-const {sanHandler} = require('@arangodb/testutils/san-file-handler');
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 const dbs = [{"name": "maçã", "id": "9999994", "isUnicode": true}, {
   "name": "cachorro",
   "id": "9999995",
@@ -142,15 +141,11 @@ function restoreIntegrationSuite() {
   };
 
   let runRestore = function (path, args, rc) {
-    let sh = new sanHandler(arangorestore, global.instanceManager.options);
-    let tmpMgr = new tmpDirMngr(fs.join('shell-restore-integration'), global.instanceManager.options);
     args.push('--input-directory');
     args.push(path);
     addConnectionArgs(args);
 
-    sh.detectLogfiles(tmpMgr.tempDir, tmpMgr.tempDir);
-    let actualRc = internal.executeExternalAndWait(arangorestore, args, false, 0, sh.getSanOptions());
-    sh.fetchSanFileAfterExit(actualRc.pid);
+    const actualRc = executeExternalAndWaitWithSanitizer(arangorestore, args, 'shell-restore-integration');
     assertTrue(actualRc.hasOwnProperty("exit"), actualRc);
     assertEqual(rc, actualRc.exit, actualRc);
   };

--- a/tests/js/client/shell/shell-verify-sst-noncluster.js
+++ b/tests/js/client/shell/shell-verify-sst-noncluster.js
@@ -38,8 +38,7 @@ const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const db = arangodb.db;
 const isEnterprise = require("internal").isEnterprise();
-const tmpDirMngr = require('@arangodb/testutils/tmpDirManager').tmpDirManager;
-const {sanHandler} = require('@arangodb/testutils/san-file-handler');
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 
 function verifySstSuite() {
   'use strict';
@@ -103,10 +102,7 @@ function verifySstSuite() {
         ];
 
         // call ArangoDB with `--rocksdb.verify-sst true` and check exit code
-        let sh = new sanHandler(arangod, global.instanceManager.options);
-        let tmpMgr = new tmpDirMngr(fs.join('shell-verify-sst-noncluster'), global.instanceManager.options);
-        let actualRc = internal.executeExternalAndWait(arangod, args, false, 0, sh.getSanOptions());
-        sh.fetchSanFileAfterExit(actualRc.pid);
+        const actualRc = executeExternalAndWaitWithSanitizer(arangod, args, 'shell-verify-sst-noncluster');
         assertTrue(actualRc.hasOwnProperty("exit"), actualRc);
         assertEqual(0, actualRc.exit, actualRc);
       };


### PR DESCRIPTION
Extract function, preparation for backport (which is needed to fix red test in https://github.com/arangodb/arangodb/pull/21504).
Unfortunately currently not testable because the tsan runs fail due to the linking issue with lapack.