### PR TITLE
Fixes crash in H2CommTask

### DIFF
--- a/arangod/GeneralServer/H2CommTask.cpp
+++ b/arangod/GeneralServer/H2CommTask.cpp
@@ -736,7 +736,7 @@ void H2CommTask<T>::sendResponse(std::unique_ptr<GeneralResponse> res,
   } catch (...) {
     retries = 0;
   }
-  if (--retries == 0) {
+  if (retries == 0) {
     LOG_TOPIC("924dc", WARN, Logger::REQUESTS)
         << "was not able to queue response this=" << (void*)this;
     // we are overloaded close stream


### PR DESCRIPTION
### Scope & Purpose

Fixes a off-by-one which leads to a double delete call.

