### PR TITLE
Bug fix/bts 2228 fix streaming cursor exception during prepare

### DIFF
--- a/arangod/Aql/QueryCursor.cpp
+++ b/arangod/Aql/QueryCursor.cpp
@@ -581,9 +581,13 @@ ExecutionState QueryStreamCursor::finalization() {
 
 void QueryStreamCursor::cleanupStateCallback() {
   TRI_ASSERT(_query);
-  transaction::Methods trx(_ctx);
-  if (_stateChangeCb && trx.status() == transaction::Status::RUNNING) {
-    trx.removeStatusChangeCallback(&_stateChangeCb);
-    _stateChangeCb = nullptr;
+  if (_ctx != nullptr) {
+    transaction::Methods trx(_ctx);
+    if (_stateChangeCb && trx.status() == transaction::Status::RUNNING) {
+      trx.removeStatusChangeCallback(&_stateChangeCb);
+      _stateChangeCb = nullptr;
+    }
+  } else {
+    TRI_ASSERT(_stateChangeCb == nullptr);
   }
 }


### PR DESCRIPTION
### Scope & Purpose

Invalid query strings caused crashes for streaming cursors (e.g. `RETURN x`, where `x` is undefined). Detailed description in [BTS-2228](https://arangodb.atlassian.net/browse/BTS-2228).

- [X] :hankey: Bugfix

### Checklist

No CHANGELOG or backports, as this regression was not released.

- [X] Tests
  - [X] **Regression tests**
- [ ] :book: CHANGELOG entry made
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [X] GitHub issue / Jira ticket: [BTS-2228](https://arangodb.atlassian.net/browse/BTS-2228).
