### PR TITLE
Introduced the supervised buffer to Ast.cpp

### DIFF
--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1518,7 +1518,8 @@ AstNode* Ast::createNodeIntersectedArray(AstNode const* lhs,
       cache(nl, basics::VelocyPackHelper::VPackHash(),
             basics::VelocyPackHelper::VPackEqual());
 
-  VPackBuilder temp;
+  VPackBuilder temp(std::make_shared<velocypack::SupervisedBuffer>(
+      query().resourceMonitor()));
 
   for (size_t i = 0; i < nl; ++i) {
     auto member = lhs->getMemberUnchecked(i);
@@ -1563,7 +1564,8 @@ AstNode* Ast::createNodeUnionizedArray(AstNode const* lhs, AstNode const* rhs) {
       cache(nl + nr, basics::VelocyPackHelper::VPackHash(),
             basics::VelocyPackHelper::VPackEqual());
 
-  VPackBuilder temp;
+  VPackBuilder temp(std::make_shared<velocypack::SupervisedBuffer>(
+      query().resourceMonitor()));
 
   for (size_t i = 0; i < nl + nr; ++i) {
     AstNode* member;
@@ -3187,7 +3189,8 @@ AstNode const* Ast::deduplicateArray(AstNode const* node) {
     return node;
   }
 
-  VPackBuilder temp;
+  VPackBuilder temp(std::make_shared<velocypack::SupervisedBuffer>(
+      query().resourceMonitor()));
 
   if (node->isSorted()) {
     bool unique = true;


### PR DESCRIPTION
### Scope & Purpose

This PR introduces the supervised buffer from 'lib/Basics/SupervisedBuffer.h' to Ast.cpp. Sometimes, in Aql runtime, VPack buffers are created to hold data temporarily, and they can lead to high memory consumption, hence must be monitored and wired to the query's ResourceMonitor or an external monitor when the first is not possible. 
There are many companions to this PR that introduce the supervised buffer to other files. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests Obs.: in a single PR that is gonna represent all files
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made Obs.: in a single PR that is gonna represent all files
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route temporary VPackBuilder usage in AST array set/unique ops through a SupervisedBuffer tied to the query ResourceMonitor.
> 
> - **AQL AST (memory supervision)**:
>   - Replace raw `VPackBuilder temp` with `VPackBuilder` using `velocypack::SupervisedBuffer(query().resourceMonitor())` in:
>     - `Ast::createNodeIntersectedArray`
>     - `Ast::createNodeUnionizedArray`
>     - `Ast::deduplicateArray`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 663ccc099b3e13281a2e5d445a022e6ce99d6da4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->