### PR TITLE
Added missing 'to_string' implementation

### DIFF
--- a/arangod/Aql/AqlCall.cpp
+++ b/arangod/Aql/AqlCall.cpp
@@ -302,3 +302,5 @@ auto aql::operator<<(std::ostream& out, AqlCall const& call) -> std::ostream& {
              << ", fullCount: " << std::boolalpha << call.fullCount
              << ", skipCount: " << call.getSkipCount() << " }";
 }
+
+auto aql::to_string(AqlCall const& call) -> std::string { return call.toString(); }

--- a/arangod/Aql/AqlCall.cpp
+++ b/arangod/Aql/AqlCall.cpp
@@ -303,4 +303,6 @@ auto aql::operator<<(std::ostream& out, AqlCall const& call) -> std::ostream& {
              << ", skipCount: " << call.getSkipCount() << " }";
 }
 
-auto aql::to_string(AqlCall const& call) -> std::string { return call.toString(); }
+auto aql::to_string(AqlCall const& call) -> std::string {
+  return call.toString();
+}


### PR DESCRIPTION
### Scope & Purpose

The definition arangodb::aql::to_string was missing. This resulted in a linker error when compiling in a conda environment.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
