### PR TITLE
Switch default enterprise branch to 4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
               if [ "$?" == "0" ] ; then
                 ENTERPRISE_BRANCH=$CIRCLE_BRANCH
               else
-                ENTERPRISE_BRANCH=devel
+                ENTERPRISE_BRANCH=4.0
               fi
               set -e
               echo "Actually using this for ENTERPRISE_BRANCH: $ENTERPRISE_BRANCH"


### PR DESCRIPTION
### Scope & Purpose

This switches the default enterprise branch to 4.0 (instead of `devel`),
which means that 4.0-derived branches will now by default use the 4.0
branch for the enterprise repo.

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports: none planned

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates CircleCI config to change the fallback enterprise branch selection.
> 
> - In `generate-config` job, updates fallback logic so when `enterprise-branch` is unset and no matching enterprise branch exists for `CIRCLE_BRANCH`, it now uses `4.0` instead of `devel`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf0ce8377892ae9b7737fa6c8249f08a4d36ff64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->