### PR TITLE
Remove redundant chaos_subqery job

### DIFF
--- a/tests/test-definitions.yml
+++ b/tests/test-definitions.yml
@@ -8,7 +8,7 @@
       - BackupAuthNoSysTests
       - BackupAuthSysTests
       - BackupNoAuthSysTests
-      - arangosh 
+      - arangosh
 - single_server_only_part2:
     options:
       type: single
@@ -85,7 +85,7 @@
     options:
       parallelity: 3
       size: small
-      type: single 
+      type: single
 - http_replication:
     options:
       priority: 500
@@ -132,7 +132,7 @@
       type: cluster
       buckets: 8
     args:
-      extremeVerbosity: true 
+      extremeVerbosity: true
 
 - recovery_server:
     options:
@@ -711,17 +711,6 @@
     args:
       dumpAgencyOnError: true
       skipNightly: false
-- chaos_subq:
-    options:
-      coverage: false
-      full: true
-      type: cluster
-      priority: 1000
-      size: medium+
-    arangosh_args:
-      javascript.v8-max-heap: "16384"
-    args:
-      dumpAgencyOnError: true
 - resilience_failover_failure:
     options:
       full: true


### PR DESCRIPTION
### Scope & Purpose

- [x] :hammer: Refactoring/simplification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes a redundant `chaos_subq` test job and cleans up minor whitespace in `tests/test-definitions.yml`.
> 
> - **Tests (`tests/test-definitions.yml`)**:
>   - Remove duplicate `chaos_subq` job from Full Cluster tests.
>   - Minor whitespace cleanup in several entries (e.g., `arangosh`, `type: single`, `extremeVerbosity`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4801ab788b3828e281402279677a87551fa93331. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->