### PR TITLE
Depracate `rocksdb.transaction-lock-timeout` option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Deprecate rocksdb.transaction-lock-timeout option since we would
+  internally change this to a different value.
+
 * FE-636: bump @babel/traverse from 7.14.8 to 7.30.0 (latest version)
 
 * Fix BTS-2201: Make aggreate collect queries work again on an empty collection

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -408,18 +408,23 @@ values to reduce a potential contention in the lock manager.
 The option defaults to the number of available cores, but is increased to a
 value of `16` if the number of cores is lower.)");
 
-  options->addOption(
-      "--rocksdb.transaction-lock-timeout",
-      "If positive, specifies the wait timeout in milliseconds when "
-      " a transaction attempts to lock a document. A negative value "
-      "is not recommended as it can lead to deadlocks (0 = no waiting, < 0 no "
-      "timeout)",
-      new Int64Parameter(&_transactionLockTimeout),
-      arangodb::options::makeFlags(
-          arangodb::options::Flags::DefaultNoComponents,
-          arangodb::options::Flags::OnAgent,
-          arangodb::options::Flags::OnDBServer,
-          arangodb::options::Flags::OnSingle));
+  options
+      ->addOption(
+          "--rocksdb.transaction-lock-timeout",
+          "If positive, specifies the wait timeout in milliseconds when "
+          " a transaction attempts to lock a document. A negative value "
+          "is not recommended as it can lead to deadlocks (0 = no waiting, < 0 "
+          "no "
+          "timeout). This is deprecated since we internally controle the lock "
+          "timeout "
+          "for diffrent cases.",
+          new Int64Parameter(&_transactionLockTimeout),
+          arangodb::options::makeFlags(
+              arangodb::options::Flags::DefaultNoComponents,
+              arangodb::options::Flags::OnAgent,
+              arangodb::options::Flags::OnDBServer,
+              arangodb::options::Flags::OnSingle))
+      .setDeprecatedIn(31206);
 
   options
       ->addOption(


### PR DESCRIPTION
### Scope & Purpose

1. The timeout parameters `--rocksdb.transaction-lock-timeout` do very little since we practically ignore the value and set our own in this part of the code in RocksDBTrxBaseMethods.cpp:
```cpp
void RocksDBTrxBaseMethods::createTransaction() {
  // start rocks transaction
  rocksdb::TransactionOptions trxOpts;

  if (_state->hasHint(transaction::Hints::Hint::IS_FOLLOWER_TRX)) {
    // write operations for the same keys on followers should normally be
    // serialized by the key locks held on the leaders. so we don't expect
    // to run into lock conflicts on followers. however, the lock_timeout
    // set here also includes locking the striped mutex for _all_ key locks,
    // which may be contended under load. to avoid timeouts caused by
    // waiting for the contented striped mutex, increase it to a higher
    // value on followers that makes this situation unlikely.
    trxOpts.lock_timeout = 3000;
  } else if (_state->options().delaySnapshot) {
    // for single operations we delay acquiring the snapshot so we can lock
    // the key _before_ we acquire the snapshot to prevent write-write
    // conflicts. in this case we obviously also want to use a higher lock
    // timeout
    // TODO - make this configurable
    trxOpts.lock_timeout = 1000;
  } else {
    // when trying to lock the same keys, we want to return quickly and not
    // spend the default 1000ms before giving up
    trxOpts.lock_timeout = 1;
  }
```
meaning that whatever was the `--rocksdb.transaction-lock-timeout` value we will override it.

We use RocksDB transactions with `set_snapshot` set to true and [pessimistic concurrency control](https://github.com/facebook/rocksdb/wiki/Transactions#transactiondb)). This means that
RocksDB locks all objects first and does not wait for Commit to perform checks; it can do them immediately.
And when another transaction wants to change the object that we are locking, then the question is whether the object that we are locking will be changed or not. E.g., using `GetForUpdate` does lock the object but might not change it; therefore, the lock timeout here serves us to determine for how long we will wait for the lock, but does not guarantee that even when the lock is released, there will not be conflicts.

The timeout plays a role when we have `delaySnapshot` and we have that only for single operations; the delay snapshot in our case, does not set `set_snapshot` of transaction, which means it does not take the snapshot and does not perform the check,s which makes it much quicker to execute and in this case the timeout does make sense, since we will not abort on conflict but will just wait until whichever transaction holds it to release it.

Also, changing the lock-timeout to 0 might not be a good option since the lock being acquired is a lock on RocksDB PointLockManager, which enables establishing a lock on the actual key. Meaning the timeout is on a lock at a level above the document lock whose timeout we would want to set.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
