### PR TITLE
Fix concurrency bug with lost threads [BTS-2087]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix concurrency bug which can lead to lost threads. See BTS-2087.
+
 * Change default for --rocksdb.periodic-compaction-ttl from 30 days to
   24 hours. Note that certain deleted keys ranges in RocksDB might only be
   compacted away through periodic background compactions. Note that this

--- a/arangod/Aql/SharedQueryState.h
+++ b/arangod/Aql/SharedQueryState.h
@@ -101,10 +101,27 @@ class SharedQueryState final
   /// execute a task in parallel if capacity is there
   template<typename F>
   bool asyncExecuteAndWakeup(F&& cb) {
+    // The atomic _numTasks counts the number of ongoing tasks. When it
+    // drops to 0, we need to wake up a thread which is waiting for this
+    // on the condition variable _cv. We must not miss this event, or
+    // ellse we might have a thread which is waiting forever.
+    // The waiting thread uses a predicate to check if _numTasks is 0,
+    // and only goes to sleep when it is not. This happens under the
+    // mutex _mutex and releasing the mutex and going to sleep is an
+    // atomic operation. Thus, to not miss the event that _numTasks
+    // is reduced to zero, we must, whenever we decrement it, do this
+    // under the mutex, and then, after releasing the mutex, notify the
+    // condition variable _cv! Then either the decrement or the going to
+    // sleep happens first (serialized by the mutex). If the decrement
+    // happens first, the waiting thread is not even going to sleep, if
+    // the going to sleep happens first, then we will wakt it up.
     unsigned num = _numTasks.fetch_add(1);
     if (num + 1 > _maxTasks) {
-      _numTasks.fetch_sub(1);  // revert
       std::forward<F>(cb)(false);
+      std::unique_lock<std::mutex> guard(_mutex);
+      _numTasks.fetch_sub(1);  // revert
+      guard.unlock();
+      _cv.notify_all();
       return false;
     }
     bool queued =
@@ -130,8 +147,11 @@ class SharedQueryState final
         });
 
     if (!queued) {
-      _numTasks.fetch_sub(1);  // revert
       std::forward<F>(cb)(false);
+      std::unique_lock<std::mutex> guard(_mutex);
+      _numTasks.fetch_sub(1);  // revert
+      guard.unlock();
+      _cv.notify_all();
     }
     return queued;
   }
@@ -166,6 +186,11 @@ class SharedQueryState final
   unsigned _callbackVersion;
 
   unsigned _maxTasks;
+  // Note that we are waiting for _numTasks to drop down to zero using
+  // the condition Variable _cv above, which is protected by the mutex
+  // _mutex above. Therefore, to avoid losing wakeups, it is necessary
+  // to only ever reduce the value of _numTasks under the mutex and then
+  // wake up the condition variable _cv!
   std::atomic<unsigned> _numTasks;
   std::atomic<bool> _valid;
 };


### PR DESCRIPTION
### Scope & Purpose

This addresses https://arangodb.atlassian.net/browse/BTS-2087

We found the issue to be an improper use of an atomic counter in
connection with a condition variable. This is in SharedQueryState and
the methods asyncExecuteAndWakeup and invalidate.

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.11: 

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2087
