### PR TITLE
don't let libc abort it

### DIFF
--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -549,7 +549,7 @@ class instance {
     }
     if ((this.useableMemory !== 0) && (this.options.memory !== undefined)) {
       if (this.useableMemory !== parseInt(this.useableMemory, 10)) {
-        throw new Error(`ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=${this.useableMemory} not parseable!`);
+        throw new Error(`ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=${this.useableMemory} not parseable: expected integer!`);
       }
       if (this.options.extremeVerbosity) {
         print(`appointed ${this.name} memory: ${this.useableMemory}`);

--- a/js/client/modules/@arangodb/testutils/instance.js
+++ b/js/client/modules/@arangodb/testutils/instance.js
@@ -548,6 +548,9 @@ class instance {
       throw new Error(`${this.name} don't have planned memory though its configured!`);
     }
     if ((this.useableMemory !== 0) && (this.options.memory !== undefined)) {
+      if (this.useableMemory !== parseInt(this.useableMemory, 10)) {
+        throw new Error(`ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY=${this.useableMemory} not parseable!`);
+      }
       if (this.options.extremeVerbosity) {
         print(`appointed ${this.name} memory: ${this.useableMemory}`);
       }

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -25,11 +25,13 @@
 
 #include "Basics/PhysicalMemory.h"
 #include "Basics/files.h"
+#include "Basics/application-exit.h"
 #include "ProgramOptions/Parameters.h"
 
 #ifdef TRI_HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#include <iostream>
 
 #ifdef TRI_HAVE_MACH
 #include <mach/mach_host.h>
@@ -84,11 +86,16 @@ struct PhysicalMemoryCache {
     std::string value;
     if (TRI_GETENV("ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY", value)) {
       if (!value.empty()) {
-        uint64_t v = arangodb::options::fromString<uint64_t>(value);
-        if (v != 0) {
-          // value in environment variable must always be > 0
-          cachedValue = v;
-          overridden = true;
+        try {
+          uint64_t v = arangodb::options::fromString<uint64_t>(value);
+          if (v != 0) {
+            // value in environment variable must always be > 0
+            cachedValue = v;
+            overridden = true;
+          }
+        } catch (...) {
+          std::cerr << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: " << value;
+          FATAL_ERROR_EXIT();
         }
       }
     }

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -97,8 +97,7 @@ struct PhysicalMemoryCache {
         } catch (...) {
           std::cerr
               << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: "
-              << "expected integer, got " <<
-              << value <<  std::endl;
+              << "expected integer, got " << value << std::endl;
           FATAL_ERROR_EXIT();
         }
       }

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -32,6 +32,7 @@
 #include <unistd.h>
 #endif
 #include <iostream>
+#include <ostream>
 
 #ifdef TRI_HAVE_MACH
 #include <mach/mach_host.h>
@@ -94,7 +95,8 @@ struct PhysicalMemoryCache {
             overridden = true;
           }
         } catch (...) {
-          std::cerr << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: " << value;
+          std::cerr << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: " <<
+            value << std::endl;
           FATAL_ERROR_EXIT();
         }
       }

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -95,8 +95,9 @@ struct PhysicalMemoryCache {
             overridden = true;
           }
         } catch (...) {
-          std::cerr << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: " <<
-            value << std::endl;
+          std::cerr
+              << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: "
+              << value << std::endl;
           FATAL_ERROR_EXIT();
         }
       }

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -97,7 +97,8 @@ struct PhysicalMemoryCache {
         } catch (...) {
           std::cerr
               << "failed to parse ARANGODB_OVERRIDE_DETECTED_TOTAL_MEMORY: "
-              << value << std::endl;
+              << "expected integer, got " <<
+              << value <<  std::endl;
           FATAL_ERROR_EXIT();
         }
       }


### PR DESCRIPTION
### Scope & Purpose

in case we fail to parse the environment variable bail out with a meaningfull error message instead of throwing uncaught.

- [x] :hankey: Bugfix
