### PR TITLE
Fixing license feature when applying same license again.

### DIFF
--- a/arangod/Cluster/AgencyCache.cpp
+++ b/arangod/Cluster/AgencyCache.cpp
@@ -539,7 +539,7 @@ void AgencyCache::triggerWaiting(index_t commitIndex) {
   // deadlocks. At least release the mutex before, otherwise deadlocks are at
   // least in our tests guaranteed.
   for (auto& pp : promisesToResolve) {
-    pp.setValue(Result(resolveResult));
+    pp.setValue(resolveResult);
   }
 }
 


### PR DESCRIPTION
Enterprise PR: https://github.com/arangodb/enterprise/pull/1580

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts waiter resolution in `AgencyCache::triggerWaiting`.
> 
> - Replace heap-allocated `std::shared_ptr<Promise>` with by-value `Promise` handling to simplify and reduce contention
> - Queue scheduler tasks with moved promise and set value to `resolveResult` (OK or shutdown) based on `isStopping()`
> - Resolve non-scheduler promises after releasing the wait-lock, using `resolveResult` instead of always using shutdown code
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5db97582726f145c40857cdafd81e15a7f72f635. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->