### PR TITLE
Fix snappy failures on Jenkins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -811,6 +811,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   message(STATUS "Compiler type CLANG: ${CMAKE_CXX_COMPILER}")
+  # -Wno-error=unused-command-line-argument is needed otherwise snappy configure step
+  # might fails when we use additional compiler flags like fcoverage...
   set(BASE_FLAGS "-Wall -Wextra -Wno-unused-parameter -Wno-deprecated-declarations -Wno-error=unused-command-line-argument ${BASE_FLAGS}")
   set(EXTRA_CXX_FLAGS "-Wnon-virtual-dtor")
   


### PR DESCRIPTION
### Scope & Purpose

The issue was that in Snappy's CMake, a  `--fcoverage` and some other flags were set to the compiler and they were unused, which was an error in Snappy configure process (disabling `SNAPPY_HAVE_X86_CRC32` ). And that made  snappy compile time check fails, which in turn did not apply even AVX optimizations, which made the build fail
Discovered by @mpoeter 


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Clang flag to suppress unused command-line argument errors in CMake, preventing Snappy configure failures.
> 
> - **Build/CMake**:
>   - Update `CMakeLists.txt` for Clang builds to add `-Wno-error=unused-command-line-argument` to `BASE_FLAGS` to avoid Snappy configure failures when extra flags (e.g., coverage) are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aee71fedd533075a27e59a36c63104309cf05edb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->