### PR TITLE
Managed licenses are not expiring

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,14 @@ devel
 * Replace arangodb.com with arango.ai in URLs.
 
 
+3.12.7.1 (xxxx-xx-xx)
+---------------------
+
+* Licenses with "managed=true" in their grant are not "expiring". They go 
+  directly from "good" to "read-only". This is relevant for the new automatic
+  license management.
+
+
 3.12.7 (2025-12-06)
 -------------------
 


### PR DESCRIPTION
Managed licenses are not "expiring" one week before expiry.

This is the CHANGELOG PR for: https://github.com/arangodb/enterprise/pull/1568

### Scope & Purpose

- [*] :hankey: Bugfix
- [*] :pizza: New feature

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports: https://github.com/arangodb/arangodb/pull/22192 (3.12.7)


