### PR TITLE
Bug fix/bts 2213/fix increased user revision conflicts

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,13 +1,16 @@
 devel
 -----
 
+* Fix BTS-2213: Adds a retry logic to the UserManager::updateUser to retry in certain situations 
+  (e.g. DB/Col create) until it succeeds instead of giving up after some _rev conflicts.
+
 * Fix BTS-2217: If an error happens during startup, a disabled feature can
   lead to a crash. Additionally signal that the server is stopping during
   the unexpected shutdown so that in particular the RocksDBSyncThread does
   not crash with an assertion failure.
 
 * Fix BTS-2212: Fix a hang on singleserver upgrades. Some of the Upgrade tasks needed 
-  the UserManager to function properly.  
+  the UserManager to function properly.
 
 * Fix BTS-2178: If the URL in an HTTP request is bad, the server will
   now not simply close the connection but give a proper response.

--- a/arangod/Auth/UserManager.h
+++ b/arangod/Auth/UserManager.h
@@ -83,7 +83,8 @@ class UserManager {
                                 bool retryOnConflict) = 0;
 
   // Update specific user
-  virtual Result updateUser(std::string const& user, UserCallback&&) = 0;
+  virtual Result updateUser(std::string const& user, UserCallback&&,
+                            bool retryOnConflict) = 0;
 
   // Access user without modifying it
   virtual Result accessUser(std::string const& user, ConstUserCallback&&) = 0;

--- a/arangod/Auth/UserManagerImpl.cpp
+++ b/arangod/Auth/UserManagerImpl.cpp
@@ -464,13 +464,17 @@ uint64_t UserManagerImpl::globalVersion() const noexcept {
   return _globalVersion.load(std::memory_order_acquire);
 }
 
-/// Trigger eventual reload, user facing API call
 void UserManagerImpl::triggerGlobalReload() const {
+  triggerGlobalReload(_server);
+}
+
+/// Trigger eventual reload, user facing API call
+void UserManagerImpl::triggerGlobalReload(ArangodServer& server) {
   if (!ServerState::instance()->isCoordinator()) {
     return;
   }
   // tell other coordinators to reload as well
-  AgencyComm agency(_server);
+  AgencyComm agency(server);
   AgencyWriteTransaction incrementVersion({AgencyOperation(
       "Sync/UserVersion", AgencySimpleOperationType::INCREMENT_OP)});
 

--- a/arangod/Auth/UserManagerImpl.cpp
+++ b/arangod/Auth/UserManagerImpl.cpp
@@ -535,6 +535,8 @@ Result UserManagerImpl::enumerateUsers(std::function<bool(User&)>&& func,
                                        bool const retryOnConflict) {
   checkIfUserDataIsAvailable();
 
+  auto const currentInternalVersion =
+      _internalVersion.load(std::memory_order::relaxed);
   std::vector<User> toUpdate;
   {  // users are later updated with rev ID for consistency
     READ_LOCKER(readGuard, _userCacheLock);
@@ -557,10 +559,8 @@ Result UserManagerImpl::enumerateUsers(std::function<bool(User&)>&& func,
       if (res.is(TRI_ERROR_ARANGO_CONFLICT) && retryOnConflict) {
         res.reset();
         // We ran into a conflict, and we have to retry
-        // so we either wait for the update thread to re-run/finish, which is
-        // blocking anyway so we can also just reload synchronously here
-        // directly.
-        loadFromDB();
+        // so we wait for the update thread to re-run/finish
+        _internalVersion.wait(currentInternalVersion);
         READ_LOCKER(readGuard, _userCacheLock);
         UserMap::iterator it2 = _userCache.find(it->username());
         if (it2 != _userCache.end()) {
@@ -583,33 +583,47 @@ Result UserManagerImpl::enumerateUsers(std::function<bool(User&)>&& func,
   return res;
 }
 
-Result UserManagerImpl::updateUser(std::string const& name,
-                                   UserCallback&& func) {
+Result UserManagerImpl::updateUser(std::string const& name, UserCallback&& func,
+                                   bool const retryOnConflict) {
   if (name.empty()) {
     return TRI_ERROR_USER_NOT_FOUND;
   }
 
   checkIfUserDataIsAvailable();
 
-  // we require a consistent view on the user object
-  READ_LOCKER(readGuard, _userCacheLock);
+  Result r;
+  do {
+    auto const currentInternalVersion =
+        _internalVersion.load(std::memory_order::relaxed);
+    // we require a consistent view on the user object
+    READ_LOCKER(readGuard, _userCacheLock);
 
-  UserMap::iterator it = _userCache.find(name);
-  if (it == _userCache.end()) {
-    return TRI_ERROR_USER_NOT_FOUND;
-  }
+    UserMap::iterator it = _userCache.find(name);
+    if (it == _userCache.end()) {
+      return TRI_ERROR_USER_NOT_FOUND;
+    }
 
-  LOG_TOPIC("574c5", DEBUG, Logger::AUTHENTICATION) << "Updating user " << name;
-  User user = it->second;  // make a copy
-  TRI_ASSERT(!user.key().empty() && user.rev().isSet());
-  Result r = func(user);
-  if (r.fail()) {
-    return r;
-  }
-  r = storeUserInternal(user, /*replace*/ true);
+    LOG_TOPIC("574c5", DEBUG, Logger::AUTHENTICATION)
+        << "Updating user " << name;
+    User user = it->second;  // make a copy
+    TRI_ASSERT(!user.key().empty() && user.rev().isSet());
+    r = func(user);
+    if (r.fail()) {
+      return r;
+    }
+    r = storeUserInternal(user, /*replace*/ true);
 
-  // cannot hold _userCacheLock while  invalidating token cache
-  readGuard.unlock();
+    // cannot hold _userCacheLock while invalidating/reloading user cache
+    readGuard.unlock();
+
+    if (retryOnConflict && r.is(TRI_ERROR_ARANGO_CONFLICT)) {
+      // We ran into a conflict, so we know that there is a new globalVersion
+      // on the way. So we wait here on the lower-bound version that we tried
+      // to update on and retry again with after we receive the latest _users.
+      _internalVersion.wait(currentInternalVersion);
+    }
+  } while (retryOnConflict && r.is(TRI_ERROR_ARANGO_CONFLICT));
+
   if (r.ok() || r.is(TRI_ERROR_ARANGO_CONFLICT)) {
     // must also clear the basic cache here because the secret may be
     // invalid now if the password was changed
@@ -767,8 +781,8 @@ Result UserManagerImpl::accessTokens(std::string const& user,
 
 Result UserManagerImpl::deleteAccessToken(std::string const& user,
                                           uint64_t id) {
-  Result result =
-      updateUser(user, [&](User& u) { return u.deleteAccessToken(id); });
+  Result result = updateUser(
+      user, [&](User& u) { return u.deleteAccessToken(id); }, true);
 
   return result;
 }
@@ -777,9 +791,10 @@ Result UserManagerImpl::createAccessToken(std::string const& user,
                                           std::string const& name,
                                           double validUntil,
                                           velocypack::Builder& builder) {
-  Result result = updateUser(user, [&](User& u) {
-    return u.createAccessToken(name, validUntil, builder);
-  });
+  Result result = updateUser(
+      user,
+      [&](User& u) { return u.createAccessToken(name, validUntil, builder); },
+      false);
 
   return result;
 }

--- a/arangod/Auth/UserManagerImpl.h
+++ b/arangod/Auth/UserManagerImpl.h
@@ -66,7 +66,8 @@ class UserManagerImpl final : public UserManager {
   Result enumerateUsers(std::function<bool(User&)>&&,
                         bool retryOnConflict) override;
 
-  Result updateUser(std::string const& user, UserCallback&&) override;
+  Result updateUser(std::string const& user, UserCallback&&,
+                    bool retryOnConflict) override;
 
   Result accessUser(std::string const& user, ConstUserCallback&&) override;
 

--- a/arangod/Auth/UserManagerImpl.h
+++ b/arangod/Auth/UserManagerImpl.h
@@ -53,6 +53,8 @@ class UserManagerImpl final : public UserManager {
   void loadUserCacheAndStartUpdateThread() noexcept override;
   void setGlobalVersion(uint64_t version) noexcept override;
   [[nodiscard]] uint64_t globalVersion() const noexcept override;
+
+  static void triggerGlobalReload(ArangodServer&);
   void triggerGlobalReload() const override;
   void triggerCacheRevalidation() override;
   void createRootUser() override;

--- a/arangod/Cluster/ClusterInfo.cpp
+++ b/arangod/Cluster/ClusterInfo.cpp
@@ -5450,7 +5450,6 @@ Result ClusterInfo::agencyReplan(VPackSlice const plan) {
       SetOldEntry("Plan/Views", {"arango", "Plan", "Views"}, plan),
       {"Current/Version", AgencySimpleOperationType::INCREMENT_OP},
       {"Plan/Version", AgencySimpleOperationType::INCREMENT_OP},
-      {"Sync/UserVersion", AgencySimpleOperationType::INCREMENT_OP},
       {"Sync/FoxxQueueVersion", AgencySimpleOperationType::INCREMENT_OP},
       {"Sync/HotBackupRestoreDone", AgencySimpleOperationType::INCREMENT_OP}};
 

--- a/arangod/Cluster/HeartbeatThread.cpp
+++ b/arangod/Cluster/HeartbeatThread.cpp
@@ -740,7 +740,7 @@ void HeartbeatThread::handleUserVersionChange(VPackSlice userVersion) {
     } catch (...) {
     }
 
-    if (version > 0 && af.isActive() && af.userManager() != nullptr) {
+    if (version > 0 && af.userManager() != nullptr) {
       af.userManager()->setGlobalVersion(version);
     }
   }

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -974,6 +974,13 @@ Result TailingSyncer::applyLogMarker(VPackSlice const& slice,
                                      TRI_voc_tick_t /*firstRegularTick*/,
                                      TRI_voc_tick_t /*markerTick*/,
                                      TRI_replication_operation_e type) {
+  if (_usersModified) {
+    // This function can drop/create Databases/Collections
+    // this needs an up-to-date UserManager as we could run in to conflicts
+    // with changes that are not yet loaded to the internal cache.
+    reloadUsers();
+    _usersModified = false;
+  }
   // handle marker type
   if (type == REPLICATION_MARKER_DOCUMENT ||
       type == REPLICATION_MARKER_REMOVE) {

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -272,27 +272,31 @@ static Result StoreUser(auth::UserManager* um, int mode,
   } else if (mode == 2) {
     VPackBuilder doc = um->serializeUser(user);
     VPackSlice u = doc.slice();
-    r = um->updateUser(user, [&](auth::User& entry) {
-      if (json.isObject()) {
-        if (json.get("passwd").isString()) {
-          entry.updatePassword(passwd);
-        }
-        if (json.get("active").isBool()) {
-          entry.setActive(active);
-        }
-      }
+    r = um->updateUser(
+        user,
+        [&](auth::User& entry) {
+          if (json.isObject()) {
+            if (json.get("passwd").isString()) {
+              entry.updatePassword(passwd);
+            }
+            if (json.get("active").isBool()) {
+              entry.setActive(active);
+            }
+          }
 
-      VPackSlice oldExtra = u.get("extra");
-      if (extra.isObject() && oldExtra.isObject()) {
-        // Both `extra` and `oldExtra` are objects, so perform a deep merge.
-        entry.setUserData(VPackCollection::merge(oldExtra, extra, true, false));
-      } else if (!extra.isNone()) {
-        // `extra` or `oldExtra` is not an object, so a deep merge is not
-        // possible. Just overwrite the old value.
-        entry.setUserData(VPackBuilder(extra));
-      }
-      return TRI_ERROR_NO_ERROR;
-    });
+          VPackSlice oldExtra = u.get("extra");
+          if (extra.isObject() && oldExtra.isObject()) {
+            // Both `extra` and `oldExtra` are objects, so perform a deep merge.
+            entry.setUserData(
+                VPackCollection::merge(oldExtra, extra, true, false));
+          } else if (!extra.isNone()) {
+            // `extra` or `oldExtra` is not an object, so a deep merge is not
+            // possible. Just overwrite the old value.
+            entry.setUserData(VPackBuilder(extra));
+          }
+          return TRI_ERROR_NO_ERROR;
+        },
+        false);
   }
 
   return r;
@@ -408,17 +412,20 @@ RestStatus RestUsersHandler::putRequest(auth::UserManager* um) {
 
       b(VPackValue(VPackValueType::Object));
 
-      Result r = um->updateUser(name, [&](auth::User& entry) {
-        if (coll.empty()) {
-          entry.grantDatabase(db, lvl);
-          b(db, VPackValue(convertFromAuthLevel(lvl)))();
-        } else {
-          entry.grantCollection(db, coll, lvl);
-          b(db + "/" + coll, VPackValue(convertFromAuthLevel(lvl)))();
-        }
+      Result r = um->updateUser(
+          name,
+          [&](auth::User& entry) {
+            if (coll.empty()) {
+              entry.grantDatabase(db, lvl);
+              b(db, VPackValue(convertFromAuthLevel(lvl)))();
+            } else {
+              entry.grantCollection(db, coll, lvl);
+              b(db + "/" + coll, VPackValue(convertFromAuthLevel(lvl)))();
+            }
 
-        return TRI_ERROR_NO_ERROR;
-      });
+            return TRI_ERROR_NO_ERROR;
+          },
+          false);
 
       if (r.ok()) {
         generateUserResult(ResponseCode::OK, b);
@@ -438,29 +445,33 @@ RestStatus RestUsersHandler::putRequest(auth::UserManager* um) {
         // The API expects: { value : <toStore> }
         // If we get sth else than the above it is translated
         // to a remove of the config option.
-        res = um->updateUser(name, [&](auth::User& u) {
-          VPackSlice newVal = body;
-          VPackSlice oldConf = u.configData();
-          if (!newVal.isObject() || !newVal.hasKey("value")) {
-            if (oldConf.isObject() && oldConf.hasKey(key)) {
-              u.setConfigData(VPackCollection::remove(
-                  oldConf, std::unordered_set<std::string>{key}));
-            }       // Nothing to do. We do not have a config yet.
-          } else {  // We need to merge the new key into the config
-            VPackBuilder b;
-            b(VPackValue(VPackValueType::Object))(key, newVal.get("value"))();
+        res = um->updateUser(
+            name,
+            [&](auth::User& u) {
+              VPackSlice newVal = body;
+              VPackSlice oldConf = u.configData();
+              if (!newVal.isObject() || !newVal.hasKey("value")) {
+                if (oldConf.isObject() && oldConf.hasKey(key)) {
+                  u.setConfigData(VPackCollection::remove(
+                      oldConf, std::unordered_set<std::string>{key}));
+                }       // Nothing to do. We do not have a config yet.
+              } else {  // We need to merge the new key into the config
+                VPackBuilder b;
+                b(VPackValue(VPackValueType::Object))(key,
+                                                      newVal.get("value"))();
 
-            if (oldConf.isObject() &&
-                !oldConf.isEmptyObject()) {  // merge value in
-              u.setConfigData(
-                  VPackCollection::merge(oldConf, b.slice(), false));
-            } else {
-              u.setConfigData(std::move(b));
-            }
-          }
+                if (oldConf.isObject() &&
+                    !oldConf.isEmptyObject()) {  // merge value in
+                  u.setConfigData(
+                      VPackCollection::merge(oldConf, b.slice(), false));
+                } else {
+                  u.setConfigData(std::move(b));
+                }
+              }
 
-          return TRI_ERROR_NO_ERROR;
-        });
+              return TRI_ERROR_NO_ERROR;
+            },
+            false);
       }
       if (res.ok()) {
         resetResponse(ResponseCode::OK);
@@ -526,10 +537,13 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
   } else if (suffixes.size() == 2) {
     std::string const& user = suffixes[0];
     if (suffixes[1] == "config" && canAccessUser(user)) {
-      Result r = um->updateUser(user, [&](auth::User& u) {
-        u.setConfigData(VPackBuilder());
-        return TRI_ERROR_NO_ERROR;
-      });
+      Result r = um->updateUser(
+          user,
+          [&](auth::User& u) {
+            u.setConfigData(VPackBuilder());
+            return TRI_ERROR_NO_ERROR;
+          },
+          false);
       if (r.ok()) {
         resetResponse(ResponseCode::OK);
       } else {
@@ -563,15 +577,18 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
         }
       }
 
-      Result r = um->updateUser(user, [&](auth::User& entry) {
-        if (coll.empty()) {
-          entry.removeDatabase(db);
-        } else {
-          entry.removeCollection(db, coll);
-        }
+      Result r = um->updateUser(
+          user,
+          [&](auth::User& entry) {
+            if (coll.empty()) {
+              entry.removeDatabase(db);
+            } else {
+              entry.removeCollection(db, coll);
+            }
 
-        return TRI_ERROR_NO_ERROR;
-      });
+            return TRI_ERROR_NO_ERROR;
+          },
+          true);
 
       if (r.ok()) {
         VPackBuilder b;
@@ -586,15 +603,19 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
       // remove internal config data, used in the WebUI
       if (canAccessUser(user)) {
         std::string const& key = suffixes[2];
-        Result r = um->updateUser(user, [&](auth::User& u) {
-          VPackBuilder b;
-          b(VPackValue(VPackValueType::Object))(key, VPackSlice::nullSlice())();
-          if (!u.configData().isNone()) {
-            u.setConfigData(
-                VPackCollection::merge(u.configData(), b.slice(), false, true));
-          }
-          return TRI_ERROR_NO_ERROR;
-        });
+        Result r = um->updateUser(
+            user,
+            [&](auth::User& u) {
+              VPackBuilder b;
+              b(VPackValue(VPackValueType::Object))(key,
+                                                    VPackSlice::nullSlice())();
+              if (!u.configData().isNone()) {
+                u.setConfigData(VPackCollection::merge(u.configData(),
+                                                       b.slice(), false, true));
+              }
+              return TRI_ERROR_NO_ERROR;
+            },
+            false);
 
         if (r.ok()) {
           resetResponse(ResponseCode::OK);

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -227,10 +227,13 @@ void UpgradeFeature::start() {
           if (ServerState::instance()->isSingleServer()) {
             um->loadUserCacheAndStartUpdateThread();
           }
-          Result res = um->updateUser("root", [&](auth::User& user) {
-            user.updatePassword(init.defaultPassword());
-            return TRI_ERROR_NO_ERROR;
-          });
+          Result res = um->updateUser(
+              "root",
+              [&](auth::User& user) {
+                user.updatePassword(init.defaultPassword());
+                return TRI_ERROR_NO_ERROR;
+              },
+              true);
           if (res.is(TRI_ERROR_USER_NOT_FOUND)) {
             VPackSlice extras = VPackSlice::noneSlice();
             res = um->storeUser(false, "root", init.defaultPassword(), true,

--- a/arangod/V8Server/v8-users.cpp
+++ b/arangod/V8Server/v8-users.cpp
@@ -178,18 +178,21 @@ static void JS_UpdateUser(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
                                    "users are not supported on this server");
   }
-  um->updateUser(username, [&](auth::User& u) {
-    if (args.Length() > 1 && args[1]->IsString()) {
-      u.updatePassword(TRI_ObjectToString(isolate, args[1]));
-    }
-    if (args.Length() > 2 && args[2]->IsBoolean()) {
-      u.setActive(TRI_ObjectToBoolean(isolate, args[2]));
-    }
-    if (!extras.isEmpty()) {
-      u.setUserData(std::move(extras));
-    }
-    return TRI_ERROR_NO_ERROR;
-  });
+  um->updateUser(
+      username,
+      [&](auth::User& u) {
+        if (args.Length() > 1 && args[1]->IsString()) {
+          u.updatePassword(TRI_ObjectToString(isolate, args[1]));
+        }
+        if (args.Length() > 2 && args[2]->IsBoolean()) {
+          u.setActive(TRI_ObjectToBoolean(isolate, args[2]));
+        }
+        if (!extras.isEmpty()) {
+          u.setUserData(std::move(extras));
+        }
+        return TRI_ERROR_NO_ERROR;
+      },
+      false);
 
   TRI_V8_RETURN_TRUE();
   TRI_V8_TRY_CATCH_END
@@ -290,10 +293,13 @@ static void JS_GrantDatabase(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
                                    "user are not supported on this server");
   }
-  Result r = um->updateUser(username, [&](auth::User& entry) {
-    entry.grantDatabase(db, lvl);
-    return TRI_ERROR_NO_ERROR;
-  });
+  Result r = um->updateUser(
+      username,
+      [&](auth::User& entry) {
+        entry.grantDatabase(db, lvl);
+        return TRI_ERROR_NO_ERROR;
+      },
+      false);
   if (!r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
@@ -320,10 +326,13 @@ static void JS_RevokeDatabase(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   std::string username = TRI_ObjectToString(isolate, args[0]);
   std::string db = TRI_ObjectToString(isolate, args[1]);
-  Result r = um->updateUser(username, [&](auth::User& entry) {
-    entry.removeDatabase(db);
-    return TRI_ERROR_NO_ERROR;
-  });
+  Result r = um->updateUser(
+      username,
+      [&](auth::User& entry) {
+        entry.removeDatabase(db);
+        return TRI_ERROR_NO_ERROR;
+      },
+      true);
   if (!r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
@@ -372,10 +381,13 @@ static void JS_GrantCollection(
     lvl = auth::convertToAuthLevel(type);
   }
 
-  Result r = um->updateUser(username, [&](auth::User& entry) {
-    entry.grantCollection(db, coll, lvl);
-    return TRI_ERROR_NO_ERROR;
-  });
+  Result r = um->updateUser(
+      username,
+      [&](auth::User& entry) {
+        entry.grantCollection(db, coll, lvl);
+        return TRI_ERROR_NO_ERROR;
+      },
+      false);
 
   if (!r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
@@ -418,10 +430,13 @@ static void JS_RevokeCollection(
     }
   }
 
-  Result r = um->updateUser(username, [&](auth::User& entry) {
-    entry.removeCollection(db, coll);
-    return TRI_ERROR_NO_ERROR;
-  });
+  Result r = um->updateUser(
+      username,
+      [&](auth::User& entry) {
+        entry.removeCollection(db, coll);
+        return TRI_ERROR_NO_ERROR;
+      },
+      true);
 
   if (!r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
@@ -460,12 +475,15 @@ static void JS_UpdateConfigData(
                                    "user are not supported on this server");
   }
 
-  Result r = um->updateUser(username, [&](auth::User& u) {
-    VPackBuilder updated = velocypack::Collection::merge(
-        u.configData(), merge.slice(), true, true);
-    u.setConfigData(std::move(updated));
-    return TRI_ERROR_NO_ERROR;
-  });
+  Result r = um->updateUser(
+      username,
+      [&](auth::User& u) {
+        VPackBuilder updated = velocypack::Collection::merge(
+            u.configData(), merge.slice(), true, true);
+        u.setConfigData(std::move(updated));
+        return TRI_ERROR_NO_ERROR;
+      },
+      false);
   if (!r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -697,39 +697,31 @@ Collections::create(         // create collection
       // this should not fail, we can not get here without database RW access
       // however, there may be races for updating the users account, so we try
       // a few times in case of a conflict
-      int tries = 0;
-      while (true) {
-        Result r = um->updateUser(exec.user(), [&](auth::User& entry) {
-          for (auto const& col : *results) {
-            // do not grant rights on system collections
-            if (!col->system()) {
-              entry.grantCollection(vocbase.name(), col->name(),
-                                    auth::Level::RW);
+      Result r = um->updateUser(
+          exec.user(),
+          [&](auth::User& entry) {
+            for (auto const& col : *results) {
+              // do not grant rights on system collections
+              if (!col->system()) {
+                entry.grantCollection(vocbase.name(), col->name(),
+                                      auth::Level::RW);
+              }
             }
-          }
-          return TRI_ERROR_NO_ERROR;
-        });
-        if (r.ok() || r.is(TRI_ERROR_USER_NOT_FOUND) ||
-            r.is(TRI_ERROR_USER_EXTERNAL)) {
-          // it seems to be allowed to created collections with an unknown user
-          break;
-        }
-        if (!r.is(TRI_ERROR_ARANGO_CONFLICT) || ++tries == 10) {
-          // This could be 116bb again, as soon as "old code" is removed
-          LOG_TOPIC("116bc", WARN, Logger::AUTHENTICATION)
-              << "Updating user failed with error: " << r.errorMessage()
-              << ". giving up!";
-          for (auto const& col : *results) {
-            events::CreateCollection(vocbase.name(), col->name(),
-                                     r.errorNumber());
-          }
-          return r;
-        }
-        // try again in case of conflict
-        // This could be ff123 again, as soon as "old code" is removed
-        LOG_TOPIC("ff124", TRACE, Logger::AUTHENTICATION)
+            return TRI_ERROR_NO_ERROR;
+          },
+          true);
+      const bool expectedResult = r.ok() || r.is(TRI_ERROR_USER_NOT_FOUND) ||
+                                  r.is(TRI_ERROR_USER_EXTERNAL);
+      if (!expectedResult) {
+        // This could be 116bb again, as soon as "old code" is removed
+        LOG_TOPIC("116bc", WARN, Logger::AUTHENTICATION)
             << "Updating user failed with error: " << r.errorMessage()
-            << ". trying again";
+            << ". giving up!";
+        for (auto const& col : *results) {
+          events::CreateCollection(vocbase.name(), col->name(),
+                                   r.errorNumber());
+        }
+        return r;
       }
     }
   } catch (basics::Exception const& ex) {

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -143,8 +143,7 @@ Result Databases::info(TRI_vocbase_t* vocbase, velocypack::Builder& result) {
 
 // Grant permissions on newly created database to current user
 // to be able to run the upgrade script
-Result Databases::grantCurrentUser(CreateDatabaseInfo const& info,
-                                   int64_t timeout) {
+Result Databases::grantCurrentUser(CreateDatabaseInfo const& info) {
   auth::UserManager* um = AuthenticationFeature::instance()->userManager();
 
   Result res;
@@ -155,25 +154,15 @@ Result Databases::grantCurrentUser(CreateDatabaseInfo const& info,
     // called us, or when authentication is off), granting rights
     // will fail. We hence ignore it here, but issue a warning below
     if (!exec.isAdminUser()) {
-      auto const endTime =
-          std::chrono::steady_clock::now() + std::chrono::seconds(timeout);
-      while (true) {
-        res = um->updateUser(exec.user(), [&](auth::User& entry) {
-          entry.grantDatabase(info.getName(), auth::Level::RW);
-          entry.grantCollection(info.getName(), "*", auth::Level::RW);
-          return TRI_ERROR_NO_ERROR;
-        });
-        if (res.ok() || !res.is(TRI_ERROR_ARANGO_CONFLICT) ||
-            std::chrono::steady_clock::now() > endTime) {
-          break;
-        }
-
-        if (info.server().isStopping()) {
-          res.reset(TRI_ERROR_SHUTTING_DOWN);
-          break;
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      }
+      res = um->updateUser(
+          exec.user(),
+          [&](auth::User& entry) {
+            entry.grantDatabase(info.getName(), auth::Level::RW);
+            entry.grantCollection(info.getName(), "*", auth::Level::RW);
+            return TRI_ERROR_NO_ERROR;
+          },
+          true);
+      return res;
     }
 
     LOG_TOPIC("2a4dd", DEBUG, Logger::FIXME)
@@ -263,7 +252,7 @@ Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
     }
   });
 
-  res = grantCurrentUser(info, 5);
+  res = grantCurrentUser(info);
   if (!res.ok()) {
     return res;
   }
@@ -345,7 +334,7 @@ Result Databases::createOther(CreateDatabaseInfo const& info) {
 
   auto sg = scopeGuard([&]() noexcept { vocbase->release(); });
 
-  Result res = grantCurrentUser(info, 10);
+  Result res = grantCurrentUser(info);
   if (!res.ok()) {
     return res;
   }
@@ -362,6 +351,7 @@ Result Databases::create(ArangodServer& server, ExecContext const& exec,
                          std::string const& dbName, velocypack::Slice users,
                          velocypack::Slice options) {
   Result res = basics::catchToResult([&]() {
+    // TODO
     Result res;
 
     // Only admin users are permitted to create databases

--- a/arangod/VocBase/Methods/Databases.h
+++ b/arangod/VocBase/Methods/Databases.h
@@ -52,8 +52,7 @@ struct Databases {
 
  private:
   /// @brief will retry for at most <timeout> seconds
-  static Result grantCurrentUser(CreateDatabaseInfo const& info,
-                                 int64_t timeout);
+  static Result grantCurrentUser(CreateDatabaseInfo const& info);
 
   static Result createCoordinator(CreateDatabaseInfo const& info);
   static Result createOther(CreateDatabaseInfo const& info);

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -578,17 +578,23 @@ Result UpgradeTasks::addDefaultUserOther(TRI_vocbase_t& vocbase,
           << "could not add database user " << user << ": "
           << res.errorMessage();
     } else if (extra.isObject() && !extra.isEmptyObject()) {
-      um->updateUser(user, [&](auth::User& user) {
-        user.setUserData(VPackBuilder(extra));
-        return TRI_ERROR_NO_ERROR;
-      });
+      um->updateUser(
+          user,
+          [&](auth::User& user) {
+            user.setUserData(VPackBuilder(extra));
+            return TRI_ERROR_NO_ERROR;
+          },
+          true);
     }
 
-    res = um->updateUser(user, [&](auth::User& entry) {
-      entry.grantDatabase(vocbase.name(), auth::Level::RW);
-      entry.grantCollection(vocbase.name(), "*", auth::Level::RW);
-      return TRI_ERROR_NO_ERROR;
-    });
+    res = um->updateUser(
+        user,
+        [&](auth::User& entry) {
+          entry.grantDatabase(vocbase.name(), auth::Level::RW);
+          entry.grantCollection(vocbase.name(), "*", auth::Level::RW);
+          return TRI_ERROR_NO_ERROR;
+        },
+        true);
     if (res.fail()) {
       LOG_TOPIC("60019", WARN, Logger::STARTUP)
           << "could not set permissions for new user " << user << ": "

--- a/tests/Auth/UserManagerTest.cpp
+++ b/tests/Auth/UserManagerTest.cpp
@@ -163,7 +163,10 @@ TEST_F(UserManagerTest, usermanager_should_throw_if_called_too_early) {
               Throws<basics::Exception>(
                   Property(&basics::Exception::code, TRI_ERROR_STARTING_UP)));
   EXPECT_THAT(
-      [&] { um.updateUser("username", [](auto&) { return Result(); }); },
+      [&] {
+        um.updateUser(
+            "username", [](auto&) { return Result(); }, false);
+      },
       Throws<basics::Exception>(
           Property(&basics::Exception::code, TRI_ERROR_STARTING_UP)));
   EXPECT_THAT(

--- a/tests/Mocks/Auth/UserManagerMock.h
+++ b/tests/Mocks/Auth/UserManagerMock.h
@@ -46,7 +46,7 @@ struct UserManagerMock : UserManager {
               (override));
   MOCK_METHOD(Result, enumerateUsers, (std::function<bool(User&)>&&, bool),
               (override));
-  MOCK_METHOD(Result, updateUser, (std::string const&, UserCallback&&),
+  MOCK_METHOD(Result, updateUser, (std::string const&, UserCallback&&, bool),
               (override));
   MOCK_METHOD(Result, accessUser, (std::string const&, ConstUserCallback&&),
               (override));

--- a/tests/RestHandler/RestAnalyzerHandlerTest.cpp
+++ b/tests/RestHandler/RestAnalyzerHandlerTest.cpp
@@ -253,7 +253,8 @@ class RestAnalyzerHandlerTest
     EXPECT_CALL(*um, updateUser)
         .Times(AtLeast(1))
         .WillRepeatedly([this](std::string const& username,
-                               auth::UserManager::UserCallback&& cb) {
+                               auth::UserManager::UserCallback&& cb,
+                               bool const) {
           EXPECT_EQ(username, _user.username());
           auto const r = cb(_user);
           EXPECT_TRUE(r.ok());

--- a/tests/RestHandler/RestUsersHandlerTest.cpp
+++ b/tests/RestHandler/RestUsersHandlerTest.cpp
@@ -166,7 +166,8 @@ class RestUsersHandlerTest
     EXPECT_CALL(*um, updateUser)
         .Times(AtLeast(1))
         .WillRepeatedly([this](std::string const& username,
-                               auth::UserManager::UserCallback&& cb) {
+                               auth::UserManager::UserCallback&& cb,
+                               bool const) {
           const auto it = _userMap.find(username);
           EXPECT_NE(it, _userMap.end());
           auto const r = cb(it->second);

--- a/tests/V8Server/V8UsersTest.cpp
+++ b/tests/V8Server/V8UsersTest.cpp
@@ -177,7 +177,8 @@ class V8UsersTest
     EXPECT_CALL(*um, updateUser)
         .Times(AtLeast(1))
         .WillRepeatedly([this](std::string const& username,
-                               auth::UserManager::UserCallback&& cb) {
+                               auth::UserManager::UserCallback&& cb,
+                               bool const) {
           const auto it = _userMap.find(username);
           EXPECT_NE(it, _userMap.end());
           auto const r = cb(it->second);


### PR DESCRIPTION
### Scope & Purpose

Introduced proper conflict retry logic into the `UserManager::updateUser`. 
Removes the external logic from Database/Collection creation.
Removes synchronous `UserManager::loadFromDB` from the `UserManager::enumerateUsers` to prevent races with the UserManager cache thread.
Introduces a missing user reload to the `TailingSyncer`. On singleserver this syncer could lead to a DB/Collection drop and lokc up inside the UserManager as there is no global/agency version update.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2213
- [ ] Design document: 
