### PR TITLE
[BTS-2231] Fix divide-by-zero crash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 devel
 -----
 
+* Fix BTS-2231: Fix a divide-by-zero crash in case a smart edge collection is used in a
+  collect query with a custom index.
+
 * Add API for deployment ID: /_admin/deployment/id .
 
 * Add vertex collections for graph queries using edge collection syntax

--- a/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizerRuleCollectWithIndex.cpp
@@ -39,6 +39,10 @@
 #include "Logger/LogMacros.h"
 #include "VocBase/LogicalCollection.h"
 
+#if USE_ENTERPRISE
+#include "Enterprise/VocBase/VirtualClusterSmartEdgeCollection.h"
+#endif
+
 using namespace arangodb;
 using namespace arangodb::aql;
 using namespace arangodb::containers;
@@ -182,22 +186,36 @@ bool selectivityIsLowEnough(IndexNode const& in) {
     // TODO compare the total costs of executing the optimized vs. the
     // non-optimized execution node, which involves getting the selectivity
     // estimate of each shard separately
-
-    if (index->collection().numberOfShards() == 0 ||
-        numberOfItems == index->collection().numberOfShards()) {
-      // index->collection().numberOfShards() == 0
+    auto numberOfShards = index->collection().numberOfShards();
+    if (numberOfShards == 0) {
+#if USE_ENTERPRISE
       // In case of smart edge collections we do have 0 shards,
       // this would lead to a SIGFPE(FPE_INTDIV) and crash.
+      // So we get the number of shards of the underlying collections
+      // e.g. _local
+      try {
+        auto& virtualEdgeCol = dynamic_cast<VirtualClusterSmartEdgeCollection&>(
+            index->collection());
+        numberOfShards = virtualEdgeCol.numberOfUnderlyingShards();
+      } catch (std::bad_cast&) {
+      }
+#endif  // USE_ENTERPRISE
+      if (numberOfShards == 0) {
+        LOG_RULE << "IndexNode " << in.id()
+                 << " detected a node with zero shards,"
+                 << " which is not a virtual smart edge collection";
+        return false;
+      }
+    }
 
-      // numberOfItems == index->collection().numberOfShards() means:
+    if (numberOfItems == numberOfShards) {
       // log(1) is 0 so we are dividing by zero here
       // IEEE-754 defines division-by-zero to lead to NaN, +Inf or -Inf
       // 1.0 / 0.0 should by definition lead to +Inf, so we skip the calculation
       // and return directly.
       return true;
     }
-    requiredSelectivity =
-        1. / log(numberOfItems / index->collection().numberOfShards());
+    requiredSelectivity = 1. / log(numberOfItems / numberOfShards);
   }
 
   if (index_selectivity > requiredSelectivity) {


### PR DESCRIPTION
### Scope & Purpose

Fixes a crash when a smart-edge-collection is used in a collect query with a custom index.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1550
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2231
- [ ] Design document: 
