### PR TITLE
Task registry connecting threads

### DIFF
--- a/lib/Async/Registry/promise.h
+++ b/lib/Async/Registry/promise.h
@@ -35,6 +35,8 @@
 #include "fmt/format.h"
 #include "fmt/std.h"
 
+namespace arangodb::async_registry {
+
 namespace {
 // helper type for the visitor
 template<class... Ts>
@@ -44,8 +46,6 @@ struct overloaded : Ts... {
 template<class... Ts>
 overloaded(Ts...) -> overloaded<Ts...>;
 }  // namespace
-
-namespace arangodb::async_registry {
 
 enum class State { Running = 0, Suspended, Resolved, Deleted };
 template<typename Inspector>


### PR DESCRIPTION
This adds several capabilities to the task registry:
- You can now a thread task, meaning you execute some lambda in a new thread and this lambda execution is a new task with its parent beeing the currently running task on the old thread.
- You can schedule a task on the scheduler. The task state is then 'Scheduled'. As soon as the scheduler executes the task, the state changes to 'Running'.
- A task can have a printer object. A user can define such an object, which needs to implement  `auto operator()() -> std::string`. This method is executed as soon as a snapshot of a task is requested. This way, a string is only created when really needed.