### PR TITLE
[BTS 2203] Feature/RestAqlHandler memory monitoring

### DIFF
--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -835,9 +835,8 @@ auto RestAqlHandler::handleFinishQuery(std::string const& idString)
   answerBuilder.add(StaticStrings::Code, VPackValue(res.errorNumber()));
   answerBuilder.close();
 
-  generateResult(
-      rest::ResponseCode::OK,
-      static_cast<velocypack::Buffer<uint8_t>&&>(std::move(buffer)));
+  generateResult(rest::ResponseCode::OK,
+                 static_cast<velocypack::Buffer<uint8_t>&&>(std::move(buffer)));
 }
 
 RequestLane RestAqlHandler::lane() const {

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -201,14 +201,13 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
     co_return;
   }
 
+  // Cannot be supervised (i.e. pass ResourceMonitor&) as this will live longer
+  // than ResourceMonitor
   std::shared_ptr<VPackBuilder> bindParameters = nullptr;
   {
     VPackSlice bindParametersSlice = querySlice.get("bindParameters");
     if (bindParametersSlice.isObject()) {
-      auto sb = std::make_shared<velocypack::SupervisedBuffer>(
-          _engine->getQuery().resourceMonitor());
-      bindParameters = std::make_shared<VPackBuilder>(sb);
-      bindParameters->add(bindParametersSlice);
+      bindParameters = std::make_shared<VPackBuilder>(bindParametersSlice);
     }
   }
 

--- a/arangod/Aql/RestAqlHandler.cpp
+++ b/arangod/Aql/RestAqlHandler.cpp
@@ -270,8 +270,8 @@ futures::Future<futures::Unit> RestAqlHandler::setupClusterQuery() {
   // TODO: technically we could change the code in prepareClusterQuery to parse
   //       the collection info directly
   // Build the collection information
-  VPackBuilder collectionBuilder(std::make_shared<velocypack::SupervisedBuffer>(
-      _engine->getQuery().resourceMonitor()));
+  VPackBuilder collectionBuilder;  // Cannot add SupervisedBuffer as this will
+                                   // live longer than ResourceMonitor
   collectionBuilder.openArray();
   for (auto lockInf : VPackObjectIterator(lockInfoSlice)) {
     if (!lockInf.value.isArray()) {


### PR DESCRIPTION
### Scope & Purpose

- The memory usage by builder objects used in RestAqlHandler needs to be monitored. Instantiated SupervisedBuffer using the resource monitor from `engine`, and passed it to each builder object.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
