### PR TITLE
Allow indexed access in standalone AQL

### DIFF
--- a/arangod/Aql/StandaloneCalculation.cpp
+++ b/arangod/Aql/StandaloneCalculation.cpp
@@ -373,6 +373,7 @@ Result StandaloneCalculation::validateQuery(
             case arangodb::aql::NODE_TYPE_OBJECT:
             case arangodb::aql::NODE_TYPE_OBJECT_ELEMENT:
             case arangodb::aql::NODE_TYPE_REFERENCE:
+            case arangodb::aql::NODE_TYPE_INDEXED_ACCESS:
             case arangodb::aql::NODE_TYPE_ATTRIBUTE_ACCESS:
             case arangodb::aql::NODE_TYPE_BOUND_ATTRIBUTE_ACCESS:
             case arangodb::aql::NODE_TYPE_RANGE:


### PR DESCRIPTION
### Scope & Purpose

The `[]` operator to get a specific array element or object key is disabled for Computed Values and the `aql` Analyzer.
It might be an oversight, or it was purposefully disabled for the `aql` Analyzer (does it somehow interfere with the position tracking?) but it is certainly unintended for Computed Values. To be safe, we could only allow it for Computed Values, or investigate whether something breaks if it's enabled for both.

- [x] :pizza: New feature

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.11: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
