### PR TITLE
Repair clang-format lint

### DIFF
--- a/tests/Fuerte/ConnectionFailuresTest.cpp
+++ b/tests/Fuerte/ConnectionFailuresTest.cpp
@@ -126,8 +126,8 @@ static void tryToConnectExpectFailure(f::EventLoopService& eventLoopService,
 // that cannot be resolved.
 TEST(ConnectionFailureTest, CannotResolveHttp) {
   f::EventLoopService loop;
-  tryToConnectExpectFailure(
-      loop, "http://thishostmustnotexist.arango.ai:8529", false);
+  tryToConnectExpectFailure(loop, "http://thishostmustnotexist.arango.ai:8529",
+                            false);
 }
 
 // CannotConnect tests try to make a connection to a host with a valid name


### PR DESCRIPTION
### Scope & Purpose


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes clang-format in `tests/Fuerte/ConnectionFailuresTest.cpp` by wrapping a long function call; no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 81b94c3a138e6fb050a28e3296d9703ed0b8611a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->