### PR TITLE
Fix issue with RocksDB producing tiny SST files 3.12.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+3.12.7.1 (2025-12-XX)
+---------------------
+
+* Fix RocksDB cluttering into tiny SST files.
+
+
 3.12.7 (2025-12-06)
 -------------------
 
@@ -15,7 +21,7 @@
   causing a crash when being stored in query plan cache. The issue is a missing
   invalidateCost from the splice-subqueries rule.
 
-* FE-905: Update tooltip text for maxSkewThreshold  & minDeletionRatio. 
+* FE-905: Update tooltip text for maxSkewThreshold  & minDeletionRatio.
 
 * COR-45: Added support for index hints in vector search queries.
 

--- a/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeature.cpp
@@ -321,7 +321,7 @@ RocksDBOptionFeature::RocksDBOptionFeature(Server& server)
       _enableBlobGarbageCollection(true),
       _exclusiveWrites(false),
       _minWriteBufferNumberToMergeTouched(false),
-      _partitionFilesForDocumentsCf(true),
+      _partitionFilesForDocumentsCf(false),
       _partitionFilesForPrimaryIndexCf(false),
       _partitionFilesForEdgeIndexCf(false),
       _partitionFilesForVPackIndexCf(false),


### PR DESCRIPTION
### Scope & Purpose

*Prevent RocksDB from creating tiny SST files for large number of databases, collections*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables partitioning of document SST files by default to avoid tiny SST files and adds a 3.12.7.1 changelog entry.
> 
> - **RocksDB engine**:
>   - Default `RocksDBOptionFeature::_partitionFilesForDocumentsCf` set to `false` (affects `--rocksdb.partition-files-for-documents`), preventing overly small SST files.
> - **Changelog**:
>   - Add `3.12.7.1` entry noting fix for RocksDB creating tiny SST files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5b705071ffd68627593ddd07ca5d85b4b8b5e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->