### PR TITLE
[COR-238] Hopefully fix spurious test failure in activities

### DIFF
--- a/tests/js/client/shell/api/activities.js
+++ b/tests/js/client/shell/api/activities.js
@@ -110,13 +110,23 @@ function activityRegistrySuite() {
         IM.debugSetFailAt("RestDumpHandler::fetch-delay");
         
         const cursorId = fetchDumpAsynchronously(dumpId, server); // Rest call is kept busy with failure point
-        const activities = activitiesModule.get_snapshot_bare(server);
 
+        // make sure that dump context fetch activity is created before activities are requested
+        let maxWait = 5;
+        let activities;
+        while (maxWait > 0) {
+          activities = activitiesModule.get_snapshot_bare(server);
+          if (activities.filter(dumpContextFetchFilter()).length > 0) {
+            break;
+          }
+          internal.wait(1);
+          maxWait--;
+        }
+        assertArrayLengthLargerThan(activities.filter(dumpContextFetchFilter()), 0);
         assertArrayLengthLargerThan(activities, 3);
         assertArrayLengthLargerThan(activities.filter(activityRestHandlerFilter()), 0);
         assertArrayLengthLargerThan(activities.filter(dumpRestHandlerFilter()), 0);
         assertArrayLengthLargerThan(activities.filter(dumpContextFilter()), 0);
-        assertArrayLengthLargerThan(activities.filter(dumpContextFetchFilter()), 0);
 
         // stop first dump-fetch Rest call with a second call
         const cursorId2 = fetchDumpAsynchronously(dumpId, server);


### PR DESCRIPTION
In the test we start fetching a dump inside the failure point "RestDumpHandler::fetch-delay" which adds a busy loop into the rest handler until it is called a second time.
Now we request the activities and are supposed to get at least 4:
- the activities Rest Handler because of the activities request
- the dump context that was created before
- the dump Rest Handler because we are in the busy loop
- the dump context fetch, also because we are in the busy loop

But the error shows that the last one is currently not part of the activities:
```
[
  {\"id\":\"0x7f6a4ee28f00\",\"type\":\"ActivityRegistryRestHandler\",\"parent\":{\"id\":\"0x0\"},\"metadata\":{\"method\":\"GET\",\"url\":\"/_admin/activities\"}},
  {\"id\":\"0x7f6a4ee28b40\",\"type\":\"RestDumpHandler\",\"parent\":{\"id\":\"0x0\"},\"metadata\":{\"method\":\"POST\",\"url\":\"/_api/dump/next/dump-1856729373336403968?batchId=0\"}},
  {\"id\":\"0x7f6a4ee281e0\",\"type\":\"dump context\",\"parent\":{\"id\":\"0x7f6a4ee28500\"},\"metadata\":{\"database\":\"_system\",\"user\":\"root\",\"id\":\"dump-1856729373336403968\"}}
]
```

This could have happened because the activities request was resolved before the dump-fetch activity was created by the asynchronous REST call. Therefore I added a loop that waits for this activity to exist.
Additionally, I saw that the cursor of the asynchronous fetch Dump request that we are doing is deleted too early, so this PR move this cursor deletion further down until the request is not needed any more.