### PR TITLE
[BTS-2203] Introduced supervised buffer to AqlValue.cpp

### DIFF
--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -854,11 +854,13 @@ AqlValue AqlValue::materialize(velocypack::Options const* options,
   auto t = type();
   switch (t) {
     case RANGE: {
-      VPackBuffer<uint8_t> buffer;
-      VPackBuilder builder{buffer};
+      auto& global = arangodb::GlobalResourceMonitor::instance();
+      arangodb::ResourceMonitor dummyMonitor(global);
+      velocypack::Builder builder(
+          std::make_shared<velocypack::SupervisedBuffer>(dummyMonitor));
       toVelocyPack(options, builder, /*allowUnindexed*/ true);
       hasCopied = true;
-      return AqlValue{std::move(buffer)};
+      return AqlValue{{std::move(*builder.buffer())}};
     }
     default:
       hasCopied = false;

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -860,7 +860,7 @@ AqlValue AqlValue::materialize(velocypack::Options const* options,
           std::make_shared<velocypack::SupervisedBuffer>(dummyMonitor));
       toVelocyPack(options, builder, /*allowUnindexed*/ true);
       hasCopied = true;
-      return AqlValue{{std::move(*builder.buffer())}};
+      return AqlValue{std::move(*builder.buffer())};
     }
     default:
       hasCopied = false;


### PR DESCRIPTION
### Scope & Purpose

This PR introduces the supervised buffer from 'lib/Basics/SupervisedBuffer.h' to AqlValue.cpp. Sometimes, in Aql runtime, VPack buffers are created to hold data temporarily, and they can lead to high memory consumption, hence must be monitored and wired to the query's ResourceMonitor or an external monitor when the first is not possible. 
There are many companions to this PR that introduce the supervised buffer to other files. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests Obs.: in a single PR that is gonna represent all files
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made Obs.: in a single PR that is gonna represent all files
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces raw VPackBuffer in `AqlValue::materialize` (RANGE case) with `velocypack::SupervisedBuffer` wired to a `ResourceMonitor`.
> 
> - **AQL Runtime**:
>   - **Memory-accounted materialization**: In `arangod/Aql/AqlValue.cpp`, `AqlValue::materialize` now builds RANGE values using `velocypack::SupervisedBuffer` with `GlobalResourceMonitor`/`ResourceMonitor`, returning `AqlValue{*builder.buffer()}` instead of a raw `VPackBuffer`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f8c5ad917fd4797f482e2cd2fd7d98d80a408c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->