### PR TITLE
Fixes singleserver upgrade.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-2212: Fix a hang on singleserver upgrades. Some of the Upgrade tasks needed 
+  the UserManager to function properly.  
+
 * Fix BTS-2178: If the URL in an HTTP request is bad, the server will
   now not simply close the connection but give a proper response.
 


### PR DESCRIPTION
### Scope & Purpose

Fix a hang on singleserver upgrades. Some of the Upgrade tasks needed the UserManager to function properly.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2212
- [ ] Design document: 
