### PR TITLE
[BTS-2201] Don't apply index-collect optimizer rule to empty collection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-2201: Make aggreate collect queries work again on an empty collection
+	that has an	index used in the query.
+
 * Fix BTS-2167: Add validation of geoJSON Position in GEO_MULTIPOINT,
   GEO_LINESTRING and GEO_MULTILINESTRING. Now they only accept positions
   with two or three components.

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
@@ -271,15 +271,15 @@ IndexAggregateScanExecutor::IndexAggregateScanExecutor(Fetcher& fetcher,
   LOG_AGG_SCAN << "[SCAN] constructing stream with options " << streamOptions;
   _iterator = _infos.index->streamForCondition(&_trx, streamOptions);
 
-  _indexIncludesAnyData = _iterator->position(std::span<velocypack::Slice>{});
-  if (_indexIncludesAnyData) {
-    // fill projection slices
-    _projectionSlices.resize(streamOptions.projectedFields.size());
-    bool hasMore = _iterator->reset(_currentGroupKeySlices, {});
-    LOG_AGG_SCAN << "[SCAN] after reset at "
-                 << inspection::json(_currentGroupKeySlices)
-                 << " hasMore= " << hasMore;
+  // fill projection slices
+  _projectionSlices.resize(streamOptions.projectedFields.size());
+  bool hasMore = _iterator->reset(_currentGroupKeySlices, {});
+  LOG_AGG_SCAN << "[SCAN] after reset at "
+               << inspection::json(_currentGroupKeySlices)
+               << " hasMore= " << hasMore;
+  _indexIncludesAnyData = hasMore;
 
+  if (hasMore) {
     // loading (and also logics in produceRows and skipRowsRange) only
     // works properly (without hitting any assertions) if the index actually
     // includes data

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
@@ -120,6 +120,11 @@ auto IndexAggregateScanExecutor::skipRowsRange(
       "with one input row, but input range has {} rows",
       inputRange.countDataRows());
 
+  if (not _indexIncludesAnyData) {
+    inputRange.advanceDataRow();
+    return std::make_tuple(inputRange.upstreamState(), Stats{}, 0, AqlCall{});
+  }
+
   LocalDocumentId docId;
   bool hasMore = true;
   size_t skipped = 0;
@@ -175,6 +180,11 @@ auto IndexAggregateScanExecutor::produceRows(AqlItemBlockInputRange& inputRange,
       "IndexAggregateScanExecutor expects to be run just after a SingletonNode "
       "with one input row, but input range has {} rows",
       inputRange.countDataRows());
+
+  if (not _indexIncludesAnyData) {
+    inputRange.advanceDataRow();
+    return std::make_tuple(inputRange.upstreamState(), Stats{}, AqlCall{});
+  }
 
   _inputRow = inputRange.peekDataRow().second;
 
@@ -261,23 +271,31 @@ IndexAggregateScanExecutor::IndexAggregateScanExecutor(Fetcher& fetcher,
   LOG_AGG_SCAN << "[SCAN] constructing stream with options " << streamOptions;
   _iterator = _infos.index->streamForCondition(&_trx, streamOptions);
 
-  // fill projection slices
-  _projectionSlices.resize(streamOptions.projectedFields.size());
-  bool hasMore = _iterator->reset(_currentGroupKeySlices, {});
-  LOG_AGG_SCAN << "[SCAN] after reset at "
-               << inspection::json(_currentGroupKeySlices)
-               << " hasMore= " << hasMore;
-  _iterator->load(_projectionSlices);
-  LOG_AGG_SCAN << "[SCAN] projections are  "
-               << inspection::json(_projectionSlices);
+  _indexIncludesAnyData = _iterator->position(std::span<velocypack::Slice>{});
+  if (_indexIncludesAnyData) {
+    // fill projection slices
+    _projectionSlices.resize(streamOptions.projectedFields.size());
+    bool hasMore = _iterator->reset(_currentGroupKeySlices, {});
+    LOG_AGG_SCAN << "[SCAN] after reset at "
+                 << inspection::json(_currentGroupKeySlices)
+                 << " hasMore= " << hasMore;
 
-  // create aggregators
-  _aggregatorInstances.reserve(_infos.aggregations.size());
-  for (auto const& agg : _infos.aggregations) {
-    auto const& factory = Aggregator::factoryFromTypeString(agg.type);
-    auto instance = factory.operator()(&_infos.query->vpackOptions());
+    // loading (and also logics in produceRows and skipRowsRange) only
+    // works properly (without hitting any assertions) if the index actually
+    // includes data
+    _iterator->load(_projectionSlices);
 
-    _aggregatorInstances.emplace_back(std::move(instance))->reset();
+    LOG_AGG_SCAN << "[SCAN] projections are  "
+                 << inspection::json(_projectionSlices);
+
+    // create aggregators
+    _aggregatorInstances.reserve(_infos.aggregations.size());
+    for (auto const& agg : _infos.aggregations) {
+      auto const& factory = Aggregator::factoryFromTypeString(agg.type);
+      auto instance = factory.operator()(&_infos.query->vpackOptions());
+
+      _aggregatorInstances.emplace_back(std::move(instance))->reset();
+    }
   }
 }
 

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.h
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.h
@@ -123,7 +123,10 @@ struct IndexAggregateScanExecutor {
   // projectionFields
   containers::FlatHashMap<VariableId, size_t> _variablesToProjectionsRelative;
 
-  bool _indexIncludesAnyData;
+  // On construction this is set according to wether the index iterator contains
+  // any data. It is needed to avoid running in some assertions when using
+  // using the iterator.
+  bool _indexIncludesAnyData = false;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.h
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.h
@@ -122,6 +122,8 @@ struct IndexAggregateScanExecutor {
   // map of aggregate variable to projection field location in the iterator's
   // projectionFields
   containers::FlatHashMap<VariableId, size_t> _variablesToProjectionsRelative;
+
+  bool _indexIncludesAnyData;
 };
 
 }  // namespace aql

--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
@@ -80,6 +80,10 @@ bool isCollectNodeEligible(CollectNode const& cn) {
 }
 
 bool isIndexNodeEligible(IndexNode const& in) {
+  if (in.estimateCost().estimatedNrItems == 0) {
+    LOG_RULE << "IndexNode " << in.id() << " not eligible - no data";
+    return false;
+  }
   if (in.hasFilter()) {
     LOG_RULE << "IndexNode " << in.id()
              << " not eligible - it has a post filter";

--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
@@ -80,10 +80,6 @@ bool isCollectNodeEligible(CollectNode const& cn) {
 }
 
 bool isIndexNodeEligible(IndexNode const& in) {
-  if (in.estimateCost().estimatedNrItems == 0) {
-    LOG_RULE << "IndexNode " << in.id() << " not eligible - no data";
-    return false;
-  }
   if (in.hasFilter()) {
     LOG_RULE << "IndexNode " << in.id()
              << " not eligible - it has a post filter";

--- a/tests/js/client/aql/aql-index-collect.js
+++ b/tests/js/client/aql/aql-index-collect.js
@@ -223,6 +223,9 @@ function ExecutionTestSuite() {
       db._createDatabase(database);
       db._useDatabase(database);
     },
+    tearDown: function () {
+      db[collection].drop();
+    },
     tearDownAll: function () {
       db._useDatabase("_system");
       db._dropDatabase(database);
@@ -270,7 +273,6 @@ function ExecutionTestSuite() {
         const actualResult = db._query(query).toArray();
         assertEqual(expectedResult, actualResult);
       }
-      c.drop();
     },
 
     testQueriesOnEmptyCollection: function () {
@@ -281,10 +283,9 @@ function ExecutionTestSuite() {
         `FOR doc IN ${collection} COLLECT AGGREGATE max = MAX(doc.a) RETURN max`
       ];
       for (const query of queries) {
-        const actualResult = db._query(query).toArray();
+        const actualResult = db._query(query).toArray().filter(x => x != null);
         assertEqual(actualResult, []);
       }
-      c.drop();
     }
   };
 }

--- a/tests/js/client/aql/aql-index-collect.js
+++ b/tests/js/client/aql/aql-index-collect.js
@@ -58,7 +58,7 @@ function IndexCollectOptimizerTestSuite() {
       c.ensureIndex({ type: "persistent", fields: ["a"] });
       const query = `FOR doc IN ${collection} COLLECT a = doc.a RETURN a`;
       const explain = db._createStatement(query).explain();
-      assertTrue(explain.plan.rules.indexOf(indexCollectOptimizerRule) == -1, query);
+      assertTrue(explain.plan.rules.indexOf(indexCollectOptimizerRule) === -1, query);
       c.drop();
     },
 
@@ -218,7 +218,7 @@ function IndexAggregationCollectOptimizerTestSuite() {
       c.ensureIndex({ type: "persistent", fields: ["a"] });
       const query = `FOR doc IN ${collection} COLLECT AGGREGATE max = MAX(doc.b) RETURN max`;
       const explain = db._createStatement(query).explain();
-      assertTrue(explain.plan.rules.indexOf(indexCollectOptimizerRule) == -1, query);
+      assertTrue(explain.plan.rules.indexOf(indexCollectOptimizerRule) === -1, query);
       c.drop();
     },
 


### PR DESCRIPTION
This already worked for simple collect statements due to the selectivity check done there.
Now we also don't use the rule for aggregate collect if the collection is empty.