### PR TITLE
Update arangodb_server_statistics_cpu_cgroup_version.yaml

### DIFF
--- a/Documentation/Metrics/arangodb_server_statistics_cpu_cgroup_version.yaml
+++ b/Documentation/Metrics/arangodb_server_statistics_cpu_cgroup_version.yaml
@@ -1,5 +1,5 @@
 name: arangodb_server_statistics_cpu_cgroup_version
-introducedIn: "3.13.0"
+introducedIn: "3.12.7"
 help: |
   CGroup version detected on the system (0=none, 1=v1, 2=v2).
 unit: number


### PR DESCRIPTION
https://github.com/arangodb/arangodb/pull/22088 added three new metrics and one has a wrong version remark

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the `introducedIn` version of `arangodb_server_statistics_cpu_cgroup_version` from 3.13.0 to 3.12.7.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad0261c60a15b475769a1e58b1d42875694302b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->