### PR TITLE
Introduced supervised buffer to ExecutionBlock.cpp

### DIFF
--- a/arangod/Aql/ExecutionBlock.cpp
+++ b/arangod/Aql/ExecutionBlock.cpp
@@ -41,6 +41,7 @@
 #include <absl/strings/str_cat.h>
 #include <velocypack/Builder.h>
 #include <velocypack/Dumper.h>
+#include <velocypack/SupervisedBuffer.h>
 
 #include <string_view>
 
@@ -188,7 +189,9 @@ void ExecutionBlock::traceExecuteEnd(
                    return "nullptr";
                  } else {
                    auto const* opts = &_engine->getQuery().vpackOptions();
-                   VPackBuilder builder;
+                   VPackBuilder builder(
+                       std::make_shared<velocypack::SupervisedBuffer>(
+                           _engine->getQuery().resourceMonitor()));
                    block->toSimpleVPack(opts, builder);
                    return VPackDumper::toString(builder.slice(), opts);
                  }


### PR DESCRIPTION
### Scope & Purpose

This PR introduces the supervised buffer from 'lib/Basics/SupervisedBuffer.h' to ExecutionBlock.cpp. Sometimes, in Aql runtime, VPack buffers are created to hold data temporarily, and they can lead to high memory consumption, hence must be monitored and wired to the query's ResourceMonitor or an external monitor when the first is not possible. 
There are many companions to this PR that introduce the supervised buffer to other files. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests Obs.: in a single PR that is gonna represent all files
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made Obs.: in a single PR that is gonna represent all files
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces raw VPackBuffer in `AqlValue::materialize` (RANGE case) with `velocypack::SupervisedBuffer` wired to a `ResourceMonitor`.
> 
> - **AQL Runtime**:
>   - **Memory-accounted materialization**: In `arangod/Aql/AqlValue.cpp`, `AqlValue::materialize` now builds RANGE values using `velocypack::SupervisedBuffer` with `GlobalResourceMonitor`/`ResourceMonitor`, returning `AqlValue{*builder.buffer()}` instead of a raw `VPackBuffer`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45f8c5ad917fd4797f482e2cd2fd7d98d80a408c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->