### PR TITLE
QA-660: add rest handler for waiting for estimator sync

### DIFF
--- a/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
@@ -72,6 +72,19 @@ RestStatus RocksDBRestWalHandler::execute() {
       properties();
       return RestStatus::DONE;
     }
+  } else if (operation == "wait_for_estimator_sync" && (
+              ServerState::instance()->isCoordinator() ||
+              ServerState::instance()->isSingleServer()) ) {
+#ifndef ARANGODB_ENABLE_MAINTAINER_MODE
+    if (!ExecContext::current().isSuperuser()) {
+      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
+                    "system level access is needed for this API");
+      return RestStatus::DONE;
+    }
+#endif
+    server().getFeature<EngineSelectorFeature>()
+      .engine()
+      .waitForEstimatorSync();
   } else {
     generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
                   "expecting /_admin/wal/<operation>");

--- a/js/client/modules/@arangodb/test-helper.js
+++ b/js/client/modules/@arangodb/test-helper.js
@@ -509,7 +509,7 @@ exports.runParallelArangoshTests = function (tests, duration, cn) {
 };
 
 exports.waitForEstimatorSync = function() {
-  return arango.POST("/_admin/execute", "require('internal').waitForEstimatorSync();"); // make sure estimates are consistent
+  return arango.GET_RAW("/_admin/wal/wait_for_estimator_sync"); // make sure estimates are consistent
 };
 
 exports.waitForShardsInSync = function (cn, timeout, minimumRequiredFollowers = 0) {


### PR DESCRIPTION
### Scope & Purpose

implement `waitForEstimatorSync()` via rest-api instead of remote executing v8. 

- [x] :hankey: Bugfix
- [x] :pizza: New feature
