### PR TITLE
Aardvark: Add display label for Vector index type

### DIFF
--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/CollectionIndicesHelpers.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/CollectionIndicesHelpers.tsx
@@ -6,6 +6,7 @@ export const TYPE_TO_LABEL_MAP = {
   mdi: "MDI",
   "mdi-prefixed": "MDI (Prefixed)",
   inverted: "Inverted",
+  vector: "Vector",
   tier: "Tier",
   primary: "Primary",
   edge: "Edge",


### PR DESCRIPTION
### Scope & Purpose

Add missing entry to mapping so that the web interface shows `Vector` in the TYPE column of a collection's index overview

- [x] :hankey: Bugfix

