### PR TITLE
Always give cmake warning when compiling with gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,14 +507,10 @@ set(BASE_LIBS                         "$ENV{LIBS}"     CACHE STRING "base librar
 include(CheckCompilerVersion)
 
 CheckCompilerVersion(
-  11.2 # GCC
   16.0 # Clang
 )
 
 if(CMAKE_COMPILER_IS_CLANG) 
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "16.0")
-    message(WARNING "ArangoDB requires clang 16.0 or newer, building with older compiler versions is unsupported")
-  endif()
   list(APPEND BASE_LIBS atomic)
 endif()
 

--- a/cmake/CheckCompilerVersion.cmake
+++ b/cmake/CheckCompilerVersion.cmake
@@ -1,16 +1,12 @@
-macro(CheckCompilerVersion MIN_GCC_VERSION MIN_CLANG_VERSION)
-
-if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-  set(MIN_VERSION ${MIN_GCC_VERSION})
-elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-  set(MIN_VERSION ${MIN_CLANG_VERSION})
-endif()
+macro(CheckCompilerVersion MIN_CLANG_VERSION)
 
 string(ASCII 27 ESC)
 set(COLOR_RESET "${ESC}[m")
 set(RED        "${ESC}[31m")
 
-if (NOT DEFINED MIN_VERSION)
+if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+  set(MIN_VERSION ${MIN_CLANG_VERSION})
+else()
   message(WARNING "${RED}${CMAKE_C_COMPILER_ID}/${CMAKE_CXX_COMPILER_ID} compiler is not supported.${COLOR_RESET}")
 endif()
 


### PR DESCRIPTION
Compiling with gcc does not work any more, so this gets rid some minimal gcc version in our cmake files and now always warns when arangodb is build with gcc.