### PR TITLE
Make RestCollectionHandler and RestIndexHandler async

### DIFF
--- a/arangod/RestHandler/RestCollectionHandler.h
+++ b/arangod/RestHandler/RestCollectionHandler.h
@@ -28,36 +28,37 @@
 #include "VocBase/Methods/Collections.h"
 
 namespace arangodb {
+template<typename>
+struct async;
 
 class LogicalCollection;
 
-class RestCollectionHandler : public arangodb::RestVocbaseBaseHandler {
+class RestCollectionHandler : public RestVocbaseBaseHandler {
  public:
   RestCollectionHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
-  char const* name() const override final { return "RestCollectionHandler"; }
-  RequestLane lane() const override final;
+  char const* name() const final { return "RestCollectionHandler"; }
+  RequestLane lane() const final;
 
-  RestStatus execute() override final;
-  void shutdownExecute(bool isFinalized) noexcept override final;
+  futures::Future<futures::Unit> executeAsync() final;
+  void shutdownExecute(bool isFinalized) noexcept final;
 
  protected:
   enum class FiguresType { None = 0, Standard = 1, Detailed = 2 };
 
   enum class CountType { None = 0, Standard = 1, Detailed = 2 };
 
-  void collectionRepresentation(std::string const& name, bool showProperties,
-                                FiguresType showFigures, CountType showCount);
+  async<void> collectionRepresentation(std::string const& name,
+                                       bool showProperties,
+                                       FiguresType showFigures,
+                                       CountType showCount);
 
-  void collectionRepresentation(std::shared_ptr<LogicalCollection> coll,
-                                bool showProperties, FiguresType showFigures,
-                                CountType showCount);
+  async<void> collectionRepresentation(std::shared_ptr<LogicalCollection> coll,
+                                       bool showProperties,
+                                       FiguresType showFigures,
+                                       CountType showCount);
 
-  void collectionRepresentation(methods::Collections::Context& ctxt,
-                                bool showProperties, FiguresType showFigures,
-                                CountType showCount);
-
-  futures::Future<futures::Unit> collectionRepresentationAsync(
+  futures::Future<futures::Unit> collectionRepresentation(
       methods::Collections::Context& ctxt, bool showProperties,
       FiguresType showFigures, CountType showCount);
 
@@ -66,13 +67,13 @@ class RestCollectionHandler : public arangodb::RestVocbaseBaseHandler {
       velocypack::Builder& builder) = 0;
 
  private:
-  RestStatus standardResponse();
+  void standardResponse();
   futures::Future<futures::Unit> initializeTransaction(LogicalCollection&);
 
-  futures::Future<RestStatus> handleCommandGet();
-  void handleCommandPost();
-  futures::Future<RestStatus> handleCommandPut();
-  void handleCommandDelete();
+  async<void> handleCommandGet();
+  async<void> handleCommandPost();
+  async<void> handleCommandPut();
+  async<void> handleCommandDelete();
 
   VPackBuilder _builder;
   std::unique_ptr<transaction::Methods> _activeTrx;

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -24,6 +24,7 @@
 #include "RestIndexHandler.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Async/async.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
@@ -34,15 +35,12 @@
 #include "Network/NetworkFeature.h"
 #include "RestServer/VocbaseContext.h"
 #include "Scheduler/Scheduler.h"
-#include "Scheduler/SchedulerFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/Methods.h"
 #include "Transaction/OperationOrigin.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/Events.h"
-#include "Utils/ExecContext.h"
 #include "Utils/SingleCollectionTransaction.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Indexes.h"
@@ -63,83 +61,36 @@ RestIndexHandler::RestIndexHandler(ArangodServer& server,
                                    GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response) {}
 
-RestIndexHandler::~RestIndexHandler() {
-  std::unique_lock<std::mutex> locker(_mutex);
-  shutdownBackgroundThread();
-}
-
-RestStatus RestIndexHandler::execute() {
+futures::Future<futures::Unit> RestIndexHandler::executeAsync() {
   // extract the request type
   rest::RequestType const type = _request->requestType();
   if (type == rest::RequestType::GET) {
     if (_request->suffixes().size() == 1 &&
         _request->suffixes()[0] == "selectivity") {
-      return waitForFuture(getSelectivityEstimates());
+      co_await getSelectivityEstimates();
+      co_return;
     }
-    return getIndexes();
-  } else if (type == rest::RequestType::POST) {
+    co_await getIndexes();
+    co_return;
+  }
+  if (type == rest::RequestType::POST) {
     if (_request->suffixes().size() == 1 &&
         _request->suffixes()[0] == "sync-caches") {
       // this is an unofficial API to sync the in-memory
       // index caches with the data queued in the index
       // refill background thread. it is not supposed to
       // be used publicly.
-      return syncCaches();
+      co_return syncCaches();
     }
-    return createIndex();
-  } else if (type == rest::RequestType::DELETE_REQ) {
-    return dropIndex();
-  } else {
-    generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
-                  TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_await createIndex();
+    co_return;
   }
-}
-
-RestStatus RestIndexHandler::continueExecute() {
-  TRI_ASSERT(_request->requestType() == rest::RequestType::POST);
-
-  std::unique_lock<std::mutex> locker(_mutex);
-
-  shutdownBackgroundThread();
-
-  if (_createInBackgroundData.result.ok()) {
-    TRI_ASSERT(_createInBackgroundData.response.slice().isObject());
-
-    VPackSlice created =
-        _createInBackgroundData.response.slice().get("isNewlyCreated");
-    auto r = created.isBool() && created.getBool() ? rest::ResponseCode::CREATED
-                                                   : rest::ResponseCode::OK;
-
-    generateResult(r, _createInBackgroundData.response.slice());
-  } else {
-    if (_createInBackgroundData.result.is(TRI_ERROR_FORBIDDEN) ||
-        _createInBackgroundData.result.is(TRI_ERROR_ARANGO_INDEX_NOT_FOUND)) {
-      generateError(_createInBackgroundData.result);
-    } else {  // http_server compatibility
-      generateError(rest::ResponseCode::BAD,
-                    _createInBackgroundData.result.errorNumber(),
-                    _createInBackgroundData.result.errorMessage());
-    }
+  if (type == rest::RequestType::DELETE_REQ) {
+    co_await dropIndex();
+    co_return;
   }
-
-  return RestStatus::DONE;
-}
-
-void RestIndexHandler::shutdownExecute(bool isFinalized) noexcept {
-  auto sg = arangodb::scopeGuard(
-      [&]() noexcept { RestVocbaseBaseHandler::shutdownExecute(isFinalized); });
-  if (isFinalized && _request->requestType() == rest::RequestType::POST) {
-    std::unique_lock<std::mutex> locker(_mutex);
-    shutdownBackgroundThread();
-  }
-}
-
-void RestIndexHandler::shutdownBackgroundThread() {
-  if (_createInBackgroundData.thread != nullptr) {
-    _createInBackgroundData.thread->join();
-    _createInBackgroundData.thread.reset();
-  }
+  generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
+                TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
 }
 
 std::shared_ptr<LogicalCollection> RestIndexHandler::collection(
@@ -150,11 +101,9 @@ std::shared_ptr<LogicalCollection> RestIndexHandler::collection(
           .getFeature<ClusterFeature>()
           .clusterInfo()
           .getCollectionNT(_vocbase.name(), cName);
-    } else {
-      return _vocbase.lookupCollection(cName);
     }
+    return _vocbase.lookupCollection(cName);
   }
-
   return nullptr;
 }
 
@@ -162,7 +111,7 @@ std::shared_ptr<LogicalCollection> RestIndexHandler::collection(
 // / @brief get index infos
 // //////////////////////////////////////////////////////////////////////////////
 
-RestStatus RestIndexHandler::getIndexes() {
+async<void> RestIndexHandler::getIndexes() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
   if (suffixes.empty()) {
     // .............................................................................
@@ -175,7 +124,7 @@ RestStatus RestIndexHandler::getIndexes() {
     if (coll == nullptr) {
       generateError(rest::ResponseCode::NOT_FOUND,
                     TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
-      return RestStatus::DONE;
+      co_return;
     }
 
     auto flags = Index::makeFlags(Index::Serialize::Estimates);
@@ -195,12 +144,12 @@ RestStatus RestIndexHandler::getIndexes() {
     if (!ServerState::instance()->isCoordinator() || !withHidden) {
       // simple case: no in-progress indexes to return
       VPackBuilder indexes;
-      Result res = methods::Indexes::getAll(*coll, flags, withHidden, indexes)
-                       .waitAndGet();
+      Result res =
+          co_await methods::Indexes::getAll(*coll, flags, withHidden, indexes);
       if (!res.ok()) {
         generateError(rest::ResponseCode::BAD, res.errorNumber(),
                       res.errorMessage());
-        return RestStatus::DONE;
+        co_return;
       }
 
       TRI_ASSERT(indexes.slice().isArray());
@@ -224,27 +173,26 @@ RestStatus RestIndexHandler::getIndexes() {
       // we need to wait for the latest commit index here, because otherwise
       // we may not see all indexes that were declared ready by the
       // supervision.
-      ac.waitForLatestCommitIndex().waitAndGet();
+      co_await ac.waitForLatestCommitIndex();
 
       auto [plannedIndexes, idx] = ac.get(ap);
 
       // Let's wait until the ClusterInfo has processed at least this
       // Raft index. This means that if an index is no longer `isBuilding`
       // in the agency Plan, then ClusterInfo should know it.
-      _vocbase.server()
+      co_await _vocbase.server()
           .getFeature<ClusterFeature>()
           .clusterInfo()
-          .waitForPlan(idx)
-          .wait();
+          .waitForPlan(idx);
 
       // now fetch list of ready indexes
       VPackBuilder indexes;
-      Result res = methods::Indexes::getAll(*coll, flags, withHidden, indexes)
-                       .waitAndGet();
+      Result res =
+          co_await methods::Indexes::getAll(*coll, flags, withHidden, indexes);
       if (!res.ok()) {
         generateError(rest::ResponseCode::BAD, res.errorNumber(),
                       res.errorMessage());
-        return RestStatus::DONE;
+        co_return;
       }
 
       TRI_ASSERT(indexes.slice().isArray());
@@ -427,7 +375,7 @@ RestStatus RestIndexHandler::getIndexes() {
     if (coll == nullptr) {
       generateError(rest::ResponseCode::NOT_FOUND,
                     TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
-      return RestStatus::DONE;
+      co_return;
     }
 
     std::string const& iid = suffixes[1];
@@ -436,7 +384,7 @@ RestStatus RestIndexHandler::getIndexes() {
 
     VPackBuilder output;
     Result res =
-        methods::Indexes::getIndex(*coll, tmp.slice(), output).waitAndGet();
+        co_await methods::Indexes::getIndex(*coll, tmp.slice(), output);
     if (res.ok()) {
       VPackBuilder b;
       b.openObject();
@@ -452,7 +400,6 @@ RestStatus RestIndexHandler::getIndexes() {
   } else {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER);
   }
-  return RestStatus::DONE;
 }
 
 futures::Future<futures::Unit> RestIndexHandler::getSelectivityEstimates() {
@@ -493,7 +440,7 @@ futures::Future<futures::Unit> RestIndexHandler::getSelectivityEstimates() {
 
   TRI_ASSERT(trx != nullptr);
 
-  Result res = trx->begin();
+  Result res = co_await trx->beginAsync();
   if (res.fail()) {
     generateError(res);
     co_return;
@@ -509,7 +456,7 @@ futures::Future<futures::Unit> RestIndexHandler::getSelectivityEstimates() {
   builder.add(StaticStrings::Code,
               VPackValue(static_cast<int>(rest::ResponseCode::OK)));
   builder.add("indexes", VPackValue(VPackValueType::Object));
-  for (std::shared_ptr<Index> idx : idxs) {
+  for (auto const& idx : idxs) {
     if (idx->inProgress() || idx->isHidden()) {
       continue;
     }
@@ -523,15 +470,14 @@ futures::Future<futures::Unit> RestIndexHandler::getSelectivityEstimates() {
   builder.close();
 
   generateResult(rest::ResponseCode::OK, std::move(buffer));
-  co_return;
 }
 
-RestStatus RestIndexHandler::createIndex() {
+async<void> RestIndexHandler::createIndex() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
   bool parseSuccess = false;
   VPackSlice body = this->parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
   if (!suffixes.empty()) {
     events::CreateIndexEnd(_vocbase.name(), "(unknown)", body,
@@ -539,7 +485,7 @@ RestStatus RestIndexHandler::createIndex() {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   absl::StrCat("expecting POST ", _request->requestPath(),
                                "?collection=<collection-name>"));
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool found = false;
@@ -549,7 +495,7 @@ RestStatus RestIndexHandler::createIndex() {
                            TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
     generateError(rest::ResponseCode::NOT_FOUND,
                   TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto coll = collection(cName);
@@ -558,7 +504,7 @@ RestStatus RestIndexHandler::createIndex() {
                            TRI_ERROR_ARANGO_INDEX_NOT_FOUND);
     generateError(rest::ResponseCode::NOT_FOUND,
                   TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
-    return RestStatus::DONE;
+    co_return;
   }
 
   VPackBuilder copy;
@@ -573,70 +519,52 @@ RestStatus RestIndexHandler::createIndex() {
   VPackBuilder indexInfo;
   indexInfo.add(body);
 
-  auto execContext = VocbaseContext::create(*_request, _vocbase);
-  // this is necessary, because the execContext will release the vocbase in its
-  // dtor
-  if (!_vocbase.use()) {
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
+  Result result;
+  try {
+    arangodb::velocypack::Builder response;
+    result = co_await methods::Indexes::ensureIndex(*coll, indexInfo.slice(),
+                                                    true, response);
+
+    if (result.ok()) {
+      TRI_ASSERT(response.slice().isObject());
+      VPackSlice const created = response.slice().get("isNewlyCreated");
+      auto const resCode = created.isBool() && created.getBool()
+                               ? rest::ResponseCode::CREATED
+                               : rest::ResponseCode::OK;
+
+      VPackBuilder b;
+      b.openObject();
+      b.add(StaticStrings::Error, VPackValue(false));
+      b.add(StaticStrings::Code, VPackValue(static_cast<int>(resCode)));
+      b.close();
+      response = VPackCollection::merge(response.slice(), b.slice(), false);
+      generateResult(resCode, response.slice());
+      co_return;
+    }
+  } catch (basics::Exception const& ex) {
+    result = Result(ex.code(), ex.message());
+  } catch (std::exception const& ex) {
+    result = Result(TRI_ERROR_INTERNAL, ex.what());
   }
 
-  std::unique_lock<std::mutex> locker(_mutex);
-
-  // the following callback is executed in a background thread
-  auto cb = [this, self = shared_from_this(),
-             execContext = std::move(execContext), collection = std::move(coll),
-             body = std::move(indexInfo)] {
-    ExecContextScope scope(std::move(execContext));
-    {
-      std::unique_lock<std::mutex> locker(_mutex);
-
-      try {
-        _createInBackgroundData.result =
-            methods::Indexes::ensureIndex(*collection, body.slice(), true,
-                                          _createInBackgroundData.response)
-                .waitAndGet();
-
-        if (_createInBackgroundData.result.ok()) {
-          VPackSlice created =
-              _createInBackgroundData.response.slice().get("isNewlyCreated");
-          auto r = created.isBool() && created.getBool()
-                       ? rest::ResponseCode::CREATED
-                       : rest::ResponseCode::OK;
-
-          VPackBuilder b;
-          b.openObject();
-          b.add(StaticStrings::Error, VPackValue(false));
-          b.add(StaticStrings::Code, VPackValue(static_cast<int>(r)));
-          b.close();
-          _createInBackgroundData.response = VPackCollection::merge(
-              _createInBackgroundData.response.slice(), b.slice(), false);
-        }
-      } catch (basics::Exception const& ex) {
-        _createInBackgroundData.result = Result(ex.code(), ex.message());
-      } catch (std::exception const& ex) {
-        _createInBackgroundData.result = Result(TRI_ERROR_INTERNAL, ex.what());
-      }
-    }
-
-    // notify REST handler
-    SchedulerFeature::SCHEDULER->queue(RequestLane::INTERNAL_LOW,
-                                       [self]() { self->wakeupHandler(); });
-  };
-
-  // start background thread
-  _createInBackgroundData.thread = std::make_unique<std::thread>(std::move(cb));
-
-  return RestStatus::WAITING;
+  if (result.is(TRI_ERROR_FORBIDDEN) ||
+      result.is(TRI_ERROR_ARANGO_INDEX_NOT_FOUND)) {
+    generateError(result);
+  } else {
+    // http_server compatibility
+    generateError(rest::ResponseCode::BAD, result.errorNumber(),
+                  result.errorMessage());
+  }
 }
 
-RestStatus RestIndexHandler::dropIndex() {
+async<void> RestIndexHandler::dropIndex() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
   if (suffixes.size() != 2) {
     events::DropIndex(_vocbase.name(), "(unknown)", "(unknown)",
                       TRI_ERROR_HTTP_BAD_PARAMETER);
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting DELETE /<collection-name>/<index-identifier>");
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::string const& cName = suffixes[0];
@@ -646,7 +574,7 @@ RestStatus RestIndexHandler::dropIndex() {
                       TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
     generateError(rest::ResponseCode::NOT_FOUND,
                   TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::string const& iid = suffixes[1];
@@ -658,7 +586,7 @@ RestStatus RestIndexHandler::dropIndex() {
         VPackValue(absl::StrCat(cName, TRI_INDEX_HANDLE_SEPARATOR_STR, iid)));
   }
 
-  Result res = methods::Indexes::drop(*coll, idBuilder.slice()).waitAndGet();
+  Result res = co_await methods::Indexes::drop(*coll, idBuilder.slice());
   if (res.ok()) {
     VPackBuilder b;
     b.openObject();
@@ -670,13 +598,11 @@ RestStatus RestIndexHandler::dropIndex() {
   } else {
     generateError(res);
   }
-  return RestStatus::DONE;
 }
 
-RestStatus RestIndexHandler::syncCaches() {
+void RestIndexHandler::syncCaches() {
   StorageEngine& engine = _vocbase.engine();
   engine.syncIndexCaches();
 
   generateResult(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
-  return RestStatus::DONE;
 }

--- a/arangod/RestHandler/RestIndexHandler.h
+++ b/arangod/RestHandler/RestIndexHandler.h
@@ -35,38 +35,24 @@
 
 namespace arangodb {
 class LogicalCollection;
+template<typename>
+struct async;
 
 class RestIndexHandler : public arangodb::RestVocbaseBaseHandler {
  public:
   RestIndexHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
-  ~RestIndexHandler();
-
- public:
-  char const* name() const override final { return "RestIndexHandler"; }
-  RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
-  RestStatus execute() override;
-  RestStatus continueExecute() override;
-  void shutdownExecute(bool isFinalized) noexcept override;
+  char const* name() const final { return "RestIndexHandler"; }
+  RequestLane lane() const final { return RequestLane::CLIENT_SLOW; }
+  futures::Future<futures::Unit> executeAsync() final;
 
  private:
-  RestStatus getIndexes();
+  async<void> getIndexes();
   [[nodiscard]] futures::Future<futures::Unit> getSelectivityEstimates();
-  RestStatus createIndex();
-  RestStatus dropIndex();
-  RestStatus syncCaches();
-
-  void shutdownBackgroundThread();
+  async<void> createIndex();
+  async<void> dropIndex();
+  void syncCaches();
 
   std::shared_ptr<LogicalCollection> collection(std::string const& cName);
-
-  struct CreateInBackgroundData {
-    std::unique_ptr<std::thread> thread;
-    Result result;
-    arangodb::velocypack::Builder response;
-  };
-
-  std::mutex _mutex;
-  CreateInBackgroundData _createInBackgroundData;
 };
 }  // namespace arangodb

--- a/arangod/VocBase/Methods/Collections.h
+++ b/arangod/VocBase/Methods/Collections.h
@@ -94,6 +94,9 @@ struct Collections {
       TRI_vocbase_t* vocbase,
       std::function<void(std::shared_ptr<LogicalCollection> const&)> const&);
 
+  static std::vector<std::shared_ptr<LogicalCollection>> getNotDeleted(
+      const TRI_vocbase_t& vocbase);
+
   /// @brief lookup a collection in vocbase or clusterinfo.
   static Result lookup(              // find collection
       TRI_vocbase_t const& vocbase,  // vocbase to search

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -145,7 +145,7 @@ struct async_promise<void> : async_promise_base<void> {
 };
 
 template<typename T>
-struct async {
+struct [[nodiscard]] async {
   using promise_type = async_promise<T>;
 
   auto operator co_await() && {

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -378,7 +378,7 @@ TYPED_TEST(AsyncTest, coroutine_is_removed_before_registry_entry) {
               2);
   }
   {
-    { coro(); }
+    { std::ignore = coro(); }
 
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
     EXPECT_EQ(promise_count(arangodb::async_registry::get_thread_registry()),
@@ -470,7 +470,7 @@ TYPED_TEST(AsyncTest, execution_context_is_local_to_coroutine) {
   };
   EXPECT_EQ(ExecContext::current().user(), "Begin");
 
-  calling_coro();
+  std::ignore = calling_coro();
   EXPECT_EQ(ExecContext::current().user(), "Begin");
 
   ExecContextScope new_exec(std::make_shared<ExecContext_End>());
@@ -561,7 +561,7 @@ TYPED_TEST(
     };
   };
 
-  Functions::waiter_fn(this);
+  std::ignore = Functions::waiter_fn(this);
 
   this->wait.resume();
   this->wait.await();
@@ -631,7 +631,7 @@ TYPED_TEST(
     };
   };
 
-  Functions::waiter_fn(this);
+  std::ignore = Functions::waiter_fn(this);
 
   this->wait.resume();
   this->wait.await();
@@ -681,7 +681,7 @@ TYPED_TEST(AsyncTest,
   };
 
   auto awaited_coro = Functions::awaited_fn(this);
-  Functions::waiter_fn(std::move(awaited_coro));
+  std::ignore = Functions::waiter_fn(std::move(awaited_coro));
 
   this->wait.resume();
   this->wait.await();
@@ -723,7 +723,7 @@ TYPED_TEST(
   };
 
   auto awaited_coro = Functions::awaited_fn();
-  Functions::waiter_fn(std::move(awaited_coro), this);
+  std::ignore = Functions::waiter_fn(std::move(awaited_coro), this);
 
   this->wait.resume();
   this->wait.await();


### PR DESCRIPTION
Removes explicit synchronous/wait code from Index and Collection Rest Handler.

Adds simple get method to the Collections method.
Makes async-type nondiscard.
Fix nodiscard errors in tests.

### Scope & Purpose

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
