### PR TITLE
Get rid of use-after-free in async registry

### DIFF
--- a/lib/TaskMonitoring/include/TaskMonitoring/task.h
+++ b/lib/TaskMonitoring/include/TaskMonitoring/task.h
@@ -122,7 +122,6 @@ struct TaskInRegistry {
 
   std::string const name;
   std::atomic<State> state;
-  std::atomic<bool> isDeleted = false;
   ParentTask parent;
   std::optional<basics::ThreadId>
       running_thread;  // proably has to also be atomic because

--- a/tests/TaskMonitoring/TaskRegistryTest.cpp
+++ b/tests/TaskMonitoring/TaskRegistryTest.cpp
@@ -54,24 +54,6 @@ struct MyTask : public Task {
 
 struct TaskRegistryTest : ::testing::Test {
   void TearDown() override {
-    // garbage collection has to run at most twice in order to clean everything
-    // up on the current thread:
-    // - when a child task scope is deleted, the child's task-in-registry is
-    //   marked for deletion
-    // - at this point its parent task scope can still exist, therefore it is
-    //   not marked for deletion inside the child task scope destructor
-    // - when then the parent task scope is deleted, the parent's
-    //   task-in-registry is still referenced by the child's task-in-registry
-    //   (which is not yet deleted), therefore it is not yet marked for deletion
-
-    // the first gc run destroys the child's task-in-registry
-    // which destroys the last reference to the parent's task-in-registry, which
-    // is therfore marked for deletion (together with all remaining
-    // task-in-registries higher up in the hierarchy that are not referenced by
-    // any other tasks)
-    get_thread_registry().garbage_collect();
-    // the second gc run destroys the parent's task-in-registry (and possibly
-    // other marked for deletion items)
     get_thread_registry().garbage_collect();
     EXPECT_EQ(get_all_tasks().size(), 0);
   }


### PR DESCRIPTION
Use-after-free happened in nightly alubsan run.

The mark for deletion of a node after all its references are gone was actually much too complicated: I wanted to make sure that if there is a hierarchy of parents where each parent has only one child and the lowest child is marked for deletion like this:
```
parent
  child
    child of child
      child of child of child (marked for deletion)
```
all parents in the hierarchy are directly marked for deletion as well and we don't have to run the garbage collection several times to do that (A node has a shared pointer to its parent: when the shared pointer to the parent is destroyed - normally happening in the garbage collection - the node is marked for deletion). In the old behaviour, we cascaded through the full hierarchy and marked parents for deletion as well. Then at some point the shared pointer to the parent is also destroyed, leading to another try to access the parent node. If a garbage collection ran in between, the node was already deleted, leading to a use-after-free.
This easy solution: Get rid of the parent reference when marking the node for deletion. Then the shared pointer to the parent is potentially destroyed earlier, leading to a mark for deletion of the parent automatically. Don't know why I did not thought about this earlier...