### PR TITLE
Origin/feature/audit log read

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 devel
 -----
 
+* Implemented FRB-419: Added audit log event for user permission read
+
 * Updated ArangoDB Starter to v0.19.15.
 
 * Rebuilt included rclone v1.65.2 with go1.24.11 and non-vulnerable

--- a/arangod/Utils/Events.cpp
+++ b/arangod/Utils/Events.cpp
@@ -79,6 +79,8 @@ void QueryDocument(std::string const& db, VPackSlice const&, int code) {}
 void CreateHotbackup(std::string const& id, ErrorCode result) {}
 void RestoreHotbackup(std::string const& id, ErrorCode result) {}
 void DeleteHotbackup(std::string const& id, ErrorCode result) {}
+void ReadUser(std::string const& username, Result const& result,
+              ExecContext const& context) {}
 
 }  // namespace events
 }  // namespace arangodb

--- a/arangod/Utils/Events.h
+++ b/arangod/Utils/Events.h
@@ -93,5 +93,7 @@ void AqlQuery(aql::Query const& query);
 void CreateHotbackup(std::string const& id, ErrorCode result);
 void RestoreHotbackup(std::string const& id, ErrorCode result);
 void DeleteHotbackup(std::string const& id, ErrorCode result);
+void ReadUser(std::string const& username, Result const& result,
+              ExecContext const& context);
 }  // namespace events
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

Add audit logging for all read operations on the `_users` system collection. Implementing FRB-419.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### 1. Core Audit Event Implementation

#### Files Modified:
1. **`arangod/Utils/Events.h`**
   - Added `ReadUser()` function declaration

2. **`arangod/Utils/Events.cpp`** (Community Edition)
   - Added stub implementation for `ReadUser()`

3. **`enterprise/Enterprise/Audit/EventsEE.cpp`** (Enterprise Edition)
   - Added full implementation of `ReadUser()` audit event
   - Logs to `DOCUMENT` topic at `INFO` level
   - Format: `read user '<username>' | ok/failed`

4. **`arangod/RestHandler/RestUsersHandler.cpp`**
   - Added `#include "Utils/Events.h"`
   - Added `events::ReadUser()` calls to all GET endpoints:
     - `GET /_api/user` → logs as `read user '*'`
     - `GET /_api/user/<user>` → logs as `read user '<user>'`
     - `GET /_api/user/<user>/database` → logs user read
     - `GET /_api/user/<user>/database/<dbname>` → logs user read
     - `GET /_api/user/<user>/database/<dbname>/<collection>` → logs user read
     - `GET /_api/user/<user>/config` → logs user read

### 2. Test Implementation

#### Files Modified:
1. **`enterprise/tests/js/common/audit/audit.js`**
   - Updated `toSkip` regex to allow "read user" events while filtering other `_users` operations
   - Added 7 comprehensive test cases (skip in server context):
     - `testReadUser` - Read specific user
     - `testReadUserFailed` - Read non-existent user
     - `testReadAllUsers` - List all users
     - `testReadUserDatabasePermissions` - Read user DB permissions
     - `testReadUserSpecificDatabasePermission` - Read specific DB permission
     - `testReadUserCollectionPermission` - Read collection permission
     - `testReadUserConfig` - Read user config

2. **`enterprise/tests/js/client/audit/audit.js`**
   - Added 2 test cases for HTTP client context:
     - `testReadUser`
     - `testReadAllUsers`

3. **`enterprise/tests/js/server/audit/audit.js`**
   - Removed HTTP-based tests (not applicable in server context)

### 3. Documentation Updates

#### Files Modified:
1. **`docs-hugo/site/content/arangodb/4.0/operations/security/audit-logging.md`**

**Added New Section: "User Management"**


### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [x] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [x] Docs PR: https://github.com/arangodb/docs-hugo/pull/860
- [ ] Enterprise PR: https://github.com/arangodb/enterprise/pull/1571
- [ ] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/FRB-419
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements audit logging for reads from the users API.
> 
> - Introduces `events::ReadUser(username, result, context)` in `Utils/Events.h/.cpp`
> - Calls `events::ReadUser` in `RestUsersHandler::getRequest` for: listing all users, fetching a user, and reading database/collection permissions and `config` data
> - Updates `CHANGELOG` with FRB-419 entry
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a1f28f470d14f641f5870cd19c292f88d58a5ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->