### PR TITLE
Fix deadlock in UserManager on shutdown

### DIFF
--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -424,7 +424,7 @@ void AuthenticationFeature::start() {
   LOG_TOPIC("3844e", INFO, arangodb::Logger::AUTHENTICATION) << out.str();
 }
 
-void AuthenticationFeature::beginShutdown() {
+void AuthenticationFeature::stop() {
   if (_userManager) {
     _userManager->shutdown();
   }

--- a/arangod/GeneralServer/AuthenticationFeature.h
+++ b/arangod/GeneralServer/AuthenticationFeature.h
@@ -52,7 +52,7 @@ class AuthenticationFeature final
   void validateOptions(std::shared_ptr<options::ProgramOptions>) override final;
   void prepare() override final;
   void start() override final;
-  void beginShutdown() override final;
+  void stop() override final;
   void unprepare() override final;
 
   static AuthenticationFeature* instance() noexcept;


### PR DESCRIPTION
### Scope & Purpose

The UserManager background thread uses AQL queries to fetch the existing
users, but the AQL feature is stopped before the AuthenticationFeature
which owns the UserManager.

Also fix a deadlock in the UserManager which can happen on shutdown.

This is a backport of https://github.com/arangodb/arangodb/pull/22406

- [x] :hankey: Bugfix

### Checklist

- [*] :book: CHANGELOG entry made
- [*] Backports:
  - [*] Backport for 3.12.8: This is it.

