### PR TITLE
Revert rocksdb parameters to the established

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Reverted RocksDB defaults for maximum wal size, number of sub
+  compactions and compaction read ahead to stay close to established
+  behaviour.
+
 * Fix BTS-2214: In a rare hash collision situation it can happen that a
   valid edge in an enterprise graph fails to validate and is rejected.
 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -231,7 +231,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _maxWriteBufferNumber(RocksDBColumnFamilyManager::numberOfColumnFamilies +
                             2),  // number of column families plus 2
       _maxWriteBufferSizeToMaintain(0),
-      _maxTotalWalSize(256 << 20),
+      _maxTotalWalSize(80 << 20),
       _delayedWriteRate(rocksDBDefaults.delayed_write_rate),
       _minWriteBufferNumberToMerge(defaultMinWriteBufferNumberToMerge(
           _totalWriteBufferSize, _writeBufferSize, _maxWriteBufferNumber)),
@@ -243,7 +243,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       // set max number of background jobs to the number of available cores
       _maxBackgroundJobs(static_cast<int32_t>(
           std::max(static_cast<size_t>(2), NumberOfCores::getValue()))),
-      _maxSubcompactions(4),
+      _maxSubcompactions(2),
       _numThreadsHigh(0),
       _numThreadsLow(0),
       _targetFileSizeBase(rocksDBDefaults.target_file_size_base),
@@ -263,7 +263,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
           rocksDBTableOptionsDefaults.block_size,
           static_cast<decltype(rocksDBTableOptionsDefaults.block_size)>(16 *
                                                                         1024))),
-      _compactionReadaheadSize(8 * 1024 * 1024),
+      _compactionReadaheadSize(2 * 1024 * 1024),
       _level0CompactionTrigger(2),
       _level0SlowdownTrigger(16),
       _level0StopTrigger(256),


### PR DESCRIPTION
### Scope & Purpose

*Default for #subcompaction, max wal size and compaction read ahead adjusted to the established*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
