### PR TITLE
[3.12.5][BTS-2231] Fix divide-by-zero crash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 3.12.5.4 (2025-09-22)
 ---------------------
 
+* Fix BTS-2231: Fix a divide-by-zero crash in case a smart edge collection is used in a
+  collect query with a custom index.
+
 * Fix ES-2678: In the upgrade scenario, we disable the ClusterFeature.
   We should therefore check before accessing clusterInfo() whether we are in an
   upgrade scenario. Added those checks in iresearch.


### PR DESCRIPTION
### Scope & Purpose

Fixes a crash when a smart-edge-collection is used in a collect query with a custom index.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1551
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2231
- [ ] Design document: 
