### PR TITLE
[BTS-2203] Change buffer of SubqueryEndExecutor to SupervisedBuffer

### DIFF
--- a/arangod/Aql/Executor/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.cpp
@@ -138,11 +138,6 @@ auto SubqueryEndExecutor::consumeShadowRow(ShadowAqlItemRow shadowRow,
 }
 
 void SubqueryEndExecutor::Accumulator::reset() noexcept {
-  // if (_memoryUsage > 0) {
-  //   _resourceMonitor.decreaseMemoryUsage(_memoryUsage);
-  //   _memoryUsage = 0;
-  // }
-
   // Buffer present. we can get away with reusing and clearing
   // the existing Builder, which points to the Buffer
   _builder.clear();
@@ -151,31 +146,10 @@ void SubqueryEndExecutor::Accumulator::reset() noexcept {
 }
 
 void SubqueryEndExecutor::Accumulator::addValue(AqlValue const& value) {
-  //size_t previousLength = _builder.bufferRef().byteSize();
-
   TRI_ASSERT(_builder.isOpenArray());
   value.toVelocyPack(_options, _builder,
                      /*allowUnindexed*/ false);
   ++_numValues;
-
-  //size_t currentLength = _builder.bufferRef().byteSize();
-  //TRI_ASSERT(currentLength >= previousLength);
-
-  // per-item overhead (this is because we have to account for the index
-  // table entries as well, which are only added later in VelocyPack when
-  // the array is closed). this is approximately only, but that should be
-  // ok here.
-  // size_t entryOverhead;
-  // if (_memoryUsage > 65535) {
-  //   entryOverhead = 4;
-  // } else if (_memoryUsage > 255) {
-  //   entryOverhead = 2;
-  // } else {
-  //   entryOverhead = 1;
-  // }
-  // size_t diff = currentLength - previousLength + entryOverhead;
-  // _resourceMonitor.increaseMemoryUsage(diff);
-  // _memoryUsage += diff;
 }
 
 SubqueryEndExecutor::Accumulator::Accumulator(
@@ -185,10 +159,6 @@ SubqueryEndExecutor::Accumulator::Accumulator(
       _buffer(resourceMonitor),
       _builder(_buffer) {
   reset();
-}
-
-SubqueryEndExecutor::Accumulator::~Accumulator() {
-  //_resourceMonitor.decreaseMemoryUsage(_memoryUsage);
 }
 
 AqlValueGuard SubqueryEndExecutor::Accumulator::stealValue(AqlValue& result) {

--- a/arangod/Aql/Executor/SubqueryEndExecutor.cpp
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.cpp
@@ -138,10 +138,10 @@ auto SubqueryEndExecutor::consumeShadowRow(ShadowAqlItemRow shadowRow,
 }
 
 void SubqueryEndExecutor::Accumulator::reset() noexcept {
-  if (_memoryUsage > 0) {
-    _resourceMonitor.decreaseMemoryUsage(_memoryUsage);
-    _memoryUsage = 0;
-  }
+  // if (_memoryUsage > 0) {
+  //   _resourceMonitor.decreaseMemoryUsage(_memoryUsage);
+  //   _memoryUsage = 0;
+  // }
 
   // Buffer present. we can get away with reusing and clearing
   // the existing Builder, which points to the Buffer
@@ -151,41 +151,44 @@ void SubqueryEndExecutor::Accumulator::reset() noexcept {
 }
 
 void SubqueryEndExecutor::Accumulator::addValue(AqlValue const& value) {
-  size_t previousLength = _builder.bufferRef().byteSize();
+  //size_t previousLength = _builder.bufferRef().byteSize();
 
   TRI_ASSERT(_builder.isOpenArray());
   value.toVelocyPack(_options, _builder,
                      /*allowUnindexed*/ false);
   ++_numValues;
 
-  size_t currentLength = _builder.bufferRef().byteSize();
-  TRI_ASSERT(currentLength >= previousLength);
+  //size_t currentLength = _builder.bufferRef().byteSize();
+  //TRI_ASSERT(currentLength >= previousLength);
 
   // per-item overhead (this is because we have to account for the index
   // table entries as well, which are only added later in VelocyPack when
   // the array is closed). this is approximately only, but that should be
   // ok here.
-  size_t entryOverhead;
-  if (_memoryUsage > 65535) {
-    entryOverhead = 4;
-  } else if (_memoryUsage > 255) {
-    entryOverhead = 2;
-  } else {
-    entryOverhead = 1;
-  }
-  size_t diff = currentLength - previousLength + entryOverhead;
-  _resourceMonitor.increaseMemoryUsage(diff);
-  _memoryUsage += diff;
+  // size_t entryOverhead;
+  // if (_memoryUsage > 65535) {
+  //   entryOverhead = 4;
+  // } else if (_memoryUsage > 255) {
+  //   entryOverhead = 2;
+  // } else {
+  //   entryOverhead = 1;
+  // }
+  // size_t diff = currentLength - previousLength + entryOverhead;
+  // _resourceMonitor.increaseMemoryUsage(diff);
+  // _memoryUsage += diff;
 }
 
 SubqueryEndExecutor::Accumulator::Accumulator(
     arangodb::ResourceMonitor& resourceMonitor, VPackOptions const* options)
-    : _resourceMonitor(resourceMonitor), _options(options), _builder(_buffer) {
+    : _resourceMonitor(resourceMonitor),
+      _options(options),
+      _buffer(resourceMonitor),
+      _builder(_buffer) {
   reset();
 }
 
 SubqueryEndExecutor::Accumulator::~Accumulator() {
-  _resourceMonitor.decreaseMemoryUsage(_memoryUsage);
+  //_resourceMonitor.decreaseMemoryUsage(_memoryUsage);
 }
 
 AqlValueGuard SubqueryEndExecutor::Accumulator::stealValue(AqlValue& result) {

--- a/arangod/Aql/Executor/SubqueryEndExecutor.h
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.h
@@ -30,6 +30,7 @@
 #include "Aql/RegisterInfos.h"
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/Stats.h"
+#include "Basics/SupervisedBuffer.h"
 
 #include <velocypack/Builder.h>
 
@@ -136,7 +137,7 @@ class SubqueryEndExecutor {
    private:
     arangodb::ResourceMonitor& _resourceMonitor;
     velocypack::Options const* _options;
-    arangodb::velocypack::Buffer<uint8_t> _buffer;
+    arangodb::velocypack::SupervisedBuffer _buffer;
     velocypack::Builder _builder;
     size_t _memoryUsage{0};
     size_t _numValues{0};

--- a/arangod/Aql/Executor/SubqueryEndExecutor.h
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.h
@@ -124,7 +124,7 @@ class SubqueryEndExecutor {
    public:
     explicit Accumulator(arangodb::ResourceMonitor& resourceMonitor,
                          velocypack::Options const* options);
-    ~Accumulator() {}
+    ~Accumulator() = default;
 
     void reset() noexcept;
 

--- a/arangod/Aql/Executor/SubqueryEndExecutor.h
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.h
@@ -124,7 +124,7 @@ class SubqueryEndExecutor {
    public:
     explicit Accumulator(arangodb::ResourceMonitor& resourceMonitor,
                          velocypack::Options const* options);
-    ~Accumulator() {};
+    ~Accumulator() {}
 
     void reset() noexcept;
 

--- a/arangod/Aql/Executor/SubqueryEndExecutor.h
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.h
@@ -139,7 +139,6 @@ class SubqueryEndExecutor {
     velocypack::Options const* _options;
     arangodb::velocypack::SupervisedBuffer _buffer;
     velocypack::Builder _builder;
-    size_t _memoryUsage{0};
     size_t _numValues{0};
   };
 

--- a/arangod/Aql/Executor/SubqueryEndExecutor.h
+++ b/arangod/Aql/Executor/SubqueryEndExecutor.h
@@ -124,7 +124,7 @@ class SubqueryEndExecutor {
    public:
     explicit Accumulator(arangodb::ResourceMonitor& resourceMonitor,
                          velocypack::Options const* options);
-    ~Accumulator();
+    ~Accumulator() {};
 
     void reset() noexcept;
 


### PR DESCRIPTION
### Scope & Purpose

- `SubqueryEndExecutor`'s `Accumulator` uses Buffer.
- Change the Buffer to SupervisedBuffer.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace Accumulator's Buffer with SupervisedBuffer in SubqueryEndExecutor and eliminate manual memory accounting.
> 
> - **AQL Executor**:
>   - **Buffer management**: Switch `Accumulator` buffer from `velocypack::Buffer<uint8_t>` to `velocypack::SupervisedBuffer` and include `Basics/SupervisedBuffer`.
>   - **Construction**: Initialize `_buffer` with `ResourceMonitor` and pass to `velocypack::Builder`.
>   - **Memory accounting**: Remove manual `_memoryUsage` increase/decrease logic in `reset()`, `addValue()`, and destructor; destructor simplified.
>   - **Behavior**: Retains accumulation/steal logic; only ownership/memory management changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ca022407413d281de945dcdb987a7016fd2e834. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->