### PR TITLE
Web interface: Make Try it out button in Swagger UI stand out more

### DIFF
--- a/js/server/assets/swagger/index.css
+++ b/js/server/assets/swagger/index.css
@@ -59,4 +59,10 @@ body {
     font-family: sans-serif;
     font-weight: normal;
 }
+
+.swagger-ui .try-out__btn {
+    background-color: #5b6f3e;
+    border-color: #5b6f3e;
+    color: #fff;
+}
 /* #endregion */


### PR DESCRIPTION
### Scope & Purpose

![image](https://github.com/user-attachments/assets/07d5525d-5e10-46c2-82e4-297d77f5e8f0)

Before:

![image](https://github.com/user-attachments/assets/a2eeae50-c6b8-4f76-ab84-188aa2e17d86)

Uses the ArangoDB dark green but keeps the original style for the Cancel button it changes to.

This is an improvement that has been requested by Tilman.