### PR TITLE
use pre-populated node_modules for arrdvark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,6 @@ test.cpp.txt
 
 js/apps/*
 !js/apps/system/
-js/apps/system/_admin/aardvark/APP/react/node_modules/
 js/apps/system/_admin/aardvark/APP/react/build/
 js/node/**/node_modules/.bin/
 js/node/node_modules/**/*.md

--- a/cmake/frontend/aardvark.cmake
+++ b/cmake/frontend/aardvark.cmake
@@ -10,7 +10,7 @@ set(FRONTEND_DESTINATION ${PROJECT_SOURCE_DIR}/js/apps/system/_admin/aardvark/AP
 add_custom_target(frontend ALL
   COMMENT "create frontend build"
   WORKING_DIRECTORY ${FRONTEND_DESTINATION}
-  COMMAND yarn install
+  #COMMAND yarn install
   COMMAND yarn build
 )
 


### PR DESCRIPTION
### Scope & Purpose

no longer download node modules for the webinterface at build time.

- [x] :pizza: New feature
