### PR TITLE
Handle corrupt URLs in HTTP requests gracefully [BTS-2112]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix BTS-2112: If the URL in an HTTP request is corrupt, don't just close
+  the connection, rather, return a proper HTTP 400 BAD response. This was
+  found by fuzzing.
+
 * Fix BTS-2106: A MoveShard operation could get stuck if a new collection
   with `distributeShardsLike` was created at the wrong moment when the leader
   of a shard group was currently being asked to resign.

--- a/arangod/GeneralServer/HttpCommTask.h
+++ b/arangod/GeneralServer/HttpCommTask.h
@@ -97,6 +97,7 @@ class HttpCommTask final : public GeneralCommTask<T> {
   bool _lastHeaderWasValue;
   bool _shouldKeepAlive;  /// keep connection open
   bool _messageDone;
+  bool _urlCorrupt;
 };
 }  // namespace rest
 }  // namespace arangodb


### PR DESCRIPTION
Previously, when the URL in an HTTP request was corrupt, the server
would simply close the connection. With this fix here, a proper
HTTP 400 BAD REQUEST response is sent.

This fixes https://arangodb.atlassian.net/browse/BTS-2112

- **Handle corrupt URL gracefully.**
- **CHANGELOG.**

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: none planned

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2112
