### PR TITLE
clang-format.sh: Disable "label" security option for bind mount to fix permission denied caused by SELinux

### DIFF
--- a/scripts/clang-format.sh
+++ b/scripts/clang-format.sh
@@ -63,7 +63,7 @@ if [ -s "$changed_files_filename" ]; then
   cat -n "$changed_files_filename.sorted"
   echo
 
-  docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb arangodb/clang-format:1.2 "format" "$changed_files_filename.sorted" 
+  docker run --rm -u "$(id -u):$(id -g)" --mount type=bind,source="$adb_path",target=/usr/src/arangodb --security-opt label=disable arangodb/clang-format:1.2 "format" "$changed_files_filename.sorted" 
 fi
 status=$?
 


### PR DESCRIPTION
On Fedora for example, running the script failed despite having Docker installed (i.e. not using Podman via aliasing the docker command). This is because SELinux labels also apply to containers. With `:z`, Docker relabels file objects and the volume content will be shared between containers (shared volumes labels allow all containers to read/write content).

Alternatively, we could also specify `--security-opt label=disable`, but I guess `:z` can be used for selective.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the `docker run` invocation in a developer formatting script; impact is limited to local tooling behavior on SELinux-enabled hosts.
> 
> **Overview**
> Updates `scripts/clang-format.sh` to run the `arangodb/clang-format` container with `--security-opt label=disable` on the bind mount, avoiding SELinux-related permission issues when formatting files from the host workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86b1fb204a1922480476cf869473afdabebad83b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->