### PR TITLE
Bug fix/print on violated block ordering

### DIFF
--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -221,8 +221,10 @@ auto ExecutionBlock::isDependencyInList(std::unordered_set<ExecutionBlock*> cons
 }
 
 auto ExecutionBlock::printBlockAndDependenciesInfo() const noexcept -> std::string const {
+  
   std::stringstream ss;
   ss << printBlockInfo();
+  ss << " async prefetching type: " <<(int) getPlanNode()->canUseAsyncPrefetching();
   ss << " calls: [";
   for (auto const& dependency : _dependencies) {
     ss << " " << dependency->printBlockInfo() << ",";

--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -210,3 +210,23 @@ auto ExecutionBlock::printBlockInfo() const -> std::string const {
 }
 
 auto ExecutionBlock::stopAsyncTasks() -> void {}
+
+auto ExecutionBlock::isDependencyInList(std::unordered_set<ExecutionBlock*> const& seenBlocks) const noexcept -> ExecutionBlock* {
+  for (auto const& dependency : _dependencies) {
+    if (seenBlocks.find(dependency) != seenBlocks.end()) {
+      return dependency;
+    }
+  }
+  return nullptr;
+}
+
+auto ExecutionBlock::printBlockAndDependenciesInfo() const noexcept -> std::string const {
+  std::stringstream ss;
+  ss << printBlockInfo();
+  ss << " calls: [";
+  for (auto const& dependency : _dependencies) {
+    ss << " " << dependency->printBlockInfo() << ",";
+  }
+  ss << " ]";
+  return ss.str();
+}

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -31,9 +31,11 @@
 
 #include <atomic>
 #include <cstdint>
-#include <string_view>
+#include <unordered_set>
 #include <utility>
+#include <string_view>
 #include <vector>
+
 
 namespace arangodb {
 namespace transaction {
@@ -131,8 +133,14 @@ class ExecutionBlock {
 
   [[nodiscard]] auto printBlockInfo() const -> std::string const;
   [[nodiscard]] auto printTypeInfo() const -> std::string const;
+  [[nodiscard]] auto printBlockAndDependenciesInfo() const noexcept
+      -> std::string const;
 
   virtual auto stopAsyncTasks() -> void;
+
+  [[nodiscard]] auto isDependencyInList(
+      std::unordered_set<ExecutionBlock*> const& seenBlocks) const noexcept
+      -> ExecutionBlock*;
 
  protected:
   // Trace the start of a execute call


### PR DESCRIPTION
### Scope & Purpose

*This PR adds. more visibility into a violated assumptions. The cleanup of AQL expects Blocks to be in a particular order in the cleanup lists. This PR should add visibility in cases where it is unexpectedly not.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
