### PR TITLE
Add more visibility to catch sleeping barber

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+3.12.4.4 (XXXX-XX-XX)
+---------------------
+
+* Add detection of two threads working on an ExecutionBlock concurrently.
+
+* Add detection of two threads waiting for a PrefetchTask concurrently.
+
+* Add visibility into the state if a thread waits for more than a second
+  on a PrefetchTask.
+
+
 3.12.4.3 (2025-04-25)
 ---------------------
 

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -187,8 +187,8 @@ class ExecutionBlock {
   /// The `execute` method as well as the destructor increment it at their
   /// start and decrement it at their end. If we detect a double use, we
   /// log the stack traces.
-  std::atomic<uint64_t> _numberOfUsers;
-  std::atomic<bool> _logStacktrace;
+  std::atomic<uint64_t> _numberOfUsers{0};
+  std::atomic<bool> _logStacktrace{false};
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -182,6 +182,13 @@ class ExecutionBlock {
   /// this would harm our implementation.
   std::atomic<bool> _isBlockInUse{false};
 #endif
+
+  /// @brief The following is always 0 or 1, if our assumptions are correct.
+  /// The `execute` method as well as the destructor increment it at their
+  /// start and decrement it at their end. If we detect a double use, we
+  /// log the stack traces.
+  std::atomic<uint64_t> _numberOfUsers;
+  std::atomic<bool> _logStacktrace;
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionBlockImpl.h
+++ b/arangod/Aql/ExecutionBlockImpl.h
@@ -414,6 +414,8 @@ class ExecutionBlockImpl final : public ExecutionBlock {
 
     ExecutionBlockImpl& _block;
     AqlCallStack _stack;
+    mutable std::atomic<uint64_t> _numberWaiters{0};
+    mutable std::atomic<bool> _logStacktrace{false};
   };
 
   /**

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -352,7 +352,7 @@ ExecutionBlockImpl<Executor>::~ExecutionBlockImpl() {
   // Double use diagnostics:
   uint64_t userCount = _numberOfUsers.fetch_add(1);
   if (userCount > 0) {
-    LOG_TOPIC("52637", WARN, Logger::QUERIES)
+    LOG_TOPIC("52637", WARN, Logger::AQL)
         << "ALERT: Double use of ExecutionBlock detected, stacktrace:";
     CrashHandler::logBacktrace();
     _logStacktrace.store(true, std::memory_order_relaxed);
@@ -360,8 +360,7 @@ ExecutionBlockImpl<Executor>::~ExecutionBlockImpl() {
   auto guard = scopeGuard([&]() noexcept {
     uint64_t userCount = _numberOfUsers.fetch_sub(1);
     if (_logStacktrace.load(std::memory_order_relaxed)) {
-      LOG_TOPIC("52638", WARN, Logger::QUERIES)
-          << "ALERT: Found _logStacktrace:";
+      LOG_TOPIC("52638", WARN, Logger::AQL) << "ALERT: Found _logStacktrace:";
       CrashHandler::logBacktrace();
       if (userCount == 0) {
         _logStacktrace.store(false, std::memory_order_relaxed);
@@ -517,7 +516,7 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
   // Double use diagnostics:
   uint64_t userCount = _numberOfUsers.fetch_add(1);
   if (userCount > 0) {
-    LOG_TOPIC("52635", WARN, Logger::QUERIES)
+    LOG_TOPIC("52635", WARN, Logger::AQL)
         << "ALERT: Double use of ExecutionBlock detected, stacktrace:";
     CrashHandler::logBacktrace();
     _logStacktrace.store(true, std::memory_order_relaxed);
@@ -525,8 +524,7 @@ ExecutionBlockImpl<Executor>::execute(AqlCallStack const& stack) {
   auto waechter = scopeGuard([&]() noexcept {
     uint64_t userCount = _numberOfUsers.fetch_sub(1);
     if (_logStacktrace.load(std::memory_order_relaxed)) {
-      LOG_TOPIC("52636", WARN, Logger::QUERIES)
-          << "ALERT: Found _logStacktrace:";
+      LOG_TOPIC("52636", WARN, Logger::AQL) << "ALERT: Found _logStacktrace:";
       CrashHandler::logBacktrace();
       if (userCount == 0) {
         _logStacktrace.store(false, std::memory_order_relaxed);
@@ -2621,7 +2619,7 @@ template<class Executor>
 void ExecutionBlockImpl<Executor>::PrefetchTask::waitFor() const noexcept {
   uint64_t count = _numberWaiters.fetch_add(1, std::memory_order_relaxed);
   if (count > 0) {
-    LOG_TOPIC("62515", WARN, Logger::QUERIES)
+    LOG_TOPIC("62515", WARN, Logger::AQL)
         << "ALERT: Detected " << count + 1
         << " waiters for a PrefetchTask, stacktrace:";
     CrashHandler::logBacktrace();
@@ -2637,7 +2635,7 @@ void ExecutionBlockImpl<Executor>::PrefetchTask::waitFor() const noexcept {
       // this is the only one we expect when a timeout occurs!
       std::string_view alerting =
           state.status == Status::InProgress ? "" : "ALERT: ";
-      LOG_TOPIC("62514", WARN, Logger::QUERIES)
+      LOG_TOPIC("62514", WARN, Logger::AQL)
           << alerting
           << "Have waited for a second on an async prefetch task, state "
              "is "
@@ -2646,7 +2644,7 @@ void ExecutionBlockImpl<Executor>::PrefetchTask::waitFor() const noexcept {
   }
   count = _numberWaiters.fetch_sub(1);
   if (_logStacktrace.load(std::memory_order_relaxed) == true) {
-    LOG_TOPIC("62516", WARN, Logger::QUERIES) << "ALERT: Found logStacktrace:";
+    LOG_TOPIC("62516", WARN, Logger::AQL) << "ALERT: Found logStacktrace:";
     CrashHandler::logBacktrace();
     if (count == 0) {
       _logStacktrace.store(false, std::memory_order_relaxed);

--- a/arangod/Aql/ExecutionBlockImpl.tpp
+++ b/arangod/Aql/ExecutionBlockImpl.tpp
@@ -349,6 +349,11 @@ ExecutionBlockImpl<Executor>::ExecutionBlockImpl(
 
 template<class Executor>
 ExecutionBlockImpl<Executor>::~ExecutionBlockImpl() {
+  stopAsyncTasks();
+}
+
+template<class Executor>
+void ExecutionBlockImpl<Executor>::stopAsyncTasks() {
   // Double use diagnostics:
   uint64_t userCount = _numberOfUsers.fetch_add(1);
   if (userCount > 0) {
@@ -367,11 +372,6 @@ ExecutionBlockImpl<Executor>::~ExecutionBlockImpl() {
       }
     }
   });
-  stopAsyncTasks();
-}
-
-template<class Executor>
-void ExecutionBlockImpl<Executor>::stopAsyncTasks() {
   if (_prefetchTask && !_prefetchTask->isConsumed() &&
       !_prefetchTask->tryClaim()) {
     // some thread is still working on our prefetch task


### PR DESCRIPTION
For our hunt of a sleeper we add further diagnosis:

 1. The `PrefetchTask::waitFor` gets a loop with a timeout and
    more logging if the timeout occurs.
 2. We detect, if an ExecutionBlock is used by more than one
    thread concurrently w.r.t. `execute()` and the destructor.
 3. We detect, if more than one thread is waiting for a PrefetchTask
    concurrently.


### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] Visibility

### Checklist

- [*] :book: CHANGELOG entry made

