### PR TITLE
BTS-2163: reload routing to make sure collection objects in .js get discarded

### DIFF
--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -614,10 +614,11 @@ arangodb::Result triggerFoxxHeal(
   }
   std::string reloadRoutingUrl = "/_admin/routing/reload";
   response.reset(httpClient.request(arangodb::rest::RequestType::POST,
-                                    reloadRoutingUrl, body.c_str(), body.length()));
+                                    reloadRoutingUrl, body.c_str(),
+                                    body.length()));
   return arangodb::HttpResponseChecker::check(
-      httpClient.getErrorMessage(), response.get(), "trigger reload routing", body,
-      arangodb::HttpResponseChecker::PayloadType::JSON);
+      httpClient.getErrorMessage(), response.get(), "trigger reload routing",
+      body, arangodb::HttpResponseChecker::PayloadType::JSON);
 }
 
 arangodb::Result processInputDirectory(

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -606,8 +606,17 @@ arangodb::Result triggerFoxxHeal(
   std::string foxxHealUrl = "/_api/foxx/_local/heal";
   response.reset(httpClient.request(arangodb::rest::RequestType::POST,
                                     foxxHealUrl, body.c_str(), body.length()));
-  return arangodb::HttpResponseChecker::check(
+  auto res = arangodb::HttpResponseChecker::check(
       httpClient.getErrorMessage(), response.get(), "trigger self heal", body,
+      arangodb::HttpResponseChecker::PayloadType::JSON);
+  if (res.fail()) {
+    return res;
+  }
+  std::string foxxHealUrl = "/_admin/routing/reload";
+  response.reset(httpClient.request(arangodb::rest::RequestType::POST,
+                                    foxxHealUrl, body.c_str(), body.length()));
+  return arangodb::HttpResponseChecker::check(
+      httpClient.getErrorMessage(), response.get(), "trigger reload routing", body,
       arangodb::HttpResponseChecker::PayloadType::JSON);
 }
 

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -606,15 +606,15 @@ arangodb::Result triggerFoxxHeal(
   std::string foxxHealUrl = "/_api/foxx/_local/heal";
   response.reset(httpClient.request(arangodb::rest::RequestType::POST,
                                     foxxHealUrl, body.c_str(), body.length()));
-  auto res = arangodb::HttpResponseChecker::check(
+  res = arangodb::HttpResponseChecker::check(
       httpClient.getErrorMessage(), response.get(), "trigger self heal", body,
       arangodb::HttpResponseChecker::PayloadType::JSON);
   if (res.fail()) {
     return res;
   }
-  std::string foxxHealUrl = "/_admin/routing/reload";
+  std::string reloadRoutingUrl = "/_admin/routing/reload";
   response.reset(httpClient.request(arangodb::rest::RequestType::POST,
-                                    foxxHealUrl, body.c_str(), body.length()));
+                                    reloadRoutingUrl, body.c_str(), body.length()));
   return arangodb::HttpResponseChecker::check(
       httpClient.getErrorMessage(), response.get(), "trigger reload routing", body,
       arangodb::HttpResponseChecker::PayloadType::JSON);


### PR DESCRIPTION
### Scope & Purpose

if we replace foxxes and their collections, we need to reload the routing, else instances of now gone collections are referenced.

- [x] :hankey: Bugfix
