### PR TITLE
Do not use BuilderLeaser in PathValidator

### DIFF
--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -282,8 +282,8 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
     return ValidationResult{ValidationResult::Type::FILTER_AND_PRUNE};
   }
 
-  auto vertexBuilder = transaction::BuilderLeaser(_provider.trx());
-  auto edgeBuilder = transaction::BuilderLeaser(_provider.trx());
+  auto vertexBuilder = std::make_unique<VPackBuilder>();
+  auto edgeBuilder = std::make_unique<VPackBuilder>();
 
   // evaluate if vertex needs to be pruned
   ValidationResult res{ValidationResult::Type::TAKE};


### PR DESCRIPTION
### Scope & Purpose

For queries that use async prefetch this leads to concurrent use of the transaction context. The transaction context is not safe for use concurrently.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces `transaction::BuilderLeaser` with local `std::make_unique<VPackBuilder>` for vertex and edge builders in `arangod/Graph/PathManagement/PathValidator.cpp`.
> 
> - **Graph/PathValidator**
>   - Use local `std::make_unique<VPackBuilder>` for `vertexBuilder` and `edgeBuilder` instead of `transaction::BuilderLeaser(_provider.trx())` in `evaluateVertexCondition` of `PathValidator.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b846b5841d5d90476b8531855c2ddfd5be1a010b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->