### PR TITLE
[3.11] Fix data race in connection cache

### DIFF
--- a/lib/SimpleHttpClient/ConnectionCache.h
+++ b/lib/SimpleHttpClient/ConnectionCache.h
@@ -61,7 +61,7 @@ struct ConnectionLease {
 
   ConnectionCache* _cache;
   std::unique_ptr<GeneralClientConnection> _connection;
-  bool _preventRecycling;
+  std::atomic<bool> _preventRecycling;
 };
 
 class ConnectionCache {


### PR DESCRIPTION
Fix data race shown in in [arangodb-3.11-asan-and-coverage-biweekly run this Saturday](https://jenkins.arangodb.biz/job/arangodb-ANY-linux-san.x86-64/2637/EDITION=enterprise,SAN_MODE=TSan,STORAGE_ENGINE=rocksdb,TEST_SUITE=single,limit=linux&&test&&cloud&&x86-64/artifact/testfailures.txt).
This was already fixed in devel by using an atomic instead of a plain boolean variable in #21026.