### PR TITLE
[BTS 2203] Feature/modifier memory monitoring

### DIFF
--- a/arangod/Aql/Executor/ModificationExecutorInfos.cpp
+++ b/arangod/Aql/Executor/ModificationExecutorInfos.cpp
@@ -28,6 +28,7 @@
 #include "Aql/RegisterPlan.h"
 #include "Aql/QueryContext.h"
 #include "Cluster/ServerState.h"
+#include "Basics/ResourceUsage.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -67,4 +68,8 @@ ModificationExecutorInfos::ModificationExecutorInfos(
   auto isDBServer = ServerState::instance()->isDBServer();
   _producesResults = ProducesResults(_producesResults || !_options.silent ||
                                      (isDBServer && _ignoreDocumentNotFound));
+}
+
+ResourceMonitor& ModificationExecutorInfos::getResourceMonitor() const {
+  return _query.resourceMonitor();
 }

--- a/arangod/Aql/Executor/ModificationExecutorInfos.cpp
+++ b/arangod/Aql/Executor/ModificationExecutorInfos.cpp
@@ -27,8 +27,8 @@
 #include "Aql/Collection.h"
 #include "Aql/RegisterPlan.h"
 #include "Aql/QueryContext.h"
-#include "Cluster/ServerState.h"
 #include "Basics/ResourceUsage.h"
+#include "Cluster/ServerState.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;

--- a/arangod/Aql/Executor/ModificationExecutorInfos.h
+++ b/arangod/Aql/Executor/ModificationExecutorInfos.h
@@ -31,6 +31,10 @@
 
 #include <velocypack/Slice.h>
 
+namespace arangodb {
+struct ResourceMonitor;
+}
+
 namespace arangodb::aql {
 struct Collection;
 class ExecutionEngine;
@@ -79,6 +83,8 @@ struct ModificationExecutorInfos {
   RegisterId _outputNewRegisterId;
   RegisterId _outputOldRegisterId;
   RegisterId _outputRegisterId;  // single remote
+
+  ResourceMonitor& getResourceMonitor() const;
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/RemoveModifier.cpp
+++ b/arangod/Aql/RemoveModifier.cpp
@@ -29,12 +29,20 @@
 #include "Aql/Executor/ModificationExecutorHelpers.h"
 #include "Aql/QueryContext.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
 
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::aql::ModificationExecutorHelpers;
+
+RemoveModifierCompletion::RemoveModifierCompletion(
+    ModificationExecutorInfos& infos)
+    : _infos(infos),
+      // Monitors memory usage for builder object
+      _keyDocBuilder(std::make_shared<velocypack::SupervisedBuffer>(
+          infos.getResourceMonitor())) {}
 
 ModifierOperationType RemoveModifierCompletion::accumulate(
     ModificationExecutorAccumulator& accu, InputAqlItemRow& row) {

--- a/arangod/Aql/RemoveModifier.h
+++ b/arangod/Aql/RemoveModifier.h
@@ -36,8 +36,8 @@ struct ModificationExecutorInfos;
 
 class RemoveModifierCompletion {
  public:
-  explicit RemoveModifierCompletion(ModificationExecutorInfos& infos)
-      : _infos(infos) {}
+  explicit RemoveModifierCompletion(ModificationExecutorInfos& infos);
+
   ~RemoveModifierCompletion() = default;
 
   ModifierOperationType accumulate(ModificationExecutorAccumulator& accu,

--- a/arangod/Aql/UpdateReplaceModifier.cpp
+++ b/arangod/Aql/UpdateReplaceModifier.cpp
@@ -29,11 +29,11 @@
 #include "Aql/Executor/ModificationExecutorAccumulator.h"
 #include "Aql/Executor/ModificationExecutorHelpers.h"
 #include "Aql/QueryContext.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Transaction/Methods.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
-#include "Basics/SupervisedBuffer.h"
 
 class CollectionNameResolver;
 

--- a/arangod/Aql/UpdateReplaceModifier.cpp
+++ b/arangod/Aql/UpdateReplaceModifier.cpp
@@ -33,12 +33,19 @@
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Collection.h>
+#include "Basics/SupervisedBuffer.h"
 
 class CollectionNameResolver;
 
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::aql::ModificationExecutorHelpers;
+
+UpdateReplaceModifierCompletion::UpdateReplaceModifierCompletion(
+    ModificationExecutorInfos& infos)
+    : _infos(infos),
+      _keyDocBuilder(std::make_shared<velocypack::SupervisedBuffer>(
+          infos.getResourceMonitor())) {}
 
 ModifierOperationType UpdateReplaceModifierCompletion::accumulate(
     ModificationExecutorAccumulator& accu, InputAqlItemRow& row) {

--- a/arangod/Aql/UpdateReplaceModifier.h
+++ b/arangod/Aql/UpdateReplaceModifier.h
@@ -36,8 +36,8 @@ struct ModificationExecutorInfos;
 
 class UpdateReplaceModifierCompletion {
  public:
-  explicit UpdateReplaceModifierCompletion(ModificationExecutorInfos& infos)
-      : _infos(infos) {}
+  explicit UpdateReplaceModifierCompletion(ModificationExecutorInfos& infos);
+
   ~UpdateReplaceModifierCompletion() = default;
 
   ModifierOperationType accumulate(ModificationExecutorAccumulator& accu,

--- a/arangod/Aql/UpsertModifier.cpp
+++ b/arangod/Aql/UpsertModifier.cpp
@@ -34,6 +34,7 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/application-exit.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Logger/LogTopic.h"
 #include "Logger/LogLevel.h"
 #include "Logger/LogMacros.h"
@@ -147,6 +148,8 @@ UpsertModifier::UpsertModifier(ModificationExecutorInfos& infos)
     : _infos(infos),
       _updateResults(Result(), infos._options),
       _insertResults(Result(), infos._options),
+      _keyDocBuilder(std::make_shared<velocypack::SupervisedBuffer>(
+          infos.getResourceMonitor())),  // Monitoring memory usage for builder
       // Batch size has to be 1 in case the upsert modifier sees its own
       // writes. otherwise it will use the default batching
       _batchSize(_infos._batchSize),


### PR DESCRIPTION
### Scope & Purpose

- `RemoveModifier`,  `UpsertModifier` and `UpdateReplaceModifier` use builder. The builder object needs to be memory monitored. 
- They hold `ModificationExecutorInfos` as a member variable in common. Therefore, adding `ResourceMonitor` to it is the easiest way to instantiate supervised builder.
- `ModificationExecutorInfos` actually already holds `QueryContext _query`, so just implemented `getResourceMonitor()` in the infos class. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
