### PR TITLE
[BTS-1732, BTS-2177] Fix stopping the rocksdb sync thread during shutdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-1732 and BTS-2177: Possible crashes during shutdown, and maintainer
+  mode (i.e. non-production) assertions during tests.
+
 * During AQL setup, the Coordinator will no longer block threads while waiting
   for DBServers to finish the query instantiation.
 

--- a/arangod/Replication2/Version.h
+++ b/arangod/Replication2/Version.h
@@ -41,14 +41,6 @@ namespace arangodb::replication {
 
 enum class Version { ONE = 1, TWO = 2 };
 
-// We disable Replication2 in Production environments for now
-// This we only allow to use Version one.
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-constexpr inline auto allowedVersions = {Version::ONE, Version::TWO};
-#else
-constexpr inline auto allowedVersions = {Version::ONE};
-#endif
-
 auto parseVersion(std::string_view version) -> ResultT<replication::Version>;
 auto parseVersion(velocypack::Slice version) -> ResultT<replication::Version>;
 

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -31,6 +31,7 @@
 #include "Aql/QueryRegistry.h"
 #include "Auth/UserManager.h"
 #include "Basics/ArangoGlobalContext.h"
+#include "Basics/FeatureFlags.h"
 #include "Basics/FileUtils.h"
 #include "Basics/NumberUtils.h"
 #include "Basics/ScopeGuard.h"
@@ -289,10 +290,14 @@ void DatabaseFeature::collectOptions(
     std::shared_ptr<options::ProgramOptions> options) {
   options->addSection("database", "database options");
 
-  auto static const allowedReplicationVersions = [] {
-    auto result = std::unordered_set<std::string>();
-    for (auto const& version : replication::allowedVersions) {
-      result.emplace(replication::versionToString(version));
+  auto static allowedReplicationVersions = [] {
+    using namespace arangodb::replication;
+    using namespace arangodb::replication2;
+
+    auto result = std::unordered_set<std::string>{};
+    result.emplace(versionToString(Version::ONE));
+    if (EnableReplication2) {
+      result.emplace(versionToString(Version::TWO));
     }
     return result;
   }();

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1395,7 +1395,6 @@ void RocksDBEngine::stop() {
     while (_backgroundThread->isRunning()) {
       std::this_thread::yield();
     }
-    _backgroundThread.reset();
   }
 
   if (_syncThread) {
@@ -1406,7 +1405,6 @@ void RocksDBEngine::stop() {
     while (_syncThread->isRunning()) {
       std::this_thread::yield();
     }
-    _syncThread.reset();
   }
 
   waitForCompactionJobsToFinish();
@@ -1414,6 +1412,10 @@ void RocksDBEngine::stop() {
 
 void RocksDBEngine::unprepare() {
   TRI_ASSERT(isEnabled());
+  TRI_ASSERT(!_backgroundThread->isRunning());
+  _backgroundThread.reset();
+  TRI_ASSERT(!_syncThread->isRunning());
+  _syncThread.reset();
   waitForCompactionJobsToFinish();
   shutdownRocksDBInstance();
 }

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -96,9 +96,16 @@ Result RocksDBSyncThread::sync(rocksdb::DB* db) {
 void RocksDBSyncThread::beginShutdown() {
   Thread::beginShutdown();
 
-  // wake up the thread that may be waiting in run()
-  std::lock_guard guard{_condition.mutex};
-  _condition.cv.notify_all();
+  {  // wake up the thread that may be waiting in run()
+    std::lock_guard guard{_condition.mutex};
+    _condition.cv.notify_all();
+  }
+
+  { // acquire the mutex (exclusively); all notifySyncListeners() calls that
+    // happen later (acquiring the shared mutex) will now see that the thread
+    // is shutting down and not execute any listeners.
+    std::lock_guard lock(_syncListenersMutex);
+  }
 }
 
 void RocksDBSyncThread::registerSyncListener(
@@ -206,6 +213,16 @@ void RocksDBSyncThread::run() {
 void RocksDBSyncThread::notifySyncListeners(
     rocksdb::SequenceNumber seq) noexcept {
   std::shared_lock lock(_syncListenersMutex);
+  if (isStopping()) {
+    // The thread should be stopped exactly during RocksDBEngine::stop(), so
+    // we have to be in a shutdown.
+    TRI_ASSERT(_engine.server().isStopping());
+    // It's no longer safe to execute listeners. Dependencies of RocksDBEngine
+    // might be stopped already, or at any moment.
+    // It should be OK not to execute them, because a crash could also leave us
+    // in a state where they haven't been executed.
+    return;
+  }
   for (auto& listener : _syncListeners) {
     listener->onSync(seq);
   }

--- a/arangod/RocksDBEngine/RocksDBSyncThread.cpp
+++ b/arangod/RocksDBEngine/RocksDBSyncThread.cpp
@@ -101,7 +101,7 @@ void RocksDBSyncThread::beginShutdown() {
     _condition.cv.notify_all();
   }
 
-  { // acquire the mutex (exclusively); all notifySyncListeners() calls that
+  {  // acquire the mutex (exclusively); all notifySyncListeners() calls that
     // happen later (acquiring the shared mutex) will now see that the thread
     // is shutting down and not execute any listeners.
     std::lock_guard lock(_syncListenersMutex);


### PR DESCRIPTION
### Scope & Purpose

A test running into a maintainer mode assertion in a commit during shutdown revealed possible races regarding the RocksDBSyncThread during shutdown.

The following changes are made in this PR:

* After the RocksDBSyncThread has been stopped, it no longer executes listeners.
  This directly addresses [BTS-1732](https://arangodb.atlassian.net/browse/BTS-1732), where the listener scheduled a task after the Scheduler was stopped.
* The thread is still stopped in `RocksDBEngine::stop()`, but its destruction was moved to `RocksDBEngine::unprepare()`.
  Data structures should always be destroyed and deleted in unprepare, not in stop. This could have lead to use-after-free errors during shutdown ([BTS-2177](https://arangodb.atlassian.net/browse/BTS-2177)).
* When Replication 2 is disabled, the RocksDBEngine no longer creates a log persistor for it, nor registers it as a sync listener in the RocksDBSyncThread. This listener was the one posting on the Scheduler, triggering the assertion.

- [X] :hankey: Bugfix

### Checklist

- [X] :book: CHANGELOG entry made

#### Related Information

- [X] Jira ticket: https://arangodb.atlassian.net/browse/BTS-1732
- [X] Jira ticket: https://arangodb.atlassian.net/browse/BTS-2177

[BTS-2177]: https://arangodb.atlassian.net/browse/BTS-2177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BTS-2177]: https://arangodb.atlassian.net/browse/BTS-2177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BTS-1732]: https://arangodb.atlassian.net/browse/BTS-1732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ