### PR TITLE
Accept null for roles in JWT [BTS-2325]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 3.12.8 (XXXX-XX-XX)
 -------------------
 
+* Accept `null` as valid value for the `roles` attribute in JWT tokens.
+
 * Serve OpenAPI spec on /_arango/vX/openapi.json .
 
 * Fixed BTS-2309: Treat empty object as null with respect to schema.

--- a/arangod/Auth/TokenCache.cpp
+++ b/arangod/Auth/TokenCache.cpp
@@ -403,7 +403,7 @@ auth::TokenCache::Entry auth::TokenCache::validateJwtBody(
 
   // Extract roles from JWT token if present
   VPackSlice const rolesSlice = bodySlice.get("roles");
-  if (!rolesSlice.isNone()) {
+  if (!rolesSlice.isNone() && !rolesSlice.isNull()) {
     if (!rolesSlice.isArray()) {
       LOG_TOPIC("89899", TRACE, arangodb::Logger::AUTHENTICATION)
           << "roles must be an array";


### PR DESCRIPTION
### Scope & Purpose

Backport of: https://github.com/arangodb/arangodb/pull/22400

Be more tolerant for `roles` attribute in JWT token.
Accept a value of `null`.

- [*] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports:
  - [*] Backport for 3.12.8: this is it.


