### PR TITLE
Change message log level

### DIFF
--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -804,31 +804,19 @@ void initGroups(std::string const& userName, gid_t groupId) noexcept {
 #endif
 
 std::optional<int64_t> readCgroupFileValue(const std::string& path) {
-  try {
-    std::string content = arangodb::basics::FileUtils::slurp(path);
+  std::string content = arangodb::basics::FileUtils::slurp(path);
 
-    // Get first line only
-    std::istringstream stream(content);
-    std::string line;
-    if (!std::getline(stream, line)) {
-      return false;
-    }
-
-    if (line == "max") {
-      return std::numeric_limits<int64_t>::max();
-    }
-
-    return std::stoll(line);
-  } catch (std::exception const& ex) {
-    LOG_TOPIC("a3c21", INFO, arangodb::Logger::FIXME)
-        << "failed to read cgroup file '" << path
-        << "' for metric collection: " << ex.what();
-    return {};
-  } catch (...) {
-    LOG_TOPIC("a3c22", INFO, arangodb::Logger::FIXME)
-        << "failed to read cgroup file '" << path
-        << " for metric collection': unknown error";
-    return {};
+  // Get first line only
+  std::istringstream stream(content);
+  std::string line;
+  if (!std::getline(stream, line)) {
+    return false;
   }
+
+  if (line == "max") {
+    return std::numeric_limits<int64_t>::max();
+  }
+
+  return std::stoll(line);
 }
 }  // namespace arangodb::basics::FileUtils

--- a/lib/Basics/NumberOfCores.cpp
+++ b/lib/Basics/NumberOfCores.cpp
@@ -70,14 +70,25 @@ std::size_t numberOfEffectiveCoresImpl() {
       break;
     }
     case cgroup::Version::V1: {
-      auto quota = arangodb::basics::FileUtils::readCgroupFileValue(
-          "/sys/fs/cgroup/cpu/cpu.cfs_quota_us");
-      auto period = arangodb::basics::FileUtils::readCgroupFileValue(
-          "/sys/fs/cgroup/cpu/cpu.cfs_period_us");
-      if (quota && period) {
-        if (*quota > 0 && *period > 0) {
-          return *quota / *period;
+      try {
+        auto quota = arangodb::basics::FileUtils::readCgroupFileValue(
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us");
+        auto period = arangodb::basics::FileUtils::readCgroupFileValue(
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us");
+        if (quota && period) {
+          if (*quota > 0 && *period > 0) {
+            return *quota / *period;
+          }
         }
+      } catch (std::exception const& ex) {
+        LOG_TOPIC("a3c21", INFO, arangodb::Logger::FIXME)
+            << "Failed to determine the number of CPU cores from cgroup v1 "
+               "cpu.cfs_quota_us/cpu.cfs_period_us files: "
+            << ex.what();
+      } catch (...) {
+        LOG_TOPIC("a3c22", INFO, arangodb::Logger::FIXME)
+            << "Failed to determine the number of CPU cores from cgroup v1 "
+               "cpu.cfs_quota_us/cpu.cfs_period_us files: unknown error";
       }
       break;
     }
@@ -95,12 +106,12 @@ std::size_t numberOfEffectiveCoresImpl() {
         }
       } catch (std::exception const& ex) {
         LOG_TOPIC("a3c23", INFO, arangodb::Logger::FIXME)
-            << "failed to determine the number of CPU cores from cgroup v2 "
+            << "Failed to determine the number of CPU cores from cgroup v2 "
                "cpu.max file: "
             << ex.what();
       } catch (...) {
         LOG_TOPIC("a3c24", INFO, arangodb::Logger::FIXME)
-            << "failed to determine the number of CPU cores from cgroup v2 "
+            << "Failed to determine the number of CPU cores from cgroup v2 "
                "cpu.max file: unknown error";
       }
       break;

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -95,23 +95,45 @@ uint64_t effectivePhysicalMemoryImpl() {
       break;
     }
     case cgroup::Version::V1: {
-      if (auto const limit = arangodb::basics::FileUtils::readCgroupFileValue(
-              "/sys/fs/cgroup/memory/memory.limit_in_bytes");
-          limit) {
-        // Check if it's not the "unlimited" value (very large number)
-        if (limit > 0 && *limit != std::numeric_limits<int64_t>::max()) {
-          return *limit;
+      try {
+        if (auto const limit = arangodb::basics::FileUtils::readCgroupFileValue(
+                "/sys/fs/cgroup/memory/memory.limit_in_bytes");
+            limit) {
+          // Check if it's not the "unlimited" value (very large number)
+          if (limit > 0 && *limit != std::numeric_limits<int64_t>::max()) {
+            return *limit;
+          }
         }
+      } catch (std::exception const& ex) {
+        LOG_TOPIC("b4d32", INFO, arangodb::Logger::FIXME)
+            << "Failed to determine physical memory from cgroup v1 "
+               "memory.limit_in_bytes file: "
+            << ex.what();
+      } catch (...) {
+        LOG_TOPIC("b4d33", INFO, arangodb::Logger::FIXME)
+            << "Failed to determine physical memory from cgroup v1 "
+               "memory.limit_in_bytes file: unknown error";
       }
       break;
     }
     case cgroup::Version::V2: {
-      if (auto const limit = arangodb::basics::FileUtils::readCgroupFileValue(
-              "/sys/fs/cgroup/memory.max");
-          limit) {
-        if (limit > 0 && *limit != std::numeric_limits<int64_t>::max()) {
-          return *limit;
+      try {
+        if (auto const limit = arangodb::basics::FileUtils::readCgroupFileValue(
+                "/sys/fs/cgroup/memory.max");
+            limit) {
+          if (limit > 0 && *limit != std::numeric_limits<int64_t>::max()) {
+            return *limit;
+          }
         }
+      } catch (std::exception const& ex) {
+        LOG_TOPIC("b4d34", INFO, arangodb::Logger::FIXME)
+            << "Failed to determine physical memory from cgroup v2 "
+               "memory.max file: "
+            << ex.what();
+      } catch (...) {
+        LOG_TOPIC("b4d35", INFO, arangodb::Logger::FIXME)
+            << "Failed to determine physical memory from cgroup v2 "
+               "memory.max file: unknown error";
       }
       break;
     }


### PR DESCRIPTION
### Scope & Purpose

Messages for printing that the CGroup file was not found could be confusing if left in the error log level, since they are not infrequent.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
