### PR TITLE
Deduplicate code in AST setup 

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -361,7 +361,7 @@ LogicalDataSource::Category addDataSource(
 }
 
 std::optional<std::string> edgeCollectionNodeGetName(
-    CollectionNameResolver const& resolver, AstNode const* edgeCollection) {
+    AstNode const* edgeCollection) {
   if (edgeCollection->type == NODE_TYPE_DIRECTION) {
     TRI_ASSERT(edgeCollection->numMembers() == 2)
         << "expected 2 members in NODE_TYPE_DIRECTION, found "
@@ -1653,11 +1653,9 @@ AstNode* Ast::createNodeCollectionList(AstNode const* edgeCollections,
       << edgeCollections->getTypeString();
 
   for (size_t i = 0; i < edgeCollections->numMembers(); ++i) {
-    // TODO Direction Parsing!
     auto edgeCollection = edgeCollections->getMember(i);
 
-    auto edgeCollectionName =
-        edgeCollectionNodeGetName(resolver, edgeCollection);
+    auto edgeCollectionName = edgeCollectionNodeGetName(edgeCollection);
 
     if (edgeCollectionName.has_value()) {
       auto edgeCollectionNameRef = std::string_view{*edgeCollectionName};


### PR DESCRIPTION
### Scope & Purpose

This small PR just consolidates two identical bits of code into a common function.

Should be covered by existing tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates datasource registration in AQL AST by returning resolved names from injectDataSourceInQuery and introducing helpers to unify WITH/edge collection handling.
> 
> - **AQL AST refactor**:
>   - `injectDataSourceInQuery` now returns `(Category, resolved_name)` and takes `name` by value; resolves numeric IDs to names and consistently registers datasources.
>   - New helpers:
>     - `addDataSource` centralizes datasource registration (incl. coordinator shard real-name expansion).
>     - `edgeCollectionNodeGetName` extracts edge collection names (supports `NODE_TYPE_DIRECTION`).
>   - Updated call sites:
>     - `createNodeDataSource` and `createNodeCollection` use `resolved_name` when creating nodes/adding collections.
>     - `createNodeWithCollections` and `createNodeCollectionList` simplified to use `addDataSource`; improved validation and error messages; added assert details.
>   - Minor adjustments: consistent `std::string` conversions on registration; view handling registers using provided name; tightened assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ccca62c9cbbb2041962aacaf46e008c4856029d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->