### PR TITLE
Fixes a bug with unintentional double-log-line spam.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* BTS-2090: Fixes double log-lines per log
+
 * Fix vector index comparison in maintenance, which causes loop with agency and
   dbservers.
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -713,16 +713,25 @@ void LoggerFeature::prepare() {
   Logger::setLogRequestParameters(_logRequestParameters);
   Logger::setUseJson(_useJson);
 
+  bool shouldLogToStd = false;
   for (auto const& definition : _output) {
     if (_supervisor && definition.starts_with("file://")) {
       Logger::addAppender(Logger::defaultLogGroup(),
                           definition + ".supervisor");
     } else {
       Logger::addAppender(Logger::defaultLogGroup(), definition);
+      if (shouldLogToStd == false) {
+        shouldLogToStd = definition == "+" || definition == "-";
+      }
     }
   }
 
-  if (_foregroundTty) {
+  // if the user defines `--log.output=+`(stderr) explicitly in an environment with a terminal
+  // this code will add also an appender to stdout, leading to 2 logline per log
+  // this will ensure that its only logging once to std(err/out).
+  // If the double log line is still desired it is still possible to do it via chain arguments:
+  // `--log.output=+ --log.output=-`
+  if (_foregroundTty && !shouldLogToStd) {
     Logger::addAppender(Logger::defaultLogGroup(), "-");
   }
 

--- a/lib/Logger/LoggerFeature.cpp
+++ b/lib/Logger/LoggerFeature.cpp
@@ -726,10 +726,11 @@ void LoggerFeature::prepare() {
     }
   }
 
-  // if the user defines `--log.output=+`(stderr) explicitly in an environment with a terminal
-  // this code will add also an appender to stdout, leading to 2 logline per log
-  // this will ensure that its only logging once to std(err/out).
-  // If the double log line is still desired it is still possible to do it via chain arguments:
+  // if the user defines `--log.output=+`(stderr) explicitly in an environment
+  // with a terminal this code will add also an appender to stdout, leading to 2
+  // logline per log this will ensure that its only logging once to
+  // std(err/out). If the double log line is still desired it is still possible
+  // to do it via chain arguments:
   // `--log.output=+ --log.output=-`
   if (_foregroundTty && !shouldLogToStd) {
     Logger::addAppender(Logger::defaultLogGroup(), "-");


### PR DESCRIPTION
### Scope & Purpose

Double log lines with --log.output=+. Due to a small regression/behaviour with 3.12.2: if you had `--log.output=+` in a tty environment it would lead to double log-lines per log. One to stdout and one to stderr. This PR will remove this automatic stdout output if the stderr is already defined by the user.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification
