### PR TITLE
[BTS-2203] Add SupervisedBuffer to EnumeratePathsExecutor

### DIFF
--- a/arangod/Aql/Executor/EnumeratePathsExecutor.cpp
+++ b/arangod/Aql/Executor/EnumeratePathsExecutor.cpp
@@ -27,7 +27,6 @@
 #include "Aql/OutputAqlItemRow.h"
 #include "Aql/Query.h"
 #include "Aql/SingleRowFetcher.h"
-#include "Basics/SupervisedBuffer.h"
 #include "Graph/Providers/ClusterProvider.h"
 #include "Graph/Providers/SingleServerProvider.h"
 #include "Graph/Queues/FifoQueue.h"
@@ -143,10 +142,10 @@ EnumeratePathsExecutor<FinderType>::EnumeratePathsExecutor(Fetcher& fetcher,
       _inputRow{CreateInvalidInputRowHint{}},
       _rowState(ExecutionState::HASMORE),
       _finder{infos.finder()},
-      _sourceBuilder(std::make_shared<velocypack::SupervisedBuffer>(
-          infos.query().resourceMonitor())),
-      _targetBuilder(std::make_shared<velocypack::SupervisedBuffer>(
-          infos.query().resourceMonitor())) {
+      _sourceBuilderSB(infos.query().resourceMonitor()),
+      _targetBuilderSB(infos.query().resourceMonitor()),
+      _sourceBuilder(_sourceBuilderSB),
+      _targetBuilder(_targetBuilderSB) {
   if (!_infos.useRegisterForSourceInput()) {
     _sourceBuilder.add(VPackValue(_infos.getSourceInputValue()));
   }

--- a/arangod/Aql/Executor/EnumeratePathsExecutor.cpp
+++ b/arangod/Aql/Executor/EnumeratePathsExecutor.cpp
@@ -27,6 +27,7 @@
 #include "Aql/OutputAqlItemRow.h"
 #include "Aql/Query.h"
 #include "Aql/SingleRowFetcher.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Graph/Providers/ClusterProvider.h"
 #include "Graph/Providers/SingleServerProvider.h"
 #include "Graph/Queues/FifoQueue.h"
@@ -142,8 +143,10 @@ EnumeratePathsExecutor<FinderType>::EnumeratePathsExecutor(Fetcher& fetcher,
       _inputRow{CreateInvalidInputRowHint{}},
       _rowState(ExecutionState::HASMORE),
       _finder{infos.finder()},
-      _sourceBuilder{},
-      _targetBuilder{} {
+      _sourceBuilder(std::make_shared<velocypack::SupervisedBuffer>(
+          infos.query().resourceMonitor())),
+      _targetBuilder(std::make_shared<velocypack::SupervisedBuffer>(
+          infos.query().resourceMonitor())) {
   if (!_infos.useRegisterForSourceInput()) {
     _sourceBuilder.add(VPackValue(_infos.getSourceInputValue()));
   }

--- a/arangod/Aql/Executor/EnumeratePathsExecutor.h
+++ b/arangod/Aql/Executor/EnumeratePathsExecutor.h
@@ -29,6 +29,7 @@
 #include "Aql/ExecutionState.h"
 #include "Aql/InputAqlItemRow.h"
 #include "Aql/RegisterInfos.h"
+#include "Basics/SupervisedBuffer.h"
 #include "Transaction/Methods.h"
 
 #include <velocypack/Builder.h>
@@ -182,6 +183,9 @@ class EnumeratePathsExecutor {
   ExecutionState _rowState;
   /// @brief the shortest path finder.
   FinderType& _finder;
+
+  arangodb::velocypack::SupervisedBuffer _sourceBuilderSB;
+  arangodb::velocypack::SupervisedBuffer _targetBuilderSB;
 
   /// @brief temporary memory mangement for source id
   arangodb::velocypack::Builder _sourceBuilder;


### PR DESCRIPTION
### Scope & Purpose

- EnumeratePathsExecutor uses builder object in `_sourceBuilder` and `_targetBuilder`.
- Added SupervisedBuffer to them.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
