### PR TITLE
Deduce Vertex Collections for Traversal from Named Graphs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 devel
 -----
+* Add vertex collections for graph queries using edge collection syntax
+  from named graphs. This means that if a query uses edge collection syntax
+  and a named graph defines the from and to vertex collections for that edge
+  collection, the WITH statement is no longer required.
 
 * Upgraded OpenSSL to 3.5.4.
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4590,27 +4590,12 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
       if (match->type == arangodb::aql::NODE_TYPE_COLLECTION_LIST) {
         for (size_t i = 0; i < match->numMembers(); ++i) {
           auto const* member = match->getMemberUnchecked(i);
-          switch (member->type) {
-            case NODE_TYPE_VALUE: {
-              TRI_ASSERT(member->isStringValue());
-              edgeCollections.emplace(member->getString());
-            } break;
-            case NODE_TYPE_COLLECTION: {
-              edgeCollections.emplace(member->getString());
-            } break;
-            case NODE_TYPE_DIRECTION: {
-              TRI_ASSERT(member->numMembers() == 2);
-              auto subMember = member->getMember(1);
+          auto collectionName = edgeCollectionNodeGetName(member);
 
-              TRI_ASSERT(subMember->isStringValue() ||
-                         subMember->type == NODE_TYPE_COLLECTION)
-                  << subMember->getTypeString();
-              edgeCollections.emplace(subMember->getString());
-            } break;
-            default: {
-              // TODO: throw maybe.
-              ADB_PROD_CRASH() << "unhandled: " << member->getTypeString();
-            }
+          TRI_ASSERT(collectionName.has_value());
+
+          if (collectionName.has_value()) {
+            edgeCollections.emplace(*collectionName);
           }
         }
       } else {

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4558,3 +4558,34 @@ AstNode const* Ast::getSubqueryForVariable(Variable const* variable) const {
   }
   return nullptr;
 }
+
+void Ast::addCollection(CollectionNameResolver const& resolver,
+                        std::string name) {
+  std::string_view nameRef(name);
+  auto const isCoordinator = ServerState::instance()->isCoordinator();
+
+  LogicalDataSource::Category category = injectDataSourceInQuery(
+      *this, resolver, AccessMode::Type::READ, false, nameRef);
+  if (category == LogicalDataSource::Category::kCollection) {
+    if (isCoordinator) {
+      auto& ci =
+          _query.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
+      auto c = ci.getCollectionNT(_query.vocbase().name(), name);
+      if (c != nullptr) {
+        auto const& names = c->realNames();
+
+        for (auto const& n : names) {
+          std::string_view shardsNameRef(n);
+          LogicalDataSource::Category shardsCategory = injectDataSourceInQuery(
+              *this, resolver, AccessMode::Type::READ, false, shardsNameRef);
+          TRI_ASSERT(shardsCategory ==
+                     LogicalDataSource::Category::kCollection);
+        }
+      }  // else { TODO Should we really not react? }
+    }
+  } else {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,
+        absl::StrCat(nameRef, " is required to be a collection"));
+  }
+}

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4605,7 +4605,7 @@ auto matchGraphSubjectWhenVertexCollectionsNotSet(AstNode const* node)
     } break;
     case NODE_TYPE_SHORTEST_PATH: {
       graphSubject = node->getMember(3);
-      options = node->getMember(5);
+      options = node->getMember(4);
     } break;
     case NODE_TYPE_ENUMERATE_PATHS: {
       graphSubject = node->getMember(4);

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -330,7 +330,7 @@ injectDataSourceInQuery(Ast& ast, CollectionNameResolver const& resolver,
 
 LogicalDataSource::Category addDataSource(
     Ast& ast, CollectionNameResolver const& resolver,
-    std::string_view& nameRef) {
+    std::string_view nameRef) {
   auto [category, resolved_name] = injectDataSourceInQuery(
       ast, resolver, AccessMode::Type::READ, false, nameRef);
 
@@ -382,57 +382,6 @@ std::optional<std::string> edgeCollectionNodeGetName(
   // not)
   TRI_ASSERT(false) << "Unhandled node type for edge collection: "
                     << edgeCollection->getTypeString();
-  return std::nullopt;
-}
-
-LogicalDataSource::Category addDataSource(
-    Ast& ast, CollectionNameResolver const& resolver, std::string name) {
-  std::string_view nameRef(name);
-
-  auto category = injectDataSourceInQuery(ast, resolver, AccessMode::Type::READ,
-                                          false, nameRef);
-
-  if (category == LogicalDataSource::Category::kCollection) {
-    if (ServerState::instance()->isCoordinator()) {
-      auto& ci = ast.query()
-                     .vocbase()
-                     .server()
-                     .getFeature<ClusterFeature>()
-                     .clusterInfo();
-      auto c = ci.getCollectionNT(ast.query().vocbase().name(), name);
-      if (c != nullptr) {
-        auto const& names = c->realNames();
-
-        for (auto const& n : names) {
-          std::string_view shardsNameRef(n);
-
-          LogicalDataSource::Category shardsCategory = injectDataSourceInQuery(
-              ast, resolver, AccessMode::Type::READ, false, shardsNameRef);
-
-          TRI_ASSERT(shardsCategory ==
-                     LogicalDataSource::Category::kCollection);
-        }
-      }  // else { TODO Should we really not react? }
-    }
-  }
-
-  return category;
-}
-
-std::optional<std::string> edgeCollectionNodeGetName(
-    CollectionNameResolver const& resolver, AstNode const* edgeCollection) {
-  if (edgeCollection->isStringValue()) {
-    return edgeCollection->getString();
-  } else if (edgeCollection->type == NODE_TYPE_DIRECTION) {
-    TRI_ASSERT(edgeCollection->numMembers() == 2);
-    auto eCSub = edgeCollection->getMember(1);
-
-    if (eCSub->isStringValue()) {
-      return eCSub->getString();
-    }
-  }
-
-  // TODO: find whether this can ever happen
   return std::nullopt;
 }
 
@@ -4686,7 +4635,7 @@ void Ast::addGraphNodeImplicitVertexCollections(
     auto r = gm.findVertexCollectionsFromEdgeCollection(edgeCollectionName);
     if (r.has_value()) {
       for (auto&& vertexCollectionName : *r) {
-        addDataSource(*this, resolver, vertexCollectionName);
+        addDataSource(*this, resolver, std::string_view{vertexCollectionName});
       }
     }
   }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -418,8 +418,8 @@ LogicalDataSource::Category addDataSource(
   return category;
 }
 
-std::string edgeCollectionNodeGetName(CollectionNameResolver const& resolver,
-                                      AstNode const* edgeCollection) {
+std::optional<std::string> edgeCollectionNodeGetName(
+    CollectionNameResolver const& resolver, AstNode const* edgeCollection) {
   if (edgeCollection->isStringValue()) {
     return edgeCollection->getString();
   } else if (edgeCollection->type == NODE_TYPE_DIRECTION) {
@@ -429,10 +429,10 @@ std::string edgeCollectionNodeGetName(CollectionNameResolver const& resolver,
     if (eCSub->isStringValue()) {
       return eCSub->getString();
     }
-  }  // else bindParameter use default for collection bindVar
+  }
 
-  // TODO: what? probably assert?
-  return "";
+  // TODO: find whether this can ever happen
+  return std::nullopt;
 }
 
 }  // namespace

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4584,8 +4584,8 @@ void Ast::addCollection(CollectionNameResolver const& resolver,
       }  // else { TODO Should we really not react? }
     }
   } else {
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,
-        absl::StrCat(nameRef, " is required to be a collection"));
+    //    THROW_ARANGO_EXCEPTION_MESSAGE(
+    //    TRI_ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,
+    //    absl::StrCat(nameRef, " is required to be a collection"));
   }
 }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4610,3 +4610,106 @@ AstNode const* Ast::getSubqueryForVariable(Variable const* variable) const {
   }
   return nullptr;
 }
+
+containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
+    const {
+  auto edgeCollections = containers::FlatHashSet<std::string>(4);
+
+  auto edgeTraversalVisitor = [&edgeCollections](AstNode const* node) -> void {
+    auto maybeMatch = [&node]() -> std::optional<AstNode const*> {
+      switch (node->type) {
+        case NODE_TYPE_TRAVERSAL: {
+          return node->getMember(2);
+        } break;
+        case NODE_TYPE_SHORTEST_PATH: {
+          return node->getMember(3);
+        } break;
+        case NODE_TYPE_ENUMERATE_PATHS: {
+          return node->getMember(4);
+        } break;
+        default: {
+          return std::nullopt;
+        } break;
+      };
+    }();
+
+    if (maybeMatch.has_value()) {
+      auto const* match = *maybeMatch;
+
+      // Found a traversal, shortest path, path search that uses
+      // edge collection syntax
+      if (match->type == arangodb::aql::NODE_TYPE_COLLECTION_LIST) {
+        for (size_t i = 0; i < match->numMembers(); ++i) {
+          auto const* member = match->getMemberUnchecked(i);
+          switch (member->type) {
+            case NODE_TYPE_VALUE: {
+              edgeCollections.emplace(member->getString());
+            } break;
+            case NODE_TYPE_COLLECTION: {
+              edgeCollections.emplace(member->getString());
+            } break;
+            default: {
+              // TODO: throw maybe.
+              ADB_PROD_CRASH() << "unknown.";
+            }
+          }
+        }
+      } else {
+        // Graph syntax is not interesting for this function
+      }
+    }
+  };
+
+  traverseReadOnly(_root, edgeTraversalVisitor);
+
+  return edgeCollections;
+}
+
+void Ast::addGraphNodeImplicitVertexCollections(
+    CollectionNameResolver const& resolver) {
+  // Edge Collections used in traversals/
+  auto edgeCollections = collectGraphNodeEdgeCollections();
+
+  auto gm = graph::GraphManager(query().vocbase(), query().operationOrigin());
+
+  auto& ci =
+      _query.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
+  auto ss = ServerState::instance();
+
+  for (auto&& edgeCollectionName : edgeCollections) {
+    auto r = gm.findVertexCollectionsFromEdgeCollection(edgeCollectionName);
+    if (r.has_value()) {
+      for (auto&& vertexCollectionName : *r) {
+        auto vertexCollectionNameRef = std::string_view{vertexCollectionName};
+        auto category =
+            injectDataSourceInQuery(*this, resolver, AccessMode::Type::READ,
+                                    false, vertexCollectionNameRef);
+
+        if (category == LogicalDataSource::Category::kCollection) {
+          if (ss->isCoordinator()) {
+            auto c = ci.getCollectionNT(_query.vocbase().name(),
+                                        vertexCollectionName);
+            if (c != nullptr) {
+              auto const& names = c->realNames();
+
+              for (auto const& n : names) {
+                std::string_view shardsNameRef(n);
+                LogicalDataSource::Category shardsCategory =
+                    injectDataSourceInQuery(*this, resolver,
+                                            AccessMode::Type::READ, false,
+                                            shardsNameRef);
+                TRI_ASSERT(shardsCategory ==
+                           LogicalDataSource::Category::kCollection);
+              }
+            }  // else { TODO Should we really not react? }
+          }
+        } else {
+          THROW_ARANGO_EXCEPTION_MESSAGE(
+              TRI_ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,
+              absl::StrCat(vertexCollectionNameRef,
+                           " is required to be a collection"));
+        }
+      }
+    }
+  }
+}

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4682,9 +4682,7 @@ void Ast::addGraphNodeImplicitVertexCollections(
 
   auto gm = graph::GraphManager(query().vocbase(), query().operationOrigin());
 
-  auto& ci =
-      _query.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
-  auto ss = ServerState::instance();
+  auto isCoordinator = ServerState::instance()->isCoordinator();
 
   for (auto&& edgeCollectionName : edgeCollections) {
     auto r = gm.findVertexCollectionsFromEdgeCollection(edgeCollectionName);
@@ -4696,7 +4694,12 @@ void Ast::addGraphNodeImplicitVertexCollections(
                                     false, vertexCollectionNameRef);
 
         if (category == LogicalDataSource::Category::kCollection) {
-          if (ss->isCoordinator()) {
+          if (isCoordinator) {
+            auto& ci = _query.vocbase()
+                           .server()
+                           .getFeature<ClusterFeature>()
+                           .clusterInfo();
+
             auto c = ci.getCollectionNT(_query.vocbase().name(),
                                         vertexCollectionName);
             if (c != nullptr) {

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4615,17 +4615,19 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
 
 void Ast::addGraphNodeImplicitVertexCollections(
     CollectionNameResolver const& resolver) {
-  // Edge Collections used in traversals/
-  auto edgeCollections = collectGraphNodeEdgeCollections();
-
   auto gm = graph::GraphManager(query().vocbase(), query().operationOrigin());
 
-  for (auto&& edgeCollectionName : edgeCollections) {
-    auto r = gm.findVertexCollectionsFromEdgeCollection(edgeCollectionName);
-    if (r.has_value()) {
-      for (auto&& vertexCollectionName : *r) {
-        addDataSource(*this, resolver, std::string_view{vertexCollectionName});
-      }
+  // Collect all edge collection names used in graph operations using
+  // edge collection syntax.
+  auto edgeCollections = collectGraphNodeEdgeCollections();
+  auto maybeImplicitVertexCollections =
+      gm.findImplicitVertexCollectionsFromEdgeCollections(edgeCollections);
+
+  if (maybeImplicitVertexCollections.ok()) {
+    for (auto&& vertexCollectionName : maybeImplicitVertexCollections.get()) {
+      addDataSource(*this, resolver, std::string_view{vertexCollectionName});
     }
+  } else {
+    THROW_ARANGO_EXCEPTION(maybeImplicitVertexCollections.result());
   }
 }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -46,6 +46,7 @@
 #include "Containers/FlatHashSet.h"
 #include "Containers/SmallVector.h"
 #include "Graph/Graph.h"
+#include "Graph/GraphManager.h"
 #include "RestServer/DatabaseFeature.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/Methods.h"

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -384,6 +384,57 @@ std::optional<std::string> edgeCollectionNodeGetName(
   return std::nullopt;
 }
 
+LogicalDataSource::Category addDataSource(
+    Ast& ast, CollectionNameResolver const& resolver, std::string name) {
+  std::string_view nameRef(name);
+
+  auto category = injectDataSourceInQuery(ast, resolver, AccessMode::Type::READ,
+                                          false, nameRef);
+
+  if (category == LogicalDataSource::Category::kCollection) {
+    if (ServerState::instance()->isCoordinator()) {
+      auto& ci = ast.query()
+                     .vocbase()
+                     .server()
+                     .getFeature<ClusterFeature>()
+                     .clusterInfo();
+      auto c = ci.getCollectionNT(ast.query().vocbase().name(), name);
+      if (c != nullptr) {
+        auto const& names = c->realNames();
+
+        for (auto const& n : names) {
+          std::string_view shardsNameRef(n);
+
+          LogicalDataSource::Category shardsCategory = injectDataSourceInQuery(
+              ast, resolver, AccessMode::Type::READ, false, shardsNameRef);
+
+          TRI_ASSERT(shardsCategory ==
+                     LogicalDataSource::Category::kCollection);
+        }
+      }  // else { TODO Should we really not react? }
+    }
+  }
+
+  return category;
+}
+
+std::string edgeCollectionNodeGetName(CollectionNameResolver const& resolver,
+                                      AstNode const* edgeCollection) {
+  if (edgeCollection->isStringValue()) {
+    return edgeCollection->getString();
+  } else if (edgeCollection->type == NODE_TYPE_DIRECTION) {
+    TRI_ASSERT(edgeCollection->numMembers() == 2);
+    auto eCSub = edgeCollection->getMember(1);
+
+    if (eCSub->isStringValue()) {
+      return eCSub->getString();
+    }
+  }  // else bindParameter use default for collection bindVar
+
+  // TODO: what? probably assert?
+  return "";
+}
+
 }  // namespace
 
 Ast::SpecialNodes::SpecialNodes()
@@ -4557,35 +4608,4 @@ AstNode const* Ast::getSubqueryForVariable(Variable const* variable) const {
     return it->second;
   }
   return nullptr;
-}
-
-void Ast::addCollection(CollectionNameResolver const& resolver,
-                        std::string name) {
-  std::string_view nameRef(name);
-  auto const isCoordinator = ServerState::instance()->isCoordinator();
-
-  LogicalDataSource::Category category = injectDataSourceInQuery(
-      *this, resolver, AccessMode::Type::READ, false, nameRef);
-  if (category == LogicalDataSource::Category::kCollection) {
-    if (isCoordinator) {
-      auto& ci =
-          _query.vocbase().server().getFeature<ClusterFeature>().clusterInfo();
-      auto c = ci.getCollectionNT(_query.vocbase().name(), name);
-      if (c != nullptr) {
-        auto const& names = c->realNames();
-
-        for (auto const& n : names) {
-          std::string_view shardsNameRef(n);
-          LogicalDataSource::Category shardsCategory = injectDataSourceInQuery(
-              *this, resolver, AccessMode::Type::READ, false, shardsNameRef);
-          TRI_ASSERT(shardsCategory ==
-                     LogicalDataSource::Category::kCollection);
-        }
-      }  // else { TODO Should we really not react? }
-    }
-  } else {
-    //    THROW_ARANGO_EXCEPTION_MESSAGE(
-    //    TRI_ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,
-    //    absl::StrCat(nameRef, " is required to be a collection"));
-  }
 }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4682,46 +4682,11 @@ void Ast::addGraphNodeImplicitVertexCollections(
 
   auto gm = graph::GraphManager(query().vocbase(), query().operationOrigin());
 
-  auto isCoordinator = ServerState::instance()->isCoordinator();
-
   for (auto&& edgeCollectionName : edgeCollections) {
     auto r = gm.findVertexCollectionsFromEdgeCollection(edgeCollectionName);
     if (r.has_value()) {
       for (auto&& vertexCollectionName : *r) {
-        auto vertexCollectionNameRef = std::string_view{vertexCollectionName};
-        auto category =
-            injectDataSourceInQuery(*this, resolver, AccessMode::Type::READ,
-                                    false, vertexCollectionNameRef);
-
-        if (category == LogicalDataSource::Category::kCollection) {
-          if (isCoordinator) {
-            auto& ci = _query.vocbase()
-                           .server()
-                           .getFeature<ClusterFeature>()
-                           .clusterInfo();
-
-            auto c = ci.getCollectionNT(_query.vocbase().name(),
-                                        vertexCollectionName);
-            if (c != nullptr) {
-              auto const& names = c->realNames();
-
-              for (auto const& n : names) {
-                std::string_view shardsNameRef(n);
-                LogicalDataSource::Category shardsCategory =
-                    injectDataSourceInQuery(*this, resolver,
-                                            AccessMode::Type::READ, false,
-                                            shardsNameRef);
-                TRI_ASSERT(shardsCategory ==
-                           LogicalDataSource::Category::kCollection);
-              }
-            }  // else { TODO Should we really not react? }
-          }
-        } else {
-          THROW_ARANGO_EXCEPTION_MESSAGE(
-              TRI_ERROR_ARANGO_COLLECTION_TYPE_MISMATCH,
-              absl::StrCat(vertexCollectionNameRef,
-                           " is required to be a collection"));
-        }
+        addDataSource(*this, resolver, vertexCollectionName);
       }
     }
   }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4564,6 +4564,42 @@ AstNode const* Ast::getSubqueryForVariable(Variable const* variable) const {
   return nullptr;
 }
 
+namespace {
+
+auto getVertexCollectionsFromGraphOptionsNode(AstNode const* options)
+    -> containers::FlatHashSet<std::string> {
+  auto result = containers::FlatHashSet<std::string>{};
+
+  if (options != nullptr) {
+    TRI_ASSERT(options->type == NODE_TYPE_OBJECT);
+    auto n = options->numMembers();
+    for (auto i = size_t{0}; i < n; ++i) {
+      auto member = options->getMemberUnchecked(i);
+      if (member != nullptr and
+          member->type == arangodb::aql::NODE_TYPE_OBJECT_ELEMENT) {
+        auto const name = member->getStringView();
+        if (name == "vertexCollections") {
+          auto value = member->getMember(0);
+          if (value->isStringValue()) {
+            result.insert(value->getString());
+          } else if (value->type == NODE_TYPE_ARRAY) {
+            auto nn = value->numMembers();
+            for (auto j = size_t{0}; j < nn; ++j) {
+              auto c = value->getMemberUnchecked(j);
+              TRI_ASSERT(c->isStringValue());
+              result.insert(c->getString());
+            }
+          } else {
+            // ...
+          }
+        }
+      }
+    }
+  }
+
+  return result;
+}
+}  // namespace
 containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
     const {
   auto edgeCollections = containers::FlatHashSet<std::string>(4);
@@ -4572,12 +4608,15 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
     auto maybeMatch = [&node]() -> std::optional<AstNode const*> {
       switch (node->type) {
         case NODE_TYPE_TRAVERSAL: {
+          getVertexCollectionsFromGraphOptionsNode(node->getMember(4));
           return node->getMember(2);
         } break;
         case NODE_TYPE_SHORTEST_PATH: {
+          // getVertexCollectionsFromGraphOptionsNode(node->getMember(5));
           return node->getMember(3);
         } break;
         case NODE_TYPE_ENUMERATE_PATHS: {
+          // getVertexCollectionsFromGraphOptionsNode(node->getMember(5));
           return node->getMember(4);
         } break;
         default: {
@@ -4603,7 +4642,8 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
           }
         }
       } else {
-        // Graph syntax case (I hope); is not interesting for this function
+        // Graph syntax case (I hope); is not interesting for this
+        // function
       }
     }
   };

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -374,6 +374,10 @@ std::optional<std::string> edgeCollectionNodeGetName(
     return edgeCollection->getString();
   }
 
+  if (edgeCollection->type == NODE_TYPE_COLLECTION) {
+    return edgeCollection->getString();
+  }
+
   if (edgeCollection->type == NODE_TYPE_PARAMETER_DATASOURCE) {
     return std::nullopt;
   }

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4566,12 +4566,9 @@ AstNode const* Ast::getSubqueryForVariable(Variable const* variable) const {
 
 namespace {
 
-auto getVertexCollectionsFromGraphOptionsNode(AstNode const* options)
-    -> containers::FlatHashSet<std::string> {
-  auto result = containers::FlatHashSet<std::string>{};
-
-  if (options != nullptr) {
-    TRI_ASSERT(options->type == NODE_TYPE_OBJECT);
+auto hasVertexCollectionsOption(AstNode const* options) -> bool {
+  if (options != nullptr && options->type != NODE_TYPE_NOP) {
+    TRI_ASSERT(options->type == NODE_TYPE_OBJECT) << options->getTypeString();
     auto n = options->numMembers();
     for (auto i = size_t{0}; i < n; ++i) {
       auto member = options->getMemberUnchecked(i);
@@ -4581,48 +4578,55 @@ auto getVertexCollectionsFromGraphOptionsNode(AstNode const* options)
         if (name == "vertexCollections") {
           auto value = member->getMember(0);
           if (value->isStringValue()) {
-            result.insert(value->getString());
+            return true;
           } else if (value->type == NODE_TYPE_ARRAY) {
             auto nn = value->numMembers();
-            for (auto j = size_t{0}; j < nn; ++j) {
-              auto c = value->getMemberUnchecked(j);
-              TRI_ASSERT(c->isStringValue());
-              result.insert(c->getString());
+            if (nn > 0) {
+              return true;
             }
-          } else {
-            // ...
           }
         }
       }
     }
   }
 
-  return result;
+  return false;
 }
 }  // namespace
 containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
     const {
   auto edgeCollections = containers::FlatHashSet<std::string>(4);
 
-  auto edgeTraversalVisitor = [&edgeCollections](AstNode const* node) -> void {
+  // Look for Graph nodes that use edge collection syntax
+  // and do not have the vertexCollections option set.
+  auto matcher = [&edgeCollections](AstNode const* node) -> void {
     auto maybeMatch = [&node]() -> std::optional<AstNode const*> {
+      auto const* graphSubject = (AstNode const*){};
+      auto const* options = (AstNode const*){};
+
       switch (node->type) {
         case NODE_TYPE_TRAVERSAL: {
-          getVertexCollectionsFromGraphOptionsNode(node->getMember(4));
-          return node->getMember(2);
+          graphSubject = node->getMember(2);
+          options = node->getMember(4);
         } break;
         case NODE_TYPE_SHORTEST_PATH: {
-          // getVertexCollectionsFromGraphOptionsNode(node->getMember(5));
-          return node->getMember(3);
+          graphSubject = node->getMember(3);
+          options = node->getMember(5);
         } break;
         case NODE_TYPE_ENUMERATE_PATHS: {
-          // getVertexCollectionsFromGraphOptionsNode(node->getMember(5));
-          return node->getMember(4);
+          graphSubject = node->getMember(4);
+          options = node->getMember(5);
         } break;
         default: {
           return std::nullopt;
         } break;
       };
+
+      if (not hasVertexCollectionsOption(options)) {
+        return {graphSubject};
+      }
+
+      return std::nullopt;
     }();
 
     if (maybeMatch.has_value()) {
@@ -4642,13 +4646,13 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
           }
         }
       } else {
-        // Graph syntax case (I hope); is not interesting for this
+        // Graph syntax case is not interesting for this
         // function
       }
     }
   };
 
-  traverseReadOnly(_root, edgeTraversalVisitor);
+  traverseReadOnly(_root, matcher);
 
   return edgeCollections;
 }
@@ -4661,6 +4665,13 @@ void Ast::addGraphNodeImplicitVertexCollections(
   if (edgeCollections.empty()) {
     // The operations below are fairly expensive, so at least for queries
     // that do not involve edge collection syntax, shortcut
+
+    // Note *also* that the graph manager executes a query to determine all
+    // graphs (which does not contain edge collection syntax); if one does not
+    // return here, the AQL execution enters an infinite loop and blows out the
+    // stack.
+    //
+    // This is clearly terrible.
     return;
   }
 

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4592,42 +4592,46 @@ auto hasVertexCollectionsOption(AstNode const* options) -> bool {
 
   return false;
 }
+
+auto matchGraphSubjectWhenVertexCollectionsNotSet(AstNode const* node)
+    -> std::optional<AstNode const*> {
+  auto const* graphSubject = (AstNode const*){};
+  auto const* options = (AstNode const*){};
+
+  switch (node->type) {
+    case NODE_TYPE_TRAVERSAL: {
+      graphSubject = node->getMember(2);
+      options = node->getMember(4);
+    } break;
+    case NODE_TYPE_SHORTEST_PATH: {
+      graphSubject = node->getMember(3);
+      options = node->getMember(5);
+    } break;
+    case NODE_TYPE_ENUMERATE_PATHS: {
+      graphSubject = node->getMember(4);
+      options = node->getMember(5);
+    } break;
+    default: {
+      return std::nullopt;
+    } break;
+  };
+
+  if (not hasVertexCollectionsOption(options)) {
+    return {graphSubject};
+  }
+
+  return std::nullopt;
+}
 }  // namespace
-containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
-    const {
+
+containers::FlatHashSet<std::string>
+Ast::collectGraphNodeEdgeCollectionsWithoutVertexCollectionOption() const {
   auto edgeCollections = containers::FlatHashSet<std::string>(4);
 
   // Look for Graph nodes that use edge collection syntax
   // and do not have the vertexCollections option set.
   auto matcher = [&edgeCollections](AstNode const* node) -> void {
-    auto maybeMatch = [&node]() -> std::optional<AstNode const*> {
-      auto const* graphSubject = (AstNode const*){};
-      auto const* options = (AstNode const*){};
-
-      switch (node->type) {
-        case NODE_TYPE_TRAVERSAL: {
-          graphSubject = node->getMember(2);
-          options = node->getMember(4);
-        } break;
-        case NODE_TYPE_SHORTEST_PATH: {
-          graphSubject = node->getMember(3);
-          options = node->getMember(5);
-        } break;
-        case NODE_TYPE_ENUMERATE_PATHS: {
-          graphSubject = node->getMember(4);
-          options = node->getMember(5);
-        } break;
-        default: {
-          return std::nullopt;
-        } break;
-      };
-
-      if (not hasVertexCollectionsOption(options)) {
-        return {graphSubject};
-      }
-
-      return std::nullopt;
-    }();
+    auto maybeMatch = matchGraphSubjectWhenVertexCollectionsNotSet(node);
 
     if (maybeMatch.has_value()) {
       auto const* match = *maybeMatch;
@@ -4660,8 +4664,9 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
 void Ast::addGraphNodeImplicitVertexCollections(
     CollectionNameResolver const& resolver) {
   // Collect all edge collection names used in graph operations using
-  // edge collection syntax.
-  auto edgeCollections = collectGraphNodeEdgeCollections();
+  // edge collection syntax that do not have vertexCollections set.
+  auto edgeCollections =
+      collectGraphNodeEdgeCollectionsWithoutVertexCollectionOption();
   if (edgeCollections.empty()) {
     // The operations below are fairly expensive, so at least for queries
     // that do not involve edge collection syntax, shortcut

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4643,19 +4643,29 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
           auto const* member = match->getMemberUnchecked(i);
           switch (member->type) {
             case NODE_TYPE_VALUE: {
+              TRI_ASSERT(member->isStringValue());
               edgeCollections.emplace(member->getString());
             } break;
             case NODE_TYPE_COLLECTION: {
               edgeCollections.emplace(member->getString());
             } break;
+            case NODE_TYPE_DIRECTION: {
+              TRI_ASSERT(member->numMembers() == 2);
+              auto subMember = member->getMember(1);
+
+              TRI_ASSERT(subMember->isStringValue() ||
+                         subMember->type == NODE_TYPE_COLLECTION)
+                  << subMember->getTypeString();
+              edgeCollections.emplace(subMember->getString());
+            } break;
             default: {
               // TODO: throw maybe.
-              ADB_PROD_CRASH() << "unknown.";
+              ADB_PROD_CRASH() << "unhandled: " << member->getTypeString();
             }
           }
         }
       } else {
-        // Graph syntax is not interesting for this function
+        // Graph syntax case (I hope); is not interesting for this function
       }
     }
   };

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -4615,11 +4615,17 @@ containers::FlatHashSet<std::string> Ast::collectGraphNodeEdgeCollections()
 
 void Ast::addGraphNodeImplicitVertexCollections(
     CollectionNameResolver const& resolver) {
-  auto gm = graph::GraphManager(query().vocbase(), query().operationOrigin());
-
   // Collect all edge collection names used in graph operations using
   // edge collection syntax.
   auto edgeCollections = collectGraphNodeEdgeCollections();
+  if (edgeCollections.empty()) {
+    // The operations below are fairly expensive, so at least for queries
+    // that do not involve edge collection syntax, shortcut
+    return;
+  }
+
+  // TODO: the graphmanager should belong to the Query(Context)
+  auto gm = graph::GraphManager(query().vocbase(), query().operationOrigin());
   auto maybeImplicitVertexCollections =
       gm.findImplicitVertexCollectionsFromEdgeCollections(edgeCollections);
 

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -496,6 +496,15 @@ class Ast {
 
   static size_t extractParallelism(AstNode const* optionsNode);
 
+  /// @brief finds all Graph nodes that use edge collection syntax
+  /// and collects the edge collections refered to.
+  containers::FlatHashSet<std::string> collectGraphNodeEdgeCollections() const;
+
+  /// @brief Adds vertex collections that are implied by using edge collection
+  /// syntax in graph operations.
+  void addGraphNodeImplicitVertexCollections(
+      CollectionNameResolver const& resolver);
+
   /// @brief optimizes the AST
   void validateAndOptimize(transaction::Methods&,
                            ValidateAndOptimizeOptions const& options);

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -572,8 +572,6 @@ class Ast {
 
   AstNode const* getSubqueryForVariable(Variable const* variable) const;
 
-  void addCollection(CollectionNameResolver const& resolver, std::string name);
-
   /** Make sure to replace the AstNode* you pass into TraverseAndModify
    *  if it was changed. This is necessary because the function itself
    *  has only access to the node but not its parent / owner.

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -498,7 +498,8 @@ class Ast {
 
   /// @brief finds all Graph nodes that use edge collection syntax
   /// and collects the edge collections refered to.
-  containers::FlatHashSet<std::string> collectGraphNodeEdgeCollections() const;
+  containers::FlatHashSet<std::string>
+  collectGraphNodeEdgeCollectionsWithoutVertexCollectionOption() const;
 
   /// @brief Adds vertex collections that are implied by using edge collection
   /// syntax in graph operations.

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -572,6 +572,8 @@ class Ast {
 
   AstNode const* getSubqueryForVariable(Variable const* variable) const;
 
+  void addCollection(CollectionNameResolver const& resolver, std::string name);
+
   /** Make sure to replace the AstNode* you pass into TraverseAndModify
    *  if it was changed. This is necessary because the function itself
    *  has only access to the node but not its parent / owner.

--- a/arangod/Aql/ExecutionNode/GraphNode.cpp
+++ b/arangod/Aql/ExecutionNode/GraphNode.cpp
@@ -266,17 +266,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
         }
       }
 
-      // TODO: DONT LEAVE THIS JUNK HERE
-      //      auto& collections = plan->getAst()->query().collections();
-      auto& q = plan->getAst()->query();
-      auto gm = graph::GraphManager(q.vocbase(), q.operationOrigin());
-
-      auto r = gm.findVertexCollectionsFromEdgeCollection(eColName);
-      if (r.has_value()) {
-        for (auto&& v : *r) {
-          addVertexCollection(collections, v);
-        }
-      }
+      auto& collections = plan->getAst()->query().collections();
 
       _graphInfo.add(VPackValue(eColName));
       if (ServerState::instance()->isRunningInCluster()) {

--- a/arangod/Aql/ExecutionNode/GraphNode.cpp
+++ b/arangod/Aql/ExecutionNode/GraphNode.cpp
@@ -45,6 +45,7 @@
 #include "Graph/BaseOptions.h"
 #include "Graph/Graph.h"
 #include "Graph/TraverserOptions.h"
+#include "Graph/GraphManager.h"
 #include "Utils/CollectionNameResolver.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
@@ -265,7 +266,17 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
         }
       }
 
-      auto& collections = plan->getAst()->query().collections();
+      // TODO: DONT LEAVE THIS JUNK HERE
+      //      auto& collections = plan->getAst()->query().collections();
+      auto& q = plan->getAst()->query();
+      auto gm = graph::GraphManager(q.vocbase(), q.operationOrigin());
+
+      auto r = gm.findVertexCollectionsFromEdgeCollection(eColName);
+      if (r.has_value()) {
+        for (auto&& v : *r) {
+          addVertexCollection(collections, v);
+        }
+      }
 
       _graphInfo.add(VPackValue(eColName));
       if (ServerState::instance()->isRunningInCluster()) {
@@ -288,6 +299,7 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
       }
     }
     _graphInfo.close();
+
   } else if (graph->isStringValue()) {
     std::string graphName = graph->getString();
     _graphInfo.add(VPackValue(graphName));

--- a/arangod/Aql/ExecutionNode/GraphNode.cpp
+++ b/arangod/Aql/ExecutionNode/GraphNode.cpp
@@ -45,7 +45,6 @@
 #include "Graph/BaseOptions.h"
 #include "Graph/Graph.h"
 #include "Graph/TraverserOptions.h"
-#include "Graph/GraphManager.h"
 #include "Utils/CollectionNameResolver.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
@@ -289,7 +288,6 @@ GraphNode::GraphNode(ExecutionPlan* plan, ExecutionNodeId id,
       }
     }
     _graphInfo.close();
-
   } else if (graph->isStringValue()) {
     std::string graphName = graph->getString();
     _graphInfo.add(VPackValue(graphName));

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -630,7 +630,7 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
 
   _ast->injectBindParametersSecondStage(_bindParameters);
 
-  _ast->addEdgeTraversalVertexCollections(this->resolver());
+  _ast->addGraphNodeImplicitVertexCollections(this->resolver());
 
   if (_ast->containsUpsertNode()) {
     // UPSERTs and intermediate commits do not play nice together, because the
@@ -1443,7 +1443,7 @@ QueryResult Query::explain() {
     _ast->injectBindParametersSecondStage(_bindParameters);
     _bindParameters.validateAllUsed();
 
-    _ast->addEdgeTraversalVertexCollections(this->resolver());
+    _ast->addGraphNodeImplicitVertexCollections(this->resolver());
 
     // optimize and validate the ast
     enterState(QueryExecutionState::ValueType::AST_OPTIMIZATION);

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -630,6 +630,8 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
 
   _ast->injectBindParametersSecondStage(_bindParameters);
 
+  _ast->addEdgeTraversalVertexCollections(this->resolver());
+
   if (_ast->containsUpsertNode()) {
     // UPSERTs and intermediate commits do not play nice together, because the
     // intermediate commit invalidates the read-own-write iterator required by
@@ -1440,6 +1442,8 @@ QueryResult Query::explain() {
                                                  this->resolver());
     _ast->injectBindParametersSecondStage(_bindParameters);
     _bindParameters.validateAllUsed();
+
+    _ast->addEdgeTraversalVertexCollections(this->resolver());
 
     // optimize and validate the ast
     enterState(QueryExecutionState::ValueType::AST_OPTIMIZATION);

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -33,6 +33,7 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
+#include "Containers/FlatHashSet.h"
 #include "Graph/Graph.h"
 #include "Graph/GraphOperations.h"
 #include "Logger/LogMacros.h"
@@ -1294,25 +1295,26 @@ void GraphManager::invalidateQueryOptimizerCaches() const {
   // So we just return here and let the request objects go out of scope.
 }
 
-auto GraphManager::findVertexCollectionsFromEdgeCollection(
-    std::string edgeCollectionName) const
-    -> std::optional<std::vector<std::string>> {
-  // TODO: I hate every single step in this code.
-  auto found = false;
-  auto result = std::vector<std::string>{};
+auto GraphManager::findImplicitVertexCollectionsFromEdgeCollections(
+    containers::FlatHashSet<std::string> const& edgeCollections) const
+    -> ResultT<containers::FlatHashSet<std::string>> {
+  auto result = containers::FlatHashSet<std::string>{};
 
   auto callback = [&](std::unique_ptr<Graph> graph) -> Result {
-    if (!found) {
+    for (auto&& edgeCollectionName : edgeCollections) {
       auto maybeDef = graph->getEdgeDefinition(edgeCollectionName);
       if (maybeDef.has_value()) {
         auto& def = maybeDef->get();
+
         auto const& from = def.getFrom();
-        result.insert(std::end(result), std::cbegin(from), std::cend(from));
+        for (auto&& cn : from) {
+          result.insert(cn);
+        }
 
         auto const& to = def.getTo();
-        result.insert(std::end(result), std::cbegin(to), std::cend(to));
-
-        found = true;
+        for (auto&& cn : to) {
+          result.insert(cn);
+        }
       }
     }
     return Result{};
@@ -1321,7 +1323,7 @@ auto GraphManager::findVertexCollectionsFromEdgeCollection(
   Result res = applyOnAllGraphs(callback);
 
   if (res.fail()) {
-    return std::nullopt;
+    return res;
   } else {
     return {result};
   }

--- a/arangod/Graph/GraphManager.cpp
+++ b/arangod/Graph/GraphManager.cpp
@@ -1293,3 +1293,36 @@ void GraphManager::invalidateQueryOptimizerCaches() const {
   // do would be to retry, but this is already done by `sendRequestRetry`.
   // So we just return here and let the request objects go out of scope.
 }
+
+auto GraphManager::findVertexCollectionsFromEdgeCollection(
+    std::string edgeCollectionName) const
+    -> std::optional<std::vector<std::string>> {
+  // TODO: I hate every single step in this code.
+  auto found = false;
+  auto result = std::vector<std::string>{};
+
+  auto callback = [&](std::unique_ptr<Graph> graph) -> Result {
+    if (!found) {
+      auto maybeDef = graph->getEdgeDefinition(edgeCollectionName);
+      if (maybeDef.has_value()) {
+        auto& def = maybeDef->get();
+        auto const& from = def.getFrom();
+        result.insert(std::end(result), std::cbegin(from), std::cend(from));
+
+        auto const& to = def.getTo();
+        result.insert(std::end(result), std::cbegin(to), std::cend(to));
+
+        found = true;
+      }
+    }
+    return Result{};
+  };
+
+  Result res = applyOnAllGraphs(callback);
+
+  if (res.fail()) {
+    return std::nullopt;
+  } else {
+    return {result};
+  }
+}

--- a/arangod/Graph/GraphManager.h
+++ b/arangod/Graph/GraphManager.h
@@ -177,10 +177,10 @@ class GraphManager {
    * @brief Invalidate all query optimizer caches in the database of this
    * GraphManager. This is necessary in the cluster when the GraphManager
    * runs on a coordinator and all coordinators need to be informed that
-   * their query optimizer caches are now invalid, since some graph
-   * definition has been changed. This method is called in the other
-   * GraphManager methods, whenever some graph is changed on a coordinator.
-   * This is a fire-and-forget method.
+   * their query optimizer caches are now invalid, since some graph definition
+   * has been changed. This method is called in the other GraphManager
+   * methods, whenever some graph is changed on a coordinator. This is a
+   * fire-and-forget method.
    */
   void invalidateQueryOptimizerCaches() const;
 

--- a/arangod/Graph/GraphManager.h
+++ b/arangod/Graph/GraphManager.h
@@ -158,15 +158,29 @@ class GraphManager {
   Result applyOnAllGraphs(
       std::function<Result(std::unique_ptr<Graph>)> const& callback) const;
 
+  /**
+   * @brief Find whether there is a named graph which contains the
+   * given edge collection.
+   *
+   * If so, return the fromCollections and toCollections, otherwise return
+   * std::nullopt
+   *
+   * @param edgeCollectionName The name of the edge collection to look for
+   *
+   * @return Either fromCollections and toCOllections or std::nullopt.
+   */
+  auto findVertexCollectionsFromEdgeCollection(std::string edgeCollectionName)
+      const -> std::optional<std::vector<std::string>>;
+
  private:
   /**
    * @brief Invalidate all query optimizer caches in the database of this
    * GraphManager. This is necessary in the cluster when the GraphManager
    * runs on a coordinator and all coordinators need to be informed that
-   * their query optimizer caches are now invalid, since some graph definition
-   * has been changed. This method is called in the other GraphManager
-   * methods, whenever some graph is changed on a coordinator. This is a
-   * fire-and-forget method.
+   * their query optimizer caches are now invalid, since some graph
+   * definition has been changed. This method is called in the other
+   * GraphManager methods, whenever some graph is changed on a coordinator.
+   * This is a fire-and-forget method.
    */
   void invalidateQueryOptimizerCaches() const;
 

--- a/arangod/Graph/GraphManager.h
+++ b/arangod/Graph/GraphManager.h
@@ -159,18 +159,17 @@ class GraphManager {
       std::function<Result(std::unique_ptr<Graph>)> const& callback) const;
 
   /**
-   * @brief Find whether there is a named graph which contains the
-   * given edge collection.
+   * @brief Find whether there is a named graph which contains any of the
+   * given edge collections.
    *
-   * If so, return the fromCollections and toCollections, otherwise return
-   * std::nullopt
+   * @param edgeCollectionNames The names of the edge collections to look for
    *
-   * @param edgeCollectionName The name of the edge collection to look for
-   *
-   * @return Either fromCollections and toCOllections or std::nullopt.
+   * @return a set of fromCollections and toCollections implied by
+   * edgeCollections.
    */
-  auto findVertexCollectionsFromEdgeCollection(std::string edgeCollectionName)
-      const -> std::optional<std::vector<std::string>>;
+  auto findImplicitVertexCollectionsFromEdgeCollections(
+      containers::FlatHashSet<std::string> const& edgeCollections) const
+      -> ResultT<containers::FlatHashSet<std::string>>;
 
  private:
   /**

--- a/js/client/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
+++ b/js/client/modules/@arangodb/testutils/aql-graph-traversal-generic-tests.js
@@ -2201,22 +2201,6 @@ function testOpenDiamondKShortestPathEnabledWeightCheckLimit1Gen(testGraph, gene
   });
 }
 
-function testSmallCircleClusterOnlyWithInvalidStartNode(testGraph) {
-  if (isCluster) {
-    assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
-    try {
-      const query = aql`
-        FOR v IN 0..1 OUTBOUND ${testGraph.vertex('A') + 'invalidNode'} ${testGraph.edgeCollectionName()}
-        RETURN v
-      `;
-      db._query(query);
-      fail();
-    } catch (err) {
-      assertEqual(err.errorNum, errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code);
-    }
-  }
-}
-
 function testSmallCircleTestDocumentsShardsAPI(testGraph) {
   assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
 
@@ -2268,22 +2252,6 @@ function testSmallCircleTestDocumentsShardsAPI(testGraph) {
       assertEqual(err.errorNum, errors.ERROR_NOT_IMPLEMENTED.code);
       // Unfortunately cannot assert this, different implementations client vs. server (v8)
       // assertEqual(err.errorMessage, errors.ERROR_NOT_IMPLEMENTED.message);
-    }
-  }
-}
-
-function testSmallCircleClusterOnlyWithoutWithClause(testGraph) {
-  if (isCluster) {
-    assertTrue(testGraph.name().startsWith(protoGraphs.smallCircle.name()));
-    try {
-      const query = aql`
-        FOR v IN 0..1 OUTBOUND ${testGraph.vertex('A')} ${testGraph.edgeCollectionName()}
-        RETURN v
-      `;
-      db._query(query);
-      fail();
-    } catch (err) {
-      assertEqual(err.errorNum, errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code);
     }
   }
 }
@@ -6772,8 +6740,6 @@ const testsByGraph = {
   },
   smallCircle: {
     testSmallCircleTestDocumentsShardsAPI,
-    testSmallCircleClusterOnlyWithInvalidStartNode,
-    testSmallCircleClusterOnlyWithoutWithClause,
     testSmallCircleDfsUniqueVerticesPath,
     testSmallCircleDfsUniqueVerticesNone,
     testSmallCircleDfsUniqueEdgesPath,

--- a/tests/IResearch/IResearchQueryTraversalTest.cpp
+++ b/tests/IResearch/IResearchQueryTraversalTest.cpp
@@ -43,6 +43,13 @@ namespace {
 class QueryTraversal : public QueryTest {
  protected:
   void create() {
+    // create _graphs system collection as it is required to parse graph queries
+    {
+      auto createJson = arangodb::velocypack::Parser::fromJson(
+          "{ \"name\": \"_graphs\", \"isSystem\": true }");
+      auto collection = _vocbase.createCollection(createJson->slice());
+      ASSERT_NE(nullptr, collection);
+    }
     // create collection0
     {
       auto createJson = arangodb::velocypack::Parser::fromJson(

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -139,15 +139,15 @@ var createBaseGraph = function() {
   db[vertexCollectionName3].insert([
     {
       _key: "ALPHA",
-      _id: vertexCollectionName2 + "/ALPHA"
+      _id: vertexCollectionName3 + "/ALPHA"
     },
     {
       _key: "BETA",
-      _id: vertexCollectionName2 + "/BETA"
+      _id: vertexCollectionName3 + "/BETA"
     },
     {
-      _key: "THREE",
-      _id: vertexCollectionName2 + "/GAMMA"
+      _key: "GAMMA",
+      _id: vertexCollectionName3 + "/GAMMA"
     }
   ]);
   db[edgeCollectionName3].insert([

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -1,0 +1,276 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertTrue, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2025 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Markus Pfeiffer
+/// @author Copyright 2025
+// //////////////////////////////////////////////////////////////////////////////
+
+var jsunity = require("jsunity");
+var internal = require("internal");
+var errors = internal.errors;
+var db = require("@arangodb").db,
+  indexId;
+var gm = require("@arangodb/general-graph");
+
+const graphName = "WithTestGraph";
+const productCollectionName = "RegressionProduct";
+const customerCollectionName = "RegressionCustomer";
+const ownsEdgeCollectionName = "RegressionOwns";
+
+const expectedResult = [
+  {
+    _key: "396",
+    _id: customerCollectionName + "/396",
+    name: "John",
+    surname: "Smith",
+    age: 52,
+    alive: false,
+    _class: "com.arangodb.springframework.testdata.Customer"
+  },
+  {
+    _key: "397",
+    _id: customerCollectionName + "/397",
+    name: "Matt",
+    surname: "Smith",
+    age: 34,
+    alive: false,
+    _class: "com.arangodb.springframework.testdata.Customer"
+  }
+];
+
+var cleanup = function() {
+  try {
+    gm._drop(graphName, true);
+  } catch (e) {
+  }
+  db._drop(productCollectionName);
+  db._drop(customerCollectionName);
+  db._drop(ownsEdgeCollectionName);
+};
+
+var createBaseGraph = function() {
+  gm._create(graphName, [gm._relation(ownsEdgeCollectionName, customerCollectionName, productCollectionName)], [], {});
+
+  db[customerCollectionName].ensureIndex({
+    fields: ["location"],
+    geoJson: false,
+    name: "idx_1661521530578796544",
+    sparse: true,
+    type: "geo",
+    unique: false
+  });
+
+  db[productCollectionName].ensureIndex({
+    fields: ["location"],
+    geoJson: false,
+    name: "idx_1661521530657439744",
+    sparse: true,
+    type: "geo",
+    unique: false
+  });
+
+  db[customerCollectionName].insert([
+    {
+      _key: "396",
+      _id: customerCollectionName + "/396",
+      _rev: "_aM4ZTRW---",
+      name: "John",
+      surname: "Smith",
+      age: 52,
+      alive: false,
+      _class: "com.arangodb.springframework.testdata.Customer"
+    },
+    {
+      _key: "397",
+      _id: customerCollectionName + "/397",
+      _rev: "_aM4ZTRW--_",
+      name: "Matt",
+      surname: "Smith",
+      age: 34,
+      alive: false,
+      _class: "com.arangodb.springframework.testdata.Customer"
+    },
+    {
+      _key: "398",
+      _id: customerCollectionName + "/398",
+      _rev: "_aM4ZTRW--A",
+      name: "Adam",
+      surname: "Smith",
+      age: 294,
+      alive: false,
+      _class: "com.arangodb.springframework.testdata.Customer"
+    }
+  ]);
+  db[ownsEdgeCollectionName].insert([
+    {
+      _key: "400",
+      _id: ownsEdgeCollectionName + "/400",
+      _from: customerCollectionName + "/396",
+      _to: productCollectionName + "/390",
+      _rev: "_aM4ZTR2---",
+      _class: "com.arangodb.springframework.testdata.Owns"
+    },
+    {
+      _key: "402",
+      _id: ownsEdgeCollectionName + "/402",
+      _from: customerCollectionName + "/396",
+      _to: productCollectionName + "/392",
+      _rev: "_aM4ZTR6---",
+      _class: "com.arangodb.springframework.testdata.Owns"
+    },
+    {
+      _key: "404",
+      _id: ownsEdgeCollectionName + "/404",
+      _from: customerCollectionName + "/398",
+      _to: productCollectionName + "/394",
+      _rev: "_aM4ZTS----",
+      _class: "com.arangodb.springframework.testdata.Owns"
+    },
+    {
+      _key: "406",
+      _id: ownsEdgeCollectionName + "/406",
+      _from: customerCollectionName + "/397",
+      _to: productCollectionName + "/390",
+      _rev: "_aM4ZTSC---",
+      _class: "com.arangodb.springframework.testdata.Owns"
+    },
+    {
+      _key: "408",
+      _id: ownsEdgeCollectionName + "/408",
+      _from: customerCollectionName + "/397",
+      _to: productCollectionName + "/392",
+      _rev: "_aM4ZTSG---",
+      _class: "com.arangodb.springframework.testdata.Owns"
+    },
+    {
+      _key: "410",
+      _id: ownsEdgeCollectionName + "/410",
+      _from: customerCollectionName + "/397",
+      _to: productCollectionName + "/394",
+      _rev: "_aM4ZTSG--_",
+      _class: "com.arangodb.springframework.testdata.Owns"
+    }
+  ]);
+  db[productCollectionName].insert([
+    {
+      _key: "390",
+      _id: productCollectionName + "/390",
+      _rev: "_aM4ZTPy---",
+      name: "phone",
+      _class: "com.arangodb.springframework.testdata.Product"
+    },
+    {
+      _key: "392",
+      _id: productCollectionName + "/392",
+      _rev: "_aM4ZTQG---",
+      name: "car",
+      _class: "com.arangodb.springframework.testdata.Product"
+    },
+    {
+      _key: "394",
+      _id: productCollectionName + "/394",
+      _rev: "_aM4ZTQK---",
+      name: "chair",
+      _class: "com.arangodb.springframework.testdata.Product"
+    }
+  ]);
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function withClauseTestSuite() {
+  return {
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief set up
+    ////////////////////////////////////////////////////////////////////////////////
+
+    setUpAll: function() {
+      cleanup();
+      createBaseGraph();
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief tear down
+    ////////////////////////////////////////////////////////////////////////////////
+
+    tearDownAll: function() {
+      cleanup();
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test that cluster does not need a with clause if a named graph exists
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeeded: function() {
+      const query = `FOR e IN ${customerCollectionName}
+                         FILTER (FOR e1 IN 1..1 ANY e._id ${ownsEdgeCollectionName}
+                                   FILTER e1.name == @0
+                                   RETURN 1)[0] == 1 AND
+                                (FOR e1 IN 1..1 ANY e._id ${ownsEdgeCollectionName}
+                                   FILTER e1.name == @1
+                                   RETURN 1)[0] == 1
+                         RETURN UNSET(e, "_rev")`;
+
+      const bindVars = {
+        "0": "phone",
+        "1": "phone"
+      };
+
+      var actual = db._query(query, bindVars);
+      assertEqual(actual.toArray(), expectedResult);
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test that cluster does not need a with clause if a named graph exists
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeededBindVar: function() {
+      const query = `FOR e IN @@customer
+                         FILTER (FOR e1 IN 1..1 ANY e._id @@owns
+                                   FILTER e1.name == @0
+                                   RETURN 1)[0] == 1 AND
+                                (FOR e1 IN 1..1 ANY e._id @@owns
+                                   FILTER e1.name == @1
+                                   RETURN 1)[0] == 1
+                         RETURN UNSET(e, "_rev")`;
+
+      const bindVars = {
+        "0": "phone",
+        "1": "phone",
+        "@customer": customerCollectionName,
+        "@owns": ownsEdgeCollectionName
+      };
+
+      var actual = db._query(query, bindVars);
+      assertEqual(actual.toArray(), expectedResult);
+    }
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief executes the test suite
+////////////////////////////////////////////////////////////////////////////////
+
+jsunity.run(withClauseTestSuite);
+
+return jsunity.done();

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -33,165 +33,127 @@ var db = require("@arangodb").db,
 var gm = require("@arangodb/general-graph");
 
 const graphName = "WithTestGraph";
-const productCollectionName = "RegressionProduct";
-const customerCollectionName = "RegressionCustomer";
-const ownsEdgeCollectionName = "RegressionOwns";
-
-const expectedResult = [
-  {
-    _key: "396",
-    _id: customerCollectionName + "/396",
-    name: "John",
-    surname: "Smith",
-    age: 52,
-    alive: false,
-    _class: "com.arangodb.springframework.testdata.Customer"
-  },
-  {
-    _key: "397",
-    _id: customerCollectionName + "/397",
-    name: "Matt",
-    surname: "Smith",
-    age: 34,
-    alive: false,
-    _class: "com.arangodb.springframework.testdata.Customer"
-  }
-];
+const vertexCollectionName1 = "VertexCollection1";
+const vertexCollectionName2 = "VertexCollection2";
+const vertexCollectionName3 = "VertexCollection3";
+const edgeCollectionName = "EdgeCollection";
+const edgeCollectionName2 = "EdgeCollection2";
+const edgeCollectionName3 = "Edgecollection3";
 
 var cleanup = function() {
   try {
     gm._drop(graphName, true);
   } catch (e) {
   }
-  db._drop(productCollectionName);
-  db._drop(customerCollectionName);
-  db._drop(ownsEdgeCollectionName);
+  db._drop(vertexCollectionName1);
+  db._drop(vertexCollectionName2);
+  db._drop(vertexCollectionName3);
+  db._drop(edgeCollectionName);
+  db._drop(edgeCollectionName2);
+  db._drop(edgeCollectionName3);
 };
 
 var createBaseGraph = function() {
-  gm._create(graphName, [gm._relation(ownsEdgeCollectionName, customerCollectionName, productCollectionName)], [], {});
+  gm._create(graphName, [gm._relation(edgeCollectionName, vertexCollectionName1, vertexCollectionName2),
+                         gm._relation(edgeCollectionName2, vertexCollectionName3, vertexCollectionName2)], [], {});
 
-  db[customerCollectionName].ensureIndex({
-    fields: ["location"],
-    geoJson: false,
-    name: "idx_1661521530578796544",
-    sparse: true,
-    type: "geo",
-    unique: false
-  });
+  db._createEdgeCollection(edgeCollectionName3);
 
-  db[productCollectionName].ensureIndex({
-    fields: ["location"],
-    geoJson: false,
-    name: "idx_1661521530657439744",
-    sparse: true,
-    type: "geo",
-    unique: false
-  });
-
-  db[customerCollectionName].insert([
+  db[vertexCollectionName1].insert([
     {
-      _key: "396",
-      _id: customerCollectionName + "/396",
-      _rev: "_aM4ZTRW---",
-      name: "John",
-      surname: "Smith",
-      age: 52,
-      alive: false,
-      _class: "com.arangodb.springframework.testdata.Customer"
+      _key: "A",
+      _id: vertexCollectionName1 + "/A",
+      name: "Danny",
+      surname: "Carey"
     },
     {
-      _key: "397",
-      _id: customerCollectionName + "/397",
-      _rev: "_aM4ZTRW--_",
-      name: "Matt",
-      surname: "Smith",
-      age: 34,
-      alive: false,
-      _class: "com.arangodb.springframework.testdata.Customer"
+      _key: "B",
+      _id: vertexCollectionName1 + "/B",
+      name: "Mike",
+      surname: "Portnoy"
     },
     {
-      _key: "398",
-      _id: customerCollectionName + "/398",
-      _rev: "_aM4ZTRW--A",
-      name: "Adam",
-      surname: "Smith",
-      age: 294,
-      alive: false,
-      _class: "com.arangodb.springframework.testdata.Customer"
+      _key: "C",
+      _id: vertexCollectionName1 + "/C",
+      name: "Ringo",
+      surname: "Starr",
     }
   ]);
-  db[ownsEdgeCollectionName].insert([
+  db[edgeCollectionName].insert([
     {
-      _key: "400",
-      _id: ownsEdgeCollectionName + "/400",
-      _from: customerCollectionName + "/396",
-      _to: productCollectionName + "/390",
-      _rev: "_aM4ZTR2---",
-      _class: "com.arangodb.springframework.testdata.Owns"
+      _id: edgeCollectionName + "/400",
+      _from: vertexCollectionName1 + "/A",
+      _to: vertexCollectionName2 + "/ONE",
     },
     {
-      _key: "402",
-      _id: ownsEdgeCollectionName + "/402",
-      _from: customerCollectionName + "/396",
-      _to: productCollectionName + "/392",
-      _rev: "_aM4ZTR6---",
-      _class: "com.arangodb.springframework.testdata.Owns"
+      _id: edgeCollectionName + "/402",
+      _from: vertexCollectionName1 + "/C",
+      _to: vertexCollectionName2 + "/TWO",
     },
     {
-      _key: "404",
-      _id: ownsEdgeCollectionName + "/404",
-      _from: customerCollectionName + "/398",
-      _to: productCollectionName + "/394",
-      _rev: "_aM4ZTS----",
-      _class: "com.arangodb.springframework.testdata.Owns"
+      _id: edgeCollectionName + "/404",
+      _from: vertexCollectionName1 + "/A",
+      _to: vertexCollectionName2 + "/THREE",
     },
     {
-      _key: "406",
-      _id: ownsEdgeCollectionName + "/406",
-      _from: customerCollectionName + "/397",
-      _to: productCollectionName + "/390",
-      _rev: "_aM4ZTSC---",
-      _class: "com.arangodb.springframework.testdata.Owns"
-    },
-    {
-      _key: "408",
-      _id: ownsEdgeCollectionName + "/408",
-      _from: customerCollectionName + "/397",
-      _to: productCollectionName + "/392",
-      _rev: "_aM4ZTSG---",
-      _class: "com.arangodb.springframework.testdata.Owns"
-    },
-    {
-      _key: "410",
-      _id: ownsEdgeCollectionName + "/410",
-      _from: customerCollectionName + "/397",
-      _to: productCollectionName + "/394",
-      _rev: "_aM4ZTSG--_",
-      _class: "com.arangodb.springframework.testdata.Owns"
+      _id: edgeCollectionName + "/406",
+      _from: vertexCollectionName1 + "/C",
+      _to: vertexCollectionName2 + "/ONE",
     }
   ]);
-  db[productCollectionName].insert([
+  db[vertexCollectionName2].insert([
     {
-      _key: "390",
-      _id: productCollectionName + "/390",
-      _rev: "_aM4ZTPy---",
+      _key: "ONE",
+      _id: vertexCollectionName2 + "/ONE",
       name: "phone",
-      _class: "com.arangodb.springframework.testdata.Product"
     },
     {
-      _key: "392",
-      _id: productCollectionName + "/392",
-      _rev: "_aM4ZTQG---",
+      _key: "TWO",
+      _id: vertexCollectionName2 + "/TWO",
       name: "car",
-      _class: "com.arangodb.springframework.testdata.Product"
     },
     {
-      _key: "394",
-      _id: productCollectionName + "/394",
-      _rev: "_aM4ZTQK---",
+      _key: "THREE",
+      _id: vertexCollectionName2 + "/THREE",
       name: "chair",
-      _class: "com.arangodb.springframework.testdata.Product"
+    }
+  ]);
+  db[edgeCollectionName2].insert([
+    {
+      _from: vertexCollectionName3 + "/ALPHA",
+      _to: vertexCollectionName2 + "/ONE",
+    },
+    {
+      _from: vertexCollectionName3 + "/GAMMA",
+      _to: vertexCollectionName2 + "/TWO",
+    },
+    {
+      _from: vertexCollectionName3 + "/ALPHA",
+      _to: vertexCollectionName2 + "/THREE",
+    },
+    {
+      _from: vertexCollectionName3 + "/BETA",
+      _to: vertexCollectionName2 + "/ONE",
+    }
+  ]);
+  db[vertexCollectionName3].insert([
+    {
+      _key: "ALPHA",
+      _id: vertexCollectionName2 + "/ALPHA"
+    },
+    {
+      _key: "BETA",
+      _id: vertexCollectionName2 + "/BETA"
+    },
+    {
+      _key: "THREE",
+      _id: vertexCollectionName2 + "/GAMMA"
+    }
+  ]);
+  db[edgeCollectionName3].insert([
+    {
+      _from: vertexCollectionName1 + "/A",
+      _to: vertexCollectionName2 + "/ONE"
     }
   ]);
 };
@@ -220,50 +182,107 @@ function withClauseTestSuite() {
     },
 
     ////////////////////////////////////////////////////////////////////////////////
-    /// @brief test that cluster does not need a with clause if a named graph exists
+    /// @brief test with clause not needed with named graph
     ////////////////////////////////////////////////////////////////////////////////
-    testWithClauseNotNeeded: function() {
-      const query = `FOR e IN ${customerCollectionName}
-                         FILTER (FOR e1 IN 1..1 ANY e._id ${ownsEdgeCollectionName}
-                                   FILTER e1.name == @0
-                                   RETURN 1)[0] == 1 AND
-                                (FOR e1 IN 1..1 ANY e._id ${ownsEdgeCollectionName}
-                                   FILTER e1.name == @1
-                                   RETURN 1)[0] == 1
-                         RETURN UNSET(e, "_rev")`;
+    testNamedGraphWithClauseNotNeeded: function() {
+      const startNode = "VertexCollection1/A";
+      const query = `FOR v,e,p IN 1..1 ANY "${startNode}" GRAPH ${graphName}
+                       RETURN LENGTH(p)`;
 
-      const bindVars = {
-        "0": "phone",
-        "1": "phone"
-      };
-
-      var actual = db._query(query, bindVars);
-      assertEqual(actual.toArray(), expectedResult);
+      var actual = db._query(query).toArray();
+      assertEqual(actual, [ 3, 3 ]);
     },
 
     ////////////////////////////////////////////////////////////////////////////////
-    /// @brief test that cluster does not need a with clause if a named graph exists
+    /// @brief test with clause not needed with edge collection if a named graph
+    //  exists
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeeded: function() {
+      const startNode = "VertexCollection1/A";
+      const query = `FOR v,e,p IN 1..1 ANY "${startNode}" ${edgeCollectionName}
+                       RETURN LENGTH(p)`;
+
+      var actual = db._query(query).toArray();
+      assertEqual(actual, [ 3, 3 ]);
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test with clause not needed with edge collection if a named graph
+    //  exists using bindVars
     ////////////////////////////////////////////////////////////////////////////////
     testWithClauseNotNeededBindVar: function() {
-      const query = `FOR e IN @@customer
-                         FILTER (FOR e1 IN 1..1 ANY e._id @@owns
-                                   FILTER e1.name == @0
-                                   RETURN 1)[0] == 1 AND
-                                (FOR e1 IN 1..1 ANY e._id @@owns
-                                   FILTER e1.name == @1
-                                   RETURN 1)[0] == 1
-                         RETURN UNSET(e, "_rev")`;
+      const query = `FOR start IN @@vertex1
+                       FOR v, e1, p IN 1..1 ANY start._id @@edge
+                         RETURN LENGTH(p)`;
 
       const bindVars = {
-        "0": "phone",
-        "1": "phone",
-        "@customer": customerCollectionName,
-        "@owns": ownsEdgeCollectionName
+        "@vertex1": vertexCollectionName1,
+        "@edge": edgeCollectionName
       };
 
-      var actual = db._query(query, bindVars);
-      assertEqual(actual.toArray(), expectedResult);
-    }
+      var actual = db._query(query, bindVars).toArray();
+      assertEqual(actual, [ 3, 3, 3, 3 ]);
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test with clause not needed with edge collection if a named graph
+    //  exists using bindVars and multiple collections
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeededTwoCollections: function() {
+      const query = `FOR start IN @@vertex1
+                       FOR v, e1, p IN 1..2 ANY start._id @@edge, @@edge2
+                         RETURN LENGTH(p)`;
+
+      const bindVars = {
+        "@vertex1": vertexCollectionName1,
+        "@edge": edgeCollectionName,
+        "@edge2": edgeCollectionName2
+      };
+
+      const actual = db._query(query, bindVars).toArray();
+      assertEqual(actual, [3,3,3,3,3,3,3,3,3,3,3,3], JSON.stringify(actual));
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test with clause not needed with edge collection if a named graph
+    //  exists using bindVars and multiple collections and direction
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeededTwoCollectionsDirection: function() {
+      const query = `FOR start IN @@vertex1
+                       FOR v, e1, p IN 1..2 ANY start._id INBOUND @@edge, @@edge2
+                         RETURN LENGTH(p)`;
+
+      const bindVars = {
+        "@vertex1": vertexCollectionName1,
+        "@edge": edgeCollectionName,
+        "@edge2": edgeCollectionName2
+      };
+
+      const actual = db._query(query, bindVars).toArray();
+      assertEqual(actual, []);
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test with clause *is* needed with edge collection if no named graph
+    //  has definiton of vertex collections.
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNeededIfNoNamedGraph: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const query = `FOR v, e1, p IN 1..2 ANY "${startNode}" @@edge
+                         RETURN LENGTH(p)`;
+
+      const bindVars = {
+        "@edge": edgeCollectionName3
+      };
+
+
+      try {
+        const actual = db._query(query, bindVars).toArray();
+        assert(false);
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code, err.errorNum, JSON.stringify(err));
+      }
+    },
   };
 }
 

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -278,7 +278,10 @@ function withClauseTestSuite() {
 
       try {
         const actual = db._query(query, bindVars).toArray();
-        assertTrue(false);
+        
+        if(require("internal").isCluster()) {
+          assertTrue(false);
+        }
       } catch (err) {
         assertEqual(internal.errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code, err.errorNum, JSON.stringify(err));
       }

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -54,8 +54,12 @@ var cleanup = function() {
 };
 
 var createBaseGraph = function() {
-  gm._create(graphName, [gm._relation(edgeCollectionName, vertexCollectionName1, vertexCollectionName2),
-                         gm._relation(edgeCollectionName2, vertexCollectionName3, vertexCollectionName2)], [], {});
+    gm._create(graphName, [gm._relation(edgeCollectionName,
+                                        [vertexCollectionName1, vertexCollectionName2, vertexCollectionName3],
+                                        [vertexCollectionName2, vertexCollectionName3]),
+                           gm._relation(edgeCollectionName2,
+                                        vertexCollectionName3,
+                                        vertexCollectionName2)], [], {});
 
   db._createEdgeCollection(edgeCollectionName3);
 
@@ -99,6 +103,16 @@ var createBaseGraph = function() {
       _id: edgeCollectionName + "/406",
       _from: vertexCollectionName1 + "/C",
       _to: vertexCollectionName2 + "/ONE",
+    },
+    {
+      _id: edgeCollectionName + "/407",
+      _from: vertexCollectionName1 + "/A",
+      _to: vertexCollectionName3 + "/ALPHA"
+    },
+    {
+      _id: edgeCollectionName + "/407",
+      _from: vertexCollectionName3 + "/ALPHA",
+      _to: vertexCollectionName3 + "/ALPHA"
     }
   ]);
   db[vertexCollectionName2].insert([
@@ -187,24 +201,64 @@ function withClauseTestSuite() {
     testNamedGraphWithClauseNotNeeded: function() {
       const startNode = "VertexCollection1/A";
       const query = `FOR v,e,p IN 1..1 ANY "${startNode}" GRAPH ${graphName}
-                       RETURN LENGTH(p)`;
+                       RETURN p.vertices[*]._id`;
 
       var actual = db._query(query).toArray();
-      assertEqual(actual, [ 3, 3 ]);
+      assertEqual(actual, [
+          [
+              "VertexCollection1/A", 
+              "VertexCollection3/ALPHA" 
+          ],
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection2/THREE" 
+          ], 
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection2/ONE" 
+          ]]);
     },
 
     ////////////////////////////////////////////////////////////////////////////////
-    /// @brief test with clause not needed with edge collection if a named graph
-    //  exists
+    /// @brief WITH clause not needed: vertexCollections option gives the only
+    ///        required vertex collection.
+    ///        If the OPTIONS are not given, the query works too, but the query
+    ///        engine automatically adds all vertex collections to the query, as
+    ///        they are part of the named graph definition including EdgeCollection
     ////////////////////////////////////////////////////////////////////////////////
     testWithClauseNotNeededOptions: function() {
-      const startNode = "VertexCollection1/A";
-      const query = `FOR v,e,p IN 1..1 ANY "${startNode}" ${edgeCollectionName}
-                       OPTIONS { vertexCollections: [ "${vertexCollectionName1}", "${vertexCollectionName2}" ] }
-                       RETURN LENGTH(p)`;
+      const startNode = "VertexCollection3/ALPHA";
+      const query = `FOR v,e,p IN 1..1 OUTBOUND "${startNode}" ${edgeCollectionName}
+                       OPTIONS { vertexCollections: "${vertexCollectionName3}" }
+                       RETURN p.vertices[*]._id`;
 
       var actual = db._query(query).toArray();
-      assertEqual(actual, [ 3, 3 ]);
+      assertEqual(actual, [
+          [ 
+              "VertexCollection3/ALPHA",
+              "VertexCollection3/ALPHA"
+          ]]); 
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief Should fail requiring a WITH clause because the usage of the
+    /// vertexCollections clause prevents lookup in the named graph.
+    ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeededOptionsRestriction: function() {
+      const startNode = "VertexCollection3/ALPHA";
+      const query = `FOR v,e,p IN 1..1 OUTBOUND "${startNode}" ${edgeCollectionName}
+                       OPTIONS { vertexCollections: "${vertexCollectionName1}" }
+                       RETURN p.vertices[*]._id`;
+
+      try {
+        const actual = db._query(query).toArray();
+        
+        if(require("internal").isCluster()) {
+          assertTrue(false);
+        }
+      } catch (err) {
+        assertEqual(internal.errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code, err.errorNum, JSON.stringify(err));
+      }
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -214,10 +268,22 @@ function withClauseTestSuite() {
     testWithClauseNotNeeded: function() {
       const startNode = "VertexCollection1/A";
       const query = `FOR v,e,p IN 1..1 ANY "${startNode}" ${edgeCollectionName}
-                       RETURN LENGTH(p)`;
+                       RETURN SORTED(p.vertices[*]._id)`;
 
       var actual = db._query(query).toArray();
-      assertEqual(actual, [ 3, 3 ]);
+      assertEqual(actual, [
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection3/ALPHA" 
+          ], 
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection2/THREE" 
+          ], 
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection2/ONE" 
+          ]]);
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -227,7 +293,7 @@ function withClauseTestSuite() {
     testWithClauseNotNeededBindVar: function() {
       const query = `FOR start IN @@vertex1
                        FOR v, e1, p IN 1..1 ANY start._id @@edge
-                         RETURN LENGTH(p)`;
+                         RETURN SORTED(p.vertices[*]._id)`;
 
       const bindVars = {
         "@vertex1": vertexCollectionName1,
@@ -235,7 +301,27 @@ function withClauseTestSuite() {
       };
 
       var actual = db._query(query, bindVars).toArray();
-      assertEqual(actual, [ 3, 3, 3, 3 ]);
+      assertEqual(actual, [
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection3/ALPHA" 
+          ], 
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection2/THREE" 
+          ], 
+          [ 
+              "VertexCollection1/A", 
+              "VertexCollection2/ONE" 
+          ], 
+          [ 
+              "VertexCollection1/C", 
+              "VertexCollection2/ONE" 
+          ], 
+          [ 
+              "VertexCollection1/C", 
+              "VertexCollection2/TWO" 
+          ]]);
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -245,7 +331,7 @@ function withClauseTestSuite() {
     testWithClauseNotNeededTwoCollections: function() {
       const query = `FOR start IN @@vertex1
                        FOR v, e1, p IN 1..2 ANY start._id @@edge, @@edge2
-                         RETURN LENGTH(p)`;
+                         RETURN SORTED(p.vertices[*]._id)`;
 
       const bindVars = {
         "@vertex1": vertexCollectionName1,
@@ -254,7 +340,24 @@ function withClauseTestSuite() {
       };
 
       const actual = db._query(query, bindVars).toArray();
-      assertEqual(actual, [3,3,3,3,3,3,3,3,3,3,3,3], JSON.stringify(actual));
+      assertEqual(actual, [
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection2/THREE", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection2/THREE" ],
+        [ "VertexCollection1/A", "VertexCollection2/THREE", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection2/ONE" ], 
+        [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection3/BETA" ], 
+        [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection1/C", "VertexCollection2/ONE" ], 
+        [ "VertexCollection1/C", "VertexCollection2/ONE" ], 
+        [ "VertexCollection1/C", "VertexCollection2/ONE", "VertexCollection3/BETA" ], 
+        [ "VertexCollection1/C", "VertexCollection2/ONE", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection1/C", "VertexCollection2/ONE" ], 
+        [ "VertexCollection1/C", "VertexCollection2/TWO" ], 
+        [ "VertexCollection1/C", "VertexCollection2/TWO", "VertexCollection3/GAMMA" ]]);
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -264,7 +367,7 @@ function withClauseTestSuite() {
     testWithClauseNotNeededTwoCollectionsDirection: function() {
       const query = `FOR start IN @@vertex1
                        FOR v, e1, p IN 1..2 ANY start._id INBOUND @@edge, @@edge2
-                         RETURN LENGTH(p)`;
+                         RETURN p.vertices[*]._id`;
 
       const bindVars = {
         "@vertex1": vertexCollectionName1,
@@ -283,7 +386,7 @@ function withClauseTestSuite() {
     testWithClauseNeededIfNoNamedGraph: function() {
       const startNode = vertexCollectionName1 + "/A";
       const query = `FOR v, e1, p IN 1..2 ANY "${startNode}" @@edge
-                         RETURN LENGTH(p)`;
+                         RETURN p.vertices[*]._id`;
 
       const bindVars = {
         "@edge": edgeCollectionName3
@@ -300,6 +403,47 @@ function withClauseTestSuite() {
         assertEqual(internal.errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code, err.errorNum, JSON.stringify(err));
       }
     },
+
+    testWithClauseNotNeededShortestPath: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND SHORTEST_PATH ${startNode} TO ${endNode} ${edgeCollectionName} 
+                       RETURN p`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, []);
+    },
+
+    testWithClauseNotNeededKShortestPaths: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND K_SHORTEST_PATHS ${startNode} TO ${endNode} ${edgeCollectionName} 
+                       RETURN p`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, []);
+    },
+
+    testWithClauseNotNeededKPaths: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN 1..1 OUTBOUND K_PATHS ${startNode} TO ${endNode} ${edgeCollectionName} 
+                       RETURN p`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, []);
+    },
+
+     testWithClauseNotNeededKPaths: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND ALL_SHORTEST_PATHS ${startNode} TO ${endNode} ${edgeCollectionName} 
+                       RETURN p`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, []);
+    },
+
   };
 }
 

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -197,6 +197,20 @@ function withClauseTestSuite() {
     /// @brief test with clause not needed with edge collection if a named graph
     //  exists
     ////////////////////////////////////////////////////////////////////////////////
+    testWithClauseNotNeededOptions: function() {
+      const startNode = "VertexCollection1/A";
+      const query = `FOR v,e,p IN 1..1 ANY "${startNode}" ${edgeCollectionName}
+                       OPTIONS { vertexCollections: [ "${vertexCollectionName1}", "${vertexCollectionName2}" ] }
+                       RETURN LENGTH(p)`;
+
+      var actual = db._query(query).toArray();
+      assertEqual(actual, [ 3, 3 ]);
+    },
+
+    ////////////////////////////////////////////////////////////////////////////////
+    /// @brief test with clause not needed with edge collection if a named graph
+    //  exists
+    ////////////////////////////////////////////////////////////////////////////////
     testWithClauseNotNeeded: function() {
       const startNode = "VertexCollection1/A";
       const query = `FOR v,e,p IN 1..1 ANY "${startNode}" ${edgeCollectionName}

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -330,8 +330,8 @@ function withClauseTestSuite() {
     ////////////////////////////////////////////////////////////////////////////////
     testWithClauseNotNeededTwoCollections: function() {
       const query = `FOR start IN @@vertex1
-                       FOR v, e1, p IN 1..2 ANY start._id @@edge, @@edge2
-                         RETURN SORTED(p.vertices[*]._id)`;
+                       FOR v, e1, p IN 2..2 ANY start._id @@edge, @@edge2
+                         RETURN p.vertices[*]._id`;
 
       const bindVars = {
         "@vertex1": vertexCollectionName1,
@@ -340,24 +340,19 @@ function withClauseTestSuite() {
       };
 
       const actual = db._query(query, bindVars).toArray();
-      assertEqual(actual, [
-        [ "VertexCollection1/A", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection2/THREE", "VertexCollection3/ALPHA" ], 
+      assertEqual(actual.sort(), [
+        [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection1/C" ], 
         [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection2/THREE" ],
-        [ "VertexCollection1/A", "VertexCollection2/THREE", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection2/ONE" ], 
         [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection3/BETA" ], 
-        [ "VertexCollection1/A", "VertexCollection2/ONE", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection1/C", "VertexCollection2/ONE" ], 
-        [ "VertexCollection1/C", "VertexCollection2/ONE" ], 
-        [ "VertexCollection1/C", "VertexCollection2/ONE", "VertexCollection3/BETA" ], 
+        [ "VertexCollection1/A", "VertexCollection2/THREE", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection2/ONE" ], 
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection2/THREE" ], 
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/A", "VertexCollection3/ALPHA", "VertexCollection3/ALPHA" ], 
+        [ "VertexCollection1/C", "VertexCollection2/ONE", "VertexCollection1/A" ], 
         [ "VertexCollection1/C", "VertexCollection2/ONE", "VertexCollection3/ALPHA" ], 
-        [ "VertexCollection1/A", "VertexCollection1/C", "VertexCollection2/ONE" ], 
-        [ "VertexCollection1/C", "VertexCollection2/TWO" ], 
-        [ "VertexCollection1/C", "VertexCollection2/TWO", "VertexCollection3/GAMMA" ]]);
+        [ "VertexCollection1/C", "VertexCollection2/ONE", "VertexCollection3/BETA" ], 
+        [ "VertexCollection1/C", "VertexCollection2/TWO", "VertexCollection3/GAMMA" ]].sort());
     },
 
     ////////////////////////////////////////////////////////////////////////////////
@@ -407,43 +402,86 @@ function withClauseTestSuite() {
     testWithClauseNotNeededShortestPath: function() {
       const startNode = vertexCollectionName1 + "/A";
       const endNode = vertexCollectionName2 + "/ONE";
-      const query = `FOR p IN OUTBOUND SHORTEST_PATH ${startNode} TO ${endNode} ${edgeCollectionName} 
-                       RETURN p`;
+      const query = `FOR p IN OUTBOUND SHORTEST_PATH "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       RETURN p._id`;
 
       const actual = db._query(query).toArray();
-      assertEqual(actual, []);
+      assertEqual(actual, [ "VertexCollection1/A", "VertexCollection2/ONE" ]);
+    },
+
+    disabled_testWithClauseNotNeededShortestPathOptions: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND SHORTEST_PATH "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       OPTIONS { vertexCollections: [ "${vertexCollectionName1}" ] }
+                       RETURN p._id`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, [ "VertexCollection1/A", "VertexCollection2/ONE" ]);
     },
 
     testWithClauseNotNeededKShortestPaths: function() {
       const startNode = vertexCollectionName1 + "/A";
       const endNode = vertexCollectionName2 + "/ONE";
-      const query = `FOR p IN OUTBOUND K_SHORTEST_PATHS ${startNode} TO ${endNode} ${edgeCollectionName} 
-                       RETURN p`;
+      const query = `FOR p IN OUTBOUND K_SHORTEST_PATHS "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       RETURN p.vertices[*]._id`;
 
       const actual = db._query(query).toArray();
-      assertEqual(actual, []);
+      assertEqual(actual, [ [ "VertexCollection1/A", "VertexCollection2/ONE" ] ]);
+    },
+
+    disabled_testWithClauseNotNeededKShortestPathsOptions: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND K_SHORTEST_PATHS "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       OPTIONS { vertexCollections: [ "${vertexCollectionName1}" ] }
+                       RETURN p.vertices[*]._id`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, [ [ "VertexCollection1/A", "VertexCollection2/ONE" ] ]);
     },
 
     testWithClauseNotNeededKPaths: function() {
       const startNode = vertexCollectionName1 + "/A";
       const endNode = vertexCollectionName2 + "/ONE";
-      const query = `FOR p IN 1..1 OUTBOUND K_PATHS ${startNode} TO ${endNode} ${edgeCollectionName} 
-                       RETURN p`;
+      const query = `FOR p IN 1..1 OUTBOUND K_PATHS "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       RETURN p.vertices[*]._id`;
 
       const actual = db._query(query).toArray();
-      assertEqual(actual, []);
+      assertEqual(actual, [ [ "VertexCollection1/A", "VertexCollection2/ONE" ] ]);
     },
 
-     testWithClauseNotNeededKPaths: function() {
+    disabled_testWithClauseNotNeededKPathsOptions: function() {
       const startNode = vertexCollectionName1 + "/A";
       const endNode = vertexCollectionName2 + "/ONE";
-      const query = `FOR p IN OUTBOUND ALL_SHORTEST_PATHS ${startNode} TO ${endNode} ${edgeCollectionName} 
-                       RETURN p`;
+      const query = `FOR p IN 1..1 OUTBOUND K_PATHS "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       OPTIONS { vertexCollections: [ "${vertexCollectionName1}" ] }
+                       RETURN p.vertices[*]._id`;
 
       const actual = db._query(query).toArray();
-      assertEqual(actual, []);
+      assertEqual(actual, [ [ "VertexCollection1/A", "VertexCollection2/ONE" ] ]);
     },
 
+    testWithClauseNotNeededAllShortestPaths: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND ALL_SHORTEST_PATHS "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       RETURN p.vertices[*]._id`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, [ [ "VertexCollection1/A", "VertexCollection2/ONE" ] ]); 
+    },
+
+    disabled_testWithClauseNotNeededAllShortestPathsOptions: function() {
+      const startNode = vertexCollectionName1 + "/A";
+      const endNode = vertexCollectionName2 + "/ONE";
+      const query = `FOR p IN OUTBOUND ALL_SHORTEST_PATHS "${startNode}" TO "${endNode}" ${edgeCollectionName} 
+                       OPTIONS { vertexCollections: [ "${vertexCollectionName1}" ] }
+                       RETURN p.vertices[*]._id`;
+
+      const actual = db._query(query).toArray();
+      assertEqual(actual, [ [ "VertexCollection1/A", "VertexCollection2/ONE" ] ]); 
+    },
   };
 }
 

--- a/tests/js/client/aql/aql-graph-with-clause.js
+++ b/tests/js/client/aql/aql-graph-with-clause.js
@@ -278,7 +278,7 @@ function withClauseTestSuite() {
 
       try {
         const actual = db._query(query, bindVars).toArray();
-        assert(false);
+        assertTrue(false);
       } catch (err) {
         assertEqual(internal.errors.ERROR_QUERY_COLLECTION_LOCK_FAILED.code, err.errorNum, JSON.stringify(err));
       }


### PR DESCRIPTION
### Scope & Purpose

This PR adds the ability to deduce which vertex collections will be used by a graph query (Traversal, Shortest Path, K-Shortest Path, All Paths, K-Path) if the edge-collection syntax is used, i.e. in a query of the form

```
FOR v,e,p IN 1..2 OUTBOUND "components/A1" connections 
  RETURN p
```

AQL now looks for the edge collection `connections` in *all* named graphs, and if it finds it, it takes out the from and to collections and adds them to the querie's data sources.

When done this change will make the use of a `WITH` statement redundant.

If the user uses `OPTIONS` with `vertexCollections`, then the deduction code skips this graph operation. This is intended as a fallback in case the user wants to add fewer vertex collections than the named graph deduction would add.

The `WITH` statement works as before.

**NOTE** That #21991 should be merged before this one


- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> AQL now auto-adds vertex collections for traversals using edge collection syntax by resolving definitions from named graphs, eliminating the need for WITH when applicable.
> 
> - **AQL/AST & Query**:
>   - Add `Ast::collectGraphNodeEdgeCollections` and `Ast::addGraphNodeImplicitVertexCollections` to detect edge-collection syntax in graph ops and inject implied vertex collections.
>   - Invoke implicit vertex collection injection in `Query.cpp` after bind-parameter processing (both parse paths).
>   - Minor: adjust `addDataSource` signature; handle `NODE_TYPE_COLLECTION` in `edgeCollectionNodeGetName`.
> - **GraphManager**:
>   - Introduce `findVertexCollectionsFromEdgeCollection` to resolve from/to vertex collections for a given edge collection across named graphs.
> - **Tests**:
>   - Add `tests/js/client/aql/aql-graph-with-clause.js` validating no-WITH behavior with named graphs, multiple collections, bindVars, and direction cases; ensure WITH still required when no named graph mapping exists.
>   - Remove obsolete cluster-only tests expecting lock failures without WITH.
> - **CHANGELOG**: note new behavior for deducing vertex collections in graph queries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9643a8ccfc2d855e1c6550464b0189e717d86db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->