### PR TITLE
Fix coroutine argument goes out of scope

### DIFF
--- a/lib/Async/include/Async/SuspensionCounter.h
+++ b/lib/Async/include/Async/SuspensionCounter.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <utility>
 
 #include "Async/async.h"
 
@@ -105,13 +106,15 @@ requires requires(F f) {
 }
 [[nodiscard]] auto waitingFunToCoro(SuspensionCounter& suspensionCounter,
                                     F&& fun) -> async<T> {
-  auto res = fun();
+  // Move the function into the coroutine frame to ensure proper lifetime
+  auto movedFun = std::move(fun);
+  auto res = movedFun();
   while (!res.has_value()) {
-    // Get the number of wakeups. We call fun() up to that many
+    // Get the number of wakeups. We call movedFun() up to that many
     // times before suspending again.
     auto n = co_await suspensionCounter.await();
     for (decltype(n) i = 0; i < n && !res.has_value(); ++i) {
-      res = fun();
+      res = movedFun();
     }
   }
   co_return std::move(res).value();

--- a/lib/Async/include/Async/SuspensionCounter.h
+++ b/lib/Async/include/Async/SuspensionCounter.h
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <utility>
 
 #include "Async/async.h"
 


### PR DESCRIPTION
### Scope & Purpose

The `waitingFunToCoro` function was capturing the function parameter F by reference, but not moving it into the coroutine frame. This caused a use-after-free when the coroutine continued executing after the calling function returned, leading to SIGSEGV crashes in debug builds.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
