### PR TITLE
Fix selectivity estimate based optimizer rule in cluster

### DIFF
--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
@@ -18,6 +18,7 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
+#include "Cluster/ServerState.h"
 #include "Aql/Ast.h"
 #include "Aql/Collection.h"
 #include "Aql/Condition.h"
@@ -36,6 +37,7 @@
 #include "Aql/Query.h"
 #include "Indexes/Index.h"
 #include "Logger/LogMacros.h"
+#include "VocBase/LogicalCollection.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -152,16 +154,35 @@ bool selectivityIsLowEnough(IndexNode const& in) {
   // assume there are n documents in the collection and we have
   // k distinct features. A linear search is in O(n) while a distinct scan
   // requires O(k log n). So checking for k log n < n, it follows
-  // k / n < 1 / log n, where k / n is precisely the selectivity estimate.
-  double selectivity = index->selectivityEstimate();
+  // k / n < 1 / log n.
+  // We cannot easily know the number of distinct features k, but we know the
+  // index selectivity estimate k_index / n, which is an upper bound for k / n
+  // because the distinct fields for the collect need to be a prefex of the
+  // index fields.
+  double index_selectivity = index->selectivityEstimate();
   auto numberOfItems = in.estimateCost().estimatedNrItems;
 
-  double const requiredSelectivity = 1. / log(numberOfItems);
+  double requiredSelectivity;
+  if (ServerState::instance()->isSingleServer()) {
+    requiredSelectivity = 1. / log(numberOfItems);
+  } else {
+    // in cluster mode, we use the same equation as an approximation, although
+    // actually
+    // 1. each shard has its own selectivity estimate (the selectivity estimate
+    // used here is an average over all shards)
+    // 2. each shard includes a different number of documents (depending on the
+    // sharding strategy used)
+    // TODO compare the total costs of executing the optimized vs. the
+    // non-optimized execution node, which involves getting the selectivity
+    // estimate of each shard separately
+    requiredSelectivity =
+        1. / log(numberOfItems / index->collection().numberOfShards());
+  }
 
-  if (selectivity > requiredSelectivity) {
+  if (index_selectivity > requiredSelectivity) {
     LOG_RULE << "IndexNode " << in.id()
              << " not eligible - selectivity is too high, actual = "
-             << selectivity << " max allowed = " << requiredSelectivity;
+             << index_selectivity << " max allowed = " << requiredSelectivity;
     return false;
   }
 

--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
@@ -157,7 +157,7 @@ bool selectivityIsLowEnough(IndexNode const& in) {
   // k / n < 1 / log n.
   // We cannot easily know the number of distinct features k, but we know the
   // index selectivity estimate k_index / n, which is an upper bound for k / n
-  // because the distinct fields for the collect need to be a prefex of the
+  // because the distinct fields for the collect need to be a prefix of the
   // index fields.
   double index_selectivity = index->selectivityEstimate();
   auto numberOfItems = in.estimateCost().estimatedNrItems;

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -3298,6 +3298,7 @@ RocksDBVPackIndex::distinctScanFor(
   TRI_ASSERT(supportsDistinctScan(scanOptions));
 
   std::vector<std::size_t> inverseFieldMapping;
+  // distinct fields can only include a prefix of the index fields
   inverseFieldMapping.resize(scanOptions.distinctFields.size());
   for (size_t k = 0; k < scanOptions.distinctFields.size(); k++) {
     inverseFieldMapping[scanOptions.distinctFields[k]] = k;


### PR DESCRIPTION
The index collect optimizer rule that was recently added checks the selectivity of the index to decide whether the rule should be applied. The estimate that was done here was actually not correct (it was too conservative) in cluster mode: 
The rule should be applied if k / n < 1 / log n, where k is the number of distinct values, n is the number of documents and k/n is the selectivity. In cluster mode each shard has its own selectivity k_shard / n_shard, but also its own number of documents n_shard. The selectivity estimate used in the rule is the average over all shards, but before this PR the right hand side 1/ log n used the total number of documents in a collection rather than the average number of documents per shard, which is fixed now.
Actually, to have a correct estimate, we would need to go back and compare the runtime behaviors of both nodes (the optimizes and the not-optimized one) and compare the total costs of execution:
- optimized: O(k log n), cost in cluster: sum_shard k_shard log n_shard
- non-optimized: O(n), cost in cluster: sum_shard n_shard
So here we would need to know the selectivity and number of documents per shard instead of one value, which requires some more changes in the selectivity estimate computation. For now I fixed the obvious error in the calculation, added two tests for that and added a TODO to finalize the work.