### PR TITLE
BTS-2139: Accept `z` in GEO position definition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-2139: GeoJSON coordinate validation now properly accepts both 2D and 3D
+  coordinates for Point geometries.
+
 * Add new API /_admin/server/aql-queries to show recently executed AQL queries.
   This is per server and only available on coordinators and single servers.
 

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -440,7 +440,7 @@ void AqlFunctionFeature::addGeometryConstructors() {
       FF::CanRunOnDBServerOneShard, FF::CanUseInAnalyzer);
 
   // geometry types
-  add({"GEO_POINT", ".,.", flags, &functions::GeoPoint});
+  add({"GEO_POINT", ".,.|.", flags, &functions::GeoPoint});
   add({"GEO_MULTIPOINT", ".", flags, &functions::GeoMultiPoint});
   add({"GEO_POLYGON", ".", flags, &functions::GeoPolygon});
   add({"GEO_MULTIPOLYGON", ".", flags, &functions::GeoMultiPolygon});

--- a/lib/Geo/GeoJson.cpp
+++ b/lib/Geo/GeoJson.cpp
@@ -200,7 +200,8 @@ template<bool Validation, bool GeoJson>
 bool parseImpl(velocypack::Slice vpack, S2LatLng& vertex) {
   TRI_ASSERT(vpack.isArray());
   velocypack::ArrayIterator jt{vpack};
-  if (Validation && ADB_UNLIKELY(jt.size() != 2)) {
+  // We ignore Z coordinate for now since it's not supported by S2
+  if (Validation && (jt.size() < 2 || jt.size() > 3)) [[unlikely]] {
     return false;
   }
   auto const first = *jt;

--- a/tests/Geo/GeoJsonTest.cpp
+++ b/tests/Geo/GeoJsonTest.cpp
@@ -182,6 +182,7 @@ TEST_F(InvalidGeoJSONInputTest, bad_point_too_many_coordinates) {
     coords->add(VPackValue(0.0));
     coords->add(VPackValue(0.0));
     coords->add(VPackValue(0.0));
+    coords->add(VPackValue(0.0));  // 4 coordinates - this should be invalid
   }
   VPackSlice vpack = builder.slice();
 
@@ -290,12 +291,14 @@ TEST_F(InvalidGeoJSONInputTest, bad_multipoint_extra_numbers_in_bad_points) {
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
     {
       velocypack::ArrayBuilder point(&builder);
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
   }
   VPackSlice vpack = builder.slice();
@@ -355,12 +358,14 @@ TEST_F(InvalidGeoJSONInputTest, bad_linestring_extra_numbers_in_bad_points) {
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
     {
       velocypack::ArrayBuilder point(&builder);
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
   }
   VPackSlice vpack = builder.slice();
@@ -440,12 +445,14 @@ TEST_F(InvalidGeoJSONInputTest,
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
     {
       velocypack::ArrayBuilder point(&builder);
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
   }
   VPackSlice vpack = builder.slice();
@@ -515,12 +522,14 @@ TEST_F(InvalidGeoJSONInputTest, bad_loop_extra_numbers_in_bad_points) {
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
     {
       velocypack::ArrayBuilder point(&builder);
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
       point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));  // 4 coordinates - invalid
     }
   }
   VPackSlice vpack = builder.slice();
@@ -655,24 +664,28 @@ TEST_F(InvalidGeoJSONInputTest, bad_polygon_extra_numbers_in_bad_points) {
         point->add(VPackValue(0.0));
         point->add(VPackValue(0.0));
         point->add(VPackValue(0.0));
+        point->add(VPackValue(0.0));  // 4 coordinates - invalid
       }
       {
         velocypack::ArrayBuilder point(&builder);
         point->add(VPackValue(1.0));
         point->add(VPackValue(0.0));
         point->add(VPackValue(0.0));
+        point->add(VPackValue(0.0));  // 4 coordinates - invalid
       }
       {
         velocypack::ArrayBuilder point(&builder);
         point->add(VPackValue(0.0));
         point->add(VPackValue(1.0));
         point->add(VPackValue(0.0));
+        point->add(VPackValue(0.0));  // 4 coordinates - invalid
       }
       {
         velocypack::ArrayBuilder point(&builder);
         point->add(VPackValue(0.0));
         point->add(VPackValue(0.0));
         point->add(VPackValue(0.0));
+        point->add(VPackValue(0.0));  // 4 coordinates - invalid
       }
     }
   }
@@ -1002,24 +1015,28 @@ TEST_F(InvalidGeoJSONInputTest, bad_multipolygon_extra_numbers_in_bad_points) {
           point->add(VPackValue(0.0));
           point->add(VPackValue(0.0));
           point->add(VPackValue(0.0));
+          point->add(VPackValue(0.0));  // 4 coordinates - invalid
         }
         {
           velocypack::ArrayBuilder point(&builder);
           point->add(VPackValue(1.0));
           point->add(VPackValue(0.0));
           point->add(VPackValue(0.0));
+          point->add(VPackValue(0.0));  // 4 coordinates - invalid
         }
         {
           velocypack::ArrayBuilder point(&builder);
           point->add(VPackValue(0.0));
           point->add(VPackValue(1.0));
           point->add(VPackValue(0.0));
+          point->add(VPackValue(0.0));  // 4 coordinates - invalid
         }
         {
           velocypack::ArrayBuilder point(&builder);
           point->add(VPackValue(0.0));
           point->add(VPackValue(0.0));
           point->add(VPackValue(0.0));
+          point->add(VPackValue(0.0));  // 4 coordinates - invalid
         }
       }
     }
@@ -1274,6 +1291,23 @@ TEST_F(ValidGeoJSONInputTest, valid_point_with_z_coordinate) {
     coords->add(VPackValue(0.0));
     coords->add(VPackValue(1.0));
     coords->add(VPackValue(100.0));  // Z coordinate (elevation)
+  }
+  VPackSlice vpack = builder.slice();
+
+  ASSERT_EQ(geo::json::Type::POINT, geo::json::type(vpack));
+  ASSERT_TRUE(geo::json::parsePoint(vpack, point).ok());
+  ASSERT_EQ(0.0, point.lng().degrees());
+  ASSERT_EQ(1.0, point.lat().degrees());
+}
+
+TEST_F(ValidGeoJSONInputTest, valid_point_with_z_coordinate_negative) {
+  {
+    velocypack::ObjectBuilder object(&builder);
+    object->add("type", VPackValue("Point"));
+    velocypack::ArrayBuilder coords(&builder, "coordinates");
+    coords->add(VPackValue(0.0));
+    coords->add(VPackValue(1.0));
+    coords->add(VPackValue(-100.0));  // Negative Z coordinate
   }
   VPackSlice vpack = builder.slice();
 
@@ -2242,6 +2276,48 @@ TEST_F(ValidGeoJSONInputTest, NestedHoles) {
   VPackSlice polyS = velocypack::Slice(poly->data());
   auto r = geo::json::parseRegion(polyS, shape, false);
   ASSERT_TRUE(r.ok()) << r.errorMessage();
+}
+
+TEST_F(ValidGeoJSONInputTest, valid_linestring_with_z_coordinates) {
+  {
+    velocypack::ObjectBuilder object(&builder);
+    object->add("type", VPackValue("Linestring"));
+    velocypack::ArrayBuilder points(&builder, "coordinates");
+    {
+      velocypack::ArrayBuilder point(&builder);
+      point->add(VPackValue(0.0));
+      point->add(VPackValue(0.0));
+      point->add(VPackValue(100.0));  // Z coordinate
+    }
+    {
+      velocypack::ArrayBuilder point(&builder);
+      point->add(VPackValue(1.0));
+      point->add(VPackValue(0.0));
+      point->add(VPackValue(200.0));  // Z coordinate
+    }
+    {
+      velocypack::ArrayBuilder point(&builder);
+      point->add(VPackValue(1.0));
+      point->add(VPackValue(1.0));
+      point->add(VPackValue(300.0));  // Z coordinate
+    }
+    {
+      velocypack::ArrayBuilder point(&builder);
+      point->add(VPackValue(0.0));
+      point->add(VPackValue(1.0));
+      point->add(VPackValue(400.0));  // Z coordinate
+    }
+  }
+  VPackSlice vpack = builder.slice();
+
+  ASSERT_EQ(geo::json::Type::LINESTRING, geo::json::type(vpack));
+  ASSERT_TRUE(geo::json::parseLinestring(vpack, line).ok());
+
+  ASSERT_EQ(4, line.num_vertices());
+  ASSERT_EQ(S2LatLng::FromDegrees(0.0, 0.0).ToPoint(), line.vertex(0));
+  ASSERT_EQ(S2LatLng::FromDegrees(0.0, 1.0).ToPoint(), line.vertex(1));
+  ASSERT_EQ(S2LatLng::FromDegrees(1.0, 1.0).ToPoint(), line.vertex(2));
+  ASSERT_EQ(S2LatLng::FromDegrees(1.0, 0.0).ToPoint(), line.vertex(3));
 }
 
 }  // namespace arangodb

--- a/tests/Geo/GeoJsonTest.cpp
+++ b/tests/Geo/GeoJsonTest.cpp
@@ -189,6 +189,35 @@ TEST_F(InvalidGeoJSONInputTest, bad_point_too_many_coordinates) {
   ASSERT_TRUE(geo::json::parsePoint(vpack, point).is(TRI_ERROR_BAD_PARAMETER));
 }
 
+TEST_F(InvalidGeoJSONInputTest, bad_point_invalid_coordinate_count) {
+  {
+    velocypack::ObjectBuilder object(&builder);
+    object->add("type", VPackValue("Point"));
+    velocypack::ArrayBuilder coords(&builder, "coordinates");
+    coords->add(VPackValue(0.0));
+  }
+  VPackSlice vpack = builder.slice();
+
+  ASSERT_EQ(geo::json::Type::POINT, geo::json::type(vpack));
+  ASSERT_TRUE(geo::json::parsePoint(vpack, point).is(TRI_ERROR_BAD_PARAMETER));
+}
+
+TEST_F(InvalidGeoJSONInputTest, bad_point_four_coordinates) {
+  {
+    velocypack::ObjectBuilder object(&builder);
+    object->add("type", VPackValue("Point"));
+    velocypack::ArrayBuilder coords(&builder, "coordinates");
+    coords->add(VPackValue(0.0));
+    coords->add(VPackValue(0.0));
+    coords->add(VPackValue(0.0));
+    coords->add(VPackValue(0.0));
+  }
+  VPackSlice vpack = builder.slice();
+
+  ASSERT_EQ(geo::json::Type::POINT, geo::json::type(vpack));
+  ASSERT_TRUE(geo::json::parsePoint(vpack, point).is(TRI_ERROR_BAD_PARAMETER));
+}
+
 TEST_F(InvalidGeoJSONInputTest, bad_point_multiple_points) {
   {
     velocypack::ObjectBuilder object(&builder);
@@ -1228,6 +1257,23 @@ TEST_F(ValidGeoJSONInputTest, valid_point) {
     velocypack::ArrayBuilder coords(&builder, "coordinates");
     coords->add(VPackValue(0.0));
     coords->add(VPackValue(1.0));
+  }
+  VPackSlice vpack = builder.slice();
+
+  ASSERT_EQ(geo::json::Type::POINT, geo::json::type(vpack));
+  ASSERT_TRUE(geo::json::parsePoint(vpack, point).ok());
+  ASSERT_EQ(0.0, point.lng().degrees());
+  ASSERT_EQ(1.0, point.lat().degrees());
+}
+
+TEST_F(ValidGeoJSONInputTest, valid_point_with_z_coordinate) {
+  {
+    velocypack::ObjectBuilder object(&builder);
+    object->add("type", VPackValue("Point"));
+    velocypack::ArrayBuilder coords(&builder, "coordinates");
+    coords->add(VPackValue(0.0));
+    coords->add(VPackValue(1.0));
+    coords->add(VPackValue(100.0));  // Z coordinate (elevation)
   }
   VPackSlice vpack = builder.slice();
 

--- a/tests/js/client/aql/aql-geo-distance-range.js
+++ b/tests/js/client/aql/aql-geo-distance-range.js
@@ -258,11 +258,11 @@ function GeoDistanceRange() {
       }); 
     },
 
+    // BTS-2139 test with two and three coordinates
     testWithMixedCoordinates: function() {
       // Repeat the same tests but with mixed 2D and 3D coordinates
       // Results should be identical since Z coordinates are ignored
       const queries = [
-        // BTS-470 with mixed coordinates
         [`
           LET lines = GEO_MULTILINESTRING([
             [[ 6.537, 50.332, 100 ], [ 6.537, 50.376 ]],
@@ -329,7 +329,6 @@ function GeoDistanceRange() {
             RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines)})  
           `, 2
         ],
-        // BTS-471 with mixed coordinates
         [
           `
           LET lines = GEO_MULTILINESTRING([
@@ -414,6 +413,7 @@ function GeoDistanceRange() {
       }); 
     },
 
+    // BTS-2139 accept z coordinates in geojson
     testZCoordinateIgnored: function() {
       // Test that Z coordinates are ignored in geo_distance calculations
       // Distance between points with same lat/lng should be 0 regardless of Z
@@ -434,6 +434,7 @@ function GeoDistanceRange() {
       assertEqual(distance2, 0);
     },
 
+    // BTS-2139 accept z coordinates in geojson
     testZCoordinateIgnored2: function() {
       // Test that Z coordinates are ignored in geo_distance calculations
       // Distance between points with same lat/lng should be 0 regardless of Z

--- a/tests/js/client/aql/aql-geo-distance-range.js
+++ b/tests/js/client/aql/aql-geo-distance-range.js
@@ -256,6 +256,202 @@ function GeoDistanceRange() {
           fail(err);
         }
       }); 
+    },
+
+    testWithMixedCoordinates: function() {
+      // Repeat the same tests but with mixed 2D and 3D coordinates
+      // Results should be identical since Z coordinates are ignored
+      const queries = [
+        // BTS-470 with mixed coordinates
+        [`
+          LET lines = GEO_MULTILINESTRING([
+            [[ 6.537, 50.332, 100 ], [ 6.537, 50.376 ]],
+            [[ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_DISTANCE(doc.location, lines) < 100, "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 5
+        ],
+        [`
+          LET lines = GEO_MULTILINESTRING([
+            [[ 6.537, 50.332, 100 ], [ 6.537, 50.376 ]],
+            [[ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_DISTANCE(doc.location, lines) < 3000, "geo_json")
+            FILTER doc.location.type != "Point"
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 3
+        ],
+        [
+          `
+          LET lines = GEO_MULTILINESTRING([
+            [[ 37.614323, 55.705898, 150 ], [ 37.615825, 55.705898 ]],
+            [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652, 250 ]]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_DISTANCE(doc.location, lines) < 100, "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines)})
+          `, 2
+        ],
+        [
+          `
+          LET lines = GEO_MULTIPOINT([
+            [ 6.537, 50.332, 100 ], [ 6.537, 50.376 ],
+            [ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_DISTANCE(doc.location, lines) < 100, "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 5
+        ],
+        [
+          `
+          LET lines = GEO_MULTIPOINT([
+            [ 6.537, 50.332, 100 ], [ 6.537, 50.376 ],
+            [ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_DISTANCE(doc.location, lines ) < 3000, "geo_json")
+            FILTER doc.location.type != "Point"
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 3
+        ],
+        [
+          `
+          LET lines = GEO_MULTIPOINT([
+            [ 37.614323, 55.705898, 150 ], [ 37.615825, 55.705898 ],
+            [ 37.614323, 55.70652 ], [ 37.615825, 55.70652, 250 ]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_DISTANCE(doc.location, lines) < 100, "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines)})  
+          `, 2
+        ],
+        // BTS-471 with mixed coordinates
+        [
+          `
+          LET lines = GEO_MULTILINESTRING([
+            [[ 6.537, 50.332, 100 ], [ 6.537, 50.376 ]],
+            [[ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_IN_RANGE(doc.location, lines, 0, 100), "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 5
+        ],
+        [
+          `
+          LET lines = GEO_MULTILINESTRING([
+            [[ 6.537, 50.332, 100 ], [ 6.537, 50.376 ]],
+            [[ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_IN_RANGE(doc.location, lines, 0, 3000), "geo_json")
+            FILTER doc.location.type != "Point"
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 3
+        ],
+        [
+          `
+          LET lines = GEO_MULTILINESTRING([
+            [[ 37.614323, 55.705898, 150 ], [ 37.615825, 55.705898 ]],
+            [[ 37.614323, 55.70652 ], [ 37.615825, 55.70652, 250 ]]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_IN_RANGE(doc.location, lines, 0, 100), "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines)})
+          `, 2
+        ],
+        [
+          `
+          LET lines = GEO_MULTIPOINT([
+            [ 6.537, 50.332, 100 ], [ 6.537, 50.376 ],
+            [ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_IN_RANGE(doc.location, lines, 0, 100), "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 5
+        ],
+        [
+          `
+          LET lines = GEO_MULTIPOINT([
+            [ 6.537, 50.332, 100 ], [ 6.537, 50.376 ],
+            [ 6.621, 50.332 ], [ 6.621, 50.376, 200 ]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_IN_RANGE(doc.location, lines, 0, 3000), "geo_json")
+            FILTER doc.location.type != "Point"
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines )})
+          `, 3
+        ],
+        [
+          `
+          LET lines = GEO_MULTIPOINT([
+            [ 37.614323, 55.705898, 150 ], [ 37.615825, 55.705898 ],
+            [ 37.614323, 55.70652 ], [ 37.615825, 55.70652, 250 ]
+          ])
+          FOR doc IN geo_view
+            SEARCH ANALYZER(GEO_IN_RANGE(doc.location, lines, 0, 100), "geo_json")
+            RETURN MERGE(doc, { distance: GEO_DISTANCE(doc.location, lines)})
+          `, 2
+        ]
+      ];
+
+      queries.forEach( function (query_tuple, index) {
+        let [query, expected] = query_tuple;
+        let actual;
+        try {
+          actual = db._query(query).toArray().length;
+          assertEqual(actual, expected);
+        } catch (err) {
+          print(`Actual: ${actual}, Expected: ${expected}, Index: ${index}`);
+          print(query);
+          fail(err);
+        }
+      }); 
+    },
+
+    testZCoordinateIgnored: function() {
+      // Test that Z coordinates are ignored in geo_distance calculations
+      // Distance between points with same lat/lng should be 0 regardless of Z
+      const distance1 = db._query(`
+        LET p1 = GEO_POINT(6.537, 50.332)
+        LET p2 = GEO_POINT(6.537, 50.332)
+        RETURN GEO_DISTANCE(p1, p2)
+      `).toArray()[0];
+      
+      const distance2 = db._query(`
+        LET p1 = GEO_POINT(6.537, 50.332, -100)
+        LET p2 = GEO_POINT(6.537, 50.332, 100)
+        RETURN GEO_DISTANCE(p1, p2)
+      `).toArray()[0];
+      
+      // Both distances should be 0 since lat/lng are identical (Z is ignored)
+      assertEqual(distance1, 0);
+      assertEqual(distance2, 0);
+    },
+
+    testZCoordinateIgnored2: function() {
+      // Test that Z coordinates are ignored in geo_distance calculations
+      // Distance between points with same lat/lng should be 0 regardless of Z
+      const distance1 = db._query(`
+        LET p1 = {type: "Point", coordinates: [6.537, 50.332]}
+        LET p2 = {type: "Point", coordinates: [6.537, 50.332]}
+        RETURN GEO_DISTANCE(p1, p2)
+      `).toArray()[0];
+      
+      const distance2 = db._query(`
+        LET p1 = {type: "Point", coordinates: [6.537, 50.332, -100]}
+        LET p2 = {type: "Point", coordinates: [6.537, 50.332, 100]}
+        RETURN GEO_DISTANCE(p1, p2)
+      `).toArray()[0];
+      
+      // Both distances should be 0 since lat/lng are identical (Z is ignored)
+      assertEqual(distance1, 0);
+      assertEqual(distance2, 0);
     }
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Fix BTS-213: GeoJSON coordinate validation for Point geometries, now we accept `lat,lng, z` but still ignore `z` value during calculation.

The fix ensures GeoJSON Point geometries with optional Z coordinates are properly validated and processed according to the [GeoJSON specification](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1).


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2139
- [ ] Design document: 
