### PR TITLE
enable vector index since later java driver versions add tests for it

### DIFF
--- a/js/client/modules/@arangodb/testsuites/java.js
+++ b/js/client/modules/@arangodb/testsuites/java.js
@@ -264,10 +264,11 @@ arangodb.acquireHostList=true
 }
 
 function javaDriver (options) {
-  let localOptions = Object.assign({extraArgs: { 'vector-index': true }}, options, tu.testServerAuthInfo);
+  let localOptions = Object.assign({}, options, tu.testServerAuthInfo);
   if (localOptions.cluster && localOptions.dbServers < 3) {
     localOptions.dbServers = 3;
   }
+  localOptions['extraArgs']['vector-index'] =  true;
   let rc = new runInJavaTest(localOptions, 'java_test').run([ 'java_test.js']);
   options.cleanup = options.cleanup && localOptions.cleanup;
   return rc;


### PR DESCRIPTION
### Scope & Purpose

Enable vector index for java driver tests

- [x] :pizza: New feature
