### PR TITLE
Introduced supervised buffer to AqlItemBlock.cpp

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -30,6 +30,7 @@
 #include "Aql/SharedAqlItemBlockPtr.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Containers/FlatHashMap.h"
 #include "Containers/HashSet.h"
@@ -710,8 +711,8 @@ void AqlItemBlock::toVelocyPack(size_t from, size_t to,
 
   // use an on-stack buffer for building the result. this avoids creating
   // a buffer object on the heap using a shared_ptr
-  VPackBufferUInt8 buffer;
-  VPackBuilder raw(buffer, &options);
+  arangodb::velocypack::SupervisedBuffer sb(_manager.resourceMonitor());
+  VPackBuilder raw(sb, &options);
   raw.openArray();
   // Two nulls in the beginning such that indices start with 2
   raw.add(VPackValue(VPackValueType::Null));

--- a/tests/Aql/AqlItemBlockInputRangeTest.cpp
+++ b/tests/Aql/AqlItemBlockInputRangeTest.cpp
@@ -25,15 +25,10 @@
 #include "gtest/gtest.h"
 
 #include "Aql/AqlItemBlockManager.h"
-#include "Aql/InputAqlItemRow.h"
 #include "Aql/ShadowAqlItemRow.h"
 #include "AqlItemBlockHelper.h"
 #include "Basics/GlobalResourceMonitor.h"
 #include "Basics/ResourceUsage.h"
-#include "Basics/VelocyPackHelper.h"
-
-#include <velocypack/Builder.h>
-#include <velocypack/Slice.h>
 
 using namespace arangodb;
 using namespace arangodb::aql;


### PR DESCRIPTION
### Scope & Purpose

This PR introduces the supervised buffer from 'lib/Basics/SupervisedBuffer.h' to AqlItemBlock.cpp. Sometimes, in Aql runtime, VPack buffers are created to hold data temporarily, and they can lead to high memory consumption, hence must be monitored and wired to the query's ResourceMonitor or an external monitor when the first is not possible. 
There are many companions to this PR that introduce the supervised buffer to other files. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests Obs.: in a single PR that is gonna represent all files
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made Obs.: in a single PR that is gonna represent all files
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ad-hoc `VPackBuilder` instances with `SupervisedBuffer`-backed builders tied to `GlobalResourceMonitor` across `AstNode.cpp`.
> 
> - **AQL/AstNode memory supervision**:
>   - Replace local `VPackBuilder` constructions with supervised builders using `SupervisedBuffer` + `ResourceMonitor(GlobalResourceMonitor::instance())` in:
>     - `compareAstNodes(...): Object` comparison path
>     - Maintainer-mode `toStream` (debug dump)
>     - `computeValue(VPackBuilder*):` fallback builder
>     - `toString(AstNode const*)`
>     - `toVelocyPackValue(...):` `NODE_TYPE_ATTRIBUTE_ACCESS` temp builder
>   - Add includes: `Basics/ResourceUsage.h`, `Basics/SupervisedBuffer.h`, `Basics/GlobalResourceMonitor.h`, and `<memory>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a3916b15e41c4f65a3666606c5c32ffe3c171ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->