### PR TITLE
Introduced supervised buffer to QuerySnippet

### DIFF
--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -23,6 +23,7 @@
 
 #include "QuerySnippet.h"
 
+#include "Aql/Ast.h"
 #include "Aql/ExecutionNode/CollectionAccessingNode.h"
 #include "Aql/ExecutionNode/DistributeConsumerNode.h"
 #include "Aql/ExecutionNode/DistributeNode.h"
@@ -34,6 +35,7 @@
 #include "Aql/ExecutionNode/RemoteNode.h"
 #include "Aql/ExecutionNode/ScatterNode.h"
 #include "Aql/ExecutionPlan.h"
+#include "Aql/QueryContext.h"
 #include "Aql/ShardLocking.h"
 #include "Aql/WalkerWorker.h"
 #include "Basics/Exceptions.h"
@@ -41,6 +43,8 @@
 #include "Cluster/ServerState.h"
 #include "Logger/LogLevel.h"
 #include "Logger/LogMacros.h"
+
+#include "Basics/SupervisedBuffer.h"
 
 #ifdef USE_ENTERPRISE
 #include "Enterprise/Aql/LocalGraphNode.h"
@@ -280,7 +284,9 @@ void CloneWorker::processAfter(ExecutionNode* node) {
 
   auto deps = node->getDependencies();
   for (auto d : deps) {
-    VPackBuilder builder;
+    auto sb = std::make_shared<velocypack::SupervisedBuffer>(
+        d->plan()->getAst()->query().resourceMonitor());
+    VPackBuilder builder(sb);
     d->toVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS);
     TRI_ASSERT(_originalToClone.count(d) == 1);
     auto depClone = _originalToClone.at(d);


### PR DESCRIPTION
### Scope & Purpose

This PR introduces the supervised buffer from 'lib/Basics/SupervisedBuffer.h' to QuerySnippet.cpp. Sometimes, in Aql runtime, VPack buffers are created to hold data temporarily, and they can lead to high memory consumption, hence must be monitored and wired to the query's ResourceMonitor or an external monitor when the first is not possible. 
There are many companions to this PR that introduce the supervised buffer to other files. 

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests Obs.: in a single PR that is gonna represent all files
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made Obs.: in a single PR that is gonna represent all files
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
