### PR TITLE
Fix flakiness of `aql-index-cache` test

### DIFF
--- a/tests/js/server/aql/aql-index-cache.js
+++ b/tests/js/server/aql/aql-index-cache.js
@@ -205,7 +205,7 @@ function FiguresSuite () {
 function VPackIndexCacheModifySuite (unique) {
   const n = 2000;
 
-  const maxTries = 5;
+  const maxTries = 10;
   
   let setFailurePointForPointLookup = () => {
     if (canUseFailAt) {

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -96,7 +96,7 @@ shell_client_multi priority=1500 cluster suffix=http2 -- --http2 true
 shell_client_multi priority=2500 cluster suffix=vst -- --vst true
 
 # different number of buckets in cluster
-shell_server_aql priority=1000 size=medium+ cluster buckets=4 -- --dumpAgencyOnError true
+shell_server_aql priority=1000 size=medium+ cluster buckets=16 -- --dumpAgencyOnError true
 shell_client priority=500 cluster buckets=5 -- --dumpAgencyOnError true
 shell_client_transaction priority=500 cluster parallelity=5 size=small buckets=5 -- --dumpAgencyOnError true
 shell_server priority=500 size=medium+ cluster buckets=6 -- --dumpAgencyOnError true


### PR DESCRIPTION
### Scope & Purpose

Tries to address the issue of a query having no cache hits after by increasing the maximum number of tries. The CI reported the assertion failure on cache hits, which was 0. The tests in question were:
- `testPointLookupAndUpdate_nonUnique` on CI
- `testPointLookupAndUpdate_unique` on CI
- `testPointLookupAndTruncate_nonUnique` locally

Increasing the number of `maxTries` solves the problem of local execution, but it appears on CI afterward. The assumed issue is that the caching does not happen since, in the test, the system is overwhelmed and does not manage to cache queries, therefore, dropping the bucket's size reduces the flakiness.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
