### PR TITLE
[COR-124] Fail when access denied in async registry REST handler

### DIFF
--- a/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
+++ b/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
@@ -128,6 +128,7 @@ auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
   if (!ExecContext::current().isSuperuser()) {
     generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
                   "you need super user rights for log operations");
+    co_return;
   }
 
   if (_request->requestType() != rest::RequestType::GET) {


### PR DESCRIPTION
### Scope & Purpose

The async registry rest handler contains a check that the calling user is a superuser, generates an error, but then does not return, answering the request.

This PR fixes that behaviour.




- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes missing early return in `AsyncRegistry/RestHandler.cpp` so unauthorized requests stop processing immediately.
> 
> - Adds `co_return` after superuser check in `RestHandler::executeAsync`, ensuring a 403 is returned without continuing the request handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2186c08f4ce503c3287238275591cc08252e99e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->