### PR TITLE
Add thread name back in

### DIFF
--- a/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/asyncregistry/gdb_data.py
+++ b/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/asyncregistry/gdb_data.py
@@ -24,7 +24,6 @@ class State:
 class Thread:
     posix_id: gdb.Value
     lwpid: gdb.Value
-    # TODO is there a way to get the thread name?
 
     @classmethod
     def from_gdb(cls, value: gdb.Value | None):
@@ -35,7 +34,6 @@ class Thread:
     def __str__(self):
         return f"LWPID {self.lwpid} (pthread {self.posix_id})"
 
-# new one
 @dataclass
 class ThreadInfo:
     lwpid: gdb.Value

--- a/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/asyncregistry/gdb_forest.py
+++ b/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/asyncregistry/gdb_forest.py
@@ -1,5 +1,5 @@
 from typing import Iterable, Any
-from asyncregistry.gdb_data import Promise, PromiseId, Thread
+from asyncregistry.gdb_data import Promise, PromiseId, ThreadInfo
 
 Id = str
 class Forest:
@@ -31,7 +31,7 @@ class Forest:
                 yield child
 
     @classmethod
-    def from_promises(cls, promises: Iterable[tuple[PromiseId, PromiseId, Any]]):
+    def from_promises(cls, promises: Iterable[tuple[PromiseId, ThreadInfo | PromiseId, Any]]):
         parents: [Id] = [] # all parents promise ids
         nodes: [Any] = [] # all nodes
         positions: {Id: int} = {} # lookup table for parent and node per promise id
@@ -42,7 +42,7 @@ class Forest:
             promise_id = str(promise.id)
             positions[promise_id] = count
             nodes.append(data)
-            if type(parent) == Thread:
+            if type(parent) == ThreadInfo:
                 parents.append(None)
                 roots.append(promise_id)
             else:

--- a/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/pretty-printer.py
+++ b/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/pretty-printer.py
@@ -24,6 +24,16 @@ class Thread(object):
     def __str__(self):
         return f"LWPID {self.id} (pthread {self.posix_id})"
 
+class ThreadInfo(object):
+    def __init__(self, lwpid: int, name: str):
+        self.lwpid = lwpid
+        self.name = name
+    @classmethod
+    def from_json(cls, blob: dict):
+        return cls(blob["LWPID"], blob["name"])
+    def __str__(self):
+        return f"{self.name} (LWPID {self.lwpid})"
+
 class SourceLocation(object):
     def __init__(self, file_name: str, line: int, function_name: str):
         self.file_name = file_name
@@ -34,7 +44,7 @@ class SourceLocation(object):
         return cls(blob["file_name"], blob["line"], blob["function_name"])
     def __str__(self):
         return self.function_name + " (" + self.file_name + ":" + str(self.line) + ")"
-    
+
 class Requester(object):
     def __init__(self, is_sync: bool, item: int):
         self.is_sync = is_sync
@@ -58,7 +68,8 @@ class Requester(object):
             return ""
 
 class Data(object):
-    def __init__(self, running_thread: Optional[Thread], source_location: SourceLocation, id: int, state: str, requester: Requester):
+    def __init__(self, owning_thread: ThreadInfo, running_thread: Optional[Thread], source_location: SourceLocation, id: int, state: str, requester: Requester):
+        self.owning_thread = owning_thread
         self.running_thread = running_thread
         self.source_location = source_location
         self.id = id
@@ -66,11 +77,11 @@ class Data(object):
         self.state = state
     @classmethod
     def from_json(cls, blob: dict):
-        return cls(Thread.from_json(blob["running_thread"]) if "running_thread" in blob else None, SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Requester.from_json(blob["requester"]))
+        return cls(ThreadInfo.from_json(blob["owning_thread"]), Thread.from_json(blob["running_thread"]) if "running_thread" in blob else None, SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Requester.from_json(blob["requester"]))
     def __str__(self):
         waiter_str = str(self.waiter) if self.waiter != None else ""
         thread_str = f" on {self.running_thread}" if self.running_thread else ""
-        return str(self.source_location) + ", " + self.state + thread_str + waiter_str
+        return str(self.source_location) + ", owned by " + str(self.owning_thread) + ", " + self.state + thread_str + waiter_str
         
 class Promise(object):
     def __init__(self, hierarchy: int, data: Data):

--- a/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/pretty-printer.py
+++ b/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/pretty-printer.py
@@ -45,25 +45,33 @@ class SourceLocation(object):
     def __str__(self):
         return self.function_name + " (" + self.file_name + ":" + str(self.line) + ")"
 
+class PromiseId(object):
+    def __init__(self, id):
+        self.id = id
+    @classmethod
+    def from_json(cls, blob: dict):
+        return cls(blob["id"])
+    def __str__(self):
+        return self.id
+    
 class Requester(object):
-    def __init__(self, is_sync: bool, item: int):
+    def __init__(self, is_sync: bool, item: ThreadInfo | PromiseId):
         self.is_sync = is_sync
         self.item = item
     @classmethod
     def from_json(cls, blob: dict):
         if not blob:
             return None
-        sync = blob.get("thread")
-        if sync is not None:
-            return cls(True, sync)
+        if "LWPID" in blob:
+            return cls(True, ThreadInfo.from_json(blob))
         else:
-            return cls(False, blob["promise"])
+            return cls(False, PromiseId.from_json(blob))
     def __str__(self):
         if self.is_sync:
             # a sync requester is always at the bottom of a tree,
             # but has no entry on its own,
             # therefore just add it here in a new line
-            return "\n" + "─ " + str(Thread.from_json(self.item))
+            return "\n" + "─ " + str(self.item)
         else:
             return ""
 

--- a/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
+++ b/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
@@ -72,10 +72,10 @@ auto all_undeleted_promises() -> ForestWithRoots<PromiseSnapshot> {
   registry.for_node([&](PromiseSnapshot promise) {
     if (promise.state != State::Deleted) {
       std::visit(overloaded{
-                     [&](PromiseId async_waiter) {
+                     [&](PromiseId const& async_waiter) {
                        forest.insert(promise.id.id, async_waiter.id, promise);
                      },
-                     [&](basics::ThreadId sync_waiter_thread) {
+                     [&](basics::ThreadInfo const& sync_waiter_thread) {
                        forest.insert(promise.id.id, nullptr, promise);
                        roots.emplace_back(promise.id.id);
                      },

--- a/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
+++ b/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
@@ -73,11 +73,11 @@ auto all_undeleted_promises() -> ForestWithRoots<PromiseSnapshot> {
     if (promise.state != State::Deleted) {
       std::visit(overloaded{
                      [&](PromiseId async_waiter) {
-                       forest.insert(promise.id, async_waiter, promise);
+                       forest.insert(promise.id.id, async_waiter.id, promise);
                      },
                      [&](basics::ThreadId sync_waiter_thread) {
-                       forest.insert(promise.id, nullptr, promise);
-                       roots.emplace_back(promise.id);
+                       forest.insert(promise.id.id, nullptr, promise);
+                       roots.emplace_back(promise.id.id);
                      },
                  },
                  promise.requester);

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -29,7 +29,7 @@
 using namespace arangodb::async_registry;
 
 Promise::Promise(Requester requester, std::source_location entry_point)
-    : owning_thread{basics::ThreadId::current()},
+    : owning_thread{basics::ThreadInfo::current()},
       requester{requester},
       state{State::Running},
       running_thread{basics::ThreadId::current()},

--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -144,7 +144,7 @@ struct Promise {
     state.store(State::Deleted, std::memory_order_relaxed);
   }
 
-  containers::SharedReference<basics::ThreadInfo> owning_thread;
+  containers::SharedPtr<basics::ThreadInfo> owning_thread;
   std::atomic<Requester> requester;
   std::atomic<State> state = State::Running;
   std::atomic<std::optional<basics::ThreadId>> running_thread;

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -27,7 +27,7 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
 
   async_promise_base(std::source_location loc)
       : async_registry::AddToAsyncRegistry{std::move(loc)}, _context{} {
-    *async_registry::get_current_coroutine() = {id()};
+    *async_registry::get_current_coroutine() = {id().value()};
   }
 
   std::suspend_never initial_suspend() noexcept {
@@ -86,7 +86,7 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
 
     // update promises in registry
     if constexpr (CanUpdateRequester<U>) {
-      co_awaited_expression.update_requester({this->id()});
+      co_awaited_expression.update_requester(this->id());
     }
     update_source_location(loc);
 
@@ -181,10 +181,18 @@ struct [[nodiscard]] async {
   bool valid() const noexcept { return _handle != nullptr; }
   operator bool() const noexcept { return valid(); }
 
-  auto update_requester(async_registry::Requester waiter) {
-    _handle.promise().update_requester(waiter);
+  auto update_requester(std::optional<async_registry::PromiseId> waiter) {
+    if (_handle) {
+      _handle.promise().update_requester(waiter);
+    }
   }
-  auto id() -> void* { return _handle.promise().id(); }
+  auto id() -> std::optional<async_registry::PromiseId> {
+    if (_handle) {
+      return _handle.promise().id();
+    } else {
+      return std::nullopt;
+    }
+  }
 
   ~async() { reset(); }
 

--- a/lib/Async/include/Async/context.h
+++ b/lib/Async/include/Async/context.h
@@ -37,7 +37,7 @@ namespace arangodb {
  */
 struct Context {
   std::shared_ptr<ExecContext const> _execContext;
-  async_registry::Requester _requester;
+  async_registry::CurrentRequester _requester;
   task_monitoring::Task* _task;
 
   Context()

--- a/lib/Async/include/Async/coro-utils.h
+++ b/lib/Async/include/Async/coro-utils.h
@@ -52,12 +52,9 @@ auto get_awaitable_object(T&& t) {
 }
 
 template<typename T>
-concept CanUpdateRequester = requires(T t, async_registry::Requester waiter) {
-  t.update_requester(waiter);
-};
-template<typename T>
-concept HasId = requires(T t) {
-  { t.id() } -> std::convertible_to<void*>;
+concept CanUpdateRequester =
+    requires(T t, std::optional<async_registry::PromiseId> requester) {
+  t.update_requester(requester);
 };
 
 }  // namespace arangodb

--- a/lib/Containers/Concurrent/CMakeLists.txt
+++ b/lib/Containers/Concurrent/CMakeLists.txt
@@ -5,3 +5,8 @@ target_link_libraries(arango_thread_owning_list
   PRIVATE
   arango_basic_utils
   arango_inspection)
+
+add_library(arango_shared INTERFACE
+  shared.h)
+# TODO need to have include dir and include ${CMAKE_CURRENT_SOURCE_DIR}/include
+target_include_directories(arango_shared INTERFACE ${PROJECT_SOURCE_DIR}/lib)

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -96,12 +96,11 @@ struct SharedPtr {
     }
   }
   operator bool() const { return _resource != nullptr; }
-  auto get() -> std::optional<T*> {
-    if (_resource) {
-      return {_resource->get()};
-    } else {
-      return std::nullopt;
+  auto get() -> T* {
+    if (not _resource) {
+      return nullptr;
     }
+    return {_resource->get()};
   }
   auto get_ref() const -> std::optional<std::reference_wrapper<T>> {
     if (not _resource) {
@@ -156,11 +155,8 @@ struct AtomicSharedOrRawPtr {
     }
   }
 
-  auto get() const -> std::optional<std::variant<Left*, Right*>> {
+  auto get() const -> std::variant<Left*, Right*> {
     auto data = _resource.load();
-    if (data == 0) {
-      return std::nullopt;
-    }
     constexpr auto flag_mask = (1 << num_flag_bits) - 1;
     constexpr auto data_mask = ~flag_mask;
     if (data & flag_mask) {
@@ -180,4 +176,5 @@ namespace arangodb::inspection {
 template<typename T>
 struct Access<containers::SharedPtr<T>>
     : OptionalAccess<containers::SharedPtr<T>> {};
+
 }  // namespace arangodb::inspection

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -33,9 +33,12 @@
 namespace arangodb::containers {
 
 /**
-   Reference counting wrapper for a constant resource
+   Reference counting wrapper for a resource
 
    Destroys itself when the reference count decrements to zero.
+   This resource can be referenced - in contrast to a simle std::shared_ptr - by
+   different types of pointers at the same time, e.g. by a SharedPtr (similar to
+   an std::shared_ptr) and an AtomicSharedOrRawPtr.
  */
 template<typename T>
 struct SharedResource {

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -1,0 +1,113 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <iostream>
+
+#include "Inspection/Access.h"
+
+namespace arangodb::containers {
+
+/**
+   Reference counting wrapper for a resource
+
+   Destroys itself when the reference count decrements to zero.
+ */
+template<typename T>
+struct Shared {
+  auto increment() -> void { _count.fetch_add(1, std::memory_order_acq_rel); }
+  auto decrement() -> void {
+    auto old = _count.fetch_sub(1, std::memory_order_acq_rel);
+    if (old == 1) {
+      delete this;
+    }
+  }
+  template<class... Input>
+  Shared(Input... args) : _data{args...} {}
+  auto get_ref() -> T& { return _data; }
+  auto ref_count() -> size_t { return _count.load(std::memory_order_relaxed); }
+
+ private:
+  std::atomic<std::size_t> _count = 1;
+  T _data;
+};
+
+template<typename T>
+struct SharedReference {
+  SharedReference(SharedReference&& other) : _resource{other._resource} {
+    other._resource = nullptr;
+  }
+  auto operator=(SharedReference&& other) -> SharedReference& {
+    _resource = other._resource;
+    other._resource = nullptr;
+    return *this;
+  }
+  SharedReference(SharedReference const& other) : _resource{other._resource} {
+    _resource->increment();
+  }
+  auto operator=(SharedReference const& other) -> SharedReference& {
+    _resource = other._resource;
+    _resource->increment();
+    return *this;
+  }
+  ~SharedReference() {
+    if (_resource) {
+      _resource->decrement();
+    }
+  }
+  template<class... Input>
+  SharedReference(Input... args) : _resource{new Shared<T>(args...)} {}
+  auto operator*() -> std::optional<std::reference_wrapper<T>> {
+    return get_ref();
+  }
+  operator bool() const { return _resource != nullptr; }
+  auto get_ref() -> std::optional<std::reference_wrapper<T>> {
+    if (_resource) {
+      return {_resource->get_ref()};
+    } else {
+      return std::nullopt;
+    }
+  }
+  auto ref_count() -> size_t {
+    if (_resource) {
+      return _resource->ref_count();
+    } else {
+      return 0;
+    }
+  }
+
+ private:
+  Shared<T>* _resource = nullptr;
+};
+
+}  // namespace arangodb::containers
+
+namespace arangodb::inspection {
+template<typename T>
+struct Access<containers::SharedReference<T>>
+    : OptionalAccess<containers::SharedReference<T>> {};
+}  // namespace arangodb::inspection

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -48,52 +48,50 @@ struct Shared {
   }
   template<class... Input>
   Shared(Input... args) : _data{args...} {}
-  auto get_ref() const -> T const& { return _data; }
+  auto get_ref() -> T& { return _data; }
   auto ref_count() const -> size_t {
     return _count.load(std::memory_order_relaxed);
   }
 
  private:
   std::atomic<std::size_t> _count = 1;
-  const T _data;
+  T _data;
 };
 
 template<typename T, typename ExpectedT>
 concept SameAs = std::is_same_v<T, ExpectedT>;
 
 template<typename T>
-struct SharedReference {
-  SharedReference(SharedReference&& other) : _resource{other._resource} {
+struct SharedPtr {
+  SharedPtr(SharedPtr&& other) : _resource{other._resource} {
     other._resource = nullptr;
   }
-  auto operator=(SharedReference&& other) -> SharedReference& {
+  auto operator=(SharedPtr&& other) -> SharedPtr& {
     _resource = other._resource;
     other._resource = nullptr;
     return *this;
   }
-  SharedReference(SharedReference const& other) {
-    // TODO should both store and increment not be done at same time?
+  SharedPtr(SharedPtr const& other) {
     other._resource->increment();
     _resource = other._resource;
   }
-  auto operator=(SharedReference const& other) -> SharedReference& {
-    // TODO should both store and increment not be done at same time?
+  auto operator=(SharedPtr const& other) -> SharedPtr& {
     other._resource->increment();
     _resource = other._resource;
     return *this;
   }
-  ~SharedReference() {
+  ~SharedPtr() {
     if (_resource) {
       _resource->decrement();
     }
   }
   template<class... Input>
-  SharedReference(Input... args) : _resource{new Shared<T>(args...)} {}
-  auto operator*() const -> std::optional<std::reference_wrapper<const T>> {
+  SharedPtr(Input... args) : _resource{new Shared<T>(args...)} {}
+  auto operator*() -> std::optional<std::reference_wrapper<T>> {
     return get_ref();
   }
   operator bool() const { return _resource != nullptr; }
-  auto get_ref() const -> std::optional<std::reference_wrapper<const T>> {
+  auto get_ref() -> std::optional<std::reference_wrapper<T>> {
     if (_resource) {
       return {_resource->get_ref()};
     } else {
@@ -108,62 +106,48 @@ struct SharedReference {
     }
   }
 
-  // TODO private:
   Shared<T>* _resource = nullptr;
 };
 
-// lock-free atomic variant (intrusive)
-// either shared or simple pointer
-template<typename T, typename K>
-struct VariantPtr {
+/**
+   Lock-free atomic either type for either a shared or a raw pointer
+
+   Works if both types have an alignment larger than 1,
+   then the last bit of a pointer to one of these types is unused and can be
+   used as a flag for the type of the pointer.
+*/
+template<typename Left, typename Right>
+struct AtomicSharedOrRawPtr {
   static constexpr auto num_flag_bits = 1;
-  static_assert(std::alignment_of_v<Shared<T>> >= (1 << num_flag_bits) &&
-                std::alignment_of_v<K> >= (1 << num_flag_bits));
+  static_assert(std::alignment_of_v<Shared<Left>> >= (1 << num_flag_bits) &&
+                std::alignment_of_v<Right> >= (1 << num_flag_bits));
 
-  template<SameAs<K> U>
-  VariantPtr(U* second)
-      : _resource{reinterpret_cast<std::uintptr_t>(second) | 0} {}
+  template<SameAs<Right> U>
+  AtomicSharedOrRawPtr(U* right)
+      : _resource{reinterpret_cast<std::uintptr_t>(right) | 0} {}
 
-  template<SameAs<T> U>
-  VariantPtr(SharedReference<U> const& first) {
-    // TODO should both store and increment not be done at same time?
-    auto resource = first._resource;
+  template<SameAs<Left> U>
+  AtomicSharedOrRawPtr(SharedPtr<U> const& left) {
+    auto resource = left._resource;
     resource->increment();
     _resource.store(reinterpret_cast<std::uintptr_t>(resource) | 1);
   }
 
-  ~VariantPtr() {
+  ~AtomicSharedOrRawPtr() {
+    // if resource includes a shared ptr, decrement it
     auto data = _resource.load();
     if (data != 0) {
       constexpr auto flag_mask = (1 << num_flag_bits) - 1;
       constexpr auto data_mask = ~flag_mask;
       if (data & flag_mask) {
-        // this is the shared ptr
-        reinterpret_cast<Shared<T>*>(data & data_mask)->decrement();
+        reinterpret_cast<Shared<Left>*>(data & data_mask)->decrement();
       }
     }
   }
-  // explicitly delete because we don't need them
-  VariantPtr(VariantPtr&&) = delete;
-  auto operator=(VariantPtr&&) -> VariantPtr& = delete;
-  VariantPtr(VariantPtr const&) = delete;
-  auto operator=(VariantPtr const&) -> VariantPtr& = delete;
 
-  // TODO get rid of these because we need to do cleanup for them
-  template<class... Input>
-  static auto first(Input... args) -> VariantPtr {
-    auto ptr = new Shared<T>(args...);
-    return VariantPtr{ptr};
-  }
-  template<class... Input>
-  static auto second(Input... args) -> VariantPtr {
-    auto ptr = new K(args...);
-    return VariantPtr{ptr};
-  }
-
-  auto get_ref()
-      -> std::optional<std::variant<std::reference_wrapper<const T>,
-                                    std::reference_wrapper<const K>>> {
+  auto get_ref() const
+      -> std::optional<std::variant<std::reference_wrapper<Left>,
+                                    std::reference_wrapper<Right>>> {
     auto data = _resource.load();
     if (data == 0) {
       return std::nullopt;
@@ -171,18 +155,15 @@ struct VariantPtr {
     constexpr auto flag_mask = (1 << num_flag_bits) - 1;
     constexpr auto data_mask = ~flag_mask;
     if (data & flag_mask) {
-      return {std::reference_wrapper<const T>{
-          reinterpret_cast<Shared<T>*>(data & data_mask)->get_ref()}};
+      return {std::reference_wrapper<Left>{
+          reinterpret_cast<Shared<Left>*>(data & data_mask)->get_ref()}};
     } else {
-      return {std::reference_wrapper<const K>{
-          *reinterpret_cast<K*>(data & data_mask)}};
+      return {std::reference_wrapper<Right>{
+          *reinterpret_cast<Right*>(data & data_mask)}};
     }
   }
 
  private:
-  template<SameAs<T> U>
-  VariantPtr(Shared<U>* shared)
-      : _resource{reinterpret_cast<std::uintptr_t>(shared) | 1} {}
   std::atomic<std::uintptr_t> _resource;
 };
 
@@ -190,6 +171,6 @@ struct VariantPtr {
 
 namespace arangodb::inspection {
 template<typename T>
-struct Access<containers::SharedReference<T>>
-    : OptionalAccess<containers::SharedReference<T>> {};
+struct Access<containers::SharedPtr<T>>
+    : OptionalAccess<containers::SharedPtr<T>> {};
 }  // namespace arangodb::inspection

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -169,6 +169,17 @@ struct AtomicSharedOrRawPtr {
  private:
   std::atomic<std::uintptr_t> _resource;
 };
+template<typename Inspector, typename Left, typename Right>
+auto inspect(Inspector& f, AtomicSharedOrRawPtr<Left, Right>& x) {
+  if constexpr (not Inspector::isLoading) {  // only serialization
+    auto var = x.get();
+    if (std::holds_alternative<Left*>(var)) {
+      return f.apply(*std::get<Left*>(var));
+    } else {
+      return f.apply(*std::get<Right*>(var));
+    }
+  }
+}
 
 }  // namespace arangodb::containers
 

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -125,13 +125,12 @@ struct SharedPtr {
    Works if both types have an alignment larger than 1,
    then the last bit of a pointer to one of these types is unused and can be
    used as a flag for the type of the pointer.
+
+   Make sure that Raw define the pointer type with alignment
+   larger than (1 << num_flag_bits)
 */
 template<typename Shared, typename Raw>
 struct AtomicSharedOrRawPtr {
-  static constexpr auto num_flag_bits = 1;
-  static_assert(std::alignment_of_v<Shared<Left>> >= (1 << num_flag_bits) &&
-                std::alignment_of_v<Right> >= (1 << num_flag_bits));
-
   template<SameAs<Raw> U>
   AtomicSharedOrRawPtr(U* right) : _resource{raw_to_ptr(right)} {}
 

--- a/lib/Containers/Concurrent/thread.cpp
+++ b/lib/Containers/Concurrent/thread.cpp
@@ -33,3 +33,13 @@ auto ThreadId::current() noexcept -> ThreadId {
 auto ThreadId::name() -> std::string {
   return std::string{ThreadNameFetcher{posix_id}.get()};
 }
+
+auto ThreadInfo::current() noexcept -> ThreadInfo& {
+  struct Guard {
+    std::shared_ptr<ThreadInfo> _info = std::make_shared<ThreadInfo>(
+        arangodb::Thread::currentKernelThreadId(),
+        std::string{arangodb::ThreadNameFetcher{}.get()});
+  };
+  static thread_local auto guard = Guard{};
+  return *guard._info;
+}

--- a/lib/Containers/Concurrent/thread.cpp
+++ b/lib/Containers/Concurrent/thread.cpp
@@ -34,12 +34,12 @@ auto ThreadId::name() -> std::string {
   return std::string{ThreadNameFetcher{posix_id}.get()};
 }
 
-auto ThreadInfo::current() noexcept -> ThreadInfo& {
+auto ThreadInfo::current() noexcept -> containers::SharedPtr<ThreadInfo> {
   struct Guard {
-    std::shared_ptr<ThreadInfo> _info = std::make_shared<ThreadInfo>(
+    containers::SharedPtr<ThreadInfo> _info = containers::SharedPtr<ThreadInfo>(
         arangodb::Thread::currentKernelThreadId(),
         std::string{arangodb::ThreadNameFetcher{}.get()});
   };
   static thread_local auto guard = Guard{};
-  return *guard._info;
+  return guard._info;
 }

--- a/lib/Containers/Concurrent/thread.h
+++ b/lib/Containers/Concurrent/thread.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Basics/threads-posix.h"
+#include "Containers/Concurrent/shared.h"
 #include "Inspection/Format.h"
 
 namespace arangodb::basics {
@@ -41,7 +42,7 @@ auto inspect(Inspector& f, ThreadId& x) {
 }
 
 struct ThreadInfo {
-  static auto current() noexcept -> ThreadInfo&;
+  static auto current() noexcept -> containers::SharedPtr<ThreadInfo>;
   pid_t kernel_id;
   std::string name;
   bool operator==(ThreadInfo const&) const = default;

--- a/lib/Containers/Concurrent/thread.h
+++ b/lib/Containers/Concurrent/thread.h
@@ -40,6 +40,18 @@ auto inspect(Inspector& f, ThreadId& x) {
                             f.field("posix_id", x.posix_id));
 }
 
+struct ThreadInfo {
+  static auto current() noexcept -> ThreadInfo&;
+  pid_t kernel_id;
+  std::string name;
+  bool operator==(ThreadInfo const&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ThreadInfo& x) {
+  return f.object(x).fields(f.field("LWPID", x.kernel_id),
+                            f.field("name", x.name));
+}
+
 }  // namespace arangodb::basics
 
 template<>

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -30,6 +30,7 @@
 #include <thread>
 
 #include "Async/Registry/promise.h"
+#include "Containers/Concurrent/thread.h"
 #include "Futures/Exceptions.h"
 #include "Futures/Promise.h"
 #include "Futures/SharedState.h"
@@ -273,7 +274,7 @@ class [[nodiscard]] Future {
 
   /// Blocks until this Future is complete.
   void wait() {
-    update_requester(async_registry::Requester::current_thread());
+    update_requester(basics::ThreadId::current());
     detail::waitImpl(*this);
   }
 
@@ -313,7 +314,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
-    update_requester({future.id()});
+    update_requester(future.id());
     getState().setCallback([fn = std::forward<DF>(fn),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -344,7 +345,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
-    update_requester({future.id()});
+    update_requester(future.id());
     getState().setCallback([fn = std::forward<DF>(fn), pr = std::move(promise),
                             future_id = future.id()](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -352,7 +353,7 @@ class [[nodiscard]] Future {
       } else {
         try {
           auto f = std::invoke(std::forward<DF>(fn), std::move(t).get());
-          f.update_requester({future_id});
+          f.update_requester(future_id);
           std::move(f).thenFinal([pr = std::move(pr)](Try<B>&& t) mutable {
             pr.setTry(std::move(t));
           });
@@ -380,7 +381,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
-    update_requester({future.id()});
+    update_requester(future.id());
     getState().setCallback([fn = std::forward<DF>(func),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       pr.setTry(detail::makeTryWith([&fn, &t] {
@@ -403,12 +404,12 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
-    update_requester({future.id()});
+    update_requester(future.id());
     getState().setCallback([fn = std::forward<F>(func), pr = std::move(promise),
                             future_id = future.id()](Try<T>&& t) mutable {
       try {
         auto f = std::invoke(std::forward<F>(fn), std::move(t));
-        f.update_requester({future_id});
+        f.update_requester(future_id);
         std::move(f).thenFinal([pr = std::move(pr)](Try<B>&& t) mutable {
           pr.setTry(std::move(t));
         });
@@ -443,7 +444,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
-    update_requester({future.id()});
+    update_requester(future.id());
     getState().setCallback([fn = std::forward<DF>(func),
                             pr = std::move(promise)](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -477,7 +478,7 @@ class [[nodiscard]] Future {
 
     Promise<B> promise{std::move(loc)};
     auto future = promise.getFuture();
-    update_requester({future.id()});
+    update_requester(future.id());
     getState().setCallback([fn = std::forward<DF>(fn), pr = std::move(promise),
                             future_id = future.id()](Try<T>&& t) mutable {
       if (t.hasException()) {
@@ -486,7 +487,7 @@ class [[nodiscard]] Future {
         } catch (ET& e) {
           try {
             auto f = std::invoke(std::forward<DF>(fn), e);
-            f.update_requester({future_id});
+            f.update_requester(future_id);
             std::move(f).thenFinal([pr = std::move(pr)](Try<B>&& t) mutable {
               pr.setTry(std::move(t));
             });
@@ -503,16 +504,21 @@ class [[nodiscard]] Future {
     return future;
   }
 
-  auto update_requester(async_registry::Requester waiter) {
+  auto update_requester(std::optional<async_registry::PromiseId> requester) {
     if (_state != nullptr) {
-      _state->update_requester(waiter);
+      _state->update_requester(requester);
     }
   }
-  auto id() -> void* {
+  auto update_requester(basics::ThreadId&& requester) {
     if (_state != nullptr) {
-      return _state->id();
+      _state->update_requester(std::move(requester));
+    }
+  }
+  auto id() -> std::optional<async_registry::PromiseId> {
+    if (_state != nullptr) {
+      return {_state->id()};
     } else {
-      return nullptr;
+      return std::nullopt;
     }
   }
 

--- a/lib/Futures/include/Futures/Future.h
+++ b/lib/Futures/include/Futures/Future.h
@@ -274,7 +274,7 @@ class [[nodiscard]] Future {
 
   /// Blocks until this Future is complete.
   void wait() {
-    update_requester(basics::ThreadId::current());
+    update_requester_to_current_thread();
     detail::waitImpl(*this);
   }
 
@@ -509,9 +509,9 @@ class [[nodiscard]] Future {
       _state->update_requester(requester);
     }
   }
-  auto update_requester(basics::ThreadId&& requester) {
+  auto update_requester_to_current_thread() {
     if (_state != nullptr) {
-      _state->update_requester(std::move(requester));
+      _state->update_requester_to_current_thread();
     }
   }
   auto id() -> std::optional<async_registry::PromiseId> {

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -121,16 +121,31 @@ class Promise {
 
   arangodb::futures::Future<T> getFuture();
 
-  auto id() -> void* { return _state->id(); }
+  auto id() -> std::optional<async_registry::PromiseId> {
+    if (_state) {
+      return _state->id();
+    } else {
+      return std::nullopt;
+    }
+  }
   auto update_source_location(std::source_location loc) -> void {
-    _state->update_source_location(std::move(loc));
+    if (_state) {
+      _state->update_source_location(std::move(loc));
+    }
   }
   auto update_state(async_registry::State state)
       -> std::optional<async_registry::State> {
-    return _state->update_state(std::move(state));
+    if (_state) {
+      return _state->update_state(std::move(state));
+    } else {
+      return std::nullopt;
+    }
   }
-  auto update_requester(async_registry::Requester waiter) -> void {
-    return _state->update_requester(waiter);
+  auto update_requester(std::optional<async_registry::PromiseId> waiter)
+      -> void {
+    if (_state) {
+      return _state->update_requester(waiter);
+    }
   }
 
  private:

--- a/lib/Futures/include/Futures/Utilities.h
+++ b/lib/Futures/include/Futures/Utilities.h
@@ -158,7 +158,7 @@ collectAll(InputIterator first, InputIterator last) {
 
   auto ctx = std::make_shared<Context>(size_t(std::distance(first, last)));
   for (size_t i = 0; first != last; ++first, ++i) {
-    first->update_requester({ctx->p.id()});
+    first->update_requester(ctx->p.id());
     std::move(*first).thenFinal(
         [i, ctx](auto&& t) { ctx->results[i] = std::move(t); });
   }
@@ -177,7 +177,7 @@ namespace gather {
 
 template<typename C, typename... Ts, std::size_t... I>
 void thenFinalAll(C& c, std::index_sequence<I...>, Future<Ts>&&... ts) {
-  (ts.update_requester({c->p.id()}), ...);
+  (ts.update_requester(c->p.id()), ...);
   (std::move(ts).thenFinal(
        [&](Try<Ts>&& t) { std::get<I>(c->results) = std::move(t); }),
    ...);
@@ -213,7 +213,7 @@ namespace collect {
 
 template<typename C, typename... Ts, std::size_t... I>
 void thenFinalAll(C& c, std::index_sequence<I...>, Future<Ts>&&... ts) {
-  (ts.update_requester({c->p.id()}), ...);
+  (ts.update_requester(c->p.id()), ...);
   (std::move(ts).thenFinal([c](Try<Ts>&& t) {
     if (t.hasException()) {
       if (c->hadError.exchange(true, std::memory_order_release) == false) {

--- a/lib/Futures/include/Futures/coro-helper.h
+++ b/lib/Futures/include/Futures/coro-helper.h
@@ -62,7 +62,7 @@ struct future_promise_base {
 
   future_promise_base(std::source_location loc)
       : promise{std::move(loc)}, context{} {
-    *arangodb::async_registry::get_current_coroutine() = {promise.id()};
+    *arangodb::async_registry::get_current_coroutine() = {promise.id().value()};
   }
   ~future_promise_base() {}
 
@@ -122,7 +122,7 @@ struct future_promise_base {
 
     // update promises in registry
     if constexpr (arangodb::CanUpdateRequester<U>) {
-      co_awaited_expression.update_requester({promise.id()});
+      co_awaited_expression.update_requester(promise.id());
     }
     promise.update_source_location(std::move(loc));
 

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -1,6 +1,7 @@
 #include "Async/async.h"
 #include "Async/Registry/promise.h"
 #include "Async/Registry/registry_variable.h"
+#include "Containers/Concurrent/shared.h"
 #include "Inspection/Format.h"
 #include "Inspection/JsonPrintInspector.h"
 #include "Utils/ExecContext.h"
@@ -153,7 +154,8 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
     wait.stop();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
     EXPECT_EQ(promise_count_in_registry(), 0);
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<
+                arangodb::containers::SharedPtr<arangodb::basics::ThreadInfo>>(
         *arangodb::async_registry::get_current_coroutine()));
   }
 
@@ -529,8 +531,8 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
 
@@ -549,8 +551,8 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -589,8 +591,8 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
       auto fn_2 = Functions::awaited_2_fn();
@@ -619,8 +621,8 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -640,7 +642,8 @@ TYPED_TEST(AsyncTest,
     static auto awaited_fn(TestType test) -> async<void> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<basics::ThreadId>(promise->requester));
+      EXPECT_TRUE(
+          std::holds_alternative<basics::ThreadInfo>(promise->requester));
 
       co_await test->wait;
 
@@ -649,13 +652,13 @@ TYPED_TEST(AsyncTest,
     static auto waiter_fn(async<void>&& fn) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_await std::move(fn);
 
@@ -667,8 +670,8 @@ TYPED_TEST(AsyncTest,
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -699,8 +702,8 @@ TYPED_TEST(
 
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -23,6 +23,7 @@
 #include "Async/Registry/promise.h"
 #include "Async/Registry/registry_variable.h"
 #include "thread.h"
+#include "Basics/Thread.h"
 
 #include <gtest/gtest.h>
 #include <optional>
@@ -183,4 +184,22 @@ TEST_F(AsyncRegistryTest, inpection_works_on_after_thread_was_deleted) {
   // we just make sure that we can still inspect the promise (and it does not
   // crash the system), although the thread the promise was created on is gone
   EXPECT_NE(fmt::format("{}", inspection::json(promise_snapshot)), "");
+}
+
+TEST_F(AsyncRegistryTest, size_tests) {
+  std::cout << "ThreadInfo: " << sizeof(basics::ThreadInfo) << std::endl;
+  std::cout << "ThreadInfo::current(): "
+            << sizeof(basics::ThreadInfo::current()) << std::endl;
+  std::shared_ptr<basics::ThreadInfo> shared_ptr =
+      std::make_shared<basics::ThreadInfo>(
+          arangodb::Thread::currentKernelThreadId(),
+          std::string{arangodb::ThreadNameFetcher{}.get()});
+  std::cout << "shared_ptr<ThreadInfo>: " << sizeof(shared_ptr) << std::endl;
+  int* bla = new int{};
+  std::cout << "int: " << sizeof(bla) << std::endl;
+  basics::ThreadInfo* normal_ptr =
+      new basics::ThreadInfo{arangodb::Thread::currentKernelThreadId(),
+                             std::string{arangodb::ThreadNameFetcher{}.get()}};
+  std::cout << "ThreadInfo*: " << sizeof(normal_ptr) << std::endl;
+  std::cout << "shared_ptr<ThreadInfo>*: " << sizeof(&shared_ptr) << std::endl;
 }

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -50,7 +50,7 @@ struct MyPromise : public AddToAsyncRegistry {
         source_location{basics::SourceLocationSnapshot::from(std::move(loc))},
         thread{basics::ThreadId::current()} {}
   auto snapshot(State state = State::Running) -> PromiseSnapshot {
-    return PromiseSnapshot{.id = id(),
+    return PromiseSnapshot{.id = id().value(),
                            .requester = {thread},
                            .state = state,
                            .thread = thread,

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -54,6 +54,7 @@ struct MyPromise : public AddToAsyncRegistry {
         thread{basics::ThreadInfo::current()} {}
   auto snapshot(State state = State::Running) -> PromiseSnapshot {
     return PromiseSnapshot{.id = id().value(),
+                           .owning_thread = thread.get_ref().value(),
                            .requester = {thread.get_ref().value()},
                            .state = state,
                            .thread = thread_id,
@@ -187,22 +188,4 @@ TEST_F(AsyncRegistryTest, inpection_works_on_after_thread_was_deleted) {
   // we just make sure that we can still inspect the promise (and it does not
   // crash the system), although the thread the promise was created on is gone
   EXPECT_NE(fmt::format("{}", inspection::json(promise_snapshot)), "");
-}
-
-TEST_F(AsyncRegistryTest, size_tests) {
-  std::cout << "ThreadInfo: " << sizeof(basics::ThreadInfo) << std::endl;
-  std::cout << "ThreadInfo::current(): "
-            << sizeof(basics::ThreadInfo::current()) << std::endl;
-  std::shared_ptr<basics::ThreadInfo> shared_ptr =
-      std::make_shared<basics::ThreadInfo>(
-          arangodb::Thread::currentKernelThreadId(),
-          std::string{arangodb::ThreadNameFetcher{}.get()});
-  std::cout << "shared_ptr<ThreadInfo>: " << sizeof(shared_ptr) << std::endl;
-  int* bla = new int{};
-  std::cout << "int: " << sizeof(bla) << std::endl;
-  basics::ThreadInfo* normal_ptr =
-      new basics::ThreadInfo{arangodb::Thread::currentKernelThreadId(),
-                             std::string{arangodb::ThreadNameFetcher{}.get()}};
-  std::cout << "ThreadInfo*: " << sizeof(normal_ptr) << std::endl;
-  std::cout << "shared_ptr<ThreadInfo>*: " << sizeof(&shared_ptr) << std::endl;
 }

--- a/tests/Async/Registry/RegistryTest.cpp
+++ b/tests/Async/Registry/RegistryTest.cpp
@@ -22,7 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 #include "Async/Registry/promise.h"
 #include "Async/Registry/registry_variable.h"
-#include "thread.h"
+#include "Containers/Concurrent/shared.h"
+#include "Containers/Concurrent/thread.h"
 #include "Basics/Thread.h"
 
 #include <gtest/gtest.h>
@@ -44,16 +45,18 @@ auto promises_in_registry() -> std::vector<PromiseSnapshot> {
 
 struct MyPromise : public AddToAsyncRegistry {
   basics::SourceLocationSnapshot source_location;
-  basics::ThreadId thread;
+  basics::ThreadId thread_id;
+  containers::SharedPtr<basics::ThreadInfo> thread;
   MyPromise(std::source_location loc = std::source_location::current())
       : AddToAsyncRegistry{loc},
         source_location{basics::SourceLocationSnapshot::from(std::move(loc))},
-        thread{basics::ThreadId::current()} {}
+        thread_id{basics::ThreadId::current()},
+        thread{basics::ThreadInfo::current()} {}
   auto snapshot(State state = State::Running) -> PromiseSnapshot {
     return PromiseSnapshot{.id = id().value(),
-                           .requester = {thread},
+                           .requester = {thread.get_ref().value()},
                            .state = state,
-                           .thread = thread,
+                           .thread = thread_id,
                            .source_location = source_location};
   }
 };

--- a/tests/Containers/Concurrent/CMakeLists.txt
+++ b/tests/Containers/Concurrent/CMakeLists.txt
@@ -4,3 +4,15 @@ target_sources(arangodbtests
   ListOfNonOwnedListsTest.cpp)
 target_link_libraries(arangodbtests
   arango_thread_owning_list)
+
+add_library(arango_test_shared OBJECT
+  SharedTest.cpp)
+target_link_libraries(arango_test_shared PRIVATE
+  arango_shared
+  arango_inspection
+  velocypack
+  gtest)
+add_executable(arangodbtests_shared EXCLUDE_FROM_ALL)
+target_link_libraries(arangodbtests_shared
+  arango_test_shared
+  gtest_main)

--- a/tests/Containers/Concurrent/SharedTest.cpp
+++ b/tests/Containers/Concurrent/SharedTest.cpp
@@ -68,3 +68,20 @@ TEST(SharedTest, variant_ptr_works_like_a_variant) {
   EXPECT_EQ(
       std::get<std::reference_wrapper<int>>(second_type.get_ref().value()), 22);
 }
+
+TEST(SharedTest, variant_ptr_includes_a_copy_of_a_shared_reference) {
+  auto ref = SharedReference<int>{435};
+  EXPECT_EQ(ref.get_ref(), 435);
+  EXPECT_EQ(ref.ref_count(), 1);
+  {
+    auto variant = VariantPtr<int, Bla>{ref};
+    EXPECT_EQ(ref.ref_count(), 2);
+    EXPECT_TRUE(variant.get_ref().has_value());
+    EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<int>>(
+        variant.get_ref().value()));
+    EXPECT_EQ(std::get<std::reference_wrapper<int>>(variant.get_ref().value()),
+              435);
+  }
+  EXPECT_EQ(ref.ref_count(), 1);
+  EXPECT_EQ(ref.get_ref(), 435);
+}

--- a/tests/Containers/Concurrent/SharedTest.cpp
+++ b/tests/Containers/Concurrent/SharedTest.cpp
@@ -24,6 +24,7 @@
 #include "Inspection/Format.h"
 
 #include <gtest/gtest.h>
+#include <variant>
 
 using namespace arangodb::containers;
 
@@ -46,4 +47,24 @@ TEST(SharedTest, shared_reference_extends_lifetime) {
 TEST(SharedTest, inspection_of_shared_reference_gives_shared_object) {
   auto ref = SharedReference<int>{4};
   EXPECT_EQ(fmt::format("{}", arangodb::inspection::json(ref)), "4");
+}
+
+struct Bla {
+  Bla(){};
+  std::string a;
+};
+TEST(SharedTest, variant_ptr_works_like_a_variant) {
+  auto first_type = VariantPtr<int, Bla>::first(18);
+  EXPECT_TRUE(first_type.get_ref().has_value());
+  EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<int>>(
+      first_type.get_ref().value()));
+  EXPECT_EQ(std::get<std::reference_wrapper<int>>(first_type.get_ref().value()),
+            18);
+
+  auto second_type = VariantPtr<Shared<Bla>, int>::second(22);
+  EXPECT_TRUE(second_type.get_ref().has_value());
+  EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<int>>(
+      second_type.get_ref().value()));
+  EXPECT_EQ(
+      std::get<std::reference_wrapper<int>>(second_type.get_ref().value()), 22);
 }

--- a/tests/Containers/Concurrent/SharedTest.cpp
+++ b/tests/Containers/Concurrent/SharedTest.cpp
@@ -41,7 +41,7 @@ TEST(SharedTest, shared_reference_extends_lifetime) {
     EXPECT_EQ(initial_ref.ref_count(), ref_copy.ref_count());
   }
   EXPECT_EQ(ref_copy.ref_count(), 1);
-  EXPECT_EQ(ref_copy.get_ref(), 435);
+  EXPECT_EQ(*ref_copy.get().value(), 435);
 }
 
 TEST(SharedTest, inspection_of_shared_reference_gives_shared_object) {
@@ -57,37 +57,31 @@ struct MyStruct {
 TEST(SharedTest, variant_ptr_can_include_a_copy_of_a_shared_reference) {
   {
     auto ref = SharedPtr<int>{435};
-    EXPECT_EQ(ref.get_ref(), 435);
+    EXPECT_EQ(*ref.get().value(), 435);
     EXPECT_EQ(ref.ref_count(), 1);
     {
       auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ref};
       EXPECT_EQ(ref.ref_count(), 2);
-      EXPECT_TRUE(variant.get_ref().has_value());
-      EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<int>>(
-          variant.get_ref().value()));
-      EXPECT_EQ(
-          std::get<std::reference_wrapper<int>>(variant.get_ref().value()),
-          435);
+      EXPECT_TRUE(variant.get().has_value());
+      EXPECT_TRUE(std::holds_alternative<int*>(variant.get().value()));
+      EXPECT_EQ(*std::get<int*>(variant.get().value()), 435);
     }
     EXPECT_EQ(ref.ref_count(), 1);
-    EXPECT_EQ(ref.get_ref(), 435);
+    EXPECT_EQ(*ref.get().value(), 435);
   }
   {
     auto ref = SharedPtr<MyStruct>{"abcde"};
-    EXPECT_EQ(ref.get_ref(), MyStruct{"abcde"});
+    EXPECT_EQ(*ref.get().value(), MyStruct{"abcde"});
     EXPECT_EQ(ref.ref_count(), 1);
     {
       auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ref};
       EXPECT_EQ(ref.ref_count(), 2);
-      EXPECT_TRUE(variant.get_ref().has_value());
-      EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<MyStruct>>(
-          variant.get_ref().value()));
-      EXPECT_EQ(
-          std::get<std::reference_wrapper<MyStruct>>(variant.get_ref().value()),
-          MyStruct{"abcde"});
+      EXPECT_TRUE(variant.get().has_value());
+      EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant.get().value()));
+      EXPECT_EQ(*std::get<MyStruct*>(variant.get().value()), MyStruct{"abcde"});
     }
     EXPECT_EQ(ref.ref_count(), 1);
-    EXPECT_EQ(ref.get_ref(), MyStruct{"abcde"});
+    EXPECT_EQ(*ref.get().value(), MyStruct{"abcde"});
   }
 }
 
@@ -95,20 +89,15 @@ TEST(SharedTest, variant_ptr_can_include_a_raw_pointer) {
   {
     auto ptr = new int{32};
     auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ptr};
-    EXPECT_TRUE(variant.get_ref().has_value());
-    EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<int>>(
-        variant.get_ref().value()));
-    EXPECT_EQ(std::get<std::reference_wrapper<int>>(variant.get_ref().value()),
-              32);
+    EXPECT_TRUE(variant.get().has_value());
+    EXPECT_TRUE(std::holds_alternative<int*>(variant.get().value()));
+    EXPECT_EQ(*std::get<int*>(variant.get().value()), 32);
   }
   {
     auto ptr = new MyStruct{"abcde"};
     auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};
-    EXPECT_TRUE(variant.get_ref().has_value());
-    EXPECT_TRUE(std::holds_alternative<std::reference_wrapper<MyStruct>>(
-        variant.get_ref().value()));
-    EXPECT_EQ(
-        std::get<std::reference_wrapper<MyStruct>>(variant.get_ref().value()),
-        MyStruct{"abcde"});
+    EXPECT_TRUE(variant.get().has_value());
+    EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant.get().value()));
+    EXPECT_EQ(*std::get<MyStruct*>(variant.get().value()), MyStruct{"abcde"});
   }
 }

--- a/tests/Containers/Concurrent/SharedTest.cpp
+++ b/tests/Containers/Concurrent/SharedTest.cpp
@@ -1,0 +1,49 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#include "Containers/Concurrent/shared.h"
+#include "Inspection/Format.h"
+
+#include <gtest/gtest.h>
+
+using namespace arangodb::containers;
+
+TEST(SharedTest, shared_reference_extends_lifetime) {
+  SharedReference<int> ref_copy;
+  EXPECT_EQ(ref_copy.ref_count(), 1);
+  {
+    auto initial_ref = SharedReference<int>{435};
+    EXPECT_EQ(initial_ref.ref_count(), 1);
+    EXPECT_EQ(ref_copy.ref_count(), 1);
+
+    ref_copy = initial_ref;
+    EXPECT_EQ(ref_copy.ref_count(), 2);
+    EXPECT_EQ(initial_ref.ref_count(), ref_copy.ref_count());
+  }
+  EXPECT_EQ(ref_copy.ref_count(), 1);
+  EXPECT_EQ(ref_copy.get_ref(), 435);
+}
+
+TEST(SharedTest, inspection_of_shared_reference_gives_shared_object) {
+  auto ref = SharedReference<int>{4};
+  EXPECT_EQ(fmt::format("{}", arangodb::inspection::json(ref)), "4");
+}

--- a/tests/Containers/Concurrent/SharedTest.cpp
+++ b/tests/Containers/Concurrent/SharedTest.cpp
@@ -41,7 +41,7 @@ TEST(SharedTest, shared_reference_extends_lifetime) {
     EXPECT_EQ(initial_ref.ref_count(), ref_copy.ref_count());
   }
   EXPECT_EQ(ref_copy.ref_count(), 1);
-  EXPECT_EQ(*ref_copy.get().value(), 435);
+  EXPECT_EQ(*ref_copy.get(), 435);
 }
 
 TEST(SharedTest, inspection_of_shared_reference_gives_shared_object) {
@@ -57,42 +57,39 @@ struct MyStruct {
 TEST(SharedTest, variant_ptr_can_include_a_copy_of_a_shared_reference) {
   {
     auto ref = SharedPtr<int>{435};
-    EXPECT_EQ(*ref.get().value(), 435);
+    EXPECT_EQ(*ref.get(), 435);
     EXPECT_EQ(ref.ref_count(), 1);
     {
       auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ref};
       EXPECT_EQ(ref.ref_count(), 2);
-      EXPECT_TRUE(variant.get().has_value());
-      EXPECT_TRUE(std::holds_alternative<int*>(variant.get().value()));
-      EXPECT_EQ(*std::get<int*>(variant.get().value()), 435);
+      EXPECT_TRUE(std::holds_alternative<int*>(variant.get()));
+      EXPECT_EQ(*std::get<int*>(variant.get()), 435);
     }
     EXPECT_EQ(ref.ref_count(), 1);
-    EXPECT_EQ(*ref.get().value(), 435);
+    EXPECT_EQ(*ref.get(), 435);
   }
   {
     auto ref = SharedPtr<MyStruct>{"abcde"};
-    EXPECT_EQ(*ref.get().value(), MyStruct{"abcde"});
+    EXPECT_EQ(*ref.get(), MyStruct{"abcde"});
     EXPECT_EQ(ref.ref_count(), 1);
     {
       auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ref};
       EXPECT_EQ(ref.ref_count(), 2);
-      EXPECT_TRUE(variant.get().has_value());
-      EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant.get().value()));
-      EXPECT_EQ(*std::get<MyStruct*>(variant.get().value()), MyStruct{"abcde"});
+      EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant.get()));
+      EXPECT_EQ(*std::get<MyStruct*>(variant.get()), MyStruct{"abcde"});
     }
     EXPECT_EQ(ref.ref_count(), 1);
-    EXPECT_EQ(*ref.get().value(), MyStruct{"abcde"});
+    EXPECT_EQ(*ref.get(), MyStruct{"abcde"});
   }
 }
 
 TEST(SharedTest, variant_ptr_can_include_a_raw_pointer) {
-  {
-    auto ptr = new int{32};
-    auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ptr};
-    EXPECT_TRUE(variant.get().has_value());
-    EXPECT_TRUE(std::holds_alternative<int*>(variant.get().value()));
-    EXPECT_EQ(*std::get<int*>(variant.get().value()), 32);
-  }
+  auto ptr = new MyStruct{"abcde"};
+  auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};
+  EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant.get()));
+  EXPECT_EQ(*std::get<MyStruct*>(variant.get()), MyStruct{"abcde"});
+}
+
   {
     auto ptr = new MyStruct{"abcde"};
     auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};

--- a/tests/Futures/FutureCoroutineTest.cpp
+++ b/tests/Futures/FutureCoroutineTest.cpp
@@ -111,7 +111,8 @@ template<typename WaitType>
 struct FutureTest : ::testing::Test {
   void SetUp() override {
     arangodb::async_registry::get_thread_registry().garbage_collect();
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<
+                arangodb::containers::SharedPtr<arangodb::basics::ThreadInfo>>(
         *arangodb::async_registry::get_current_coroutine()));
   }
 
@@ -199,7 +200,7 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> Future<Unit> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
@@ -219,7 +220,7 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       co_return;
@@ -239,7 +240,7 @@ TYPED_TEST(FutureTest,
     static auto awaited_fn(TestType test) -> Future<Unit> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           promise->requester));
 
       co_await test->wait;
@@ -249,12 +250,12 @@ TYPED_TEST(FutureTest,
     static auto waiter_fn(Future<Unit>&& fn) -> Future<Unit> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       co_await std::move(fn);
@@ -267,7 +268,7 @@ TYPED_TEST(FutureTest,
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       co_return;

--- a/tests/Futures/FutureTest.cpp
+++ b/tests/Futures/FutureTest.cpp
@@ -933,7 +933,7 @@ TEST(FutureTest,
     EXPECT_TRUE(waiter_promise.has_value());
     EXPECT_EQ(awaited_promise->requester,
               arangodb::async_registry::Requester{waiter_promise->id});
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
         waiter_promise->requester));
   }
 }
@@ -981,7 +981,7 @@ TEST(FutureTest, collected_async_promises_in_async_registry_know_their_waiter) {
               arangodb::async_registry::Requester{waiter_promise->id});
     EXPECT_EQ(awaited_promises[1].requester,
               arangodb::async_registry::Requester{waiter_promise->id});
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
         waiter_promise->requester));
   }
 }

--- a/tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration/async_registry_gdb_pretty_printer_test.cpp
+++ b/tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration/async_registry_gdb_pretty_printer_test.cpp
@@ -32,8 +32,10 @@ using namespace arangodb::async_registry;
 
 auto breakpoint() { raise(SIGINT); }
 
-auto format(arangodb::basics::SourceLocationSnapshot const& loc) -> std::string {
-  return fmt::format("\"{}\" (\"{}\":{})", loc.function_name, loc.file_name, loc.line);
+auto format(arangodb::basics::SourceLocationSnapshot const& loc)
+    -> std::string {
+  return fmt::format("\"{}\" (\"{}\":{})", loc.function_name, loc.file_name,
+                     loc.line);
 }
 auto format(arangodb::basics::ThreadId const& thread) -> std::string {
   return fmt::format("LWPID {} (pthread {})", thread.kernel_id,
@@ -44,8 +46,7 @@ auto format(arangodb::basics::ThreadInfo const& thread) -> std::string {
 }
 auto format(PromiseSnapshot const& snapshot) -> std::string {
   if (snapshot.thread == std::nullopt) {
-    return fmt::format("{}, owned by {}, {}",
-                       format(snapshot.source_location),
+    return fmt::format("{}, owned by {}, {}", format(snapshot.source_location),
                        format(snapshot.owning_thread),
                        arangodb::inspection::json(snapshot.state));
   } else {
@@ -73,7 +74,7 @@ int main() {
   // empty registry
   auto test_registry = Registry{};
   auto thread_registry = ThreadRegistry::make();
-  auto current_thread = arangodb::basics::ThreadId::current();
+  auto current_thread = arangodb::basics::ThreadInfo::current();
   test_registry.add(thread_registry);
 
   breakpoint();
@@ -84,15 +85,16 @@ int main() {
 
   // add a promise
   auto parent = thread_registry->add([&]() {
-    return Promise{{current_thread}, std::source_location::current()};
+    return Promise{CurrentRequester{current_thread},
+                   std::source_location::current()};
   });
   expected = fmt::format(
       "async registry = {{\n"
       "[{}] = \n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()), format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -103,8 +105,8 @@ int main() {
       "[{}] = \n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()), format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -118,8 +120,9 @@ int main() {
       "    ┌ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child->data.snapshot()),
-      format(parent->data.snapshot()), format(current_thread));
+      format(current_thread.get_ref().value()), format(child->data.snapshot()),
+      format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -134,9 +137,9 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child->data.snapshot()),
+      format(current_thread.get_ref().value()), format(child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -152,9 +155,10 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child_of_child->data.snapshot()),
-      format(child->data.snapshot()), format(second_child->data.snapshot()),
-      format(parent->data.snapshot()), format(current_thread));
+      format(current_thread.get_ref().value()),
+      format(child_of_child->data.snapshot()), format(child->data.snapshot()),
+      format(second_child->data.snapshot()), format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -171,17 +175,17 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child_of_child->data.snapshot()),
-      format(child->data.snapshot()),
+      format(current_thread.get_ref().value()),
+      format(child_of_child->data.snapshot()), format(child->data.snapshot()),
       format(child_of_second_child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
   // add a completely unrelated promise
   auto* second_parent = thread_registry->add([&]() {
-    return Promise{{arangodb::basics::ThreadId::current()},
+    return Promise{{arangodb::basics::ThreadInfo::current()},
                    std::source_location::current()};
   });
   expected = fmt::format(
@@ -196,17 +200,20 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(second_parent->data.snapshot()),
-      format(current_thread), format(current_thread),
+      format(current_thread.get_ref().value()),
+      format(second_parent->data.snapshot()),
+      format(current_thread.get_ref().value()),
+      format(current_thread.get_ref().value()),
       format(child_of_child->data.snapshot()), format(child->data.snapshot()),
       format(child_of_second_child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
   auto second_thread_registry = ThreadRegistry::make();
-  auto other_thread = arangodb::basics::ThreadId{};
+  auto other_thread =
+      arangodb::basics::ThreadInfo{};  // simulate another thread
   test_registry.add(second_thread_registry);
 
   // add a new promise on another thread
@@ -228,12 +235,14 @@ int main() {
       "[{}] = \n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(second_parent->data.snapshot()),
-      format(current_thread), format(current_thread),
+      format(current_thread.get_ref().value()),
+      format(second_parent->data.snapshot()),
+      format(current_thread.get_ref().value()),
+      format(current_thread.get_ref().value()),
       format(child_of_child->data.snapshot()), format(child->data.snapshot()),
       format(child_of_second_child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread), format(other_thread),
+      format(current_thread.get_ref().value()), format(other_thread),
       format(parent_on_other_thread->data.snapshot()), format(other_thread));
 
   breakpoint();


### PR DESCRIPTION
[PR](https://github.com/arangodb/arangodb/pull/21776) got rid of printing the involved thread names in the async registry due to a bug. This PR adds the thread name back in, but now we directly save the thread name string when creating the `ThreadInfo` object that includes all needed thread infos for the async registry. We use this `ThreadInfo` object several times. To save the object - and therefore the string - only once, we wrap the ThreadInfo object into a shared resource object. A `ThreadInfo` instance is deleted when all its references are gone.

With this PR we use the shared `ThreadInfo` resource in two places of a promise in the async registry:
1. the owning thread of a promise (this is set during creation of the promise and never changes)
2. the parent of a promise, which can either be another Promise or another thread: this parent can change during the lifetime of the promise, therefore we have to take care of synchronization because the promise can be read and changed at the same time. The async registry needs to be highly performant - because it will  be used everywhere in the code, therefore we need a lock-free synchronization here.

Due to these requirements, the PR adds a new `SharedResource` that now wraps the `ThreadInfo` and has an atomic reference counter.
For 1. we don't need any synchronization, therefore the owning thead is a `SharedPtr`, which only takes care of properly incrementing and decrementing the reference counter of the `SharedResource`.
For 2. we need synchronization and we wrote our own `AtomicSharedOrRawPtr`, wich is a lock-free either-or type that includes an atomic pointer to either a `SharedResource` or a raw pointer (which in our case is a void pointer - we identify a promise by its this pointer and cast that - due to usability reasons - to a void ptr. This PR actually wraps this void ptr now into a `PromiseId` type to make it a bit better readable).

There is now one more member in a promise that needs to reference the new `ThreadInfo`: The running_thread currently still uses the old `ThreadId` type that does not include a thread name string. This will be part of another PR.