### PR TITLE
Bug fix/bts 2184

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+ * Fix BTS-2184: Vector index creation fails on documents which don't have
+  and embedding field defined.
+
 * Fix BTS-2174: When a more complex query get's killed and the server
   (or DBServer in the cluster) is under high query load, there was a
   race condition in the asynchrounous query execution which would cause

--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -317,6 +317,40 @@ function VectorIndexTestCreationWithVectors() {
                     e.errorNum);
             }
         },
+
+        testCreatingVectorIndexWhenFieldNotPresent: function() {
+            let gen = randomNumberGeneratorFloat(seed);
+
+            let docs = [];
+            for (let i = 0; i < 20; ++i) {
+                if (i > 10) {
+                  const vector = Array.from({
+                      length: dimension
+                  }, () => gen());
+                  docs.push({vector});
+                } else {
+                  docs.push({value: i});
+                }
+            }
+            collection.insert(docs);
+
+            try {
+                let result = collection.ensureIndex({
+                    name: "vector_l2",
+                    type: "vector",
+                    fields: ["vector"],
+                    inBackground: false,
+                    params: {
+                        metric: "l2",
+                        dimension: dimension,
+                        nLists: 1,
+                        trainingIterations: 10,
+                    },
+                });
+            } catch (e) {
+                assertEqual(undefined, e);
+            }
+        },
     };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Vector index creation fails on documents that don't have an embedding field defined. Now these documents are being ignored and are not handled by the vector index.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2184
- [ ] Design document: 
