### PR TITLE
Show running thread in async registry

### DIFF
--- a/arangod/AsyncRegistryServer/PrettyPrinter/src/asyncregistry/gdb_data.py
+++ b/arangod/AsyncRegistryServer/PrettyPrinter/src/asyncregistry/gdb_data.py
@@ -26,7 +26,9 @@ class Thread:
     # TODO is there a way to get the thread name?
 
     @classmethod
-    def from_gdb(cls, value: gdb.Value):
+    def from_gdb(cls, value: gdb.Value | None):
+        if not value:
+            return None
         return cls(value['posix_id'], value['kernel_id'])
 
     def __str__(self):
@@ -79,7 +81,7 @@ class PromiseId:
 @dataclass
 class Promise:
     id: PromiseId
-    thread: Thread
+    thread: Optional[Thread]
     source_location: SourceLocation
     requester: Requester
     state: State
@@ -88,7 +90,7 @@ class Promise:
     def from_gdb(cls, ptr: gdb.Value, value: gdb.Value):
         return cls(
             PromiseId(ptr),
-            Thread.from_gdb(value["thread"]),
+            Thread.from_gdb(GdbOptional.from_gdb(value["running_thread"])._value),
             SourceLocation.from_gdb(value["source_location"]),
             Requester.from_gdb(value["requester"]["_M_i"]),
             State.from_gdb(value["state"])
@@ -98,8 +100,22 @@ class Promise:
         return not self.state.is_deleted()
 
     def __str__(self):
-        return str(self.source_location) + ", " + str(self.thread) + ", " + str(self.state)
+        thread_str = "" if not self.thread else " on " + str(self.thread)
+        return str(self.source_location) + ", " + str(self.state) + thread_str
 
+@dataclass
+class GdbOptional:
+    _value: Optional[gdb.Value]
+
+    @classmethod
+    def from_gdb(cls, value: gdb.Value):
+        payload = value["_M_i"]["_M_payload"]
+        engaged = payload["_M_engaged"]
+        if not engaged:
+            return cls(None)
+        internal_value = payload["_M_payload"]["_M_value"]
+        return cls(internal_value)
+    
 @dataclass
 class GdbAtomicList:
     _head_ptr: gdb.Value

--- a/arangod/AsyncRegistryServer/PrettyPrinter/src/pretty-printer.py
+++ b/arangod/AsyncRegistryServer/PrettyPrinter/src/pretty-printer.py
@@ -58,18 +58,19 @@ class Requester(object):
             return ""
 
 class Data(object):
-    def __init__(self, owning_thread: Thread, source_location: SourceLocation, id: int, state: str, requester: Requester):
-        self.owning_thread = owning_thread
+    def __init__(self, running_thread: Optional[Thread], source_location: SourceLocation, id: int, state: str, requester: Requester):
+        self.running_thread = running_thread
         self.source_location = source_location
         self.id = id
         self.waiter = requester
         self.state = state
     @classmethod
     def from_json(cls, blob: dict):
-        return cls(Thread.from_json(blob["owning_thread"]), SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Requester.from_json(blob["requester"]))
+        return cls(Thread.from_json(blob["running_thread"]) if "running_thread" in blob else None, SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Requester.from_json(blob["requester"]))
     def __str__(self):
         waiter_str = str(self.waiter) if self.waiter != None else ""
-        return str(self.source_location) + ", " + str(self.owning_thread) + ", " + self.state + waiter_str
+        thread_str = "" if not self.running_thread else " on " + str(self.running_thread)
+        return str(self.source_location) + ", " + self.state + thread_str + waiter_str
         
 class Promise(object):
     def __init__(self, hierarchy: int, data: Data):


### PR DESCRIPTION
Arangod crashed after requesting the async registry, due to a bug: When reading the registry, every promise inside it requests the thread name of its owning thread in order to print that name. The problem is that this owning thread does not need to exist any more although the promise still exists, e.g. because the promise was suspended (so is currently not running at all) or resumed on another thread. So when requesting the thread name of a thread that does not exist any more, we crash.
Actually, the owning thread is not interesting for the user, the user just wants to see on which thread the promise is currently running (if it is running). Therefore, this PR adds a running_thread member to the promise and updates it when a state change occurs: if the state is running, then the promise has a running thread, otherwise the promise has no running thread.
The PR also updates the pretty printers of the async registry.