### PR TITLE
Install Maven 3.9.11 instead of default one in Java driver test container

### DIFF
--- a/scripts/docker/java-test/Dockerfile
+++ b/scripts/docker/java-test/Dockerfile
@@ -4,11 +4,20 @@ MAINTAINER hackers@arango.ai
 ARG arch
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y openjdk-21-jdk-headless git maven netcat-traditional && \
+    apt-get install -y openjdk-21-jdk-headless git netcat-traditional && \
     apt-get update && \
     apt-get upgrade -y && \
-    rm -rf /var/cache/apt/archives /var/lib/apt/lists 
-    
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists && \
+    cd /tmp/ && \
+    wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz && \
+    tar xf apache-maven-3.9.11-bin.tar.gz -C /opt && \
+    echo 'export M3_HOME=/opt/apache-maven-3.9.11\nexport MAVEN_HOME=/opt/apache-maven-3.9.11\nexport PATH=${M3_HOME}/bin:${PATH}\n' > /etc/profile.d/maven.sh && \
+    chmod +x /etc/profile.d/maven.sh && \
+    ln -s /opt/apache-maven-3.9.11/bin/mvn /usr/bin/ && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists /tmp/*gz
+
+
+
 RUN git clone -n --depth=1 --filter=tree:0 https://github.com/arangodb/arangodb-java-driver && \
   cd arangodb-java-driver && \
   git checkout && \


### PR DESCRIPTION
### Scope & Purpose

Install Maven 3.9.11 instead of default one in Java driver test container:
```
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.6.2:enforce (enforce) on project kafka-connect-arangodb: 
[ERROR] Rule 4: org.apache.maven.enforcer.rules.version.RequireMavenVersion failed with message:
[ERROR] Detected Maven Version: 3.8.7 is not in the allowed range [3.9,).
...
```

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] Java **integration tests**
  - [x] Kafka **integration tests**