### PR TITLE
Fix index api shortly after successful creation [BTS-2044]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 v3.11.14 (XXXX-XX-XX)
 ---------------------
 
+* Fix a bug in the index API /_api/index?withHidden=true, which can lead to
+  two problems: (1) A newly created index is potentially not shown in the very
+  moment when it is finished. (2) A newly created index is shown twice in
+  the result, once with `isBuilding: true` and once without.
+  This fixes BTS-2044.
+
 * Fix concurrency bug which can lead to lost threads. See BTS-2087.
 
 * The agency supervision is clearing "finished" jobs too quickly from

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -277,8 +277,7 @@ RestStatus RestIndexHandler::getIndexes() {
           tmp.add(pi);
 
           // note this index as already covered
-          auto pos = iid.find('/');
-          if (pos != std::string::npos) {
+          if (auto pos = iid.find('/'); pos != std::string::npos) {
             iid = iid.substr(pos + 1);
           }
           covered.emplace(iid);

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -313,7 +313,7 @@ RestStatus RestIndexHandler::getIndexes() {
             if (source.key.stringView() == StaticStrings::IndexId) {
               tmp.add(StaticStrings::IndexId,
                       VPackValue(
-                          absl::StrCat(cName, "/", source.key.stringView())));
+                          absl::StrCat(cName, "/", source.value.stringView())));
             } else {
               tmp.add(source.key.stringView(), source.value);
             }

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -248,7 +248,7 @@ RestStatus RestIndexHandler::getIndexes() {
             .wait();
       } else {
         LOG_TOPIC("12536", WARN, Logger::CLUSTER)
-            << "Expected numberin /arango/Plan/Version, instead found: "
+            << "Expected number in /arango/Plan/Version, instead found: "
             << planVersion->slice().toJson();
       }
 


### PR DESCRIPTION
This is a backport, original PR: https://github.com/arangodb/arangodb/pull/21646

When used with the `withHidden=true` option, it can happen that
a newly created index is not shown at all or it is shown twice,
once with `isBuilding:true` and once without. Both only happen
directly after successful index creation.

The reason is that two sources are combined in the API implementation:
the agency which does show indexes currently being built and the
LogicalCollection object which is local on the coordinator.

See source code comments in the patch for details.

This has made some tests unstable.

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: this is it

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2044

