### PR TITLE
Fix datarace in tcp acceptor

### DIFF
--- a/arangod/GeneralServer/Acceptor.cpp
+++ b/arangod/GeneralServer/Acceptor.cpp
@@ -44,21 +44,19 @@ Acceptor::Acceptor(rest::GeneralServer& server, rest::IoContext& context,
       _open(false),
       _acceptFailures(0) {}
 
-std::unique_ptr<Acceptor> Acceptor::factory(rest::GeneralServer& server,
+std::shared_ptr<Acceptor> Acceptor::factory(rest::GeneralServer& server,
                                             rest::IoContext& context,
                                             Endpoint* endpoint) {
 #ifdef ARANGODB_HAVE_DOMAIN_SOCKETS
   if (endpoint->domainType() == Endpoint::DomainType::UNIX) {
-    return std::make_unique<AcceptorUnixDomain>(server, context, endpoint);
+    return AcceptorUnixDomain::make(server, context, endpoint);
   }
 #endif
   if (endpoint->encryption() == Endpoint::EncryptionType::SSL) {
-    return std::make_unique<AcceptorTcp<rest::SocketType::Ssl>>(server, context,
-                                                                endpoint);
+    return AcceptorTcp<rest::SocketType::Ssl>::make(server, context, endpoint);
   } else {
     TRI_ASSERT(endpoint->encryption() == Endpoint::EncryptionType::NONE);
-    return std::make_unique<AcceptorTcp<rest::SocketType::Tcp>>(server, context,
-                                                                endpoint);
+    return AcceptorTcp<rest::SocketType::Tcp>::make(server, context, endpoint);
   }
 }
 

--- a/arangod/GeneralServer/Acceptor.h
+++ b/arangod/GeneralServer/Acceptor.h
@@ -45,7 +45,7 @@ class Acceptor {
   virtual void asyncAccept() = 0;
 
  public:
-  static std::unique_ptr<Acceptor> factory(rest::GeneralServer& server,
+  static std::shared_ptr<Acceptor> factory(rest::GeneralServer& server,
                                            rest::IoContext& context, Endpoint*);
 
  protected:

--- a/arangod/GeneralServer/GeneralServer.cpp
+++ b/arangod/GeneralServer/GeneralServer.cpp
@@ -127,7 +127,7 @@ void GeneralServer::startListening(EndpointList& list) {
 
 /// stop accepting new connections
 void GeneralServer::stopListening() {
-  for (std::unique_ptr<Acceptor>& acceptor : _acceptors) {
+  for (auto& acceptor : _acceptors) {
     acceptor->close();
   }
 }

--- a/arangod/GeneralServer/GeneralServer.h
+++ b/arangod/GeneralServer/GeneralServer.h
@@ -79,7 +79,7 @@ class GeneralServer {
   bool const _allowEarlyConnections;
 
   std::recursive_mutex _tasksLock;
-  std::vector<std::unique_ptr<Acceptor>> _acceptors;
+  std::vector<std::shared_ptr<Acceptor>> _acceptors;
   std::map<void*, std::shared_ptr<rest::CommTask>> _commTasks;
 
   /// protect ssl context creation


### PR DESCRIPTION
Tsan stacktrace: https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/2608/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=cluster,limit=linux&&test&&cloud&&x86-64/artifact/testfailures.txt

An `AcceptorTcp` was deleted but at the same time a lambda (instantiated inside `AcceptorTcp::asyncAccept`) ran which captured `this` ptr to this instance by reference.
Solved this by using shared ptrs to the Acceptor instead of unique ptrs, now we capture a weak ptr to `this`, such that if the instance is destroyed before (e.g. via shutting down everything), nothing is executed any more but if the instance still exists it makes sure that it lives as long as the lambda runs.
To make sure that the `AcceptorTcp` is only created as a shared ptr, I made the constructor private and added a static method that creates directly a shared ptr.


Backport: https://github.com/arangodb/arangodb/pull/21684