### PR TITLE
[BTS-2203] Add SupervisedBuffer to SingleRemoteModificationExecutor

### DIFF
--- a/arangod/Aql/Executor/ModificationExecutorInfos.cpp
+++ b/arangod/Aql/Executor/ModificationExecutorInfos.cpp
@@ -59,7 +59,8 @@ ModificationExecutorInfos::ModificationExecutorInfos(
       _input3RegisterId(input3RegisterId),
       _outputNewRegisterId(outputNewRegisterId),
       _outputOldRegisterId(outputOldRegisterId),
-      _outputRegisterId(outputRegisterId) {
+      _outputRegisterId(outputRegisterId),
+      _resourceMonitor(query.resourceMonitor()) {
   // If we're running on a DBServer in a cluster some modification operations
   // legitimately fail due to the affected document not being available (which
   // is reflected in _ignoreDocumentNotFound). This makes sure that results are

--- a/arangod/Aql/Executor/ModificationExecutorInfos.h
+++ b/arangod/Aql/Executor/ModificationExecutorInfos.h
@@ -31,7 +31,11 @@
 
 #include <velocypack/Slice.h>
 
-namespace arangodb::aql {
+namespace arangodb {
+struct ResourceMonitor;
+
+namespace aql {
+
 struct Collection;
 class ExecutionEngine;
 class QueryContext;
@@ -54,6 +58,7 @@ struct ModificationExecutorInfos {
   ~ModificationExecutorInfos() = default;
 
   ExecutionEngine* engine() const { return _engine; }
+  ResourceMonitor& resourceMonitor() const { return _resourceMonitor; }
 
   /// @brief the variable produced by Return
   arangodb::aql::ExecutionEngine* _engine;
@@ -79,6 +84,9 @@ struct ModificationExecutorInfos {
   RegisterId _outputNewRegisterId;
   RegisterId _outputOldRegisterId;
   RegisterId _outputRegisterId;  // single remote
+
+  ResourceMonitor& _resourceMonitor;
 };
 
-}  // namespace arangodb::aql
+}  // namespace aql
+}  // namespace arangodb

--- a/arangod/Aql/Executor/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/Executor/SingleRemoteModificationExecutor.cpp
@@ -166,9 +166,7 @@ auto SingleRemoteModificationExecutor<
     inSlice = inBuilder.slice();
   }
 
-  velocypack::SupervisedBuffer sbForMergedBuilder(_info.resourceMonitor());
-  auto mergedBuilder = std::make_unique<VPackBuilder>(sbForMergedBuilder);
-  // std::unique_ptr<VPackBuilder> mergedBuilder = nullptr;
+  std::unique_ptr<VPackBuilder> mergedBuilder = nullptr;
   if (!_info._key.empty()) {
     mergedBuilder =
         merge(inSlice, _info._key, RevisionId::none(), _info.resourceMonitor());

--- a/arangod/Aql/Executor/SingleRemoteModificationExecutor.cpp
+++ b/arangod/Aql/Executor/SingleRemoteModificationExecutor.cpp
@@ -31,6 +31,7 @@
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/QueryContext.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Cluster/ServerState.h"
 #include "VocBase/LogicalCollection.h"
 
@@ -42,8 +43,10 @@ namespace arangodb::aql {
 
 namespace {
 std::unique_ptr<VPackBuilder> merge(VPackSlice document, std::string const& key,
-                                    RevisionId revision) {
-  auto builder = std::make_unique<VPackBuilder>();
+                                    RevisionId revision,
+                                    ResourceMonitor& resourceMonitor) {
+  auto sb = std::make_shared<velocypack::SupervisedBuffer>(resourceMonitor);
+  auto builder = std::make_unique<VPackBuilder>(sb);
   {
     VPackObjectBuilder guard(builder.get());
     TRI_SanitizeObject(document, *builder);
@@ -154,7 +157,8 @@ auto SingleRemoteModificationExecutor<
                                    "missing document reference");
   }
 
-  VPackBuilder inBuilder;
+  velocypack::SupervisedBuffer sbForInBuilder(_info.resourceMonitor());
+  VPackBuilder inBuilder(sbForInBuilder);
   VPackSlice inSlice = VPackSlice::emptyObjectSlice();
   if (_info._input1RegisterId.isValid()) {  // IF NOT REMOVE OR SELECT
     AqlValue const& inDocument = input.getValue(_info._input1RegisterId);
@@ -162,9 +166,12 @@ auto SingleRemoteModificationExecutor<
     inSlice = inBuilder.slice();
   }
 
-  std::unique_ptr<VPackBuilder> mergedBuilder = nullptr;
+  velocypack::SupervisedBuffer sbForMergedBuilder(_info.resourceMonitor());
+  auto mergedBuilder = std::make_unique<VPackBuilder>(sbForMergedBuilder);
+  // std::unique_ptr<VPackBuilder> mergedBuilder = nullptr;
   if (!_info._key.empty()) {
-    mergedBuilder = merge(inSlice, _info._key, RevisionId::none());
+    mergedBuilder =
+        merge(inSlice, _info._key, RevisionId::none(), _info.resourceMonitor());
     inSlice = mergedBuilder->slice();
   }
 


### PR DESCRIPTION
### Scope & Purpose

- Added ResourceMonitor& to `ModificationExecutorInfos`. SingleRemoteModificationInfos and MultipleRemoteModificationInfos inherit from this.
- This PR is only involved with SingleRemoteModificationExecutor, which uses SingleRemoteModificationInfos. Added ResourceMonitor to its parent class because MultipleRemoteModificationExecutor might need ResourceMonitor in the future.
- Changed the signature of `merge` method in SingleRemoteModificationExecutor.cpp.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
