### PR TITLE
Add cache metrics

### DIFF
--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -598,4 +598,8 @@ bool Cache::migrate(std::shared_ptr<Table> newTable) {
   return true;
 }
 
+std::string_view Cache::name() const noexcept {
+  return _name;
+}
+
 }  // namespace arangodb::cache

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -49,7 +49,7 @@ using SpinLocker = ::arangodb::basics::SpinLocker;
 using SpinUnlocker = ::arangodb::basics::SpinUnlocker;
 
 Cache::Cache(
-    Manager* manager, std::uint64_t id, std::string const& name,
+    Manager* manager, std::uint64_t id, std::string_view name,
     Metadata&& metadata, std::shared_ptr<Table> table, bool enableWindowedStats,
     std::function<Table::BucketClearer(Cache*, Metadata*)> bucketClearer,
     std::size_t slotsPerBucket)

--- a/arangod/Cache/Cache.cpp
+++ b/arangod/Cache/Cache.cpp
@@ -49,13 +49,14 @@ using SpinLocker = ::arangodb::basics::SpinLocker;
 using SpinUnlocker = ::arangodb::basics::SpinUnlocker;
 
 Cache::Cache(
-    Manager* manager, std::uint64_t id, Metadata&& metadata,
-    std::shared_ptr<Table> table, bool enableWindowedStats,
+    Manager* manager, std::uint64_t id, std::string const& name,
+    Metadata&& metadata, std::shared_ptr<Table> table, bool enableWindowedStats,
     std::function<Table::BucketClearer(Cache*, Metadata*)> bucketClearer,
     std::size_t slotsPerBucket)
     : _shutdown(false),
       _manager(manager),
       _id(id),
+      _name(name),
       _metadata(std::move(metadata)),
       _memoryUsageDiff(0),
       _table(std::move(table)),

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -70,8 +70,9 @@ class Cache : public std::enable_shared_from_this<Cache> {
     friend class TransactionalCache;
   };
 
-  Cache(Manager* manager, std::uint64_t id, std::string const& name,
-        Metadata&& metadata, std::shared_ptr<Table> table, bool enableWindowedStats,
+  Cache(Manager* manager, std::uint64_t id, std::string_view name,
+        Metadata&& metadata, std::shared_ptr<Table> table,
+        bool enableWindowedStats,
         std::function<Table::BucketClearer(Cache*, Metadata*)> bucketClearer,
         std::size_t slotsPerBucket);
 

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -253,6 +253,7 @@ class Cache : public std::enable_shared_from_this<Cache> {
 
   // management
   Metadata& metadata();
+  std::string_view name() const noexcept;
   std::shared_ptr<Table> table() const;
   void shutdown();
   [[nodiscard]] bool canResize() noexcept;

--- a/arangod/Cache/Cache.h
+++ b/arangod/Cache/Cache.h
@@ -70,8 +70,8 @@ class Cache : public std::enable_shared_from_this<Cache> {
     friend class TransactionalCache;
   };
 
-  Cache(Manager* manager, std::uint64_t id, Metadata&& metadata,
-        std::shared_ptr<Table> table, bool enableWindowedStats,
+  Cache(Manager* manager, std::uint64_t id, std::string const& name,
+        Metadata&& metadata, std::shared_ptr<Table> table, bool enableWindowedStats,
         std::function<Table::BucketClearer(Cache*, Metadata*)> bucketClearer,
         std::size_t slotsPerBucket);
 
@@ -282,6 +282,7 @@ class Cache : public std::enable_shared_from_this<Cache> {
   // allow communication with manager
   Manager* _manager;
   std::uint64_t const _id;
+  std::string _name;
   Metadata _metadata;
 
   // local buffer for tracking allocations/deallocations by this cache.

--- a/arangod/Cache/CacheManagerFeature.cpp
+++ b/arangod/Cache/CacheManagerFeature.cpp
@@ -93,8 +93,8 @@ void CacheManagerFeature::start() {
       << ", max spare allocation: " << _options.maxSpareAllocation
       << ", enable windowed stats: " << _options.enableWindowedStats;
 
-  _manager = std::make_unique<Manager>(_sharedPRNGFeature, std::move(postFn),
-                                       _options);
+  _manager = std::make_unique<Manager>(scheduler->server(), _sharedPRNGFeature,
+                                       std::move(postFn), _options);
 
   _rebalancer = std::make_unique<CacheRebalancerThread>(
       server(), _manager.get(), _options.rebalancingInterval);

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -78,7 +78,6 @@ namespace {
 template<typename T>
 T getMetric(std::string_view name) {
   T metric;
-  metric.reserveSpaceForLabels(4 + name.size());
   metric.addLabel("name", name);
   return metric;
 }

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -65,6 +65,8 @@ DECLARE_GAUGE(rocksdb_cache_labeled_allocated, uint64_t,
               "Labeled cache allocated size");
 DECLARE_GAUGE(rocksdb_cache_labeled_deserved, uint64_t,
               "Labeled cache deserved size");
+DECLARE_GAUGE(rocksdb_cache_labeled_usage, uint64_t,
+              "Labeled cache usage");
 DECLARE_GAUGE(rocksdb_cache_labeled_hard_limit, uint64_t,
               "Labeled cache hard limit");
 DECLARE_GAUGE(rocksdb_cache_labeled_soft_limit, uint64_t,
@@ -138,6 +140,8 @@ Manager::Manager(application_features::ApplicationServer& server,
           rocksdb_cache_labeled_allocated{})),
       _cacheLabeledDeserved(server.getFeature<metrics::MetricsFeature>().add(
           rocksdb_cache_labeled_deserved{})),
+      _cacheLabeledUsage(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_usage{})),
       _cacheLabeledHardLimit(server.getFeature<metrics::MetricsFeature>().add(
           rocksdb_cache_labeled_hard_limit{})),
       _cacheLabeledSoftLimit(server.getFeature<metrics::MetricsFeature>().add(
@@ -720,7 +724,31 @@ void Manager::unprepareTask(Manager::TaskEnvironment environment,
 /// Then, given the pool of memory, and the expressed needs of each cache,
 /// attempt to allocate memory evenly, up to the additional amount requested.
 ErrorCode Manager::rebalance(bool onlyCalculate) {
-  { SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate); }
+  PriorityList cacheList;
+  std::vector<std::pair<std::string_view, std::vector<uint64_t>>> cacheStats{};
+
+  {
+    SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);
+    try {
+      cacheList = priorityList();
+      for (auto& pair : cacheList) {
+        std::shared_ptr<Cache>& cache = pair.first;
+        Metadata const& md = cache->metadata();
+        cacheStats.push_back(
+          {cache->name(),
+           {md.fixedSize, md.tableSize, md.maxSize,
+                                  md.allocatedSize, md.deservedSize, md.usage,
+                                  md.softUsageLimit, md.hardUsageLimit}});
+      }
+    } catch (std::exception const& ex) {
+        // we must not throw an exception from here without cleaning up
+        // the _rebalancing attribute
+        LOG_TOPIC("c0109", WARN, Logger::CACHE)
+            << "Caught exception during cache metrics collection: "
+            << ex.what();
+    }
+  }
+  
 
   SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);
 
@@ -738,8 +766,6 @@ ErrorCode Manager::rebalance(bool onlyCalculate) {
     // start rebalancing
     _rebalancing = true;
   }
-
-  PriorityList cacheList;
 
   // adjust deservedSize for each cache
   try {

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -140,6 +140,7 @@ Manager::~Manager() {
 
 template<typename Hasher>
 std::shared_ptr<Cache> Manager::createCache(CacheType type,
+                                            std::string const& name,
                                             bool enableWindowedStats,
                                             std::uint64_t maxSize) {
   std::shared_ptr<Cache> result;
@@ -182,12 +183,12 @@ std::shared_ptr<Cache> Manager::createCache(CacheType type,
 
       switch (type) {
         case CacheType::Plain:
-          result = PlainCache<Hasher>::create(this, id, std::move(metadata),
+          result = PlainCache<Hasher>::create(this, id, name, std::move(metadata),
                                               table, enableWindowedStats);
           break;
         case CacheType::Transactional:
           result = TransactionalCache<Hasher>::create(
-              this, id, std::move(metadata), table, enableWindowedStats);
+              this, id, name, std::move(metadata), table, enableWindowedStats);
           break;
         default:
           ADB_UNREACHABLE;
@@ -1129,9 +1130,9 @@ bool Manager::pastRebalancingGracePeriod() const {
 
 // template instantiations for createCache()
 template std::shared_ptr<Cache> Manager::createCache<BinaryKeyHasher>(
-    CacheType type, bool enableWindowedStats, std::uint64_t maxSize);
+  CacheType type, std::string const& name, bool enableWindowedStats, std::uint64_t maxSize);
 
 template std::shared_ptr<Cache> Manager::createCache<VPackKeyHasher>(
-    CacheType type, bool enableWindowedStats, std::uint64_t maxSize);
+  CacheType type, std::string const& name, bool enableWindowedStats, std::uint64_t maxSize);
 
 }  // namespace arangodb::cache

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -73,6 +73,18 @@ DECLARE_GAUGE(rocksdb_cache_labeled_soft_limit, uint64_t,
 
 using namespace arangodb::application_features;
 
+namespace {
+// build a dynamic shard-access metric
+template<typename T>
+T getMetric(std::string_view name) {
+  T metric;
+  metric.reserveSpaceForLabels(4 + name.size());
+  metric.addLabel("name", name);
+  return metric;
+}
+
+}  // namespace
+
 namespace arangodb::cache {
 
 using SpinLocker = ::arangodb::basics::SpinLocker;
@@ -129,7 +141,7 @@ Manager::Manager(application_features::ApplicationServer& server,
       _resizingTasks(0),
       _rebalanceCompleted(std::chrono::steady_clock::now() -
                           rebalancingGracePeriod),
-      _mf(server.getFeature<metrics::MetricsFeature>());
+      _mf(server.getFeature<metrics::MetricsFeature>()),
       _cacheLabeledFixed(server.getFeature<metrics::MetricsFeature>().add(
           rocksdb_cache_labeled_fixed{})),
       _cacheLabeledTables(server.getFeature<metrics::MetricsFeature>().add(
@@ -727,40 +739,6 @@ ErrorCode Manager::rebalance(bool onlyCalculate) {
   PriorityList cacheList;
   std::vector<std::pair<std::string_view, std::vector<uint64_t>>> cacheStats{};
 
-  {
-    SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);
-    try {
-      cacheList = priorityList();
-      for (auto& pair : cacheList) {
-        std::shared_ptr<Cache>& cache = pair.first;
-        Metadata const& md = cache->metadata();
-        cacheStats.push_back({cache->name(),
-                              {md.fixedSize, md.tableSize, md.maxSize,
-                               md.allocatedSize, md.deservedSize, md.usage,
-                               md.softUsageLimit, md.hardUsageLimit}});
-      }
-    } catch (std::exception const& ex) {
-      // we must not throw an exception from here without cleaning up
-      // the _rebalancing attribute
-      LOG_TOPIC("c0109", WARN, Logger::CACHE)
-          << "Caught exception during cache metrics collection: " << ex.what();
-    }
-  }
-
-  auto& mf = _vocbase.server().getFeature<metrics::MetricsFeature>();
-  for (auto pair : cacheStats) {
-    auto name = pair.first;
-    auto vals = pair.second;
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_fixed>(name)) = vals[0];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_tables>(name)) = vals[1];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_max>(name)) = vals[2];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_allocated>(name)) = vals[3];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_deserved>(name)) = vals[4];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_usage>(name)) = vals[5];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_hard_limit>(name)) = vals[6];
-    _mf.addDynamic(getMetric<rocksdb_cache_labeled_soft_limit>(name)) = vals[7];
-  }
-
   SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);
 
   if (!onlyCalculate) {
@@ -797,18 +775,39 @@ ErrorCode Manager::rebalance(bool onlyCalculate) {
       }
 #endif
       Metadata& metadata = cache->metadata();
-      SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+      std::vector<uint64_t> vals{};
+      {
+        SpinLocker metaGuard(SpinLocker::Mode::Write, metadata.lock());
+
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-      std::uint64_t fixed =
-          metadata.fixedSize + metadata.tableSize + kCacheRecordOverhead;
-      if (newDeserved < fixed) {
-        LOG_TOPIC("e63e4", DEBUG, Logger::CACHE)
-            << "Setting deserved cache size " << newDeserved
-            << " below usage: " << fixed << " ; Using weight  " << weight;
-      }
+        std::uint64_t fixed =
+            metadata.fixedSize + metadata.tableSize + kCacheRecordOverhead;
+        if (newDeserved < fixed) {
+          LOG_TOPIC("e63e4", DEBUG, Logger::CACHE)
+              << "Setting deserved cache size " << newDeserved
+              << " below usage: " << fixed << " ; Using weight  " << weight;
+        }
 #endif
-      metadata.adjustDeserved(newDeserved);
+        metadata.adjustDeserved(newDeserved);
+        vals = {metadata.fixedSize,      metadata.tableSize,
+                metadata.maxSize,        metadata.allocatedSize,
+                metadata.deservedSize,   metadata.usage,
+                metadata.softUsageLimit, metadata.hardUsageLimit};
+      }
+      std::string_view name = cache->name();
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_fixed>(name)) = vals[0];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_tables>(name)) = vals[1];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_max>(name)) = vals[2];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_allocated>(name)) =
+          vals[3];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_deserved>(name)) = vals[4];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_usage>(name)) = vals[5];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_hard_limit>(name)) =
+          vals[6];
+      _mf.addDynamic(getMetric<rocksdb_cache_labeled_soft_limit>(name)) =
+          vals[7];
     }
+
   } catch (std::exception const& ex) {
     // we must not throw an exception from here without cleaning up
     // the _rebalancing attribute

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -53,7 +53,24 @@
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
+#include "Metrics/GaugeBuilder.h"
+#include "Metrics/MetricsFeature.h"
 #include "RestServer/SharedPRNGFeature.h"
+
+DECLARE_GAUGE(rocksdb_cache_labeled_fixed, uint64_t, "Labled cache fixed size");
+DECLARE_GAUGE(rocksdb_cache_labeled_tables, uint64_t,
+              "Labled cache table size");
+DECLARE_GAUGE(rocksdb_cache_labeled_max, uint64_t, "Labled cache max size");
+DECLARE_GAUGE(rocksdb_cache_labeled_allocated, uint64_t,
+              "Labeled cache allocated size");
+DECLARE_GAUGE(rocksdb_cache_labeled_deserved, uint64_t,
+              "Labeled cache deserved size");
+DECLARE_GAUGE(rocksdb_cache_labeled_hard_limit, uint64_t,
+              "Labeled cache hard limit");
+DECLARE_GAUGE(rocksdb_cache_labeled_soft_limit, uint64_t,
+              "Labeled cache hard limit");
+
+using namespace arangodb::application_features;
 
 namespace arangodb::cache {
 
@@ -69,7 +86,8 @@ std::uint64_t const Manager::minCacheAllocation =
              TransactionalCache<BinaryKeyHasher>::allocationSize()) +
     kCacheRecordOverhead;
 
-Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
+Manager::Manager(application_features::ApplicationServer& server,
+                 SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
                  CacheOptions const& options)
     : _sharedPRNG(sharedPRNG),
       _options(options),
@@ -109,7 +127,23 @@ Manager::Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
       _rebalancingTasks(0),
       _resizingTasks(0),
       _rebalanceCompleted(std::chrono::steady_clock::now() -
-                          rebalancingGracePeriod) {
+                          rebalancingGracePeriod),
+      _cacheLabeledFixed(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_fixed{})),
+      _cacheLabeledTables(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_tables{})),
+      _cacheLabeledMax(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_max{})),
+      _cacheLabeledAllocated(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_allocated{})),
+      _cacheLabeledDeserved(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_deserved{})),
+      _cacheLabeledHardLimit(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_hard_limit{})),
+      _cacheLabeledSoftLimit(server.getFeature<metrics::MetricsFeature>().add(
+          rocksdb_cache_labeled_soft_limit{}))
+
+{
   TRI_ASSERT(_globalAllocation < _globalSoftLimit);
   TRI_ASSERT(_globalAllocation < _globalHardLimit);
   if (_options.enableWindowedStats) {
@@ -140,7 +174,7 @@ Manager::~Manager() {
 
 template<typename Hasher>
 std::shared_ptr<Cache> Manager::createCache(CacheType type,
-                                            std::string const& name,
+                                            std::string_view name,
                                             bool enableWindowedStats,
                                             std::uint64_t maxSize) {
   std::shared_ptr<Cache> result;
@@ -183,8 +217,8 @@ std::shared_ptr<Cache> Manager::createCache(CacheType type,
 
       switch (type) {
         case CacheType::Plain:
-          result = PlainCache<Hasher>::create(this, id, name, std::move(metadata),
-                                              table, enableWindowedStats);
+          result = PlainCache<Hasher>::create(
+              this, id, name, std::move(metadata), table, enableWindowedStats);
           break;
         case CacheType::Transactional:
           result = TransactionalCache<Hasher>::create(
@@ -686,6 +720,8 @@ void Manager::unprepareTask(Manager::TaskEnvironment environment,
 /// Then, given the pool of memory, and the expressed needs of each cache,
 /// attempt to allocate memory evenly, up to the additional amount requested.
 ErrorCode Manager::rebalance(bool onlyCalculate) {
+  { SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate); }
+
   SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);
 
   if (!onlyCalculate) {
@@ -1130,9 +1166,11 @@ bool Manager::pastRebalancingGracePeriod() const {
 
 // template instantiations for createCache()
 template std::shared_ptr<Cache> Manager::createCache<BinaryKeyHasher>(
-  CacheType type, std::string const& name, bool enableWindowedStats, std::uint64_t maxSize);
+    CacheType type, std::string_view name, bool enableWindowedStats,
+    std::uint64_t maxSize);
 
 template std::shared_ptr<Cache> Manager::createCache<VPackKeyHasher>(
-  CacheType type, std::string const& name, bool enableWindowedStats, std::uint64_t maxSize);
+    CacheType type, std::string_view name, bool enableWindowedStats,
+    std::uint64_t maxSize);
 
 }  // namespace arangodb::cache

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -129,6 +129,7 @@ Manager::Manager(application_features::ApplicationServer& server,
       _resizingTasks(0),
       _rebalanceCompleted(std::chrono::steady_clock::now() -
                           rebalancingGracePeriod),
+      _mf(server.getFeature<metrics::MetricsFeature>());
       _cacheLabeledFixed(server.getFeature<metrics::MetricsFeature>().add(
           rocksdb_cache_labeled_fixed{})),
       _cacheLabeledTables(server.getFeature<metrics::MetricsFeature>().add(
@@ -750,14 +751,14 @@ ErrorCode Manager::rebalance(bool onlyCalculate) {
   for (auto pair : cacheStats) {
     auto name = pair.first;
     auto vals = pair.second;
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_fixed>(name)) = vals[0];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_tables>(name)) = vals[1];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_max>(name)) = vals[2];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_allocated>(name)) = vals[3];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_deserved>(name)) = vals[4];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_usage>(name)) = vals[5];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_hard_limit>(name)) = vals[6];
-    mf.addDynamic(getMetric<rocksdb_cache_labeled_soft_limit>(name)) = vals[7];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_fixed>(name)) = vals[0];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_tables>(name)) = vals[1];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_max>(name)) = vals[2];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_allocated>(name)) = vals[3];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_deserved>(name)) = vals[4];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_usage>(name)) = vals[5];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_hard_limit>(name)) = vals[6];
+    _mf.addDynamic(getMetric<rocksdb_cache_labeled_soft_limit>(name)) = vals[7];
   }
 
   SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);

--- a/arangod/Cache/Manager.cpp
+++ b/arangod/Cache/Manager.cpp
@@ -65,8 +65,7 @@ DECLARE_GAUGE(rocksdb_cache_labeled_allocated, uint64_t,
               "Labeled cache allocated size");
 DECLARE_GAUGE(rocksdb_cache_labeled_deserved, uint64_t,
               "Labeled cache deserved size");
-DECLARE_GAUGE(rocksdb_cache_labeled_usage, uint64_t,
-              "Labeled cache usage");
+DECLARE_GAUGE(rocksdb_cache_labeled_usage, uint64_t, "Labeled cache usage");
 DECLARE_GAUGE(rocksdb_cache_labeled_hard_limit, uint64_t,
               "Labeled cache hard limit");
 DECLARE_GAUGE(rocksdb_cache_labeled_soft_limit, uint64_t,
@@ -734,21 +733,32 @@ ErrorCode Manager::rebalance(bool onlyCalculate) {
       for (auto& pair : cacheList) {
         std::shared_ptr<Cache>& cache = pair.first;
         Metadata const& md = cache->metadata();
-        cacheStats.push_back(
-          {cache->name(),
-           {md.fixedSize, md.tableSize, md.maxSize,
-                                  md.allocatedSize, md.deservedSize, md.usage,
-                                  md.softUsageLimit, md.hardUsageLimit}});
+        cacheStats.push_back({cache->name(),
+                              {md.fixedSize, md.tableSize, md.maxSize,
+                               md.allocatedSize, md.deservedSize, md.usage,
+                               md.softUsageLimit, md.hardUsageLimit}});
       }
     } catch (std::exception const& ex) {
-        // we must not throw an exception from here without cleaning up
-        // the _rebalancing attribute
-        LOG_TOPIC("c0109", WARN, Logger::CACHE)
-            << "Caught exception during cache metrics collection: "
-            << ex.what();
+      // we must not throw an exception from here without cleaning up
+      // the _rebalancing attribute
+      LOG_TOPIC("c0109", WARN, Logger::CACHE)
+          << "Caught exception during cache metrics collection: " << ex.what();
     }
   }
-  
+
+  auto& mf = _vocbase.server().getFeature<metrics::MetricsFeature>();
+  for (auto pair : cacheStats) {
+    auto name = pair.first;
+    auto vals = pair.second;
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_fixed>(name)) = vals[0];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_tables>(name)) = vals[1];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_max>(name)) = vals[2];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_allocated>(name)) = vals[3];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_deserved>(name)) = vals[4];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_usage>(name)) = vals[5];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_hard_limit>(name)) = vals[6];
+    mf.addDynamic(getMetric<rocksdb_cache_labeled_soft_limit>(name)) = vals[7];
+  }
 
   SpinLocker guard(SpinLocker::Mode::Write, _lock, !onlyCalculate);
 

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -138,7 +138,7 @@ class Manager {
   //////////////////////////////////////////////////////////////////////////////
   template<typename Hasher>
   std::shared_ptr<Cache> createCache(
-      CacheType type, bool enableWindowedStats = false,
+    CacheType type, std::string const& name, bool enableWindowedStats = false, 
       std::uint64_t maxSize = std::numeric_limits<std::uint64_t>::max());
 
   //////////////////////////////////////////////////////////////////////////////

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -318,6 +318,7 @@ class Manager {
   metrics::Gauge<uint64_t>& _cacheLabeledMax;
   metrics::Gauge<uint64_t>& _cacheLabeledAllocated;
   metrics::Gauge<uint64_t>& _cacheLabeledDeserved;
+  metrics::Gauge<uint64_t>& _cacheLabeledUsage;
   metrics::Gauge<uint64_t>& _cacheLabeledHardLimit;
   metrics::Gauge<uint64_t>& _cacheLabeledSoftLimit;
 

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -313,6 +313,7 @@ class Manager {
   time_point _rebalanceCompleted;
 
   // cache usage detailed
+  metrics::MetricsFeature& _mf;
   metrics::Gauge<uint64_t>& _cacheLabeledFixed;
   metrics::Gauge<uint64_t>& _cacheLabeledTables;
   metrics::Gauge<uint64_t>& _cacheLabeledMax;

--- a/arangod/Cache/Manager.h
+++ b/arangod/Cache/Manager.h
@@ -33,6 +33,7 @@
 #include "Cache/Table.h"
 #include "Cache/Transaction.h"
 #include "Cache/TransactionManager.h"
+#include "Metrics/Fwd.h"
 
 #include <array>
 #include <atomic>
@@ -115,7 +116,8 @@ class Manager {
   /// @brief Initialize the manager with a scheduler post method and global
   /// usage limit.
   //////////////////////////////////////////////////////////////////////////////
-  Manager(SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
+  Manager(application_features::ApplicationServer& server,
+          SharedPRNGFeature& sharedPRNG, PostFn schedulerPost,
           CacheOptions const& options);
 
   Manager(Manager const&) = delete;
@@ -138,7 +140,7 @@ class Manager {
   //////////////////////////////////////////////////////////////////////////////
   template<typename Hasher>
   std::shared_ptr<Cache> createCache(
-    CacheType type, std::string const& name, bool enableWindowedStats = false, 
+      CacheType type, std::string_view name, bool enableWindowedStats = false,
       std::uint64_t maxSize = std::numeric_limits<std::uint64_t>::max());
 
   //////////////////////////////////////////////////////////////////////////////
@@ -309,6 +311,15 @@ class Manager {
   std::atomic<std::uint64_t> _rebalancingTasks;
   std::atomic<std::uint64_t> _resizingTasks;
   time_point _rebalanceCompleted;
+
+  // cache usage detailed
+  metrics::Gauge<uint64_t>& _cacheLabeledFixed;
+  metrics::Gauge<uint64_t>& _cacheLabeledTables;
+  metrics::Gauge<uint64_t>& _cacheLabeledMax;
+  metrics::Gauge<uint64_t>& _cacheLabeledAllocated;
+  metrics::Gauge<uint64_t>& _cacheLabeledDeserved;
+  metrics::Gauge<uint64_t>& _cacheLabeledHardLimit;
+  metrics::Gauge<uint64_t>& _cacheLabeledSoftLimit;
 
   // friend class tasks and caches to allow access
   friend class Cache;

--- a/arangod/Cache/Metadata.cpp
+++ b/arangod/Cache/Metadata.cpp
@@ -26,6 +26,7 @@
 #include "Basics/debugging.h"
 #include "Cache/Cache.h"
 #include "Cache/Manager.h"
+#include "Metrics/GaugeBuilder.h"
 
 #include <algorithm>
 

--- a/arangod/Cache/Metadata.h
+++ b/arangod/Cache/Metadata.h
@@ -137,8 +137,6 @@ struct Metadata {
   //////////////////////////////////////////////////////////////////////////////
   void toggleResizing() noexcept { _resizing = !_resizing; }
 
-  void updateMetrics(uint64_t) noexcept {}
-
  private:
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void checkInvariants() const noexcept;

--- a/arangod/Cache/Metadata.h
+++ b/arangod/Cache/Metadata.h
@@ -137,6 +137,8 @@ struct Metadata {
   //////////////////////////////////////////////////////////////////////////////
   void toggleResizing() noexcept { _resizing = !_resizing; }
 
+  void updateMetrics(uint64_t) noexcept {}
+
  private:
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   void checkInvariants() const noexcept;

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -198,7 +198,7 @@ std::string_view PlainCache<Hasher>::hasherName() const noexcept {
 template<typename Hasher>
 std::shared_ptr<Cache> PlainCache<Hasher>::create(Manager* manager,
                                                   std::uint64_t id,
-                                                  std::string const& name,
+                                                  std::string_view name,
                                                   Metadata&& metadata,
                                                   std::shared_ptr<Table> table,
                                                   bool enableWindowedStats) {
@@ -210,8 +210,7 @@ std::shared_ptr<Cache> PlainCache<Hasher>::create(Manager* manager,
 template<typename Hasher>
 PlainCache<Hasher>::PlainCache(Cache::ConstructionGuard /*guard*/,
                                Manager* manager, std::uint64_t id,
-                               std::string const& name,
-                               Metadata&& metadata,
+                               std::string_view name, Metadata&& metadata,
                                std::shared_ptr<Table> table,
                                bool enableWindowedStats)
     : Cache(manager, id, name, std::move(metadata), std::move(table),

--- a/arangod/Cache/PlainCache.cpp
+++ b/arangod/Cache/PlainCache.cpp
@@ -198,21 +198,23 @@ std::string_view PlainCache<Hasher>::hasherName() const noexcept {
 template<typename Hasher>
 std::shared_ptr<Cache> PlainCache<Hasher>::create(Manager* manager,
                                                   std::uint64_t id,
+                                                  std::string const& name,
                                                   Metadata&& metadata,
                                                   std::shared_ptr<Table> table,
                                                   bool enableWindowedStats) {
   return std::make_shared<PlainCache<Hasher>>(
-      Cache::ConstructionGuard(), manager, id, std::move(metadata),
+      Cache::ConstructionGuard(), manager, id, name, std::move(metadata),
       std::move(table), enableWindowedStats);
 }
 
 template<typename Hasher>
 PlainCache<Hasher>::PlainCache(Cache::ConstructionGuard /*guard*/,
                                Manager* manager, std::uint64_t id,
+                               std::string const& name,
                                Metadata&& metadata,
                                std::shared_ptr<Table> table,
                                bool enableWindowedStats)
-    : Cache(manager, id, std::move(metadata), std::move(table),
+    : Cache(manager, id, name, std::move(metadata), std::move(table),
             enableWindowedStats, PlainCache::bucketClearer,
             PlainBucket::kSlotsData) {}
 

--- a/arangod/Cache/PlainCache.h
+++ b/arangod/Cache/PlainCache.h
@@ -50,7 +50,7 @@ template<typename Hasher>
 class PlainCache final : public Cache {
  public:
   PlainCache(Cache::ConstructionGuard guard, Manager* manager, std::uint64_t id,
-             Metadata&& metadata, std::shared_ptr<Table> table,
+             std::string const& name, Metadata&& metadata, std::shared_ptr<Table> table,
              bool enableWindowedStats);
   ~PlainCache();
 
@@ -104,6 +104,7 @@ class PlainCache final : public Cache {
   friend class MigrateTask;
 
   static std::shared_ptr<Cache> create(Manager* manager, std::uint64_t id,
+                                       std::string const& name,
                                        Metadata&& metadata,
                                        std::shared_ptr<Table> table,
                                        bool enableWindowedStats);

--- a/arangod/Cache/PlainCache.h
+++ b/arangod/Cache/PlainCache.h
@@ -50,8 +50,8 @@ template<typename Hasher>
 class PlainCache final : public Cache {
  public:
   PlainCache(Cache::ConstructionGuard guard, Manager* manager, std::uint64_t id,
-             std::string const& name, Metadata&& metadata, std::shared_ptr<Table> table,
-             bool enableWindowedStats);
+             std::string_view name, Metadata&& metadata,
+             std::shared_ptr<Table> table, bool enableWindowedStats);
   ~PlainCache();
 
   PlainCache() = delete;
@@ -104,7 +104,7 @@ class PlainCache final : public Cache {
   friend class MigrateTask;
 
   static std::shared_ptr<Cache> create(Manager* manager, std::uint64_t id,
-                                       std::string const& name,
+                                       std::string_view name,
                                        Metadata&& metadata,
                                        std::shared_ptr<Table> table,
                                        bool enableWindowedStats);

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -250,8 +250,9 @@ std::string_view TransactionalCache<Hasher>::hasherName() const noexcept {
 
 template<typename Hasher>
 std::shared_ptr<Cache> TransactionalCache<Hasher>::create(
-    Manager* manager, std::uint64_t id, std::string const& name, Metadata&& metadata,
-    std::shared_ptr<Table> table, bool enableWindowedStats) {
+    Manager* manager, std::uint64_t id, std::string_view name,
+    Metadata&& metadata, std::shared_ptr<Table> table,
+    bool enableWindowedStats) {
   return std::make_shared<TransactionalCache<Hasher>>(
       Cache::ConstructionGuard(), manager, id, name, std::move(metadata),
       std::move(table), enableWindowedStats);
@@ -260,7 +261,7 @@ std::shared_ptr<Cache> TransactionalCache<Hasher>::create(
 template<typename Hasher>
 TransactionalCache<Hasher>::TransactionalCache(
     Cache::ConstructionGuard /*guard*/, Manager* manager, std::uint64_t id,
-    std::string const& name, Metadata&& metadata, std::shared_ptr<Table> table,
+    std::string_view name, Metadata&& metadata, std::shared_ptr<Table> table,
     bool enableWindowedStats)
     : Cache(manager, id, name, std::move(metadata), std::move(table),
             enableWindowedStats, TransactionalCache::bucketClearer,

--- a/arangod/Cache/TransactionalCache.cpp
+++ b/arangod/Cache/TransactionalCache.cpp
@@ -250,18 +250,19 @@ std::string_view TransactionalCache<Hasher>::hasherName() const noexcept {
 
 template<typename Hasher>
 std::shared_ptr<Cache> TransactionalCache<Hasher>::create(
-    Manager* manager, std::uint64_t id, Metadata&& metadata,
+    Manager* manager, std::uint64_t id, std::string const& name, Metadata&& metadata,
     std::shared_ptr<Table> table, bool enableWindowedStats) {
   return std::make_shared<TransactionalCache<Hasher>>(
-      Cache::ConstructionGuard(), manager, id, std::move(metadata),
+      Cache::ConstructionGuard(), manager, id, name, std::move(metadata),
       std::move(table), enableWindowedStats);
 }
 
 template<typename Hasher>
 TransactionalCache<Hasher>::TransactionalCache(
     Cache::ConstructionGuard /*guard*/, Manager* manager, std::uint64_t id,
-    Metadata&& metadata, std::shared_ptr<Table> table, bool enableWindowedStats)
-    : Cache(manager, id, std::move(metadata), std::move(table),
+    std::string const& name, Metadata&& metadata, std::shared_ptr<Table> table,
+    bool enableWindowedStats)
+    : Cache(manager, id, name, std::move(metadata), std::move(table),
             enableWindowedStats, TransactionalCache::bucketClearer,
             TransactionalBucket::kSlotsData) {}
 

--- a/arangod/Cache/TransactionalCache.h
+++ b/arangod/Cache/TransactionalCache.h
@@ -58,7 +58,7 @@ template<typename Hasher>
 class TransactionalCache final : public Cache {
  public:
   TransactionalCache(Cache::ConstructionGuard guard, Manager* manager,
-                     std::uint64_t id, Metadata&& metadata,
+                     std::uint64_t id, std::string const& name, Metadata&& metadata,
                      std::shared_ptr<Table> table, bool enableWindowedStats);
   ~TransactionalCache();
 
@@ -122,6 +122,7 @@ class TransactionalCache final : public Cache {
   friend class MigrateTask;
 
   static std::shared_ptr<Cache> create(Manager* manager, std::uint64_t id,
+                                       std::string const& name,
                                        Metadata&& metadata,
                                        std::shared_ptr<Table> table,
                                        bool enableWindowedStats);

--- a/arangod/Cache/TransactionalCache.h
+++ b/arangod/Cache/TransactionalCache.h
@@ -58,8 +58,9 @@ template<typename Hasher>
 class TransactionalCache final : public Cache {
  public:
   TransactionalCache(Cache::ConstructionGuard guard, Manager* manager,
-                     std::uint64_t id, std::string const& name, Metadata&& metadata,
-                     std::shared_ptr<Table> table, bool enableWindowedStats);
+                     std::uint64_t id, std::string_view name,
+                     Metadata&& metadata, std::shared_ptr<Table> table,
+                     bool enableWindowedStats);
   ~TransactionalCache();
 
   TransactionalCache() = delete;
@@ -122,7 +123,7 @@ class TransactionalCache final : public Cache {
   friend class MigrateTask;
 
   static std::shared_ptr<Cache> create(Manager* manager, std::uint64_t id,
-                                       std::string const& name,
+                                       std::string_view name,
                                        Metadata&& metadata,
                                        std::shared_ptr<Table> table,
                                        bool enableWindowedStats);

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -2095,7 +2095,7 @@ void RocksDBCollection::setupCache() const {
     TRI_ASSERT(_cacheManager->options().maxCacheValueSize > 0);
     LOG_TOPIC("f5df2", DEBUG, Logger::CACHE) << "Creating document cache";
     cache = _cacheManager->createCache<cache::BinaryKeyHasher>(
-        cache::CacheType::Transactional);
+      cache::CacheType::Transactional, _logicalCollection.name());
     std::atomic_store_explicit(&_cache, std::move(cache),
                                std::memory_order_relaxed);
   }

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -345,7 +345,7 @@ bool RocksDBIndex::canWarmup() const noexcept { return useCache() != nullptr; }
 std::shared_ptr<cache::Cache> RocksDBIndex::makeCache() const {
   TRI_ASSERT(_cacheManager != nullptr);
   return _cacheManager->createCache<cache::BinaryKeyHasher>(
-      cache::CacheType::Transactional);
+      cache::CacheType::Transactional, _collection.name());
 }
 
 // banish given key from transactional cache

--- a/arangod/RocksDBEngine/RocksDBIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndex.cpp
@@ -344,8 +344,9 @@ bool RocksDBIndex::canWarmup() const noexcept { return useCache() != nullptr; }
 
 std::shared_ptr<cache::Cache> RocksDBIndex::makeCache() const {
   TRI_ASSERT(_cacheManager != nullptr);
+
   return _cacheManager->createCache<cache::BinaryKeyHasher>(
-      cache::CacheType::Transactional, _collection.name());
+      cache::CacheType::Transactional, _collection.name() + "/" + _name);
 }
 
 // banish given key from transactional cache

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -2842,8 +2842,9 @@ Result RocksDBVPackIndex::drop() {
 
 std::shared_ptr<cache::Cache> RocksDBVPackIndex::makeCache() const {
   TRI_ASSERT(_cacheManager != nullptr);
+
   return _cacheManager->createCache<cache::VPackKeyHasher>(
-      cache::CacheType::Transactional, _collection.name());
+      cache::CacheType::Transactional, _collection.name() + "/" + _name);
 }
 
 RocksDBCuckooIndexEstimatorType* RocksDBVPackIndex::estimator() {

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -2843,7 +2843,7 @@ Result RocksDBVPackIndex::drop() {
 std::shared_ptr<cache::Cache> RocksDBVPackIndex::makeCache() const {
   TRI_ASSERT(_cacheManager != nullptr);
   return _cacheManager->createCache<cache::VPackKeyHasher>(
-      cache::CacheType::Transactional);
+      cache::CacheType::Transactional, _collection.name());
 }
 
 RocksDBCuckooIndexEstimatorType* RocksDBVPackIndex::estimator() {

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -8,7 +8,7 @@ if [ $(ulimit -S -n) -lt 131072 ]; then
     ulimit -S -n 131072 || true
 fi
 
-rm -rf cluster
+#rm -rf cluster
 if [ -d cluster-init ];then
   echo "== creating cluster directory from existing cluster-init directory"
   cp -a cluster-init cluster
@@ -167,6 +167,7 @@ for aid in `seq 0 $(( $NRAGENTS - 1 ))`; do
       --server.descriptors-minimum 0 
       --network.compression-method lz4
       --network.compress-request-threshold 1
+      --vector-index true
 EOM
 
     AGENCY_OPTIONS="$AGENCY_OPTIONS $AUTHENTICATION $SSLKEYFILE $ENCRYPTION"

--- a/tests/Cache/Manager.cpp
+++ b/tests/Cache/Manager.cpp
@@ -31,6 +31,7 @@
 #include <thread>
 #include <vector>
 
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/debugging.h"
 #include "Cache/BinaryKeyHasher.h"
@@ -64,7 +65,7 @@ TEST_F(CacheManagerTest, test_memory_usage_for_cache_creation) {
   CacheOptions co;
   co.cacheSize = requestLimit;
   co.maxSpareAllocation = 0;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -75,7 +76,8 @@ TEST_F(CacheManagerTest, test_memory_usage_for_cache_creation) {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
     ASSERT_EQ(0, beforeStats.activeTables);
 
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     ASSERT_NE(nullptr, cache);
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
@@ -96,7 +98,7 @@ TEST_F(CacheManagerTest, test_memory_usage_for_cache_reusage) {
   CacheOptions co;
   co.cacheSize = requestLimit;
   co.maxSpareAllocation = 256 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -107,7 +109,8 @@ TEST_F(CacheManagerTest, test_memory_usage_for_cache_reusage) {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
     ASSERT_EQ(0, beforeStats.activeTables);
 
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     ASSERT_NE(nullptr, cache);
 
     manager.destroyCache(std::move(cache));
@@ -117,7 +120,7 @@ TEST_F(CacheManagerTest, test_memory_usage_for_cache_reusage) {
     ASSERT_EQ(1, afterStats.spareTables);
     ASSERT_LT(beforeStats.globalAllocation, afterStats.globalAllocation);
 
-    cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
 
     auto afterStats2 = manager.memoryStats(cache::Cache::triesGuarantee);
     ASSERT_EQ(1, afterStats2.activeTables);
@@ -150,7 +153,7 @@ TEST_F(CacheManagerTest,
   CacheOptions co;
   co.cacheSize = requestLimit;
   co.maxSpareAllocation = 256 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -164,11 +167,12 @@ TEST_F(CacheManagerTest,
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
 
     TRI_AddFailurePointDebugging("CacheAllocation::fail1");
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     ASSERT_EQ(nullptr, cache);
 
     TRI_ClearFailurePointsDebugging();
-    cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     ASSERT_NE(nullptr, cache);
 
     manager.destroyCache(std::move(cache));
@@ -185,7 +189,7 @@ TEST_F(CacheManagerTest,
 
     TRI_AddFailurePointDebugging("CacheAllocation::fail2");
     ASSERT_ANY_THROW(
-        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, ""));
 
     manager.freeUnusedTablesForTesting();
 
@@ -199,7 +203,7 @@ TEST_F(CacheManagerTest,
 
     TRI_AddFailurePointDebugging("CacheAllocation::fail3");
     ASSERT_ANY_THROW(
-        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, ""));
 
     manager.freeUnusedTablesForTesting();
 
@@ -218,7 +222,7 @@ TEST_F(CacheManagerTest,
   CacheOptions co;
   co.cacheSize = requestLimit;
   co.maxSpareAllocation = 0;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -232,7 +236,8 @@ TEST_F(CacheManagerTest,
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
 
     TRI_AddFailurePointDebugging("CacheAllocation::fail1");
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     ASSERT_EQ(nullptr, cache);
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
@@ -246,7 +251,7 @@ TEST_F(CacheManagerTest,
 
     TRI_AddFailurePointDebugging("CacheAllocation::fail2");
     ASSERT_ANY_THROW(
-        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, ""));
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
     ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
@@ -259,7 +264,7 @@ TEST_F(CacheManagerTest,
 
     TRI_AddFailurePointDebugging("CacheAllocation::fail3");
     ASSERT_ANY_THROW(
-        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, ""));
 
     auto afterStats = manager.memoryStats(cache::Cache::triesGuarantee);
     ASSERT_EQ(beforeStats.globalAllocation, afterStats.globalAllocation);
@@ -274,7 +279,7 @@ TEST_F(CacheManagerTest, test_create_and_destroy_caches) {
   auto postFn = [](std::function<void()>) -> bool { return false; };
   CacheOptions co;
   co.cacheSize = requestLimit;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -287,7 +292,8 @@ TEST_F(CacheManagerTest, test_create_and_destroy_caches) {
     auto beforeStats = manager.memoryStats(cache::Cache::triesGuarantee);
     ASSERT_EQ(i, beforeStats.activeTables);
 
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     ASSERT_NE(nullptr, cache);
     ASSERT_GT(cache->size(),
               40 * 1024);  // size of each cache is about 40kb without stats
@@ -338,9 +344,10 @@ TEST_F(CacheManagerTest, test_manager_shutdown) {
   co.cacheSize = requestLimit;
 
   {
-    Manager manager(sharedPRNG, postFn, co);
+    Manager manager(server.server(), sharedPRNG, postFn, co);
 
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
     // now only manager owns cache pointer
     cache.reset();
 
@@ -358,9 +365,10 @@ TEST_F(CacheManagerTest, test_manager_shutdown_with_data_and_stats) {
   co.cacheSize = requestLimit;
 
   {
-    Manager manager(sharedPRNG, postFn, co);
+    Manager manager(server.server(), sharedPRNG, postFn, co);
 
-    auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+    auto cache =
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
 
     std::string key;
     std::string value;
@@ -397,7 +405,7 @@ TEST_F(CacheManagerTest, test_basic_constructor_function) {
   auto postFn = [](std::function<void()>) -> bool { return false; };
   CacheOptions co;
   co.cacheSize = requestLimit;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -407,7 +415,7 @@ TEST_F(CacheManagerTest, test_basic_constructor_function) {
   std::uint64_t bigRequestLimit = 4ULL * 1024ULL * 1024ULL * 1024ULL;
   CacheOptions co2;
   co2.cacheSize = bigRequestLimit;
-  Manager bigManager(sharedPRNG, nullptr, co2);
+  Manager bigManager(server.server(), sharedPRNG, nullptr, co2);
 
   ASSERT_EQ(bigRequestLimit, bigManager.globalLimit());
 
@@ -423,7 +431,7 @@ TEST_F(CacheManagerTest, test_memory_usage_for_data) {
   CacheOptions co;
   co.cacheSize = requestLimit;
   co.maxSpareAllocation = 0;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   ASSERT_EQ(requestLimit, manager.globalLimit());
 
@@ -439,7 +447,8 @@ TEST_F(CacheManagerTest, test_memory_usage_for_data) {
 
   auto guard = scopeGuard([]() noexcept { TRI_ClearFailurePointsDebugging(); });
 
-  auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+  auto cache =
+      manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
 
   // clear failure point
   guard.fire();
@@ -502,13 +511,13 @@ TEST_F(CacheManagerTest, test_mixed_cache_types_under_mixed_load_LongRunning) {
 
   CacheOptions co;
   co.cacheSize = 1024ULL * 1024ULL * 1024ULL;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   std::size_t cacheCount = 4;
   std::size_t threadCount = 4;
   std::vector<std::shared_ptr<Cache>> caches;
   for (std::size_t i = 0; i < cacheCount; i++) {
     auto res = manager.createCache<BinaryKeyHasher>(
-        (i % 2 == 0) ? CacheType::Plain : CacheType::Transactional);
+        (i % 2 == 0) ? CacheType::Plain : CacheType::Transactional, "");
     TRI_ASSERT(res);
     caches.emplace_back(res);
   }
@@ -617,7 +626,7 @@ TEST_F(CacheManagerTest, test_manager_under_cache_lifecycle_chaos_LongRunning) {
 
   CacheOptions co;
   co.cacheSize = 1024ULL * 1024ULL * 1024ULL;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   std::size_t threadCount = 4;
   std::uint64_t operationCount = 4ULL * 1024ULL;
 
@@ -630,7 +639,7 @@ TEST_F(CacheManagerTest, test_manager_under_cache_lifecycle_chaos_LongRunning) {
       switch (r) {
         case 0: {
           auto res = manager.createCache<BinaryKeyHasher>(
-              (i % 2 == 0) ? CacheType::Plain : CacheType::Transactional);
+              (i % 2 == 0) ? CacheType::Plain : CacheType::Transactional, "");
           if (res) {
             caches.emplace(res);
           }

--- a/tests/Cache/PlainCache.cpp
+++ b/tests/Cache/PlainCache.cpp
@@ -56,11 +56,11 @@ TEST_F(CachePlainCacheTest, test_basic_cache_creation) {
   auto postFn = [](std::function<void()>) -> bool { return false; };
   CacheOptions co;
   co.cacheSize = 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache1 =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, false, 256 * 1024);
-  auto cache2 =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, false, 512 * 1024);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache1 = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "",
+                                                     false, 256 * 1024);
+  auto cache2 = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "",
+                                                     false, 512 * 1024);
 
   ASSERT_EQ(0, cache1->usage());
   ASSERT_TRUE(256 * 1024 >= cache1->size());
@@ -76,9 +76,9 @@ TEST_F(CachePlainCacheTest, check_that_insertion_works_as_expected) {
   auto postFn = [](std::function<void()>) -> bool { return false; };
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, false, cacheLimit);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "", false,
+                                                    cacheLimit);
 
   for (std::uint64_t i = 0; i < 1024; i++) {
     CachedValue* value = CachedValue::construct(&i, sizeof(std::uint64_t), &i,
@@ -130,9 +130,9 @@ TEST_F(CachePlainCacheTest, test_that_removal_works_as_expected) {
   auto postFn = [](std::function<void()>) -> bool { return false; };
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, false, cacheLimit);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "", false,
+                                                    cacheLimit);
 
   for (std::uint64_t i = 0; i < 1024; i++) {
     CachedValue* value = CachedValue::construct(&i, sizeof(std::uint64_t), &i,
@@ -200,8 +200,8 @@ TEST_F(
 
   CacheOptions co;
   co.cacheSize = 1024 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Plain);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "");
   std::uint64_t minimumUsage = cache->usageLimit() * 2;
 
   for (std::uint64_t i = 0; i < 4 * 1024 * 1024; i++) {
@@ -230,10 +230,10 @@ TEST_F(CachePlainCacheTest, test_behavior_under_mixed_load_LongRunning) {
 
   CacheOptions co;
   co.cacheSize = 1024 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   std::size_t threadCount = 4;
   std::shared_ptr<Cache> cache =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain);
+      manager.createCache<BinaryKeyHasher>(CacheType::Plain, "");
 
   std::uint64_t chunkSize = 16 * 1024 * 1024;
   std::uint64_t initialInserts = 4 * 1024 * 1024;
@@ -330,13 +330,13 @@ TEST_F(CachePlainCacheTest, test_hit_rate_statistics_reporting) {
 
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cacheMiss =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, true, cacheLimit);
-  auto cacheHit =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, true, cacheLimit);
-  auto cacheMixed =
-      manager.createCache<BinaryKeyHasher>(CacheType::Plain, true, cacheLimit);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cacheMiss = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "",
+                                                        true, cacheLimit);
+  auto cacheHit = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "",
+                                                       true, cacheLimit);
+  auto cacheMixed = manager.createCache<BinaryKeyHasher>(CacheType::Plain, "",
+                                                         true, cacheLimit);
 
   for (std::uint64_t i = 0; i < 1024; i++) {
     CachedValue* value = CachedValue::construct(&i, sizeof(std::uint64_t), &i,

--- a/tests/Cache/Rebalancer.cpp
+++ b/tests/Cache/Rebalancer.cpp
@@ -81,14 +81,15 @@ TEST(CacheRebalancerTest, test_rebalancing_with_plaincache_LongRunning) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 128 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   Rebalancer rebalancer(&manager);
 
   std::size_t cacheCount = 4;
   std::size_t threadCount = 4;
   std::vector<std::shared_ptr<Cache>> caches;
   for (std::size_t i = 0; i < cacheCount; i++) {
-    caches.emplace_back(manager.createCache<BinaryKeyHasher>(CacheType::Plain));
+    caches.emplace_back(
+        manager.createCache<BinaryKeyHasher>(CacheType::Plain, ""));
   }
 
   std::atomic<bool> doneRebalancing(false);
@@ -211,7 +212,7 @@ TEST(CacheRebalancerTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 128 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   Rebalancer rebalancer(&manager);
 
   std::size_t cacheCount = 4;
@@ -219,7 +220,7 @@ TEST(CacheRebalancerTest,
   std::vector<std::shared_ptr<Cache>> caches;
   for (std::size_t i = 0; i < cacheCount; i++) {
     caches.emplace_back(
-        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, ""));
   }
 
   std::atomic_bool doneRebalancing = false;
@@ -361,7 +362,7 @@ TEST(
   CacheOptions co;
   // small enough so that we have memory pressure!
   co.cacheSize = 8 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   Rebalancer rebalancer(&manager);
 
   std::size_t cacheCount = 4;
@@ -369,7 +370,7 @@ TEST(
   std::vector<std::shared_ptr<Cache>> caches;
   for (std::size_t i = 0; i < cacheCount; i++) {
     caches.emplace_back(
-        manager.createCache<BinaryKeyHasher>(CacheType::Transactional));
+        manager.createCache<BinaryKeyHasher>(CacheType::Transactional, ""));
   }
 
   std::atomic_bool doneRebalancing = false;

--- a/tests/Cache/Table.cpp
+++ b/tests/Cache/Table.cpp
@@ -58,7 +58,7 @@ TEST(CacheTableTest, test_basic_constructor_behavior) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 16ULL * 1024ULL * 1024ULL;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   for (std::uint32_t i = Table::kMinLogSize; i <= 20; i++) {
     auto table = std::make_shared<Table>(i, &manager);
@@ -80,7 +80,7 @@ TEST(CacheTableTest, test_basic_bucket_fetching_behavior) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 16ULL * 1024ULL * 1024ULL;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
 
   auto table = std::make_shared<Table>(Table::kMinLogSize, &manager);
   ASSERT_NE(table.get(), nullptr);
@@ -118,7 +118,7 @@ class CacheTableMigrationTest : public ::testing::Test {
       : scheduler(4),
         co{.cacheSize = 16ULL * 1024ULL * 1024ULL},
         manager(
-            server.getFeature<SharedPRNGFeature>(),
+            server.server(), server.getFeature<SharedPRNGFeature>(),
             [this](std::function<void()> fn) -> bool {
               scheduler.post(fn);
               return true;

--- a/tests/Cache/TransactionalCache.cpp
+++ b/tests/Cache/TransactionalCache.cpp
@@ -54,11 +54,11 @@ TEST(CacheTransactionalCacheTest, test_basic_cache_construction) {
 
   CacheOptions co;
   co.cacheSize = 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   auto cache1 = manager.createCache<BinaryKeyHasher>(CacheType::Transactional,
-                                                     false, 256 * 1024);
+                                                     "", false, 256 * 1024);
   auto cache2 = manager.createCache<BinaryKeyHasher>(CacheType::Transactional,
-                                                     false, 512 * 1024);
+                                                     "", false, 512 * 1024);
 
   ASSERT_EQ(0, cache1->usage());
   ASSERT_TRUE(256 * 1024 >= cache1->size());
@@ -76,9 +76,9 @@ TEST(CacheTransactionalCacheTest, verify_that_insertion_works_as_expected) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional,
-                                                    false, cacheLimit);
+                                                    "", false, cacheLimit);
 
   for (std::uint64_t i = 0; i < 1024; i++) {
     CachedValue* value = CachedValue::construct(&i, sizeof(std::uint64_t), &i,
@@ -132,9 +132,9 @@ TEST(CacheTransactionalCacheTest, verify_removal_works_as_expected) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional,
-                                                    false, cacheLimit);
+                                                    "", false, cacheLimit);
 
   for (std::uint64_t i = 0; i < 1024; i++) {
     CachedValue* value = CachedValue::construct(&i, sizeof(std::uint64_t), &i,
@@ -198,9 +198,9 @@ TEST(CacheTransactionalCacheTest, verify_banishing_works_as_expected) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional,
-                                                    false, cacheLimit);
+                                                    "", false, cacheLimit);
 
   Transaction tx;
   manager.beginTransaction(tx, false);
@@ -274,8 +274,9 @@ TEST(CacheTransactionalCacheTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 1024 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache = manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache =
+      manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
   std::uint64_t minimumUsage = cache->usageLimit() * 2;
 
   for (std::uint64_t i = 0; i < 4 * 1024 * 1024; i++) {
@@ -305,10 +306,10 @@ TEST(CacheTransactionalCacheTest, test_behavior_under_mixed_load_LongRunning) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 1024 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   std::size_t threadCount = 4;
   std::shared_ptr<Cache> cache =
-      manager.createCache<BinaryKeyHasher>(CacheType::Transactional);
+      manager.createCache<BinaryKeyHasher>(CacheType::Transactional, "");
 
   std::uint64_t chunkSize = 16 * 1024 * 1024;
   std::uint64_t initialInserts = 4 * 1024 * 1024;

--- a/tests/Cache/TransactionalCacheVPackKeyHasher.cpp
+++ b/tests/Cache/TransactionalCacheVPackKeyHasher.cpp
@@ -29,6 +29,7 @@
 #include <thread>
 #include <vector>
 
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Cache/CacheOptionsProvider.h"
 #include "Cache/Common.h"
@@ -53,8 +54,8 @@ TEST(CacheTransactionalCacheVPackKeyHasherTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional,
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional, "",
                                                    false, cacheLimit);
 
   VPackBuilder builder;
@@ -105,8 +106,8 @@ TEST(CacheTransactionalCacheVPackKeyHasherTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional,
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional, "",
                                                    false, cacheLimit);
 
   std::vector<std::uint8_t> builder;
@@ -250,8 +251,8 @@ TEST(CacheTransactionalCacheVPackKeyHasherTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional,
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional, "",
                                                    false, cacheLimit);
 
   std::vector<std::uint8_t> builder;
@@ -436,8 +437,8 @@ TEST(CacheTransactionalCacheVPackKeyHasherTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 4 * cacheLimit;
-  Manager manager(sharedPRNG, postFn, co);
-  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional,
+  Manager manager(server.server(), sharedPRNG, postFn, co);
+  auto cache = manager.createCache<VPackKeyHasher>(CacheType::Transactional, "",
                                                    false, cacheLimit);
 
   Transaction tx;

--- a/tests/Cache/TransactionalStore.cpp
+++ b/tests/Cache/TransactionalStore.cpp
@@ -74,7 +74,7 @@ TransactionalStore::TransactionalStore(Manager* manager)
       _txOptions(rocksdb::TransactionOptions()) {
   TRI_ASSERT(manager != nullptr);
   _cache =
-      manager->createCache<BinaryKeyHasher>(CacheType::Transactional, true);
+      manager->createCache<BinaryKeyHasher>(CacheType::Transactional, "", true);
   TRI_ASSERT(_cache.get() != nullptr);
 
   _directory.appendText(TRI_GetTempPath());

--- a/tests/Cache/TransactionsWithBackingStore.cpp
+++ b/tests/Cache/TransactionsWithBackingStore.cpp
@@ -106,7 +106,7 @@ TEST(CacheWithBackingStoreTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 16 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   TransactionalStore store(&manager);
   std::uint64_t totalDocuments = 1000000;
   std::uint64_t hotsetSize = 50000;
@@ -162,7 +162,7 @@ TEST(CacheWithBackingStoreTest, test_hit_rate_for_mixed_workload_LongRunning) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 256 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   TransactionalStore store(&manager);
   std::uint64_t totalDocuments = 1000000;
   std::uint64_t batchSize = 1000;
@@ -256,7 +256,7 @@ TEST(CacheWithBackingStoreTest,
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 256 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   TransactionalStore store(&manager);
   std::uint64_t totalDocuments = 1000000;
   std::uint64_t writeBatchSize = 1000;
@@ -344,7 +344,7 @@ TEST(CacheWithBackingStoreTest, test_rebalancing_in_the_wild_LongRunning) {
   SharedPRNGFeature& sharedPRNG = server.getFeature<SharedPRNGFeature>();
   CacheOptions co;
   co.cacheSize = 16 * 1024 * 1024;
-  Manager manager(sharedPRNG, postFn, co);
+  Manager manager(server.server(), sharedPRNG, postFn, co);
   Rebalancer rebalancer(&manager);
   auto store1 = std::make_unique<TransactionalStore>(&manager);
   auto store2 = std::make_unique<TransactionalStore>(&manager);


### PR DESCRIPTION
### Scope & Purpose

*Add metrics to caches of the cache manager*

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly constructor/signature plumbing plus updated call sites; low behavioral risk aside from potential compile/runtime issues if any remaining `createCache` callers weren’t updated.
> 
> **Overview**
> Caches created via `cache::Manager::createCache()` now accept and store a `name` string, threading it through `Cache`/`PlainCache`/`TransactionalCache` constructors and the manager’s template instantiations.
> 
> RocksDB document and index caches are updated to pass the owning collection name when creating transactional caches, enabling per-cache identification for future metrics/observability work.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b51cf2032ee42836e99081a51024005a9f57f19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->