### PR TITLE
[BTS-2203] Add SupervisedBuffer to DistanceFunctions

### DIFF
--- a/arangod/Aql/Function/DistanceFunctions.cpp
+++ b/arangod/Aql/Function/DistanceFunctions.cpp
@@ -28,6 +28,7 @@
 #include "Aql/Function.h"
 #include "Aql/Functions.h"
 #include "Basics/StringUtils.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"
@@ -40,6 +41,7 @@
 #include <algorithm>
 #include <cmath>
 #include <unordered_map>
+#include <Aql/FixedVarExpressionContext.h>
 
 using namespace arangodb;
 
@@ -68,6 +70,10 @@ AqlValue DistanceImpl(aql::ExpressionContext* expressionContext,
 
     return distanceFunc(lhsIt, rhsIt);
   };
+
+  auto* execCtx = dynamic_cast<FixedVarExpressionContext*>(expressionContext);
+  ResourceMonitor* resourceMonitor =
+      execCtx ? &execCtx->resourceMonitor() : nullptr;
 
   // extract arguments
   AqlValue const& argLhs =
@@ -100,6 +106,14 @@ AqlValue DistanceImpl(aql::ExpressionContext* expressionContext,
     }
 
     VPackBuilder builder;
+    if (resourceMonitor != nullptr) {
+      // sb needs to be a shared_ptr since it will be stolen, which returns
+      // shared_ptr<Buffer> otherwise the shared_ptr will be dangling.
+      auto sb =
+          std::make_shared<velocypack::SupervisedBuffer>(*resourceMonitor);
+      builder = VPackBuilder(sb);
+    }
+
     {
       VPackArrayBuilder arrayBuilder(&builder);
       for (VPackSlice currRow : VPackArrayIterator(matrix)) {

--- a/arangod/Aql/Function/DistanceFunctions.cpp
+++ b/arangod/Aql/Function/DistanceFunctions.cpp
@@ -25,6 +25,7 @@
 #include "Aql/AqlValueMaterializer.h"
 #include "Aql/AstNode.h"
 #include "Aql/ExpressionContext.h"
+#include "Aql/FixedVarExpressionContext.h"
 #include "Aql/Function.h"
 #include "Aql/Functions.h"
 #include "Basics/StringUtils.h"
@@ -41,7 +42,6 @@
 #include <algorithm>
 #include <cmath>
 #include <unordered_map>
-#include <Aql/FixedVarExpressionContext.h>
 
 using namespace arangodb;
 

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -27,12 +27,12 @@
 #include "QueryContext.h"
 #include "Aql/AqlValue.h"
 #include "Basics/ErrorCode.h"
+#include "Basics/ResourceUsage.h"
 #include "Containers/FlatHashMap.h"
 
 #include <velocypack/Slice.h>
 
 #include <string_view>
-#include <Basics/ResourceUsage.h>
 
 namespace arangodb {
 struct ValidatorBase;

--- a/arangod/Aql/QueryExpressionContext.h
+++ b/arangod/Aql/QueryExpressionContext.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "ExpressionContext.h"
+#include "QueryContext.h"
 #include "Aql/AqlValue.h"
 #include "Basics/ErrorCode.h"
 #include "Containers/FlatHashMap.h"
@@ -31,6 +32,7 @@
 #include <velocypack/Slice.h>
 
 #include <string_view>
+#include <Basics/ResourceUsage.h>
 
 namespace arangodb {
 struct ValidatorBase;
@@ -50,7 +52,8 @@ class QueryExpressionContext : public aql::ExpressionContext {
       : ExpressionContext(),
         _trx(trx),
         _query(query),
-        _aqlFunctionsInternalCache(cache) {}
+        _aqlFunctionsInternalCache(cache),
+        _resourceMonitor(query.resourceMonitor()) {}
 
   void registerWarning(ErrorCode errorCode,
                        std::string_view msg) override final;
@@ -83,6 +86,8 @@ class QueryExpressionContext : public aql::ExpressionContext {
   // unregister a temporary variable from the ExpressionContext.
   void clearVariable(Variable const* variable) noexcept override;
 
+  ResourceMonitor& resourceMonitor() const { return _resourceMonitor; }
+
  protected:
   // return temporary variable if set, otherwise call lambda for
   // retrieving variable value
@@ -110,6 +115,7 @@ class QueryExpressionContext : public aql::ExpressionContext {
   // here are not owned by the QueryExpressionContext!
   containers::FlatHashMap<Variable const*, arangodb::velocypack::Slice>
       _variables;
+  ResourceMonitor& _resourceMonitor;
 };
 }  // namespace aql
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

- `DistanceFunctions.cpp`'s `DistanceImpl` uses a builder object. This function brings `ExpressionContext*`.
- Actual type of `ExpressionContext*` is `FixedVarExpressionContext*`.
- Added `ResourceMonitor&` to `QueryExpressionContext` since FixedVarExpressionContext inherits from it.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 1cc5cae2e3144c0d1c2bc2ca6ff21f54bf20c4bd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->