### PR TITLE
Stabilize write concern test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Stabilize a test concerning write concern.
+
 * Fix BTS-2106: A MoveShard operation could get stuck if a new collection
   with `distributeShardsLike` was created at the wrong moment when the leader
   of a shard group was currently being asked to resign.


### PR DESCRIPTION
### Scope & Purpose

This stabilizes a test involving write concern. It is possible that a
write concern change is done in the agency but has not yet propagated
to all involved leaders. Therefore one has to put a short retry loop
around the next write request which is supposed to work.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: none planned

#### Related Information

- [ ] Failed test run: https://app.circleci.com/pipelines/github/arangodb/arangodb/34477/workflows/028e5c29-ad48-428a-a559-0a3ef154d726/jobs/3058085/tests#failed-test-0
