### PR TITLE
Docs: `arangodb_shards_out_of_sync` metric only exposed by DB-Servers

### DIFF
--- a/Documentation/Metrics/arangodb_shards_out_of_sync.yaml
+++ b/Documentation/Metrics/arangodb_shards_out_of_sync.yaml
@@ -7,9 +7,7 @@ type: gauge
 category: Replication
 complexity: simple
 exposedBy:
-  - coordinator
   - dbserver
-  - agent
 description: |
   Number of leader shards not fully replicated. This is counted for all
   shards for which this server is currently the leader. The number is


### PR DESCRIPTION
Brought to light by Aidar