### PR TITLE
[BTS-2217] Attempting to STOP a non-started feature

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix BTS-2217: If an error happens during startup, a disabled feature can
+  lead to a crash. Additionally signal that the server is stopping during
+  the unexpected shutdown so that in particular the RocksDBSyncThread does
+  not crash with an assertion failure.
+
 * Fix BTS-2212: Fix a hang on singleserver upgrades. Some of the Upgrade tasks needed 
   the UserManager to function properly.  
 

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -727,6 +727,9 @@ void ApplicationServer::start() {
       for (auto it = _orderedFeatures.rbegin(); it != _orderedFeatures.rend();
            ++it) {
         ApplicationFeature& feature = *it;
+        if (!feature.isEnabled()) {
+          continue;
+        }
         ADB_PROD_ASSERT(feature.state() == ApplicationFeature::State::STOPPED ||
                         feature.state() == ApplicationFeature::State::PREPARED)
             << "feature " << feature.name() << " is in state "

--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -700,6 +700,8 @@ void ApplicationServer::start() {
         }
       }
 
+      reportServerProgress(State::IN_STOP);
+      _state.store(State::IN_STOP, std::memory_order_release);
       // try to stop all feature that we just started
       for (auto it = _orderedFeatures.rbegin(); it != _orderedFeatures.rend();
            ++it) {
@@ -723,6 +725,8 @@ void ApplicationServer::start() {
         }
       }
 
+      reportServerProgress(State::IN_UNPREPARE);
+      _state.store(State::IN_UNPREPARE, std::memory_order_release);
       // try to unprepare all feature that we just started
       for (auto it = _orderedFeatures.rbegin(); it != _orderedFeatures.rend();
            ++it) {


### PR DESCRIPTION
If an error happens during `ApplicationServer::start()`, the function attempts to shutdown all previously started features.

During startup only the enabled features are started, non-enabled features are skipped.

The shutdown loop was missing the code skipping non-enabled features and hence ran into an `ADB_PROD_ASSERT.

Testing the above fix I also found that the server is not put into the correct state when stopping and unpreparing features, so that code is added, too.


### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
