### PR TITLE
Fix error message

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Fix error message to use proper terminology order instead of mode.
+
 * FE-636: bump http-proxy-middleware from 2.0.6 to 2.0.9 (latest 2.X version).
 
 * FE-636: bump @babel/traverse from 7.14.8 to 7.30.0 (latest version)

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -399,7 +399,7 @@ std::unique_ptr<graph::BaseOptions> createTraversalOptions(
       !(options->isUniqueGlobalVerticesAllowed())) {
     THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER,
                                    "uniqueVertices: 'global' is only "
-                                   "supported, with mode: bfs|weighted due to "
+                                   "supported, with order: bfs|weighted due to "
                                    "otherwise unpredictable results.");
   }
 


### PR DESCRIPTION
### Scope & Purpose
Fix error message:
Before:
```
uniqueVertices: 'global' is only supported, with mode: bfs|weighted due to otherwise unpredictable results.");
```
Now:
```
uniqueVertices: 'global' is only supported, with order: bfs|weighted due to otherwise unpredictable results.");
```


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
