### PR TITLE
Fix typo in activities metric description

### DIFF
--- a/arangod/SystemMonitor/Activities/Feature.cpp
+++ b/arangod/SystemMonitor/Activities/Feature.cpp
@@ -48,7 +48,7 @@ DECLARE_GAUGE(arangodb_activities_ready_for_deletion, std::uint64_t,
               "for their garbage collection");
 
 DECLARE_COUNTER(arangodb_activities_thread_registries_total,
-                "Total number of threads that started actities "
+                "Total number of threads that started activities "
                 "since database process start");
 
 DECLARE_GAUGE(arangodb_activities_existing_thread_registries, std::uint64_t,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a metric description string; no behavior or data handling is affected.
> 
> **Overview**
> Fixes a typo in the help/description string for the `arangodb_activities_thread_registries_total` metric ("actities"  "activities").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57e2bf4f1e01aaff74d159cb15f60affb2694fb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->