### PR TITLE
Fix a race when collecting list ongoing transactions.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 devel
 -----
 
+* Fix a race when collecting list ongoing transactions.
+  The GET /_api/transaction API was missing a lock which could lead to undefined
+  behavior if a transaction would update its state at the same time while we are
+  collecting its details.
+
 * Fix defaults for inverted indexes and views. Consolidations 5 times
   less frequently, with minimum of 50(1 before) segments and 24M bytes
   (2M before), maximum 200 (10 before) segments and 8G bytes (800M

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,15 +1,13 @@
 devel
 -----
 
-<<<<<<< HEAD
 * Fix a race when collecting list ongoing transactions.
   The GET /_api/transaction API was missing a lock which could lead to
   undefined behavior if a transaction would update its state at the same time
   while we are collecting its details.
-=======
+
 * Improved performance of filtered vector index queries by batching document
   fetches during index iteration.
->>>>>>> origin/devel
 
 * Fix BTS-2226: Fix INSERT with overwriteMode: "ignore" failing when run
   multiple times on smart graph edge collections in cluster mode. The issue

--- a/arangod/Transaction/Manager.cpp
+++ b/arangod/Transaction/Manager.cpp
@@ -1542,6 +1542,8 @@ void Manager::toVelocyPack(VPackBuilder& builder, std::string const& database,
           return;
         }
 
+        READ_LOCKER(guard, trx.rwlock);
+
         builder.openObject(true);
         builder.add("id", VPackValue(std::to_string(tid.id())));
         if (trx.state == nullptr) {


### PR DESCRIPTION
### Scope & Purpose

The GET /_api/transaction API was missing a lock which could lead to undefined behavior if a transaction would update its state at the same time while we are collecting its details.

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  I was thinking about adding a regression test, but it is only a small change and designing a test for this specific issue would have been very akward because we need to jump through a lot of hoops to artifically construct the relevant situation.

- [x] :book: CHANGELOG entry made
