### PR TITLE
Fix supervised buffer gro throwing after reallocating memory so build…

### DIFF
--- a/lib/Basics/SupervisedBuffer.h
+++ b/lib/Basics/SupervisedBuffer.h
@@ -84,25 +84,62 @@ class SupervisedBuffer : public Buffer<uint8_t> {
 
  private:
   void grow(ValueLength length) override {
-    auto currentCapacity = this->capacity();
-    Buffer<uint8_t>::grow(length);
-    auto newCapacity = this->capacity();
-    if (newCapacity > currentCapacity) {
-      _usageScope.increase(newCapacity - currentCapacity);
+    auto beforeCap = this->capacity();
+    auto beforeSize = this->size();
+
+    // got the precharge values from looking into Buffer::grow()
+    constexpr double growthFactor = 1.5;
+    ValueLength newLen = beforeSize + length;
+    if (newLen < static_cast<ValueLength>(growthFactor * beforeSize)) {
+      newLen = static_cast<ValueLength>(growthFactor * beforeSize);
+    }
+
+    // how much we expect grow() will allocate
+    ValueLength prechargeAmount =
+        (newLen > beforeCap) ? (newLen - beforeCap) : 0;
+
+    if (prechargeAmount > 0) {
+      _usageScope.increase(
+          prechargeAmount);  // may throw here if exceeds memory limit
+    }
+
+    try {
+      Buffer<uint8_t>::grow(length);
+
+      auto afterCap = this->capacity();
+      // the expected amount might not be the actual amount allocated so we
+      // adjust
+      if (afterCap > beforeCap) {
+        auto actualAmount = afterCap - beforeCap;
+        if (actualAmount > prechargeAmount) {
+          _usageScope.increase(actualAmount - prechargeAmount);
+        } else if (actualAmount < prechargeAmount) {
+          _usageScope.decrease(prechargeAmount - actualAmount);
+        }
+      } else if (prechargeAmount > 0) {
+        _usageScope.decrease(prechargeAmount);
+      }
+    } catch (...) {
+      if (prechargeAmount > 0) {
+        _usageScope.decrease(prechargeAmount);  // undo precharge if it throws
+      }
+      throw;
     }
   }
+
+}
 
   void clear() noexcept override {
-    auto before = this->capacity();
-    Buffer<uint8_t>::clear();
-    auto after = this->capacity();
-    // if before > after, means that it has released usage from the heap
-    if (before > after) {
-      _usageScope.decrease(before - after);
-    }
+  auto before = this->capacity();
+  Buffer<uint8_t>::clear();
+  auto after = this->capacity();
+  // if before > after, means that it has released usage from the heap
+  if (before > after) {
+    _usageScope.decrease(before - after);
   }
+}
 
-  ResourceUsageScope _usageScope;
+ResourceUsageScope _usageScope;
 };
 
 }  // namespace arangodb::velocypack


### PR DESCRIPTION
This PR fixes the following use-after-free error:

When the builder must expand its underlying buffer by allocating more memory, it gows along the path of Builder::reserve() all the way down to Buffer::grow(). 
When the buffer is a SupervisedBuffer, Buffer::grow is called inside SupervisedBuffer::grow(). 
In the former grow() method:
`   auto currentCapacity = this->capacity();
    Buffer<uint8_t>::grow(length);
    auto newCapacity = this->capacity();
    if (newCapacity > currentCapacity) {
      _usageScope.increase(newCapacity - currentCapacity);
    }`
the following could happen: allocation succeeds because the SO doesn't acknowledge the memory limit configured for the query runtime, a new block of memory is allocated and the old block is freed. Then, if we exceed the memory limit, _usageScope.increase() is gonna throw. This will call the destructors and, depending on the caller, one of them could be ~ObjectBuilder, which accesses the Builder's pointer _start that hadn't been updated yet at the time of the throw inside grow(), it would still be pointing to the memory that was free, causing UAF. 
The fix is to precharge _usageScope with the amount expected to be incrased in grow(), but before grow() is called, so then, if _usageScope throws, no memory has been reallocated yet. Then, if grow() is successful, we adjust the memory increase or, if grow() is unsuccessful, we undo the precharge increase.

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
