### PR TITLE
Extend the lifetime of `queryInfo`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix BTS-2135: Fix the regression when queries are being destroyed.
+
 * Switched to customized (instead of official) forked rclone v1.65.2 built with
   go1.23.8 to avoid CVEs.
 

--- a/arangod/Aql/QueryRegistry.h
+++ b/arangod/Aql/QueryRegistry.h
@@ -212,7 +212,8 @@ class QueryRegistry {
 
   auto lookupQueryForFinalization(QueryId id, ErrorCode errorCode)
       -> QueryInfoMap::iterator;
-  void deleteQuery(QueryInfoMap::iterator queryMapIt);
+
+  std::unique_ptr<QueryInfo> deleteQuery(QueryInfoMap::iterator queryMapIt);
 
   /// @brief _queries, the actual map of maps for the registry
   /// maps from vocbase name to list queries


### PR DESCRIPTION
### Scope & Purpose

Extend the lifetime of `queryInfo` when destroying the query, so that the last shared ptr to `Query` dies while we are not holding the RW lock. Because of that we don't run the `ClusterQuery::destroy` while holding the RW lock.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2135
- [ ] Design document: 
