### PR TITLE
Fix `arangodb_metadata_number_of_shards` metric documentation

### DIFF
--- a/Documentation/Metrics/arangodb_metadata_number_of_shards.yaml
+++ b/Documentation/Metrics/arangodb_metadata_number_of_shards.yaml
@@ -10,7 +10,7 @@ exposedBy:
   - coordinator
 description: |
   Total number of shards in the deployment. In a cluster,
-  this is the number of shards across all collections. In a single server, this equals the number of collections.
+  this is the number of shards across all collections.
 troubleshoot: |
   **Configuration:**
   - Max per collection: `--cluster.max-number-of-shards` (default: 1000)


### PR DESCRIPTION
### Scope & Purpose

Remove the part where it says that it is also exposed on a single server.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
