### PR TITLE
Remove compiler warnings due to missing field initializers

### DIFF
--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
@@ -334,7 +334,8 @@ bool isIndexStreamSupported(IndexNode const& idx,
                             std::vector<size_t> groupFields,
                             std::vector<size_t> aggregationFields) {
   IndexStreamOptions streamOptions{.usedKeyFields = std::move(groupFields),
-                                   .projectedFields = aggregationFields};
+                                   .projectedFields = aggregationFields,
+                                   .constantFields = {}};
   if (auto support =
           idx.getSingleIndex()->supportsStreamInterface(streamOptions);
       support.hasSupport()) {

--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleReplaceEqualAttributeAccess.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleReplaceEqualAttributeAccess.cpp
@@ -161,7 +161,7 @@ std::optional<VarAttribKey> extractVariableAttributeAccess(
     AstNode const* node) {
   if (node->type == NODE_TYPE_REFERENCE) {
     auto* var = static_cast<Variable const*>(node->getData());
-    return VarAttribKey{.var = var};
+    return VarAttribKey{.var = var, .path = {}};
   } else if (node->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
     auto result = extractVariableAttributeAccess(node->getMember(0));
     result->path.emplace_back(node->getStringValue(), node->getStringLength());

--- a/arangod/Aql/Optimizer/Rule/OptimizerRulesIResearchView.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRulesIResearchView.cpp
@@ -325,7 +325,8 @@ bool optimizeScoreSort(IResearchViewNode& viewNode, ExecutionPlan* plan) {
         }
         auto source = viewNode.getSourceColumnInfo(sort.var->id);
         TRI_ASSERT(source.first != std::numeric_limits<ptrdiff_t>::max());
-        heapSort.push_back(HeapSortElement{.source = source.first,
+        heapSort.push_back(HeapSortElement{.postfix = {},
+                                           .source = source.first,
                                            .fieldNumber = source.second,
                                            .ascending = sort.ascending});
       } break;
@@ -353,9 +354,11 @@ bool optimizeScoreSort(IResearchViewNode& viewNode, ExecutionPlan* plan) {
             if (s == std::end(scorers)) {
               return false;
             }
-            heapSort.push_back(
-                HeapSortElement{.source = std::distance(scorers.begin(), s),
-                                .ascending = sort.ascending});
+            heapSort.push_back(HeapSortElement{
+                .postfix = {},
+                .source = std::distance(scorers.begin(), s),
+                .ascending = sort.ascending,
+            });
           } break;
           case AstNodeType::NODE_TYPE_ATTRIBUTE_ACCESS:
             if (checkAttributeAccess(astCalcNode, viewVariable, false)) {
@@ -373,7 +376,8 @@ bool optimizeScoreSort(IResearchViewNode& viewNode, ExecutionPlan* plan) {
               } catch (::arangodb::basics::Exception const&) {
                 return false;
               }
-              heapSort.push_back(HeapSortElement{.ascending = sort.ascending});
+              heapSort.push_back(
+                  HeapSortElement{.postfix = {}, .ascending = sort.ascending});
               attrs.push_back(std::move(af));
               storedMaps.insert({attrs.size() - 1, heapSort.size() - 1});
             } else {

--- a/arangod/Aql/Optimizer/Rule/OptimizerRulesJoin.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRulesJoin.cpp
@@ -1082,6 +1082,7 @@ void arangodb::aql::joinIndexNodesRule(Optimizer* opt,
 
               auto info = JoinNode::IndexInfo{
                   .collection = c->collection(),
+                  .usedShard = {},
                   .outVariable = c->outVariable(),
                   .condition = c->condition()->clone(),
                   .filter = c->hasFilter() ? c->filter()->clone(plan->getAst())


### PR DESCRIPTION
### Scope & Purpose

Really self explanatory.



*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize newly added fields in optimizer rule structs (e.g., IndexStreamOptions, HeapSortElement, JoinNode::IndexInfo, VarAttribKey) to silence missing-field warnings.
> 
> - **AQL Optimizer**:
>   - `OptimizerRuleCollectWithIndex.cpp`: Initialize `IndexStreamOptions.constantFields` to `{}` in `isIndexStreamSupported`.
>   - `OptimizerRuleReplaceEqualAttributeAccess.cpp`: Initialize `VarAttribKey.path` to `{}` for `NODE_TYPE_REFERENCE` in `extractVariableAttributeAccess`.
>   - `OptimizerRulesIResearchView.cpp`: Initialize `HeapSortElement.postfix` to `{}` in multiple `heapSort.push_back(...)` sites.
>   - `OptimizerRulesJoin.cpp`: Initialize `JoinNode::IndexInfo.usedShard` to `{}` during construction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d35b12b3361e741c00af05fd0e2158ca79201b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->