### PR TITLE
redirect http trace logging to its own log file

### DIFF
--- a/3rdParty/fuerte/include/fuerte/connection.h
+++ b/3rdParty/fuerte/include/fuerte/connection.h
@@ -242,5 +242,9 @@ class ConnectionBuilder {
  private:
   detail::ConnectionConfiguration _conf;
 };
+
+// convert the boolean flag to a loggeable string
+std::string to_string(Connection::State state);
+
 }}}  // namespace arangodb::fuerte::v1
 #endif

--- a/3rdParty/fuerte/src/connection.cpp
+++ b/3rdParty/fuerte/src/connection.cpp
@@ -26,6 +26,20 @@
 #include <fuerte/waitgroup.h>
 
 namespace arangodb { namespace fuerte { inline namespace v1 {
+
+std::string to_string(Connection::State state) {
+  switch(state) {
+  case Connection::State::Created:
+    return "Created";
+  case Connection::State::Connecting:
+    return "Connecting";
+  case Connection::State::Connected:
+    return "Connected";
+  case Connection::State::Closed:
+    return "Closed";
+  }
+}
+
 // Deconstructor
 Connection::~Connection() {
   FUERTE_LOG_DEBUG << "Destroying Connection"

--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -1475,7 +1475,7 @@ static void ClientConnection_httpFuzzRequests(
     // log the random seed value for later reproducibility.
     // log level must be warning here because log levels < WARN are suppressed
     // during testing.
-    LOG_TOPIC("39e50", WARN, arangodb::Logger::FIXME)
+    LOG_TOPIC("39e50", WARN, arangodb::Logger::HTTPCLIENT)
         << "fuzzer producing " << numReqs << " requests(s) with " << numIts
         << " iteration(s) each, using seed " << fuzzer.getSeed()
         << " from: " << v8connection->getLocalEndpoint();
@@ -2878,19 +2878,21 @@ uint32_t V8ClientConnection::sendFuzzRequest(fuzzer::RequestFuzzer& fuzzer) {
   } catch (fu::Error const& ec) {
     rc = ec;
     if (rc != fu::Error::NoError) {
-      LOG_TOPIC("39e53", WARN, arangodb::Logger::FIXME)
+      LOG_TOPIC("39e53", INFO, arangodb::Logger::HTTPCLIENT)
           << "rc: " << static_cast<uint32_t>(rc)
           << " from: " << getLocalEndpoint();
     }
   }
   if (!connection || connection->state() == fu::Connection::State::Closed) {
-    LOG_TOPIC("39e51", WARN, arangodb::Logger::FIXME)
+    LOG_TOPIC("39e51", INFO, arangodb::Logger::HTTPCLIENT)
         << "connection closed after " << fuerte::v1::to_string(req_copy)
+        << " state: " << to_string(connection->state())
         << " from: " << localEndpoint;
   }
   if (response) {
-    LOG_TOPIC("39e52", WARN, arangodb::Logger::FIXME)
-        << "Server responce: " << response;
+    LOG_TOPIC("39e52", INFO, arangodb::Logger::HTTPCLIENT)
+        << " state: " << to_string(connection->state())
+        << "Server response: " << fuerte::v1::to_string(*response);
     if (response->messageHeader().metaByKey("connection") == "Close") {
       _foundConnectionClose = true;
     }

--- a/lib/ProgramOptions/Translator.cpp
+++ b/lib/ProgramOptions/Translator.cpp
@@ -90,6 +90,8 @@ std::string arangodb::options::EnvironmentTranslator(std::string const& value,
           if (vv.length() == 0) {
             if (k == "PID") {
               vv = std::to_string(Thread::currentProcessId());
+            } else if (k == "BASE_DIR") {
+              vv = TRI_GetTempPath();
             }
           }
 

--- a/tests/test-definitions.txt
+++ b/tests/test-definitions.txt
@@ -144,8 +144,8 @@ dump_with_crashes_non_parallel size=medium parallelity=1 priority=2000 -- --dump
 audit_client,audit_server enterprise name=audit -- --dumpAgencyOnError true
 
 # Full Tests Single Server
-shell_fuzzer full !coverage cluster priority=500 parallelity=6 size=large -- --dumpAgencyOnError true --extraArgs:experimental-vector-index true --oneTestTimeout 1200
-shell_fuzzer full !coverage single priority=500 -- --dumpAgencyOnError true --extraArgs:experimental-vector-index true --oneTestTimeout 1200
+shell_fuzzer full !coverage cluster priority=500 parallelity=6 size=large --log.level httpclient=trace --log.output httpclient=file://@BASE_DIR@/httptrace.log -- --dumpAgencyOnError true --extraArgs:experimental-vector-index true --oneTestTimeout 1200
+shell_fuzzer full !coverage single priority=500 --log.level httpclient=trace --log.output httpclient=file://@BASE_DIR@/httptrace.log -- --dumpAgencyOnError true --extraArgs:experimental-vector-index true --oneTestTimeout 1200
 authentication_parameters single full priority=1000
 config single full priority=1000
 foxx_manager single full priority=500


### PR DESCRIPTION
### Scope & Purpose

- add @BASE_DIR@ substitution by the current temporary directory, which in arangosh / testing.js will be the base directory to the tests
- redirect fuzzing httpclient trace-log-traffic to its own log file

- [x] :hankey: Bugfix
- [x] :pizza: New feature
