### PR TITLE
Revert "[COR-153] fix current activity"

### DIFF
--- a/arangod/Scheduler/Scheduler.h
+++ b/arangod/Scheduler/Scheduler.h
@@ -33,7 +33,6 @@
 #include <string_view>
 #include <utility>
 
-#include "ActivityRegistry/activity.h"
 #include "Futures/Future.h"
 #include "Futures/Unit.h"
 #include "Futures/Utilities.h"
@@ -189,9 +188,7 @@ class Scheduler {
   template<typename F>
   struct WorkItem final : WorkItemBase, F {
     explicit WorkItem(F f)
-        : F(std::move(f)),
-          logContext(LogContext::current()),
-          activity("work item") {
+        : F(std::move(f)), logContext(LogContext::current()) {
       schedulerJobMemoryAccounting(static_cast<int64_t>(sizeof(*this)));
     }
     ~WorkItem() {
@@ -200,13 +197,11 @@ class Scheduler {
     void invoke() override {
       LogContext::ScopedContext ctxGuard(
           logContext, LogContext::ScopedContext::DontRestoreOldContext{});
-      auto activityScope = activity.activate();
       this->operator()();
     }
 
    private:
     LogContext logContext;
-    activity_registry::Activity activity;
   };
 
   // Enqueues a task - this is implemented on the specific scheduler

--- a/arangod/SystemMonitor/ActivityRegistry/RestHandler.cpp
+++ b/arangod/SystemMonitor/ActivityRegistry/RestHandler.cpp
@@ -30,7 +30,6 @@
 #include "ActivityRegistry/activity.h"
 #include "ActivityRegistry/activity_registry_variable.h"
 #include "Inspection/VPack.h"
-#include "Scheduler/SchedulerFeature.h"
 
 using namespace arangodb;
 using namespace arangodb::activity_registry;
@@ -116,7 +115,6 @@ auto serialize(IndexedForestWithRoots<ActivityInRegistrySnapshot> const& forest)
 }  // namespace
 
 auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
-  auto scope = _activity.activate();
   if (!ExecContext::current().isAdminUser()) {
     generateError(
         rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
@@ -134,8 +132,6 @@ auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
   if (isForwarded) {
     co_return;
   }
-
-  SchedulerFeature::SCHEDULER->queue(RequestLane::CLIENT_UI, []() {});
 
   auto lock_guard = co_await _feature.asyncLock();
 

--- a/arangod/SystemMonitor/ActivityRegistry/RestHandler.h
+++ b/arangod/SystemMonitor/ActivityRegistry/RestHandler.h
@@ -49,7 +49,6 @@ class RestHandler : public arangodb::RestVocbaseBaseHandler {
   futures::Future<futures::Unit> executeAsync() override;
 
   Feature& _feature;
-  Activity _activity{"activity registry REST"};
 };
 
 }  // namespace arangodb::activity_registry

--- a/lib/ActivityRegistry/activity.cpp
+++ b/lib/ActivityRegistry/activity.cpp
@@ -95,15 +95,6 @@ auto mark_finished_nodes_for_deletion(Node* node) {
 }
 }  // namespace
 
-Activity::ActiveScope::ActiveScope(Activity* activity)
-    : _currentActivity{activity} {
-  _activityBefore = *get_current_activity();
-  *get_current_activity() = activity;
-}
-Activity::ActiveScope::~ActiveScope() {
-  *get_current_activity() = _activityBefore;
-}
-
 Activity::Activity(std::string name, std::source_location loc)
     : _node_in_registry{NodeReference(
           reinterpret_cast<Node*>(get_thread_registry().add([&]() {
@@ -117,14 +108,14 @@ Activity::Activity(std::string name, std::source_location loc)
   // remember its parent activity to switch the current activity back to the
   // parent activity when this activity is destroyed
   parent = *get_current_activity();
+  *get_current_activity() = this;
 }
 
 Activity::~Activity() {
   _node_in_registry->data.state.store(State::Finished,
                                       std::memory_order_relaxed);
+  *get_current_activity() = parent;
 }
-
-auto Activity::activate() -> Activity::ActiveScope { return ActiveScope{this}; }
 
 auto Activity::id() -> ActivityId { return _node_in_registry->data.id(); }
 

--- a/lib/ActivityRegistry/include/ActivityRegistry/activity.h
+++ b/lib/ActivityRegistry/include/ActivityRegistry/activity.h
@@ -186,14 +186,6 @@ struct Activity {
            std::source_location loc = std::source_location::current());
   ~Activity();
 
-  struct ActiveScope {
-    ActiveScope(Activity* activity);
-    ~ActiveScope();
-    Activity* _currentActivity;
-    Activity* _activityBefore;
-  };
-
-  auto activate() -> ActiveScope;
   auto id() -> ActivityId;
 
  private:


### PR DESCRIPTION
Reverts arangodb/arangodb#22236 as the CI tests are failing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the earlier "fix current activity" behavior and simplifies activity tracking.
> 
> - Removes `Activity::ActiveScope` API; `Activity` now sets current activity on construction and restores it on destruction
> - Drops activity instrumentation from `Scheduler::WorkItem::invoke()` and removes the `ActivityRegistry/activity.h` include
> - Cleans up `ActivityRegistry` REST handler: removes per-request `Activity` member and an unused scheduler queue call, plus related includes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c98ffdb25da1dad855b102db3fdf6d67ca76f846. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->