### PR TITLE
Remove overeager assertion

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 v3.11.14 (XXXX-XX-XX)
 ---------------------
 
+* Remove overeager assert, only relevant for testing.
+
 * Updated ArangoDB Starter to v0.18.13-preview-2 and arangosync to
   v2.19.13-preview-1.
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -819,7 +819,7 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
       _queryRegistry->finishQuery(qid, errorCode)
           .thenValue([self = shared_from_this(), this,
                       errorCode](std::shared_ptr<ClusterQuery> query) mutable
-                     -> futures::Future<futures::Unit> {
+                         -> futures::Future<futures::Unit> {
             if (query == nullptr) {
               // this may be a race between query garbage collection and
               // the client  shutting down the query. it is debatable
@@ -858,8 +858,6 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
 }
 
 RequestLane RestAqlHandler::lane() const {
-  TRI_ASSERT(!ServerState::instance()->isSingleServer());
-
   if (ServerState::instance()->isCoordinator()) {
     // continuation requests on coordinators will get medium priority,
     // so that they don't block query parts elsewhere

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -819,7 +819,7 @@ RestStatus RestAqlHandler::handleFinishQuery(std::string const& idString) {
       _queryRegistry->finishQuery(qid, errorCode)
           .thenValue([self = shared_from_this(), this,
                       errorCode](std::shared_ptr<ClusterQuery> query) mutable
-                         -> futures::Future<futures::Unit> {
+                     -> futures::Future<futures::Unit> {
             if (query == nullptr) {
               // this may be a race between query garbage collection and
               // the client  shutting down the query. it is debatable


### PR DESCRIPTION
### Scope & Purpose

While the RestAqlHandler is only for internal use in a cluster, it still can be called on a single server. So the assertion is out of place and was triggered during a fuzz test. Proper error handling is already implemented in ::execute().

This does not affect production builds, only maintainer mode.

Backport of https://github.com/arangodb/arangodb/pull/21694

