### PR TITLE
Stabilize test for ASAN using larger timeout

### DIFF
--- a/tests/js/client/shell/shell-duplicate-collection-names-cluster.js
+++ b/tests/js/client/shell/shell-duplicate-collection-names-cluster.js
@@ -55,7 +55,7 @@ function createDuplicateCollectionNameSuite() {
           break;
         }
         internal.wait(1);
-        if (++count > 10) {
+        if (++count > 60) {
           assertTrue(false, "Async job did not finish quickly enough!");
         }
       }


### PR DESCRIPTION
### Scope & Purpose

It seems that in ASAN runs the timeout to wait for a newly created
collection is not large enough. 

This PR fixes this. Increase timeout to 60s (from 10s).

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
