### PR TITLE
Fix recently introduced ASan issue

### DIFF
--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -95,7 +95,8 @@ std::string connectionIdentifier(fuerte::ConnectionBuilder& builder) {
 
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   LOG_TOPIC("9aaaa", TRACE, arangodb::Logger::HTTPCLIENT)
-      << "Connection identifier " << std::string(hex, 32) << " calculated from: " << raw;
+      << "Connection identifier " << std::string(hex, 32)
+      << " calculated from: " << raw;
 #endif
   // and return
   return std::string(hex, 32);


### PR DESCRIPTION
### Scope & Purpose

- [x] :hankey: Bugfix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tiny, failure-test-only logging change that does not affect connection behavior or request handling.
> 
> **Overview**
> Fixes an ASan-triggering logging issue in `V8ClientConnection.cpp` by ensuring the MD5 hex buffer is converted to a bounded `std::string(hex, 32)` before being streamed in the failure-test-only `LOG_TOPIC` message, instead of treating `hex` as a C-string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 464e8ecb0bea339d64d191eca562ee84c484fc38. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->