### PR TITLE
[BTS-2237] Make Mocha test timeout 80s for instrumented arangojs tests

### DIFF
--- a/js/client/modules/@arangodb/testsuites/js.js
+++ b/js/client/modules/@arangodb/testsuites/js.js
@@ -95,7 +95,7 @@ function jsDriver (options) {
         "--require",
         "source-map-support/register",
         "--timeout",
-        options.isInstrumented ? "80000" : "10000",
+        this.options.isInstrumented ? "80000" : "10000",
         "build/esm/test"
       ];
       if (this.options.testCase) {


### PR DESCRIPTION
### Scope & Purpose

Make Mocha test timeout 60s for arangojs tests for instrumented (sanitized or code coverage enabled) ArangoDB builds.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set Mocha timeout to 80s when instrumented, otherwise keep 10s, in arangojs test runner.
> 
> - **Tests**:
>   - Update `js/client/modules/@arangodb/testsuites/js.js` to set Mocha `--timeout` to `80000` when `this.options.isInstrumented` is true; otherwise use `10000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73793b18dd49cd8a938572762b24d6751cc62328. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->