### PR TITLE
Necessary backport for RTA tests

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -22,7 +22,7 @@ parameters:
     default: "arangodb/ubuntubuildarangodb-devel:15"
   test-docker-image:
     type: string
-    default: public.ecr.aws/b0b8h2r4/test-ubuntu:24.04-5b5ffda4
+    default: public.ecr.aws/b0b8h2r4/test-ubuntu:24.04-9cfa8ba1
   # Unused here, but it will be forwarded from config and will cause errors if not defined
   enterprise-branch:
     type: string
@@ -622,6 +622,9 @@ jobs:
       arangosh_args:
         type: string
         default: ""
+      docker_image:
+        type: string
+        default: "<< pipeline.parameters.test-docker-image >>"
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -631,6 +634,7 @@ jobs:
       - run:
           name: Clone RTA
           command: |
+            set + x
             mkdir work/release-test-automation
             cd work/release-test-automation
             git clone git@github.com:arangodb/release-test-automation.git .
@@ -639,6 +643,7 @@ jobs:
           name: Run << parameters.suiteName >> tests
           no_output_timeout: 20m
           command: |
+            set +x
             pwd
             export SOURCE=nightlypublic
             export RTA_EDITION=<< parameters.enterprise >>
@@ -660,6 +665,7 @@ jobs:
             fi
             mkdir -p  work/release-test-automation/allure-results work/release-test-automation/allure-config
             cd work/release-test-automation
+            export DOCKER_CONTAINER="<< parameters.docker_image >>"
             bash -x ./jenkins/circleci_tar.sh \
               --no-checkdata \
               --no-run-upgrade  \

--- a/.circleci/build_test_image.yml
+++ b/.circleci/build_test_image.yml
@@ -33,6 +33,16 @@ commands:
             echo "Fetching stuff"
             git fetch --depth 1 origin << pipeline.git.revision >>
             git checkout << pipeline.git.revision >>
+  checkout-rta:
+    parameters:
+      destination:
+        type: string
+    steps:
+      - run:
+          name: Checkout RTA
+          command: |
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+            git clone git@github.com:arangodb/release-test-automation.git <<parameters.destination>>
 
 jobs:
   build-test-docker-image:
@@ -57,13 +67,24 @@ jobs:
           public_registry: true
       - checkout-arangodb:
           destination: /home/circleci/project
+      - checkout-rta:
+          destination: /home/circleci/project-rta
       - run:
           name: Build Docker Image
           command: |
             cd /home/circleci/project/scripts/docker/test
             /bin/sh build-image.sh << parameters.image >> << parameters.arch >>
       - run:
-          name: Determine Docker Tag
+          name: Build RTA Docker Image
+          command: |
+            set -x
+            TAG="$(cat /home/circleci/project/scripts/docker/<< parameters.arch >>-tag.txt)"
+            cd /home/circleci/project-rta
+            ls -alh
+            image=<< parameters.image >>
+            ./jenkins/build_and_push_circle-ci-containers.sh "${image}" "${TAG}"
+      - run:
+          name: Build GO Docker Image
           command: |
             cd /home/circleci/project/scripts/docker/test
             /bin/sh determine-tag.sh << parameters.image >> << parameters.arch >> | tee << parameters.arch >>-tag.txt
@@ -95,6 +116,8 @@ jobs:
             - "f9:49:75:1a:ad:44:89:10:4b:3c:70:70:ba:d3:c3:ce"
       - checkout-arangodb:
           destination: /home/circleci/project
+      - checkout-rta:
+          destination: /home/circleci/project-rta
       - attach_workspace:
           at: .
       - setup_remote_docker:
@@ -108,6 +131,27 @@ jobs:
           command: |
             cd scripts/docker/test
             ./build-manifest.sh << parameters.image >> $(cat amd64-tag.txt)
+      - run:
+          name: Build RTA container manifest
+          command: |
+            TAG="$(cat /home/circleci/project/scripts/docker/amd64-tag.txt)"
+            cd /home/circleci/project-rta
+            ./jenkins/build_and_push_circle-ci-manifests.sh << parameters.image >> $TAG
+      - run:
+          name: Build go test container manifest
+          command: |
+            cd scripts/docker/
+            ./build-manifest.sh << parameters.image >>-go $(cat amd64-tag-go.txt)
+      - run:
+          name: Build js test container manifest
+          command: |
+            cd scripts/docker/
+            ./build-manifest.sh << parameters.image >>-js $(cat amd64-tag-js.txt)
+      - run:
+          name: Build java test container manifest
+          command: |
+            cd scripts/docker
+            ./build-manifest.sh << parameters.image >>-java $(cat amd64-tag-java.txt)
       # TODO - commit the tag file to the repository
       # - run:
       #     name: Update TagFile


### PR DESCRIPTION
### Scope & Purpose

This is a necessary backport from `devel` to 3.12.5 to have green RTA
tests.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **integration tests**

