### PR TITLE
[BTS-2220] Fix for CI not available on upgrade

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix BTS-2220: Fix failing autoupgrade of databases in cluster mode.
+  This was caused by key generation now using the cluster key
+  generator on dbservers, which fails during upgrade with a message that
+  the database was shutting down.
+
 * Fix BTS-2217: If an error happens during startup, a disabled feature can
   lead to a crash. Additionally signal that the server is stopping during
   the unexpected shutdown so that in particular the RocksDBSyncThread does

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -1149,21 +1149,18 @@ std::shared_ptr<HeartbeatThread> ClusterFeature::heartbeatThread() {
 
 ClusterInfo& ClusterFeature::clusterInfo() {
   if (!_clusterInfo) {
-    LOG_TOPIC("3bc4a", FATAL, Logger::CLUSTER)
-        << "exiting prematurely, because clusterInfo was accessed but is "
-           "unavailable";
-
-    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+    if (server().isStopping()) {
+      THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
+    } else {
+      ADB_PROD_ASSERT(_clusterInfo != nullptr)
+          << "_clusterInfo is null, but server is not shutting down";
+    }
   }
   return *_clusterInfo;
 }
 
 AgencyCache& ClusterFeature::agencyCache() {
   if (_agencyCache == nullptr) {
-    LOG_TOPIC("76e07", FATAL, Logger::CLUSTER)
-        << "exiting prematurely because agencyCache was accessed but is "
-           "unavailable";
-
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
   return *_agencyCache;

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -1149,6 +1149,10 @@ std::shared_ptr<HeartbeatThread> ClusterFeature::heartbeatThread() {
 
 ClusterInfo& ClusterFeature::clusterInfo() {
   if (!_clusterInfo) {
+    LOG_TOPIC("3bc4a", FATAL, Logger::CLUSTER)
+        << "exiting prematurely, because clusterInfo was accessed but is "
+           "unavailable";
+
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
   return *_clusterInfo;
@@ -1156,6 +1160,10 @@ ClusterInfo& ClusterFeature::clusterInfo() {
 
 AgencyCache& ClusterFeature::agencyCache() {
   if (_agencyCache == nullptr) {
+    LOG_TOPIC("76e07", FATAL, Logger::CLUSTER)
+        << "exiting prematurely because agencyCache was accessed but is "
+           "unavailable";
+
     THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
   return *_agencyCache;

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -48,6 +48,8 @@
 #include <string>
 #include <string_view>
 
+#include "Logger/LogMacros.h"
+
 using namespace arangodb;
 using namespace arangodb::basics;
 
@@ -367,8 +369,9 @@ class TraditionalKeyGeneratorCoordinator final
     : public TraditionalKeyGenerator {
  public:
   explicit TraditionalKeyGeneratorCoordinator(
-      ClusterInfo& ci, LogicalCollection const& collection, bool allowUserKeys)
-      : TraditionalKeyGenerator(collection, allowUserKeys), _ci(ci) {
+      /* ClusterInfo& ci, */ LogicalCollection const& collection,
+      bool allowUserKeys)
+      : TraditionalKeyGenerator(collection, allowUserKeys) /* , _ci(ci) */ {
     TRI_ASSERT(ServerState::instance()->isCoordinator() ||
                ServerState::instance()->isDBServer());
   }
@@ -382,14 +385,18 @@ class TraditionalKeyGeneratorCoordinator final
       // for testing purposes only
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
-    return _ci.uniqid();
+    return _collection.vocbase()
+        .server()
+        .getFeature<ClusterFeature>()
+        .clusterInfo()
+        .uniqid();
   }
 
   /// @brief track a key value (internal)
   void trackValue(uint64_t /* value */) noexcept override {}
 
  private:
-  ClusterInfo& _ci;
+  /* ClusterInfo& _ci; */
 };
 
 /// @brief base class for padded key generators
@@ -732,12 +739,9 @@ std::unordered_map<GeneratorMapType,
           // In these cases we have to generate a key using a cluster-wide
           // unique identifier, so we use the "Coordinator" key generator
           // also on DBServers.
-          auto& ci = collection.vocbase()
-                         .server()
-                         .getFeature<ClusterFeature>()
-                         .clusterInfo();
+
           return std::make_unique<TraditionalKeyGeneratorCoordinator>(
-              ci, collection, allowUserKeys);
+              /* ci, */ collection, allowUserKeys);
         }
         return std::make_unique<TraditionalKeyGeneratorSingle>(
             collection, allowUserKeys, ::readLastValue(options));
@@ -1004,7 +1008,6 @@ std::unique_ptr<KeyGenerator> KeyGeneratorHelper::createKeyGenerator(
   // if necessary
   return createEnterpriseKeyGenerator(std::move(generator));
 }
-
 #ifndef USE_ENTERPRISE
 
 std::unique_ptr<KeyGenerator> KeyGeneratorHelper::createEnterpriseKeyGenerator(

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -196,7 +196,8 @@ enum class GeneratorType : int {
   kTraditional = 1,
   kAutoincrement = 2,
   kUuid = 3,
-  kPadded = 4
+  kPadded = 4,
+  kUpgrade = 5
 };
 
 /// @brief for older compilers
@@ -675,12 +676,44 @@ class UuidKeyGenerator final : public KeyGenerator {
   boost::uuids::random_generator _uuid;
 };
 
+/// @brief upgrade key generator;
+//
+//  This generator is created if a DBServer is upgrading
+//  the database;
+//  If any code tries generating a key this crashes the process, as
+//  database upgrades are strictly a dbserver-local process and hence
+//  must not rely on any cluster-global state!
+//
+class UpgradeKeyGenerator final : public KeyGenerator {
+ public:
+  /// @brief create the generator
+  explicit UpgradeKeyGenerator(LogicalCollection const& collection)
+      : KeyGenerator(collection, false) {}
+
+  bool hasDynamicState() const noexcept override { return false; }
+
+  /// @brief generate a key; crashes in all cases
+  std::string generate(velocypack::Slice /*input*/) override {
+    ADB_PROD_CRASH() << "TODO: ...insert helpful message";
+    return "upgradekey";
+  }
+
+  /// @brief track usage of a key
+  void track(std::string_view /*key*/) noexcept override {}
+
+  void toVelocyPack(velocypack::Builder& builder) const override {
+    KeyGenerator::toVelocyPack(builder);
+    builder.add("type", VPackValue("upgrade"));
+  }
+};
+
 /// @brief all generators, by name
 std::unordered_map<std::string, GeneratorType> const generatorNames = {
     {"traditional", GeneratorType::kTraditional},
     {"autoincrement", GeneratorType::kAutoincrement},
     {"uuid", GeneratorType::kUuid},
-    {"padded", GeneratorType::kPadded}};
+    {"padded", GeneratorType::kPadded},
+    {"upgrade", GeneratorType::kUpgrade}};
 
 /// @brief get the generator type from VelocyPack
 GeneratorType generatorType(VPackSlice parameters) {
@@ -740,7 +773,7 @@ std::unordered_map<GeneratorMapType,
 
           auto const upgrading = server.getFeature<DatabaseFeature>().upgrade();
           if (upgrading) {
-            return nullptr;
+            return std::make_unique<UpgradeKeyGenerator>(collection);
           } else {
             auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
 
@@ -848,6 +881,11 @@ std::unordered_map<GeneratorMapType,
         }
         return std::make_unique<PaddedKeyGeneratorSingle>(
             collection, allowUserKeys, ::readLastValue(options));
+      }},
+     {static_cast<GeneratorMapType>(GeneratorType::kUpgrade),
+      [](LogicalCollection const& collection,
+         VPackSlice options) -> std::unique_ptr<UpgradeKeyGenerator> {
+        return std::make_unique<UpgradeKeyGenerator>(collection);
       }}};
 
 }  // namespace

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -873,12 +873,17 @@ std::unordered_map<GeneratorMapType,
           // In these cases we have to generate a key using a cluster-wide
           // unique identifier, so we use the "Coordinator" key generator
           // also on DBServers.
-          auto& ci = collection.vocbase()
-                         .server()
-                         .getFeature<ClusterFeature>()
-                         .clusterInfo();
-          return std::make_unique<PaddedKeyGeneratorCoordinator>(
-              ci, collection, allowUserKeys, ::readLastValue(options));
+          auto const& server = collection.vocbase().server();
+
+          auto const upgrading = server.getFeature<DatabaseFeature>().upgrade();
+          if (upgrading) {
+            return std::make_unique<UpgradeKeyGenerator>(collection);
+          } else {
+            auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
+
+            return std::make_unique<PaddedKeyGeneratorCoordinator>(
+                ci, collection, allowUserKeys, ::readLastValue(options));
+          }
         }
         return std::make_unique<PaddedKeyGeneratorSingle>(
             collection, allowUserKeys, ::readLastValue(options));

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -694,7 +694,8 @@ class UpgradeKeyGenerator final : public KeyGenerator {
 
   /// @brief generate a key; crashes in all cases
   std::string generate(velocypack::Slice /*input*/) override {
-    ADB_PROD_CRASH() << "TODO: ...insert helpful message";
+    ADB_PROD_CRASH()
+        << "tried generating a cluster-wide unique-key during database upgrade";
     return "upgradekey";
   }
 

--- a/arangod/VocBase/KeyGenerator.cpp
+++ b/arangod/VocBase/KeyGenerator.cpp
@@ -34,6 +34,7 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
+#include "RestServer/DatabaseFeature.h"
 #include "Utilities/NameValidator.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
@@ -369,9 +370,8 @@ class TraditionalKeyGeneratorCoordinator final
     : public TraditionalKeyGenerator {
  public:
   explicit TraditionalKeyGeneratorCoordinator(
-      /* ClusterInfo& ci, */ LogicalCollection const& collection,
-      bool allowUserKeys)
-      : TraditionalKeyGenerator(collection, allowUserKeys) /* , _ci(ci) */ {
+      ClusterInfo& ci, LogicalCollection const& collection, bool allowUserKeys)
+      : TraditionalKeyGenerator(collection, allowUserKeys), _ci(ci) {
     TRI_ASSERT(ServerState::instance()->isCoordinator() ||
                ServerState::instance()->isDBServer());
   }
@@ -385,18 +385,14 @@ class TraditionalKeyGeneratorCoordinator final
       // for testing purposes only
       THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
     }
-    return _collection.vocbase()
-        .server()
-        .getFeature<ClusterFeature>()
-        .clusterInfo()
-        .uniqid();
+    return _ci.uniqid();
   }
 
   /// @brief track a key value (internal)
   void trackValue(uint64_t /* value */) noexcept override {}
 
  private:
-  /* ClusterInfo& _ci; */
+  ClusterInfo& _ci;
 };
 
 /// @brief base class for padded key generators
@@ -740,8 +736,17 @@ std::unordered_map<GeneratorMapType,
           // unique identifier, so we use the "Coordinator" key generator
           // also on DBServers.
 
-          return std::make_unique<TraditionalKeyGeneratorCoordinator>(
-              /* ci, */ collection, allowUserKeys);
+          auto const& server = collection.vocbase().server();
+
+          auto const upgrading = server.getFeature<DatabaseFeature>().upgrade();
+          if (upgrading) {
+            return nullptr;
+          } else {
+            auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
+
+            return std::make_unique<TraditionalKeyGeneratorCoordinator>(
+                ci, collection, allowUserKeys);
+          }
         }
         return std::make_unique<TraditionalKeyGeneratorSingle>(
             collection, allowUserKeys, ::readLastValue(options));


### PR DESCRIPTION
### Scope & Purpose

In a recent PR the KeyGenerator was changed so that it is always guaranteed to produce unique IDs on INSERT or UPGRADE in a cluster. This was achieved by using cluster wide unique key generation which relies on the Cluster feature to be started.

When a database upgrade happens in a Cluster, all LogicalCollections are created on startup and initialise their KeyGenerator as part of that process. Crucially the Cluster feature is not started during upgrades.

This PR introduces a UpgradeKeyGenerator that is created when the ArangoDB process is opening collections in upgrade mode. If any code tries creating a key the database process crashes.

With this PR the arangod process also crashes if any code tries to access the `_clusterInfo` member of the Cluster feature in any state other than the shutdown phase. This enables slightly better debugging.

Additio
- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.5: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2220
- [ ] Design document: 
