### PR TITLE
Add switch --database.auto-upgrade-full-compaction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+3.12.5.1 (XXXX-XX-XX)
+---------------------
+
+* Add option --database.auto-upgrade-full-compaction to run a full RocksDB
+  compaction on database upgrade.
+
+
 3.12.5 (2025-06-18)
 -------------------
 

--- a/arangod/RestServer/UpgradeFeature.h
+++ b/arangod/RestServer/UpgradeFeature.h
@@ -57,12 +57,14 @@ class UpgradeFeature final : public ArangodFeature {
 
  private:
   void upgradeLocalDatabase();
+  Result performFullCompaction();
 
  private:
   friend struct methods::Upgrade;  // to allow access to '_tasks'
 
   bool _upgrade;
   bool _upgradeCheck;
+  bool _upgradeFullCompaction;
 
   int* _result;
   std::span<const size_t> _nonServerFeatures;

--- a/lib/Basics/exitcodes.dat
+++ b/lib/Basics/exitcodes.dat
@@ -28,6 +28,7 @@ EXIT_ICU_INITIALIZATION_FAILED,26,"failed to initialize ICU library","Will be re
 EXIT_TZDATA_INITIALIZATION_FAILED,27,"failed to locate tzdata","Will be returned if tzdata is not found"
 EXIT_RESOURCES_TOO_LOW,28,"the system restricts resources below what is required to start arangod","Will be returned if i.e. ulimit is too restrictive"
 EXIT_SST_FILE_CHECK,29,"sst file check unsuccessful","Will be returned when either sst file open or sst file check was unsuccessful i.e. sst file is not valid"
+EXIT_FULL_COMPACTION_FAILED,30,"Full RocksDB compaction failed.","Will be returned when --database.auto-upgrade-full-compaction is set and the full compaction after database upgrade failed"
 # network
 #EXIT_NO_COORDINATOR
 #EXIT_NO_AGENCY


### PR DESCRIPTION
This is a backport from `devel`.

This adds a switch --database.auto-upgrade-full-compaction option. This
is good to perform a cluster upgrade to prevent problems due to sorting
issues. With this option it is possible to upgrade a dbserver (after it
has resigned from its shard leaderships), go to a new version and verify
any sorting problems on upgrade by means of a full RocksDB compaction,
which would surface any potential sorting problem. If this goes wrong,
one can still go back to the previous version and run a full dbserver
replacement.

This is at the same time a new feature and a bug fix, since it addresses
the problems in index-sorting.

- **Implement feature.**
- **CHANGELOG.**

### Scope & Purpose

- [*] :hankey: Bugfix
- [*] :pizza: New feature

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [*] :book: CHANGELOG entry made
- [*] Backports
  - [*] Backport for 3.12.5: this is it

### References

- [*] Original PR: https://github.com/arangodb/arangodb/pull/21860


