### PR TITLE
Fix unstable network pool test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Make an unstable test stable again for the NetworkConnectionPool.
+
 * BTS-2074: fix installing Foxx service from zip file upload using the web UI
   with multi-coordinator load balancing.
 

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -327,7 +327,7 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
   std::this_thread::sleep_for(std::chrono::milliseconds(21));
 
   tries = 0;
-  while (++tries < 1'000) {
+  while (++tries < 100) {
     std::cout << "numOpenConnections: " << pool.numOpenConnections()
               << std::endl;
     if (pool.numOpenConnections() == 0) {

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -328,6 +328,7 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
 
   tries = 0;
   while (++tries < 1'000) {
+    std::cout << "numOpenConnections: " << pool.numOpenConnections() << std::endl;
     if (pool.numOpenConnections() == 0) {
       break;
     }

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -328,7 +328,8 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
 
   tries = 0;
   while (++tries < 1'000) {
-    std::cout << "numOpenConnections: " << pool.numOpenConnections() << std::endl;
+    std::cout << "numOpenConnections: " << pool.numOpenConnections()
+              << std::endl;
     if (pool.numOpenConnections() == 0) {
       break;
     }


### PR DESCRIPTION
This tries to fix an unstable test for the NetworkConnectionPool.

First we move away from existing endpoints, since we never know how
long they are going to take to respond.

Secondly, we prolong the timeout and then add further logging in
case things go wrong.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made

