### PR TITLE
Fix BTS-2182 filters not pushed in Traversal node

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix BTS-2182: When a filter with inequality operator was used with
+  traversals, the Filter node was not pushed into the Traversal node. This
+  fixes that problem in the optimization rule
+  remove-filter-covered-by-traversal.
+
 * Fix BTS-2174: When a more complex query get's killed and the server
   (or DBServer in the cluster) is under high query load, there was a
   race condition in the asynchrounous query execution which would cause

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1052,8 +1052,6 @@ void Condition::collectOverlappingMembers(
     bool isPathCondition) {
   bool const isFromTraverser{index == nullptr};
   bool const isSparse = (index != nullptr && index->sparse());
-  LOG_DEVEL << ADB_HERE << " andNode: " << andNode->toString()
-            << " otherAndNode: " << otherAndNode->toString();
 
   std::pair<Variable const*, std::vector<basics::AttributeName>> result;
 
@@ -1063,8 +1061,6 @@ void Condition::collectOverlappingMembers(
     auto operand = andNode->getMemberUnchecked(i);
     bool allowOps = operand->isComparisonOperator();
 
-    LOG_DEVEL << ADB_HERE << " Checking: " << operand->toString();
-    LOG_DEVEL << ADB_HERE << " allowOps: " << allowOps;
     if (isSparse && allowOps && !isFromTraverser &&
         (operand->type == NODE_TYPE_OPERATOR_BINARY_NE ||
          operand->type == NODE_TYPE_OPERATOR_BINARY_GT)) {
@@ -1094,16 +1090,11 @@ void Condition::collectOverlappingMembers(
           // otherwise only remove the condition if the index is exactly on the
           // same attribute as the condition
 
-          auto identical = index->fields().size() == 1 &&
-                           basics::AttributeName::isIdentical(
-                               result.second, index->fields()[0], false);
-          LOG_DEVEL << ADB_HERE << " " << result.second << " and "
-                    << index->fields()[0];
-          return identical;
+          return index->fields().size() == 1 &&
+                 basics::AttributeName::isIdentical(result.second,
+                                                    index->fields()[0], false);
         }();
 
-        LOG_DEVEL << ADB_HERE << " mayRemoveIndexNonNullAttribute: "
-                  << mayRemoveIndexNonNullAttribute;
         if (mayRemoveIndexNonNullAttribute) {
           toRemove.emplace(i);
           // removed, no need to go on below...
@@ -1112,15 +1103,11 @@ void Condition::collectOverlappingMembers(
       }
     }
 
-    LOG_DEVEL << ADB_HERE << " allowOps: " << allowOps;
     if (isFromTraverser) {
       allowOps = allowOps || operand->isArrayComparisonOperator();
-      LOG_DEVEL << ADB_HERE << " allowOps: " << allowOps;
     } else {
       allowOps = allowOps && operand->type != NODE_TYPE_OPERATOR_BINARY_NE &&
                  operand->type != NODE_TYPE_OPERATOR_BINARY_NIN;
-      LOG_DEVEL << ADB_HERE << " allowOps: " << allowOps
-                << " operand type: " << operand->getTypeString();
     }
 
     if (allowOps) {
@@ -1139,9 +1126,6 @@ void Condition::collectOverlappingMembers(
           ConditionPart current(variable, result.second, operand,
                                 ATTRIBUTE_LEFT, nullptr);
 
-          LOG_DEVEL << ADB_HERE << " Can remove: " << lhs->toString() << " AND "
-                    << rhs->toString() << " canRemove: "
-                    << canRemove(plan, current, otherAndNode, isFromTraverser);
           if (canRemove(plan, current, otherAndNode, isFromTraverser)) {
             toRemove.emplace(i);
           }
@@ -1230,7 +1214,6 @@ AstNode* Condition::removeCondition(ExecutionPlan const* plan,
     return _root;
   }
 
-  LOG_DEVEL << ADB_HERE << " n: " << n << " toRemove: " << toRemove.size();
   // build a new AST condition
   AstNode* newNode = nullptr;
 

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1104,7 +1104,9 @@ void Condition::collectOverlappingMembers(
     }
 
     if (isFromTraverser) {
-      allowOps = allowOps || operand->isArrayComparisonOperator();
+      if (isPathCondition) {
+        allowOps = allowOps || operand->isArrayComparisonOperator();
+      }
     } else {
       allowOps = allowOps && operand->type != NODE_TYPE_OPERATOR_BINARY_NE &&
                  operand->type != NODE_TYPE_OPERATOR_BINARY_NIN;

--- a/arangod/Aql/Condition.cpp
+++ b/arangod/Aql/Condition.cpp
@@ -1061,6 +1061,8 @@ void Condition::collectOverlappingMembers(
     auto operand = andNode->getMemberUnchecked(i);
     bool allowOps = operand->isComparisonOperator();
 
+    // We can enter here only if we have index node, therefore we know that we
+    // are not dealing with the Traversal Node
     if (isSparse && allowOps && !isFromTraverser &&
         (operand->type == NODE_TYPE_OPERATOR_BINARY_NE ||
          operand->type == NODE_TYPE_OPERATOR_BINARY_GT)) {
@@ -1074,9 +1076,8 @@ void Condition::collectOverlappingMembers(
 
       ::clearAttributeAccess(result);
 
-      TRI_ASSERT(!isFromTraverser) << "This is impossible!";
       if (rhs->isNullValue() &&
-          lhs->isAttributeAccessForVariable(result, false) &&
+          lhs->isAttributeAccessForVariable(result, isFromTraverser) &&
           result.first == variable) {
         auto const mayRemoveIndexNonNullAttribute = [&] {
           if (auto ty = index->type();

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -8,7 +8,7 @@ if [ $(ulimit -S -n) -lt 131072 ]; then
     ulimit -S -n 131072 || true
 fi
 
-rm -rf cluster
+#rm -rf cluster
 if [ -d cluster-init ];then
   echo "== creating cluster directory from existing cluster-init directory"
   cp -a cluster-init cluster

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -55,6 +55,10 @@ describe('Single Traversal Optimizer', function () {
     expect(findExecutionNodes(plan, "FilterNode").length).to.equal(0, "Plan should have no filter node");
   };
 
+  const hasFilterNode = (plan) => {
+    expect(findExecutionNodes(plan, "FilterNode").length).to.equal(1, "Plan should have a single filter node");
+  };
+
   const validateResult = (query, bindVars) => {
     let resultOpt = db._query(query, bindVars, activateOptimizer).toArray().sort();
     let resultNoOpt = db._query(query, bindVars, deactivateOptimizer).toArray().sort();
@@ -76,7 +80,7 @@ describe('Single Traversal Optimizer', function () {
       edges.push({_from: startId, _to: `${vertexCollection}/a${i}`, foo: i});
       for (let j = 0; j < 10; ++j) {
         vertices.push({_key: `a${i}${j}`, foo: j});
-        edges.push({_from: `${vertexCollection}/a${i}`, _to: `${vertexCollection}/a${i}${j}`, foo: j});
+        edges.push({_from: `${vertexCollection}/a${i}`, _to: `${vertexCollection}/a${i}${j}`, foo: j, bar: [1, 2, 3, 4, 5]});
       }
     }
 
@@ -145,7 +149,7 @@ describe('Single Traversal Optimizer', function () {
       // BTS-2182
       it('on v.foo != 3 AND v.foo < 10', () => {
         let query = `WITH @@vertices
-                       FOR v, e IN 0 OUTBOUND @start @@edges
+                       FOR v, e IN 0..2 ANY @start @@edges
                        FILTER v.foo < 10
                        FILTER v.foo != 3
                        RETURN v`;
@@ -156,7 +160,7 @@ describe('Single Traversal Optimizer', function () {
 
       it('on e.bar != 4 AND v.foo < 10 AND v.foo != 3', () => {
         let query = `WITH @@vertices
-                       FOR v, e IN 0 OUTBOUND @start @@edges
+                       FOR v, e IN 0..2 ANY @start @@edges
                        FILTER e.bar != 4
                        FILTER v.foo < 10 AND v.foo != 3
                        RETURN v`;
@@ -164,9 +168,32 @@ describe('Single Traversal Optimizer', function () {
         hasNoFilterNode(plan);
         validateResult(query, bindVars);
       });
- 
-    });
 
+      // This check that in array will not be handler by Traversal Node
+      it('on p.edges[*].foo ALL > 3 AND FILTER v.bar[*] ALL < 10', () => {
+        let query = `WITH @@vertices
+                       FOR v, e, p IN 0..2 ANY @start @@edges
+                       FILTER p.edges[*].foo ALL > 3
+                       FILTER v.bar[*] ALL < 10
+                       RETURN v`;
+        let plan = db._createStatement({query: query, bindVars:  bindVars, options:  activateOptimizer}).explain();
+
+        hasFilterNode(plan);
+        validateResult(query, bindVars);
+      });
+
+      it('on p.edges[*].foo ALL > 3 AND e.bar[*] ANY == 3', () => {
+        let query = `WITH @@vertices
+                       FOR v, e, p IN OUTBOUND @start @@edges
+                       FILTER p.edges[*].foo ALL > 3
+                       FILTER e.bar[*] ANY == 2
+                       RETURN v`;
+        let plan = db._createStatement({query: query, bindVars:  bindVars, options:  activateOptimizer}).explain();
+
+        hasFilterNode(plan);
+        validateResult(query, bindVars);
+      });
+    });
   });
 
 });

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -141,10 +141,32 @@ describe('Single Traversal Optimizer', function () {
         hasNoFilterNode(plan);
         validateResult(query, bindVars);
       });
+
+      // BTS-2182
+      it('on v.foo != 3 AND v.foo < 10', () => {
+        let query = `WITH @@vertices
+                       FOR v, e IN 0 OUTBOUND @start @@edges
+                       FILTER v.foo < 10
+                       FILTER v.foo != 3
+                       RETURN v`;
+        let plan = db._createStatement({query: query, bindVars:  bindVars, options:  activateOptimizer}).explain();
+        hasNoFilterNode(plan);
+        validateResult(query, bindVars);
+      });
+
+      it('on e.bar != 4 AND v.foo < 10 AND v.foo != 3', () => {
+        let query = `WITH @@vertices
+                       FOR v, e IN 0 OUTBOUND @start @@edges
+                       FILTER e.bar != 4
+                       FILTER v.foo < 10 AND v.foo != 3
+                       RETURN v`;
+        let plan = db._createStatement({query: query, bindVars:  bindVars, options:  activateOptimizer}).explain();
+        hasNoFilterNode(plan);
+        validateResult(query, bindVars);
+      });
  
     });
 
   });
-
 
 });


### PR DESCRIPTION
### Scope & Purpose

Filter nodes are not being properly handled when `!=` operator is present when it is coming before TraversalNode. e.g. for the query:
```
FOR v, e IN 1 OUTBOUND 'col1/node_0' Graph myGraph
OPTIONS {edgeCollections:['ec1'], vertexCollections:['col1']}
FILTER e.type == 'ec1'
FILTER (v['value'] > 1000) AND v.value2 != true
RETURN 1
```
The generated plan was:
```
 Id   NodeType          Site  Par   Est.   Comment
  1   SingletonNode     COOR           1   * ROOT
  2   TraversalNode     COOR           7     - FOR v  /* vertex (projections: `value2`, `value`) */, e  /* edge (projections: `_from`, `_id`, `_to`, `type`) */ IN 1..1  /* min..maxPathDepth */ OUTBOUND 'col1/node_0' /* startnode */  GRAPH 'myGraph' /* order: dfs */
 10   CalculationNode   COOR           7       - LET #4 = (v.`value2` != true)   /* simple expression */
  6   FilterNode        COOR           7       - FILTER #4


Traversals on graphs:
 Id  Depth  Vertex collections  Edge collections  Options                                              Filter / Prune Conditions
 2   1..1   col1                ec1               uniqueVertices: none, uniqueEdges: path, order: dfs  FILTER ((e.`type` == "ec1") && (v.`value2` != true) && (v.`value` > 1000))
```
And now should be:
```
 Id   NodeType          Site  Par   Est.   Comment
  1   SingletonNode     COOR           1   * ROOT
  2   TraversalNode     COOR           7     - FOR v  /* vertex (projections: `value2`, `value`) */, e  /* edge (projections: `_from`, `_id`, `_to`, `type`) */ IN 1..1  /* min..maxPathDepth */ OUTBOUND 'col1/node_0' /* startnode */  GRAPH 'myGraph' /* order: dfs */

Traversals on graphs:
 Id  Depth  Vertex collections  Edge collections  Options                                              Filter / Prune Conditions
 2   1..1   col1                ec1               uniqueVertices: none, uniqueEdges: path, order: dfs  FILTER ((e.`type` == "ec1") && (v.`value2` != true) && (v.`value` > 1000))
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2182
- [ ] Design document: 
