### PR TITLE
if we don't waitpid, we leave zombies. Don't do that.

### DIFF
--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -494,6 +494,8 @@ exports.runParallelArangoshTests = function (tests, duration, cn) {
           if (status === 'RUNNING') {
             debug(`forcefully killing test client with pid ${client.pid}`);
             internal.killExternal(client.pid, 9 /*SIGKILL*/);
+            let status = internal.statusExternal(client.pid).status;
+            debug(`killed test client with pid ${client.pid}: ${status}`);            
           }
         } catch (err) { }
       }


### PR DESCRIPTION
### Scope & Purpose

As can be observed in client-tools.js we need to waitpid after killing, else zombies will occur:
https://github.com/arangodb/arangodb/blob/devel/js/client/modules/%40arangodb/testutils/client-tools.js#L522

- [x] :hankey: Bugfix
- [x] backport https://github.com/arangodb/arangodb/pull/21667