### PR TITLE
Feature/inverted index defaults

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix defaults for inverted indexes and views. Consolidations 5 times
+  less frequently, with minimum of 50(1 before) segments and 24M bytes
+  (2M before), maximum 200 (10 before) segments and 8G bytes (800M
+  before).
+
 * Fix BTS-2216: Fix a possible use-after-free. It can occur when a query is
   killed at the end of being prepared. Only non-streaming cursors in a cluster
   are affected.

--- a/arangod/IResearch/IResearchDataStoreMeta.cpp
+++ b/arangod/IResearch/IResearchDataStoreMeta.cpp
@@ -200,7 +200,7 @@ IResearchDataStoreMeta::Mask::Mask(bool mask /*=false*/) noexcept
 IResearchDataStoreMeta::IResearchDataStoreMeta()
     : _cleanupIntervalStep(2),
       _commitIntervalMsec(1000),
-      _consolidationIntervalMsec(1000),
+      _consolidationIntervalMsec(5000),
       _version(static_cast<uint32_t>(ViewVersion::MAX)),
       _writebufferActive(0),
       _writebufferIdle(64),

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/useCreateInvertedIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/invertedIndex/useCreateInvertedIndex.ts
@@ -85,7 +85,7 @@ const initialValues: InvertedIndexValuesType = {
   fields: [],
   cleanupIntervalStep: 2,
   commitIntervalMsec: 1000,
-  consolidationIntervalMsec: 1000,
+  consolidationIntervalMsec: 5000,
   writebufferIdle: 64,
   writebufferActive: 0,
   writebufferSizeMax: 33554432,
@@ -101,10 +101,10 @@ const initialValues: InvertedIndexValuesType = {
   ],
   consolidationPolicy: {
     type: "tier",
-    segmentsMin: 1,
-    segmentsMax: 10,
-    segmentsBytesMax: 5368709120,
-    segmentsBytesFloor: 2097152,
+    segmentsMin: 50,
+    segmentsMax: 200,
+    segmentsBytesMax: 8589934592,
+    segmentsBytesFloor: 25165824,
     minScore: 0
   }
 };

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/views/arangoSearchView/SearchJSONSchema.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/views/arangoSearchView/SearchJSONSchema.ts
@@ -172,7 +172,7 @@ export const arangoSearchViewJSONSchema: JSONSchemaType<ArangoSearchViewProperti
         type: "integer",
         nullable: true,
         minimum: 0,
-        default: 1000
+        default: 5000
       },
       writebufferIdle: {
         type: "integer",
@@ -226,7 +226,7 @@ export const arangoSearchViewJSONSchema: JSONSchemaType<ArangoSearchViewProperti
                 maximum: {
                   $data: "1/segmentsMax"
                 },
-                default: 1
+                default: 200
               },
               segmentsMax: {
                 type: "integer",
@@ -234,19 +234,19 @@ export const arangoSearchViewJSONSchema: JSONSchemaType<ArangoSearchViewProperti
                 minimum: {
                   $data: "1/segmentsMin"
                 },
-                default: 10
+                default: 50
               },
               segmentsBytesMax: {
                 type: "integer",
                 nullable: false,
                 minimum: 0,
-                default: 5368709120
+                default: 8589934592
               },
               segmentsBytesFloor: {
                 type: "integer",
                 nullable: false,
                 minimum: 0,
-                default: 2097152
+                default: 25165824
               },
               minScore: {
                 type: "number",
@@ -261,10 +261,10 @@ export const arangoSearchViewJSONSchema: JSONSchemaType<ArangoSearchViewProperti
         ],
         default: {
           type: "tier",
-          segmentsMin: 1,
-          segmentsMax: 10,
-          segmentsBytesMax: 5368709120,
-          segmentsBytesFloor: 2097152
+          segmentsMin: 50,
+          segmentsMax: 200,
+          segmentsBytesMax: 8589934592,
+          segmentsBytesFloor: 25165824
         },
         required: ["type"]
       },

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -8,7 +8,7 @@ if [ $(ulimit -S -n) -lt 131072 ]; then
     ulimit -S -n 131072 || true
 fi
 
-rm -rf cluster
+#rm -rf cluster
 if [ -d cluster-init ];then
   echo "== creating cluster directory from existing cluster-init directory"
   cp -a cluster-init cluster


### PR DESCRIPTION
### Scope & Purpose

* Defaults for views and inverted indexes have caused many index creations to drive file descriptors into limits on cloud volumes. There is no impact on view / index performance. Only consolidations are done less regularly and with more data.*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [X] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
