### PR TITLE
Fuzzer: bad URL gives response [BTS-2178]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-2178: If the URL in an HTTP request is bad, the server will
+  now not simply close the connection but give a proper response.
+
 * Fix BTS-2174: When a more complex query get's killed and the server
   (or DBServer in the cluster) is under high query load, there was a
   race condition in the asynchrounous query execution which would cause

--- a/arangod/GeneralServer/HttpCommTask.cpp
+++ b/arangod/GeneralServer/HttpCommTask.cpp
@@ -331,7 +331,7 @@ bool HttpCommTask<T>::readCallback(asio_ns::error_code ec) {
 
         err = llhttp_execute(&_parser, data, datasize);
         if (err != HPE_OK) {
-          if (err == HPE_INVALID_HEADER_TOKEN) {
+          if (err == HPE_INVALID_HEADER_TOKEN || err == HPE_INVALID_URL) {
             _headerCorrupt = true;
           }
           ptrdiff_t diff = llhttp_get_error_pos(&_parser) - data;


### PR DESCRIPTION
This is about https://arangodb.atlassian.net/browse/BTS-2178 .

- **Proper response if URL is bad.**
- **CHANGELOG.**

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests: 
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: none planned

