### PR TITLE
Enable vector index tests for Go driver

### DIFF
--- a/js/client/modules/@arangodb/testsuites/go.js
+++ b/js/client/modules/@arangodb/testsuites/go.js
@@ -82,6 +82,7 @@ function goDriver (options) {
       } else {
         opts.extraArgs['server.authentication'] = true;
       }
+      opts.extraArgs['vector-index'] = true;
       opts['arangodConfig'] = 'arangod-auth.conf';
       super(opts, testname, ...optionalArgs);
       this.info = "runInGoTest";


### PR DESCRIPTION
### Scope & Purpose

Enable vector index tests for Go driver

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Go **driver tests**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Turns on vector index support in Go driver tests.
> 
> - Adds `opts.extraArgs['vector-index'] = true` in `testsuites/go.js` when starting ArangoDB
> - Sets `ENABLE_VECTOR_INDEX=true` in the Go test environment
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33aec371916e4fb94cbacec74e8964a73600b86c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->