### PR TITLE
Enable two tests that have been disabled so far

### DIFF
--- a/tests/Aql/RegisterPlanTest.cpp
+++ b/tests/Aql/RegisterPlanTest.cpp
@@ -769,8 +769,7 @@ TEST_F(RegisterPlanTest, variable_usage_with_subquery_using_many_registers) {
   }
 }
 
-// The current register planning isn't optimal enough to satisfy this test.
-TEST_F(RegisterPlanTest, DISABLED_multiple_spliced_subqueries) {
+TEST_F(RegisterPlanTest, multiple_spliced_subqueries) {
   auto&& [vars, ptrs] = generateVars<10>();
   auto [maria, andrew, douglas, christopher, patricia, betty, doris, christine,
         wanda, ronald] = ptrs;
@@ -839,9 +838,7 @@ TEST_F(RegisterPlanTest, DISABLED_multiple_spliced_subqueries) {
   }
 }
 
-// The current register planning cannot reuse registers that are never used.
-// Also see the comment on "brenda".
-TEST_F(RegisterPlanTest, DISABLED_reuse_unused_register) {
+TEST_F(RegisterPlanTest, reuse_unused_register) {
   auto&& [vars, ptrs] = generateVars<2>();
   auto [howard, brenda] = ptrs;
   std::vector<ExecutionNodeMock> nodes{


### PR DESCRIPTION
### Scope & Purpose

Enable two existing tests, that had been disabled since their introduction. At that point, the register planning didn't yet support the necessary optimizations, but they have been introduced since. As far as I could tell without taking more time to verify, the required changes have been done in https://github.com/arangodb/arangodb/pull/11665.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables two previously disabled tests in `tests/Aql/RegisterPlanTest.cpp`: `multiple_spliced_subqueries` and `reuse_unused_register`.
> 
> - **Tests (AQL RegisterPlan)**:
>   - Enable `multiple_spliced_subqueries` (remove `DISABLED_` prefix).
>   - Enable `reuse_unused_register` (remove `DISABLED_` prefix).
>   - Drop outdated comments preceding these tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit defa2c932e71a77dac371f553d48dbfce63c8c3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->