### PR TITLE
QA-764: enable resillience tests for V8-less builds

### DIFF
--- a/js/client/modules/@arangodb/testsuites/resilience.js
+++ b/js/client/modules/@arangodb/testsuites/resilience.js
@@ -60,15 +60,6 @@ const testPaths = {
 
 var _resilience = function(path, enableAliveMonitor, skipServerJS) {
   this.func = function resilience (options) {
-    if (skipServerJS && options.skipServerJS) {
-      return {
-        [path]: {
-          status: true,
-          message: 'test needs v8 on the server. please recompile with -DUSE_V8=On'
-        },
-        status: true
-      };
-    }
     let suiteName = path;
     let localOptions = _.clone(options);
     localOptions.cluster = true;


### PR DESCRIPTION
### Scope & Purpose

Re-enable the the resillience tests for builds without V8

- [x] :hankey: Bugfix
