### PR TITLE
FE-914 | Add UI support for `storedValues` in vector indexes for 3.12.7.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+3.12.7.1 (XXXX-XX-XX)
+---------------------
+
+* FE-914: Add UI support for `storedValues` in vector index.
+
+* FE-636: bump rollup from 2.79.1 to 2.79.2.
+
+
 3.12.7 (2025-12-06)
 -------------------
 

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/CollectionIndex.types.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/CollectionIndex.types.ts
@@ -8,6 +8,7 @@ type MdiPrefixed = Omit<MdiIndex, "type"> & {
 type Vector = {
   type: "vector";
   fields: string[];
+  storedValues?: string[];
   name?: string;
   params: {
     metric: "cosine" | "l2" | "innerProduct" | string;

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/collections/indices/addIndex/vectorIndex/useCreateVectorIndex.ts
@@ -5,6 +5,7 @@ import { useCreateIndex } from "../useCreateIndex";
 export const INITIAL_VALUES = {
   type: "vector",
   fields: "",
+  storedValues: "",
   name: commonFieldsMap.name.initialValue,
   params: {
     metric: "",
@@ -27,6 +28,12 @@ export const FIELDS = [
     tooltip: "The name of the attribute that contains the vector embeddings. Only a single attribute is supported."
   },
   commonFieldsMap.name,
+  {
+    label: "Extra stored values",
+    name: "storedValues",
+    type: "string",
+    tooltip: "Store additional attributes in the index that you want to filter by (comma-separated list). Avoids materializing documents twice, once for the filtering and once for the matches."
+  },
   {
     label: "Metric",
     name: "params.metric",
@@ -89,6 +96,16 @@ export const FIELDS = [
 
 export const SCHEMA = Yup.object({
   fields: Yup.string().trim().required("Field is required"),
+  storedValues: Yup.string()
+    .test(
+      "max-stored-values",
+      "The maximum number of attributes that you can use in storedValues is 32.",
+      value => {
+        if (!value) return true;
+        return value.split(",").length <= 32;
+      }
+    )
+    .optional(),
   name: commonSchema.name,
   params: Yup.object({
     metric: Yup.string().required("Metric is required"),
@@ -102,16 +119,20 @@ export const SCHEMA = Yup.object({
   inBackground: commonSchema.inBackground
 });
 
-type ValuesType = Omit<typeof INITIAL_VALUES, "fields"> & {
+type VectorIndexPayload = Omit<typeof INITIAL_VALUES, "fields" | "storedValues"> & {
   fields: string[];
+  storedValues?: string[];
 };
 
 export const useCreateVectorIndex = () => {
-  const { onCreate: onCreateIndex } = useCreateIndex<ValuesType>();
+  const { onCreate: onCreateIndex } = useCreateIndex<VectorIndexPayload>();
   const onCreate = async ({ values }: { values: typeof INITIAL_VALUES }) => {
     return onCreateIndex({
       type: values.type,
       fields: [values.fields.trim()],
+      storedValues: values.storedValues
+        ? values.storedValues.split(",").map(field => field.trim())
+        : undefined,
       name: values.name,
       params: values.params,
       parallelism: values.parallelism,


### PR DESCRIPTION
### Scope & Purpose

Add `storedValues` (vector index) to UI: backport of https://github.com/arangodb/arangodb/pull/22178

- [X] :pizza: New feature

#### Related Information

- [X] GitHub Core PR: https://github.com/arangodb/arangodb/pull/21985

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds UI support to specify and validate `storedValues` for vector indexes, mapping a comma-separated input to the API payload.
> 
> - **Frontend/UI (Vector Index)**:
>   - **Types**: Extend `Vector` in `CollectionIndex.types.ts` with optional `storedValues: string[]`.
>   - **Form** (`useCreateVectorIndex.ts`):
>     - Add `storedValues` field (comma-separated string) to `INITIAL_VALUES` and `FIELDS` with tooltip.
>     - Validation: limit `storedValues` to max 32 attributes.
>     - Submission: map `storedValues` string to `string[]` in payload; add `VectorIndexPayload` type and update `useCreateIndex` generic.
> - **Changelog**: Note UI support for `storedValues` in vector index; mention rollup bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a16fafed4bfe1fcc8077992dbc7201e3addfc71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->