### PR TITLE
if we have an infrastructure failure make sure that we still have a meaningfull testfailurse.txt

### DIFF
--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -447,14 +447,24 @@ function iterateTests(cases, options) {
     let status = true;
     let shutdownSuccess = true;
 
-    result = testFuncs[currentTest](localOptions);
-    // grrr...normalize structure
-    delete result.status;
-    delete result.failed;
-    delete result.crashed;
-    if (result.hasOwnProperty('shutdown')) {
-      shutdownSuccess = result['shutdown'];
-      delete result.shutdown;
+    try {
+      result = testFuncs[currentTest](localOptions);
+      // grrr...normalize structure
+      delete result.status;
+      delete result.failed;
+      delete result.crashed;
+      if (result.hasOwnProperty('shutdown')) {
+        shutdownSuccess = result['shutdown'];
+        delete result.shutdown;
+      }
+    } catch (err) {
+      result = {
+        currentTest: {
+          status: false,
+          failed: true,
+          message: `caught exception in testsuite: ${err.message}\n${err.stack}`
+        }};
+      pu.serverCrashed = true;
     }
 
     if (currentTest === "auto") {

--- a/js/client/modules/@arangodb/testutils/testing.js
+++ b/js/client/modules/@arangodb/testutils/testing.js
@@ -459,7 +459,7 @@ function iterateTests(cases, options) {
       }
     } catch (err) {
       result = {
-        currentTest: {
+        [currentTest]: {
           status: false,
           failed: true,
           message: `caught exception in testsuite: ${err.message}\n${err.stack}`


### PR DESCRIPTION
### Scope & Purpose

The `testfailures.txt` will now contain this instead of a json dump of the test attributes:

```
* Test "arangosh"
    [FAILED]  currentTest

      "test" failed: caught exception in testsuite: snatoehusnatoehu
Error: snatoehusnatoehu
    at runTest (/home/willi/src/devel/js/client/modules/@arangodb/testsuites/arangosh.js:108:11)
    at Object.arangosh (/home/willi/src/devel/js/client/modules/@arangodb/testsuites/arangosh.js:184:3)
    at iterateTests (/home/willi/src/devel/js/client/modules/@arangodb/testutils/testing.js:451:38)
    at unitTest (/home/willi/src/devel/js/client/modules/@arangodb/testutils/testing.js:551:12)
    at main (js/client/modules/@arangodb/testutils/unittest.js:102:14)
    at js/client/modules/@arangodb/testutils/unittest.js:156:14
   Suites failed: 1 Tests Failed: 0
Marking crashy!
```
- [x] :hankey: Bugfix
