### PR TITLE
Fix data race in AgencyCache::applyTestTransaction

### DIFF
--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -506,10 +506,11 @@ AgencyCache::applyTestTransaction(velocypack::Slice trxs) {
   std::vector<uint64_t> toCall;
   std::unordered_set<std::string> pc, cc;
   std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t> res;
+  consensus::index_t commitIndex;
 
   {
     std::lock_guard g(_storeLock);
-    ++_commitIndex;
+    commitIndex = ++_commitIndex;
     res = std::pair<std::vector<consensus::apply_ret_t>, consensus::index_t>{
         _readDB.applyTransactions(trxs, AgentInterface::WriteMode{true, true}),
         _commitIndex};  // apply logs
@@ -527,7 +528,7 @@ AgencyCache::applyTestTransaction(velocypack::Slice trxs) {
     }
   }
 
-  triggerWaiting(_commitIndex);
+  triggerWaiting(commitIndex);
   invokeCallbacks(toCall);
   return res;
 }


### PR DESCRIPTION
[TSAN](https://app.circleci.com/pipelines/github/arangodb/arangodb/22966/workflows/2cbfe9bb-ca27-4857-858f-3453fca821ef/jobs/3021932) showed a data race between increasing the member variable `_commitIndex` (line 512) and reading it later to trigger some waiting (line 530). There is locked mutex, but it is released before the read. As far as I understand, we want to trigger some waiting with the index we just increased, therefore we now save the current commit index in a local variable that is then used for the triggering.