### PR TITLE
Hotfix: bts-2152 fix overfetch input on parallel traversals

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,30 +1,23 @@
 3.12.5.1 (XXXX-XX-XX)
-
-* Fix BTS-2174: When a more complex query get's killed and the server
-  (or DBServer in the cluster) is under high query load, there was a
-  race condition in the asynchrounous query execution which would cause
-  the kill process of the query to get stuck. This race was one
-  of the root causes for a stall which was fixed in BTS-2135 previously.
-  This situation could only be reached if the async-prefetch optimizer rule
-  is active, which can only be applied on read-only queries.
+---------------------
 
 * Fix BTS-2152 Overfetch input on parallel Traversals. For queries like this:
-  
+
   FOR x IN largeCollection
     FOR v IN 1 OUTBOUND x edges {parallelism: 4}
       LIMIT 10
       RETURN v
-  
-  Before this bugfix we would always enumerate largeCollection in full,
-  even though a small portion of the collection would have sufficed.
-  This is now handled better. We now enumerate only the necessary amount
-  of batches required to fulfill the limit.
-  This also improves cluster queries (replace the traversal with another FOR loop)
-  which had the same behaviour and are now enumerating less unused
+
+  Before this bugfix we would always enumerate largeCollection in full, even
+  though a small portion of the collection would have sufficed.
+  This is now handled better. We now enumerate only the necessary amount of
+  batches required to fulfill the limit.
+  This also improves cluster queries (replace the traversal with another FOR
+  loop) which had the same behaviour and are now enumerating less unused
   intermediate results.
-  Please Note: If the above situation is encapsulated inside a subquery
-  like this:
-  
+  Please Note: If the above situation is encapsulated inside a subquery like
+  this:
+
   FOR y IN 1..2
   LET subquery = (
     FOR x IN largeCollection
@@ -36,9 +29,17 @@
 
   The issue still exists.
 
+* Fix BTS-2174: When a more complex query get's killed and the server
+  (or DBServer in the cluster) is under high query load, there was a
+  race condition in the asynchrounous query execution which would cause
+  the kill process of the query to get stuck. This race was one
+  of the root causes for a stall which was fixed in BTS-2135 previously.
+  This situation could only be reached if the async-prefetch optimizer rule
+  is active, which can only be applied on read-only queries.
 
 * Add option --database.auto-upgrade-full-compaction to run a full RocksDB
   compaction on database upgrade.
+
 
 3.12.5 (2025-06-18)
 -------------------

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,20 @@
   This also improves cluster queries (replace the traversal with another FOR loop)
   which had the same behaviour and are now enumerating less unused
   intermediate results.
+  Please Note: If the above situation is encapsulated inside a subquery
+  like this:
+  
+  FOR y IN 1..2
+  LET subquery = (
+    FOR x IN largeCollection
+      FOR v IN 1 OUTBOUND x edges {parallelism: 4}
+        LIMIT 10
+        RETURN v
+  )
+  RETURN {y, subquery}
+
+  The issue still exists.
+
 
 * Add option --database.auto-upgrade-full-compaction to run a full RocksDB
   compaction on database upgrade.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,21 @@
   This situation could only be reached if the async-prefetch optimizer rule
   is active, which can only be applied on read-only queries.
 
+* Fix BTS-2152 Overfetch input on prallel Traversals. For queries like this:
+  
+  FOR x IN largeCollection
+    FOR v IN 1 OUTBOUND x edges {parallelism: 4}
+      LIMIT 10
+      RETURN v
+  
+  Before this bugfix we would always enumerate largeCollection in full,
+  even though a small portion of the collection would have sufficed.
+  This is now handled better. We now enumerate only the necessary amount
+  of batches required to fulfill the limit.
+  This also improves cluster queries (replace the traversal with another FOR loop)
+  which had the same behaviour and are now enumerating less unused
+  intermediate results.
+
 * Add option --database.auto-upgrade-full-compaction to run a full RocksDB
   compaction on database upgrade.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@
   This situation could only be reached if the async-prefetch optimizer rule
   is active, which can only be applied on read-only queries.
 
-* Fix BTS-2152 Overfetch input on prallel Traversals. For queries like this:
+* Fix BTS-2152 Overfetch input on parallel Traversals. For queries like this:
   
   FOR x IN largeCollection
     FOR v IN 1 OUTBOUND x edges {parallelism: 4}

--- a/arangod/Aql/BlocksWithClients.cpp
+++ b/arangod/Aql/BlocksWithClients.cpp
@@ -199,9 +199,62 @@ auto BlocksWithClientsImpl<Executor>::executeWithoutTraceForClient(
   auto callList = stack.popCall();
   auto call = callList.peekNextCall();
 
+  auto& dataContainer = it->second;
+  /*
+   * In this block we need to handle the following behavior:
+   * 1) Call without a hardLimit:
+   * - Pull what is already on the dataContainer,
+   * - if dataContainer does not have more data, fetch more from upstream.
+   *
+   * 2) Call with a hardLimit = 0, without fullCount:
+   * - This indicates this lane is complete and does not need more data.
+   * - Clear what is still active in the dataContainer. (Do not drop ShadowRows)
+   * - If all other lanes already reported a hardLimit, and upstream still
+   * HASMORE, then send hardLimit to upstream.
+   *
+   * 3) Call with hardLimit = 0 and fullCount:
+   * - This indicates this lane is ready to skip and count.
+   * - I do not think that this is possible in practice. Therefore this will be
+   * asserted, but in prod handled like case 1.
+   * - As case 1 is slower then necessary, but always correct.
+   *
+   * Also NOTE: We are only doing this in the main query, not in subqueries. In
+   * the main query we can simply return DONE with an empty block. For
+   * subqueries we would need to return a ShadowRow. However, the row is not yet
+   * available, if upstream is not fully consumed. We can only fix this by
+   * returning WAITING here, and waking up the caller, as soon as the ShadowRow
+   * is available.
+   */
+  if (stack.empty() && call.hasHardLimit() && call.getLimit() == 0 &&
+      !call.fullCount) {
+    dataContainer.setSeenHardLimit();
+    // Need to handle this case separately, as we do not want to fetch more
+    // data from upstream.
+    // We will not be able to fetch any more rows.
+    // Clear what is still active in the dataContainer. (Do not drop ShadowRows)
+    if (dataContainer.hasDataFor(call)) {
+      stack.pushCall(callList);
+      while (dataContainer.hasDataFor(call)) {
+        // Just clear out what is still on the queue.
+        std::ignore = dataContainer.execute(stack, _upstreamState);
+      }
+      stack.popCall();
+    }
+    if (allLanesComplete() && _upstreamState != ExecutionState::DONE) {
+      // We send a hardLimit to the dependency to skip over remaining rows.
+      auto state = hardLimitDependency(stack);
+      if (state == ExecutionState::WAITING) {
+        return {state, SkipResult{}, nullptr};
+      }
+      _upstreamState = state;
+    }
+    // Report everything is consumed.
+    return {ExecutionState::DONE, SkipResult{}, nullptr};
+  }
+
+  // We are done, with everything, we will not be able to fetch any more
   // We do not have anymore data locally.
   // Need to fetch more from upstream
-  auto& dataContainer = it->second;
   while (true) {
     while (!dataContainer.hasDataFor(call)) {
       if (_upstreamState == ExecutionState::DONE) {
@@ -231,6 +284,43 @@ auto BlocksWithClientsImpl<Executor>::executeWithoutTraceForClient(
       stack.popCall();
     }
   }
+}
+
+template<class Executor>
+auto BlocksWithClientsImpl<Executor>::hardLimitDependency(AqlCallStack stack)
+    -> ExecutionState {
+  if (_engine->getQuery().killed()) {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_KILLED);
+  }
+
+  // NOTE: We do not handle limits / skip here
+  // They can differ between different calls to this executor.
+  // We may need to revisit this for performance reasons.
+  stack.pushCall(AqlCallList{AqlCall{0, false, 0, AqlCall::LimitType::HARD}});
+
+  TRI_ASSERT(_dependencies.size() == 1);
+  auto [state, skipped, block] = _dependencies[0]->execute(stack);
+
+  // We could need the row in a different block, and once skipped
+  // we cannot get it back.
+  TRI_ASSERT(skipped.getSkipCount() == 0);
+
+  TRI_IF_FAILURE("ExecutionBlock::getBlock") {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+  }
+
+  // Waiting -> no block
+  TRI_ASSERT(state != ExecutionState::WAITING || block == nullptr);
+
+  if (state != ExecutionState::WAITING && block != nullptr) {
+    // We need to report everything that is not waiting
+    // Here this could be a ShadowRow!
+    TRI_ASSERT(false) << "Right now we cannot get here, as the optimization is "
+                         "not yet active on subqueries.";
+    _executor.distributeBlock(block, skipped, _clientBlockData);
+  }
+
+  return state;
 }
 
 template<class Executor>
@@ -266,6 +356,25 @@ auto BlocksWithClientsImpl<Executor>::fetchMore(AqlCallStack stack)
 
   return state;
 }
+
+template<class Executor>
+auto BlocksWithClientsImpl<Executor>::allLanesComplete() const noexcept
+    -> bool {
+  return std::ranges::none_of(_clientBlockData, [](const auto& entry) {
+    return !entry.second.gotHardLimit();
+  });
+}
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+template<class Executor>
+auto BlocksWithClientsImpl<Executor>::remainingRowsForClient(
+    std::string const& clientId) const -> uint64_t {
+  auto it = _clientBlockData.find(clientId);
+  TRI_ASSERT(it != _clientBlockData.end())
+      << "Test setup issue, clientId " << clientId << " is not registered";
+  return it->second.remainingRows();
+}
+#endif
 
 template class ::arangodb::aql::BlocksWithClientsImpl<ScatterExecutor>;
 template class ::arangodb::aql::BlocksWithClientsImpl<DistributeExecutor>;

--- a/arangod/Aql/DistributeClientBlock.cpp
+++ b/arangod/Aql/DistributeClientBlock.cpp
@@ -88,6 +88,14 @@ auto DistributeClientBlock::clear() -> void {
 auto DistributeClientBlock::addBlock(SkipResult const& skipResult,
                                      SharedAqlItemBlockPtr block,
                                      std::vector<size_t> usedIndexes) -> void {
+  if (gotHardLimit()) {
+    // We have already seen a hard limit, so we do not need to add more data.
+    TRI_ASSERT(!block->hasShadowRows())
+        << "The logic here is not implemented yet for subqueries. If we want "
+           "to activate it, we need to move the ShadowRow over even if we have "
+           "seen a hardLimit.";
+    return;
+  }
   TRI_ASSERT(!usedIndexes.empty() || block == nullptr);
   _queue.emplace_back(skipResult, std::move(block), std::move(usedIndexes));
 }
@@ -216,3 +224,29 @@ auto DistributeClientBlock::execute(AqlCallStack callStack,
   }
   return {state, std::move(skipped), std::move(result)};
 }
+
+/**
+ * @brief Check if we have received a hard limit
+ * @return true if we have received a hard limit
+ */
+auto DistributeClientBlock::gotHardLimit() const -> bool {
+  return _gotHardLimit;
+}
+
+/**
+ * @brief Reset the hard limit
+ */
+auto DistributeClientBlock::resetHardLimit() -> void { _gotHardLimit = false; }
+
+/**
+ * @brief Set hard limit has been seen.
+ */
+auto DistributeClientBlock::setSeenHardLimit() -> void { _gotHardLimit = true; }
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+auto DistributeClientBlock::remainingRows() const -> uint64_t {
+  return std::accumulate(
+      _queue.begin(), _queue.end(), 0,
+      [](uint64_t sum, auto const& item) { return sum + item.numRows(); });
+}
+#endif

--- a/arangod/Aql/DistributeClientBlock.h
+++ b/arangod/Aql/DistributeClientBlock.h
@@ -73,6 +73,26 @@ class DistributeClientBlock {
   auto execute(AqlCallStack callStack, ExecutionState upstreamState)
       -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
 
+  /**
+   * @brief Check if we have received a hard limit
+   * @return true if we have received a hard limit
+   */
+  auto gotHardLimit() const -> bool;
+
+  /**
+   * @brief Reset the hard limit
+   */
+  auto resetHardLimit() -> void;
+
+  /**
+   * @brief Set hard limit has been seen.
+   */
+  auto setSeenHardLimit() -> void;
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  auto remainingRows() const -> uint64_t;
+#endif
+
  private:
   /**
    * @brief This call will join as many blocks as available from the queue
@@ -96,6 +116,7 @@ class DistributeClientBlock {
   // This is unique_ptr to get away with everything being forward declared...
   std::unique_ptr<ExecutionBlock> _executor;
   bool _executorHasMore = false;
+  bool _gotHardLimit = false;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Executor/ScatterExecutor.cpp
+++ b/arangod/Aql/Executor/ScatterExecutor.cpp
@@ -123,6 +123,25 @@ auto ScatterExecutor::ClientBlockData::execute(AqlCallStack const& callStack,
   return {state, std::move(skipped), std::move(result)};
 }
 
+auto ScatterExecutor::ClientBlockData::remainingRows() const -> uint64_t {
+  return std::accumulate(_queue.begin(), _queue.end(), 0,
+                         [](uint64_t sum, auto const& item) {
+                           return sum + std::get<0>(item)->numRows();
+                         });
+}
+
+auto ScatterExecutor::ClientBlockData::gotHardLimit() const -> bool {
+  return _gotHardLimit;
+}
+
+auto ScatterExecutor::ClientBlockData::resetHardLimit() -> void {
+  _gotHardLimit = false;
+}
+
+auto ScatterExecutor::ClientBlockData::setSeenHardLimit() -> void {
+  _gotHardLimit = true;
+}
+
 ScatterExecutor::ScatterExecutor(Infos const&) {}
 
 auto ScatterExecutor::distributeBlock(

--- a/arangod/Aql/Executor/ScatterExecutor.h
+++ b/arangod/Aql/Executor/ScatterExecutor.h
@@ -59,11 +59,30 @@ class ScatterExecutor {
     auto execute(AqlCallStack const& callStack, ExecutionState upstreamState)
         -> std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>;
 
+    auto remainingRows() const -> uint64_t;
+
+    /**
+     * @brief Check if we have received a hard limit
+     * @return true if we have received a hard limit
+     */
+    auto gotHardLimit() const -> bool;
+
+    /**
+     * @brief Reset the hard limit
+     */
+    auto resetHardLimit() -> void;
+
+    /**
+     * @brief Set hard limit has been seen.
+     */
+    auto setSeenHardLimit() -> void;
+
    private:
     std::deque<std::tuple<SharedAqlItemBlockPtr, SkipResult>> _queue;
     // This is unique_ptr to get away with everything being forward declared...
     std::unique_ptr<ExecutionBlock> _executor;
     bool _executorHasMore;
+    bool _gotHardLimit = false;
   };
 
   explicit ScatterExecutor(Infos const&);

--- a/tests/Aql/WaitingExecutionBlockMock.cpp
+++ b/tests/Aql/WaitingExecutionBlockMock.cpp
@@ -113,6 +113,7 @@ WaitingExecutionBlockMock::initializeCursor(
 
 std::tuple<ExecutionState, SkipResult, SharedAqlItemBlockPtr>
 WaitingExecutionBlockMock::execute(AqlCallStack const& stack) {
+  _lastCall = stack.peek();
   traceExecuteBegin(stack);
   auto res = executeWithoutTrace(stack);
   traceExecuteEnd(res);
@@ -213,4 +214,12 @@ void WaitingExecutionBlockMock::executeCallback() {
   if (_executeCallback) {
     _executeCallback();
   }
+}
+
+auto WaitingExecutionBlockMock::remainingRows() const -> uint64_t {
+  return _blockData.remainingRows();
+}
+
+auto WaitingExecutionBlockMock::getLastCall() const -> arangodb::aql::AqlCall {
+  return _lastCall;
 }

--- a/tests/Aql/WaitingExecutionBlockMock.h
+++ b/tests/Aql/WaitingExecutionBlockMock.h
@@ -90,6 +90,10 @@ class WaitingExecutionBlockMock final : public arangodb::aql::ExecutionBlock {
              arangodb::aql::SharedAqlItemBlockPtr>
   execute(arangodb::aql::AqlCallStack const& stack) override;
 
+  auto remainingRows() const -> uint64_t;
+
+  auto getLastCall() const -> arangodb::aql::AqlCall;
+
  private:
   // Implementation of execute
   std::tuple<arangodb::aql::ExecutionState, arangodb::aql::SkipResult,
@@ -108,6 +112,7 @@ class WaitingExecutionBlockMock final : public arangodb::aql::ExecutionBlock {
   typename arangodb::aql::ScatterExecutor::ClientBlockData _blockData;
   std::function<void()> _wakeUpCallback;
   std::function<void()> _executeCallback;
+  arangodb::aql::AqlCall _lastCall;
 };
 }  // namespace aql
 

--- a/tests/Mocks/MockTcpDummyServer.h
+++ b/tests/Mocks/MockTcpDummyServer.h
@@ -1,0 +1,167 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2025 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jure Bajic
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include <thread>
+
+#include <boost/asio.hpp>
+#include "Assertions/Assert.h"
+
+namespace arangodb::tests::mocks {
+using boost::asio::ip::tcp;
+
+namespace {
+
+// Simple session class to handle an individual connection
+class Session : public std::enable_shared_from_this<Session> {
+ public:
+  Session(tcp::socket socket) : socket_(std::move(socket)) {}
+
+  void start() { do_read(); }
+
+  void stop() {
+    if (socket_.is_open()) {
+      boost::system::error_code ec;
+      std::ignore = socket_.close(ec);
+    }
+  }
+
+ private:
+  void do_read() {
+    auto self(shared_from_this());
+    socket_.async_read_some(
+        boost::asio::buffer(data_),
+        [this, self](boost::system::error_code ec, std::size_t length) {
+          if (!ec) {
+            handle_http_request(length);
+          } else {
+            // Connection closed or error occurred
+            stop();
+          }
+        });
+  }
+
+  void handle_http_request(std::size_t length) {
+    // Create a simple HTTP response
+    std::string response_body = "Hello from TCP Dummy Server!\n";
+    response_body += "Received " + std::to_string(length) + " bytes.\n";
+
+    std::string response =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Type: text/plain\r\n"
+        "Content-Length: " +
+        std::to_string(response_body.length()) +
+        "\r\n"
+        "Connection: close\r\n"
+        "\r\n" +
+        response_body;
+
+    do_write(response);
+  }
+
+  void do_write(const std::string& response) {
+    auto self(shared_from_this());
+
+    boost::asio::async_write(
+        socket_, boost::asio::buffer(response),
+        [this, self](boost::system::error_code ec, std::size_t /*length*/) {
+          if (!ec) {
+            // Close the connection after sending response
+            stop();
+          } else {
+            // Write error occurred
+            stop();
+          }
+        });
+  }
+
+  tcp::socket socket_;
+  std::array<char, 1024> data_;  // Buffer for received data
+};
+
+// Server class to accept new connections
+class TcpDummyServer {
+ public:
+  TcpDummyServer(boost::asio::io_context& io_context, short port)
+      : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)), running_(true) {
+    do_accept();
+  }
+
+  ~TcpDummyServer() { stop(); }
+
+  void stop() {
+    running_ = false;
+    if (acceptor_.is_open()) {
+      boost::system::error_code ec;
+      std::ignore = acceptor_.close(ec);
+    }
+  }
+
+ private:
+  void do_accept() {
+    if (!running_) {
+      return;
+    }
+
+    acceptor_.async_accept(
+        [this](boost::system::error_code ec, tcp::socket socket) {
+          if (!ec && running_) {
+            std::make_shared<Session>(std::move(socket))->start();
+          }
+          // Continue accepting new connections only if still running
+          if (running_) {
+            do_accept();
+          }
+        });
+  }
+
+  tcp::acceptor acceptor_;
+  std::atomic<bool> running_;
+};
+}  // namespace
+
+class MockTcpServer final {
+ public:
+  MockTcpServer(int port) : tcpDummyServer(io_context, port) {}
+
+  ~MockTcpServer() { TRI_ASSERT(io_context.stopped()); }
+
+  void start() {
+    serverThread = std::jthread([this]() { io_context.run(); });
+  }
+
+  void stop() {
+    tcpDummyServer.stop();
+    io_context.stop();
+    if (serverThread.joinable()) {
+      serverThread.join();
+    }
+  }
+
+ private:
+  boost::asio::io_context io_context;
+  std::jthread serverThread;
+  TcpDummyServer tcpDummyServer;
+};
+
+}  // namespace arangodb::tests::mocks


### PR DESCRIPTION
* Added a test for the MutexExecutor accessing above rows

* Simplified test setup

* Added a test suite to define the expected improved behaviour of the MutexExecutor

* Added assertions that all rows are used up by hardlimit. The test is red for now

* Fixed crash

* Added CHANGELOG entry

* Discard blocks on distirbution Node if we already have seen the HardLimit

* Removed an assert, for code i assumed to be unreachable, but it is reached within our own tests

* Fixed memory leak

* Applied clangformat

* Update arangod/Aql/BlocksWithClients.cpp



* Update arangod/Aql/BlocksWithClients.cpp



---------

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
