### PR TITLE
[BTS-2194] Avoid nullptr deref in maintainer-mode assertion

### DIFF
--- a/arangod/Aql/DistributeClientBlock.cpp
+++ b/arangod/Aql/DistributeClientBlock.cpp
@@ -88,15 +88,15 @@ auto DistributeClientBlock::clear() -> void {
 auto DistributeClientBlock::addBlock(SkipResult const& skipResult,
                                      SharedAqlItemBlockPtr block,
                                      std::vector<size_t> usedIndexes) -> void {
+  TRI_ASSERT(!usedIndexes.empty() || block == nullptr);
   if (gotHardLimit()) {
     // We have already seen a hard limit, so we do not need to add more data.
-    TRI_ASSERT(!block->hasShadowRows())
+    TRI_ASSERT(block == nullptr || !block->hasShadowRows())
         << "The logic here is not implemented yet for subqueries. If we want "
            "to activate it, we need to move the ShadowRow over even if we have "
            "seen a hardLimit.";
     return;
   }
-  TRI_ASSERT(!usedIndexes.empty() || block == nullptr);
   _queue.emplace_back(skipResult, std::move(block), std::move(usedIndexes));
 }
 


### PR DESCRIPTION
### Scope & Purpose

This fixes possible crashes in maintainer mode, no production impact. Was introduced in https://github.com/arangodb/arangodb/pull/21808.

- [X] :hankey: Bugfix
