### PR TITLE
Make sure arangoserver uses correct jemalloc include path

### DIFF
--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -238,8 +238,13 @@ if(USE_V8)
   target_link_libraries(arangoserver arango_v8server)
 endif()
 
+
+if(USE_JEMALLOC)
 target_include_directories(arangoserver PRIVATE
-  "${JEMALLOC_HOME}/include"
+  "${JEMALLOC_HOME}/include")
+endif()
+
+target_include_directories(arangoserver PRIVATE
   "${PROJECT_SOURCE_DIR}/arangod"
   "${PROJECT_SOURCE_DIR}/${ENTERPRISE_INCLUDE_DIR}")
 


### PR DESCRIPTION
### Scope & Purpose

When compiling inside an environment that does not have jemalloc installed as a system library, compilation fails; this patch makes sure we use the in-tree jemalloc headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `arangoserver` compiles with in-tree jemalloc headers when jemalloc isn’t installed system-wide.
> 
> - Adds conditional `target_include_directories` for `USE_JEMALLOC` to include `"${JEMALLOC_HOME}/include"` in `arangod/arangoserver.cmake`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af3b2881c3cb2253c9043f0c5e3f519bec80bce0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->