### PR TITLE
CircleCI: update rclone usage (after it was removed from oskar)

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -355,7 +355,9 @@ jobs:
                 command: |
                   set -x
                   STARTER_REV=$(grep -Po "STARTER_REV \"\Kv\d+\.\d+\.\d+[a-z0-9-]*" VERSIONS)
+                  RCLONE_GO=$(grep -Po "RCLONE_GO \"\K\d+\.\d+\.\d+\-[0-9a-h]+" VERSIONS)
                   RCLONE_VERSION=$(grep -Po "RCLONE_VERSION \"\K\d+\.\d+\.\d+" VERSIONS)
+                  ARANGO_MAJOR_MINOR_VERSION=$(grep -Po "\K\d+\.\d+" ARANGO-VERSION)
                   arch="<<parameters.arch>>"
                   if test "$arch" == "x64"; then
                     arch="amd64"
@@ -363,7 +365,7 @@ jobs:
                   curl -s -L -o build/bin/arangodb "https://github.com/arangodb-helper/arangodb/releases/download/$STARTER_REV/arangodb-linux-$arch"
                   chmod a+x build/bin/arangodb
                   if [ << parameters.enterprise >> = true ]; then
-                    curl -s -L -o build/bin/rclone-arangodb "https://github.com/arangodb/oskar/raw/master/rclone/v$RCLONE_VERSION/rclone-arangodb-linux-$arch"
+                    curl -s -L -o build/bin/rclone-arangodb "https://github.com/arangodb/rclone-arangodb/releases/download/golang-${RCLONE_GO}/golang-${RCLONE_GO}_${ARANGO_MAJOR_MINOR_VERSION}_v${RCLONE_VERSION}_rclone-arangodb-linux-$arch"
                     chmod a+x build/bin/rclone-arangodb
                   fi
       - when:


### PR DESCRIPTION
### Scope & Purpose

Use arangodb/rclone-arangodb not oskar to download rclone within CircleCI.

- [x] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
