### PR TITLE
Fix vpack representation of vector index definition

### DIFF
--- a/arangod/Indexes/VectorIndexDefinition.h
+++ b/arangod/Indexes/VectorIndexDefinition.h
@@ -94,7 +94,7 @@ struct UserVectorIndexDefinition {
               return inspection::Status::Success{};
             }),
         f.field("metric", x.metric), f.field("nLists", x.nLists),
-        f.field("nLists", x.nLists), f.field("factory", x.factory),
+        f.field("factory", x.factory),
         f.field("trainingIterations", x.trainingIterations)
             .fallback(kdefaultTrainingIterations),
         f.field("defaultNProbe", x.defaultNProbe)


### PR DESCRIPTION
### Scope & Purpose

Remove duplicated nLists from the vector index definition.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: BTS-2054
- [ ] Design document: 
