### PR TITLE
Update documentation links

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13445,7 +13445,7 @@ v3.5.0-rc.1 (2019-05-14)
   - `--javascript.endpoints-whitelist`: control accessible endpoints in JavaScript
   - `--javascript.files-whitelist`: control file access in JavaScript
 
-  Note: There is a [detailed description of all options](https://www.arangodb.com/docs/devel/security-security-options.html).
+  Note: There is a [detailed description of all options](https://docs.arangodb.com/stable/operations/security/security-options/).
 
 * Prevented arangod from making a call to www.arangodb.com at startup.
 

--- a/Installation/ARM/postinst
+++ b/Installation/ARM/postinst
@@ -11,7 +11,7 @@ First Steps with ArangoDB:
   http:/www.arangodb.com/quickstart
 
 Upgrading ArangoDB:
-  https://www.arangodb.com/docs/stable/upgrading.html
+  https://docs.arangodb.com/stable/operations/upgrading/
 
 Upgrading ArangoDB database files:
   > /etc/init.d/arangodb3 upgrade

--- a/Installation/rpm/arangodb.spec.in
+++ b/Installation/rpm/arangodb.spec.in
@@ -227,10 +227,10 @@ ArangoDB 3 (https://www.arangodb.com)
   or JavaScript extensions.
 
 First Steps with ArangoDB:
-  https://www.arangodb.com/docs/stable/getting-started.html
+  https://docs.arangodb.com/stable/get-started/
 
 Upgrading ArangoDB:
-  https://www.arangodb.com/docs/stable/upgrading.html
+  https://docs.arangodb.com/stable/operations/upgrading/
 
 Upgrading ArangoDB database files:
   > /etc/init.d/arangodb3 upgrade

--- a/etc/arangodb3/arangod.conf.in
+++ b/etc/arangodb3/arangod.conf.in
@@ -1,7 +1,7 @@
 # ArangoDB configuration file
 # 
 # Documentation: 
-# https://www.arangodb.com/docs/stable/administration-configuration.html
+# https://docs.arangodb.com/stable/operations/administration/configuration/
 # 
 
 [database]

--- a/js/client/modules/@arangodb/foxx/manager.js
+++ b/js/client/modules/@arangodb/foxx/manager.js
@@ -184,7 +184,7 @@ var help = function () {
   if (!version.match(/^(\d+\.\d+)$/)) {
     version = 'stable';
   }
-  arangodb.print('https://www.arangodb.com/docs/' + version + '/foxx.html');
+  arangodb.print('https://docs.arangodb.com/' + version + '/develop/foxx-microservices/');
 
   // additional newline
   arangodb.print();
@@ -557,7 +557,7 @@ var tests = function (mount, options) {
 var run = function (args) {
   var version = internal.version.split('.').slice(0, 2).join('.');
   arangodb.print('NOTE: foxx-manager is deprecated and will be removed in ArangoDB v4.0.');
-  arangodb.print(`Please use foxx-cli instead: https://www.arangodb.com/docs/${version}/programs-foxx-cli.html\n`);
+  arangodb.print(`Please use foxx-cli instead: https://docs.arangodb.com/${version}/components/tools/foxx-cli/\n`);
 
   if (args === undefined || args.length === 0) {
     arangodb.print('Expecting a command, please try:\n');


### PR DESCRIPTION
There are redirects in place but they point to 3.11 (in order to not create additional maintenance cost)