### PR TITLE
arangoimport: Fix issues with import of separated values

### DIFF
--- a/lib/Basics/csv.cpp
+++ b/lib/Basics/csv.cpp
@@ -362,7 +362,8 @@ ErrorCode TRI_ParseCsvString(TRI_csv_parser_t* parser, char const* line,
             }
 
             // ignore spaces
-            while ((*ptr == ' ' || *ptr == '\t') && (ptr + 1) < parser->_stop) {
+            while ((*ptr == ' ' || *ptr == '\t') && *ptr != parser->_quote &&
+                   (ptr + 1) < parser->_stop) {
               ++ptr;
             }
 

--- a/lib/Basics/csv.cpp
+++ b/lib/Basics/csv.cpp
@@ -361,9 +361,9 @@ ErrorCode TRI_ParseCsvString(TRI_csv_parser_t* parser, char const* line,
               break;
             }
 
-            // ignore spaces
-            while ((*ptr == ' ' || *ptr == '\t') && *ptr != parser->_quote &&
-                   (ptr + 1) < parser->_stop) {
+            // ignore spaces (unless it's a field separator)
+            while ((*ptr == ' ' || *ptr == '\t') &&
+                   *ptr != parser->_separator && (ptr + 1) < parser->_stop) {
               ++ptr;
             }
 


### PR DESCRIPTION
### Scope & Purpose

- Don't ignore spaces/tabs if the character is used as separator (e.g. CSV with `\t` as separator)

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
