### PR TITLE
ES-2678: Added checks to verify that clusterInfo() is (#21972)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+
+3.12.5.4 (2025-09-19)
+---------------------
+
+* Fix ES-2678: In the upgrade scenario, we disable the ClusterFeature.
+  We should therefore check before accessing clusterInfo() whether we're
+  in an upgrade scenario. Added those checks in iresearch.
+
 3.12.5.3 (2025-09-09)
 ---------------------
 

--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -1149,12 +1149,16 @@ std::shared_ptr<HeartbeatThread> ClusterFeature::heartbeatThread() {
 
 ClusterInfo& ClusterFeature::clusterInfo() {
   if (!_clusterInfo) {
-    if (server().isStopping()) {
-      THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
-    } else {
-      ADB_PROD_ASSERT(_clusterInfo != nullptr)
+    if (!server().isStopping()) {
+      TRI_ASSERT(_clusterInfo != nullptr)
           << "_clusterInfo is null, but server is not shutting down";
+
+      LOG_TOPIC("325b6", ERR, arangodb::Logger::CLUSTER)
+          << "_clusterInfo is null, but server is not shutting down";
+      //  log crash dump feature
+      CrashHandler::logBacktrace();
     }
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_SHUTTING_DOWN);
   }
   return *_clusterInfo;
 }

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -323,7 +323,9 @@ uint32_t computeThreadsCount(uint32_t threads, uint32_t threadsLimit,
 Result upgradeArangoSearchLinkCollectionName(
     TRI_vocbase_t& vocbase, velocypack::Slice /*upgradeParams*/) {
   using application_features::ApplicationServer;
-  if (!ServerState::instance()->isDBServer()) {
+  if (!ServerState::instance()->isDBServer() ||
+      !vocbase.server().hasFeature<ClusterFeature>() ||
+      !vocbase.server().getFeature<ClusterFeature>().isEnabled()) {
     return {};  // not applicable for other ServerState roles
   }
   auto& selector = vocbase.server().getFeature<EngineSelectorFeature>();

--- a/arangod/IResearch/IResearchLink.cpp
+++ b/arangod/IResearch/IResearchLink.cpp
@@ -184,7 +184,14 @@ Result IResearchLink::initSingleServer(bool& pathExists,
 
 Result IResearchLink::initCoordinator(InitCallback const& init) {
   auto& vocbase = index().collection().vocbase();
-  auto& ci = vocbase.server().getFeature<ClusterFeature>().clusterInfo();
+  auto& cf = vocbase.server().getFeature<ClusterFeature>();
+  if (!cf.isEnabled()) {
+    LOG_TOPIC("9be20", DEBUG, TOPIC)
+        << "Skipped link '" << index().id().id()
+        << "' maybe due to disabled cluster features.";
+    return {};
+  }
+  auto& ci = cf.clusterInfo();
   std::shared_ptr<IResearchViewCoordinator> view;
   if (auto r = toView(ci.getView(vocbase.name(), _viewGuid), view); !view) {
     return r;

--- a/arangod/IResearch/IResearchViewCoordinator.cpp
+++ b/arangod/IResearch/IResearchViewCoordinator.cpp
@@ -79,7 +79,8 @@ struct IResearchViewCoordinator::ViewFactory final : arangodb::ViewFactory {
   Result create(LogicalView::ptr& view, TRI_vocbase_t& vocbase,
                 VPackSlice definition, bool isUserRequest) const final {
     auto& server = vocbase.server();
-    if (!server.hasFeature<ClusterFeature>()) {
+    if (!server.hasFeature<ClusterFeature>() ||
+        !server.getFeature<ClusterFeature>().isEnabled()) {
       return {TRI_ERROR_INTERNAL,
               absl::StrCat("failure to find 'ClusterInfo' instance while "
                            "creating arangosearch View in database '",
@@ -341,7 +342,8 @@ Result IResearchViewCoordinator::properties(velocypack::Slice slice,
                                             bool isUserRequest,
                                             bool partialUpdate) {
   auto& server = vocbase().server();
-  if (!server.hasFeature<ClusterFeature>()) {
+  if (!server.hasFeature<ClusterFeature>() ||
+      !server.getFeature<ClusterFeature>().isEnabled()) {
     return {
         TRI_ERROR_INTERNAL,
         absl::StrCat(
@@ -447,7 +449,8 @@ Result IResearchViewCoordinator::properties(velocypack::Slice slice,
 
 Result IResearchViewCoordinator::dropImpl() {
   auto& server = vocbase().server();
-  if (!server.hasFeature<ClusterFeature>()) {
+  if (!server.hasFeature<ClusterFeature>() ||
+      !server.getFeature<ClusterFeature>().isEnabled()) {
     return {
         TRI_ERROR_INTERNAL,
         absl::StrCat(


### PR DESCRIPTION
* ES-2678: Added checks to verify that clusterInfo() is availble before accessing it.

* Fixed linter errors

* Fixed error reported by Cursor Bugbot

* Added Changelog entry

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
