### PR TITLE
Fix crash in query kill logging without bind parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix a crash when bind parameters are not set and killing of a query
+  is logged (no version with this bug was ever released!).
+
 * Updated ArangoDB Starter to v0.19.10.
 
 * Rebuilt included rclone v1.65.5 with go1.22.12 and non-vulnerable

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -601,7 +601,8 @@ struct DistributedQueryInstanciator final
                   << "killing query " << id
                   << " because participating DB server " << srvr
                   << " is unavailable, query string:" << qs
-                  << ", bind parameters: " << bp->slice().toJson();
+                  << ", bind parameters: "
+                  << ((bp != nullptr) ? bp->slice().toJson() : std::string());
               try {
                 methods::Queries::kill(df, vn, id);
               } catch (...) {


### PR DESCRIPTION
### Scope & Purpose

Fix crash in logging when the killing of a query without bind parameters
is logged.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports: none needed

