### PR TITLE
only add message on error to the xml report

### DIFF
--- a/js/client/modules/@arangodb/testutils/result-processing.js
+++ b/js/client/modules/@arangodb/testutils/result-processing.js
@@ -303,7 +303,7 @@ function saveToJunitXML(options, results) {
         name: state.xmlName,
       };
       state.xml.elem('testsuite', addOptionalDuration(elm, testSuite));
-      if (testSuite.hasOwnProperty('message') && testSuite.message !== "") {
+      if (!testSuite.status && testSuite.hasOwnProperty('message') && testSuite.message !== "") {
         state.xml.elem('testcase', addOptionalDuration({ name: `whole testsuite ${testSuiteName} failed` }, testSuiteName), false);
         state.xml.elem('failure');
         state.xml.text('<![CDATA[' + stripAnsiColors(testSuite.message) + ']]>\n');


### PR DESCRIPTION
### Scope & Purpose

If we have the message on success in the xml report, circleci will create weird ghost reports. Thus adjust the adapter not to write it on success. 

- [x] :hankey: Bugfix
