### PR TITLE
Forward port for: print on violated block ordering (#21743)

### DIFF
--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -210,3 +210,32 @@ auto ExecutionBlock::printBlockInfo() const -> std::string const {
 }
 
 auto ExecutionBlock::stopAsyncTasks() -> void {}
+
+auto ExecutionBlock::isDependencyInList(
+    std::unordered_set<ExecutionBlock*> const& seenBlocks) const noexcept
+    -> ExecutionBlock* {
+  for (auto const& dependency : _dependencies) {
+    if (seenBlocks.find(dependency) != seenBlocks.end()) {
+      return dependency;
+    }
+  }
+  return nullptr;
+}
+
+auto ExecutionBlock::printBlockAndDependenciesInfo() const noexcept
+    -> std::string const {
+  std::stringstream ss;
+  ss << printBlockInfo();
+  ss << " async prefetching type: "
+     << (int)getPlanNode()->canUseAsyncPrefetching();
+  ss << " calls: [";
+  for (auto const& dependency : _dependencies) {
+    ss << " " << dependency->printBlockInfo() << ",";
+  }
+  ss << " ]";
+  return ss.str();
+}
+
+auto ExecutionBlock::hasStoppedAsyncTasks() const noexcept -> bool {
+  return _stoppedAsyncTasks;
+}

--- a/arangod/Aql/ExecutionBlock.h
+++ b/arangod/Aql/ExecutionBlock.h
@@ -31,8 +31,9 @@
 
 #include <atomic>
 #include <cstdint>
-#include <string_view>
+#include <unordered_set>
 #include <utility>
+#include <string_view>
 #include <vector>
 
 namespace arangodb {
@@ -131,8 +132,16 @@ class ExecutionBlock {
 
   [[nodiscard]] auto printBlockInfo() const -> std::string const;
   [[nodiscard]] auto printTypeInfo() const -> std::string const;
+  [[nodiscard]] auto printBlockAndDependenciesInfo() const noexcept
+      -> std::string const;
 
   virtual auto stopAsyncTasks() -> void;
+
+  [[nodiscard]] auto isDependencyInList(
+      std::unordered_set<ExecutionBlock*> const& seenBlocks) const noexcept
+      -> ExecutionBlock*;
+
+  [[nodiscard]] auto hasStoppedAsyncTasks() const noexcept -> bool;
 
  protected:
   // Trace the start of a execute call
@@ -175,6 +184,10 @@ class ExecutionBlock {
 
   /// @brief if this is set, we are done, this is reset to false by execute()
   bool _done;
+
+  /// @brief if this is set, we have stopped async tasks, this is set to true by
+  /// stopAsyncTasks()
+  bool _stoppedAsyncTasks{false};
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   /// @brief if this is set to true, one thread is using this block, so we can

--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -272,10 +272,40 @@ ExecutionEngine::~ExecutionEngine() {
   // tasks running on any dependent which could start another on the
   // current block.
   // The blocks are pushed in a reversed topological order.
-  for (auto it = _blocks.rbegin(); it != _blocks.rend(); ++it) {
-    (*it)->stopAsyncTasks();
+  {
+    // Note: We can use raw pointers here because we are not taking
+    // any responsibilty of the pointer. It is still managed by the _blocks
+    // vector. Also we are in the destructor here, so we have guaranteed,
+    // that no one else is cleaning up the blocks.
+    std::unordered_set<ExecutionBlock*> seenBlocks;
+    bool needToPrintViolation = false;
+    for (auto it = _blocks.rbegin(); it != _blocks.rend(); ++it) {
+      auto block = it->get();
+      if (ExecutionBlock* seenDependency =
+              block->isDependencyInList(seenBlocks);
+          seenDependency != nullptr &&
+          block->getPlanNode()->getType() != ExecutionNode::GATHER) {
+        // We have a dependency that has already been seen, we need to log this
+        // situation in theory this could lead to deadlocks. Some Blocks are
+        // fine we just want to see those here.
+        // Gather Nodes are known to violate this, but they are safe.
+        LOG_TOPIC("a6c2b", WARN, Logger::AQL)
+            << "ALERT Stopping async tasks for " << block->printBlockInfo()
+            << " but have already stopped dependency "
+            << seenDependency->printBlockInfo();
+        needToPrintViolation = true;
+      }
+      block->stopAsyncTasks();
+      seenBlocks.insert(block);
+    }
+    if (needToPrintViolation) {
+      for (auto it2 = _blocks.rbegin(); it2 != _blocks.rend(); ++it2) {
+        LOG_TOPIC("a6c2d", WARN, Logger::AQL)
+            << (*it2)->printBlockAndDependenciesInfo();
+      }
+      TRI_ASSERT(false) << "Triggered violation in ExecutionBlock ordering";
+    }
   }
-
   if (_sharedState) {  // ensure no async task is working anymore
     _sharedState->invalidate();
   }


### PR DESCRIPTION
### Scope & Purpose

*This PR adds more visibility into a violated assumptions. The cleanup of AQL expects Blocks to be in a particular order in the cleanup lists. This PR should add visibility in cases where it is unexpectedly not.*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
