### PR TITLE
abort fuzzing if we loose the connection to the arangod

### DIFF
--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -1432,6 +1432,10 @@ static void ClientConnection_httpFuzzRequests(
 
   for (uint64_t i = 0; i < numReqs; ++i) {
     uint32_t returnCode = v8connection->sendFuzzRequest(fuzzer);
+    if (returnCode == kFuzzNotConnected) {
+      TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_SIMPLE_CLIENT_COULD_NOT_CONNECT,
+                                     "connection lost during fuzzing tests");
+    }
     fuzzReturnCodesCount[returnCode]++;
   }
 


### PR DESCRIPTION
### Scope & Purpose

when our connection goes away we should no longer hammer it - the server is dead. 

- [x] :hankey: Bugfix
- [x] backport https://github.com/arangodb/arangodb/pull/21680
