### PR TITLE
Deactivate cluster overwhelm on agents [BTS-2077]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Disable cluster overwhelm protection on agents. This fixes a bug which happens
+  if the number of dbservers and coordinators grows beyond 4x the number
+  of threads in the agency leader.
+
 * Make an unstable test stable again for the NetworkConnectionPool.
 
 * BTS-2074: fix installing Foxx service from zip file upload using the web UI

--- a/arangod/Scheduler/SchedulerFeature.cpp
+++ b/arangod/Scheduler/SchedulerFeature.cpp
@@ -335,7 +335,8 @@ void SchedulerFeature::prepare() {
       // requests. this is because coordinators are the gatekeepers, and they
       // should perform all the throttling.
       uint64_t ongoingLowPriorityLimit =
-          ServerState::instance()->isDBServer()
+          ServerState::instance()->isDBServer() ||
+                  ServerState::instance()->isAgent()
               ? 0
               : static_cast<uint64_t>(_ongoingLowPriorityMultiplier *
                                       _nrMaximalThreads);


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-2077

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports:
-     - 3.11: https://github.com/arangodb/arangodb/pull/21600

