### PR TITLE
Fix miscounting bug for scheduled SynchronizeShard jobs [BTS-2202]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-3.12.5.2 (2025-07-25)
+3.12.5.2 (XXXX-XX-XX)
 ---------------------
 
 * Fix miscounting bug for number of SynchronizeShard jobs scheduled.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+3.12.5.2 (2025-07-25)
+---------------------
+
+* Fix miscounting bug for number of SynchronizeShard jobs scheduled.
+  This fixes BTS-2202. The bug could show up as a dbserver not syncing
+  its follower shards with the leader.
+
+
 3.12.5.1 (2025-07-25)
 ---------------------
 

--- a/arangod/Cluster/Maintenance.cpp
+++ b/arangod/Cluster/Maintenance.cpp
@@ -2712,6 +2712,8 @@ void arangodb::maintenance::syncReplicatedShardsWithLeaders(
             << " local theLeader = " << theLeader.toJson();
 
         if (!feature.increaseNumberOfSyncShardActionsQueued()) {
+          // Roll back the counting:
+          feature.decreaseNumberOfSyncShardActionsQueued();
           // Need to revisit this database on next run:
           makeDirty.emplace(dbname);
           LOG_TOPIC("25342", DEBUG, Logger::MAINTENANCE)

--- a/arangod/Cluster/MaintenanceFeature.h
+++ b/arangod/Cluster/MaintenanceFeature.h
@@ -158,11 +158,7 @@ class MaintenanceFeature : public ArangodFeature {
   /// increased.
   bool increaseNumberOfSyncShardActionsQueued() noexcept {
     uint64_t n = _numberOfSyncShardActionsQueued.fetch_add(1);
-    if (n + 1 > _maximalNumberOfSyncShardActionsQueued) {
-      _numberOfSyncShardActionsQueued.fetch_sub(1);
-      return false;
-    }
-    return true;
+    return n <= _maximalNumberOfSyncShardActionsQueued;
   }
 
   void decreaseNumberOfSyncShardActionsQueued() noexcept {


### PR DESCRIPTION
This fixes https://arangodb.atlassian.net/browse/BTS-2202.

This is a backport of https://github.com/arangodb/arangodb/pull/21891 to
3.12.5 for 3.12.5.2

This bug is a regression introduced by another bug fix, which limited
the number of scheduled SynchronizeShard jobs.

The details are described in the above ticket.

- **Fix miscounting bug.**
- **CHANGELOG.**

### Scope & Purpose

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports
  - [ ] Backport for 3.12.5: TODO

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2202.

