### PR TITLE
Add switch --database.auto-upgrade-full-compaction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Add option --database.auto-upgrade-full-compaction to run a full RocksDB
+  compaction on database upgrade. This is needed for a quicker cluster
+  upgrade.
+
 * Fix logging of the request body when compression is present.
 
 * Move crash handling to a separate thread, this is cleaner and does not

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,8 +2,7 @@ devel
 -----
 
 * Add option --database.auto-upgrade-full-compaction to run a full RocksDB
-  compaction on database upgrade. This is needed for a quicker cluster
-  upgrade.
+  compaction on database upgrade.
 
 * Fix logging of the request body when compression is present.
 

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -25,11 +25,9 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Auth/UserManager.h"
-#include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/application-exit.h"
 #include "Basics/exitcodes.h"
-#include "Basics/voc-errors.h"
 #include "Cluster/ServerState.h"
 #ifdef USE_ENTERPRISE
 #include "Enterprise/StorageEngine/HotBackupFeature.h"
@@ -39,7 +37,6 @@
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 #include "ProgramOptions/ProgramOptions.h"
-#include "ProgramOptions/Section.h"
 #include "Replication/ReplicationFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/InitDatabaseFeature.h"

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -144,7 +144,7 @@ void UpgradeFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
         << " will perform database auto-upgrade and immediately restart.";
   }
   if (_upgrade && !_upgradeCheck) {
-    LOG_TOPIC("47698", FATAL, arangodb::Logger::ENGINES)
+    LOG_TOPIC("47698", FATAL, arangodb::Logger::FIXME)
         << "cannot specify both '--database.auto-upgrade true' and "
            "'--database.upgrade-check false'";
     FATAL_ERROR_EXIT_CODE(TRI_EXIT_INVALID_OPTION_VALUE);

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -43,6 +43,8 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/InitDatabaseFeature.h"
 #include "RestServer/RestartAction.h"
+#include "StorageEngine/EngineSelectorFeature.h"
+#include "StorageEngine/StorageEngine.h"
 #include "VocBase/Methods/Upgrade.h"
 #include "VocBase/vocbase.h"
 
@@ -57,6 +59,7 @@ UpgradeFeature::UpgradeFeature(Server& server, int* result,
     : ArangodFeature{server, *this},
       _upgrade(false),
       _upgradeCheck(true),
+      _upgradeFullCompaction(false),
       _result(result),
       _nonServerFeatures(nonServerFeatures) {
   setOptional(false);
@@ -99,6 +102,20 @@ in the `VERSION` file, the server refuses to start.)");
       "--database.upgrade-check", "Skip the database upgrade if set to false.",
       new BooleanParameter(&_upgradeCheck),
       arangodb::options::makeDefaultFlags(arangodb::options::Flags::Uncommon));
+
+  options
+      ->addOption("--database.auto-upgrade-full-compaction",
+                  "Perform a full RocksDB compaction after database upgrade.",
+                  new BooleanParameter(&_upgradeFullCompaction))
+      .setLongDescription(R"(If this option is specified together with 
+--database.auto-upgrade, the server will perform a full RocksDB compaction 
+after the database upgrade has completed successfully but before shutting down.
+
+This performs a complete compaction of all column families with both 
+changeLevel and compactBottomMostLevel options enabled, which can help 
+optimize the database files after an upgrade.
+
+The server will exit with an error code if the compaction fails.)");
 }
 
 static int upgradeRestart() {
@@ -129,6 +146,13 @@ void UpgradeFeature::validateOptions(std::shared_ptr<ProgramOptions> options) {
     LOG_TOPIC("47698", FATAL, arangodb::Logger::FIXME)
         << "cannot specify both '--database.auto-upgrade true' and "
            "'--database.upgrade-check false'";
+    FATAL_ERROR_EXIT_CODE(TRI_EXIT_INVALID_OPTION_VALUE);
+  }
+
+  if (_upgradeFullCompaction && !_upgrade) {
+    LOG_TOPIC("47699", FATAL, arangodb::Logger::FIXME)
+        << "cannot specify '--database.auto-upgrade-full-compaction true' "
+           "without '--database.auto-upgrade true'";
     FATAL_ERROR_EXIT_CODE(TRI_EXIT_INVALID_OPTION_VALUE);
   }
 
@@ -253,6 +277,12 @@ void UpgradeFeature::start() {
     }
   }
 
+  // perform full compaction if requested
+  if (_upgrade && _upgradeFullCompaction &&
+      !ServerState::instance()->isCoordinator()) {
+    performFullCompaction();
+  }
+
   // and force shutdown
   if (_upgrade || init.isInitDatabase() || init.restoreAdmin()) {
     if (init.isInitDatabase()) {
@@ -337,6 +367,30 @@ void UpgradeFeature::upgradeLocalDatabase() {
   // and return from the context
   LOG_TOPIC("01a03", TRACE, arangodb::Logger::FIXME)
       << "finished database init/upgrade";
+}
+
+void UpgradeFeature::performFullCompaction() {
+  LOG_TOPIC("e8f45", INFO, arangodb::Logger::FIXME)
+      << "starting full RocksDB compaction after upgrade";
+
+  TRI_ASSERT(server().hasFeature<EngineSelectorFeature>());
+  StorageEngine& engine = server().getFeature<EngineSelectorFeature>().engine();
+
+  // Perform full compaction with both changeLevel and compactBottomMostLevel
+  // enabled This matches the behavior of the /_admin/compact API with
+  // bottomMost=true and changeLevels=true
+  Result res = engine.compactAll(true, true);
+
+  if (res.fail()) {
+    LOG_TOPIC("e8f46", FATAL, arangodb::Logger::FIXME)
+        << "full RocksDB compaction after upgrade failed: "
+        << res.errorMessage();
+    *_result = EXIT_FAILURE;
+    FATAL_ERROR_EXIT_CODE(TRI_EXIT_FAILED);
+  }
+
+  LOG_TOPIC("e8f47", INFO, arangodb::Logger::FIXME)
+      << "full RocksDB compaction after upgrade completed successfully";
 }
 
 }  // namespace arangodb

--- a/arangod/RestServer/UpgradeFeature.h
+++ b/arangod/RestServer/UpgradeFeature.h
@@ -57,12 +57,14 @@ class UpgradeFeature final : public ArangodFeature {
 
  private:
   void upgradeLocalDatabase();
+  void performFullCompaction();
 
  private:
   friend struct methods::Upgrade;  // to allow access to '_tasks'
 
   bool _upgrade;
   bool _upgradeCheck;
+  bool _upgradeFullCompaction;
 
   int* _result;
   std::span<const size_t> _nonServerFeatures;

--- a/arangod/RestServer/UpgradeFeature.h
+++ b/arangod/RestServer/UpgradeFeature.h
@@ -57,7 +57,7 @@ class UpgradeFeature final : public ArangodFeature {
 
  private:
   void upgradeLocalDatabase();
-  void performFullCompaction();
+  Result performFullCompaction();
 
  private:
   friend struct methods::Upgrade;  // to allow access to '_tasks'

--- a/lib/Basics/exitcodes.dat
+++ b/lib/Basics/exitcodes.dat
@@ -28,6 +28,7 @@ EXIT_ICU_INITIALIZATION_FAILED,26,"failed to initialize ICU library","Will be re
 EXIT_TZDATA_INITIALIZATION_FAILED,27,"failed to locate tzdata","Will be returned if tzdata is not found"
 EXIT_RESOURCES_TOO_LOW,28,"the system restricts resources below what is required to start arangod","Will be returned if i.e. ulimit is too restrictive"
 EXIT_SST_FILE_CHECK,29,"sst file check unsuccessful","Will be returned when either sst file open or sst file check was unsuccessful i.e. sst file is not valid"
+EXIT_FULL_COMPACTION_FAILED,30,"Full RocksDB compaction failed.","Will be returned when --database.auto-upgrade-full-compaction is set and the full compaction after database upgrade failed"
 # network
 #EXIT_NO_COORDINATOR
 #EXIT_NO_AGENCY


### PR DESCRIPTION
This adds a switch --database.auto-upgrade-full-compaction option. This
is good to perform a cluster upgrade to prevent problems due to sorting
issues. With this option it is possible to upgrade a dbserver (after it
has resigned from its shard leaderships), go to a new version and verify
any sorting problems on upgrade by means of a full RocksDB compaction,
which would surface any potential sorting problem. If this goes wrong,
one can still go back to the previous version and run a full dbserver
replacement.

This is at the same time a new feature and a bug fix, since it addresses
the problems in index-sorting.

- **Implement feature.**
- **CHANGELOG.**

### Scope & Purpose

- [*] :hankey: Bugfix
- [*] :pizza: New feature

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.5: 

