### PR TITLE
Fix priority inversion in Maintenance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 v3.11.14 (XXXX-XX-XX)
 ---------------------
 
+* Fix BTS-2100: Due to a priority inversion it was possible that a lot of
+  scheduled SynchronizeShard actions blocked higher priority 
+  TakeoverShardLeadership actions in the cluster Maintenance. This
+  could lead to service interruption during upgrades and after failovers.
+
 * Fix a bug in the index API /_api/index?withHidden=true, which can lead to
   two problems: (1) A newly created index is potentially not shown in the very
   moment when it is finished. (2) A newly created index is shown twice in

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -2271,6 +2271,23 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
             << " current servers = " << cservers.toJson()
             << " local theLeader = " << theLeader.toJson();
 
+        if (!feature.increaseNumberOfSyncShardActionsQueued()) {
+          // Need to revisit this database on next run:
+          makeDirty.emplace(dbname);
+          LOG_TOPIC("25342", DEBUG, Logger::MAINTENANCE)
+              << "Not scheduling necessary SynchronizeShard actions because "
+                 "too many are already in flight.";
+          continue;
+        }
+
+        // From here on, we must be very careful, if we do not manage to
+        // schedule the action below, we must decrease the number of sync shard
+        // actions queued again! Otherwise we lose counter values and
+        // eventually, we no longer schedule SynchronizeShard actions at all!
+        ScopeGuard scopeGuard([&feature]() noexcept {
+          feature.decreaseNumberOfSyncShardActionsQueued();
+        });
+
         std::string leader = pservers[0].copyString();
         std::string forcedResync =
             needsResyncBecauseOfRestart ? "true" : "false";
@@ -2295,7 +2312,11 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
         TRI_ASSERT(ok);
         try {
           Result res = feature.addAction(description, false);
-          if (res.fail()) {
+          if (res.ok()) {
+            scopeGuard.cancel();  // Here we can be sure that the action is
+                                  // queued and will eventually be executed,
+                                  // then we decrease the counter again!
+          } else {
             feature.unlockShard(shardName);
           }
         } catch (std::exception const& exc) {

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -194,6 +194,19 @@ void MaintenanceFeature::collectOptions(
           arangodb::options::Flags::Dynamic));
 
   options
+      ->addOption(
+          "--server.maximal-number-sync-shard-actions",
+          "The maximum number of SynchronizeShard actions which may be queued "
+          "at any given time.",
+          new UInt64Parameter(&_maximalNumberOfSyncShardActionsQueued, 1, 1,
+                              std::numeric_limits<uint64_t>::max()),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnDBServer,
+              arangodb::options::Flags::Uncommon))
+      .setIntroducedIn(31205);
+
+  options
       ->addOption("--server.maintenance-slow-threads",
                   "The maximum number of threads available for slow "
                   "maintenance actions (long SynchronizeShard and long "
@@ -1305,6 +1318,9 @@ Result MaintenanceFeature::requeueAction(
     std::shared_ptr<maintenance::Action>& action, int newPriority) {
   TRI_ASSERT(action->getState() == ActionState::COMPLETE ||
              action->getState() == ActionState::FAILED);
+  if (action->describe().get(NAME) == SYNCHRONIZE_SHARD) {
+    increaseNumberOfSyncShardActionsQueued();
+  }
   auto newAction =
       std::make_shared<maintenance::Action>(*this, action->describe());
   newAction->setPriority(newPriority);

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -26,10 +26,8 @@
 
 #include "Basics/Common.h"
 #include "Basics/ConditionVariable.h"
-#include "Basics/ReadWriteLock.h"
 #include "Basics/Result.h"
 #include "Cluster/Action.h"
-#include "Cluster/ClusterTypes.h"
 #include "Cluster/MaintenanceWorker.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "RestServer/arangod.h"
@@ -170,6 +168,22 @@ class MaintenanceFeature : public ArangodFeature {
 
   /// @brief Get shard locks, this copies the whole map of shard locks.
   ShardActionMap getShardLocks() const;
+
+  /// @brief Count a SynchronizeShard actions in flight, returns `false`
+  /// if there are two many already, in which case the number is not
+  /// increased.
+  bool increaseNumberOfSyncShardActionsQueued() noexcept {
+    uint64_t n = _numberOfSyncShardActionsQueued.fetch_add(1);
+    if (n + 1 > _maximalNumberOfSyncShardActionsQueued) {
+      _numberOfSyncShardActionsQueued.fetch_sub(1);
+      return false;
+    }
+    return true;
+  }
+
+  void decreaseNumberOfSyncShardActionsQueued() noexcept {
+    _numberOfSyncShardActionsQueued.fetch_sub(1);
+  }
 
   /// @brief check if a database is dirty
   bool isDirty(std::string const& dbName) const;
@@ -587,6 +601,17 @@ class MaintenanceFeature : public ArangodFeature {
 
   std::vector<std::string> _databasesToCheck;
   size_t _lastNumberOfDatabases;
+
+  // Here we count how many SynchronizeShard actions are either queued
+  // or currently executing. We use this number to avoid scheduling too
+  // many of them, since each one of then holds the shard lock and prevents
+  // other - potentially higher priority actions - from being scheduled.
+  // This is in particular important for TakeoverShardLeadership actions,
+  // which can become necessary when a dbserver should be come a leader but
+  // still has a SynchronizeShard action queued from its previous life as
+  // a shard follower for the shard.
+  std::atomic<uint64_t> _numberOfSyncShardActionsQueued = 0;
+  uint64_t _maximalNumberOfSyncShardActionsQueued = 32;
 
  public:
   metrics::Histogram<metrics::LogScale<uint64_t>>* _phase1_runtime_msec =

--- a/arangod/Cluster/SynchronizeShard.cpp
+++ b/arangod/Cluster/SynchronizeShard.cpp
@@ -25,7 +25,6 @@
 #include "SynchronizeShard.h"
 
 #include "Agency/AgencyStrings.h"
-#include "ApplicationFeatures/ApplicationServer.h"
 #include "Auth/TokenCache.h"
 #include "Basics/GlobalSerialization.h"
 #include "Basics/ScopeGuard.h"
@@ -45,7 +44,6 @@
 #include "Cluster/ReplicationTimeoutFeature.h"
 #include "Cluster/ServerState.h"
 #include "GeneralServer/AuthenticationFeature.h"
-#include "Logger/LogMacros.h"
 #include "Metrics/Counter.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
@@ -58,7 +56,6 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/ServerIdFeature.h"
 #include "RocksDBEngine/RocksDBCollection.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/StandaloneContext.h"
@@ -725,7 +722,17 @@ static arangodb::ResultT<SyncerId> replicationSynchronize(
 }
 
 bool SynchronizeShard::first() {
-  TRI_IF_FAILURE("SynchronizeShard::disable") { return false; }
+  // Note that this can be called multiple times during the existence of the
+  // object. This happens when requeues happen. To keep the counter of queued
+  // actions correct, we decrement only once in the lifetime of this object.
+  std::call_once(_decrementOnce, [this]() {
+    feature().decreaseNumberOfSyncShardActionsQueued();
+  });
+
+  TRI_IF_FAILURE("SynchronizeShard::disable") {
+    result(TRI_ERROR_FAILED);
+    return false;
+  }
   TRI_IF_FAILURE("SynchronizeShard::delay") {
     // Increase the race timeout before we try to get back into sync as a
     // follower

--- a/arangod/Cluster/SynchronizeShard.h
+++ b/arangod/Cluster/SynchronizeShard.h
@@ -109,6 +109,9 @@ class SynchronizeShard : public ActionBase, public ShardDefinition {
 
   /// @brief end time (timestamp in seconds)
   std::chrono::time_point<std::chrono::steady_clock> _endTimeForAttempt;
+
+  /// @brief Used to decrement count exactly once:
+  std::once_flag _decrementOnce;
 };
 
 }  // namespace maintenance


### PR DESCRIPTION
This addresses https://arangodb.atlassian.net/browse/BTS-2100 :

This is a backport of https://github.com/arangodb/arangodb/pull/21664

If a SynchronizeShard action is scheduled for a shard in the Maintenance of a DBServer, then no other action can be discovered because of a shard lock. This means in particular, that no TakeoverShardLeadership action can be scheduled (and executed). This means that if a DBServer A is restarted, it schedules SynchronizeShard actions for all its shards and if then leadership is transferred back to A, it is possible that it does not take over leadership because of these locks. This can lead to unavailability, in particular since it can block threads of Coordinators in getResponsibleServer.

This is in particular bad in connection with the returnLeadership feature, which during a rolling upgrade moves shard  leadership automatically back to a restarted DBServer.

- **Implement limitation on how many SynchronizeShard jobs to queue.**
- **Make database dirty.**
- **Fix limits for command line option.**
- **First count down and then fail because of failure point.**

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix
- [*] :fire: Performance improvement

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [x] **resilience tests**
- [x] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2100
- [*] Jira ticket: https://arangodb.atlassian.net/browse/OASIS-26201
- [*] Design document: https://github.com/arangodb/documents/blob/master/DesignDocuments/01_IDEAS/overscheduling.md
- [*] Original PR: https://github.com/arangodb/arangodb/pull/21664

