### PR TITLE
Refactor rest handlers into coroutines

### DIFF
--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -160,9 +160,9 @@ auto RestAgencyHandler::pollIndex(index_t const& start, double const& timeout)
   auto pollResult = _agent->poll(start, timeout);
 
   if (std::get<1>(pollResult)) {
-    auto rb = co_await std::move(std::get<0>(pollResult));
-
     try {
+      auto rb = co_await std::move(std::get<0>(pollResult));
+
       VPackSlice res = rb->slice();
 
       if (res.isObject() && res.hasKey("result")) {

--- a/arangod/Agency/RestAgencyHandler.cpp
+++ b/arangod/Agency/RestAgencyHandler.cpp
@@ -33,6 +33,7 @@
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/StandaloneContext.h"
 
+#include <Async/async.h>
 #include <velocypack/Builder.h>
 
 #include <thread>
@@ -53,29 +54,26 @@ RestAgencyHandler::RestAgencyHandler(ArangodServer& server,
                                      GeneralResponse* response, Agent* agent)
     : RestVocbaseBaseHandler(server, request, response), _agent(agent) {}
 
-RestStatus RestAgencyHandler::reportErrorEmptyRequest() {
+void RestAgencyHandler::reportErrorEmptyRequest() {
   LOG_TOPIC("46536", WARN, Logger::AGENCY)
       << "Empty request to public agency interface.";
   generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::reportTooManySuffices() {
+void RestAgencyHandler::reportTooManySuffices() {
   LOG_TOPIC("ef6ae", WARN, Logger::AGENCY)
       << "Too many suffixes. Agency public interface takes one path.";
   generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::reportUnknownMethod() {
+void RestAgencyHandler::reportUnknownMethod() {
   LOG_TOPIC("9b810", WARN, Logger::AGENCY)
       << "Public REST interface has no method " << _request->suffixes()[0];
   generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::reportMessage(rest::ResponseCode code,
-                                            std::string const& message) {
+void RestAgencyHandler::reportMessage(rest::ResponseCode code,
+                                      std::string const& message) {
   LOG_TOPIC("8a454", DEBUG, Logger::AGENCY) << message;
   Builder body;
   {
@@ -83,7 +81,6 @@ RestStatus RestAgencyHandler::reportMessage(rest::ResponseCode code,
     body.add("message", VPackValue(message));
   }
   generateResult(code, body.slice());
-  return RestStatus::DONE;
 }
 
 void RestAgencyHandler::redirectRequest(std::string const& leaderId) {
@@ -99,7 +96,7 @@ void RestAgencyHandler::redirectRequest(std::string const& leaderId) {
   }
 }
 
-RestStatus RestAgencyHandler::handleTransient() {
+void RestAgencyHandler::handleTransient() {
   // Must be a POST request
   if (_request->requestType() != rest::RequestType::POST) {
     return reportMethodNotAllowed();
@@ -151,8 +148,6 @@ RestStatus RestAgencyHandler::handleTransient() {
       redirectRequest(ret.redirect);
     }
   }
-
-  return RestStatus::DONE;
 }
 
 /// Poll from agency starting with start.
@@ -160,80 +155,73 @@ RestStatus RestAgencyHandler::handleTransient() {
 /// { accepted:bool, result: { firstIndex, commitIndex, logs:[{index, log}] } }
 /// if !accepted, lost leadership
 /// else respond
-RestStatus RestAgencyHandler::pollIndex(index_t const& start,
-                                        double const& timeout) {
+auto RestAgencyHandler::pollIndex(index_t const& start, double const& timeout)
+    -> async<void> {
   auto pollResult = _agent->poll(start, timeout);
 
   if (std::get<1>(pollResult)) {
-    return waitForFuture(
-        std::move(std::get<0>(pollResult))
-            .thenValue([this, start](std::shared_ptr<VPackBuilder>&& rb) {
-              VPackSlice res = rb->slice();
+    auto rb = co_await std::move(std::get<0>(pollResult));
 
-              if (res.isObject() && res.hasKey("result")) {
-                if (res.hasKey(StaticStrings::Error)) {  // leadership loss
-                  generateError(rest::ResponseCode::SERVICE_UNAVAILABLE,
-                                TRI_ERROR_HTTP_SERVICE_UNAVAILABLE,
-                                "No leader");
-                  return;
-                }
+    try {
+      VPackSlice res = rb->slice();
 
-                VPackSlice slice = res.get("result");
+      if (res.isObject() && res.hasKey("result")) {
+        if (res.hasKey(StaticStrings::Error)) {  // leadership loss
+          generateError(rest::ResponseCode::SERVICE_UNAVAILABLE,
+                        TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
+          co_return;
+        }
 
-                if (slice.hasKey("log")) {
-                  VPackBuilder builder;
-                  {
-                    VPackObjectBuilder ob(&builder);
-                    builder.add(StaticStrings::Error, VPackValue(false));
-                    builder.add("code", VPackValue(int(ResponseCode::OK)));
-                    builder.add(VPackValue("result"));
-                    VPackObjectBuilder r(&builder);
-                    if (!slice.get("firstIndex").isNumber()) {
-                      generateError(rest::ResponseCode::SERVER_ERROR,
-                                    TRI_ERROR_HTTP_SERVER_ERROR,
-                                    "invalid first log index.");
-                      return;
-                    } else if (slice.get("firstIndex").getNumber<uint64_t>() >
-                               start) {
-                      generateError(
-                          rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR,
-                          "first log index is greater than requested.");
-                      return;
-                    }
-                    uint64_t firstIndex =
-                                 slice.get("firstIndex").getNumber<uint64_t>(),
-                             i = 0;
+        VPackSlice slice = res.get("result");
 
-                    builder.add("commitIndex", slice.get("commitIndex"));
-                    VPackSlice logs = slice.get("log");
-                    if (start <= firstIndex) {
-                      builder.add("firstIndex", logs[i].get("index"));
-                    }
-                    builder.add(VPackValue("log"));
-                    VPackArrayBuilder a(&builder);
-                    if (start <= firstIndex) {
-                      uint64_t i = start - firstIndex;
-                      for (; i < logs.length(); ++i) {
-                        builder.add(logs[i]);
-                      }
-                    }
-                  }
-                  generateResult(rest::ResponseCode::OK,
-                                 std::move(*builder.steal()));
-                } else {
-                  generateResult(rest::ResponseCode::OK,
-                                 std::move(*rb->steal()));
-                }
-              } else {
-                generateError(rest::ResponseCode::SERVICE_UNAVAILABLE,
-                              TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
-              }
-            })
-            .thenError<std::exception>([this](std::exception const& e) {
+        if (slice.hasKey("log")) {
+          VPackBuilder builder;
+          {
+            VPackObjectBuilder ob(&builder);
+            builder.add(StaticStrings::Error, VPackValue(false));
+            builder.add("code", VPackValue(int(ResponseCode::OK)));
+            builder.add(VPackValue("result"));
+            VPackObjectBuilder r(&builder);
+            if (!slice.get("firstIndex").isNumber()) {
               generateError(rest::ResponseCode::SERVER_ERROR,
-                            TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-            }));
+                            TRI_ERROR_HTTP_SERVER_ERROR,
+                            "invalid first log index.");
+              co_return;
+            } else if (slice.get("firstIndex").getNumber<uint64_t>() > start) {
+              generateError(rest::ResponseCode::SERVER_ERROR,
+                            TRI_ERROR_HTTP_SERVER_ERROR,
+                            "first log index is greater than requested.");
+              co_return;
+            }
+            uint64_t firstIndex = slice.get("firstIndex").getNumber<uint64_t>(),
+                     i = 0;
+
+            builder.add("commitIndex", slice.get("commitIndex"));
+            VPackSlice logs = slice.get("log");
+            if (start <= firstIndex) {
+              builder.add("firstIndex", logs[i].get("index"));
+            }
+            builder.add(VPackValue("log"));
+            VPackArrayBuilder a(&builder);
+            if (start <= firstIndex) {
+              uint64_t i = start - firstIndex;
+              for (; i < logs.length(); ++i) {
+                builder.add(logs[i]);
+              }
+            }
+          }
+          generateResult(rest::ResponseCode::OK, std::move(*builder.steal()));
+        } else {
+          generateResult(rest::ResponseCode::OK, std::move(*rb->steal()));
+        }
+      } else {
+        generateError(rest::ResponseCode::SERVICE_UNAVAILABLE,
+                      TRI_ERROR_HTTP_SERVICE_UNAVAILABLE, "No leader");
+      }
+    } catch (std::exception const& e) {
+      generateError(rest::ResponseCode::SERVER_ERROR,
+                    TRI_ERROR_HTTP_SERVER_ERROR, e.what());
+    }
   } else {
     auto const& leader = std::get<2>(pollResult);
     if (leader == NO_LEADER) {
@@ -242,7 +230,7 @@ RestStatus RestAgencyHandler::pollIndex(index_t const& start,
     } else {
       redirectRequest(leader);
     }
-    return RestStatus::DONE;
+    co_return;
   }
 }
 
@@ -267,10 +255,10 @@ static bool readValue(GeneralRequest const& req, char const* name, T& val) {
 }
 }  // namespace
 
-RestStatus RestAgencyHandler::handlePoll() {
+auto RestAgencyHandler::handlePoll() -> async<void> {
   // GET only
   if (_request->requestType() != rest::RequestType::GET) {
-    return reportMethodNotAllowed();
+    co_return reportMethodNotAllowed();
   }
 
   // WARNING ////////////////////////////////////////////////////
@@ -278,12 +266,12 @@ RestStatus RestAgencyHandler::handlePoll() {
   auto const& leaderId = _agent->leaderID();
   if (!_agent->leading()) {  // Redirect to leader
     if (leaderId == NO_LEADER) {
-      return reportMessage(rest::ResponseCode::SERVICE_UNAVAILABLE,
-                           "No leader");
+      co_return reportMessage(rest::ResponseCode::SERVICE_UNAVAILABLE,
+                              "No leader");
     } else {
       TRI_ASSERT(leaderId != _agent->id());
       redirectRequest(leaderId);
-      return RestStatus::DONE;
+      co_return;
     }
   }
 
@@ -294,10 +282,10 @@ RestStatus RestAgencyHandler::handlePoll() {
   readValue(*_request, "index", index);
   readValue(*_request, "timeout", timeout);
 
-  return pollIndex(index, timeout);
+  co_return co_await pollIndex(index, timeout);
 }
 
-RestStatus RestAgencyHandler::handleStores() {
+void RestAgencyHandler::handleStores() {
   if (_request->requestType() == rest::RequestType::GET) {
     Builder body;
     {
@@ -325,13 +313,13 @@ RestStatus RestAgencyHandler::handleStores() {
       }
     }
     generateResult(rest::ResponseCode::OK, body.slice());
-    return RestStatus::DONE;
+    return;
   }
 
   return reportMethodNotAllowed();
 }
 
-RestStatus RestAgencyHandler::handleStore() {
+void RestAgencyHandler::handleStore() {
   if (_request->requestType() == rest::RequestType::POST) {
     velocypack::Slice query = _request->payload();
     arangodb::consensus::index_t index = 0;
@@ -348,14 +336,13 @@ RestStatus RestAgencyHandler::handleStore() {
     } catch (...) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER);
     }
-
-    return RestStatus::DONE;
+    return;
   }
 
   return reportMethodNotAllowed();
 }
 
-RestStatus RestAgencyHandler::handleWrite() {
+void RestAgencyHandler::handleWrite() {
   using namespace std::chrono;
   if (_request->requestType() != rest::RequestType::POST) {
     return reportMethodNotAllowed();
@@ -480,11 +467,9 @@ RestStatus RestAgencyHandler::handleWrite() {
       redirectRequest(ret.redirect);
     }
   }
-
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::handleTransact() {
+void RestAgencyHandler::handleTransact() {
   if (_request->requestType() != rest::RequestType::POST) {
     return reportMethodNotAllowed();
   }
@@ -541,11 +526,9 @@ RestStatus RestAgencyHandler::handleTransact() {
       redirectRequest(ret.redirect);
     }
   }
-
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::handleInquire() {
+void RestAgencyHandler::handleInquire() {
   if (_request->requestType() != rest::RequestType::POST) {
     return reportMethodNotAllowed();
   }
@@ -558,7 +541,7 @@ RestStatus RestAgencyHandler::handleInquire() {
   } catch (std::exception const& ex) {
     LOG_TOPIC("78755", DEBUG, Logger::AGENCY) << ex.what();
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER);
-    return RestStatus::DONE;
+    return;
   }
 
   // Leadership established?
@@ -650,11 +633,9 @@ RestStatus RestAgencyHandler::handleInquire() {
       redirectRequest(ret.redirect);
     }
   }
-
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::handleRead() {
+void RestAgencyHandler::handleRead() {
   if (_request->requestType() == rest::RequestType::POST) {
     velocypack::Slice query;
     try {
@@ -684,13 +665,13 @@ RestStatus RestAgencyHandler::handleRead() {
         redirectRequest(ret.redirect);
       }
     }
-    return RestStatus::DONE;
+    return;
   }
 
   return reportMethodNotAllowed();
 }
 
-RestStatus RestAgencyHandler::handleConfig() {
+void RestAgencyHandler::handleConfig() {
   LOG_TOPIC("eda22", DEBUG, Logger::AGENCY) << "handleConfig start";
   // Update endpoint of peer
   if (_request->requestType() == rest::RequestType::POST) {
@@ -699,7 +680,7 @@ RestStatus RestAgencyHandler::handleConfig() {
     } catch (std::exception const& e) {
       generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
                     e.what());
-      return RestStatus::DONE;
+      return;
     }
   } else if (_request->requestType() == rest::RequestType::PUT) {
     try {
@@ -707,7 +688,7 @@ RestStatus RestAgencyHandler::handleConfig() {
     } catch (std::exception const& e) {
       generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
                     e.what());
-      return RestStatus::DONE;
+      return;
     }
   }
 
@@ -736,10 +717,9 @@ RestStatus RestAgencyHandler::handleConfig() {
   generateResult(rest::ResponseCode::OK, body.slice());
 
   LOG_TOPIC("77891", DEBUG, Logger::AGENCY) << "handleConfig after before done";
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::handleState() {
+void RestAgencyHandler::handleState() {
   bool found;
   std::string const& val_str = _request->value("redirectToLeader", found);
   bool redirectToLeader = found && val_str == "true";
@@ -754,7 +734,7 @@ RestStatus RestAgencyHandler::handleState() {
       }
       if (leader != _agent->id()) {
         redirectRequest(leader);
-        return RestStatus::DONE;
+        return;
       }
     }
   }
@@ -769,59 +749,57 @@ RestStatus RestAgencyHandler::handleState() {
   auto origin = transaction::OperationOriginInternal{"returning agency state"};
   transaction::StandaloneContext ctx(_vocbase, origin);
   generateResult(rest::ResponseCode::OK, body.slice(), ctx.getVPackOptions());
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::reportMethodNotAllowed() {
+void RestAgencyHandler::reportMethodNotAllowed() {
   generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                 TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-  return RestStatus::DONE;
 }
 
-RestStatus RestAgencyHandler::execute() {
+auto RestAgencyHandler::executeAsync() -> futures::Future<futures::Unit> {
   response()->setAllowCompression(
       rest::ResponseCompressionType::kAllowCompression);
   try {
     auto const& suffixes = _request->suffixes();
     if (suffixes.empty()) {  // Empty request
-      return reportErrorEmptyRequest();
+      co_return reportErrorEmptyRequest();
     } else if (suffixes.size() > 1) {  // path size >= 2
-      return reportTooManySuffices();
+      co_return reportTooManySuffices();
     } else {
       if (suffixes[0] == "write") {
-        return handleWrite();
+        co_return handleWrite();
       } else if (suffixes[0] == "read") {
-        return handleRead();
+        co_return handleRead();
       } else if (suffixes[0] == "poll") {
-        return handlePoll();
+        co_return co_await handlePoll();
       } else if (suffixes[0] == "inquire") {
-        return handleInquire();
+        co_return handleInquire();
       } else if (suffixes[0] == "transient") {
-        return handleTransient();
+        co_return handleTransient();
       } else if (suffixes[0] == "transact") {
-        return handleTransact();
+        co_return handleTransact();
       } else if (suffixes[0] == "config") {
         if (_request->requestType() != rest::RequestType::GET &&
             _request->requestType() != rest::RequestType::PUT &&
             _request->requestType() != rest::RequestType::POST) {
-          return reportMethodNotAllowed();
+          co_return reportMethodNotAllowed();
         }
-        return handleConfig();
+        co_return handleConfig();
       } else if (suffixes[0] == "state") {
         if (_request->requestType() != rest::RequestType::GET) {
-          return reportMethodNotAllowed();
+          co_return reportMethodNotAllowed();
         }
-        return handleState();
+        co_return handleState();
       } else if (suffixes[0] == "stores") {
-        return handleStores();
+        co_return handleStores();
       } else if (suffixes[0] == "store") {
-        return handleStore();
+        co_return handleStore();
       } else {
-        return reportUnknownMethod();
+        co_return reportUnknownMethod();
       }
     }
   } catch (...) {
     // Ignore this error
   }
-  return RestStatus::DONE;
+  co_return;
 }

--- a/arangod/Agency/RestAgencyHandler.h
+++ b/arangod/Agency/RestAgencyHandler.h
@@ -46,31 +46,29 @@ class RestAgencyHandler : public RestVocbaseBaseHandler {
     return RequestLane::AGENCY_CLUSTER;
   }
 
-  RestStatus execute() override;
-
-  using fvoid = futures::Future<futures::Unit>;
-
+  auto executeAsync() -> futures::Future<futures::Unit> override;
   /**
    * @brief Async call to Agent poll with index to wait for within timeout
    */
-  RestStatus pollIndex(consensus::index_t const& index, double const& timeout);
+  auto pollIndex(consensus::index_t const& index, double const& timeout)
+      -> async<void>;
 
  private:
-  RestStatus reportErrorEmptyRequest();
-  RestStatus reportTooManySuffices();
-  RestStatus reportUnknownMethod();
-  RestStatus reportMessage(arangodb::rest::ResponseCode, std::string const&);
-  RestStatus handleStores();
-  RestStatus handleStore();
-  RestStatus handleRead();
-  RestStatus handleWrite();
-  RestStatus handleTransact();
-  RestStatus handleConfig();
-  RestStatus reportMethodNotAllowed();
-  RestStatus handleState();
-  RestStatus handleTransient();
-  RestStatus handleInquire();
-  RestStatus handlePoll();
+  void reportErrorEmptyRequest();
+  void reportTooManySuffices();
+  void reportUnknownMethod();
+  void reportMessage(arangodb::rest::ResponseCode, std::string const&);
+  void handleStores();
+  void handleStore();
+  void handleRead();
+  void handleWrite();
+  void handleTransact();
+  void handleConfig();
+  void reportMethodNotAllowed();
+  void handleState();
+  void handleTransient();
+  void handleInquire();
+  auto handlePoll() -> async<void>;
 
   void redirectRequest(std::string const& leaderId);
   consensus::Agent* _agent;

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -50,6 +50,9 @@ template<typename T>
 class Future;
 }  // namespace futures
 
+template<typename>
+struct async;
+
 class GeneralRequest;
 class RequestStatistics;
 class Result;

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -1726,9 +1726,7 @@ async<void> RestAdminClusterHandler::setDBServerMaintenance(
     auto result = co_await sendTransaction();
     if (result.ok() && result.statusCode() == 200) {
       VPackBuilder builder;
-      {
-        VPackObjectBuilder obj(&builder);
-      }
+      { VPackObjectBuilder obj(&builder); }
       generateOk(rest::ResponseCode::OK, builder);
       co_await waitForDBServerMaintenance(serverId, isMaintenanceMode);
     } else {

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -355,7 +355,7 @@ std::string const RestAdminClusterHandler::VPackSortMigrationMigrate =
     "migrate";
 std::string const RestAdminClusterHandler::VPackSortMigrationStatus = "status";
 
-RestStatus RestAdminClusterHandler::execute() {
+auto RestAdminClusterHandler::executeAsync() -> futures::Future<futures::Unit> {
   // here we first do a glboal check, which is based on the setting in startup
   // option
   // `--cluster.api-jwt-policy`:
@@ -378,7 +378,7 @@ RestStatus RestAdminClusterHandler::execute() {
     if (apiJwtPolicy == "jwt-all" ||
         (apiJwtPolicy == "jwt-write" && isWriteOperation)) {
       generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-      return RestStatus::DONE;
+      co_return;
     }
   }
 
@@ -394,69 +394,89 @@ RestStatus RestAdminClusterHandler::execute() {
     std::string const& command = suffixes.at(0);
 
     if (command == Health) {
-      return handleHealth();
+      co_await handleHealth();
+      co_return;
     } else if (command == NumberOfServers) {
-      return handleNumberOfServers();
+      co_await handleNumberOfServers();
+      co_return;
     } else if (command == Maintenance) {
-      return handleMaintenance();
+      co_await handleMaintenance();
+      co_return;
     } else if (command == NodeVersion) {
-      return handleNodeVersion();
+      co_await handleNodeVersion();
+      co_return;
     } else if (command == NodeEngine) {
-      return handleNodeEngine();
+      co_await handleNodeEngine();
+      co_return;
     } else if (command == NodeStatistics) {
-      return handleNodeStatistics();
+      co_await handleNodeStatistics();
+      co_return;
     } else if (command == Statistics) {
-      return handleStatistics();
+      co_await handleStatistics();
+      co_return;
     } else if (command == ShardDistribution) {
-      return handleShardDistribution();
+      handleShardDistribution();
+      co_return;
     } else if (command == CollectionShardDistribution) {
-      return handleCollectionShardDistribution();
+      handleCollectionShardDistribution();
+      co_return;
     } else if (command == CleanoutServer) {
-      return handleCleanoutServer();
+      co_await handleCleanoutServer();
+      co_return;
     } else if (command == ResignLeadership) {
-      return handleResignLeadership();
+      co_await handleResignLeadership();
+      co_return;
     } else if (command == MoveShard) {
-      return handleMoveShard();
+      co_await handleMoveShard();
+      co_return;
     } else if (command == CancelJob) {
-      return handleCancelJob();
+      co_await handleCancelJob();
+      co_return;
     } else if (command == QueryJobStatus) {
-      return handleQueryJobStatus();
+      co_await handleQueryJobStatus();
+      co_return;
     } else if (command == RemoveServer) {
-      return handleRemoveServer();
+      co_await handleRemoveServer();
+      co_return;
     } else if (command == RebalanceShards) {
-      return handleRebalanceShards();
+      co_await handleRebalanceShards();
+      co_return;
     } else if (command == Rebalance) {
-      return handleRebalance();
+      co_await handleRebalance();
+      co_return;
     } else if (command == ShardStatistics) {
-      return handleShardStatistics();
+      handleShardStatistics();
+      co_return;
     } else {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     std::string("invalid command '") + command + "'");
-      return RestStatus::DONE;
+      co_return;
     }
   } else if (len == 2) {
     std::string const& command = suffixes.at(0);
     if (command == Rebalance) {
-      return handleRebalance();
+      co_await handleRebalance();
+      co_return;
     } else if (command == Maintenance) {
-      return handleDBServerMaintenance(suffixes.at(1));
+      co_await handleDBServerMaintenance(suffixes.at(1));
+      co_return;
     } else if (command == VPackSortMigration) {
-      return waitForFuture(handleVPackSortMigration(suffixes.at(1)));
+      co_await handleVPackSortMigration(suffixes.at(1));
+      co_return;
     } else {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     std::string("invalid command '") + command +
                         "', expecting 'rebalance' or 'maintenance'");
-      return RestStatus::DONE;
+      co_return;
     }
   }
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                 "expecting URL /_admin/cluster/<command>");
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestAdminClusterHandler::FutureVoid
-RestAdminClusterHandler::retryTryDeleteServer(
+futures::Future<futures::Unit> RestAdminClusterHandler::retryTryDeleteServer(
     std::unique_ptr<RemoveServerContext>&& ctx) {
   if (++ctx->tries < 60) {
     return SchedulerFeature::SCHEDULER->delay("remove-server", 1s)
@@ -471,7 +491,7 @@ RestAdminClusterHandler::retryTryDeleteServer(
   }
 }
 
-RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::tryDeleteServer(
+futures::Future<futures::Unit> RestAdminClusterHandler::tryDeleteServer(
     std::unique_ptr<RemoveServerContext>&& ctx) {
   auto rootPath = arangodb::cluster::paths::root()->arango();
   VPackBuffer<uint8_t> trx;
@@ -609,37 +629,36 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::tryDeleteServer(
       });
 }
 
-RestStatus RestAdminClusterHandler::handlePostRemoveServer(
+async<void> RestAdminClusterHandler::handlePostRemoveServer(
     std::string const& server) {
   auto ctx = std::make_unique<RemoveServerContext>(server);
 
-  return waitForFuture(
-      tryDeleteServer(std::move(ctx))
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    co_await tryDeleteServer(std::move(ctx));
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleRemoveServer() {
+async<void> RestAdminClusterHandler::handleRemoveServer() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() != rest::RequestType::POST) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   VPackSlice server = VPackSlice::noneSlice();
@@ -651,37 +670,37 @@ RestStatus RestAdminClusterHandler::handleRemoveServer() {
 
   if (server.isString()) {
     std::string serverId = resolveServerNameID(server.copyString());
-    return handlePostRemoveServer(serverId);
+    co_return co_await handlePostRemoveServer(serverId);
   }
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                 "expecting string or object with key `server`");
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestAdminClusterHandler::handleShardStatistics() {
+void RestAdminClusterHandler::handleShardStatistics() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    return;
   }
 
   if (request()->requestType() != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::NOT_IMPLEMENTED,
                   TRI_ERROR_CLUSTER_ONLY_ON_COORDINATOR);
-    return RestStatus::DONE;
+    return;
   }
 
   if (!_vocbase.isSystem()) {
     generateError(
         GeneralResponse::responseCode(TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE),
         TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE);
-    return RestStatus::DONE;
+    return;
   }
 
   std::string const& restrictServer = _request->value("DBserver");
@@ -703,16 +722,14 @@ RestStatus RestAdminClusterHandler::handleShardStatistics() {
   } else {
     generateError(res);
   }
-
-  return RestStatus::DONE;
 }
 
-RestStatus RestAdminClusterHandler::handleCleanoutServer() {
-  return handleSingleServerJob("cleanOutServer");
+async<void> RestAdminClusterHandler::handleCleanoutServer() {
+  co_return co_await handleSingleServerJob("cleanOutServer");
 }
 
-RestStatus RestAdminClusterHandler::handleResignLeadership() {
-  return handleSingleServerJob("resignLeadership");
+async<void> RestAdminClusterHandler::handleResignLeadership() {
+  co_return co_await handleSingleServerJob("resignLeadership");
 }
 
 std::unique_ptr<RestAdminClusterHandler::MoveShardContext>
@@ -743,23 +760,23 @@ RestAdminClusterHandler::MoveShardContext::fromVelocyPack(VPackSlice slice) {
   return nullptr;
 }
 
-RestStatus RestAdminClusterHandler::handleMoveShard() {
+async<void> RestAdminClusterHandler::handleMoveShard() {
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() != rest::RequestType::POST) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::unique_ptr<MoveShardContext> ctx =
@@ -776,21 +793,21 @@ RestStatus RestAdminClusterHandler::handleMoveShard() {
     if (!canAccess) {
       generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                     "insufficient permissions on database to move shard");
-      return RestStatus::DONE;
+      co_return;
     }
 
     ctx->fromServer = resolveServerNameID(ctx->fromServer);
     ctx->toServer = resolveServerNameID(ctx->toServer);
-    return handlePostMoveShard(std::move(ctx));
+    co_return co_await handlePostMoveShard(std::move(ctx));
   }
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                 "object with keys `database`, `collection`, `shard`, "
                 "`fromServer` and `toServer` (all strings) expected");
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
+async<void> RestAdminClusterHandler::createMoveShard(
     std::unique_ptr<MoveShardContext>&& ctx, VPackSlice plan) {
   auto planPath = arangodb::cluster::paths::root()->arango()->plan();
 
@@ -801,7 +818,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
   if (!serversFound) {
     generateError(ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "one or both dbservers not found");
-    return futures::makeFuture();
+    co_return;
   }
 
   VPackSlice collection = plan.get(planPath->collections()
@@ -811,14 +828,14 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
   if (!collection.isObject()) {
     generateError(ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "database/collection not found");
-    return futures::makeFuture();
+    co_return;
   }
 
   if (collection.hasKey(StaticStrings::DistributeShardsLike)) {
     generateError(ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "MoveShard only allowed for collections which have "
                   "distributeShardsLike unset.");
-    return futures::makeFuture();
+    co_return;
   }
 
   VPackSlice shard =
@@ -826,7 +843,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
   if (!shard.isArray()) {
     generateError(ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "shard not found");
-    return futures::makeFuture();
+    co_return;
   }
 
   bool fromFound = false;
@@ -841,7 +858,7 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
   if (!fromFound) {
     generateError(ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "shard is not located on the server");
-    return futures::makeFuture();
+    co_return;
   }
 
   std::string jobId = std::to_string(
@@ -878,26 +895,23 @@ RestAdminClusterHandler::FutureVoid RestAdminClusterHandler::createMoveShard(
         .done();
   }
 
-  return AsyncAgencyComm()
-      .sendWriteTransaction(20s, std::move(trx))
-      .thenValue([this, ctx = std::move(ctx),
-                  jobId = std::move(jobId)](AsyncAgencyCommResult&& result) {
-        if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-          VPackBuilder builder;
-          ;
-          {
-            VPackObjectBuilder ob(&builder);
-            builder.add("id", VPackValue(jobId));
-          }
+  auto result =
+      co_await AsyncAgencyComm().sendWriteTransaction(20s, std::move(trx));
 
-          generateOk(rest::ResponseCode::ACCEPTED, builder);
-        } else {
-          generateError(result.asResult());
-        }
-      });
+  if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+    VPackBuilder builder;
+    {
+      VPackObjectBuilder ob(&builder);
+      builder.add("id", VPackValue(jobId));
+    }
+
+    generateOk(rest::ResponseCode::ACCEPTED, builder);
+  } else {
+    generateError(result.asResult());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handlePostMoveShard(
+async<void> RestAdminClusterHandler::handlePostMoveShard(
     std::unique_ptr<MoveShardContext>&& ctx) {
   std::shared_ptr<LogicalCollection> collection =
       server().getFeature<ClusterFeature>().clusterInfo().getCollectionNT(
@@ -906,7 +920,7 @@ RestStatus RestAdminClusterHandler::handlePostMoveShard(
   if (collection == nullptr) {
     generateError(ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "database/collection not found");
-    return RestStatus::DONE;
+    co_return;
   }
 
   // base64-encode collection id with RevisionId
@@ -928,59 +942,55 @@ RestStatus RestAdminClusterHandler::handlePostMoveShard(
   }
 
   // gather information about that shard
-  return waitForFuture(
-      AsyncAgencyComm()
-          .sendReadTransaction(20s, std::move(trx))
-          .thenValue([this, ctx = std::move(ctx)](
-                         AsyncAgencyCommResult&& result) mutable {
-            if (result.ok()) {
-              switch (result.statusCode()) {
-                case fuerte::StatusOK:
-                  return createMoveShard(std::move(ctx), result.slice().at(0));
-                case fuerte::StatusNotFound:
-                  generateError(rest::ResponseCode::NOT_FOUND,
-                                TRI_ERROR_HTTP_NOT_FOUND, "unknown collection");
-                  return futures::makeFuture();
-                default:
-                  break;
-              }
-            }
+  try {
+    auto result =
+        co_await AsyncAgencyComm().sendReadTransaction(20s, std::move(trx));
+    if (result.ok()) {
+      switch (result.statusCode()) {
+        case fuerte::StatusOK:
+          co_return co_await createMoveShard(std::move(ctx),
+                                             result.slice().at(0));
+        case fuerte::StatusNotFound:
+          generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
+                        "unknown collection");
+          co_return;
+        default:
+          break;
+      }
+    }
 
-            generateError(result.asResult());
-            return futures::makeFuture();
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+    generateError(result.asResult());
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleQueryJobStatus() {
+async<void> RestAdminClusterHandler::handleQueryJobStatus() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::string jobId = request()->value("id");
   if (jobId.empty()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                   "missing id parameter");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto targetPath = arangodb::cluster::paths::root()->arango()->target();
@@ -991,78 +1001,73 @@ RestStatus RestAdminClusterHandler::handleQueryJobStatus() {
       targetPath->toDo()->job(jobId)->str(),
   };
 
-  return waitForFuture(
-      AsyncAgencyComm()
-          .sendTransaction(20s, AgencyReadTransaction{std::move(paths)})
-          .thenValue([this, targetPath, jobId = std::move(jobId)](
-                         AsyncAgencyCommResult&& result) {
-            if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-              auto paths = std::vector{
-                  targetPath->pending()->job(jobId)->vec(),
-                  targetPath->failed()->job(jobId)->vec(),
-                  targetPath->finished()->job(jobId)->vec(),
-                  targetPath->toDo()->job(jobId)->vec(),
-              };
+  try {
+    auto result = co_await AsyncAgencyComm().sendTransaction(
+        20s, AgencyReadTransaction{std::move(paths)});
+    if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+      auto paths = std::vector{
+          targetPath->pending()->job(jobId)->vec(),
+          targetPath->failed()->job(jobId)->vec(),
+          targetPath->finished()->job(jobId)->vec(),
+          targetPath->toDo()->job(jobId)->vec(),
+      };
 
-              for (auto const& path : paths) {
-                VPackSlice job = result.slice().at(0).get(path);
+      for (auto const& path : paths) {
+        VPackSlice job = result.slice().at(0).get(path);
 
-                if (job.isObject()) {
-                  VPackBuffer<uint8_t> payload;
-                  {
-                    VPackBuilder builder(payload);
-                    VPackObjectBuilder ob(&builder);
+        if (job.isObject()) {
+          VPackBuffer<uint8_t> payload;
+          {
+            VPackBuilder builder(payload);
+            VPackObjectBuilder ob(&builder);
 
-                    // append all the job keys
-                    builder.add(VPackObjectIterator(job));
-                    builder.add("error", VPackValue(false));
-                    builder.add("job", VPackValue(jobId));
-                    builder.add("status", VPackValue(path[2]));
-                  }
+            // append all the job keys
+            builder.add(VPackObjectIterator(job));
+            builder.add("error", VPackValue(false));
+            builder.add("job", VPackValue(jobId));
+            builder.add("status", VPackValue(path[2]));
+          }
 
-                  resetResponse(rest::ResponseCode::OK);
-                  response()->setPayload(std::move(payload));
-                  return;
-                }
-              }
+          resetResponse(rest::ResponseCode::OK);
+          response()->setPayload(std::move(payload));
+          co_return;
+        }
+      }
 
-              generateError(rest::ResponseCode::NOT_FOUND,
-                            TRI_ERROR_HTTP_NOT_FOUND);
-            } else {
-              generateError(result.asResult());
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+      generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
+    } else {
+      generateError(result.asResult());
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleCancelJob() {
+async<void> RestAdminClusterHandler::handleCancelJob() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() != rest::RequestType::POST) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::string jobId;
@@ -1071,7 +1076,7 @@ RestStatus RestAdminClusterHandler::handleCancelJob() {
   } else {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                   "object with key `id`");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto targetPath = arangodb::cluster::paths::root()->arango()->target();
@@ -1106,11 +1111,11 @@ RestStatus RestAdminClusterHandler::handleCancelJob() {
           generateError(
               Result{TRI_ERROR_BAD_PARAMETER,
                      "Only MoveShard and CleanOutServer jobs can be aborted"});
-          return RestStatus::DONE;
+          co_return;
         } else if (path[2] != "Pending" && path[2] != "ToDo") {
           generateError(Result{TRI_ERROR_BAD_PARAMETER,
                                path[2] + " jobs can no longer be cancelled."});
-          return RestStatus::DONE;
+          co_return;
         }
 
         // This tranaction aims at killing a job that is todo or pending.
@@ -1159,44 +1164,42 @@ RestStatus RestAdminClusterHandler::handleCancelJob() {
                                                         std::move(trxBody));
         };
 
-        return waitForFuture(
-            sendTransaction()
-                .thenValue([=, this](AsyncAgencyCommResult&& wr) {
-                  if (!wr.ok()) {
-                    // Only if no longer pending or todo.
-                    if (wr.statusCode() == 412) {
-                      auto results = wr.slice().get("results");
-                      if (results[0].getNumber<uint64_t>() == 0 &&
-                          results[1].getNumber<uint64_t>() == 0) {
-                        generateError(
-                            Result{TRI_ERROR_HTTP_PRECONDITION_FAILED,
-                                   "Job is no longer pending or to do"});
-                        return;
-                      }
-                    } else {
-                      generateError(wr.asResult());
-                      return;
-                    }
-                  }
+        try {
+          auto wr = co_await sendTransaction();
 
-                  VPackBuffer<uint8_t> payload;
-                  {
-                    VPackBuilder builder(payload);
-                    VPackObjectBuilder ob(&builder);
-                    builder.add("job", VPackValue(jobId));
-                    builder.add("status", VPackValue("aborted"));
-                    builder.add("error", VPackValue(false));
-                  }
-                  resetResponse(rest::ResponseCode::OK);
-                  response()->setPayload(std::move(payload));
-                })
-                .thenError<VPackException>([this](VPackException const& e) {
-                  generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-                })
-                .thenError<std::exception>([this](std::exception const& e) {
-                  generateError(rest::ResponseCode::SERVER_ERROR,
-                                TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-                }));
+          if (!wr.ok()) {
+            // Only if no longer pending or todo.
+            if (wr.statusCode() == 412) {
+              auto results = wr.slice().get("results");
+              if (results[0].getNumber<uint64_t>() == 0 &&
+                  results[1].getNumber<uint64_t>() == 0) {
+                generateError(Result{TRI_ERROR_HTTP_PRECONDITION_FAILED,
+                                     "Job is no longer pending or to do"});
+                co_return;
+              }
+            } else {
+              generateError(wr.asResult());
+              co_return;
+            }
+          }
+
+          VPackBuffer<uint8_t> payload;
+          {
+            VPackBuilder builder(payload);
+            VPackObjectBuilder ob(&builder);
+            builder.add("job", VPackValue(jobId));
+            builder.add("status", VPackValue("aborted"));
+            builder.add("error", VPackValue(false));
+          }
+          resetResponse(rest::ResponseCode::OK);
+          response()->setPayload(std::move(payload));
+        } catch (VPackException const& e) {
+          generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+        } catch (std::exception const& e) {
+          generateError(rest::ResponseCode::SERVER_ERROR,
+                        TRI_ERROR_HTTP_SERVER_ERROR, e.what());
+        }
+        co_return;
       }
     }
 
@@ -1209,48 +1212,48 @@ RestStatus RestAdminClusterHandler::handleCancelJob() {
                   e.what());
   }
 
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestAdminClusterHandler::handleSingleServerJob(
+async<void> RestAdminClusterHandler::handleSingleServerJob(
     std::string const& job) {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() != rest::RequestType::POST) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (body.isObject()) {
     VPackSlice server = body.get("server");
     if (server.isString()) {
       std::string serverId = resolveServerNameID(server.copyString());
-      return handleCreateSingleServerJob(job, serverId, body);
+      co_return co_await handleCreateSingleServerJob(job, serverId, body);
     }
   }
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                 "object with key `server`");
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestAdminClusterHandler::handleCreateSingleServerJob(
+async<void> RestAdminClusterHandler::handleCreateSingleServerJob(
     std::string const& job, std::string const& serverId, VPackSlice body) {
   std::string jobId = std::to_string(
       server().getFeature<ClusterFeature>().clusterInfo().uniqid());
@@ -1274,44 +1277,41 @@ RestStatus RestAdminClusterHandler::handleCreateSingleServerJob(
         VPackValue(timepointToString(std::chrono::system_clock::now())));
   }
 
-  return waitForFuture(
-      AsyncAgencyComm()
-          .setValue(20s, jobToDoPath, builder.slice())
-          .thenValue(
-              [this, jobId = std::move(jobId)](AsyncAgencyCommResult&& result) {
-                if (result.ok() && result.statusCode() == 200) {
-                  VPackBuilder builder;
-                  {
-                    VPackObjectBuilder ob(&builder);
-                    builder.add("id", VPackValue(jobId));
-                  }
+  try {
+    auto result =
+        co_await AsyncAgencyComm().setValue(20s, jobToDoPath, builder.slice());
 
-                  generateOk(arangodb::rest::ResponseCode::ACCEPTED, builder);
-                } else {
-                  generateError(result.asResult());
-                }
-              })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+    if (result.ok() && result.statusCode() == 200) {
+      VPackBuilder builder;
+      {
+        VPackObjectBuilder ob(&builder);
+        builder.add("id", VPackValue(jobId));
+      }
+
+      generateOk(arangodb::rest::ResponseCode::ACCEPTED, builder);
+    } else {
+      generateError(result.asResult());
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleProxyGetRequest(
+async<void> RestAdminClusterHandler::handleProxyGetRequest(
     std::string const& url, std::string const& serverFromParameter) {
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::string const& serverId = request()->value(serverFromParameter);
@@ -1319,7 +1319,7 @@ RestStatus RestAdminClusterHandler::handleProxyGetRequest(
     generateError(
         rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
         std::string("missing parameter `") + serverFromParameter + "`");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto* pool = server().getFeature<NetworkFeature>().pool();
@@ -1329,75 +1329,72 @@ RestStatus RestAdminClusterHandler::handleProxyGetRequest(
   auto frequest = network::sendRequestRetry(pool, "server:" + serverId,
                                             fuerte::RestVerb::Get, url,
                                             VPackBuffer<uint8_t>(), opt);
+  try {
+    auto result = co_await std::move(frequest);
 
-  return waitForFuture(
-      std::move(frequest)
-          .thenValue([this](network::Response&& result) {
-            if (result.ok()) {
-              resetResponse(ResponseCode(
-                  result.statusCode()));  // I quit if the values are not the
-                                          // HTTP Status Codes
-              auto payload = result.response().stealPayload();
-              response()->setPayload(std::move(*payload));
-            } else {
-              switch (result.error) {
-                case fuerte::Error::ConnectionCanceled:
-                  generateError(rest::ResponseCode::BAD,
-                                TRI_ERROR_HTTP_BAD_PARAMETER, "unknown server");
-                  break;
-                case fuerte::Error::CouldNotConnect:
-                case fuerte::Error::RequestTimeout:
-                  generateError(rest::ResponseCode::REQUEST_TIMEOUT,
-                                TRI_ERROR_HTTP_GATEWAY_TIMEOUT,
-                                "server did not answer");
-                  break;
-                default:
-                  generateError(rest::ResponseCode::SERVER_ERROR,
-                                TRI_ERROR_HTTP_SERVER_ERROR);
-              }
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+    if (result.ok()) {
+      resetResponse(ResponseCode(
+          result.statusCode()));  // I quit if the values are not the
+      // HTTP Status Codes
+      auto payload = result.response().stealPayload();
+      response()->setPayload(std::move(*payload));
+    } else {
+      switch (result.error) {
+        case fuerte::Error::ConnectionCanceled:
+          generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
+                        "unknown server");
+          break;
+        case fuerte::Error::CouldNotConnect:
+        case fuerte::Error::RequestTimeout:
+          generateError(rest::ResponseCode::REQUEST_TIMEOUT,
+                        TRI_ERROR_HTTP_GATEWAY_TIMEOUT,
+                        "server did not answer");
+          break;
+        default:
+          generateError(rest::ResponseCode::SERVER_ERROR,
+                        TRI_ERROR_HTTP_SERVER_ERROR);
+      }
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleNodeVersion() {
-  return handleProxyGetRequest("/_api/version", "ServerID");
+async<void> RestAdminClusterHandler::handleNodeVersion() {
+  co_return co_await handleProxyGetRequest("/_api/version", "ServerID");
 }
 
-RestStatus RestAdminClusterHandler::handleNodeStatistics() {
-  return handleProxyGetRequest("/_admin/statistics", "ServerID");
+async<void> RestAdminClusterHandler::handleNodeStatistics() {
+  co_return co_await handleProxyGetRequest("/_admin/statistics", "ServerID");
 }
 
-RestStatus RestAdminClusterHandler::handleNodeEngine() {
-  return handleProxyGetRequest("/_api/engine", "ServerID");
+async<void> RestAdminClusterHandler::handleNodeEngine() {
+  co_return co_await handleProxyGetRequest("/_api/engine", "ServerID");
 }
 
-RestStatus RestAdminClusterHandler::handleStatistics() {
-  return handleProxyGetRequest("/_admin/statistics", "DBserver");
+async<void> RestAdminClusterHandler::handleStatistics() {
+  co_return co_await handleProxyGetRequest("/_admin/statistics", "DBserver");
 }
 
-RestStatus RestAdminClusterHandler::handleShardDistribution() {
+void RestAdminClusterHandler::handleShardDistribution() {
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    return;
   }
 
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    return;
   }
 
   if (request()->requestType() != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    return;
   }
 
   auto reporter = cluster::ShardDistributionReporter::instance(server());
@@ -1409,15 +1406,14 @@ RestStatus RestAdminClusterHandler::handleShardDistribution() {
     reporter->getDistributionForDatabase(_vocbase.name(), builder);
   }
   generateOk(rest::ResponseCode::OK, builder);
-  return RestStatus::DONE;
 }
 
-RestStatus RestAdminClusterHandler::handleGetCollectionShardDistribution(
+void RestAdminClusterHandler::handleGetCollectionShardDistribution(
     std::string const& collection) {
   if (collection.empty()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                   "expected nonempty `collection` parameter");
-    return RestStatus::DONE;
+    return;
   }
 
   auto reporter = cluster::ShardDistributionReporter::instance(server());
@@ -1430,19 +1426,18 @@ RestStatus RestAdminClusterHandler::handleGetCollectionShardDistribution(
                                                    builder);
   }
   generateOk(rest::ResponseCode::OK, builder);
-  return RestStatus::DONE;
 }
 
-RestStatus RestAdminClusterHandler::handleCollectionShardDistribution() {
+void RestAdminClusterHandler::handleCollectionShardDistribution() {
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    return;
   }
 
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    return;
   }
 
   switch (request()->requestType()) {
@@ -1454,13 +1449,13 @@ RestStatus RestAdminClusterHandler::handleCollectionShardDistribution() {
     default:
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-      return RestStatus::DONE;
+      return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    return;
   }
 
   if (body.isObject()) {
@@ -1472,14 +1467,13 @@ RestStatus RestAdminClusterHandler::handleCollectionShardDistribution() {
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                 "object with key `collection`");
-  return RestStatus::DONE;
 }
 
-RestStatus RestAdminClusterHandler::handleGetMaintenance() {
+async<void> RestAdminClusterHandler::handleGetMaintenance() {
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto maintenancePath = arangodb::cluster::paths::root()
@@ -1487,32 +1481,27 @@ RestStatus RestAdminClusterHandler::handleGetMaintenance() {
                              ->supervision()
                              ->state()
                              ->mode();
-
-  return waitForFuture(
-      AsyncAgencyComm()
-          .getValues(maintenancePath)
-          .thenValue([this](AgencyReadResult&& result) {
-            if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-              generateOk(rest::ResponseCode::OK, result.value());
-            } else {
-              generateError(result.asResult());
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    auto result = co_await AsyncAgencyComm().getValues(maintenancePath);
+    if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+      generateOk(rest::ResponseCode::OK, result.value());
+    } else {
+      generateError(result.asResult());
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleGetDBServerMaintenance(
+async<void> RestAdminClusterHandler::handleGetDBServerMaintenance(
     std::string const& serverId) {
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto maintenancePath = arangodb::cluster::paths::root()
@@ -1521,27 +1510,22 @@ RestStatus RestAdminClusterHandler::handleGetDBServerMaintenance(
                              ->maintenanceDBServers()
                              ->dbserver(serverId);
 
-  return waitForFuture(
-      AsyncAgencyComm()
-          .getValues(maintenancePath)
-          .thenValue([this](AgencyReadResult&& result) {
-            if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-              generateOk(rest::ResponseCode::OK, result.value());
-            } else {
-              generateError(result.asResult());
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    auto result = co_await AsyncAgencyComm().getValues(maintenancePath);
+    if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+      generateOk(rest::ResponseCode::OK, result.value());
+    } else {
+      generateError(result.asResult());
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestAdminClusterHandler::FutureVoid
-RestAdminClusterHandler::waitForSupervisionState(
+futures::Future<futures::Unit> RestAdminClusterHandler::waitForSupervisionState(
     bool state, std::string const& reactivationTime,
     clock::time_point startTime) {
   return SchedulerFeature::SCHEDULER->delay("wait-for-supervision", 1s)
@@ -1592,8 +1576,8 @@ RestAdminClusterHandler::waitForSupervisionState(
       });
 }
 
-RestStatus RestAdminClusterHandler::setMaintenance(bool wantToActivate,
-                                                   uint64_t timeout) {
+async<void> RestAdminClusterHandler::setMaintenance(bool wantToActivate,
+                                                    uint64_t timeout) {
   // we don't need a timeout when disabling the maintenance
   TRI_ASSERT(wantToActivate || timeout == 0);
 
@@ -1618,28 +1602,25 @@ RestStatus RestAdminClusterHandler::setMaintenance(bool wantToActivate,
 
   auto self(shared_from_this());
 
-  return waitForFuture(
-      sendTransaction()
-          .thenValue([this, wantToActivate,
-                      reactivationTime](AsyncAgencyCommResult&& result) {
-            if (result.ok() && result.statusCode() == 200) {
-              return waitForSupervisionState(wantToActivate, reactivationTime,
-                                             std::chrono::steady_clock::now());
-            } else {
-              generateError(result.asResult());
-            }
-            return futures::makeFuture();
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    auto result = co_await sendTransaction();
+    if (result.ok() && result.statusCode() == 200) {
+      co_await waitForSupervisionState(wantToActivate, reactivationTime,
+                                       std::chrono::steady_clock::now());
+      co_return;
+    } else {
+      generateError(result.asResult());
+    }
+    co_return;
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestAdminClusterHandler::FutureVoid
+futures::Future<futures::Unit>
 RestAdminClusterHandler::waitForDBServerMaintenance(std::string const& serverId,
                                                     bool waitForMaintenance) {
   struct Context {
@@ -1689,7 +1670,7 @@ RestAdminClusterHandler::waitForDBServerMaintenance(std::string const& serverId,
   });
 }
 
-RestStatus RestAdminClusterHandler::setDBServerMaintenance(
+async<void> RestAdminClusterHandler::setDBServerMaintenance(
     std::string const& serverId, std::string const& mode, uint64_t timeout) {
   auto maintenancePath = arangodb::cluster::paths::root()
                              ->arango()
@@ -1741,41 +1722,37 @@ RestStatus RestAdminClusterHandler::setDBServerMaintenance(
 
   auto self(shared_from_this());
   bool const isMaintenanceMode = mode == "maintenance";
-
-  return waitForFuture(
-      sendTransaction()
-          .thenValue([this, reactivationTime, isMaintenanceMode,
-                      serverId](AsyncAgencyCommResult&& result) {
-            if (result.ok() && result.statusCode() == 200) {
-              VPackBuilder builder;
-              { VPackObjectBuilder obj(&builder); }
-              generateOk(rest::ResponseCode::OK, builder);
-              return waitForDBServerMaintenance(serverId, isMaintenanceMode);
-            } else {
-              generateError(result.asResult());
-            }
-            return futures::makeFuture();
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    auto result = co_await sendTransaction();
+    if (result.ok() && result.statusCode() == 200) {
+      VPackBuilder builder;
+      {
+        VPackObjectBuilder obj(&builder);
+      }
+      generateOk(rest::ResponseCode::OK, builder);
+      co_await waitForDBServerMaintenance(serverId, isMaintenanceMode);
+    } else {
+      generateError(result.asResult());
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handlePutMaintenance() {
+async<void> RestAdminClusterHandler::handlePutMaintenance() {
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (body.isString()) {
@@ -1783,10 +1760,10 @@ RestStatus RestAdminClusterHandler::handlePutMaintenance() {
       // supervision maintenance will turn itself off automatically
       // after one hour by default
       constexpr uint64_t timeout = 3600;  // 1 hour
-      return setMaintenance(true, timeout);
+      co_return co_await setMaintenance(true, timeout);
     } else if (body.isEqualString("off")) {
       // timeout doesn't matter for turning off the supervision
-      return setMaintenance(false, /*timeout*/ 0);
+      co_return co_await setMaintenance(false, /*timeout*/ 0);
     } else {
       // user sent a stringified timeout value, so lets honor this
       VPackValueLength l;
@@ -1794,29 +1771,29 @@ RestStatus RestAdminClusterHandler::handlePutMaintenance() {
       bool valid = false;
       uint64_t timeout = NumberUtils::atoi_positive<uint64_t>(p, p + l, valid);
       if (valid) {
-        return setMaintenance(true, timeout);
+        co_return co_await setMaintenance(true, timeout);
       }
       // otherwise fall-through to error
     }
   } else if (body.isNumber()) {
     // user sent a numeric timeout value, so lets honor this
     uint64_t timeout = body.getNumber<uint64_t>();
-    return setMaintenance(true, timeout);
+    co_return co_await setMaintenance(true, timeout);
   }
 
   generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                 "string expected with value `on` or `off`");
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestAdminClusterHandler::handlePutDBServerMaintenance(
+async<void> RestAdminClusterHandler::handlePutDBServerMaintenance(
     std::string const& serverId) {
   TRI_ASSERT(AsyncAgencyCommManager::INSTANCE != nullptr);
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (body.isObject() && body.hasKey("mode")) {
@@ -1833,7 +1810,7 @@ RestStatus RestAdminClusterHandler::handlePutDBServerMaintenance(
           }
         }
       }
-      return setDBServerMaintenance(serverId, mode, timeout);
+      co_return co_await setDBServerMaintenance(serverId, mode, timeout);
     }
     // otherwise fall-through to error
   }
@@ -1841,72 +1818,72 @@ RestStatus RestAdminClusterHandler::handlePutDBServerMaintenance(
   generateError(
       rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
       "object expected with attribute 'mode' and optional attribute 'timeout'");
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestAdminClusterHandler::handleMaintenance() {
+async<void> RestAdminClusterHandler::handleMaintenance() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator() &&
       !ServerState::instance()->isSingleServer()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on single server and coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   switch (request()->requestType()) {
     case rest::RequestType::GET:
-      return handleGetMaintenance();
+      co_return co_await handleGetMaintenance();
     case rest::RequestType::PUT:
-      return handlePutMaintenance();
+      co_return co_await handlePutMaintenance();
     default:
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-      return RestStatus::DONE;
+      co_return;
   }
 }
 
-RestStatus RestAdminClusterHandler::handleDBServerMaintenance(
+async<void> RestAdminClusterHandler::handleDBServerMaintenance(
     std::string const& serverId) {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   TRI_ASSERT(AsyncAgencyCommManager::INSTANCE != nullptr);
 
   switch (request()->requestType()) {
     case rest::RequestType::GET:
-      return handleGetDBServerMaintenance(serverId);
+      co_return co_await handleGetDBServerMaintenance(serverId);
     case rest::RequestType::PUT:
-      return handlePutDBServerMaintenance(serverId);
+      co_return co_await handlePutDBServerMaintenance(serverId);
     default:
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-      return RestStatus::DONE;
+      co_return;
   }
 }
 
-RestStatus RestAdminClusterHandler::handleGetNumberOfServers() {
+async<void> RestAdminClusterHandler::handleGetNumberOfServers() {
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto targetPath = arangodb::cluster::paths::root()->arango()->target();
@@ -1923,67 +1900,59 @@ RestStatus RestAdminClusterHandler::handleGetNumberOfServers() {
         .done();
   }
 
-  auto self(shared_from_this());
-  return waitForFuture(
-      AsyncAgencyComm()
-          .sendReadTransaction(10.0s, std::move(trx))
-          .thenValue([this](AsyncAgencyCommResult&& result) {
-            auto targetPath =
-                arangodb::cluster::paths::root()->arango()->target();
+  try {
+    auto result =
+        co_await AsyncAgencyComm().sendReadTransaction(10.0s, std::move(trx));
 
-            if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-              VPackBuilder builder;
-              {
-                VPackObjectBuilder ob(&builder);
-                builder.add("numberOfDBServers",
-                            result.slice().at(0).get(
-                                targetPath->numberOfDBServers()->vec()));
-                builder.add("numberOfCoordinators",
-                            result.slice().at(0).get(
-                                targetPath->numberOfCoordinators()->vec()));
-                builder.add("cleanedServers",
-                            result.slice().at(0).get(
-                                targetPath->cleanedServers()->vec()));
-              }
+    if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+      VPackBuilder builder;
+      {
+        VPackObjectBuilder ob(&builder);
+        builder.add(
+            "numberOfDBServers",
+            result.slice().at(0).get(targetPath->numberOfDBServers()->vec()));
+        builder.add("numberOfCoordinators",
+                    result.slice().at(0).get(
+                        targetPath->numberOfCoordinators()->vec()));
+        builder.add("cleanedServers", result.slice().at(0).get(
+                                          targetPath->cleanedServers()->vec()));
+      }
 
-              generateOk(rest::ResponseCode::OK, builder);
-            } else {
-              generateError(rest::ResponseCode::SERVER_ERROR,
-                            TRI_ERROR_HTTP_SERVER_ERROR,
-                            "agency communication failed");
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+      generateOk(rest::ResponseCode::OK, builder);
+    } else {
+      generateError(rest::ResponseCode::SERVER_ERROR,
+                    TRI_ERROR_HTTP_SERVER_ERROR, "agency communication failed");
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
+async<void> RestAdminClusterHandler::handlePutNumberOfServers() {
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool parseSuccess;
   VPackSlice body = parseVPackBody(parseSuccess);
   if (!parseSuccess) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!body.isObject()) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                   "object expected");
-    return RestStatus::DONE;
+    co_return;
   }
 
   std::vector<AgencyOperation> ops;
@@ -2003,7 +1972,7 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
     } else if (!numberOfCoordinators.isNone()) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                     "numberOfCoordinators: number expected");
-      return RestStatus::DONE;
+      co_return;
     }
 
     VPackSlice numberOfDBServers = body.get("numberOfDBServers");
@@ -2014,7 +1983,7 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
     } else if (!numberOfDBServers.isNone()) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                     "numberOfDBServers: number expected");
-      return RestStatus::DONE;
+      co_return;
     }
 
     VPackSlice cleanedServers = body.get("cleanedServers");
@@ -2034,12 +2003,12 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
       } else {
         generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                       "cleanedServers: array of strings expected");
-        return RestStatus::DONE;
+        co_return;
       }
     } else if (!cleanedServers.isNone()) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                     "cleanedServers: array expected");
-      return RestStatus::DONE;
+      co_return;
     }
 
     std::move(write).end().done();
@@ -2052,34 +2021,29 @@ RestStatus RestAdminClusterHandler::handlePutNumberOfServers() {
     //               "missing fields");
     // but that would break API compatibility. Introduce this behavior
     // in 4.0!!
-    return RestStatus::DONE;
+    co_return;
   }
-
-  auto self(shared_from_this());
-  return waitForFuture(
-      AsyncAgencyComm()
-          .sendWriteTransaction(20s, std::move(trx))
-          .thenValue([this](AsyncAgencyCommResult&& result) {
-            if (result.ok() && result.statusCode() == fuerte::StatusOK) {
-              generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
-            } else {
-              generateError(result.asResult());
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    auto result =
+        co_await AsyncAgencyComm().sendWriteTransaction(20s, std::move(trx));
+    if (result.ok() && result.statusCode() == fuerte::StatusOK) {
+      generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
+    } else {
+      generateError(result.asResult());
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleNumberOfServers() {
+async<void> RestAdminClusterHandler::handleNumberOfServers() {
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   // GET requests are allowed for everyone, unless --server.harden is used.
@@ -2093,47 +2057,45 @@ RestStatus RestAdminClusterHandler::handleNumberOfServers() {
 
   if (needsAdminPrivileges && !ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   switch (request()->requestType()) {
     case rest::RequestType::GET:
-      return handleGetNumberOfServers();
+      co_return co_await handleGetNumberOfServers();
     case rest::RequestType::PUT:
-      return handlePutNumberOfServers();
+      co_return co_await handlePutNumberOfServers();
     default:
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-      return RestStatus::DONE;
+      co_return;
   }
 }
 
-RestStatus RestAdminClusterHandler::handleHealth() {
+async<void> RestAdminClusterHandler::handleHealth() {
   // We allow this API whenever one is authenticated in some way. There used
   // to be a check for isAdminUser here. However, we want that the UI with
   // the cluster health dashboard works for every authenticated user.
   if (request()->requestType() != rest::RequestType::GET) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator() &&
       !ServerState::instance()->isSingleServer()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on single server and coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (AsyncAgencyCommManager::INSTANCE == nullptr) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "not allowed on single servers");
-    return RestStatus::DONE;
+    co_return;
   }
 
   // TODO handle timeout parameter
-
-  auto self(shared_from_this());
 
   // query the agency config
   auto fConfig =
@@ -2141,7 +2103,7 @@ RestStatus RestAdminClusterHandler::handleHealth() {
           .sendWithFailover(fuerte::RestVerb::Get, "/_api/agency/config", 60.0s,
                             AsyncAgencyComm::RequestType::READ,
                             VPackBuffer<uint8_t>())
-          .thenValue([self](AsyncAgencyCommResult&& result) {
+          .thenValue([this](AsyncAgencyCommResult&& result) {
             // this lambda has to capture self since collect returns early on
             // an exception and the RestHandler might be freed too early
             // otherwise
@@ -2154,7 +2116,7 @@ RestStatus RestAdminClusterHandler::handleHealth() {
             // version
             std::vector<futures::Future<::agentConfigHealthResult>> fs;
 
-            auto* pool = self->server().getFeature<NetworkFeature>().pool();
+            auto* pool = server().getFeature<NetworkFeature>().pool();
             for (auto member : VPackObjectIterator(result.slice().get(
                      std::vector<std::string>{"configuration", "pool"}))) {
               std::string endpoint = member.value.copyString();
@@ -2196,33 +2158,27 @@ RestStatus RestAdminClusterHandler::handleHealth() {
   }
   auto fStore = AsyncAgencyComm().sendReadTransaction(60.0s, std::move(trx));
 
-  return waitForFuture(
-      futures::collect(std::move(fConfig), std::move(fStore))
-          .thenValue([this](auto&& result) {
-            auto rootPath = arangodb::cluster::paths::root()->arango();
-            auto& [configResult, storeResult] = result;
-            if (storeResult.ok() &&
-                storeResult.statusCode() == fuerte::StatusOK) {
-              VPackBuilder builder;
-              {
-                VPackObjectBuilder ob(&builder);
-                ::buildHealthResult(builder, configResult,
-                                    storeResult.slice().at(0));
-              }
-              generateOk(rest::ResponseCode::OK, builder);
-            } else {
-              generateError(rest::ResponseCode::SERVER_ERROR,
-                            TRI_ERROR_HTTP_SERVER_ERROR,
-                            "agency communication failed");
-            }
-          })
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    auto result =
+        co_await futures::collect(std::move(fConfig), std::move(fStore));
+    auto& [configResult, storeResult] = result;
+    if (storeResult.ok() && storeResult.statusCode() == fuerte::StatusOK) {
+      VPackBuilder builder;
+      {
+        VPackObjectBuilder ob(&builder);
+        ::buildHealthResult(builder, configResult, storeResult.slice().at(0));
+      }
+      generateOk(rest::ResponseCode::OK, builder);
+    } else {
+      generateError(rest::ResponseCode::SERVER_ERROR,
+                    TRI_ERROR_HTTP_SERVER_ERROR, "agency communication failed");
+    }
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
 std::string RestAdminClusterHandler::resolveServerNameID(
@@ -2332,9 +2288,9 @@ void theSimpleStupidOne(
 }
 }  // namespace
 
-RestAdminClusterHandler::FutureVoid
+futures::Future<futures::Unit>
 RestAdminClusterHandler::handlePostRebalanceShards(
-    const ReshardAlgorithm& algorithm) {
+    ReshardAlgorithm const& algorithm) {
   // dbserver -> shards
   std::vector<MoveShardDescription> moves;
   std::map<std::string, std::unordered_set<CollectionShardPair>> shardMap;
@@ -2397,24 +2353,24 @@ RestAdminClusterHandler::handlePostRebalanceShards(
       });
 }
 
-RestStatus RestAdminClusterHandler::handleRebalanceShards() {
+async<void> RestAdminClusterHandler::handleRebalanceShards() {
   if (request()->requestType() != rest::RequestType::POST) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   ExecContext const& exec = ExecContext::current();
   if (!exec.canUseDatabase(auth::Level::RW)) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "insufficient permissions");
-    return RestStatus::DONE;
+    co_return;
   }
 
   // ADD YOUR ALGORITHM HERE!!!
@@ -2426,18 +2382,17 @@ RestStatus RestAdminClusterHandler::handleRebalanceShards() {
   } else {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "unknown algorithm");
-    return RestStatus::DONE;
+    co_return;
   }
 
-  return waitForFuture(
-      handlePostRebalanceShards(algorithm)
-          .thenError<VPackException>([this](VPackException const& e) {
-            generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
-          })
-          .thenError<std::exception>([this](std::exception const& e) {
-            generateError(rest::ResponseCode::SERVER_ERROR,
-                          TRI_ERROR_HTTP_SERVER_ERROR, e.what());
-          }));
+  try {
+    co_await handlePostRebalanceShards(algorithm);
+  } catch (VPackException const& e) {
+    generateError(Result{TRI_ERROR_HTTP_SERVER_ERROR, e.what()});
+  } catch (std::exception const& e) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_HTTP_SERVER_ERROR,
+                  e.what());
+  }
 }
 
 namespace {
@@ -2495,11 +2450,11 @@ RestAdminClusterHandler::countAllMoveShardJobs() {
   };
 }
 
-RestStatus RestAdminClusterHandler::handleRebalanceGet() {
+void RestAdminClusterHandler::handleRebalanceGet() {
   if (request()->suffixes().size() != 1) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_admin/cluster/rebalance");
-    return RestStatus::DONE;
+    return;
   }
 
   auto [todo, pending] = countAllMoveShardJobs();
@@ -2519,7 +2474,7 @@ RestStatus RestAdminClusterHandler::handleRebalanceGet() {
   }
 
   generateOk(rest::ResponseCode::OK, builder.slice());
-  return RestStatus::DONE;
+  return;
 }
 
 namespace {
@@ -2584,11 +2539,11 @@ futures::Future<Result> executeMoveShardOperations(std::vector<T> const& batch,
 }
 }  // namespace
 
-RestStatus RestAdminClusterHandler::handleRebalanceExecute() {
+async<void> RestAdminClusterHandler::handleRebalanceExecute() {
   if (request()->requestType() != rest::RequestType::POST) {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-    return RestStatus::DONE;
+    co_return;
   }
   auto opts =
       velocypack::deserialize<RebalanceExecuteOptions>(_request->payload());
@@ -2596,7 +2551,7 @@ RestStatus RestAdminClusterHandler::handleRebalanceExecute() {
   if (opts.version != 1) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "unknown version provided");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto& ci = server().getFeature<ClusterFeature>().clusterInfo();
@@ -2607,21 +2562,18 @@ RestStatus RestAdminClusterHandler::handleRebalanceExecute() {
 
   if (opts.moves.empty()) {
     generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
-    return RestStatus::DONE;
+    co_return;
   }
 
-  return waitForFuture(executeMoveShardOperations(opts.moves, ci, idMapper)
-                           .thenValue([this](auto&& result) {
-                             if (result.ok()) {
-                               generateOk(rest::ResponseCode::ACCEPTED,
-                                          VPackSlice::noneSlice());
-                             } else {
-                               generateError(result);
-                             }
-                           }));
+  auto result = co_await executeMoveShardOperations(opts.moves, ci, idMapper);
+  if (result.ok()) {
+    generateOk(rest::ResponseCode::ACCEPTED, VPackSlice::noneSlice());
+  } else {
+    generateError(result);
+  }
 }
 
-RestStatus RestAdminClusterHandler::handleRebalancePlan() {
+async<void> RestAdminClusterHandler::handleRebalancePlan() {
   using namespace cluster::rebalance;
 
   auto const readRebalanceOptions = [&]() -> std::optional<RebalanceOptions> {
@@ -2645,7 +2597,7 @@ RestStatus RestAdminClusterHandler::handleRebalancePlan() {
 
   auto options = readRebalanceOptions();
   if (!options) {
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto p = collectRebalanceInformation(options->databasesExcluded,
@@ -2720,57 +2672,56 @@ RestStatus RestAdminClusterHandler::handleRebalancePlan() {
   switch (request()->requestType()) {
     case rest::RequestType::POST: {
       buildResponse(rest::ResponseCode::OK);
-      return RestStatus::DONE;
+      co_return;
     }
     case rest::RequestType::PUT: {
       buildResponse(rest::ResponseCode::ACCEPTED);
-      return waitForFuture(
-          executeMoveShardOperations(moves, ci, moveShardConverter)
-              .thenValue([&](auto&& result) {
-                if (!result.ok()) {
-                  generateError(result);
-                }
-              }));
+      auto result =
+          co_await executeMoveShardOperations(moves, ci, moveShardConverter);
+      if (!result.ok()) {
+        generateError(result);
+      }
+      co_return;
     }
     default:
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
-      return RestStatus::DONE;
+      co_return;
   }
 }
 
-RestStatus RestAdminClusterHandler::handleRebalance() {
+async<void> RestAdminClusterHandler::handleRebalance() {
   if (!ServerState::instance()->isCoordinator()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "only allowed on coordinators");
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (request()->requestType() == rest::RequestType::GET) {
-    return handleRebalanceGet();
+    co_return handleRebalanceGet();
   }
 
   bool parseSuccess = false;
   std::ignore = this->parseVPackBody(parseSuccess);
   if (!parseSuccess) {  // error message generated in parseVPackBody
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (auto const& suff = request()->suffixes(); suff.size() == 2) {
     if (suff[1] != "execute") {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     "expect /_admin/cluster/rebalance[/execute]");
-      return RestStatus::DONE;
+      co_return;
     }
-    return handleRebalanceExecute();
+    co_return co_await handleRebalanceExecute();
   }
 
-  return handleRebalancePlan();
+  co_return co_await handleRebalancePlan();
 }
 
 cluster::rebalance::AutoRebalanceProblem
@@ -2912,8 +2863,7 @@ RestAdminClusterHandler::collectRebalanceInformation(
   return p;
 }
 
-RestAdminClusterHandler::FutureVoid
-RestAdminClusterHandler::handleVPackSortMigration(
+async<void> RestAdminClusterHandler::handleVPackSortMigration(
     std::string const& subCommand) {
   // First we do the authentication: We only allow superuser access, since
   // this is a critical migration operation:

--- a/arangod/RestHandler/RestAdminClusterHandler.h
+++ b/arangod/RestHandler/RestAdminClusterHandler.h
@@ -43,7 +43,7 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   ~RestAdminClusterHandler() override = default;
 
  public:
-  RestStatus execute() override;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
   char const* name() const override final { return "RestAdminClusterHandler"; }
   RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
 
@@ -71,49 +71,47 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
   static std::string const VPackSortMigrationMigrate;
   static std::string const VPackSortMigrationStatus;
 
-  RestStatus handleHealth();
-  RestStatus handleNumberOfServers();
-  RestStatus handleMaintenance();
-  RestStatus handleDBServerMaintenance(std::string const& serverId);
+  async<void> handleHealth();
+  async<void> handleNumberOfServers();
+  async<void> handleMaintenance();
+  async<void> handleDBServerMaintenance(std::string const& serverId);
 
   // timeout can be used to set an arbitrary timeout for the maintenance
   // duration. it will be ignored if "state" is not true.
-  RestStatus setMaintenance(bool state, uint64_t timeout);
-  RestStatus setDBServerMaintenance(std::string const& serverId,
-                                    std::string const& mode, uint64_t timeout);
-  RestStatus handlePutMaintenance();
-  RestStatus handleGetMaintenance();
-  RestStatus handlePutDBServerMaintenance(std::string const& serverId);
-  RestStatus handleGetDBServerMaintenance(std::string const& serverId);
+  async<void> setMaintenance(bool state, uint64_t timeout);
+  async<void> setDBServerMaintenance(std::string const& serverId,
+                                     std::string const& mode, uint64_t timeout);
+  async<void> handlePutMaintenance();
+  async<void> handleGetMaintenance();
+  async<void> handlePutDBServerMaintenance(std::string const& serverId);
+  async<void> handleGetDBServerMaintenance(std::string const& serverId);
 
-  RestStatus handleGetNumberOfServers();
-  RestStatus handlePutNumberOfServers();
+  async<void> handleGetNumberOfServers();
+  async<void> handlePutNumberOfServers();
 
-  RestStatus handleNodeVersion();
-  RestStatus handleNodeStatistics();
-  RestStatus handleNodeEngine();
-  RestStatus handleStatistics();
+  async<void> handleNodeVersion();
+  async<void> handleNodeStatistics();
+  async<void> handleNodeEngine();
+  async<void> handleStatistics();
 
-  RestStatus handleShardDistribution();
-  RestStatus handleCollectionShardDistribution();
-  RestStatus handleShardStatistics();
+  void handleShardDistribution();
+  void handleCollectionShardDistribution();
+  void handleShardStatistics();
 
-  RestStatus handleCleanoutServer();
-  RestStatus handleResignLeadership();
-  RestStatus handleMoveShard();
-  RestStatus handleCancelJob();
-  RestStatus handleQueryJobStatus();
+  async<void> handleCleanoutServer();
+  async<void> handleResignLeadership();
+  async<void> handleMoveShard();
+  async<void> handleCancelJob();
+  async<void> handleQueryJobStatus();
 
-  RestStatus handleRemoveServer();
-  RestStatus handleRebalanceShards();
-  RestStatus handleRebalance();
-  RestStatus handleRebalanceGet();
-  RestStatus handleRebalanceExecute();
-  RestStatus handleRebalancePlan();
+  async<void> handleRemoveServer();
+  async<void> handleRebalanceShards();
+  async<void> handleRebalance();
+  void handleRebalanceGet();
+  async<void> handleRebalanceExecute();
+  async<void> handleRebalancePlan();
 
-  typedef futures::Future<futures::Unit> FutureVoid;
-
-  FutureVoid handleVPackSortMigration(std::string const& subCommand);
+  async<void> handleVPackSortMigration(std::string const& subCommand);
 
   struct MoveShardContext {
     std::string database;
@@ -142,21 +140,21 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
         arangodb::velocypack::Slice slice);
   };
 
-  RestStatus handlePostMoveShard(std::unique_ptr<MoveShardContext>&& ctx);
+  async<void> handlePostMoveShard(std::unique_ptr<MoveShardContext>&& ctx);
 
-  RestStatus handleSingleServerJob(std::string const& job);
-  RestStatus handleCreateSingleServerJob(std::string const& job,
-                                         std::string const& server,
-                                         VPackSlice body);
+  async<void> handleSingleServerJob(std::string const& job);
+  async<void> handleCreateSingleServerJob(std::string const& job,
+                                          std::string const& server,
+                                          VPackSlice body);
 
   typedef std::chrono::steady_clock clock;
 
-  FutureVoid waitForSupervisionState(bool state,
-                                     std::string const& reactivationTime,
-                                     clock::time_point startTime);
+  futures::Future<futures::Unit> waitForSupervisionState(
+      bool state, std::string const& reactivationTime,
+      clock::time_point startTime);
 
-  FutureVoid waitForDBServerMaintenance(std::string const& serverId,
-                                        bool waitForMaintenance);
+  futures::Future<futures::Unit> waitForDBServerMaintenance(
+      std::string const& serverId, bool waitForMaintenance);
 
   struct RemoveServerContext {
     size_t tries;
@@ -166,17 +164,18 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
         : tries(0), server(std::move(s)) {}
   };
 
-  FutureVoid tryDeleteServer(std::unique_ptr<RemoveServerContext>&& ctx);
-  FutureVoid retryTryDeleteServer(std::unique_ptr<RemoveServerContext>&& ctx);
-  FutureVoid createMoveShard(std::unique_ptr<MoveShardContext>&& ctx,
-                             velocypack::Slice plan);
+  futures::Future<futures::Unit> tryDeleteServer(
+      std::unique_ptr<RemoveServerContext>&& ctx);
+  futures::Future<futures::Unit> retryTryDeleteServer(
+      std::unique_ptr<RemoveServerContext>&& ctx);
+  async<void> createMoveShard(std::unique_ptr<MoveShardContext>&& ctx,
+                              velocypack::Slice plan);
 
-  RestStatus handleProxyGetRequest(std::string const& url,
-                                   std::string const& serverFromParameter);
-  RestStatus handleGetCollectionShardDistribution(
-      std::string const& collection);
+  async<void> handleProxyGetRequest(std::string const& url,
+                                    std::string const& serverFromParameter);
+  void handleGetCollectionShardDistribution(std::string const& collection);
 
-  RestStatus handlePostRemoveServer(std::string const& server);
+  async<void> handlePostRemoveServer(std::string const& server);
 
   std::string resolveServerNameID(std::string const&);
 
@@ -210,7 +209,8 @@ class RestAdminClusterHandler : public RestVocbaseBaseHandler {
                          std::uint32_t, std::string)>;
 
  private:
-  FutureVoid handlePostRebalanceShards(const ReshardAlgorithm&);
+  futures::Future<futures::Unit> handlePostRebalanceShards(
+      ReshardAlgorithm const&);
 
   cluster::rebalance::AutoRebalanceProblem collectRebalanceInformation(
       std::vector<std::string> const& excludedDatabases,

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -34,7 +34,6 @@
 #include "Logger/LogLevel.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerFeature.h"
-#include "Logger/LogMacros.h"
 #include "Logger/LogTopic.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
@@ -42,6 +41,7 @@
 #include "RestServer/LogBufferFeature.h"
 #include "Utils/ExecContext.h"
 
+#include <Async/async.h>
 #include <absl/strings/str_cat.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
@@ -79,12 +79,12 @@ arangodb::Result RestAdminLogHandler::verifyPermitted() {
   return arangodb::Result();
 }
 
-RestStatus RestAdminLogHandler::execute() {
+auto RestAdminLogHandler::executeAsync() -> futures::Future<futures::Unit> {
   auto result = verifyPermitted();
   if (!result.ok()) {
     generateError(rest::ResponseCode::FORBIDDEN, result.errorNumber(),
                   result.errorMessage());
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto const& suffixes = _request->suffixes();
@@ -96,7 +96,7 @@ RestStatus RestAdminLogHandler::execute() {
       clearLogs();
     } else if (suffixes.size() == 1 && suffixes[0] == "level") {
       // reset log levels to defaults
-      handleLogLevel();
+      co_await handleLogLevel();
     } else {
       generateError(rest::ResponseCode::BAD,
                     TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
@@ -105,11 +105,11 @@ RestStatus RestAdminLogHandler::execute() {
     }
   } else if (type == rest::RequestType::GET) {
     if (suffixes.empty()) {
-      return reportLogs(/*newFormat*/ false);
+      co_await reportLogs(/*newFormat*/ false);
     } else if (suffixes.size() == 1 && suffixes[0] == "entries") {
-      return reportLogs(/*newFormat*/ true);
+      co_await reportLogs(/*newFormat*/ true);
     } else if (suffixes.size() == 1 && suffixes[0] == "level") {
-      return handleLogLevel();
+      co_await handleLogLevel();
     } else if (suffixes.size() == 1 && suffixes[0] == "structured") {
       handleLogStructuredParams();
     } else {
@@ -121,7 +121,7 @@ RestStatus RestAdminLogHandler::execute() {
   } else if (type == rest::RequestType::PUT) {
     if (suffixes.size() == 1) {
       if (suffixes[0] == "level") {
-        return handleLogLevel();
+        co_await handleLogLevel();
       } else if (suffixes[0] == "structured") {
         handleLogStructuredParams();
       } else {
@@ -147,7 +147,7 @@ RestStatus RestAdminLogHandler::execute() {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
   }
-  return RestStatus::DONE;
+  co_return;
 }
 
 void RestAdminLogHandler::clearLogs() {
@@ -155,7 +155,7 @@ void RestAdminLogHandler::clearLogs() {
   generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
 }
 
-RestStatus RestAdminLogHandler::reportLogs(bool newFormat) {
+auto RestAdminLogHandler::reportLogs(bool newFormat) -> async<void> {
   bool foundServerIdParameter;
   std::string const& serverId =
       _request->value("serverId", foundServerIdParameter);
@@ -178,7 +178,7 @@ RestStatus RestAdminLogHandler::reportLogs(bool newFormat) {
         generateError(rest::ResponseCode::NOT_FOUND,
                       TRI_ERROR_HTTP_BAD_PARAMETER,
                       "unknown serverId supplied.");
-        return RestStatus::DONE;
+        co_return;
       }
 
       NetworkFeature const& nf = server().getFeature<NetworkFeature>();
@@ -192,18 +192,17 @@ RestStatus RestAdminLogHandler::reportLogs(bool newFormat) {
       options.database = _request->databaseName();
       options.parameters = _request->parameters();
 
-      auto f = network::sendRequestRetry(
+      auto r = co_await network::sendRequestRetry(
           pool, "server:" + serverId, fuerte::RestVerb::Get,
           _request->requestPath(), VPackBuffer<uint8_t>{}, options);
-      return waitForFuture(std::move(f).thenValue(
-          [self = std::dynamic_pointer_cast<RestAdminLogHandler>(
-               shared_from_this())](network::Response const& r) {
-            if (r.fail()) {
-              self->generateError(r.combinedResult());
-            } else {
-              self->generateResult(rest::ResponseCode::OK, r.slice());
-            }
-          }));
+
+      if (r.fail()) {
+        generateError(r.combinedResult());
+      } else {
+        generateResult(rest::ResponseCode::OK, r.slice());
+      }
+
+      co_return;
     }
   }
 
@@ -245,7 +244,7 @@ RestStatus RestAdminLogHandler::reportLogs(bool newFormat) {
         generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                       absl::StrCat("unknown '", (found2 ? "level" : "upto"),
                                    "' log level: '", logLevel, "'"));
-        return RestStatus::DONE;
+        co_return;
       }
     }
   }
@@ -419,13 +418,13 @@ RestStatus RestAdminLogHandler::reportLogs(bool newFormat) {
     result.close();
 
     result.close();  // Close the result object
-  }                  // format end
+  }  // format end
 
   generateResult(rest::ResponseCode::OK, result.slice());
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestAdminLogHandler::handleLogLevel() {
+auto RestAdminLogHandler::handleLogLevel() -> async<void> {
   std::vector<std::string> const& suffixes = _request->suffixes();
   // was validated earlier
   TRI_ASSERT(!suffixes.empty());
@@ -433,7 +432,7 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
   if (suffixes[0] != "level") {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                   "superfluous suffix, expecting /_admin/log/level");
-    return RestStatus::DONE;
+    co_return;
   }
 
   bool foundServerIdParameter;
@@ -458,7 +457,7 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
         generateError(rest::ResponseCode::NOT_FOUND,
                       TRI_ERROR_HTTP_BAD_PARAMETER,
                       "unknown serverId supplied.");
-        return RestStatus::DONE;
+        co_return;
       }
 
       NetworkFeature const& nf = server().getFeature<NetworkFeature>();
@@ -492,21 +491,18 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
       });
 
       if (!body.has_value()) {
-        return RestStatus::DONE;  // error message from vpack parser
+        co_return;  // error message from vpack parser
       }
 
-      auto f = network::sendRequestRetry(pool, "server:" + serverId,
-                                         requestType, _request->requestPath(),
-                                         std::move(*body), options);
-      return waitForFuture(std::move(f).thenValue(
-          [self = std::dynamic_pointer_cast<RestAdminLogHandler>(
-               shared_from_this())](network::Response const& r) {
-            if (r.fail()) {
-              self->generateError(r.combinedResult());
-            } else {
-              self->generateResult(rest::ResponseCode::OK, r.slice());
-            }
-          }));
+      auto r = co_await network::sendRequestRetry(
+          pool, "server:" + serverId, requestType, _request->requestPath(),
+          std::move(*body), options);
+      if (r.fail()) {
+        generateError(r.combinedResult());
+      } else {
+        generateResult(rest::ResponseCode::OK, r.slice());
+      }
+      co_return;
     }
   }
 
@@ -536,7 +532,7 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     bool parseSuccess = false;
     VPackSlice slice = this->parseVPackBody(parseSuccess);
     if (!parseSuccess) {
-      return RestStatus::DONE;  // error message generated in parseVPackBody
+      co_return;  // error message generated in parseVPackBody
     }
 
     if (slice.isString()) {
@@ -559,7 +555,7 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
       if (withAppenders) {
         AppendersLogLevelConfig config;
         if (!parseConfig(config)) {
-          return RestStatus::DONE;
+          co_return;
         }
 
         auto res = Logger::setLogLevel(config);
@@ -567,12 +563,12 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
           generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                         absl::StrCat("Failed to update log levels: ",
                                      res.errorMessage()));
-          return RestStatus::DONE;
+          co_return;
         }
       } else {
         LogLevels config;
         if (!parseConfig(config)) {
-          return RestStatus::DONE;
+          co_return;
         }
         Logger::setLogLevel(config);
       }
@@ -592,8 +588,6 @@ RestStatus RestAdminLogHandler::handleLogLevel() {
     generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
   }
-
-  return RestStatus::DONE;
 }
 
 void RestAdminLogHandler::handleLogStructuredParams() {

--- a/arangod/RestHandler/RestAdminLogHandler.cpp
+++ b/arangod/RestHandler/RestAdminLogHandler.cpp
@@ -418,7 +418,7 @@ auto RestAdminLogHandler::reportLogs(bool newFormat) -> async<void> {
     result.close();
 
     result.close();  // Close the result object
-  }  // format end
+  }                  // format end
 
   generateResult(rest::ResponseCode::OK, result.slice());
   co_return;

--- a/arangod/RestHandler/RestAdminLogHandler.h
+++ b/arangod/RestHandler/RestAdminLogHandler.h
@@ -39,13 +39,13 @@ class RestAdminLogHandler : public RestBaseHandler {
  public:
   char const* name() const override final { return "RestAdminLogHandler"; }
   RequestLane lane() const override final { return RequestLane::CLIENT_FAST; }
-  RestStatus execute() override;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
 
  private:
   arangodb::Result verifyPermitted();
   void clearLogs();
-  RestStatus reportLogs(bool newFormat);
-  RestStatus handleLogLevel();
+  auto reportLogs(bool newFormat) -> async<void>;
+  auto handleLogLevel() -> async<void>;
   void handleLogStructuredParams();
 };
 }  // namespace arangodb

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -29,7 +29,6 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
-#include "Logger/LogMacros.h"
 #include "Random/RandomGenerator.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
@@ -45,6 +44,7 @@
 #include "Utils/SingleCollectionTransaction.h"
 #include "VocBase/vocbase.h"
 
+#include <Async/async.h>
 #include <thread>
 
 using namespace arangodb;
@@ -91,7 +91,7 @@ RequestLane RestDocumentHandler::lane() const {
   return RequestLane::CLIENT_SLOW;
 }
 
-RestStatus RestDocumentHandler::execute() {
+auto RestDocumentHandler::executeAsync() -> futures::Future<futures::Unit> {
   // extract the sub-request type
   auto const type = _request->requestType();
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
@@ -106,24 +106,28 @@ RestStatus RestDocumentHandler::execute() {
   // execute one of the CRUD methods
   switch (type) {
     case rest::RequestType::DELETE_REQ:
-      return waitForFuture(removeDocument());
+      co_return co_await removeDocument();
     case rest::RequestType::GET:
-      return readDocument();
+      co_return co_await readDocument();
+      ;
     case rest::RequestType::HEAD:
-      return checkDocument();
+      co_return co_await checkDocument();
+      ;
     case rest::RequestType::POST:
-      return waitForFuture(insertDocument());
+      co_return co_await insertDocument();
     case rest::RequestType::PUT:
-      return replaceDocument();
+      co_return co_await replaceDocument();
+      ;
     case rest::RequestType::PATCH:
-      return updateDocument();
+      co_return co_await updateDocument();
+      ;
     default: {
       generateNotImplemented("ILLEGAL " + DOCUMENT_PATH);
     }
   }
 
   // this handler is done
-  return RestStatus::DONE;
+  co_return;
 }
 
 void RestDocumentHandler::shutdownExecute(bool isFinalized) noexcept {
@@ -153,7 +157,7 @@ void RestDocumentHandler::shutdownExecute(bool isFinalized) noexcept {
   RestVocbaseBaseHandler::shutdownExecute(isFinalized);
 }
 
-futures::Future<futures::Unit> RestDocumentHandler::insertDocument() {
+async<void> RestDocumentHandler::insertDocument() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   if (suffixes.size() > 1) {
@@ -308,7 +312,7 @@ futures::Future<futures::Unit> RestDocumentHandler::insertDocument() {
 /// Either readSingleDocument or readAllDocuments.
 ////////////////////////////////////////////////////////////////////////////////
 
-RestStatus RestDocumentHandler::readDocument() {
+async<void> RestDocumentHandler::readDocument() {
   size_t const len = _request->suffixes().size();
 
   switch (len) {
@@ -317,20 +321,19 @@ RestStatus RestDocumentHandler::readDocument() {
       generateError(rest::ResponseCode::NOT_FOUND,
                     TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                     "expecting GET /_api/document/<collection>/<key>");
-      return RestStatus::DONE;
+      co_return;
     case 2:
-      return waitForFuture(readSingleDocument(true));
+      co_return co_await readSingleDocument(true);
 
     default:
       generateError(rest::ResponseCode::BAD,
                     TRI_ERROR_HTTP_SUPERFLUOUS_SUFFICES,
                     "expecting GET /_api/document/<collection>/<key>");
-      return RestStatus::DONE;
+      co_return;
   }
 }
 
-futures::Future<futures::Unit> RestDocumentHandler::readSingleDocument(
-    bool generateBody) {
+async<void> RestDocumentHandler::readSingleDocument(bool generateBody) {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   // split the document reference
@@ -439,33 +442,32 @@ futures::Future<futures::Unit> RestDocumentHandler::readSingleDocument(
                    trx->transactionContextPtr()->getVPackOptions());
 }
 
-RestStatus RestDocumentHandler::checkDocument() {
+async<void> RestDocumentHandler::checkDocument() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   if (suffixes.size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting HEAD /_api/document/<collection>/<key>");
-    return RestStatus::DONE;
+    co_return;
   }
 
-  return waitForFuture(readSingleDocument(false));
+  co_return co_await readSingleDocument(false);
 }
 
-RestStatus RestDocumentHandler::replaceDocument() {
+async<void> RestDocumentHandler::replaceDocument() {
   bool found;
   _request->value("onlyget", found);
   if (found) {
-    return waitForFuture(readManyDocuments());
+    co_return co_await readManyDocuments();
   }
-  return waitForFuture(modifyDocument(false));
+  co_return co_await modifyDocument(false);
 }
 
-RestStatus RestDocumentHandler::updateDocument() {
-  return waitForFuture(modifyDocument(true));
+async<void> RestDocumentHandler::updateDocument() {
+  co_return co_await modifyDocument(true);
 }
 
-futures::Future<futures::Unit> RestDocumentHandler::modifyDocument(
-    bool isPatch) {
+async<void> RestDocumentHandler::modifyDocument(bool isPatch) {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   if (suffixes.size() > 2) {
@@ -668,7 +670,7 @@ futures::Future<futures::Unit> RestDocumentHandler::modifyDocument(
               opOptions.silent, rest::ResponseCode::CREATED);
 }
 
-futures::Future<futures::Unit> RestDocumentHandler::removeDocument() {
+async<void> RestDocumentHandler::removeDocument() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   if (suffixes.size() < 1 || suffixes.size() > 2) {
@@ -809,7 +811,7 @@ futures::Future<futures::Unit> RestDocumentHandler::removeDocument() {
               opOptions.silent, rest::ResponseCode::OK);
 }
 
-futures::Future<futures::Unit> RestDocumentHandler::readManyDocuments() {
+async<void> RestDocumentHandler::readManyDocuments() {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   if (suffixes.size() != 1) {

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -109,18 +109,14 @@ auto RestDocumentHandler::executeAsync() -> futures::Future<futures::Unit> {
       co_return co_await removeDocument();
     case rest::RequestType::GET:
       co_return co_await readDocument();
-      ;
     case rest::RequestType::HEAD:
       co_return co_await checkDocument();
-      ;
     case rest::RequestType::POST:
       co_return co_await insertDocument();
     case rest::RequestType::PUT:
       co_return co_await replaceDocument();
-      ;
     case rest::RequestType::PATCH:
       co_return co_await updateDocument();
-      ;
     default: {
       generateNotImplemented("ILLEGAL " + DOCUMENT_PATH);
     }

--- a/arangod/RestHandler/RestDocumentHandler.h
+++ b/arangod/RestHandler/RestDocumentHandler.h
@@ -40,7 +40,7 @@ class RestDocumentHandler : public RestVocbaseBaseHandler {
   ~RestDocumentHandler();
 
  public:
-  RestStatus execute() override final;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
   char const* name() const override final { return "RestDocumentHandler"; }
   RequestLane lane() const override final;
 
@@ -48,32 +48,31 @@ class RestDocumentHandler : public RestVocbaseBaseHandler {
 
  private:
   // inserts a document
-  [[nodiscard]] futures::Future<futures::Unit> insertDocument();
+  async<void> insertDocument();
 
   // reads a single or all documents
-  RestStatus readDocument();
+  async<void> readDocument();
 
   // reads a single document
-  [[nodiscard]] futures::Future<futures::Unit> readSingleDocument(
-      bool generateBody);
+  async<void> readSingleDocument(bool generateBody);
 
   // reads multiple documents
-  [[nodiscard]] futures::Future<futures::Unit> readManyDocuments();
+  async<void> readManyDocuments();
 
   // reads a single document head
-  RestStatus checkDocument();
+  async<void> checkDocument();
 
   // replaces a document
-  RestStatus replaceDocument();
+  async<void> replaceDocument();
 
   // updates a document
-  RestStatus updateDocument();
+  async<void> updateDocument();
 
   // helper function for replace and update
-  [[nodiscard]] futures::Future<futures::Unit> modifyDocument(bool);
+  async<void> modifyDocument(bool);
 
   // removes a document
-  [[nodiscard]] futures::Future<futures::Unit> removeDocument();
+  async<void> removeDocument();
 
   void handleFillIndexCachesValue(OperationOptions& options);
 

--- a/arangod/RestHandler/RestGraphHandler.cpp
+++ b/arangod/RestHandler/RestGraphHandler.cpp
@@ -50,14 +50,11 @@ RestGraphHandler::RestGraphHandler(ArangodServer& server,
     : RestVocbaseBaseHandler(server, request, response),
       _graphManager(_vocbase, transaction::OperationOriginREST{::moduleName}) {}
 
-RestStatus RestGraphHandler::execute() {
-  auto f = executeGharial().thenValue([&](Result res) {
-    if (res.fail()) {
-      TRI_ASSERT(!_response->isResponseEmpty());
-    }
-  });
-
-  return waitForFuture(std::move(f));
+auto RestGraphHandler::executeAsync() -> futures::Future<futures::Unit> {
+  auto res = co_await executeGharial();
+  if (res.fail()) {
+    TRI_ASSERT(!_response->isResponseEmpty());
+  }
 }
 
 Result RestGraphHandler::returnError(ErrorCode errorNumber) {

--- a/arangod/RestHandler/RestGraphHandler.h
+++ b/arangod/RestHandler/RestGraphHandler.h
@@ -51,7 +51,7 @@ class RestGraphHandler : public arangodb::RestVocbaseBaseHandler {
 
   char const* name() const override final { return "RestGraphHandler"; }
 
-  RestStatus execute() override;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
 
   RequestLane lane() const override;
 

--- a/arangod/RestHandler/RestImportHandler.cpp
+++ b/arangod/RestHandler/RestImportHandler.cpp
@@ -53,7 +53,7 @@ RestImportHandler::RestImportHandler(ArangodServer& server,
       _onDuplicateAction(DUPLICATE_ERROR),
       _ignoreMissing(false) {}
 
-RestStatus RestImportHandler::execute() {
+auto RestImportHandler::executeAsync() -> futures::Future<futures::Unit> {
   // set default value for onDuplicate
   _onDuplicateAction = DUPLICATE_ERROR;
 
@@ -99,14 +99,17 @@ RestStatus RestImportHandler::execute() {
       std::string const& documentType = _request->value("type", found);
 
       if (_request->contentType() == arangodb::ContentType::VPACK) {
-        return waitForFuture(createFromVPack(documentType));
+        co_await createFromVPack(documentType);
+        co_return;
       } else if (found &&
                  (documentType == "documents" || documentType == "array" ||
                   documentType == "list" || documentType == "auto")) {
-        return waitForFuture(createFromJson(documentType));
+        co_await createFromJson(documentType);
+        co_return;
       } else {
         // CSV
-        return waitForFuture(createFromKeyValueList());
+        co_await createFromKeyValueList();
+        co_return;
       }
     } break;
 
@@ -116,7 +119,7 @@ RestStatus RestImportHandler::execute() {
   }
 
   // this handler is done
-  return RestStatus::DONE;
+  co_return;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/RestHandler/RestImportHandler.h
+++ b/arangod/RestHandler/RestImportHandler.h
@@ -65,7 +65,7 @@ class RestImportHandler : public RestVocbaseBaseHandler {
   explicit RestImportHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
  public:
-  RestStatus execute() override final;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
   char const* name() const override final { return "RestImportHandler"; }
   RequestLane lane() const override final { return RequestLane::CLIENT_SLOW; }
 

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -23,15 +23,11 @@
 
 #include "RestLogHandler.h"
 
-#include <velocypack/Iterator.h>
-
-#include <Cluster/ServerState.h>
-#include <Network/ConnectionPool.h>
+#include <Async/async.h>
+#include <Cluster/AgencyCache.h>
+#include <Cluster/ClusterFeature.h>
 #include <Network/Methods.h>
 #include <Network/NetworkFeature.h>
-
-#include <Cluster/ClusterFeature.h>
-#include <Cluster/AgencyCache.h>
 
 #include "Agency/AgencyPaths.h"
 #include "Inspection/VPack.h"
@@ -49,45 +45,47 @@
 using namespace arangodb;
 using namespace arangodb::replication2;
 
-RestStatus RestLogHandler::execute() {
+auto RestLogHandler::executeAsync() -> futures::Future<futures::Unit> {
   // for now required admin access to the database
   if (!ExecContext::current().isAdminUser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN);
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto methods = ReplicatedLogMethods::createInstance(_vocbase);
-  return executeByMethod(*methods);
+  co_await executeByMethod(*methods);
+  co_return;
 }
 
-RestStatus RestLogHandler::executeByMethod(
-    ReplicatedLogMethods const& methods) {
+auto RestLogHandler::executeByMethod(ReplicatedLogMethods const& methods)
+    -> async<void> {
   switch (_request->requestType()) {
     case rest::RequestType::GET:
-      return handleGetRequest(methods);
+      co_return co_await handleGetRequest(methods);
     case rest::RequestType::POST:
-      return handlePostRequest(methods);
+      co_return co_await handlePostRequest(methods);
     case rest::RequestType::DELETE_REQ:
-      return handleDeleteRequest(methods);
+      co_return co_await handleDeleteRequest(methods);
     default:
       generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
                     TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
   }
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestLogHandler::handlePostRequest(
-    ReplicatedLogMethods const& methods) {
+auto RestLogHandler::handlePostRequest(ReplicatedLogMethods const& methods)
+    -> async<void> {
   std::vector<std::string> const& suffixes = _request->decodedSuffixes();
 
   bool parseSuccess = false;
   VPackSlice body = this->parseVPackBody(parseSuccess);
   if (!parseSuccess) {  // error message generated in parseVPackBody
-    return RestStatus::DONE;
+    co_return;
   }
 
   if (suffixes.empty()) {
-    return handlePost(methods, body);
+    co_await handlePost(methods, body);
+    co_return;
   } else if (std::string_view logIdStr, toRemoveStr, toAddStr;
              rest::Match(suffixes).against(&logIdStr, "participant",
                                            &toRemoveStr, "replace-with",
@@ -98,7 +96,7 @@ RestStatus RestLogHandler::handlePostRequest(
     if (!logId) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     basics::StringUtils::concatT("Not a log id: ", logIdStr));
-      return RestStatus::DONE;
+      co_return;
     }
 
     // If this wasn't a temporary API, it would be nice to be able to pass a
@@ -119,16 +117,14 @@ RestStatus RestLogHandler::handlePostRequest(
     auto stateTarget =
         velocypack::deserialize<replication2::agency::LogTarget>(res->slice());
 
-    return waitForFuture(
-        methods.replaceParticipant(*logId, toRemove, toAdd, stateTarget.leader)
-            .thenValue([this](auto&& result) {
-              if (result.ok()) {
-                generateOk(rest::ResponseCode::OK,
-                           VPackSlice::emptyObjectSlice());
-              } else {
-                generateError(result);
-              }
-            }));
+    auto result = co_await methods.replaceParticipant(*logId, toRemove, toAdd,
+                                                      stateTarget.leader);
+    if (result.ok()) {
+      generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
+    } else {
+      generateError(result);
+    }
+    co_return;
   } else if (std::string_view logIdStr, newLeaderStr;
              rest::Match(suffixes).against(&logIdStr, "leader",
                                            &newLeaderStr)) {
@@ -137,110 +133,104 @@ RestStatus RestLogHandler::handlePostRequest(
     if (!logId) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     basics::StringUtils::concatT("Not a log id: ", logIdStr));
-      return RestStatus::DONE;
+      co_return;
     }
-    return waitForFuture(
-        methods.setLeader(*logId, newLeader).thenValue([this](auto&& result) {
-          if (result.ok()) {
-            generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
-          } else {
-            generateError(result);
-          }
-        }));
+    auto result = co_await methods.setLeader(*logId, newLeader);
+
+    if (result.ok()) {
+      generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
+    } else {
+      generateError(result);
+    }
+    co_return;
   }
 
   if (suffixes.size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect POST /_api/log/<log-id>/[verb]");
-    return RestStatus::DONE;
+    co_return;
   }
 
   LogId logId{basics::StringUtils::uint64(suffixes[0])};
   if (auto& verb = suffixes[1]; verb == "insert") {
-    return handlePostInsert(methods, logId, body);
+    co_return co_await handlePostInsert(methods, logId, body);
   } else if (verb == "release") {
-    return handlePostRelease(methods, logId);
+    co_return co_await handlePostRelease(methods, logId);
   } else if (verb == "ping") {
-    return handlePostPing(methods, logId, body);
+    co_return co_await handlePostPing(methods, logId, body);
   } else if (verb == "compact") {
-    return handlePostCompact(methods, logId);
+    co_return co_await handlePostCompact(methods, logId);
   } else if (verb == "multi-insert") {
-    return handlePostInsertMulti(methods, logId, body);
+    co_return co_await handlePostInsertMulti(methods, logId, body);
   } else {
     generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "expecting one of the resources 'insert', 'release', "
                   "'multi-insert', 'compact', 'ping'");
   }
-  return RestStatus::DONE;
+  co_return;
 }
 
-RestStatus RestLogHandler::handlePostInsert(ReplicatedLogMethods const& methods,
-                                            replication2::LogId logId,
-                                            velocypack::Slice payload) {
+auto RestLogHandler::handlePostInsert(ReplicatedLogMethods const& methods,
+                                      replication2::LogId logId,
+                                      velocypack::Slice payload)
+    -> async<void> {
   bool const waitForSync =
       _request->parsedValue(StaticStrings::WaitForSyncString, false);
   bool const dontWaitForCommit =
       _request->parsedValue(StaticStrings::DontWaitForCommit, false);
   if (dontWaitForCommit) {
-    return waitForFuture(
-        methods
-            .insertWithoutCommit(logId, LogPayload::createFromSlice(payload),
-                                 waitForSync)
-            .thenValue([this](LogIndex idx) {
-              VPackBuilder response;
-              {
-                VPackObjectBuilder result(&response);
-                response.add("index", VPackValue(idx));
-              }
-              generateOk(rest::ResponseCode::ACCEPTED, response.slice());
-            }));
+    auto idx = co_await methods.insertWithoutCommit(
+        logId, LogPayload::createFromSlice(payload), waitForSync);
 
+    VPackBuilder response;
+    {
+      VPackObjectBuilder result(&response);
+      response.add("index", VPackValue(idx));
+    }
+    generateOk(rest::ResponseCode::ACCEPTED, response.slice());
   } else {
-    return waitForFuture(
-        methods.insert(logId, LogPayload::createFromSlice(payload), waitForSync)
-            .thenValue([this](auto&& waitForResult) {
-              VPackBuilder response;
-              {
-                VPackObjectBuilder result(&response);
-                response.add("index", VPackValue(waitForResult.first));
-                response.add(VPackValue("result"));
-                waitForResult.second.toVelocyPack(response);
-              }
-              generateOk(rest::ResponseCode::CREATED, response.slice());
-            }));
+    auto waitForResult = co_await methods.insert(
+        logId, LogPayload::createFromSlice(payload), waitForSync);
+    VPackBuilder response;
+    {
+      VPackObjectBuilder result(&response);
+      response.add("index", VPackValue(waitForResult.first));
+      response.add(VPackValue("result"));
+      waitForResult.second.toVelocyPack(response);
+    }
+    generateOk(rest::ResponseCode::CREATED, response.slice());
   }
 }
 
-RestStatus RestLogHandler::handlePostPing(ReplicatedLogMethods const& methods,
-                                          replication2::LogId logId,
-                                          velocypack::Slice payload) {
+auto RestLogHandler::handlePostPing(ReplicatedLogMethods const& methods,
+                                    replication2::LogId logId,
+                                    velocypack::Slice payload) -> async<void> {
   std::optional<std::string> message;
   if (payload.isObject()) {
     if (auto messageSlice = payload.get("message"); not messageSlice.isNone()) {
       message = messageSlice.copyString();
     }
   }
-  return waitForFuture(
-      methods.ping(logId, std::move(message))
-          .thenValue([this](auto&& waitForResult) {
-            VPackBuilder response;
-            {
-              VPackObjectBuilder result(&response);
-              response.add("index", VPackValue(waitForResult.first));
-              response.add(VPackValue("result"));
-              waitForResult.second.toVelocyPack(response);
-            }
-            generateOk(rest::ResponseCode::CREATED, response.slice());
-          }));
+  auto waitForResult = co_await methods.ping(logId, std::move(message));
+
+  VPackBuilder response;
+  {
+    VPackObjectBuilder result(&response);
+    response.add("index", VPackValue(waitForResult.first));
+    response.add(VPackValue("result"));
+    waitForResult.second.toVelocyPack(response);
+  }
+  generateOk(rest::ResponseCode::CREATED, response.slice());
 }
 
-RestStatus RestLogHandler::handlePostInsertMulti(
-    ReplicatedLogMethods const& methods, replication2::LogId logId,
-    velocypack::Slice payload) {
+auto RestLogHandler::handlePostInsertMulti(ReplicatedLogMethods const& methods,
+                                           replication2::LogId logId,
+                                           velocypack::Slice payload)
+    -> async<void> {
   if (!payload.isArray()) {
     generateError(ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
                   "array expected at top-level");
-    return RestStatus::DONE;
+    co_return;
   }
   bool const waitForSync =
       _request->parsedValue(StaticStrings::WaitForSyncString, false);
@@ -249,158 +239,145 @@ RestStatus RestLogHandler::handlePostInsertMulti(
   if (dontWaitForCommit) {
     generateError(ResponseCode::BAD, TRI_ERROR_HTTP_NOT_IMPLEMENTED,
                   "dontWaitForCommit is not implemented for multiple inserts");
-    return RestStatus::DONE;
+    co_return;
   }
   auto iter = replicated_log::VPackArrayToLogPayloadIterator{payload};
-  auto f = methods.insert(logId, iter, waitForSync)
-               .thenValue([this](auto&& waitForResult) {
-                 VPackBuilder response;
-                 {
-                   VPackObjectBuilder result(&response);
-                   {
-                     VPackArrayBuilder a(&response, "indexes");
-                     for (auto index : waitForResult.first) {
-                       response.add(VPackValue(index));
-                     }
-                   }
-                   response.add(VPackValue("result"));
-                   waitForResult.second.toVelocyPack(response);
-                 }
-                 generateOk(rest::ResponseCode::CREATED, response.slice());
-               });
-  return waitForFuture(std::move(f));
+  auto waitForResult = co_await methods.insert(logId, iter, waitForSync);
+
+  VPackBuilder response;
+  {
+    VPackObjectBuilder result(&response);
+    {
+      VPackArrayBuilder a(&response, "indexes");
+      for (auto index : waitForResult.first) {
+        response.add(VPackValue(index));
+      }
+    }
+    response.add(VPackValue("result"));
+    waitForResult.second.toVelocyPack(response);
+  }
+  generateOk(rest::ResponseCode::CREATED, response.slice());
 }
 
-RestStatus RestLogHandler::handlePostRelease(
-    ReplicatedLogMethods const& methods, replication2::LogId logId) {
+auto RestLogHandler::handlePostRelease(ReplicatedLogMethods const& methods,
+                                       replication2::LogId logId)
+    -> async<void> {
   auto idx = LogIndex{basics::StringUtils::uint64(_request->value("index"))};
-  return waitForFuture(
-      methods.release(logId, idx).thenValue([this](Result&& res) {
-        if (res.fail()) {
-          generateError(res);
-        } else {
-          generateOk(rest::ResponseCode::ACCEPTED, VPackSlice::noneSlice());
-        }
-      }));
+
+  auto res = co_await methods.release(logId, idx);
+  if (res.fail()) {
+    generateError(res);
+  } else {
+    generateOk(rest::ResponseCode::ACCEPTED, VPackSlice::noneSlice());
+  }
 }
 
-RestStatus RestLogHandler::handlePostCompact(
-    ReplicatedLogMethods const& methods, replication2::LogId logId) {
-  return waitForFuture(methods.compact(logId).thenValue([this](auto&& res) {
-    VPackBuilder builder;
-    velocypack::serialize(builder, res);
-    generateOk(rest::ResponseCode::ACCEPTED, builder.slice());
-  }));
+auto RestLogHandler::handlePostCompact(ReplicatedLogMethods const& methods,
+                                       replication2::LogId logId)
+    -> async<void> {
+  auto res = co_await methods.compact(logId);
+
+  VPackBuilder builder;
+  velocypack::serialize(builder, res);
+  generateOk(rest::ResponseCode::ACCEPTED, builder.slice());
 }
 
-RestStatus RestLogHandler::handlePost(ReplicatedLogMethods const& methods,
-                                      velocypack::Slice specSlice) {
+auto RestLogHandler::handlePost(ReplicatedLogMethods const& methods,
+                                velocypack::Slice specSlice) -> async<void> {
   if (_vocbase.replicationVersion() != replication::Version::TWO) {
     generateError(
         Result{TRI_ERROR_HTTP_FORBIDDEN,
                "Replicated logs available only in replication2 databases!"});
-    return RestStatus::DONE;
+    co_return;
   }
 
   // create a new log
   auto spec =
       velocypack::deserialize<ReplicatedLogMethods::CreateOptions>(specSlice);
-  return waitForFuture(
-      methods.createReplicatedLog(std::move(spec))
-          .thenValue(
-              [this](ResultT<ReplicatedLogMethods::CreateResult>&& result) {
-                if (result.ok()) {
-                  VPackBuilder builder;
-                  velocypack::serialize(builder, result.get());
-                  generateOk(rest::ResponseCode::OK, builder.slice());
-                } else {
-                  generateError(result.result());
-                }
-              }));
+  auto result = co_await methods.createReplicatedLog(std::move(spec));
+  if (result.ok()) {
+    VPackBuilder builder;
+    velocypack::serialize(builder, result.get());
+    generateOk(rest::ResponseCode::OK, builder.slice());
+  } else {
+    generateError(result.result());
+  }
 }
 
-RestStatus RestLogHandler::handleGetRequest(
-    ReplicatedLogMethods const& methods) {
+auto RestLogHandler::handleGetRequest(ReplicatedLogMethods const& methods)
+    -> async<void> {
   std::vector<std::string> const& suffixes = _request->suffixes();
   if (suffixes.empty()) {
-    return handleGet(methods);
+    co_return co_await handleGet(methods);
   }
 
   if (suffixes.size() == 2) {
     if (suffixes[0] == "collection-status") {
       CollectionID cid{suffixes[1]};
-      return handleGetCollectionStatus(methods, std::move(cid));
+      co_return co_await handleGetCollectionStatus(methods, std::move(cid));
     }
   }
 
   LogId logId{basics::StringUtils::uint64(suffixes[0])};
 
   if (suffixes.size() == 1) {
-    return handleGetLog(methods, logId);
+    co_return co_await handleGetLog(methods, logId);
   }
 
   auto const& verb = suffixes[1];
   if (verb == "poll") {
-    return handleGetPoll(methods, logId);
+    co_return co_await handleGetPoll(methods, logId);
   } else if (verb == "head") {
-    return handleGetHead(methods, logId);
+    co_return co_await handleGetHead(methods, logId);
   } else if (verb == "tail") {
-    return handleGetTail(methods, logId);
+    co_return co_await handleGetTail(methods, logId);
   } else if (verb == "entry") {
-    return handleGetEntry(methods, logId);
+    co_return co_await handleGetEntry(methods, logId);
   } else if (verb == "slice") {
-    return handleGetSlice(methods, logId);
+    co_return co_await handleGetSlice(methods, logId);
   } else if (verb == "local-status") {
-    return handleGetLocalStatus(methods, logId);
+    co_return co_await handleGetLocalStatus(methods, logId);
   } else if (verb == "global-status") {
-    return handleGetGlobalStatus(methods, logId);
+    co_return co_await handleGetGlobalStatus(methods, logId);
   } else {
     generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
                   "expecting one of the resources 'poll', 'head', 'tail', "
                   "'entry', 'slice', 'local-status', 'global-status'");
   }
-  return RestStatus::DONE;
 }
 
-RestStatus RestLogHandler::handleDeleteRequest(
-    ReplicatedLogMethods const& methods) {
+auto RestLogHandler::handleDeleteRequest(ReplicatedLogMethods const& methods)
+    -> async<void> {
   auto const& suffixes = _request->suffixes();
   if (std::string_view logIdStr; rest::Match(suffixes).against(&logIdStr)) {
     auto const logId = replication2::LogId::fromString(logIdStr);
     if (!logId) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     basics::StringUtils::concatT("Not a log id: ", logIdStr));
-      return RestStatus::DONE;
+      co_return;
     }
-    return waitForFuture(
-        methods.deleteReplicatedLog(*logId).thenValue([this](auto&& result) {
-          if (result.ok()) {
-            generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
-          } else {
-            generateError(result);
-          }
-        }));
-
+    auto result = co_await methods.deleteReplicatedLog(*logId);
+    if (result.ok()) {
+      generateOk(rest::ResponseCode::OK, VPackSlice::noneSlice());
+    } else {
+      generateError(result);
+    }
   } else if (std::string_view logIdStr;
              rest::Match(suffixes).against(&logIdStr, "leader")) {
     auto const logId = replication2::LogId::fromString(logIdStr);
     if (!logId) {
       generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                     basics::StringUtils::concatT("Not a log id: ", logIdStr));
-      return RestStatus::DONE;
+      co_return;
     }
-    return waitForFuture(methods.setLeader(*logId, std::nullopt)
-                             .thenValue([this](auto&& result) {
-                               if (result.ok()) {
-                                 generateOk(rest::ResponseCode::OK,
-                                            VPackSlice::emptyObjectSlice());
-                               } else {
-                                 generateError(result);
-                               }
-                             }));
+    auto result = co_await methods.setLeader(*logId, std::nullopt);
+    if (result.ok()) {
+      generateOk(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
+    } else {
+      generateError(result);
+    }
   } else {
     generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
-    return RestStatus::DONE;
   }
 }
 
@@ -408,53 +385,51 @@ RestLogHandler::RestLogHandler(ArangodServer& server, GeneralRequest* req,
                                GeneralResponse* resp)
     : RestVocbaseBaseHandler(server, req, resp) {}
 
-RestStatus RestLogHandler::handleGet(ReplicatedLogMethods const& methods) {
-  return waitForFuture(methods.getReplicatedLogs().thenValue([this](
-                                                                 auto&& logs) {
-    VPackBuilder builder;
-    {
-      VPackObjectBuilder ob(&builder);
+auto RestLogHandler::handleGet(ReplicatedLogMethods const& methods)
+    -> async<void> {
+  auto logs = co_await methods.getReplicatedLogs();
+  VPackBuilder builder;
+  {
+    VPackObjectBuilder ob(&builder);
 
-      for (auto const& [idx, logInfo] : logs) {
-        builder.add(VPackValue(std::to_string(idx.id())));
-        std::visit(overload{[&](replicated_log::LogStatus const& status) {
-                              status.toVelocyPack(builder);
-                            },
-                            [&](ReplicatedLogMethods::ParticipantsList const&
-                                    participants) {
-                              VPackArrayBuilder ab(&builder);
-                              for (auto&& pid : participants) {
-                                builder.add(VPackValue(pid));
-                              }
-                            }},
-                   logInfo);
-      }
+    for (auto const& [idx, logInfo] : logs) {
+      builder.add(VPackValue(std::to_string(idx.id())));
+      std::visit(
+          overload{
+              [&](replicated_log::LogStatus const& status) {
+                status.toVelocyPack(builder);
+              },
+              [&](ReplicatedLogMethods::ParticipantsList const& participants) {
+                VPackArrayBuilder ab(&builder);
+                for (auto&& pid : participants) {
+                  builder.add(VPackValue(pid));
+                }
+              }},
+          logInfo);
     }
+  }
 
-    generateOk(rest::ResponseCode::OK, builder.slice());
-  }));
+  generateOk(rest::ResponseCode::OK, builder.slice());
 }
 
-RestStatus RestLogHandler::handleGetLog(const ReplicatedLogMethods& methods,
-                                        replication2::LogId logId) {
-  return waitForFuture(
-      methods.getStatus(logId).thenValue([this](auto&& status) {
-        std::visit(
-            [this](auto&& status) {
-              VPackBuilder buffer;
-              status.toVelocyPack(buffer);
-              generateOk(rest::ResponseCode::OK, buffer.slice());
-            },
-            status);
-      }));
+auto RestLogHandler::handleGetLog(ReplicatedLogMethods const& methods,
+                                  replication2::LogId logId) -> async<void> {
+  auto status = co_await methods.getStatus(logId);
+  std::visit(
+      [this](auto&& status) {
+        VPackBuilder buffer;
+        status.toVelocyPack(buffer);
+        generateOk(rest::ResponseCode::OK, buffer.slice());
+      },
+      status);
 }
 
-RestStatus RestLogHandler::handleGetPoll(ReplicatedLogMethods const& methods,
-                                         replication2::LogId logId) {
+auto RestLogHandler::handleGetPoll(ReplicatedLogMethods const& methods,
+                                   replication2::LogId logId) -> async<void> {
   if (_request->suffixes().size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/poll");
-    return RestStatus::DONE;
+    co_return;
   }
   bool limitFound;
   LogIndex logIdx{basics::StringUtils::uint64(_request->value("first"))};
@@ -462,84 +437,73 @@ RestStatus RestLogHandler::handleGetPoll(ReplicatedLogMethods const& methods,
       basics::StringUtils::uint64(_request->value("limit", limitFound))};
   limit = limitFound ? limit : ReplicatedLogMethods::kDefaultLimit;
 
-  auto fut = methods.poll(logId, logIdx, limit)
-                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
-                   VPackBuilder builder;
-                   {
-                     VPackArrayBuilder ab(&builder);
-                     while (auto entry = iter->next()) {
-                       entry->toVelocyPack(builder);
-                     }
-                   }
+  auto iter = co_await methods.poll(logId, logIdx, limit);
+  VPackBuilder builder;
+  {
+    VPackArrayBuilder ab(&builder);
+    while (auto entry = iter->next()) {
+      entry->toVelocyPack(builder);
+    }
+  }
 
-                   generateOk(rest::ResponseCode::OK, builder.slice());
-                 });
-
-  return waitForFuture(std::move(fut));
+  generateOk(rest::ResponseCode::OK, builder.slice());
 }
 
-RestStatus RestLogHandler::handleGetTail(ReplicatedLogMethods const& methods,
-                                         replication2::LogId logId) {
+auto RestLogHandler::handleGetTail(ReplicatedLogMethods const& methods,
+                                   replication2::LogId logId) -> async<void> {
   if (_request->suffixes().size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/tail");
-    return RestStatus::DONE;
+    co_return;
   }
   bool limitFound;
   std::size_t limit{
       basics::StringUtils::uint64(_request->value("limit", limitFound))};
   limit = limitFound ? limit : ReplicatedLogMethods::kDefaultLimit;
 
-  auto fut = methods.tail(logId, limit)
-                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
-                   VPackBuilder builder;
-                   {
-                     VPackArrayBuilder ab(&builder);
-                     while (auto entry = iter->next()) {
-                       entry->toVelocyPack(builder);
-                     }
-                   }
+  auto iter = co_await methods.tail(logId, limit);
 
-                   generateOk(rest::ResponseCode::OK, builder.slice());
-                 });
+  VPackBuilder builder;
+  {
+    VPackArrayBuilder ab(&builder);
+    while (auto entry = iter->next()) {
+      entry->toVelocyPack(builder);
+    }
+  }
 
-  return waitForFuture(std::move(fut));
+  generateOk(rest::ResponseCode::OK, builder.slice());
 }
 
-RestStatus RestLogHandler::handleGetHead(ReplicatedLogMethods const& methods,
-                                         replication2::LogId logId) {
+auto RestLogHandler::handleGetHead(ReplicatedLogMethods const& methods,
+                                   replication2::LogId logId) -> async<void> {
   if (_request->suffixes().size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/head");
-    return RestStatus::DONE;
+    co_return;
   }
   bool limitFound;
   std::size_t limit{
       basics::StringUtils::uint64(_request->value("limit", limitFound))};
   limit = limitFound ? limit : ReplicatedLogMethods::kDefaultLimit;
 
-  auto fut = methods.head(logId, limit)
-                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
-                   VPackBuilder builder;
-                   {
-                     VPackArrayBuilder ab(&builder);
-                     while (auto entry = iter->next()) {
-                       entry->toVelocyPack(builder);
-                     }
-                   }
+  auto iter = co_await methods.head(logId, limit);
+  VPackBuilder builder;
+  {
+    VPackArrayBuilder ab(&builder);
+    while (auto entry = iter->next()) {
+      entry->toVelocyPack(builder);
+    }
+  }
 
-                   generateOk(rest::ResponseCode::OK, builder.slice());
-                 });
-
-  return waitForFuture(std::move(fut));
+  generateOk(rest::ResponseCode::OK, builder.slice());
 }
 
-RestStatus RestLogHandler::handleGetSlice(ReplicatedLogMethods const& methods,
-                                          replication2::LogId logId) {
+auto RestLogHandler::handleGetSlice(ReplicatedLogMethods const& methods,
+                                    replication2::LogId logId) -> async<void> {
   if (_request->suffixes().size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/slice");
-    return RestStatus::DONE;
+    co_return;
   }
   bool stopFound;
   LogIndex start{basics::StringUtils::uint64(_request->value("start"))};
@@ -547,44 +511,42 @@ RestStatus RestLogHandler::handleGetSlice(ReplicatedLogMethods const& methods,
       basics::StringUtils::uint64(_request->value("stop", stopFound))};
   stop = stopFound ? stop : start + ReplicatedLogMethods::kDefaultLimit + 1;
 
-  auto fut = methods.slice(logId, start, stop)
-                 .thenValue([&](std::unique_ptr<LogIterator> iter) {
-                   VPackBuilder builder;
-                   {
-                     VPackArrayBuilder ab(&builder);
-                     while (auto entry = iter->next()) {
-                       entry->toVelocyPack(builder);
-                     }
-                   }
+  auto iter = co_await methods.slice(logId, start, stop);
 
-                   generateOk(rest::ResponseCode::OK, builder.slice());
-                 });
+  VPackBuilder builder;
+  {
+    VPackArrayBuilder ab(&builder);
+    while (auto entry = iter->next()) {
+      entry->toVelocyPack(builder);
+    }
+  }
 
-  return waitForFuture(std::move(fut));
+  generateOk(rest::ResponseCode::OK, builder.slice());
 }
 
-RestStatus RestLogHandler::handleGetLocalStatus(
-    ReplicatedLogMethods const& methods, replication2::LogId logId) {
+auto RestLogHandler::handleGetLocalStatus(ReplicatedLogMethods const& methods,
+                                          replication2::LogId logId)
+    -> async<void> {
   if (_request->suffixes().size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/local-status");
-    return RestStatus::DONE;
+    co_return;
   }
 
-  return waitForFuture(
-      methods.getLocalStatus(logId).thenValue([this](auto&& status) {
-        VPackBuilder buffer;
-        status.toVelocyPack(buffer);
-        generateOk(rest::ResponseCode::OK, buffer.slice());
-      }));
+  auto status = co_await methods.getLocalStatus(logId);
+
+  VPackBuilder buffer;
+  status.toVelocyPack(buffer);
+  generateOk(rest::ResponseCode::OK, buffer.slice());
 }
 
-RestStatus RestLogHandler::handleGetGlobalStatus(
-    ReplicatedLogMethods const& methods, replication2::LogId logId) {
+auto RestLogHandler::handleGetGlobalStatus(ReplicatedLogMethods const& methods,
+                                           replication2::LogId logId)
+    -> async<void> {
   if (_request->suffixes().size() != 2) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/global-status");
-    return RestStatus::DONE;
+    co_return;
   }
 
   auto specSource = std::invoke([&] {
@@ -594,47 +556,39 @@ RestStatus RestLogHandler::handleGetGlobalStatus(
     }
     return replicated_log::GlobalStatus::SpecificationSource::kRemoteAgency;
   });
+  auto status = co_await methods.getGlobalStatus(logId, specSource);
 
-  return waitForFuture(methods.getGlobalStatus(logId, specSource)
-                           .thenValue([this](auto&& status) {
-                             VPackBuilder buffer;
-                             status.toVelocyPack(buffer);
-                             generateOk(rest::ResponseCode::OK, buffer.slice());
-                           }));
+  VPackBuilder buffer;
+  status.toVelocyPack(buffer);
+  generateOk(rest::ResponseCode::OK, buffer.slice());
 }
 
-RestStatus RestLogHandler::handleGetCollectionStatus(
-    replication2::ReplicatedLogMethods const& methods, CollectionID cid) {
-  return waitForFuture(methods.getCollectionStatus(std::move(cid))
-                           .thenValue([this](auto&& status) {
-                             VPackBuilder buffer;
-                             status.toVelocyPack(buffer);
-                             generateOk(rest::ResponseCode::OK, buffer.slice());
-                           }));
+auto RestLogHandler::handleGetCollectionStatus(
+    replication2::ReplicatedLogMethods const& methods, CollectionID cid)
+    -> async<void> {
+  auto status = co_await methods.getCollectionStatus(std::move(cid));
+  VPackBuilder buffer;
+  status.toVelocyPack(buffer);
+  generateOk(rest::ResponseCode::OK, buffer.slice());
 }
 
-RestStatus RestLogHandler::handleGetEntry(ReplicatedLogMethods const& methods,
-                                          replication2::LogId logId) {
+auto RestLogHandler::handleGetEntry(ReplicatedLogMethods const& methods,
+                                    replication2::LogId logId) -> async<void> {
   auto const& suffixes = _request->suffixes();
   if (suffixes.size() != 3) {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expect GET /_api/log/<log-id>/entry/<id>");
-    return RestStatus::DONE;
+    co_return;
   }
   LogIndex logIdx{basics::StringUtils::uint64(suffixes[2])};
 
-  auto fut =
-      methods.slice(logId, logIdx, logIdx + 1)
-          .thenValue([this](std::unique_ptr<LogIterator>&& iter) {
-            if (auto entry = iter->next(); entry) {
-              VPackBuilder result;
-              entry->toVelocyPack(result);
-              generateOk(rest::ResponseCode::OK, result.slice());
-            } else {
-              generateError(rest::ResponseCode::NOT_FOUND,
-                            TRI_ERROR_HTTP_NOT_FOUND, "log index not found");
-            }
-          });
-
-  return waitForFuture(std::move(fut));
+  auto iter = co_await methods.slice(logId, logIdx, logIdx + 1);
+  if (auto entry = iter->next(); entry) {
+    VPackBuilder result;
+    entry->toVelocyPack(result);
+    generateOk(rest::ResponseCode::OK, result.slice());
+  } else {
+    generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND,
+                  "log index not found");
+  }
 }

--- a/arangod/RestHandler/RestLogHandler.h
+++ b/arangod/RestHandler/RestLogHandler.h
@@ -36,55 +36,56 @@ class RestLogHandler : public RestVocbaseBaseHandler {
   RestLogHandler(ArangodServer&, GeneralRequest*, GeneralResponse*);
 
  public:
-  RestStatus execute() final;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
   char const* name() const final { return "RestLogHandler"; }
   RequestLane lane() const final { return RequestLane::CLIENT_SLOW; }
 
  private:
-  RestStatus executeByMethod(replication2::ReplicatedLogMethods const& methods);
-  RestStatus handleGetRequest(
-      replication2::ReplicatedLogMethods const& methods);
-  RestStatus handlePostRequest(
-      replication2::ReplicatedLogMethods const& methods);
-  RestStatus handleDeleteRequest(
-      replication2::ReplicatedLogMethods const& methods);
+  auto executeByMethod(replication2::ReplicatedLogMethods const& methods)
+      -> async<void>;
+  auto handleGetRequest(replication2::ReplicatedLogMethods const& methods)
+      -> async<void>;
+  auto handlePostRequest(replication2::ReplicatedLogMethods const& methods)
+      -> async<void>;
+  auto handleDeleteRequest(replication2::ReplicatedLogMethods const& methods)
+      -> async<void>;
 
-  RestStatus handlePost(replication2::ReplicatedLogMethods const& methods,
-                        velocypack::Slice specSlice);
-  RestStatus handlePostInsert(replication2::ReplicatedLogMethods const& methods,
-                              replication2::LogId logId,
-                              velocypack::Slice payload);
-  RestStatus handlePostPing(replication2::ReplicatedLogMethods const& methods,
-                            replication2::LogId logId,
-                            velocypack::Slice payload);
-  RestStatus handlePostInsertMulti(
-      replication2::ReplicatedLogMethods const& methods,
-      replication2::LogId logId, velocypack::Slice payload);
-  RestStatus handlePostRelease(
-      replication2::ReplicatedLogMethods const& methods,
-      replication2::LogId logId);
-  RestStatus handlePostCompact(
-      replication2::ReplicatedLogMethods const& methods,
-      replication2::LogId logId);
+  auto handlePost(replication2::ReplicatedLogMethods const& methods,
+                  velocypack::Slice specSlice) -> async<void>;
+  auto handlePostInsert(replication2::ReplicatedLogMethods const& methods,
+                        replication2::LogId logId, velocypack::Slice payload)
+      -> async<void>;
+  auto handlePostPing(replication2::ReplicatedLogMethods const& methods,
+                      replication2::LogId logId, velocypack::Slice payload)
+      -> async<void>;
+  auto handlePostInsertMulti(replication2::ReplicatedLogMethods const& methods,
+                             replication2::LogId logId,
+                             velocypack::Slice payload) -> async<void>;
+  auto handlePostRelease(replication2::ReplicatedLogMethods const& methods,
+                         replication2::LogId logId) -> async<void>;
+  auto handlePostCompact(replication2::ReplicatedLogMethods const& methods,
+                         replication2::LogId logId) -> async<void>;
 
-  RestStatus handleGet(replication2::ReplicatedLogMethods const& methods);
-  RestStatus handleGetPoll(replication2::ReplicatedLogMethods const& methods,
-                           replication2::LogId);
-  RestStatus handleGetHead(replication2::ReplicatedLogMethods const& methods,
-                           replication2::LogId);
-  RestStatus handleGetTail(replication2::ReplicatedLogMethods const& methods,
-                           replication2::LogId);
-  RestStatus handleGetSlice(replication2::ReplicatedLogMethods const& methods,
-                            replication2::LogId);
-  RestStatus handleGetLocalStatus(
-      replication2::ReplicatedLogMethods const& methods, replication2::LogId);
-  RestStatus handleGetGlobalStatus(
-      replication2::ReplicatedLogMethods const& methods, replication2::LogId);
-  RestStatus handleGetCollectionStatus(
-      replication2::ReplicatedLogMethods const& methods, CollectionID cid);
-  RestStatus handleGetLog(replication2::ReplicatedLogMethods const& methods,
-                          replication2::LogId);
-  RestStatus handleGetEntry(replication2::ReplicatedLogMethods const& methods,
-                            replication2::LogId);
+  auto handleGet(replication2::ReplicatedLogMethods const& methods)
+      -> async<void>;
+  auto handleGetPoll(replication2::ReplicatedLogMethods const& methods,
+                     replication2::LogId) -> async<void>;
+  auto handleGetHead(replication2::ReplicatedLogMethods const& methods,
+                     replication2::LogId) -> async<void>;
+  auto handleGetTail(replication2::ReplicatedLogMethods const& methods,
+                     replication2::LogId) -> async<void>;
+  auto handleGetSlice(replication2::ReplicatedLogMethods const& methods,
+                      replication2::LogId) -> async<void>;
+  auto handleGetLocalStatus(replication2::ReplicatedLogMethods const& methods,
+                            replication2::LogId) -> async<void>;
+  auto handleGetGlobalStatus(replication2::ReplicatedLogMethods const& methods,
+                             replication2::LogId) -> async<void>;
+  auto handleGetCollectionStatus(
+      replication2::ReplicatedLogMethods const& methods, CollectionID cid)
+      -> async<void>;
+  auto handleGetLog(replication2::ReplicatedLogMethods const& methods,
+                    replication2::LogId) -> async<void>;
+  auto handleGetEntry(replication2::ReplicatedLogMethods const& methods,
+                      replication2::LogId) -> async<void>;
 };
 }  // namespace arangodb

--- a/arangod/RestHandler/RestLogInternalHandler.h
+++ b/arangod/RestHandler/RestLogInternalHandler.h
@@ -36,12 +36,12 @@ class RestLogInternalHandler : public RestVocbaseBaseHandler {
   ~RestLogInternalHandler() override;
 
  public:
-  RestStatus execute() final;
+  auto executeAsync() -> futures::Future<futures::Unit> final;
   char const* name() const final { return "RestLogInternalHandler"; }
   RequestLane lane() const final { return RequestLane::CLIENT_SLOW; }
 
  private:
-  RestStatus handleAppendEntries();
-  RestStatus handleUpdateSnapshotStatus();
+  auto handleAppendEntries() -> async<void>;
+  void handleUpdateSnapshotStatus();
 };
 }  // namespace arangodb

--- a/arangod/RestHandler/RestMetricsHandler.h
+++ b/arangod/RestHandler/RestMetricsHandler.h
@@ -37,10 +37,10 @@ class RestMetricsHandler : public arangodb::RestBaseHandler {
   /// @brief must be on fast lane so that metrics can always be retrieved,
   /// even from otherwise totally busy servers
   RequestLane lane() const final { return RequestLane::CLIENT_FAST; }
-  RestStatus execute() final;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
 
  private:
-  RestStatus makeRedirection(std::string const& serverId, bool last);
+  auto makeRedirection(std::string const& serverId, bool last) -> async<void>;
 };
 
 }  // namespace arangodb

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -55,7 +55,7 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
  public:
   RequestLane lane() const override final;
 
-  RestStatus execute() override;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
 
   // Never instantiate this.
   // Only specific implementations allowed

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -42,7 +42,7 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
   char const* name() const override final { return "RestTransactionHandler"; }
   RequestLane lane() const override final;
 
-  RestStatus execute() override;
+ auto executeAsync() -> futures::Future<futures::Unit> override;
   void cancel() override final;
 
  protected:

--- a/arangod/RestHandler/RestTransactionHandler.h
+++ b/arangod/RestHandler/RestTransactionHandler.h
@@ -42,7 +42,7 @@ class RestTransactionHandler : public arangodb::RestVocbaseBaseHandler {
   char const* name() const override final { return "RestTransactionHandler"; }
   RequestLane lane() const override final;
 
- auto executeAsync() -> futures::Future<futures::Unit> override;
+  auto executeAsync() -> futures::Future<futures::Unit> override;
   void cancel() override final;
 
  protected:

--- a/arangod/RestHandler/RestUsageMetricsHandler.h
+++ b/arangod/RestHandler/RestUsageMetricsHandler.h
@@ -37,10 +37,10 @@ class RestUsageMetricsHandler : public arangodb::RestBaseHandler {
   /// @brief must be on fast lane so that metrics can always be retrieved,
   /// even from otherwise totally busy servers
   RequestLane lane() const final { return RequestLane::CLIENT_FAST; }
-  RestStatus execute() final;
+  auto executeAsync() -> futures::Future<futures::Unit> final;
 
  private:
-  RestStatus makeRedirection(std::string const& serverId);
+  auto makeRedirection(std::string const& serverId) -> async<void>;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

As a prerequisite to rewriting the RestHandler's state machine (`runHandlerStateMachine()`) into a coroutine, which in turn is a prerequisite to e.g. make AQL setup & shutdown operations asynchronous, we need to get rid of existing async/WAITING glue code, namely the `waitForFuture()` methods of `RestHandler`.

This PR refactors most existing RestHandlers using that, so they consistently use `async<T>` or `futures::Future<T>`  instead of `WAITING` mechanisms, starting at implementing `executeAsync()` instead of `execute()`. This gets rid of both any `waitForFuture` calls, and any need for `RestStatus::WAITING`, and thus mostly of `RestStatus` as a whole.

The only missing RestHandlers are the AQL-related ones: RestCursorHandler and its derivatives RestSimpleHandler and RestSimpleQueryHandler, and RestAqlHandler. This will be adressed together with the refactored state machine.


- [X] :hammer: Refactoring/simplification
