### PR TITLE
properly handle connection and make sure we don't forget it

### DIFF
--- a/tests/js/client/fuzz/http-fuzz-fp.js
+++ b/tests/js/client/fuzz/http-fuzz-fp.js
@@ -33,9 +33,11 @@ const IM = global.instanceManager;
 ////////////////////////////////////////////////////////////////////////////////
 function httpRequestsFuzzerTestSuite() {
   return {
+    setUpAll: function () {
+      IM.rememberConnection();
+    },
     testRandReqs: function () {
       // main expectation here is that the server does not crash!
-      IM.rememberConnection();
       try {
         IM.arangods.forEach(arangod => {
           print(`Connecting ${arangod.getProcessInfo([])}`);
@@ -73,7 +75,6 @@ function httpRequestsFuzzerTestSuite() {
 
     testReqWithSameSeed: function () {
       // main expectation here is that the server does not crash!
-      IM.rememberConnection();
       try {
         IM.arangods.forEach(arangod => {
           print(`Connecting ${arangod.getProcessInfo([])}`);


### PR DESCRIPTION
### Scope & Purpose

we could forget our connection string during the tests, hence remember it only *once* at the start.

- [x] :hankey: Bugfix
