### PR TITLE
Remove overeager assertion

### DIFF
--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -906,8 +906,6 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
 }
 
 RequestLane RestAqlHandler::lane() const {
-  TRI_ASSERT(!ServerState::instance()->isSingleServer());
-
   if (ServerState::instance()->isCoordinator()) {
     // continuation requests on coordinators will get medium priority,
     // so that they don't block query parts elsewhere


### PR DESCRIPTION
### Scope & Purpose

While the RestAqlHandler is only for internal use in a cluster, it still can be called on a single server. So the assertion is out of place and was triggered during a fuzz test. Proper error handling is already implemented in ::execute().

This does not affect production builds, only maintainer mode.
