### PR TITLE
[BTS-2203] Add SupervisedBuffer to Query.cpp

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -943,7 +943,6 @@ futures::Future<futures::Unit> Query::execute(
             // cache low-level pointer to avoid repeated shared-ptr-derefs
             TRI_ASSERT(queryResult.data != nullptr);
             auto& resultBuilder = *queryResult.data;
-            //size_t previousLength = resultBuilder.bufferRef().byteSize();
             auto& vpackOpts = vpackOptions();
 
             size_t const n = block->numRows();
@@ -956,13 +955,6 @@ futures::Future<futures::Unit> Query::execute(
                                  /*allowUnindexed*/ true);
               }
             }
-
-            // newLength = resultBuilder.bufferRef().byteSize();
-            //TRI_ASSERT(newLength >= previousLength);
-            //size_t diff = newLength - previousLength;
-
-            //_resourceMonitor->increaseMemoryUsage(diff);
-            //_resultMemoryUsage += diff;
           }
 
           if (state == ExecutorState::DONE) {
@@ -1502,12 +1494,9 @@ QueryResult Query::explain() {
         _queryOptions.verbosePlans, _queryOptions.explainInternals,
         _queryOptions.explainRegisters == ExplainRegisterPlan::Yes);
 
-    //ResourceUsageScope scope(*_resourceMonitor);
-
     if (_queryOptions.allPlans) {
       VPackArrayBuilder guard(result.data.get());
 
-      //size_t previousSize = result.data->bufferRef().byteSize();
       auto const& plans = opt.getPlans();
       for (auto& it : plans) {
         auto& pln = it.first;
@@ -1523,11 +1512,6 @@ QueryResult Query::explain() {
         TRI_IF_FAILURE("Query::serializePlans1") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
-
-        // memory accounting for different execution plans
-        //size_t currentSize = result.data->bufferRef().byteSize();
-        //scope.increase(currentSize - previousSize);
-        //previousSize = currentSize;
 
         TRI_IF_FAILURE("Query::serializePlans2") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
@@ -1550,8 +1534,6 @@ QueryResult Query::explain() {
       TRI_IF_FAILURE("Query::serializePlans1") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
-
-      //scope.increase(result.data->bufferRef().byteSize());
 
       TRI_IF_FAILURE("Query::serializePlans2") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
@@ -1580,9 +1562,6 @@ QueryResult Query::explain() {
         }
       }
     }
-
-    // the query object no owns the memory used by the plan(s)
-    //_planMemoryUsage += scope.trackedAndSteal();
 
     // technically no need to commit, as we are only explaining here
     auto commitResult = _trx->commit();

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -873,11 +873,9 @@ futures::Future<futures::Unit> Query::execute(
         }
         // NOTE: If the options have a shorter lifetime than the builder, it
         // gets invalid (at least set() and close() are broken).
-        auto sb =
-            std::make_shared<velocypack::SupervisedBuffer>(resourceMonitor());
-        auto supervisedBuilder = std::make_shared<VPackBuilder>(sb);
-        supervisedBuilder->options = &vpackOptions();
-        queryResult.data = supervisedBuilder;
+        auto builder = std::make_shared<VPackBuilder>();
+        builder->options = &vpackOptions();
+        queryResult.data = builder;
 
         // reserve some space in Builder to avoid frequent reallocs
         queryResult.data->reserve(16 * 1024);
@@ -1148,6 +1146,7 @@ QueryResultV8 Query::executeV8(v8::Isolate* isolate) {
     options.buildUnindexedArrays = true;
     options.buildUnindexedObjects = true;
     auto builder = std::make_shared<VPackBuilder>();
+    builder->options = &options;
 
     try {
       ss->resetWakeupHandler();
@@ -1388,6 +1387,7 @@ QueryResult Query::explain() {
   options.checkAttributeUniqueness = false;
   options.buildUnindexedArrays = true;
   auto builderForResultData = std::make_shared<VPackBuilder>();
+  builderForResultData->options = &options;
   result.data = builderForResultData;
 
   try {

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -873,11 +873,8 @@ futures::Future<futures::Unit> Query::execute(
         }
         // NOTE: If the options have a shorter lifetime than the builder, it
         // gets invalid (at least set() and close() are broken).
-        auto sb =
-            std::make_shared<velocypack::SupervisedBuffer>(resourceMonitor());
-        auto supervisedBuilder = std::make_shared<VPackBuilder>(sb);
-        supervisedBuilder->options = &vpackOptions();
-        queryResult.data = supervisedBuilder;
+
+        queryResult.data = std::make_unique<velocypack::Builder>();
 
         // reserve some space in Builder to avoid frequent reallocs
         queryResult.data->reserve(16 * 1024);


### PR DESCRIPTION
### Scope & Purpose

- Make the builder objects in `Query.cpp` to be supervised.
- `Query` also uses `AqlValue` and `VPackSlice`. They are already monitored. After implementing supervised AqlValue, we need to remove memory counting for `AqlValue`.
 
- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
