### PR TITLE
[BTS-2234] Validate start node collection in traversals

### DIFF
--- a/arangod/Graph/Cache/RefactoredTraverserCache.cpp
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.cpp
@@ -383,3 +383,26 @@ arangodb::velocypack::HashedStringRef RefactoredTraverserCache::persistString(
   guard.steal();
   return res;
 }
+
+void RefactoredTraverserCache::validateVertexIdCollection(
+    velocypack::HashedStringRef id) const {
+  if (_allowImplicitCollections) {
+    return;
+  }
+
+  auto collectionNameResult = extractCollectionName(id);
+  if (collectionNameResult.fail()) {
+    THROW_ARANGO_EXCEPTION(collectionNameResult.result());
+  }
+
+  auto&& [cn, _] = collectionNameResult.get();
+
+  auto const* q = _query;
+  if (q->collections().get(cn) == nullptr) {
+    auto message = absl::StrCat("collection not known to traversal: '", cn,
+                                "'. please add 'WITH ", cn,
+                                "' as the first line in your AQL");
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_COLLECTION_LOCK_FAILED,
+                                   message);
+  }
+}

--- a/arangod/Graph/Cache/RefactoredTraverserCache.h
+++ b/arangod/Graph/Cache/RefactoredTraverserCache.h
@@ -119,6 +119,8 @@ class RefactoredTraverserCache {
   arangodb::velocypack::HashedStringRef persistString(
       arangodb::velocypack::HashedStringRef idString);
 
+  void validateVertexIdCollection(velocypack::HashedStringRef id) const;
+
  private:
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Lookup a document from the database.

--- a/arangod/Graph/Providers/SingleServerProvider.cpp
+++ b/arangod/Graph/Providers/SingleServerProvider.cpp
@@ -95,6 +95,8 @@ auto SingleServerProvider<Step>::startVertex(VertexType vertex, size_t depth,
   LOG_TOPIC("78156", TRACE, Logger::GRAPHS)
       << "<SingleServerProvider> Start Vertex:" << vertex;
 
+  _cache.validateVertexIdCollection(vertex);
+
   // Create default initial step
   // Note: Refactor naming, Strings in our cache here are not allowed to be
   // removed.


### PR DESCRIPTION
Check that the collection that contains a given start node for a traversal is known to the query as a datasource when `--query.require-with` is set for single server.

This makes the behaviour consistent with cluster.


### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
