### PR TITLE
QA-675: start adding circle-ci UI images

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -691,7 +691,7 @@ jobs:
             fi
             mkdir -p  work/release-test-automation/allure-results work/release-test-automation/allure-config
             cd work/release-test-automation
-            DOCKER_CONTAINER="<< parameters.docker_image >>"
+            DOCKER_CONTAINER="<< pipeline.parameters.test-docker-image >>"
             bash -x ./jenkins/circleci_tar.sh \
               --no-checkdata \
               --no-run-upgrade  \

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -22,7 +22,7 @@ parameters:
     default: "arangodb/ubuntubuildarangodb-devel:16"
   test-docker-image:
     type: string
-    default: public.ecr.aws/b0b8h2r4/test-ubuntu:24.04-9d7ee037
+    default: public.ecr.aws/b0b8h2r4/test-ubuntu:24.04-9cfa8ba1
   # Unused here, but it will be forwarded from config and will cause errors if not defined
   enterprise-branch:
     type: string

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -662,6 +662,7 @@ jobs:
       - run:
           name: Clone RTA
           command: |
+            set + x
             mkdir work/release-test-automation
             cd work/release-test-automation
             git clone git@github.com:arangodb/release-test-automation.git .
@@ -670,6 +671,7 @@ jobs:
           name: Run << parameters.suiteName >> tests
           no_output_timeout: 20m
           command: |
+            set +x
             pwd
             export SOURCE=nightlypublic
             export RTA_EDITION=<< parameters.enterprise >>

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -653,6 +653,9 @@ jobs:
       arangosh_args:
         type: string
         default: ""
+      docker_image:
+        type: string
+        default: "<< pipeline.parameters.test-docker-image >>"
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -693,7 +696,7 @@ jobs:
             fi
             mkdir -p  work/release-test-automation/allure-results work/release-test-automation/allure-config
             cd work/release-test-automation
-            DOCKER_CONTAINER="<< pipeline.parameters.test-docker-image >>"
+            DOCKER_CONTAINER="<< parameters.docker_image >>"
             bash -x ./jenkins/circleci_tar.sh \
               --no-checkdata \
               --no-run-upgrade  \

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -696,7 +696,7 @@ jobs:
             fi
             mkdir -p  work/release-test-automation/allure-results work/release-test-automation/allure-config
             cd work/release-test-automation
-            DOCKER_CONTAINER="<< parameters.docker_image >>"
+            export DOCKER_CONTAINER="<< parameters.docker_image >>"
             bash -x ./jenkins/circleci_tar.sh \
               --no-checkdata \
               --no-run-upgrade  \

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -691,6 +691,7 @@ jobs:
             fi
             mkdir -p  work/release-test-automation/allure-results work/release-test-automation/allure-config
             cd work/release-test-automation
+            DOCKER_CONTAINER="<< parameters.docker_image >>"
             bash -x ./jenkins/circleci_tar.sh \
               --no-checkdata \
               --no-run-upgrade  \

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -91,8 +91,8 @@ jobs:
             docker tag $image:latest-<< parameters.arch >> $image:$(cat << parameters.arch >>-tag.txt)-<< parameters.arch >>
             docker tag $image:latest-<< parameters.arch >> $image:latest
             docker push $image:$(cat << parameters.arch >>-tag.txt)-<< parameters.arch >>
-          name: Build RTA Docker Image
       - run:
+          name: Build RTA Docker Image
           command: |
             set -x
             cd /home/circleci/project-rta

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -88,8 +88,7 @@ jobs:
           name: Build RTA Docker Image
           command: |
             set -x
-            cd /home/circleci/project/scripts/docker/test
-            TAG="$(cat << parameters.arch >>-tag.txt)"
+            TAG="$(cat /home/circleci/project/scripts/docker/<< parameters.arch >>-tag.txt)"
             cd /home/circleci/project-rta
             image=<< parameters.image >>
             ./jenkins/build_and_push_circle-ci-containers.sh "${image}" "${TAG}"

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -31,8 +31,7 @@ commands:
             git init
             git remote add origin git@github.com:arangodb/arangodb.git
             echo "Fetching stuff"
-            git fetch --depth 1 origin << pipeline.git.revision >>
-            git checkout << pipeline.git.revision >>
+            git checkout main
   checkout-rta:
     parameters:
       destination:

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -88,9 +88,11 @@ jobs:
           name: Build RTA Docker Image
           command: |
             set -x
+            cd /home/circleci/project/scripts/docker/test
+            TAG="$(cat << parameters.arch >>-tag.txt)"
             cd /home/circleci/project-rta
             image=<< parameters.image >>
-            ./jenkins/build_and_push_circle-ci-containers.sh "$image" "$(cat << parameters.arch >>-tag.txt)"
+            ./jenkins/build_and_push_circle-ci-containers.sh "${image}" "${TAG}"
       - run:
           name: Build GO Docker Image
           command: |

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -147,6 +147,8 @@ jobs:
             - "f9:49:75:1a:ad:44:89:10:4b:3c:70:70:ba:d3:c3:ce"
       - checkout-arangodb:
           destination: /home/circleci/project
+      - checkout-rta:
+          destination: /home/circleci/project-rta
       - attach_workspace:
           at: .
       - setup_remote_docker:
@@ -163,8 +165,9 @@ jobs:
       - run:
           name: Build RTA container manifest
           command: |
+            TAG="$(cat /home/circleci/project/scripts/docker/<< parameters.arch >>-tag.txt)"
             cd /home/circleci/project-rta
-            ./jenkins/build_and_push_circle-ci-manifest.sh << parameters.image >> $(cat amd64-tag.txt)
+            ./jenkins/build_and_push_circle-ci-manifest.sh << parameters.image >> $TAG
       - run:
           name: Build go test container manifest
           command: |

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -165,7 +165,7 @@ jobs:
       - run:
           name: Build RTA container manifest
           command: |
-            TAG="$(cat /home/circleci/project/scripts/docker/<< parameters.arch >>-tag.txt)"
+            TAG="$(cat /home/circleci/project/scripts/docker/amd64-tag.txt)"
             cd /home/circleci/project-rta
             ./jenkins/build_and_push_circle-ci-manifest.sh << parameters.image >> $TAG
       - run:

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -42,13 +42,7 @@ commands:
           name: Checkout RTA
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
-            mkdir -p << parameters.destination >>
-            cd << parameters.destination >>
-            echo << pipeline.git.revision >>
-            git init
-            git remote add origin git@github.com:arangodb/release-test-automation.git
-            echo "Fetching stuff"
-            git checkout main
+            git clone git@github.com:arangodb/release-test-automation.git <<parameters.destination>>
 
 jobs:
   build-test-docker-image:

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -167,7 +167,7 @@ jobs:
           command: |
             TAG="$(cat /home/circleci/project/scripts/docker/amd64-tag.txt)"
             cd /home/circleci/project-rta
-            ./jenkins/build_and_push_circle-ci-manifest.sh << parameters.image >> $TAG
+            ./jenkins/build_and_push_circle-ci-manifests.sh << parameters.image >> $TAG
       - run:
           name: Build go test container manifest
           command: |

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -39,7 +39,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Checkout ArangoDB
+          name: Checkout RTA
           command: |
             ssh-keyscan github.com >> ~/.ssh/known_hosts
             mkdir -p << parameters.destination >>

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -90,6 +90,7 @@ jobs:
             set -x
             TAG="$(cat /home/circleci/project/scripts/docker/<< parameters.arch >>-tag.txt)"
             cd /home/circleci/project-rta
+            ls -alh
             image=<< parameters.image >>
             ./jenkins/build_and_push_circle-ci-containers.sh "${image}" "${TAG}"
       - run:

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -31,7 +31,8 @@ commands:
             git init
             git remote add origin git@github.com:arangodb/arangodb.git
             echo "Fetching stuff"
-            git checkout main
+            git fetch --depth 1 origin << pipeline.git.revision >>
+            git checkout << pipeline.git.revision >>
   checkout-rta:
     parameters:
       destination:
@@ -47,8 +48,7 @@ commands:
             git init
             git remote add origin git@github.com:arangodb/release-test-automation.git
             echo "Fetching stuff"
-            git fetch --depth 1 origin << pipeline.git.revision >>
-            git checkout << pipeline.git.revision >>
+            git checkout main
 
 jobs:
   build-test-docker-image:

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -33,6 +33,23 @@ commands:
             echo "Fetching stuff"
             git fetch --depth 1 origin << pipeline.git.revision >>
             git checkout << pipeline.git.revision >>
+  checkout-rta:
+    parameters:
+      destination:
+        type: string
+    steps:
+      - run:
+          name: Checkout ArangoDB
+          command: |
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            mkdir -p << parameters.destination >>
+            cd << parameters.destination >>
+            echo << pipeline.git.revision >>
+            git init
+            git remote add origin git@github.com:arangodb/release-test-automation.git
+            echo "Fetching stuff"
+            git fetch --depth 1 origin << pipeline.git.revision >>
+            git checkout << pipeline.git.revision >>
 
 jobs:
   build-test-docker-image:
@@ -57,6 +74,8 @@ jobs:
           public_registry: true
       - checkout-arangodb:
           destination: /home/circleci/project
+      - checkout-rta:
+          destination: /home/circleci/project-rta
       - run:
           name: Build Docker Image
           command: |
@@ -72,6 +91,13 @@ jobs:
             docker tag $image:latest-<< parameters.arch >> $image:$(cat << parameters.arch >>-tag.txt)-<< parameters.arch >>
             docker tag $image:latest-<< parameters.arch >> $image:latest
             docker push $image:$(cat << parameters.arch >>-tag.txt)-<< parameters.arch >>
+          name: Build RTA Docker Image
+      - run:
+          command: |
+            set -x
+            cd /home/circleci/project-rta
+            image=<< parameters.image >>
+            ./jenkins/build_and_push_circle-ci-containers.sh "$image" "$(cat << parameters.arch >>-tag.txt)"
       - run:
           name: Build GO Docker Image
           command: |
@@ -139,6 +165,11 @@ jobs:
           command: |
             cd scripts/docker/
             ./build-manifest.sh << parameters.image >> $(cat amd64-tag.txt)
+      - run:
+          name: Build RTA container manifest
+          command: |
+            cd /home/circleci/project-rta
+            ./jenkins/build_and_push_circle-ci-manifest.sh << parameters.image >> $(cat amd64-tag.txt)
       - run:
           name: Build go test container manifest
           command: |


### PR DESCRIPTION
### Scope & Purpose

we can't lean on the upstream docker library for the UI-RTA docker images. Hence we need to store them in our own as well.

https://github.com/arangodb/release-test-automation/pull/559 related RTA pull picking up this. 

- [x] :hankey: Bugfix
- [x] :pizza: New feature
