### PR TITLE
Fix flaky test `acquire_endpoint` 

### DIFF
--- a/tests/Mocks/MockTcpDummyServer.h
+++ b/tests/Mocks/MockTcpDummyServer.h
@@ -32,121 +32,119 @@ using boost::asio::ip::tcp;
 
 namespace {
 
-  // Simple session class to handle an individual connection
-  class Session : public std::enable_shared_from_this<Session> {
-   public:
-    Session(tcp::socket socket) : socket_(std::move(socket)) {}
+// Simple session class to handle an individual connection
+class Session : public std::enable_shared_from_this<Session> {
+ public:
+  Session(tcp::socket socket) : socket_(std::move(socket)) {}
 
-    void start() { do_read(); }
+  void start() { do_read(); }
 
-    void stop() {
-      if (socket_.is_open()) {
-        boost::system::error_code ec;
-        std::ignore = socket_.close(ec);
-      }
+  void stop() {
+    if (socket_.is_open()) {
+      boost::system::error_code ec;
+      std::ignore = socket_.close(ec);
+    }
+  }
+
+ private:
+  void do_read() {
+    auto self(shared_from_this());
+    socket_.async_read_some(
+        boost::asio::buffer(data_),
+        [this, self](boost::system::error_code ec, std::size_t length) {
+          if (!ec) {
+            handle_http_request(length);
+          } else {
+            // Connection closed or error occurred
+            stop();
+          }
+        });
+  }
+
+  void handle_http_request(std::size_t length) {
+    // Create a simple HTTP response
+    std::string response_body = "Hello from TCP Dummy Server!\n";
+    response_body += "Received " + std::to_string(length) + " bytes.\n";
+
+    std::string response =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/plain\r\n"
+        "Content-Length: " +
+        std::to_string(response_body.length()) +
+        "\r\n"
+        "Connection: close\r\n"
+        "\r\n" +
+        response_body;
+
+    do_write(response);
+  }
+
+  void do_write(const std::string& response) {
+    auto self(shared_from_this());
+
+    boost::asio::async_write(
+        socket_, boost::asio::buffer(response),
+        [this, self](boost::system::error_code ec, std::size_t /*length*/) {
+          if (!ec) {
+            // Close the connection after sending response
+            stop();
+          } else {
+            // Write error occurred
+            stop();
+          }
+        });
+  }
+
+  tcp::socket socket_;
+  std::array<char, 1024> data_;  // Buffer for received data
+};
+
+// Server class to accept new connections
+class TcpDummyServer {
+ public:
+  TcpDummyServer(boost::asio::io_context& io_context, short port)
+      : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)), running_(true) {
+    do_accept();
+  }
+
+  ~TcpDummyServer() { stop(); }
+
+  void stop() {
+    running_ = false;
+    if (acceptor_.is_open()) {
+      boost::system::error_code ec;
+      std::ignore = acceptor_.close(ec);
+    }
+  }
+
+ private:
+  void do_accept() {
+    if (!running_) {
+      return;
     }
 
-   private:
-    void do_read() {
-      auto self(shared_from_this());
-      socket_.async_read_some(
-          boost::asio::buffer(data_),
-          [this, self](boost::system::error_code ec, std::size_t length) {
-            if (!ec) {
-              handle_http_request(length);
-            } else {
-              // Connection closed or error occurred
-              stop();
-            }
-          });
-    }
+    acceptor_.async_accept(
+        [this](boost::system::error_code ec, tcp::socket socket) {
+          if (!ec && running_) {
+            std::make_shared<Session>(std::move(socket))->start();
+          }
+          // Continue accepting new connections only if still running
+          if (running_) {
+            do_accept();
+          }
+        });
+  }
 
-    void handle_http_request(std::size_t length) {
-      // Create a simple HTTP response
-      std::string response_body = "Hello from TCP Dummy Server!\n";
-      response_body += "Received " + std::to_string(length) + " bytes.\n";
-      
-      std::string response = 
-          "HTTP/1.1 200 OK\r\n"
-          "Content-Type: text/plain\r\n"
-          "Content-Length: " + std::to_string(response_body.length()) + "\r\n"
-          "Connection: close\r\n"
-          "\r\n" + response_body;
-      
-      do_write(response);
-    }
-
-    void do_write(const std::string& response) {
-      auto self(shared_from_this());
-      
-      boost::asio::async_write(
-          socket_, boost::asio::buffer(response),
-          [this, self](boost::system::error_code ec, std::size_t /*length*/) {
-            if (!ec) {
-              // Close the connection after sending response
-              stop();
-            } else {
-              // Write error occurred
-              stop();
-            }
-          });
-    }
-
-    tcp::socket socket_;
-    std::array<char, 1024> data_;  // Buffer for received data
-  };
-
-  // Server class to accept new connections
-  class TcpDummyServer {
-   public:
-    TcpDummyServer(boost::asio::io_context& io_context, short port)
-        : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)), 
-          running_(true) {
-      do_accept();
-    }
-
-    ~TcpDummyServer() {
-      stop();
-    }
-
-    void stop() {
-      running_ = false;
-      if (acceptor_.is_open()) {
-        boost::system::error_code ec;
-        std::ignore = acceptor_.close(ec);
-      }
-    }
-
-   private:
-    void do_accept() {
-      if (!running_) {
-        return;
-      }
-      
-      acceptor_.async_accept(
-          [this](boost::system::error_code ec, tcp::socket socket) {
-            if (!ec && running_) {
-              std::make_shared<Session>(std::move(socket))->start();
-            }
-            // Continue accepting new connections only if still running
-            if (running_) {
-              do_accept();
-            }
-          });
-    }
-
-    tcp::acceptor acceptor_;
-    std::atomic<bool> running_;
-  };
-}
+  tcp::acceptor acceptor_;
+  std::atomic<bool> running_;
+};
+}  // namespace
 
 class MockTcpServer final {
-public:
-  MockTcpServer(int port): tcpDummyServer(io_context, port) {}
+ public:
+  MockTcpServer(int port) : tcpDummyServer(io_context, port) {}
 
-  ~MockTcpServer() {
-    TRI_ASSERT(io_context.stopped());
-  }
+  ~MockTcpServer() { TRI_ASSERT(io_context.stopped()); }
 
   void start() {
     serverThread = std::jthread([this]() { io_context.run(); });
@@ -160,10 +158,10 @@ public:
     }
   }
 
-private:
+ private:
   boost::asio::io_context io_context;
   std::jthread serverThread;
   TcpDummyServer tcpDummyServer;
 };
 
-}
+}  // namespace arangodb::tests::mocks

--- a/tests/Mocks/MockTcpDummyServer.h
+++ b/tests/Mocks/MockTcpDummyServer.h
@@ -1,0 +1,169 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2025 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jure Bajic
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <thread>
+
+#include <boost/asio.hpp>
+#include "Assertions/Assert.h"
+
+namespace arangodb::tests::mocks {
+using boost::asio::ip::tcp;
+
+namespace {
+
+  // Simple session class to handle an individual connection
+  class Session : public std::enable_shared_from_this<Session> {
+   public:
+    Session(tcp::socket socket) : socket_(std::move(socket)) {}
+
+    void start() { do_read(); }
+
+    void stop() {
+      if (socket_.is_open()) {
+        boost::system::error_code ec;
+        std::ignore = socket_.close(ec);
+      }
+    }
+
+   private:
+    void do_read() {
+      auto self(shared_from_this());
+      socket_.async_read_some(
+          boost::asio::buffer(data_),
+          [this, self](boost::system::error_code ec, std::size_t length) {
+            if (!ec) {
+              handle_http_request(length);
+            } else {
+              // Connection closed or error occurred
+              stop();
+            }
+          });
+    }
+
+    void handle_http_request(std::size_t length) {
+      // Create a simple HTTP response
+      std::string response_body = "Hello from TCP Dummy Server!\n";
+      response_body += "Received " + std::to_string(length) + " bytes.\n";
+      
+      std::string response = 
+          "HTTP/1.1 200 OK\r\n"
+          "Content-Type: text/plain\r\n"
+          "Content-Length: " + std::to_string(response_body.length()) + "\r\n"
+          "Connection: close\r\n"
+          "\r\n" + response_body;
+      
+      do_write(response);
+    }
+
+    void do_write(const std::string& response) {
+      auto self(shared_from_this());
+      
+      boost::asio::async_write(
+          socket_, boost::asio::buffer(response),
+          [this, self](boost::system::error_code ec, std::size_t /*length*/) {
+            if (!ec) {
+              // Close the connection after sending response
+              stop();
+            } else {
+              // Write error occurred
+              stop();
+            }
+          });
+    }
+
+    tcp::socket socket_;
+    std::array<char, 1024> data_;  // Buffer for received data
+  };
+
+  // Server class to accept new connections
+  class TcpDummyServer {
+   public:
+    TcpDummyServer(boost::asio::io_context& io_context, short port)
+        : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)), 
+          running_(true) {
+      do_accept();
+    }
+
+    ~TcpDummyServer() {
+      stop();
+    }
+
+    void stop() {
+      running_ = false;
+      if (acceptor_.is_open()) {
+        boost::system::error_code ec;
+        std::ignore = acceptor_.close(ec);
+      }
+    }
+
+   private:
+    void do_accept() {
+      if (!running_) {
+        return;
+      }
+      
+      acceptor_.async_accept(
+          [this](boost::system::error_code ec, tcp::socket socket) {
+            if (!ec && running_) {
+              std::make_shared<Session>(std::move(socket))->start();
+            }
+            // Continue accepting new connections only if still running
+            if (running_) {
+              do_accept();
+            }
+          });
+    }
+
+    tcp::acceptor acceptor_;
+    std::atomic<bool> running_;
+  };
+}
+
+class MockTcpServer final {
+public:
+  MockTcpServer(int port): tcpDummyServer(io_context, port) {}
+
+  ~MockTcpServer() {
+    TRI_ASSERT(io_context.stopped());
+  }
+
+  void start() {
+    serverThread = std::jthread([this]() { io_context.run(); });
+  }
+
+  void stop() {
+    tcpDummyServer.stop();
+    io_context.stop();
+    if (serverThread.joinable()) {
+      serverThread.join();
+    }
+  }
+
+private:
+  boost::asio::io_context io_context;
+  std::jthread serverThread;
+  TcpDummyServer tcpDummyServer;
+};
+
+}

--- a/tests/Network/ConnectionPoolTest.cpp
+++ b/tests/Network/ConnectionPoolTest.cpp
@@ -101,14 +101,14 @@ TEST_F(NetworkConnectionPoolTest, prune_while_in_flight) {
 
   {
     bool isFromPool;
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        waiter);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:82", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -179,19 +179,21 @@ TEST_F(NetworkConnectionPoolTest, acquire_multiple_endpoint) {
   ConnectionPool pool(config);
 
   bool isFromPool;
-  auto conn1 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+  auto conn1 =
+      pool.leaseConnection(fmt::format("tcp://127.0.0.1:{}", port), isFromPool);
 
   conn1->sendRequest(
       fuerte::createRequest(fuerte::RestVerb::Get, fuerte::ContentType::Unset),
       doNothing);
 
-  auto conn2 = pool.leaseConnection("tcp://example.org:80", isFromPool);
+  auto conn2 =
+      pool.leaseConnection(fmt::format("tcp://127.0.0.1:{}", port), isFromPool);
 
   ASSERT_NE(conn1.get(), conn2.get());
   ASSERT_EQ(pool.numOpenConnections(), 2);
   EXPECT_EQ(extractCurrentMetric(), 2ull);
 
-  auto conn3 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+  auto conn3 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
   ASSERT_NE(conn1.get(), conn3.get());
 
   ASSERT_EQ(pool.numOpenConnections(), 3);
@@ -212,14 +214,14 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_one) {
 
   {
     bool isFromPool;
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:82", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -257,14 +259,14 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
 
   bool isFromPool;
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:82", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -296,11 +298,11 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:82", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -317,14 +319,14 @@ TEST_F(NetworkConnectionPoolTest, release_multiple_endpoints_two) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:82", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -381,14 +383,14 @@ TEST_F(NetworkConnectionPoolTest, force_drain) {
 
   bool isFromPool;
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
     conn1->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.0:81", isFromPool);
     conn2->sendRequest(fuerte::createRequest(fuerte::RestVerb::Get,
                                              fuerte::ContentType::Unset),
                        doNothing);
@@ -416,7 +418,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
 
   bool isFromPool;
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
@@ -424,7 +426,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -433,7 +435,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn3 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn3 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_NE(conn1.get(), conn3.get());
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 3);
@@ -463,7 +465,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
@@ -471,7 +473,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
@@ -480,7 +482,7 @@ TEST_F(NetworkConnectionPoolTest, checking_min_and_max_connections) {
                                              fuerte::ContentType::Unset),
                        doNothing);
 
-    auto conn3 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn3 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_NE(conn1.get(), conn3.get());
     ASSERT_NE(conn1.get(), conn2.get());
     ASSERT_EQ(pool.numOpenConnections(), 3);
@@ -528,7 +530,7 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
 
   bool isFromPool;
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
   }
@@ -548,11 +550,11 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
@@ -571,15 +573,15 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
 
-    auto conn3 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn3 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
     EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
@@ -612,11 +614,11 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
 
   bool isFromPool;
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
@@ -636,11 +638,11 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.0:81", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
   }
@@ -660,15 +662,15 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
 
-    auto conn3 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+    auto conn3 = pool.leaseConnection("tcp://127.0.0.0:81", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
     EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
@@ -688,24 +690,24 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
 
-    auto conn3 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn3 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 3);
     EXPECT_EQ(extractCurrentMetric(), 3ull);
   }
   {
-    auto conn4 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+    auto conn4 = pool.leaseConnection("tcp://127.0.0.0:81", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 4);
     EXPECT_EQ(extractCurrentMetric(), 4ull);
 
-    auto conn5 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+    auto conn5 = pool.leaseConnection("tcp://127.0.0.0:81", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 5);
     EXPECT_EQ(extractCurrentMetric(), 5ull);
 
@@ -723,11 +725,11 @@ TEST_F(NetworkConnectionPoolTest, checking_expiration_multiple_endpints) {
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://example.com:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.0:81", isFromPool);
     ASSERT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
 
@@ -765,17 +767,17 @@ TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
 
   bool isFromPool;
   {
-    auto conn1 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn1 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     EXPECT_FALSE(isFromPool);
     EXPECT_EQ(pool.numOpenConnections(), 1);
     EXPECT_EQ(extractCurrentMetric(), 1ull);
 
-    auto conn2 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn2 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     EXPECT_FALSE(isFromPool);
     EXPECT_EQ(pool.numOpenConnections(), 2);
     EXPECT_EQ(extractCurrentMetric(), 2ull);
 
-    auto conn3 = pool.leaseConnection("tcp://examplexxx.org:80", isFromPool);
+    auto conn3 = pool.leaseConnection("tcp://127.0.0.1:80", isFromPool);
     EXPECT_FALSE(isFromPool);
     EXPECT_EQ(pool.numOpenConnections(), 3);
     EXPECT_EQ(extractCurrentMetric(), 3ull);
@@ -784,14 +786,14 @@ TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_all) {
   EXPECT_EQ(extractCurrentMetric(), 3ull);
 
   // cancel all connections
-  pool.cancelConnections("tcp://examplexxx.org:80");
+  pool.cancelConnections("tcp://127.0.0.1:80");
   EXPECT_EQ(pool.numOpenConnections(), 0);
   EXPECT_EQ(extractCurrentMetric(), 0ull);
 }
 
 TEST_F(NetworkConnectionPoolTest, test_cancel_endpoint_some) {
-  std::string endpointA = "tcp://examplexxx.org:80";
-  std::string endpointB = "tcp://examplexxx.org:800";
+  std::string endpointA = "tcp://127.0.0.1:80";
+  std::string endpointB = "tcp://127.0.0.1:800";
   ConnectionPool::Config config;
   config.metrics = ConnectionPool::Metrics::fromMetricsFeature(
       server.getFeature<metrics::MetricsFeature>(), "");


### PR DESCRIPTION
### Scope & Purpose

The test was pinging a random site, and one test case always checks the status code of the response. That is a flaky behaviour since the server can block our requests if they happen many times... This eliminates the reliance on a random URL and utilizes a dummy TCP server.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
