### PR TITLE
Let arangorestore vector indexes only after data import [BTS-2058]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Let `arangorestore` restore vector indexes **after** data import. This
+  is necessary, since a vector index can only be created if enough data
+  for learning is available.
+
 * Make `RestImportHandler` asynchronous. This is to avoid some blockages
   observed in the context of BTS-2047.
 

--- a/client-tools/Restore/RestoreFeature.h
+++ b/client-tools/Restore/RestoreFeature.h
@@ -226,7 +226,8 @@ class RestoreFeature final : public ArangoRestoreFeature {
                        bool useVPack);
 
     /// @brief Restore a collection's indexes given its description
-    Result restoreIndexes(arangodb::httpclient::SimpleHttpClient& client);
+    Result restoreIndexes(arangodb::httpclient::SimpleHttpClient& client,
+                          bool doVectorIndexes);
 
     /// @brief Send command to restore a collection's indexes
     Result sendRestoreIndexes(arangodb::httpclient::SimpleHttpClient& client,

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -158,6 +158,7 @@ std::string const StaticStrings::IndexNameEdge("edge");
 std::string const StaticStrings::IndexNameEdgeFrom("edge_from");
 std::string const StaticStrings::IndexNameEdgeTo("edge_to");
 std::string const StaticStrings::IndexNamePrimary("primary");
+std::string const StaticStrings::IndexNameVector("vector");
 
 // index hint strings
 std::string const StaticStrings::IndexHintDisableIndex("disableIndex");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -157,6 +157,7 @@ class StaticStrings {
   static std::string const IndexNameEdgeFrom;
   static std::string const IndexNameEdgeTo;
   static std::string const IndexNamePrimary;
+  static std::string const IndexNameVector;
 
   // index hint strings
   static std::string const IndexHintDisableIndex;


### PR DESCRIPTION
### Scope & Purpose

A vector index needs training data. Therefore, it cannot be created
before data import in arangorestore. We must delay the creation of the
vector index until after data import in arangorestore.

This addresses https://arangodb.atlassian.net/browse/BTS-2058

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: none planned

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2058
