### PR TITLE
Remove unused function

### DIFF
--- a/arangod/Graph/PathManagement/PathStore.cpp
+++ b/arangod/Graph/PathManagement/PathStore.cpp
@@ -189,26 +189,6 @@ auto PathStore<Step>::visitReversePath(
   }
 }
 
-template<class Step>
-auto PathStore<Step>::modifyReversePath(
-    Step& step, std::function<bool(Step&)> const& visitor) -> bool {
-  Step* walker = &step;
-  // Guaranteed to make progress, as the schreier vector contains a loop-free
-  // tree.
-  while (true) {
-    bool cont = visitor(*walker);
-    if (!cont) {
-      // Aborted
-      return false;
-    }
-    if (walker->isFirst()) {
-      // Visited the full path
-      return true;
-    }
-    walker = &_schreier.at(walker->getPrevious());
-  }
-}
-
 /* SingleServerProvider Section */
 using SingleServerProviderStep = ::arangodb::graph::SingleServerProviderStep;
 

--- a/arangod/Graph/PathManagement/PathStore.h
+++ b/arangod/Graph/PathManagement/PathStore.h
@@ -83,9 +83,6 @@ class PathStore {
                         std::function<bool(Step const&)> const& visitor) const
       -> bool;
 
-  auto modifyReversePath(Step& step, std::function<bool(Step&)> const& visitor)
-      -> bool;
-
   template<class PathResultType>
   auto buildPath(Step const& vertex, PathResultType& path) const -> void;
 

--- a/arangod/Graph/PathManagement/PathStoreTracer.cpp
+++ b/arangod/Graph/PathManagement/PathStoreTracer.cpp
@@ -134,16 +134,6 @@ auto PathStoreTracer<PathStoreImpl>::visitReversePath(
   return _impl.visitReversePath(step, visitor);
 }
 
-template<class PathStoreImpl>
-auto PathStoreTracer<PathStoreImpl>::modifyReversePath(
-    Step& step, const std::function<bool(Step&)>& visitor) -> bool {
-  double start = TRI_microtime();
-  auto sg = arangodb::scopeGuard([&]() noexcept {
-    _stats["modifyReversePath"].addTiming(TRI_microtime() - start);
-  });
-  return _impl.modifyReversePath(step, visitor);
-}
-
 /* SingleServerProvider Section */
 using SingleServerProviderStep = ::arangodb::graph::SingleServerProviderStep;
 

--- a/arangod/Graph/PathManagement/PathStoreTracer.h
+++ b/arangod/Graph/PathManagement/PathStoreTracer.h
@@ -79,9 +79,6 @@ class PathStoreTracer {
                         std::function<bool(Step const&)> const& visitor) const
       -> bool;
 
-  auto modifyReversePath(Step& step, std::function<bool(Step&)> const& visitor)
-      -> bool;
-
  private:
   PathStoreImpl _impl;
 


### PR DESCRIPTION
### Scope & Purpose

`modifyReversePath` is unused in PathStore; remove it.