### PR TITLE
[3.11] Fix concurrency bug with lost threads [BTS-2087]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.14 (XXXX-XX-XX)
 ---------------------
 
+* Fix concurrency bug which can lead to lost threads. See BTS-2087.
+
 * The agency supervision is clearing "finished" jobs too quickly from
   Target/Finished and Failed. They will be forthwith be kept for at least 1h.
 

--- a/arangod/Aql/SharedQueryState.cpp
+++ b/arangod/Aql/SharedQueryState.cpp
@@ -24,6 +24,7 @@
 #include "SharedQueryState.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Logger/LogMacros.h"
 #include "Basics/Exceptions.h"
 #include "Basics/ScopeGuard.h"
 #include "Cluster/ServerState.h"
@@ -61,8 +62,16 @@ void SharedQueryState::invalidate() {
   _cv.notify_all();  // wakeup everyone else
 
   if (_numTasks.load() > 0) {
-    std::unique_lock<std::mutex> guard(_mutex);
-    _cv.wait(guard, [&] { return _numTasks.load() == 0; });
+    while (true) {
+      std::unique_lock<std::mutex> guard(_mutex);
+      _cv.wait_for(guard, std::chrono::milliseconds(1000),
+                   [&] { return _numTasks.load() == 0; });
+      if (_numTasks.load() == 0) {
+        break;
+      }
+      LOG_TOPIC("abcee", DEBUG, Logger::QUERIES)
+          << "Waiting for " << _numTasks.load() << " tasks to finish";
+    }
   }
 }
 

--- a/arangod/Aql/SharedQueryState.h
+++ b/arangod/Aql/SharedQueryState.h
@@ -113,9 +113,33 @@ class SharedQueryState final
   /// execute a task in parallel if capacity is there
   template<typename F>
   bool asyncExecuteAndWakeup(F&& cb) {
+    // The atomic _numTasks counts the number of ongoing tasks asynchronous
+    // tasks. We need this such that we can wait for them to finish when
+    // the query is shut down. Note that this is *not* necessary for
+    // synchronous tasks.
+    // When _numTasks drops to 0, we need to wake up a thread which
+    // is waiting for this on the condition variable _cv. We must
+    // not miss this event, or else we might have a thread which is
+    // waiting forever. The waiting thread uses a predicate to check
+    // if _numTasks is 0, and only goes to sleep when it is not. This
+    // happens under the mutex _mutex and releasing the mutex and going
+    // to sleep is an atomic operation. Thus, to not miss the event that
+    // _numTasks is reduced to zero, we must, whenever we decrement it,
+    // do this under the mutex, and then, after releasing the mutex,
+    // notify the condition variable _cv! Then either the decrement or
+    // the going to sleep happens first (serialized by the mutex). If
+    // the decrement happens first, the waiting thread is not even going
+    // to sleep, if the going to sleep happens first, then we will wakt
+    // it up.
     unsigned num = _numTasks.fetch_add(1);
     if (num + 1 > _maxTasks) {
+      // We first count down _numTasks to revert the counting up, since
+      // we have not - after all - started a new async task. Then we run
+      // the callback synchronously.
+      std::unique_lock<std::mutex> guard(_mutex);
       _numTasks.fetch_sub(1);  // revert
+      guard.unlock();
+      _cv.notify_all();
       std::forward<F>(cb)(false);
       return false;
     }
@@ -142,7 +166,13 @@ class SharedQueryState final
         });
 
     if (!queued) {
+      // We first count down _numTasks to revert the counting up, since
+      // we have not - after all - started a new async task. Then we run
+      // the callback synchronously.
+      std::unique_lock<std::mutex> guard(_mutex);
       _numTasks.fetch_sub(1);  // revert
+      guard.unlock();
+      _cv.notify_all();
       std::forward<F>(cb)(false);
     }
     return queued;
@@ -172,6 +202,11 @@ class SharedQueryState final
   unsigned _cbVersion;   // increased once callstack is done
 
   unsigned _maxTasks;
+  // Note that we are waiting for _numTasks to drop down to zero using
+  // the condition Variable _cv above, which is protected by the mutex
+  // _mutex above. Therefore, to avoid losing wakeups, it is necessary
+  // to only ever reduce the value of _numTasks under the mutex and then
+  // wake up the condition variable _cv!
   std::atomic<unsigned> _numTasks;
   std::atomic<bool> _valid;
 };


### PR DESCRIPTION
### Scope & Purpose

*This addresses https://arangodb.atlassian.net/browse/BTS-2087*

We found the issue to be an improper use of an atomic counter in
connection with a condition variable. This is in SharedQueryState and
the methods asyncExecuteAndWakeup and invalidate.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
