### PR TITLE
Fix parsing of API version

### DIFF
--- a/3rdParty/fuerte/include/fuerte/ApiVersion.h
+++ b/3rdParty/fuerte/include/fuerte/ApiVersion.h
@@ -1,0 +1,44 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Max Neunhoeffer
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstdint>
+
+namespace arangodb {
+namespace fuerte {
+inline namespace v1 {
+
+/// @brief API version constants shared between fuerte and the ArangoDB server.
+/// Defined here (in fuerte) so that fuerte does not need to include server
+/// headers.  lib/Rest/ApiVersion.h re-exports these values.
+struct ApiVersion {
+  /// Version used when no /_arango/vX prefix is present
+  static constexpr uint32_t defaultApiVersion = 0;
+
+  /// Version accessed via /_arango/experimental
+  static constexpr uint32_t experimentalApiVersion = 2;
+};
+
+}  // namespace v1
+}  // namespace fuerte
+}  // namespace arangodb

--- a/3rdParty/fuerte/include/fuerte/message.h
+++ b/3rdParty/fuerte/include/fuerte/message.h
@@ -25,6 +25,7 @@
 #ifndef ARANGO_CXX_DRIVER_MESSAGE
 #define ARANGO_CXX_DRIVER_MESSAGE
 
+#include <fuerte/ApiVersion.h>
 #include <fuerte/asio_ns.h>
 #include <fuerte/types.h>
 #include <velocypack/Buffer.h>
@@ -101,7 +102,7 @@ struct RequestHeader final : public MessageHeader {
   /// Database that is the target of the request
   std::string database;
 
-  /// Local path of the request (without "/_db/" prefix)
+  /// Local path of the request (without "/_db/" and "/_arango/vX" prefixes)
   std::string path;
 
   /// Query parameters
@@ -109,6 +110,11 @@ struct RequestHeader final : public MessageHeader {
 
   /// HTTP method
   RestVerb restVerb = RestVerb::Illegal;
+
+  /// @brief API version, if specified via /_arango/vX or /_arango/experimental.
+  /// std::nullopt means no prefix was present; appendPath will not add one.
+  /// experimentalApiVersion means /_arango/experimental was used.
+  std::optional<uint32_t> apiVersion = std::nullopt;
 
   // accept header accessors
   ContentType acceptType() const { return _acceptType; }

--- a/3rdParty/fuerte/src/http.cpp
+++ b/3rdParty/fuerte/src/http.cpp
@@ -22,6 +22,10 @@
 
 #include "http.h"
 
+#include <fuerte/ApiVersion.h>
+
+#include <string>
+
 namespace arangodb { namespace fuerte { inline namespace v1 { namespace http {
 static inline int hex2int(char ch, int errorValue = 0) {
   if ('0' <= ch && ch <= '9') {
@@ -127,6 +131,17 @@ void urlDecode(std::string& out, std::string_view str) {
 }
 
 void appendPath(Request const& req, std::string& target) {
+  // Prepend /_arango/vX or /_arango/experimental if an API version was set
+  if (req.header.apiVersion.has_value()) {
+    uint32_t v = req.header.apiVersion.value();
+    if (v == fuerte::ApiVersion::experimentalApiVersion) {
+      target.append("/_arango/experimental", 21);
+    } else {
+      target.append("/_arango/v", 10);
+      target.append(std::to_string(v));
+    }
+  }
+
   // construct request path ("/_db/<name>/" prefix)
   if (!req.header.database.empty()) {
     target.append("/_db/", 5);

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -88,13 +88,71 @@ void RequestHeader::acceptType(std::string const& type) {
 }
 
 /// @brief analyze path and split into components
-/// strips /_db/<name> prefix, sets db name and fills parameters
+/// strips /_arango/vX (or /_arango/experimental) prefix, then /_db/<name>
+/// prefix; sets apiVersion, database, path, and fills parameters
 void RequestHeader::parseArangoPath(std::string_view p) {
   this->path = extractPathParameters(p, this->parameters);
+  this->apiVersion = std::nullopt;
+
+  // Detect and strip /_arango/vX or /_arango/experimental prefix.
+  // This must come before /_db/<name>.
+  {
+    constexpr std::string_view arangoPrefix = "/_arango/";
+    constexpr std::string_view experimentalSuffix = "experimental";
+    if (this->path.size() >= arangoPrefix.size() &&
+        std::string_view(this->path).substr(0, arangoPrefix.size()) ==
+            arangoPrefix) {
+      std::string_view remainder =
+          std::string_view(this->path).substr(arangoPrefix.size());
+      bool recognized = false;
+      if (remainder.starts_with(experimentalSuffix)) {
+        size_t suffixEnd = experimentalSuffix.size();
+        if (suffixEnd == remainder.size() || remainder[suffixEnd] == '/') {
+          this->apiVersion = ApiVersion::experimentalApiVersion;
+          this->path = suffixEnd < remainder.size()
+                           ? std::string(remainder.substr(suffixEnd))
+                           : "/";
+          recognized = true;
+        }
+      } else if (!remainder.empty() && remainder[0] == 'v') {
+        std::string_view afterV = remainder.substr(1);
+        size_t numEnd = 0;
+        while (numEnd < afterV.size() && (afterV[numEnd] >= '0' && afterV[numEnd] <= '9')) {
+          ++numEnd;
+        }
+        if (numEnd > 0 && (numEnd == afterV.size() || afterV[numEnd] == '/')) {
+          // parse version number (reject leading zeros except bare "0")
+          if (!(afterV[0] == '0' && numEnd > 1)) {
+            uint32_t version = 0;
+            bool overflow = false;
+            for (size_t i = 0; i < numEnd; ++i) {
+              uint32_t d = afterV[i] - '0';
+              if (version > (UINT32_MAX - d) / 10) {
+                overflow = true;
+                break;
+              }
+              version = version * 10 + d;
+            }
+            if (!overflow) {
+              this->apiVersion = version;
+              this->path = numEnd < afterV.size()
+                               ? std::string(afterV.substr(numEnd))
+                               : "/";
+              recognized = true;
+            }
+          }
+        }
+      }
+      if (!recognized) {
+        // /_arango/ present but not a valid prefix — leave path unchanged,
+        // apiVersion stays nullopt
+      }
+    }
+  }
 
   // extract database prefix /_db/<name>/
   const char* q = this->path.c_str();
-  if (this->path.size() >= 4 && q[0] == '/' && q[1] == '_' && q[2] == 'd' &&
+  if (this->path.size() >= 5 && q[0] == '/' && q[1] == '_' && q[2] == 'd' &&
       q[3] == 'b' && q[4] == '/') {
     // request contains database name
     q += 5;

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 3.12.8 (XXXX-XX-XX)
 -------------------
 
+* Fix parsing of API version (first /_arango/vX, then /_db/<dbname>).
+
 * Accept `null` as valid value for the `roles` attribute in JWT tokens.
 
 * Serve OpenAPI spec on /_arango/vX/openapi.json .

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -199,13 +199,6 @@ CommTask::Flow CommTask::prepareExecution(
            !ServerState::isDBServerId(_requestSource);
   });
 
-  // Detect and strip API version prefix (/_arango/vX or /_arango/experimental)
-  if (Result res = req.detectAndStripApiVersion(); res.fail()) {
-    sendErrorResponse(rest::ResponseCode::BAD, req.contentTypeResponse(),
-                      req.messageId(), res.errorNumber(), res.errorMessage());
-    return Flow::Abort;
-  }
-
   // Step 2: Handle server-modes, i.e. bootstrap / DC2DC stunts
   std::string const& path = req.requestPath();
 

--- a/arangod/GeneralServer/RestHandlerFactory.cpp
+++ b/arangod/GeneralServer/RestHandlerFactory.cpp
@@ -30,6 +30,8 @@
 #include "Rest/GeneralRequest.h"
 #include "Rest/GeneralResponse.h"
 
+#include <absl/strings/str_cat.h>
+
 using namespace arangodb;
 using namespace arangodb::basics;
 using namespace arangodb::rest;
@@ -65,8 +67,10 @@ std::shared_ptr<RestHandler> RestHandlerFactory::createHandler(
     errorBuilder.add("error", VPackValue(true));
     errorBuilder.add("code", VPackValue(404));
     errorBuilder.add("errorNum", VPackValue(404));
-    errorBuilder.add("errorMessage", VPackValue("unknown API version '" +
-                                                req->fullUrl() + "'"));
+    errorBuilder.add("errorMessage",
+                     VPackValue(absl::StrCat(
+                         "unknown API version ", std::to_string(apiVersion),
+                         " for path '", req->fullUrl(), "'")));
     errorBuilder.close();
 
     return nullptr;

--- a/lib/Rest/ApiVersion.h
+++ b/lib/Rest/ApiVersion.h
@@ -26,6 +26,8 @@
 #include <cstddef>
 #include <cstdint>
 
+#include <fuerte/ApiVersion.h>
+
 namespace arangodb {
 
 /// @brief Central configuration for API versioning
@@ -36,11 +38,17 @@ struct ApiVersion {
   // The list of deprecated API versions (subset of supportedApiVersions)
   static constexpr uint32_t deprecatedApiVersions[] = {};
 
-  // The default API version used when no /_arango/vX prefix is specified
-  static constexpr uint32_t defaultApiVersion = 0;
+  // The default API version used when no /_arango/vX prefix is specified.
+  // Value is defined in fuerte so that fuerte can use it without depending on
+  // server headers.
+  static constexpr uint32_t defaultApiVersion =
+      fuerte::ApiVersion::defaultApiVersion;
 
-  // The experimental API version (accessed via /_arango/experimental)
-  static constexpr uint32_t experimentalApiVersion = 2;
+  // The experimental API version (accessed via /_arango/experimental).
+  // Value is defined in fuerte so that fuerte can use it without depending on
+  // server headers.
+  static constexpr uint32_t experimentalApiVersion =
+      fuerte::ApiVersion::experimentalApiVersion;
 
   // Helper function to get the number of supported API versions
   static constexpr size_t numSupportedApiVersions() {

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -408,115 +408,93 @@ velocypack::Options const* GeneralRequest::validationOptions(
   return &basics::VelocyPackHelper::looseRequestValidationOptions;
 }
 
-Result GeneralRequest::detectAndStripApiVersion() {
+void GeneralRequest::detectAndStripApiVersion(char const*& start,
+                                              char const* end) {
   constexpr std::string_view arangoPrefix = "/_arango/";
   constexpr std::string_view experimentalSuffix = "experimental";
 
-  // Check if path starts with /_arango/
-  if (!_requestPath.starts_with(arangoPrefix)) {
-    // No /_arango/ prefix, this is fine
-    return Result();
+  size_t len = static_cast<size_t>(end - start);
+  if (len < arangoPrefix.size() ||
+      std::string_view(start, arangoPrefix.size()) != arangoPrefix) {
+    // No /_arango/ prefix, nothing to do
+    return;
   }
 
-  // Get the part after /_arango/
-  std::string_view remainder =
-      std::string_view(_requestPath).substr(arangoPrefix.size());
+  char const* p = start + arangoPrefix.size();
+  std::string_view remainder(p, static_cast<size_t>(end - p));
 
-  // Prepare generic error message:
-  auto genericErrorMsgMaker = [&]() {
-    return Result(
+  auto throwGenericError = [&]() {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
         TRI_ERROR_HTTP_BAD_PARAMETER,
         absl::StrCat("invalid API version prefix: expected '/_arango/vX' or "
                      "'/_arango/experimental', got instead: ",
-                     _requestPath));
+                     std::string_view(start, end - start)));
   };
 
-  // Check for empty remainder (path is exactly "/_arango/" or "/_arango")
+  // Check for empty remainder (path is exactly "/_arango/")
   if (remainder.empty()) {
-    return genericErrorMsgMaker();
+    throwGenericError();
   }
 
   // Check for /_arango/experimental
   if (remainder.starts_with(experimentalSuffix)) {
     size_t suffixEnd = experimentalSuffix.size();
-    // Make sure it's followed by / or is end of string
     if (suffixEnd == remainder.size() || remainder[suffixEnd] == '/') {
       _requestedApiVersion = ApiVersion::experimentalApiVersion;
-
-      // Strip the prefix, keep the rest of the path
-      if (suffixEnd < remainder.size()) {
-        // There's more path after /experimental
-        setRequestPath(std::string(remainder.substr(suffixEnd)));
-      } else {
-        // Path is exactly /_arango/experimental
-        setRequestPath("/");
-      }
-      return Result();
-    } else {
-      return genericErrorMsgMaker();
+      start = p + suffixEnd;  // advance past "/_arango/experimental"
+      return;
     }
+    throwGenericError();
   }
 
   // Check for /_arango/vX where X is a decimal number
   if (remainder.starts_with('v')) {
     std::string_view afterV = remainder.substr(1);
 
-    // Parse decimal number
     size_t numEnd = 0;
     while (numEnd < afterV.size() && std::isdigit(afterV[numEnd])) {
       ++numEnd;
     }
 
-    if (numEnd > 0) {
-      // We found at least one digit
-      // Make sure it's followed by / or is end of string
-      if (numEnd == afterV.size() || afterV[numEnd] == '/') {
-        // Check for leading zeros: reject if version starts with '0' and has
-        // more than one digit
-        if (afterV[0] == '0' && numEnd > 1) {
-          return Result(
-              TRI_ERROR_HTTP_BAD_PARAMETER,
-              absl::StrCat("invalid API version: version number must not have "
-                           "leading zeros, got path: ",
-                           _requestPath));
-        }
-
-        // Parse the version number
-        std::string versionStr(afterV.substr(0, numEnd));
-        uint64_t version;
-        try {
-          version = std::stoull(versionStr);
-        } catch (std::exception& e) {
-          return Result(TRI_ERROR_HTTP_BAD_PARAMETER,
-                        absl::StrCat("invalid API version: failed to parse "
-                                     "version number: ",
-                                     e.what(), ", got path: ", _requestPath));
-        }
-        if (version <= std::numeric_limits<uint32_t>::max()) {
-          _requestedApiVersion = static_cast<uint32_t>(version);
-
-          // Strip the prefix, keep the rest of the path
-          if (numEnd < afterV.size()) {
-            // There's more path after /vX
-            setRequestPath(std::string(afterV.substr(numEnd)));
-          } else {
-            // Path is exactly /_arango/vX
-            setRequestPath("/");
-          }
-          return Result();
-        } else {
-          return Result(
-              TRI_ERROR_HTTP_BAD_PARAMETER,
-              absl::StrCat(
-                  "invalid API version: version number too large, got path: ",
-                  _requestPath));
-        }
+    if (numEnd > 0 && (numEnd == afterV.size() || afterV[numEnd] == '/')) {
+      // Check for leading zeros
+      if (afterV[0] == '0' && numEnd > 1) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_HTTP_BAD_PARAMETER,
+            absl::StrCat("invalid API version: version number must not have "
+                         "leading zeros, got path: ",
+                         std::string_view(start, end - start)));
       }
+
+      std::string versionStr(afterV.substr(0, numEnd));
+      uint64_t version;
+      try {
+        version = std::stoull(versionStr);
+      } catch (std::exception& e) {
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_HTTP_BAD_PARAMETER,
+            absl::StrCat(
+                "invalid API version: failed to parse version number: ",
+                e.what(),
+                ", got path: ", std::string_view(start, end - start)));
+      }
+
+      if (version <= std::numeric_limits<uint32_t>::max()) {
+        _requestedApiVersion = static_cast<uint32_t>(version);
+        start = p + 1 + numEnd;  // advance past "/_arango/vX"
+        return;
+      }
+
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_HTTP_BAD_PARAMETER,
+          absl::StrCat("invalid API version: version number too large, "
+                       "got path: ",
+                       std::string_view(start, end - start)));
     }
   }
 
-  // If we get here, we have /_arango/ but it's not followed by a valid format
-  return genericErrorMsgMaker();
+  // /_arango/ present but not followed by a valid format
+  throwGenericError();
 }
 
 }  // namespace arangodb

--- a/lib/Rest/GeneralRequest.h
+++ b/lib/Rest/GeneralRequest.h
@@ -215,10 +215,12 @@ class GeneralRequest {
   /// @brief get the requested API version
   uint32_t requestedApiVersion() const noexcept { return _requestedApiVersion; }
 
-  /// @brief detect and strip /_arango/vX or /_arango/experimental prefix from
-  /// the request path
-  /// @return Result::OK if successful, error if /_arango prefix is invalid
-  Result detectAndStripApiVersion();
+  /// @brief detect and strip /_arango/vX or /_arango/experimental prefix.
+  /// @param start  reference to current position pointer; advanced past the
+  ///               prefix on success
+  /// @param end    one-past-the-end pointer of the URL buffer
+  /// @throws ArangoException if /_arango prefix is present but invalid
+  void detectAndStripApiVersion(char const*& start, char const* end);
 
  protected:
   static RequestType findRequestType(char const*, size_t const);

--- a/lib/Rest/HttpRequest.cpp
+++ b/lib/Rest/HttpRequest.cpp
@@ -482,6 +482,9 @@ void HttpRequest::parseUrl(char const* path, size_t length) {
 
   char const* start = tmp.data();
   char const* end = start + tmp.size();
+  // Detect and strip /_arango/vX or /_arango/experimental prefix first,
+  // since it must come before /_db/<dbname>.
+  detectAndStripApiVersion(start, end);
   // look for database name in URL
   if (end - start >= 5) {
     char const* q = start;

--- a/tests/Rest/GeneralRequestTest.cpp
+++ b/tests/Rest/GeneralRequestTest.cpp
@@ -25,13 +25,43 @@
 #include "gtest/gtest.h"
 
 #include <limits>
+#include <string>
 
-#include "Basics/Result.h"
+#include "Basics/ErrorCode.h"
+#include "Basics/Exceptions.h"
 #include "Endpoint/ConnectionInfo.h"
 #include "Rest/ApiVersion.h"
 #include "Rest/HttpRequest.h"
 
 using namespace arangodb;
+
+// Helper: call detectAndStripApiVersion on a plain string path.
+// On success, returns the remaining path (from the advanced start pointer to
+// end) and sets apiVersionOut. On error (exception), returns std::nullopt and
+// sets errorNumberOut / errorMessageOut.
+struct DetectResult {
+  bool ok;
+  std::string remaining;  // path from advanced start to end
+  uint32_t apiVersion;
+  ErrorCode errorNumber;
+  std::string errorMessage;
+};
+
+static DetectResult callDetect(HttpRequest& request, std::string const& path) {
+  char const* start = path.data();
+  char const* end = path.data() + path.size();
+  try {
+    request.detectAndStripApiVersion(start, end);
+    return DetectResult{true,
+                        std::string(start, end),
+                        request.requestedApiVersion(),
+                        TRI_ERROR_NO_ERROR,
+                        {}};
+  } catch (arangodb::basics::Exception const& e) {
+    return DetectResult{false, path, request.requestedApiVersion(), e.code(),
+                        e.message()};
+  }
+}
 
 // Test fixture for API version detection tests
 class ApiVersionDetectionTest : public ::testing::Test {
@@ -42,269 +72,198 @@ class ApiVersionDetectionTest : public ::testing::Test {
 // Test: No API version prefix - should use default version
 TEST_F(ApiVersionDetectionTest, NoApiVersionPrefix) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_api/version");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_api/version", request.requestPath());
+  auto r = callDetect(request, "/_api/version");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_api/version", r.remaining);
 }
 
 // Test: Regular path without /_arango prefix
 TEST_F(ApiVersionDetectionTest, RegularPath) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/some/random/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/some/random/path", request.requestPath());
+  auto r = callDetect(request, "/some/random/path");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/some/random/path", r.remaining);
 }
 
 // Test: Valid API version v1
 TEST_F(ApiVersionDetectionTest, ValidApiVersionV1) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v1/_api/version");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(1u, request.requestedApiVersion());
-  EXPECT_EQ("/_api/version", request.requestPath());
+  auto r = callDetect(request, "/_arango/v1/_api/version");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(1u, r.apiVersion);
+  EXPECT_EQ("/_api/version", r.remaining);
 }
 
 // Test: Valid API version v2
 TEST_F(ApiVersionDetectionTest, ValidApiVersionV2) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v2/_api/collection");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(2u, request.requestedApiVersion());
-  EXPECT_EQ("/_api/collection", request.requestPath());
+  auto r = callDetect(request, "/_arango/v2/_api/collection");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(2u, r.apiVersion);
+  EXPECT_EQ("/_api/collection", r.remaining);
 }
 
 // Test: Valid API version v42
 TEST_F(ApiVersionDetectionTest, ValidApiVersionV42) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v42/_admin/status");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(42u, request.requestedApiVersion());
-  EXPECT_EQ("/_admin/status", request.requestPath());
+  auto r = callDetect(request, "/_arango/v42/_admin/status");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(42u, r.apiVersion);
+  EXPECT_EQ("/_admin/status", r.remaining);
 }
 
 // Test: Valid API version v1234567
 TEST_F(ApiVersionDetectionTest, ValidApiVersionLargeNumber) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v1234567/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(1234567u, request.requestedApiVersion());
-  EXPECT_EQ("/path", request.requestPath());
+  auto r = callDetect(request, "/_arango/v1234567/path");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(1234567u, r.apiVersion);
+  EXPECT_EQ("/path", r.remaining);
 }
 
 // Test: Experimental API version
 TEST_F(ApiVersionDetectionTest, ExperimentalApiVersion) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/experimental/_api/new-feature");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(ApiVersion::experimentalApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_api/new-feature", request.requestPath());
+  auto r = callDetect(request, "/_arango/experimental/_api/new-feature");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(ApiVersion::experimentalApiVersion, r.apiVersion);
+  EXPECT_EQ("/_api/new-feature", r.remaining);
 }
 
 // Test: Path ending exactly at version number
 TEST_F(ApiVersionDetectionTest, PathEndingAtVersion) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v5");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(5u, request.requestedApiVersion());
-  EXPECT_EQ("/", request.requestPath());
+  auto r = callDetect(request, "/_arango/v5");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(5u, r.apiVersion);
+  EXPECT_EQ("", r.remaining);
 }
 
 // Test: Path ending exactly at experimental
 TEST_F(ApiVersionDetectionTest, PathEndingAtExperimental) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/experimental");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(ApiVersion::experimentalApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/", request.requestPath());
+  auto r = callDetect(request, "/_arango/experimental");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(ApiVersion::experimentalApiVersion, r.apiVersion);
+  EXPECT_EQ("", r.remaining);
 }
 
 // Test: Invalid - path is exactly /_arango/
 TEST_F(ApiVersionDetectionTest, InvalidExactlyArango) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion,
-            request.requestedApiVersion());       // Should remain at default
-  EXPECT_EQ("/_arango/", request.requestPath());  // Path unchanged on error
+  auto r = callDetect(request, "/_arango/");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);  // unchanged on error
 }
 
 // Test: Invalid - missing v prefix
 TEST_F(ApiVersionDetectionTest, InvalidMissingVPrefix) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/1/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_arango/1/path", request.requestPath());
+  auto r = callDetect(request, "/_arango/1/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
 }
 
 // Test: Invalid - v without number
 TEST_F(ApiVersionDetectionTest, InvalidVWithoutNumber) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_arango/v/path", request.requestPath());
+  auto r = callDetect(request, "/_arango/v/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
 }
 
 // Test: Invalid - v with non-numeric characters
 TEST_F(ApiVersionDetectionTest, InvalidVWithAlpha) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/vabc/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_arango/vabc/path", request.requestPath());
+  auto r = callDetect(request, "/_arango/vabc/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
 }
 
 // Test: Invalid - random text after /_arango/
 TEST_F(ApiVersionDetectionTest, InvalidRandomText) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/invalid/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_arango/invalid/path", request.requestPath());
+  auto r = callDetect(request, "/_arango/invalid/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
 }
 
 // Test: Invalid - experimental typo
 TEST_F(ApiVersionDetectionTest, InvalidExperimentalTypo) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/experimenta/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
+  auto r = callDetect(request, "/_arango/experimenta/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
 }
 
-// Test: Edge case - v0 is valid (should match default if default is 0)
+// Test: Edge case - v0 is valid
 TEST_F(ApiVersionDetectionTest, ValidApiVersionV0) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v0/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(0u, request.requestedApiVersion());
-  EXPECT_EQ("/path", request.requestPath());
+  auto r = callDetect(request, "/_arango/v0/path");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(0u, r.apiVersion);
+  EXPECT_EQ("/path", r.remaining);
 }
 
 // Test: Version number followed by non-slash character should be invalid
 TEST_F(ApiVersionDetectionTest, InvalidVersionNotFollowedBySlash) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v1abc/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
+  auto r = callDetect(request, "/_arango/v1abc/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
 }
 
 // Test: Experimental followed by non-slash character should be invalid
 TEST_F(ApiVersionDetectionTest, InvalidExperimentalNotFollowedBySlash) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/experimentalabc/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
+  auto r = callDetect(request, "/_arango/experimentalabc/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
 }
 
-// Test: Multiple slashes after version
+// Test: Multiple slashes after version (start pointer lands at first slash,
+// remaining slashes are left for the caller to handle)
 TEST_F(ApiVersionDetectionTest, MultipleSlashesAfterVersion) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v1///path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(1, request.requestedApiVersion());
-  EXPECT_EQ("///path", request.requestPath());
+  auto r = callDetect(request, "/_arango/v1///path");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(1u, r.apiVersion);
+  EXPECT_EQ("///path", r.remaining);
 }
 
 // Test: Root path
 TEST_F(ApiVersionDetectionTest, RootPath) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/", request.requestPath());
+  auto r = callDetect(request, "/");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/", r.remaining);
 }
 
 // Test: Deep nested path with version
 TEST_F(ApiVersionDetectionTest, DeepNestedPath) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v3/_api/collection/test/document/123");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(3u, request.requestedApiVersion());
-  EXPECT_EQ("/_api/collection/test/document/123", request.requestPath());
+  auto r = callDetect(request, "/_arango/v3/_api/collection/test/document/123");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(3u, r.apiVersion);
+  EXPECT_EQ("/_api/collection/test/document/123", r.remaining);
 }
 
 // Test: Path with query parameters (should work on path only)
 TEST_F(ApiVersionDetectionTest, PathWithQueryString) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v7/_api/cursor");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(7u, request.requestedApiVersion());
-  EXPECT_EQ("/_api/cursor", request.requestPath());
+  auto r = callDetect(request, "/_arango/v7/_api/cursor");
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(7u, r.apiVersion);
+  EXPECT_EQ("/_api/cursor", r.remaining);
 }
 
 // Test: API version at max uint32_t - 1 should work
@@ -313,14 +272,10 @@ TEST_F(ApiVersionDetectionTest, MaxUint32Minus1) {
   std::string path = "/_arango/v" +
                      std::to_string(std::numeric_limits<uint32_t>::max() - 1) +
                      "/path";
-  request.setRequestPath(path);
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.ok());
-  EXPECT_EQ(std::numeric_limits<uint32_t>::max() - 1,
-            request.requestedApiVersion());
-  EXPECT_EQ("/path", request.requestPath());
+  auto r = callDetect(request, path);
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(std::numeric_limits<uint32_t>::max() - 1, r.apiVersion);
+  EXPECT_EQ("/path", r.remaining);
 }
 
 // Test: Check that default API version constant is accessible and is 0
@@ -331,190 +286,133 @@ TEST_F(ApiVersionDetectionTest, DefaultApiVersionConstant) {
 // Test: Verify default version is applied to new requests
 TEST_F(ApiVersionDetectionTest, NewRequestHasDefaultVersion) {
   HttpRequest request(ci, 1);
-  // Before calling detectAndStripApiVersion, apiVersion should be
-  // defaultApiVersion
   EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
 }
 
 // Test: API version exceeding uint32_t max should be rejected
 TEST_F(ApiVersionDetectionTest, VersionExceedsUint32Max) {
   HttpRequest request(ci, 1);
-  // Create a version number that's uint32_t::max() + 1
   uint64_t tooLarge =
       static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;
   std::string path = "/_arango/v" + std::to_string(tooLarge) + "/path";
-  request.setRequestPath(path);
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion,
-            request.requestedApiVersion());  // Should remain at default
-  EXPECT_EQ(path, request.requestPath());    // Path unchanged on error
-  // Verify the error message mentions the version is too large
-  EXPECT_NE(std::string::npos, res.errorMessage().find("too large"));
+  auto r = callDetect(request, path);
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("too large"));
 }
 
 // Test: Version with leading zero should be rejected (v01)
 TEST_F(ApiVersionDetectionTest, InvalidVersionLeadingZeroV01) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v01/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_arango/v01/path", request.requestPath());
-  // Verify the error message mentions leading zeros
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v01/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version with leading zero should be rejected (v007)
 TEST_F(ApiVersionDetectionTest, InvalidVersionLeadingZeroV007) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v007/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ("/_arango/v007/path", request.requestPath());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v007/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version with leading zero should be rejected (v0123)
 TEST_F(ApiVersionDetectionTest, InvalidVersionLeadingZeroV0123) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v0123/_api/version");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v0123/_api/version");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version v00 should be rejected
 TEST_F(ApiVersionDetectionTest, InvalidVersionV00) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v00/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v00/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version v000 should be rejected
 TEST_F(ApiVersionDetectionTest, InvalidVersionV000) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v000");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v000");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version v010 should be rejected
 TEST_F(ApiVersionDetectionTest, InvalidVersionV010) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v010");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v010");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version v0100 should be rejected
 TEST_F(ApiVersionDetectionTest, InvalidVersionV0100) {
   HttpRequest request(ci, 1);
-  request.setRequestPath("/_arango/v0100/path");
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("leading zeros"));
+  auto r = callDetect(request, "/_arango/v0100/path");
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
 // Test: Version number that exceeds uint64_t max should trigger stoull
 // exception
 TEST_F(ApiVersionDetectionTest, VersionExceedsUint64Max) {
   HttpRequest request(ci, 1);
-  // Create a version number that's way too large for uint64_t
-  // uint64_t max is 18446744073709551615 (20 digits)
-  // Let's use a number with many more digits
   std::string path = "/_arango/v99999999999999999999999999999999/path";
-  request.setRequestPath(path);
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ(path, request.requestPath());
-  // Verify the error message mentions the parsing failure
-  EXPECT_NE(std::string::npos, res.errorMessage().find("failed to parse"));
+  auto r = callDetect(request, path);
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }
 
 // Test: Version number at uint64_t max boundary
 TEST_F(ApiVersionDetectionTest, VersionAtUint64Max) {
   HttpRequest request(ci, 1);
-  // uint64_t max is 18446744073709551615
+  // uint64_t max is 18446744073709551615 - exceeds uint32_t max
   std::string path = "/_arango/v18446744073709551615/path";
-  request.setRequestPath(path);
-
-  Result res = request.detectAndStripApiVersion();
-
-  // This should succeed in parsing but fail because it exceeds uint32_t max
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ(path, request.requestPath());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("too large"));
+  auto r = callDetect(request, path);
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("too large"));
 }
 
 // Test: Version number slightly above uint64_t max
 TEST_F(ApiVersionDetectionTest, VersionSlightlyAboveUint64Max) {
   HttpRequest request(ci, 1);
-  // uint64_t max is 18446744073709551615, let's use 18446744073709551616
   std::string path = "/_arango/v18446744073709551616/path";
-  request.setRequestPath(path);
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ(path, request.requestPath());
-  // Should trigger stoull exception for out_of_range
-  EXPECT_NE(std::string::npos, res.errorMessage().find("failed to parse"));
+  auto r = callDetect(request, path);
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }
 
 // Test: Very long string of digits that would cause stoull to throw
 TEST_F(ApiVersionDetectionTest, VersionExcessivelyLongNumber) {
   HttpRequest request(ci, 1);
-  // Create a version with 100 digits
   std::string hugeNumber(100, '9');
   std::string path = "/_arango/v" + hugeNumber + "/path";
-  request.setRequestPath(path);
-
-  Result res = request.detectAndStripApiVersion();
-
-  EXPECT_TRUE(res.fail());
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, res.errorNumber());
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
-  EXPECT_EQ(path, request.requestPath());
-  EXPECT_NE(std::string::npos, res.errorMessage().find("failed to parse"));
+  auto r = callDetect(request, path);
+  EXPECT_FALSE(r.ok);
+  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }

--- a/tests/js/client/shell/api/multi/http.js
+++ b/tests/js/client/shell/api/multi/http.js
@@ -444,7 +444,7 @@ function API_versioningSuite () {
       let doc = arango.GET_RAW(cmd);
 
       // Should error because version number is missing
-      assertEqual(doc.code, 400);
+      assertEqual(doc.code, 404);
       assertTrue(doc.parsedBody.error);
       assertCspHeaders(doc);
     },
@@ -454,17 +454,7 @@ function API_versioningSuite () {
       let doc = arango.GET_RAW(cmd);
 
       // Should error because version number is not numeric
-      assertEqual(doc.code, 400);
-      assertTrue(doc.parsedBody.error);
-      assertCspHeaders(doc);
-    },
-
-    test_checks_version_endpoint_with_invalid_prefix_wrong_path: function() {
-      let cmd = "/_arango/version/_api/version";
-      let doc = arango.GET_RAW(cmd);
-
-      // Should error because prefix format is wrong (should be /vN, not /version)
-      assertEqual(doc.code, 400);
+      assertEqual(doc.code, 404);
       assertTrue(doc.parsedBody.error);
       assertCspHeaders(doc);
     },


### PR DESCRIPTION
Parse API Versioning path properly.

- **Parse path correctly.**
- **CHANGELOG.**
- **Adjust fuerte behaviour to know about /_arango/vX prefix.**
- **Fix tests and improve error message.**

This is a backport from devel for: https://github.com/arangodb/arangodb/pull/22407

### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
  - [*] **integration tests**
- [*] :book: CHANGELOG entry made
- [*] Backports:
  - [*] Backport for 3.12.8: This is it.

#### Related Information

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-273?atlOrigin=eyJpIjoiMTcwNjZlODlmOTRlNGJmMTllNDFmNDFhZDFiNGU5ODIiLCJwIjoiaiJ9

