### PR TITLE
[BTS-2203] Add SupervisedBuffer to QueryCursor

### DIFF
--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -169,6 +169,7 @@ QueryStreamCursor::QueryStreamCursor(PrivateToken, std::shared_ptr<Query> q,
                                      bool isRetriable)
     : Cursor(TRI_NewServerSpecificTick(), batchSize, ttl, /*hasCount*/ false,
              isRetriable),
+      _extrasBuffer(velocypack::SupervisedBuffer(q->resourceMonitor())),
       _query(std::move(q)),
       _queryResultPos(0),
       _finalization(false),

--- a/arangod/Aql/QueryCursor.h
+++ b/arangod/Aql/QueryCursor.h
@@ -26,6 +26,7 @@
 
 #include "Aql/QueryResult.h"
 #include "Aql/SharedAqlItemBlockPtr.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Transaction/Context.h"
 #include "Transaction/Methods.h"
 #include "Utils/Cursor.h"
@@ -157,7 +158,7 @@ class QueryStreamCursor final : public Cursor {
 
   void cleanupStateCallback();
 
-  velocypack::UInt8Buffer _extrasBuffer;
+  velocypack::SupervisedBuffer _extrasBuffer;
   std::deque<SharedAqlItemBlockPtr> _queryResults;  /// buffered results
   std::shared_ptr<transaction::Context> _ctx;       /// cache context
   std::shared_ptr<aql::Query> _query;


### PR DESCRIPTION
### Scope & Purpose

- QueryCursor.cpp's `QueryStreamCursor` uses a builder in `finalization()` function. This is the only place where a builder object is instantiated.
- Made `_extrasBuffer`'s type from Buffer to SupervisedBuffer.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
