### PR TITLE
ES-2678: Added checks to verify that clusterInfo() is

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 devel
 -----
 
+* Fix ES-2678: In the upgrade scenario, we disable the ClusterFeature.
+  We should therefore check before accessing clusterInfo() whether we're
+  in an upgrade scenario. Added those checks in iresearch.
+
 * Reverted RocksDB defaults for maximum wal size, number of sub
   compactions and compaction read ahead to stay close to established
   behaviour.

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -1149,12 +1149,16 @@ std::shared_ptr<HeartbeatThread> ClusterFeature::heartbeatThread() {
 
 ClusterInfo& ClusterFeature::clusterInfo() {
   if (!_clusterInfo) {
-    if (server().isStopping()) {
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
-    } else {
-      ADB_PROD_ASSERT(_clusterInfo != nullptr)
+    if (!server().isStopping()) {
+      TRI_ASSERT(_clusterInfo != nullptr)
           << "_clusterInfo is null, but server is not shutting down";
+
+      LOG_TOPIC("325b6", ERR, arangodb::Logger::CLUSTER)
+          << "_clusterInfo is null, but server is not shutting down";
+      //  log crash dump feature
+      CrashHandler::logBacktrace();
     }
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
   return *_clusterInfo;
 }

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -777,7 +777,8 @@ bool analyzerInUse(ArangodServer& server, std::string_view dbName,
 AnalyzerModificationTransaction::Ptr createAnalyzerModificationTransaction(
     ArangodServer& server, std::string_view vocbase) {
   if (ServerState::instance()->isCoordinator() && !vocbase.empty()) {
-    TRI_ASSERT(server.hasFeature<ClusterFeature>() && server.getFeature<ClusterFeature>().isEnabled());
+    TRI_ASSERT(server.hasFeature<ClusterFeature>() &&
+               server.getFeature<ClusterFeature>().isEnabled());
     auto& engine = server.getFeature<ClusterFeature>().clusterInfo();
     return std::make_unique<AnalyzerModificationTransaction>(vocbase, &engine,
                                                              false);

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -494,7 +494,8 @@ Result visitAnalyzers(TRI_vocbase_t& vocbase,
     auto& server = vocbase.server();
 
     std::vector<std::string> coords;
-    if (server.hasFeature<ClusterFeature>()) {
+    if (server.hasFeature<ClusterFeature>() &&
+        server.getFeature<ClusterFeature>().isEnabled()) {
       coords = server.getFeature<ClusterFeature>()
                    .clusterInfo()
                    .getCurrentCoordinators();
@@ -508,6 +509,7 @@ Result visitAnalyzers(TRI_vocbase_t& vocbase,
       TRI_IF_FAILURE("CheckDBWhenSingleShardAndForceOneShardChange") {
         THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
       }
+
       auto& clusterInfo = server.getFeature<ClusterFeature>().clusterInfo();
       auto collection = clusterInfo.getCollectionNT(
           vocbase.name(), arangodb::StaticStrings::AnalyzersCollection);
@@ -775,7 +777,7 @@ bool analyzerInUse(ArangodServer& server, std::string_view dbName,
 AnalyzerModificationTransaction::Ptr createAnalyzerModificationTransaction(
     ArangodServer& server, std::string_view vocbase) {
   if (ServerState::instance()->isCoordinator() && !vocbase.empty()) {
-    TRI_ASSERT(server.hasFeature<ClusterFeature>());
+    TRI_ASSERT(server.hasFeature<ClusterFeature>() && server.getFeature<ClusterFeature>().isEnabled());
     auto& engine = server.getFeature<ClusterFeature>().clusterInfo();
     return std::make_unique<AnalyzerModificationTransaction>(vocbase, &engine,
                                                              false);
@@ -1111,13 +1113,16 @@ IResearchAnalyzerFeature::IResearchAnalyzerFeature(Server& server)
       return;
     }
 
-    auto cleanupTrans = this->server()
-                            .getFeature<ClusterFeature>()
-                            .clusterInfo()
-                            .createAnalyzersCleanupTrans();
-    if (cleanupTrans) {
-      if (cleanupTrans->start().ok()) {
-        cleanupTrans->commit();
+    if (this->server().hasFeature<ClusterFeature>() &&
+        this->server().getFeature<ClusterFeature>().isEnabled()) {
+      auto cleanupTrans = this->server()
+                              .getFeature<ClusterFeature>()
+                              .clusterInfo()
+                              .createAnalyzersCleanupTrans();
+      if (cleanupTrans) {
+        if (cleanupTrans->start().ok()) {
+          cleanupTrans->commit();
+        }
       }
     }
 
@@ -2463,7 +2468,9 @@ AnalyzersRevision::Ptr IResearchAnalyzerFeature::getAnalyzersRevision(
     const TRI_vocbase_t& vocbase, bool forceLoadPlan /* = false */) const {
   if (ServerState::instance()->isRunningInCluster()) {
     auto const& server = vocbase.server();
-    if (server.hasFeature<ClusterFeature>()) {
+
+    if (server.hasFeature<ClusterFeature>() &&
+        server.getFeature<ClusterFeature>().isEnabled()) {
       auto ptr = server.getFeature<ClusterFeature>()
                      .clusterInfo()
                      .getAnalyzersRevision(vocbase.name(), forceLoadPlan);

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -914,7 +914,8 @@ Result IResearchDataStore::commitUnsafeImpl(
       }
       auto& collection = index().collection();
 
-      if (!collection.vocbase()
+      if (!collection.vocbase().server().hasFeature<ClusterFeature>() ||
+          !collection.vocbase()
                .server()
                .getFeature<ClusterFeature>()
                .isEnabled()) {

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -651,18 +651,26 @@ IResearchDataStore::IResearchDataStore(
       _asyncSelf(std::make_shared<AsyncLinkHandle>(nullptr)),
       _maintenanceState(std::make_shared<MaintenanceState>()) {
   // initialize transaction callback
+
 #ifdef USE_ENTERPRISE
   if (!collection.isAStub() && _asyncFeature->columnsCacheOnlyLeaders()) {
-    auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
     auto maybeShardID = ShardID::shardIdFromString(collection.name());
     if (maybeShardID.fail()) {
       // Illegal shard name, could be collection name
       _useSearchCache = false;
     } else {
-      TRI_ASSERT(maybeShardID.ok());
-      auto r = ci.getShardLeadership(ServerState::instance()->getId(),
-                                     maybeShardID.get());
-      _useSearchCache = r == ClusterInfo::ShardLeadership::kLeader;
+      if (server.hasFeature<ClusterFeature>() && server.getFeature<ClusterFeature>().isEnabled()) {
+        TRI_ASSERT(maybeShardID.ok());
+
+        auto& ci = server.getFeature<ClusterFeature>().clusterInfo();
+        auto r = ci.getShardLeadership(ServerState::instance()->getId(),
+                                       maybeShardID.get());
+        _useSearchCache = r == ClusterInfo::ShardLeadership::kLeader;
+      } else {
+        //  During an upgrade, the ClusterFeature is disabled.
+        //  Therefore we disable search cache.
+        _useSearchCache = false;
+      }
     }
   }
 #endif
@@ -904,6 +912,16 @@ Result IResearchDataStore::commitUnsafeImpl(
         return false;
       }
       auto& collection = index().collection();
+
+      if (!collection.vocbase()
+               .server()
+               .getFeature<ClusterFeature>()
+               .isEnabled()) {
+        //  clusterInfo() is only availbale when ClusterFeature is enabled
+        //  which is not the case during a local upgrade.
+        return false;
+      }
+
       auto& ci = collection.vocbase()
                      .server()
                      .getFeature<ClusterFeature>()

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -659,7 +659,8 @@ IResearchDataStore::IResearchDataStore(
       // Illegal shard name, could be collection name
       _useSearchCache = false;
     } else {
-      if (server.hasFeature<ClusterFeature>() && server.getFeature<ClusterFeature>().isEnabled()) {
+      if (server.hasFeature<ClusterFeature>() &&
+          server.getFeature<ClusterFeature>().isEnabled()) {
         TRI_ASSERT(maybeShardID.ok());
 
         auto& ci = server.getFeature<ClusterFeature>().clusterInfo();

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -323,7 +323,9 @@ uint32_t computeThreadsCount(uint32_t threads, uint32_t threadsLimit,
 Result upgradeArangoSearchLinkCollectionName(
     TRI_vocbase_t& vocbase, velocypack::Slice /*upgradeParams*/) {
   using application_features::ApplicationServer;
-  if (!ServerState::instance()->isDBServer()) {
+  if (!ServerState::instance()->isDBServer() ||
+      !vocbase.server().hasFeature<ClusterFeature>() ||
+      !vocbase.server().getFeature<ClusterFeature>().isEnabled()) {
     return {};  // not applicable for other ServerState roles
   }
   auto& selector = vocbase.server().getFeature<EngineSelectorFeature>();

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -184,7 +184,14 @@ Result IResearchLink::initSingleServer(bool& pathExists,
 
 Result IResearchLink::initCoordinator(InitCallback const& init) {
   auto& vocbase = index().collection().vocbase();
-  auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
+  auto& cf = vocbase.server().getFeature<ClusterFeature>();
+  if (!cf.isEnabled()) {
+    LOG_TOPIC("9be20", DEBUG, TOPIC)
+        << "Skipped link '" << index().id().id()
+        << "' maybe due to disabled cluster features.";
+    return {};
+  }
+  auto& ci = cf.clusterInfo();
   std::shared_ptr<IResearchViewCoordinator> view;
   if (auto r = toView(ci.getView(vocbase.name(), _viewGuid), view); !view) {
     return r;

--- a/arangod/IResearch/IResearchViewCoordinator.cpp
+++ b/arangod/IResearch/IResearchViewCoordinator.cpp
@@ -79,7 +79,8 @@ struct IResearchViewCoordinator::ViewFactory final : arangodb::ViewFactory {
   Result create(LogicalView::ptr& view, TRI_vocbase_t& vocbase,
                 VPackSlice definition, bool isUserRequest) const final {
     auto& server = vocbase.server();
-    if (!server.hasFeature<ClusterFeature>()) {
+    if (!server.hasFeature<ClusterFeature>() ||
+        !server.getFeature<ClusterFeature>().isEnabled()) {
       return {TRI_ERROR_INTERNAL,
               absl::StrCat("failure to find 'ClusterInfo' instance while "
                            "creating arangosearch View in database '",
@@ -341,7 +342,8 @@ Result IResearchViewCoordinator::properties(velocypack::Slice slice,
                                             bool isUserRequest,
                                             bool partialUpdate) {
   auto& server = vocbase().server();
-  if (!server.hasFeature<ClusterFeature>()) {
+  if (!server.hasFeature<ClusterFeature>() ||
+      !server.getFeature<ClusterFeature>().isEnabled()) {
     return {
         TRI_ERROR_INTERNAL,
         absl::StrCat(
@@ -447,7 +449,8 @@ Result IResearchViewCoordinator::properties(velocypack::Slice slice,
 
 Result IResearchViewCoordinator::dropImpl() {
   auto& server = vocbase().server();
-  if (!server.hasFeature<ClusterFeature>()) {
+  if (!server.hasFeature<ClusterFeature>() ||
+      !server.getFeature<ClusterFeature>().isEnabled()) {
     return {
         TRI_ERROR_INTERNAL,
         absl::StrCat(


### PR DESCRIPTION
availble before accessing it.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
