### PR TITLE
FE-664 | Added innerProduct metric in vector index form

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* FE-664: Add support for the new innerProduct metric in the vector index creation form in the collection Indexes view.
+
 * Fix BTS-2166: Fix a race during startup, where the async registry's metrics
   might be created before the scheduler starts its first thread. This is
   currently not known to cause any issues.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* FE-664: Add support for the new innerProduct metric in the vector index creation form in the collection Indexes view.
+
 * Add new API /_admin/server/aql-queries to show recently executed AQL queries.
   This is per server and only available on coordinators and single servers.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,6 @@
 devel
 -----
 
-* FE-664: Add support for the new innerProduct metric in the vector index creation form in the collection Indexes view.
-
 * Add new API /_admin/server/aql-queries to show recently executed AQL queries.
   This is per server and only available on coordinators and single servers.
 

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/CollectionIndex.types.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/CollectionIndex.types.ts
@@ -10,7 +10,7 @@ type Vector = {
   fields: string[];
   name?: string;
   params: {
-    metric: "cosine" | "l2" | string;
+    metric: "cosine" | "l2" | "innerProduct" | string;
     dimension: number;
     nLists: number;
     defaultNProbe?: number;

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
@@ -34,9 +34,10 @@ export const FIELDS = [
     isRequired: true,
     options: [
       { label: "Cosine", value: "cosine" },
-      { label: "L2 (Euclidean)", value: "l2" }
+      { label: "L2 (Euclidean)", value: "l2" },
+      { label: "Inner Product", value: "innerProduct" }
     ],
-    tooltip: "Distance metric used for similarity search. Choose between cosine similarity or Euclidean distance."
+    tooltip: "Distance metric used for similarity search. Choose between Cosine similarity, Euclidean distance (L2), or Inner Product."
   },
   {
     label: "Dimension",

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
@@ -34,8 +34,8 @@ export const FIELDS = [
     isRequired: true,
     options: [
       { label: "Cosine", value: "cosine" },
-      { label: "L2 (Euclidean)", value: "l2" },
-      { label: "Inner Product", value: "innerProduct" }
+      { label: "Inner Product", value: "innerProduct" },
+      { label: "L2 (Euclidean)", value: "l2" }
     ],
     tooltip: "Distance metric used for similarity search. Choose between Cosine similarity, Euclidean distance (L2), or Inner Product."
   },

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
@@ -37,7 +37,7 @@ export const FIELDS = [
       { label: "Inner Product", value: "innerProduct" },
       { label: "L2 (Euclidean)", value: "l2" }
     ],
-    tooltip: "Distance metric used for similarity search. Choose between Cosine similarity, Euclidean distance (L2), or Inner Product."
+    tooltip: "Distance metric used for similarity search. Choose between Cosine similarity, Inner Product, or Euclidean distance (L2)."
   },
   {
     label: "Dimension",


### PR DESCRIPTION
### Scope & Purpose

- [X] :sparkles: Feature

Adds support for the newly introduced **`innerProduct` metric** for vector indexes in the collection **Indexes view** of the core DB UI.  
The **`innerProduct`** option is now available in the **Metric** dropdown when creating a vector index, alongside the existing **Cosine** and **L2 (Euclidean)** options.

### Checklist

- [X] Tests  
  - [X] **Manually tested**
- [X] :book: CHANGELOG entry made

#### Related Information

- [X] Jira ticket: https://arangodb.atlassian.net/browse/FE-664  
- [X] Related PR (backend feature): https://github.com/arangodb/arangodb/pull/21814
