### PR TITLE
Fix TSAN error in trackExecutionStart and trackExecutionEnd

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1726,22 +1726,22 @@ void Query::logAtEnd() const {
 
 void Query::trackExecutionStart() noexcept {
   // We should do this only once
-  if (!_isExecuting) {
+  bool expected = false;
+  if (_isExecuting.compare_exchange_strong(expected, true)) {
     _startExecutionTime = currentSteadyClockValue();
     auto& queryRegistryFeature =
         vocbase().server().getFeature<QueryRegistryFeature>();
     queryRegistryFeature.trackQueryStart();
-    _isExecuting = true;
   }
 }
 
 void Query::trackExecutionEnd() noexcept {
-  if (_isExecuting) {
+  bool expected = true;
+  if (_isExecuting.compare_exchange_strong(expected, false)) {
     _endExecutionTime = currentSteadyClockValue();
     auto& queryRegistryFeature =
         vocbase().server().getFeature<QueryRegistryFeature>();
     queryRegistryFeature.trackQueryEnd(executionTime());
-    _isExecuting = false;
   }
 }
 

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -536,7 +536,7 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   // the consequence is that _ast is nullptr
   bool _isCached{false};
 
-  bool _isExecuting{false};
+  std::atomic<bool> _isExecuting{false};
 };
 
 }  // namespace aql


### PR DESCRIPTION
### Scope & Purpose

Fixes a tsan issue in trackExecutionStart and trackExecutionEnd:
```
WARNING: ThreadSanitizer: data race (pid=575)
  Read of size 1 at 0x72780014931a by thread T66 (mutexes: write M0):
    #0 arangodb::aql::Query::trackExecutionEnd() /root/project/arangod/Aql/Query.cpp:1739 (arangod+0x3013d09) (BuildId: ba89abee79794c7f356015a532dac020273392c4)
    #1 arangodb::aql::Query::cleanupPlanAndEngine(bool) /root/project/arangod/Aql/Query.cpp:1895 (arangod+0x300a000) (BuildId: ba89abee79794c7f356015a532dac020273392c4)
    #2 arangodb::aql::Query::kill() /root/project/arangod/Aql/Query.cpp:317 (arangod+0x300ab45) (BuildId: ba89abee79794c7f356015a532dac020273392c4)

  Previous write of size 1 at 0x72780014931a by thread T65 (mutexes: write M1):
    #0 trackExecutionStart /root/project/arangod/Aql/Query.cpp:1734 (arangod+0x3010f4e) (BuildId: ba89abee79794c7f356015a532dac020273392c4)
    #1 arangodb::aql::Query::execute(arangodb::aql::QueryResult&) /root/project/arangod/Aql/Query.cpp:748 (arangod+0x3010f4e)

  Thread T65 'SchedWorker' (tid=1002, running) created by thread T60 at:
    #0 pthread_create <null> (arangod+0x2058985) (BuildId: ba89abee79794c7f356015a532dac020273392c4)
    #1 TRI_StartThread(unsigned long*, char const*, void (*)(void*), void*) /root/project/lib/Basics/threads-posix.cpp:137 (arangod+0x4dd8777) (BuildId: ba89abee79794c7f356015a532dac020273392c4)
    #2 arangodb::Thread::start(arangodb::basics::ConditionVariable*) /root/project/lib/Basics/Thread.cpp:314 (arangod+0x4db4d9b) (BuildId: ba89abee79794c7f356015a532dac020273392c4)
SUMMARY: ThreadSanitizer: data race /root/project/arangod/Aql/Query.cpp:1739 in arangodb::aql::Query::trackExecutionEnd()
```


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
