### PR TITLE
Fix flaky vector test

### DIFF
--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -219,7 +219,7 @@ function VectorIndexTestCreationWithVectors() {
             let gen = randomNumberGeneratorFloat(seed);
 
             let docs = [];
-            for (let i = 0; i < 10; ++i) {
+            for (let i = 0; i < 100; ++i) {
                 const vector = Array.from({
                     length: dimension
                 }, () => gen());
@@ -253,7 +253,7 @@ function VectorIndexTestCreationWithVectors() {
             let gen = randomNumberGeneratorFloat(seed);
 
             let docs = [];
-            for (let i = 0; i < 10; ++i) {
+            for (let i = 0; i < 100; ++i) {
                 const vector = Array.from({
                     length: dimension
                 }, () => gen());
@@ -286,7 +286,7 @@ function VectorIndexTestCreationWithVectors() {
             let gen = randomNumberGeneratorFloat(seed);
 
             let docs = [];
-            for (let i = 0; i < 10; ++i) {
+            for (let i = 0; i < 100; ++i) {
                 const vector = Array.from({
                     length: dimension
                 }, () => gen());


### PR DESCRIPTION
### Scope & Purpose

Fixes the flakiness of the test when tested in cluster mode. Since the distribution of documents is not guaranteed, and the documents may end up all in one or two shards, then creating a vector index fails. Found from logs in https://arangodb.atlassian.net/browse/BTS-2085

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2085
- [ ] Design document: 
