### PR TITLE
[BTS-2203] Add SupervisedBuffer to MaterializeExecutor

### DIFF
--- a/arangod/Aql/Executor/MaterializeExecutor.cpp
+++ b/arangod/Aql/Executor/MaterializeExecutor.cpp
@@ -28,6 +28,7 @@
 #include "Aql/QueryContext.h"
 #include "Aql/Stats.h"
 #include "Aql/Variable.h"
+#include "Basics/SupervisedBuffer.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "RocksDBEngine/RocksDBTransactionMethods.h"
 #include "RocksDBEngine/RocksDBColumnFamilyManager.h"
@@ -45,7 +46,9 @@ MaterializeExecutorBase::MaterializeExecutorBase(Infos& infos)
 
 MaterializeRocksDBExecutor::MaterializeRocksDBExecutor(Fetcher&, Infos& infos)
     : MaterializeExecutorBase(infos),
-      _collection(infos.collection()->getCollection()->getPhysical()) {
+      _collection(infos.collection()->getCollection()->getPhysical()),
+      _projectionsBuilder(std::make_shared<velocypack::SupervisedBuffer>(
+          infos.query().resourceMonitor())) {
   TRI_ASSERT(_collection != nullptr);
 }
 


### PR DESCRIPTION
### Scope & Purpose

- MaterializeExecutor have one builder object `_projectionsBuilder`. Refactored it to be supervised.
- This class also has `_buffer`. This is already monitored by a custom buffer implementation.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
