### PR TITLE
Fix TSAN issue in LogicalCollection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.14 (XXXX-XX-XX)
 ---------------------
 
+* Fix TSAN issue in LogicalCollection.
+
 * Fix BTS-2100: Due to a priority inversion it was possible that a lot of
   scheduled SynchronizeShard actions blocked higher priority 
   TakeoverShardLeadership actions in the cluster Maintenance. This

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -744,6 +744,9 @@ void TRI_vocbase_t::persistCollection(
 
 Result TRI_vocbase_t::loadCollection(LogicalCollection& collection,
                                      bool checkPermissions) {
+  // read lock, we already need the read lock to read the name
+  READ_LOCKER_EVENTUAL(locker, collection.statusLock());
+
   TRI_ASSERT(collection.id().isSet());
 
   if (checkPermissions) {
@@ -754,9 +757,6 @@ Result TRI_vocbase_t::loadCollection(LogicalCollection& collection,
                                        collection.name() + "'"};
     }
   }
-
-  // read lock
-  READ_LOCKER_EVENTUAL(locker, collection.statusLock());
 
   if (collection.deleted()) {
     return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,


### PR DESCRIPTION
### Scope & Purpose

This is a backport of https://github.com/arangodb/arangodb/pull/21675.

This addresses BTS-2103.

We need to already hold the _statusLock on a LogicalCollection object
when we read its name.

This fixes a TSAN issue.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] TSAN-tests
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.11: this is it

#### Related Information

- [*] Jira ticket: https://arangodb.atlassian.net/browse/BTS-2103

