### PR TITLE
Fix miscounting bug for scheduled SynchronizeShard jobs [BTS-2202]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix miscounting bug for number of SynchronizeShard jobs scheduled.
+  This fixes BTS-2202. The bug could show up as a dbserver not syncing
+  its follower shards with the leader.
+
 * Fix BTS-2167: Add validation of geoJSON Position in GEO_MULTIPOINT,
   GEO_LINESTRING and GEO_MULTILINESTRING. Now they only accept positions
   with two or three components.

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -2712,6 +2712,8 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
             << " local theLeader = " << theLeader.toJson();
 
         if (!feature.increaseNumberOfSyncShardActionsQueued()) {
+          // Roll back the counting:
+          feature.decreaseNumberOfSyncShardActionsQueued();
           // Need to revisit this database on next run:
           makeDirty.emplace(dbname);
           LOG_TOPIC("25342", DEBUG, Logger::MAINTENANCE)

--- a/arangod/Cluster/MaintenanceFeature.cpp
+++ b/arangod/Cluster/MaintenanceFeature.cpp
@@ -25,6 +25,7 @@
 #include <set>
 #include <random>
 
+#include "Basics/ScopeGuard.h"
 #include "Cluster/Maintenance.h"
 #include "MaintenanceFeature.h"
 
@@ -1290,11 +1291,19 @@ Result MaintenanceFeature::requeueAction(
              action->getState() == ActionState::FAILED);
   if (action->describe().get(NAME) == SYNCHRONIZE_SHARD) {
     increaseNumberOfSyncShardActionsQueued();
+    // We intentionally ignore the result here, since we **must**
+    // count the job anyway, since it will be scheduled. And thus it will
+    // eventually be executed, which will decrease the counter again!
   }
+  // We use a scope guard to prevent miscounting if something throws during
+  // the registration:
+  ScopeGuard scopeGuard(
+      [&]() noexcept { decreaseNumberOfSyncShardActionsQueued(); });
   auto newAction =
       std::make_shared<maintenance::Action>(*this, action->describe());
   newAction->setPriority(newPriority);
   std::unique_lock guard(_actionRegistryLock);
   registerAction(std::move(newAction));
+  scopeGuard.cancel();
   return {};
 }

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -158,11 +158,7 @@ class MaintenanceFeature : public ArangodFeature {
   /// increased.
   bool increaseNumberOfSyncShardActionsQueued() noexcept {
     uint64_t n = _numberOfSyncShardActionsQueued.fetch_add(1);
-    if (n + 1 > _maximalNumberOfSyncShardActionsQueued) {
-      _numberOfSyncShardActionsQueued.fetch_sub(1);
-      return false;
-    }
-    return true;
+    return n <= _maximalNumberOfSyncShardActionsQueued;
   }
 
   void decreaseNumberOfSyncShardActionsQueued() noexcept {


### PR DESCRIPTION
This fixes https://arangodb.atlassian.net/browse/BTS-2202.

This bug is a regression introduced by another bug fix, which limited
the number of scheduled SynchronizeShard jobs.

The details are described in the above ticket.

- **Fix miscounting bug.**
- **CHANGELOG.**

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [ ] Backport for 3.12.5: TODO

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2202.
- [*] Backport to 3.12.5: https://github.com/arangodb/arangodb/pull/21894
