### PR TITLE
add more details to failures

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -1132,7 +1132,9 @@ function getGTestResults(fileName, defaultResults, name) {
       const message = testSuite.testsuite.flatMap(
         suite => {
           if (suite.hasOwnProperty('failures')) {
-            return suite.classname + " - " + suite.file + " - " + suite.name + ":\n" +
+            return suite.classname + " - " +
+              suite.file + ":" + suite.line + " - " +
+              suite.name + ":\n" +
               suite.failures.map(fail => fail.failure).join("\n");
           }
           return [];

--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -1132,7 +1132,8 @@ function getGTestResults(fileName, defaultResults, name) {
       const message = testSuite.testsuite.flatMap(
         suite => {
           if (suite.hasOwnProperty('failures')) {
-            return suite.failures.map(fail => fail.failure).join("\n");
+            return suite.classname + " - " + suite.file + " - " + suite.name + ":\n" +
+              suite.failures.map(fail => fail.failure).join("\n");
           }
           return [];
         }).join("\n");


### PR DESCRIPTION
### Scope & Purpose

We pick more fields from the gtest outputs to our own failure message:

        {
          "name": "acquire_endpoint",
          * "file": "/root/project/tests/Network/ConnectionPoolTest.cpp",
          "line": 135,
          "status": "RUN",
          "result": "COMPLETED",
          "timestamp": "2025-08-05T11:06:38Z",
          "time": "60.201s",
          "classname": "NetworkConnectionPoolTest",
          "failures": [
            {
              "failure": "unknown file\nUnknown C++ exception thrown in the test body.",
              "type": ""
            }
          ]
        },



- [x] :pizza: New feature
