### PR TITLE
Fix load memory order

### DIFF
--- a/lib/Containers/Concurrent/ThreadOwnedList.h
+++ b/lib/Containers/Concurrent/ThreadOwnedList.h
@@ -236,7 +236,7 @@ struct ThreadOwnedList
       current = next;
       next = next->next_to_free;
       // (9) - this load synchronizes with the store in (6) and (8)
-      if (current->previous.load(std::memory_order_release) != nullptr) {
+      if (current->previous.load(std::memory_order_acquire) != nullptr) {
         if (_metrics) {
           _metrics->decrement_ready_for_deletion_nodes();
         }


### PR DESCRIPTION
This fixes the load memory order in the ThreadOwnedList which is used in the async registry. Using `memory_order_release` for a load operation does not make sense and can lead to compiler or runtime errors. Unfortunately, the combination of clang and libstdc++ does not seem to catch this error during compilation.

This wrong memory order usage can lead to a data race in the async registry but which is not really relevant: this data race can happen when we run the garbage collection on the async registry which can lead to an entry in the async registry not beeing deleted. But the garbage collection runs regularly, per default every second, so in the next run the item can the be deleted properly.

This is most likely the issue leading to https://github.com/arangodb/arangodb/issues/21811.