### PR TITLE
Add thread name back in, this time without a memory leak

### DIFF
--- a/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/asyncregistry/gdb_forest.py
+++ b/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/asyncregistry/gdb_forest.py
@@ -1,5 +1,5 @@
 from typing import Iterable, Any
-from asyncregistry.gdb_data import Promise, PromiseId, Thread
+from asyncregistry.gdb_data import Promise, PromiseId, ThreadInfo
 
 Id = str
 class Forest:
@@ -31,7 +31,7 @@ class Forest:
                 yield child
 
     @classmethod
-    def from_promises(cls, promises: Iterable[tuple[PromiseId, PromiseId, Any]]):
+    def from_promises(cls, promises: Iterable[tuple[PromiseId, ThreadInfo | PromiseId, Any]]):
         parents: [Id] = [] # all parents promise ids
         nodes: [Any] = [] # all nodes
         positions: {Id: int} = {} # lookup table for parent and node per promise id
@@ -42,7 +42,7 @@ class Forest:
             promise_id = str(promise.id)
             positions[promise_id] = count
             nodes.append(data)
-            if type(parent) == Thread:
+            if type(parent) == ThreadInfo:
                 parents.append(None)
                 roots.append(promise_id)
             else:

--- a/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/pretty-printer.py
+++ b/arangod/SystemMonitor/AsyncRegistry/PrettyPrinter/src/pretty-printer.py
@@ -24,6 +24,16 @@ class Thread(object):
     def __str__(self):
         return f"LWPID {self.id} (pthread {self.posix_id})"
 
+class ThreadInfo(object):
+    def __init__(self, lwpid: int, name: str):
+        self.lwpid = lwpid
+        self.name = name
+    @classmethod
+    def from_json(cls, blob: dict):
+        return cls(blob["LWPID"], blob["name"])
+    def __str__(self):
+        return f"{self.name} (LWPID {self.lwpid})"
+
 class SourceLocation(object):
     def __init__(self, file_name: str, line: int, function_name: str):
         self.file_name = file_name
@@ -34,31 +44,40 @@ class SourceLocation(object):
         return cls(blob["file_name"], blob["line"], blob["function_name"])
     def __str__(self):
         return self.function_name + " (" + self.file_name + ":" + str(self.line) + ")"
+
+class PromiseId(object):
+    def __init__(self, id):
+        self.id = id
+    @classmethod
+    def from_json(cls, blob: dict):
+        return cls(blob["id"])
+    def __str__(self):
+        return self.id
     
 class Requester(object):
-    def __init__(self, is_sync: bool, item: int):
+    def __init__(self, is_sync: bool, item: ThreadInfo | PromiseId):
         self.is_sync = is_sync
         self.item = item
     @classmethod
     def from_json(cls, blob: dict):
         if not blob:
             return None
-        sync = blob.get("thread")
-        if sync is not None:
-            return cls(True, sync)
+        if "LWPID" in blob:
+            return cls(True, ThreadInfo.from_json(blob))
         else:
-            return cls(False, blob["promise"])
+            return cls(False, PromiseId.from_json(blob))
     def __str__(self):
         if self.is_sync:
             # a sync requester is always at the bottom of a tree,
             # but has no entry on its own,
             # therefore just add it here in a new line
-            return "\n" + "─ " + str(Thread.from_json(self.item))
+            return "\n" + "─ " + str(self.item)
         else:
             return ""
 
 class Data(object):
-    def __init__(self, running_thread: Optional[Thread], source_location: SourceLocation, id: int, state: str, requester: Requester):
+    def __init__(self, owning_thread: ThreadInfo, running_thread: Optional[Thread], source_location: SourceLocation, id: int, state: str, requester: Requester):
+        self.owning_thread = owning_thread
         self.running_thread = running_thread
         self.source_location = source_location
         self.id = id
@@ -66,11 +85,11 @@ class Data(object):
         self.state = state
     @classmethod
     def from_json(cls, blob: dict):
-        return cls(Thread.from_json(blob["running_thread"]) if "running_thread" in blob else None, SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Requester.from_json(blob["requester"]))
+        return cls(ThreadInfo.from_json(blob["owning_thread"]), Thread.from_json(blob["running_thread"]) if "running_thread" in blob else None, SourceLocation.from_json(blob["source_location"]), blob["id"], blob["state"], Requester.from_json(blob["requester"]))
     def __str__(self):
         waiter_str = str(self.waiter) if self.waiter != None else ""
         thread_str = f" on {self.running_thread}" if self.running_thread else ""
-        return str(self.source_location) + ", " + self.state + thread_str + waiter_str
+        return str(self.source_location) + ", owned by " + str(self.owning_thread) + ", " + self.state + thread_str + waiter_str
         
 class Promise(object):
     def __init__(self, hierarchy: int, data: Data):

--- a/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
+++ b/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
@@ -72,12 +72,12 @@ auto all_undeleted_promises() -> ForestWithRoots<PromiseSnapshot> {
   registry.for_node([&](PromiseSnapshot promise) {
     if (promise.state != State::Deleted) {
       std::visit(overloaded{
-                     [&](PromiseId async_waiter) {
-                       forest.insert(promise.id, async_waiter, promise);
+                     [&](PromiseId const& async_waiter) {
+                       forest.insert(promise.id.id, async_waiter.id, promise);
                      },
-                     [&](basics::ThreadId sync_waiter_thread) {
-                       forest.insert(promise.id, nullptr, promise);
-                       roots.emplace_back(promise.id);
+                     [&](basics::ThreadInfo const& sync_waiter_thread) {
+                       forest.insert(promise.id.id, nullptr, promise);
+                       roots.emplace_back(promise.id.id);
                      },
                  },
                  promise.requester);

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -28,17 +28,21 @@
 
 using namespace arangodb::async_registry;
 
-Promise::Promise(Requester requester, std::source_location entry_point)
-    : owning_thread{basics::ThreadId::current()},
-      requester{requester},
+Promise::Promise(CurrentRequester requester, std::source_location entry_point)
+    : owning_thread{basics::ThreadInfo::current()},
+      requester{
+          AtomicRequester::from(requester)},  // TODO hand this in via function
       state{State::Running},
       running_thread{basics::ThreadId::current()},
       source_location{entry_point.file_name(), entry_point.function_name(),
                       entry_point.line()} {}
 
-auto arangodb::async_registry::get_current_coroutine() noexcept -> Requester* {
+// TODO return either SharedPtr<ThreadInfo> or *void but does not need to be
+// atomic
+auto arangodb::async_registry::get_current_coroutine() noexcept
+    -> CurrentRequester* {
   struct Guard {
-    Requester identifier = Requester::current_thread();
+    CurrentRequester identifier = {basics::ThreadInfo::current()};
   };
   // make sure that this is only created once on a thread
   static thread_local auto current = Guard{};
@@ -55,16 +59,22 @@ AddToAsyncRegistry::~AddToAsyncRegistry() {
     node_in_registry->list->mark_for_deletion(node_in_registry.get());
   }
 }
-auto AddToAsyncRegistry::update_requester(Requester new_requester) -> void {
-  if (node_in_registry != nullptr) {
-    node_in_registry->data.requester.store(new_requester);
+auto AddToAsyncRegistry::update_requester(std::optional<PromiseId> requester)
+    -> void {
+  if (node_in_registry != nullptr && requester.has_value()) {
+    node_in_registry->data.requester.store(requester.value().id);
   }
 }
-auto AddToAsyncRegistry::id() -> void* {
+auto AddToAsyncRegistry::update_requester_to_current_thread() -> void {
   if (node_in_registry != nullptr) {
-    return node_in_registry->data.id();
+    node_in_registry->data.requester.store(basics::ThreadInfo::current());
+  }
+}
+auto AddToAsyncRegistry::id() -> std::optional<PromiseId> {
+  if (node_in_registry != nullptr) {
+    return {node_in_registry->data.id()};
   } else {
-    return nullptr;
+    return std::nullopt;
   }
 }
 auto AddToAsyncRegistry::update_source_location(std::source_location loc)

--- a/lib/Async/Registry/promise.cpp
+++ b/lib/Async/Registry/promise.cpp
@@ -37,8 +37,6 @@ Promise::Promise(CurrentRequester requester, std::source_location entry_point)
       source_location{entry_point.file_name(), entry_point.function_name(),
                       entry_point.line()} {}
 
-// TODO return either SharedPtr<ThreadInfo> or *void but does not need to be
-// atomic
 auto arangodb::async_registry::get_current_coroutine() noexcept
     -> CurrentRequester* {
   struct Guard {

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -27,7 +27,7 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
 
   async_promise_base(std::source_location loc)
       : async_registry::AddToAsyncRegistry{std::move(loc)}, _context{} {
-    *async_registry::get_current_coroutine() = {id()};
+    *async_registry::get_current_coroutine() = {id().value()};
   }
 
   std::suspend_never initial_suspend() noexcept {
@@ -86,7 +86,7 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
 
     // update promises in registry
     if constexpr (CanUpdateRequester<U>) {
-      co_awaited_expression.update_requester({this->id()});
+      co_awaited_expression.update_requester(this->id());
     }
     update_source_location(loc);
 
@@ -181,10 +181,18 @@ struct [[nodiscard]] async {
   bool valid() const noexcept { return _handle != nullptr; }
   operator bool() const noexcept { return valid(); }
 
-  auto update_requester(async_registry::Requester waiter) {
-    _handle.promise().update_requester(waiter);
+  auto update_requester(std::optional<async_registry::PromiseId> waiter) {
+    if (_handle) {
+      _handle.promise().update_requester(waiter);
+    }
   }
-  auto id() -> void* { return _handle.promise().id(); }
+  auto id() -> std::optional<async_registry::PromiseId> {
+    if (_handle) {
+      return _handle.promise().id();
+    } else {
+      return std::nullopt;
+    }
+  }
 
   ~async() { reset(); }
 

--- a/lib/Async/include/Async/async.h
+++ b/lib/Async/include/Async/async.h
@@ -74,7 +74,7 @@ struct async_promise_base : async_registry::AddToAsyncRegistry {
         auto old_state =
             outer_promise->update_state(async_registry::State::Running);
         if (old_state.value() == async_registry::State::Suspended) {
-          outer_promise->_context = Context{};
+          outer_promise->_context.update();
         }
         myContext.set();
         return inner_awaitable.await_resume();

--- a/lib/Async/include/Async/context.h
+++ b/lib/Async/include/Async/context.h
@@ -37,7 +37,7 @@ namespace arangodb {
  */
 struct Context {
   std::shared_ptr<ExecContext const> _execContext;
-  async_registry::Requester _requester;
+  async_registry::CurrentRequester _requester;
   task_monitoring::Task* _task;
 
   Context()

--- a/lib/Async/include/Async/coro-utils.h
+++ b/lib/Async/include/Async/coro-utils.h
@@ -52,12 +52,9 @@ auto get_awaitable_object(T&& t) {
 }
 
 template<typename T>
-concept CanUpdateRequester = requires(T t, async_registry::Requester waiter) {
-  t.update_requester(waiter);
-};
-template<typename T>
-concept HasId = requires(T t) {
-  { t.id() } -> std::convertible_to<void*>;
+concept CanUpdateRequester =
+    requires(T t, std::optional<async_registry::PromiseId> requester) {
+  t.update_requester(requester);
 };
 
 }  // namespace arangodb

--- a/lib/Containers/Concurrent/CMakeLists.txt
+++ b/lib/Containers/Concurrent/CMakeLists.txt
@@ -5,3 +5,8 @@ target_link_libraries(arango_thread_owning_list
   PRIVATE
   arango_basic_utils
   arango_inspection)
+
+add_library(arango_shared INTERFACE
+  shared.h)
+# TODO need to have include dir and include ${CMAKE_CURRENT_SOURCE_DIR}/include
+target_include_directories(arango_shared INTERFACE ${PROJECT_SOURCE_DIR}/lib)

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -68,11 +68,15 @@ concept SameAs = std::is_same_v<T, ExpectedT>;
 template<typename T>
 struct SharedPtr {
   SharedPtr(SharedPtr&& other) : _resource{other._resource} {
-    other._resource = nullptr;
+    if (&other != this) {
+      other._resource = nullptr;
+    }
   }
   auto operator=(SharedPtr&& other) -> SharedPtr& {
-    _resource = other._resource;
-    other._resource = nullptr;
+    if (&other != this) {
+      _resource = other._resource;
+      other._resource = nullptr;
+    }
     return *this;
   }
   SharedPtr(SharedPtr const& other) {

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -1,0 +1,239 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <optional>
+#include <variant>
+#include <iostream>
+
+#include "Inspection/Access.h"
+
+namespace arangodb::containers {
+
+/**
+   Reference counting wrapper for a resource
+
+   Destroys itself when the reference count decrements to zero.
+   This resource can be referenced - in contrast to a simle std::shared_ptr - by
+   different types of pointers at the same time, e.g. by a SharedPtr (similar to
+   an std::shared_ptr) and an AtomicSharedOrRawPtr.
+ */
+template<typename T>
+struct SharedResource {
+  auto increment() -> void { _count.fetch_add(1, std::memory_order_acq_rel); }
+  auto decrement() -> void {
+    auto old = _count.fetch_sub(1, std::memory_order_acq_rel);
+    if (old == 1) {
+      delete this;
+    }
+  }
+  template<class... Input>
+  SharedResource(Input... args) : _data{args...} {}
+  auto get() -> T* { return &_data; }
+  auto get_ref() -> T& { return _data; }
+  auto ref_count() const -> size_t {
+    return _count.load(std::memory_order_relaxed);
+  }
+
+ private:
+  std::atomic<std::size_t> _count = 1;
+  T _data;
+};
+
+template<typename T, typename ExpectedT>
+concept SameAs = std::is_same_v<T, ExpectedT>;
+
+template<typename T>
+struct SharedPtr {
+  SharedPtr(SharedPtr&& other) : _resource{other._resource} {
+    other._resource = nullptr;
+  }
+  auto operator=(SharedPtr&& other) -> SharedPtr& {
+    _resource = other._resource;
+    other._resource = nullptr;
+    return *this;
+  }
+  SharedPtr(SharedPtr const& other) {
+    other._resource->increment();
+    _resource = other._resource;
+  }
+  auto operator=(SharedPtr const& other) -> SharedPtr& {
+    other._resource->increment();
+    _resource = other._resource;
+    return *this;
+  }
+  ~SharedPtr() {
+    if (_resource) {
+      _resource->decrement();
+    }
+  }
+  template<class... Input>
+  SharedPtr(Input... args) : _resource{new SharedResource<T>(args...)} {}
+  auto operator*() -> std::optional<std::reference_wrapper<T>> {
+    if (_resource) {
+      return {_resource->get_ref()};
+    } else {
+      return std::nullopt;
+    }
+  }
+  operator bool() const { return _resource != nullptr; }
+  auto get() -> T* {
+    if (not _resource) {
+      return nullptr;
+    }
+    return {_resource->get()};
+  }
+  auto get_ref() const -> std::optional<std::reference_wrapper<T>> {
+    if (not _resource) {
+      return std::nullopt;
+    }
+    return {_resource->get_ref()};
+  }
+  auto ref_count() const -> size_t {
+    if (_resource) {
+      return _resource->ref_count();
+    } else {
+      return 0;
+    }
+  }
+
+  SharedResource<T>* _resource = nullptr;
+};
+
+/**
+   Lock-free atomic either type for either a shared or a raw pointer
+
+   Works if both types have an alignment larger than 1,
+   then the last bit of a pointer to one of these types is unused and can be
+   used as a flag for the type of the pointer.
+
+   Make sure that Raw define the pointer type with alignment
+   larger than (1 << num_flag_bits)
+*/
+template<typename Shared, typename Raw>
+struct AtomicSharedOrRawPtr {
+  template<SameAs<Raw> U>
+  AtomicSharedOrRawPtr(U* right) : _resource{raw_to_ptr(right)} {}
+
+  template<SameAs<Shared> U>
+  AtomicSharedOrRawPtr(SharedPtr<U> const& left) {
+    auto resource = left._resource;
+    resource->increment();
+    _resource.store(shared_to_ptr(resource), std::memory_order_relaxed);
+  }
+
+  ~AtomicSharedOrRawPtr() {
+    auto old =
+        _resource.exchange(raw_to_ptr(nullptr), std::memory_order_relaxed);
+    decrement_shared(old);
+  }
+
+  /**
+     User needs to make sure that SharedResource still exists
+   */
+  auto load() const -> std::variant<Shared, Raw*> {
+    // (1) syncs with (2), (3)
+    auto data = _resource.load(std::memory_order_acquire);
+    if (is_shared(data)) {
+      auto shared = ptr_to_shared(data);
+      return {shared->get_ref()};
+    } else {
+      return {ptr_to_raw(data)};
+    }
+  }
+
+  template<SameAs<Shared> U>
+  auto store(SharedPtr<U> left) -> void {
+    auto resource = left._resource;
+    resource->increment();
+    // (2) syncs with (1), (2), (3)
+    auto old =
+        _resource.exchange(shared_to_ptr(resource), std::memory_order_acq_rel);
+    decrement_shared(old);
+  }
+  template<SameAs<Raw> U>
+  auto store(U* right) -> void {
+    // (3) syncs with (1), (2), (3)
+    auto old = _resource.exchange(raw_to_ptr(right), std::memory_order_acq_rel);
+    decrement_shared(old);
+  }
+
+ private:
+  std::atomic<std::uintptr_t> _resource;
+
+  static constexpr auto num_flag_bits = 1;
+  static constexpr auto flag_mask = (1 << num_flag_bits) - 1;
+  static constexpr auto data_mask = ~flag_mask;
+  static_assert(std::alignment_of_v<SharedResource<Shared>> >=
+                (1 << num_flag_bits));
+
+  auto is_shared(std::uintptr_t ptr) const -> bool { return ptr & flag_mask; }
+  auto shared_to_ptr(SharedResource<Shared>* shared) const -> std::uintptr_t {
+    return reinterpret_cast<std::uintptr_t>(shared) | 1;
+  }
+  auto raw_to_ptr(Raw* raw) const -> std::uintptr_t {
+    return reinterpret_cast<std::uintptr_t>(raw) | 0;
+  }
+  auto ptr_to_shared(std::uintptr_t ptr) const -> SharedResource<Shared>* {
+    return reinterpret_cast<SharedResource<Shared>*>(ptr & data_mask);
+  }
+  auto ptr_to_raw(std::uintptr_t ptr) const -> Raw* {
+    return reinterpret_cast<Raw*>(ptr & data_mask);
+  }
+
+  /**
+     can only be called if we are sure that no-one else updates
+     given ptr in-between
+   */
+  auto decrement_shared(std::uintptr_t ptr) const -> void {
+    if (is_shared(ptr)) {
+      ptr_to_shared(ptr)->decrement();
+    }
+  }
+};
+template<typename Inspector, typename Shared, typename Raw>
+auto inspect(Inspector& f, AtomicSharedOrRawPtr<Shared, Raw>& x) {
+  if constexpr (not Inspector::isLoading) {  // only serialization
+    auto var = x.load();
+    if (std::holds_alternative<Shared>(var)) {
+      return f.apply(std::get<Shared>(var));
+    } else {
+      auto ptr = std::get<Raw*>(var);
+      if (ptr) {
+        return f.apply(*ptr);
+      }
+      return f.apply(inspection::Null{});
+    }
+  }
+}
+
+}  // namespace arangodb::containers
+
+namespace arangodb::inspection {
+template<typename T>
+struct Access<containers::SharedPtr<T>>
+    : OptionalAccess<containers::SharedPtr<T>> {};
+
+}  // namespace arangodb::inspection

--- a/lib/Containers/Concurrent/thread.cpp
+++ b/lib/Containers/Concurrent/thread.cpp
@@ -33,3 +33,13 @@ auto ThreadId::current() noexcept -> ThreadId {
 auto ThreadId::name() -> std::string {
   return std::string{ThreadNameFetcher{posix_id}.get()};
 }
+
+auto ThreadInfo::current() noexcept -> containers::SharedPtr<ThreadInfo> {
+  struct Guard {
+    containers::SharedPtr<ThreadInfo> _info = containers::SharedPtr<ThreadInfo>(
+        arangodb::Thread::currentKernelThreadId(),
+        std::string{arangodb::ThreadNameFetcher{}.get()});
+  };
+  static thread_local auto guard = Guard{};
+  return guard._info;
+}

--- a/lib/Containers/Concurrent/thread.h
+++ b/lib/Containers/Concurrent/thread.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Basics/threads-posix.h"
+#include "Containers/Concurrent/shared.h"
 #include "Inspection/Format.h"
 
 namespace arangodb::basics {
@@ -38,6 +39,18 @@ template<typename Inspector>
 auto inspect(Inspector& f, ThreadId& x) {
   return f.object(x).fields(f.field("LWPID", x.kernel_id),
                             f.field("posix_id", x.posix_id));
+}
+
+struct ThreadInfo {
+  static auto current() noexcept -> containers::SharedPtr<ThreadInfo>;
+  pid_t kernel_id;
+  std::string name;
+  bool operator==(ThreadInfo const&) const = default;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, ThreadInfo& x) {
+  return f.object(x).fields(f.field("LWPID", x.kernel_id),
+                            f.field("name", x.name));
 }
 
 }  // namespace arangodb::basics

--- a/lib/Futures/include/Futures/Promise.h
+++ b/lib/Futures/include/Futures/Promise.h
@@ -121,16 +121,31 @@ class Promise {
 
   arangodb::futures::Future<T> getFuture();
 
-  auto id() -> void* { return _state->id(); }
+  auto id() -> std::optional<async_registry::PromiseId> {
+    if (_state) {
+      return _state->id();
+    } else {
+      return std::nullopt;
+    }
+  }
   auto update_source_location(std::source_location loc) -> void {
-    _state->update_source_location(std::move(loc));
+    if (_state) {
+      _state->update_source_location(std::move(loc));
+    }
   }
   auto update_state(async_registry::State state)
       -> std::optional<async_registry::State> {
-    return _state->update_state(std::move(state));
+    if (_state) {
+      return _state->update_state(std::move(state));
+    } else {
+      return std::nullopt;
+    }
   }
-  auto update_requester(async_registry::Requester waiter) -> void {
-    return _state->update_requester(waiter);
+  auto update_requester(std::optional<async_registry::PromiseId> waiter)
+      -> void {
+    if (_state) {
+      return _state->update_requester(waiter);
+    }
   }
 
  private:

--- a/lib/Futures/include/Futures/Utilities.h
+++ b/lib/Futures/include/Futures/Utilities.h
@@ -158,7 +158,7 @@ collectAll(InputIterator first, InputIterator last) {
 
   auto ctx = std::make_shared<Context>(size_t(std::distance(first, last)));
   for (size_t i = 0; first != last; ++first, ++i) {
-    first->update_requester({ctx->p.id()});
+    first->update_requester(ctx->p.id());
     std::move(*first).thenFinal(
         [i, ctx](auto&& t) { ctx->results[i] = std::move(t); });
   }
@@ -177,7 +177,7 @@ namespace gather {
 
 template<typename C, typename... Ts, std::size_t... I>
 void thenFinalAll(C& c, std::index_sequence<I...>, Future<Ts>&&... ts) {
-  (ts.update_requester({c->p.id()}), ...);
+  (ts.update_requester(c->p.id()), ...);
   (std::move(ts).thenFinal(
        [&](Try<Ts>&& t) { std::get<I>(c->results) = std::move(t); }),
    ...);
@@ -213,7 +213,7 @@ namespace collect {
 
 template<typename C, typename... Ts, std::size_t... I>
 void thenFinalAll(C& c, std::index_sequence<I...>, Future<Ts>&&... ts) {
-  (ts.update_requester({c->p.id()}), ...);
+  (ts.update_requester(c->p.id()), ...);
   (std::move(ts).thenFinal([c](Try<Ts>&& t) {
     if (t.hasException()) {
       if (c->hadError.exchange(true, std::memory_order_release) == false) {

--- a/lib/Futures/include/Futures/coro-helper.h
+++ b/lib/Futures/include/Futures/coro-helper.h
@@ -62,7 +62,7 @@ struct future_promise_base {
 
   future_promise_base(std::source_location loc)
       : promise{std::move(loc)}, context{} {
-    *arangodb::async_registry::get_current_coroutine() = {promise.id()};
+    *arangodb::async_registry::get_current_coroutine() = {promise.id().value()};
   }
   ~future_promise_base() {}
 
@@ -122,7 +122,7 @@ struct future_promise_base {
 
     // update promises in registry
     if constexpr (arangodb::CanUpdateRequester<U>) {
-      co_awaited_expression.update_requester({promise.id()});
+      co_awaited_expression.update_requester(promise.id());
     }
     promise.update_source_location(std::move(loc));
 

--- a/lib/Futures/include/Futures/coro-helper.h
+++ b/lib/Futures/include/Futures/coro-helper.h
@@ -109,7 +109,7 @@ struct future_promise_base {
             arangodb::async_registry::State::Running);
         if (old_state.has_value() &&
             old_state.value() == arangodb::async_registry::State::Suspended) {
-          outer_promise->context = arangodb::Context{};
+          outer_promise->context.update();
         }
         myContext.set();
         return inner_awaitable.await_resume();

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -1,6 +1,7 @@
 #include "Async/async.h"
 #include "Async/Registry/promise.h"
 #include "Async/Registry/registry_variable.h"
+#include "Containers/Concurrent/shared.h"
 #include "Inspection/Format.h"
 #include "Inspection/JsonPrintInspector.h"
 #include "Utils/ExecContext.h"
@@ -153,7 +154,8 @@ struct AsyncTest<std::pair<WaitType, ValueType>> : ::testing::Test {
     wait.stop();
     EXPECT_EQ(InstanceCounterValue::instanceCounter, 0);
     EXPECT_EQ(promise_count_in_registry(), 0);
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<
+                arangodb::containers::SharedPtr<arangodb::basics::ThreadInfo>>(
         *arangodb::async_registry::get_current_coroutine()));
   }
 
@@ -529,8 +531,8 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
 
@@ -549,8 +551,8 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -589,8 +591,8 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
       auto fn_2 = Functions::awaited_2_fn();
@@ -619,8 +621,8 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -640,7 +642,8 @@ TYPED_TEST(AsyncTest,
     static auto awaited_fn(TestType test) -> async<void> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<basics::ThreadId>(promise->requester));
+      EXPECT_TRUE(
+          std::holds_alternative<basics::ThreadInfo>(promise->requester));
 
       co_await test->wait;
 
@@ -649,13 +652,13 @@ TYPED_TEST(AsyncTest,
     static auto waiter_fn(async<void>&& fn) -> async<void> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_await std::move(fn);
 
@@ -667,8 +670,8 @@ TYPED_TEST(AsyncTest,
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       co_return;
     };
@@ -699,8 +702,8 @@ TYPED_TEST(
 
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(
-          std::holds_alternative<basics::ThreadId>(waiter_promise->requester));
+      EXPECT_TRUE(std::holds_alternative<basics::ThreadInfo>(
+          waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());

--- a/tests/Containers/Concurrent/CMakeLists.txt
+++ b/tests/Containers/Concurrent/CMakeLists.txt
@@ -4,3 +4,15 @@ target_sources(arangodbtests
   ListOfNonOwnedListsTest.cpp)
 target_link_libraries(arangodbtests
   arango_thread_owning_list)
+
+add_library(arango_test_shared OBJECT
+  SharedTest.cpp)
+target_link_libraries(arango_test_shared PRIVATE
+  arango_shared
+  arango_inspection
+  velocypack
+  gtest)
+add_executable(arangodbtests_shared EXCLUDE_FROM_ALL)
+target_link_libraries(arangodbtests_shared
+  arango_test_shared
+  gtest_main)

--- a/tests/Containers/Concurrent/SharedTest.cpp
+++ b/tests/Containers/Concurrent/SharedTest.cpp
@@ -1,0 +1,129 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Volmer
+////////////////////////////////////////////////////////////////////////////////
+#include "Containers/Concurrent/shared.h"
+#include "Inspection/Format.h"
+
+#include <gtest/gtest.h>
+#include <variant>
+
+using namespace arangodb::containers;
+
+TEST(SharedTest, shared_reference_extends_lifetime) {
+  SharedPtr<int> ref_copy;
+  EXPECT_EQ(ref_copy.ref_count(), 1);
+  {
+    auto initial_ref = SharedPtr<int>{435};
+    EXPECT_EQ(initial_ref.ref_count(), 1);
+    EXPECT_EQ(ref_copy.ref_count(), 1);
+
+    ref_copy = initial_ref;
+    EXPECT_EQ(ref_copy.ref_count(), 2);
+    EXPECT_EQ(initial_ref.ref_count(), ref_copy.ref_count());
+  }
+  EXPECT_EQ(ref_copy.ref_count(), 1);
+  EXPECT_EQ(*ref_copy.get(), 435);
+}
+
+TEST(SharedTest, inspection_of_shared_reference_gives_shared_object) {
+  auto ref = SharedPtr<int>{4};
+  EXPECT_EQ(fmt::format("{}", arangodb::inspection::json(ref)), "4");
+}
+
+struct MyStruct {
+  MyStruct(std::string x) : a{std::move(x)} {};
+  bool operator==(MyStruct const&) const = default;
+  std::string a;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, MyStruct& x) {
+  return f.object(x).fields(f.field("a", x.a));
+}
+TEST(SharedTest, variant_ptr_can_include_a_copy_of_a_shared_reference) {
+  auto ref = SharedPtr<MyStruct>{"abcde"};
+  EXPECT_EQ(*ref.get(), MyStruct{"abcde"});
+  EXPECT_EQ(ref.ref_count(), 1);
+  {
+    auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ref};
+    EXPECT_EQ(ref.ref_count(), 2);
+    auto variant_value = variant.load();
+    EXPECT_TRUE(std::holds_alternative<MyStruct>(variant_value));
+    EXPECT_EQ(std::get<MyStruct>(variant_value), MyStruct{"abcde"});
+  }
+  EXPECT_EQ(ref.ref_count(), 1);
+  EXPECT_EQ(*ref.get(), MyStruct{"abcde"});
+}
+
+TEST(SharedTest, variant_ptr_can_include_a_raw_pointer) {
+  auto ptr = new MyStruct{"abcde"};
+  auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};
+  auto variant_value = variant.load();
+  EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant_value));
+  EXPECT_EQ(*std::get<MyStruct*>(variant_value), MyStruct{"abcde"});
+}
+
+TEST(SharedTest, variant_nullptr_is_raw_pointer) {
+  MyStruct* ptr = nullptr;
+  auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};
+  auto variant_value = variant.load();
+  EXPECT_TRUE(std::holds_alternative<MyStruct*>(variant_value));
+  EXPECT_EQ(std::get<MyStruct*>(variant_value), nullptr);
+}
+
+TEST(SharedTest, variant_shared_ptr_is_incr_and_decr_when_reassigned) {
+  auto ref = SharedPtr<MyStruct>{"abcde"};
+  EXPECT_EQ(ref.ref_count(), 1);
+
+  auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ref};
+  EXPECT_EQ(ref.ref_count(), 2);
+
+  auto another_ref = SharedPtr<MyStruct>{"xyz"};
+  EXPECT_EQ(another_ref.ref_count(), 1);
+
+  variant.store(another_ref);
+  EXPECT_EQ(ref.ref_count(), 1);          // was decremented
+  EXPECT_EQ(another_ref.ref_count(), 2);  // was incremented
+
+  auto ptr = new int{564};
+  variant.store(ptr);
+  EXPECT_EQ(another_ref.ref_count(), 1);  // was decremented
+}
+
+TEST(SharedTest, inspection_of_variant) {
+  {
+    auto ptr = new MyStruct{"abcde"};
+    auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};
+    EXPECT_EQ(fmt::format("{}", arangodb::inspection::json(variant)),
+              fmt::format("{}", arangodb::inspection::json(*ptr)));
+  }
+  {
+    auto ref = SharedPtr<MyStruct>{"abcde"};
+    auto variant = AtomicSharedOrRawPtr<MyStruct, int>{ref};
+    EXPECT_EQ(fmt::format("{}", arangodb::inspection::json(variant)),
+              fmt::format("{}", arangodb::inspection::json(ref)));
+  }
+  {
+    MyStruct* ptr = nullptr;
+    auto variant = AtomicSharedOrRawPtr<int, MyStruct>{ptr};
+    EXPECT_EQ(fmt::format("{}", arangodb::inspection::json(variant)), "null");
+  }
+}

--- a/tests/Futures/FutureCoroutineTest.cpp
+++ b/tests/Futures/FutureCoroutineTest.cpp
@@ -111,7 +111,8 @@ template<typename WaitType>
 struct FutureTest : ::testing::Test {
   void SetUp() override {
     arangodb::async_registry::get_thread_registry().garbage_collect();
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<
+                arangodb::containers::SharedPtr<arangodb::basics::ThreadInfo>>(
         *arangodb::async_registry::get_current_coroutine()));
   }
 
@@ -199,7 +200,7 @@ TYPED_TEST(
     static auto waiter_fn(TestType test) -> Future<Unit> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       auto fn = Functions::awaited_fn(test);
@@ -219,7 +220,7 @@ TYPED_TEST(
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       co_return;
@@ -239,7 +240,7 @@ TYPED_TEST(FutureTest,
     static auto awaited_fn(TestType test) -> Future<Unit> {
       auto promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           promise->requester));
 
       co_await test->wait;
@@ -249,12 +250,12 @@ TYPED_TEST(FutureTest,
     static auto waiter_fn(Future<Unit>&& fn) -> Future<Unit> {
       auto waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       auto awaited_promise = find_promise_by_name("awaited_fn");
       EXPECT_TRUE(awaited_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       co_await std::move(fn);
@@ -267,7 +268,7 @@ TYPED_TEST(FutureTest,
       // waiter did not change
       waiter_promise = find_promise_by_name("waiter_fn");
       EXPECT_TRUE(waiter_promise.has_value());
-      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+      EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
           waiter_promise->requester));
 
       co_return;

--- a/tests/Futures/FutureTest.cpp
+++ b/tests/Futures/FutureTest.cpp
@@ -933,7 +933,7 @@ TEST(FutureTest,
     EXPECT_TRUE(waiter_promise.has_value());
     EXPECT_EQ(awaited_promise->requester,
               arangodb::async_registry::Requester{waiter_promise->id});
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
         waiter_promise->requester));
   }
 }
@@ -981,7 +981,7 @@ TEST(FutureTest, collected_async_promises_in_async_registry_know_their_waiter) {
               arangodb::async_registry::Requester{waiter_promise->id});
     EXPECT_EQ(awaited_promises[1].requester,
               arangodb::async_registry::Requester{waiter_promise->id});
-    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadId>(
+    EXPECT_TRUE(std::holds_alternative<arangodb::basics::ThreadInfo>(
         waiter_promise->requester));
   }
 }

--- a/tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration/async_registry_gdb_pretty_printer_test.cpp
+++ b/tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration/async_registry_gdb_pretty_printer_test.cpp
@@ -32,22 +32,29 @@ using namespace arangodb::async_registry;
 
 auto breakpoint() { raise(SIGINT); }
 
+auto format(arangodb::basics::SourceLocationSnapshot const& loc)
+    -> std::string {
+  return fmt::format("\"{}\" (\"{}\":{})", loc.function_name, loc.file_name,
+                     loc.line);
+}
 auto format(arangodb::basics::ThreadId const& thread) -> std::string {
   return fmt::format("LWPID {} (pthread {})", thread.kernel_id,
                      thread.posix_id);
 }
+auto format(arangodb::basics::ThreadInfo const& thread) -> std::string {
+  return fmt::format("\"{}\" (LWPID {})", thread.name, thread.kernel_id);
+}
 auto format(PromiseSnapshot const& snapshot) -> std::string {
   if (snapshot.thread == std::nullopt) {
-    return fmt::format(
-        "\"{}\" (\"{}\":{}), {}", snapshot.source_location.function_name,
-        snapshot.source_location.file_name, snapshot.source_location.line,
-        arangodb::inspection::json(snapshot.state));
+    return fmt::format("{}, owned by {}, {}", format(snapshot.source_location),
+                       format(snapshot.owning_thread),
+                       arangodb::inspection::json(snapshot.state));
   } else {
-    return fmt::format(
-        "\"{}\" (\"{}\":{}), {} on {}", snapshot.source_location.function_name,
-        snapshot.source_location.file_name, snapshot.source_location.line,
-        arangodb::inspection::json(snapshot.state),
-        format(snapshot.thread.value()));
+    return fmt::format("{}, owned by {}, {} on {}",
+                       format(snapshot.source_location),
+                       format(snapshot.owning_thread),
+                       arangodb::inspection::json(snapshot.state),
+                       format(snapshot.thread.value()));
   }
 }
 
@@ -67,7 +74,7 @@ int main() {
   // empty registry
   auto test_registry = Registry{};
   auto thread_registry = ThreadRegistry::make();
-  auto current_thread = arangodb::basics::ThreadId::current();
+  auto current_thread = arangodb::basics::ThreadInfo::current();
   test_registry.add(thread_registry);
 
   breakpoint();
@@ -78,15 +85,16 @@ int main() {
 
   // add a promise
   auto parent = thread_registry->add([&]() {
-    return Promise{{current_thread}, std::source_location::current()};
+    return Promise{CurrentRequester{current_thread},
+                   std::source_location::current()};
   });
   expected = fmt::format(
       "async registry = {{\n"
       "[{}] = \n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()), format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -97,8 +105,8 @@ int main() {
       "[{}] = \n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()), format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -112,8 +120,9 @@ int main() {
       "    ┌ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child->data.snapshot()),
-      format(parent->data.snapshot()), format(current_thread));
+      format(current_thread.get_ref().value()), format(child->data.snapshot()),
+      format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -128,9 +137,9 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child->data.snapshot()),
+      format(current_thread.get_ref().value()), format(child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -146,9 +155,10 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child_of_child->data.snapshot()),
-      format(child->data.snapshot()), format(second_child->data.snapshot()),
-      format(parent->data.snapshot()), format(current_thread));
+      format(current_thread.get_ref().value()),
+      format(child_of_child->data.snapshot()), format(child->data.snapshot()),
+      format(second_child->data.snapshot()), format(parent->data.snapshot()),
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
@@ -165,17 +175,17 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(child_of_child->data.snapshot()),
-      format(child->data.snapshot()),
+      format(current_thread.get_ref().value()),
+      format(child_of_child->data.snapshot()), format(child->data.snapshot()),
       format(child_of_second_child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
   // add a completely unrelated promise
   auto* second_parent = thread_registry->add([&]() {
-    return Promise{{arangodb::basics::ThreadId::current()},
+    return Promise{{arangodb::basics::ThreadInfo::current()},
                    std::source_location::current()};
   });
   expected = fmt::format(
@@ -190,17 +200,20 @@ int main() {
       "    ├ {}\n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(second_parent->data.snapshot()),
-      format(current_thread), format(current_thread),
+      format(current_thread.get_ref().value()),
+      format(second_parent->data.snapshot()),
+      format(current_thread.get_ref().value()),
+      format(current_thread.get_ref().value()),
       format(child_of_child->data.snapshot()), format(child->data.snapshot()),
       format(child_of_second_child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread));
+      format(current_thread.get_ref().value()));
 
   breakpoint();
 
   auto second_thread_registry = ThreadRegistry::make();
-  auto other_thread = arangodb::basics::ThreadId{};
+  auto other_thread =
+      arangodb::basics::ThreadInfo{};  // simulate another thread
   test_registry.add(second_thread_registry);
 
   // add a new promise on another thread
@@ -222,12 +235,14 @@ int main() {
       "[{}] = \n"
       "  ┌ {}\n"
       "─ {}}}",
-      format(current_thread), format(second_parent->data.snapshot()),
-      format(current_thread), format(current_thread),
+      format(current_thread.get_ref().value()),
+      format(second_parent->data.snapshot()),
+      format(current_thread.get_ref().value()),
+      format(current_thread.get_ref().value()),
       format(child_of_child->data.snapshot()), format(child->data.snapshot()),
       format(child_of_second_child->data.snapshot()),
       format(second_child->data.snapshot()), format(parent->data.snapshot()),
-      format(current_thread), format(other_thread),
+      format(current_thread.get_ref().value()), format(other_thread),
       format(parent_on_other_thread->data.snapshot()), format(other_thread));
 
   breakpoint();


### PR DESCRIPTION
Unfortunately we had to revert the merge of https://github.com/arangodb/arangodb/pull/21791 into devel due to a missing memory leak. This PR includes all the commits from the previous PR and the memory leak fix commit.