### PR TITLE
[COR-285] Disable v1 API routes

### DIFF
--- a/3rdParty/fuerte/include/fuerte/message.h
+++ b/3rdParty/fuerte/include/fuerte/message.h
@@ -113,8 +113,7 @@ struct RequestHeader final : public MessageHeader {
 
   /// @brief API version, if specified via /_arango/vX or /_arango/experimental.
   /// std::nullopt means no prefix was present; appendPath will not add one.
-  /// experimentalApiVersion means /_arango/experimental was used.
-  std::optional<uint32_t> apiVersion = std::nullopt;
+  std::optional<std::string> apiVersion = std::nullopt;
 
   // accept header accessors
   ContentType acceptType() const { return _acceptType; }

--- a/3rdParty/fuerte/src/http.cpp
+++ b/3rdParty/fuerte/src/http.cpp
@@ -133,13 +133,8 @@ void urlDecode(std::string& out, std::string_view str) {
 void appendPath(Request const& req, std::string& target) {
   // Prepend /_arango/vX or /_arango/experimental if an API version was set
   if (req.header.apiVersion.has_value()) {
-    uint32_t v = req.header.apiVersion.value();
-    if (v == fuerte::ApiVersion::experimentalApiVersion) {
-      target.append("/_arango/experimental", 21);
-    } else {
-      target.append("/_arango/v", 10);
-      target.append(std::to_string(v));
-    }
+    target.append("/_arango/");
+    target.append(req.header.apiVersion.value());
   }
 
   // construct request path ("/_db/<name>/" prefix)

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -108,7 +108,7 @@ void RequestHeader::parseArangoPath(std::string_view p) {
       if (remainder.starts_with(experimentalSuffix)) {
         size_t suffixEnd = experimentalSuffix.size();
         if (suffixEnd == remainder.size() || remainder[suffixEnd] == '/') {
-          this->apiVersion = ApiVersion::experimentalApiVersion;
+          this->apiVersion = experimentalSuffix;
           this->path = suffixEnd < remainder.size()
                            ? std::string(remainder.substr(suffixEnd))
                            : "/";
@@ -117,7 +117,8 @@ void RequestHeader::parseArangoPath(std::string_view p) {
       } else if (!remainder.empty() && remainder[0] == 'v') {
         std::string_view afterV = remainder.substr(1);
         size_t numEnd = 0;
-        while (numEnd < afterV.size() && (afterV[numEnd] >= '0' && afterV[numEnd] <= '9')) {
+        while (numEnd < afterV.size() &&
+               (afterV[numEnd] >= '0' && afterV[numEnd] <= '9')) {
           ++numEnd;
         }
         if (numEnd > 0 && (numEnd == afterV.size() || afterV[numEnd] == '/')) {
@@ -134,7 +135,7 @@ void RequestHeader::parseArangoPath(std::string_view p) {
               version = version * 10 + d;
             }
             if (!overflow) {
-              this->apiVersion = version;
+              this->apiVersion = "v" + std::to_string(version);
               this->path = numEnd < afterV.size()
                                ? std::string(afterV.substr(numEnd))
                                : "/";

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -995,11 +995,10 @@ void GeneralServerFeature::defineRemainingHandlers(
   // actions defined in v8
   // ...........................................................................
 
-  // Note that the catchall handler must be added for every API version
-  // (including the currently unused experimental one), or else requests to
-  // unknown endpoints (Foxx) might run into a crash.
+  // Note that the catchall handler must only be added for API version 0 since
+  // this is the only one that needs to forward unknown endpoints to Foxx.
   f.addPrefixHandler("/", RestHandlerCreator<RestActionHandler>::createNoData,
-                     {0, 1, ApiVersion::experimentalApiVersion});
+                     {0});
 
   // engine specific handlers
   StorageEngine& engine = server().getFeature<EngineSelectorFeature>().engine();

--- a/arangod/GeneralServer/RestHandlerFactory.cpp
+++ b/arangod/GeneralServer/RestHandlerFactory.cpp
@@ -135,9 +135,15 @@ std::shared_ptr<RestHandler> RestHandlerFactory::createHandler(
     l = prefix->size() + 1;
   }
 
-  // we must have found a handler - at least the catch-all handler must be
-  // present
-  TRI_ASSERT(it != constructors.end());
+  // we did not find a route
+  // this may only happen for API versions > 0 since API version 0 always has a
+  // catch-all handler registered at "/" to forward to Foxx.
+  // For all other versions we return null to indicate that we have not found a
+  // handler, which will lead to a 404 response.
+  if (it == constructors.end()) {
+    TRI_ASSERT(apiVersion > 0);
+    return nullptr;
+  }
 
   size_t n = path.find('/', l);
 
@@ -169,6 +175,13 @@ void RestHandlerFactory::addHandler(std::string const& path, create_fptr func,
   TRI_ASSERT(!_sealed);
 
   for (uint32_t apiVersion : apiVersions) {
+    if (!ApiVersion::isApiVersionSupported(apiVersion) &&
+        apiVersion != ApiVersion::experimentalApiVersion) {
+      // version 1 has been removed from the list of supported versions, but we
+      // did not change the version list in the handler factory, so we need to
+      // ignore attempts to register handlers for version 1
+      continue;
+    }
     TRI_ASSERT(apiVersion < _constructors.size());
     auto& constructors = _constructors[apiVersion];
     if (!constructors.try_emplace(path, func, data).second) {
@@ -193,6 +206,13 @@ void RestHandlerFactory::addPrefixHandler(
   addHandler(path, func, apiVersions, data);
 
   for (uint32_t apiVersion : apiVersions) {
+    if (!ApiVersion::isApiVersionSupported(apiVersion) &&
+        apiVersion != ApiVersion::experimentalApiVersion) {
+      // version 1 has been removed from the list of supported versions, but we
+      // did not change the version list in the handler factory, so we need to
+      // ignore attempts to register handlers for version 1
+      continue;
+    }
     TRI_ASSERT(apiVersion < _prefixes.size());
     _prefixes[apiVersion].emplace_back(path);
   }

--- a/lib/Rest/ApiVersion.h
+++ b/lib/Rest/ApiVersion.h
@@ -33,7 +33,7 @@ namespace arangodb {
 /// @brief Central configuration for API versioning
 struct ApiVersion {
   // The list of all supported API versions (both stable and deprecated)
-  static constexpr uint32_t supportedApiVersions[] = {0, 1};
+  static constexpr uint32_t supportedApiVersions[] = {0};
 
   // The list of deprecated API versions (subset of supportedApiVersions)
   static constexpr uint32_t deprecatedApiVersions[] = {};

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -437,10 +437,12 @@ void GeneralRequest::detectAndStripApiVersion(char const*& start,
   }
 
   // Check for /_arango/experimental
+  bool isExperimental = false;
   if (remainder.starts_with(experimentalSuffix)) {
     size_t suffixEnd = experimentalSuffix.size();
     if (suffixEnd == remainder.size() || remainder[suffixEnd] == '/') {
       _requestedApiVersion = ApiVersion::experimentalApiVersion;
+      isExperimental = true;
       start = p + suffixEnd;  // advance past "/_arango/experimental"
       return;
     }
@@ -448,53 +450,49 @@ void GeneralRequest::detectAndStripApiVersion(char const*& start,
   }
 
   // Check for /_arango/vX where X is a decimal number
-  if (remainder.starts_with('v')) {
-    std::string_view afterV = remainder.substr(1);
-
-    size_t numEnd = 0;
-    while (numEnd < afterV.size() && std::isdigit(afterV[numEnd])) {
-      ++numEnd;
-    }
-
-    if (numEnd > 0 && (numEnd == afterV.size() || afterV[numEnd] == '/')) {
-      // Check for leading zeros
-      if (afterV[0] == '0' && numEnd > 1) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(
-            TRI_ERROR_HTTP_BAD_PARAMETER,
-            absl::StrCat("invalid API version: version number must not have "
-                         "leading zeros, got path: ",
-                         std::string_view(start, end - start)));
-      }
-
-      std::string versionStr(afterV.substr(0, numEnd));
-      uint64_t version;
-      try {
-        version = std::stoull(versionStr);
-      } catch (std::exception& e) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(
-            TRI_ERROR_HTTP_BAD_PARAMETER,
-            absl::StrCat(
-                "invalid API version: failed to parse version number: ",
-                e.what(),
-                ", got path: ", std::string_view(start, end - start)));
-      }
-
-      if (version <= std::numeric_limits<uint32_t>::max()) {
-        _requestedApiVersion = static_cast<uint32_t>(version);
-        start = p + 1 + numEnd;  // advance past "/_arango/vX"
-        return;
-      }
-
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          TRI_ERROR_HTTP_BAD_PARAMETER,
-          absl::StrCat("invalid API version: version number too large, "
-                       "got path: ",
-                       std::string_view(start, end - start)));
-    }
+  if (!remainder.starts_with('v')) {
+    // /_arango/ present but not followed by a valid format
+    throwGenericError();
   }
 
-  // /_arango/ present but not followed by a valid format
-  throwGenericError();
+  std::string_view afterV = remainder.substr(1);
+
+  size_t numEnd = 0;
+  while (numEnd < afterV.size() && std::isdigit(afterV[numEnd])) {
+    ++numEnd;
+  }
+
+  if (numEnd > 0 && (numEnd == afterV.size() || afterV[numEnd] == '/')) {
+    // Check for leading zeros
+    if (afterV[0] == '0' && numEnd > 1) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_HTTP_BAD_PARAMETER,
+          absl::StrCat("invalid API version: version number must not have "
+                       "leading zeros, got path: ",
+                       std::string_view(start, end - start)));
+    }
+
+    std::string versionStr(afterV.substr(0, numEnd));
+    uint64_t version;
+    try {
+      version = std::stoull(versionStr);
+    } catch (std::exception& e) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_HTTP_BAD_PARAMETER,
+          absl::StrCat(
+              "invalid API version: failed to parse version number: ", e.what(),
+              ", got path: ", std::string_view(start, end - start)));
+    }
+
+    // If the parsed version is not supported or experimental we do NOT set
+    // _requestedApiVersion or strip the prefix. This will cause the handler
+    // lookup to fail and return a 404 Not Found
+    if (version < std::numeric_limits<uint32_t>::max() &&
+        (ApiVersion::isApiVersionSupported(version) || isExperimental)) {
+      _requestedApiVersion = static_cast<uint32_t>(version);
+      start = p + 1 + numEnd;  // advance past "/_arango/vX"
+    }
+  }
 }
 
 }  // namespace arangodb

--- a/tests/Rest/GeneralRequestTest.cpp
+++ b/tests/Rest/GeneralRequestTest.cpp
@@ -87,40 +87,12 @@ TEST_F(ApiVersionDetectionTest, RegularPath) {
   EXPECT_EQ("/some/random/path", r.remaining);
 }
 
-// Test: Valid API version v1
-TEST_F(ApiVersionDetectionTest, ValidApiVersionV1) {
+TEST_F(ApiVersionDetectionTest, UnsupportedVersionNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v1/_api/version");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(1u, r.apiVersion);
-  EXPECT_EQ("/_api/version", r.remaining);
-}
-
-// Test: Valid API version v2
-TEST_F(ApiVersionDetectionTest, ValidApiVersionV2) {
-  HttpRequest request(ci, 1);
-  auto r = callDetect(request, "/_arango/v2/_api/collection");
-  EXPECT_TRUE(r.ok);
-  EXPECT_EQ(2u, r.apiVersion);
-  EXPECT_EQ("/_api/collection", r.remaining);
-}
-
-// Test: Valid API version v42
-TEST_F(ApiVersionDetectionTest, ValidApiVersionV42) {
-  HttpRequest request(ci, 1);
-  auto r = callDetect(request, "/_arango/v42/_admin/status");
-  EXPECT_TRUE(r.ok);
-  EXPECT_EQ(42u, r.apiVersion);
-  EXPECT_EQ("/_admin/status", r.remaining);
-}
-
-// Test: Valid API version v1234567
-TEST_F(ApiVersionDetectionTest, ValidApiVersionLargeNumber) {
-  HttpRequest request(ci, 1);
-  auto r = callDetect(request, "/_arango/v1234567/path");
-  EXPECT_TRUE(r.ok);
-  EXPECT_EQ(1234567u, r.apiVersion);
-  EXPECT_EQ("/path", r.remaining);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/v1/_api/version", r.remaining);
 }
 
 // Test: Experimental API version
@@ -135,9 +107,9 @@ TEST_F(ApiVersionDetectionTest, ExperimentalApiVersion) {
 // Test: Path ending exactly at version number
 TEST_F(ApiVersionDetectionTest, PathEndingAtVersion) {
   HttpRequest request(ci, 1);
-  auto r = callDetect(request, "/_arango/v5");
+  auto r = callDetect(request, "/_arango/v0");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(5u, r.apiVersion);
+  EXPECT_EQ(0u, r.apiVersion);
   EXPECT_EQ("", r.remaining);
 }
 
@@ -168,22 +140,22 @@ TEST_F(ApiVersionDetectionTest, InvalidMissingVPrefix) {
   EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
 }
 
-// Test: Invalid - v without number
-TEST_F(ApiVersionDetectionTest, InvalidVWithoutNumber) {
+// Test: v without number - unrecognized, not stripped
+TEST_F(ApiVersionDetectionTest, VWithoutNumberNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v/path");
-  EXPECT_FALSE(r.ok);
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_TRUE(r.ok);
   EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/v/path", r.remaining);
 }
 
-// Test: Invalid - v with non-numeric characters
-TEST_F(ApiVersionDetectionTest, InvalidVWithAlpha) {
+// Test: v with non-numeric characters - unrecognized, not stripped
+TEST_F(ApiVersionDetectionTest, VWithAlphaNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/vabc/path");
-  EXPECT_FALSE(r.ok);
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_TRUE(r.ok);
   EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/vabc/path", r.remaining);
 }
 
 // Test: Invalid - random text after /_arango/
@@ -213,12 +185,14 @@ TEST_F(ApiVersionDetectionTest, ValidApiVersionV0) {
   EXPECT_EQ("/path", r.remaining);
 }
 
-// Test: Version number followed by non-slash character should be invalid
-TEST_F(ApiVersionDetectionTest, InvalidVersionNotFollowedBySlash) {
+// Test: Version number followed by non-slash character - unrecognized, not
+// stripped
+TEST_F(ApiVersionDetectionTest, VersionFollowedByAlphaNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v1abc/path");
-  EXPECT_FALSE(r.ok);
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_TRUE(r.ok);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/v1abc/path", r.remaining);
 }
 
 // Test: Experimental followed by non-slash character should be invalid
@@ -229,14 +203,13 @@ TEST_F(ApiVersionDetectionTest, InvalidExperimentalNotFollowedBySlash) {
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
 }
 
-// Test: Multiple slashes after version (start pointer lands at first slash,
-// remaining slashes are left for the caller to handle)
-TEST_F(ApiVersionDetectionTest, MultipleSlashesAfterVersion) {
+// Test: Unsupported version with multiple slashes - not stripped
+TEST_F(ApiVersionDetectionTest, UnsupportedVersionWithMultipleSlashes) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v1///path");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(1u, r.apiVersion);
-  EXPECT_EQ("///path", r.remaining);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/v1///path", r.remaining);
 }
 
 // Test: Root path
@@ -248,34 +221,34 @@ TEST_F(ApiVersionDetectionTest, RootPath) {
   EXPECT_EQ("/", r.remaining);
 }
 
-// Test: Deep nested path with version
-TEST_F(ApiVersionDetectionTest, DeepNestedPath) {
+// Test: Unsupported version with deep nested path - not stripped
+TEST_F(ApiVersionDetectionTest, UnsupportedVersionWithNestedPath) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v3/_api/collection/test/document/123");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(3u, r.apiVersion);
-  EXPECT_EQ("/_api/collection/test/document/123", r.remaining);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/v3/_api/collection/test/document/123", r.remaining);
 }
 
-// Test: Path with query parameters (should work on path only)
-TEST_F(ApiVersionDetectionTest, PathWithQueryString) {
+// Test: Another unsupported version - not stripped
+TEST_F(ApiVersionDetectionTest, UnsupportedVersionV7NotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v7/_api/cursor");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(7u, r.apiVersion);
-  EXPECT_EQ("/_api/cursor", r.remaining);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ("/_arango/v7/_api/cursor", r.remaining);
 }
 
-// Test: API version at max uint32_t - 1 should work
-TEST_F(ApiVersionDetectionTest, MaxUint32Minus1) {
+// Test: Large unsupported version (uint32_t max - 1) - not stripped
+TEST_F(ApiVersionDetectionTest, UnsupportedLargeVersionNotStripped) {
   HttpRequest request(ci, 1);
   std::string path = "/_arango/v" +
                      std::to_string(std::numeric_limits<uint32_t>::max() - 1) +
                      "/path";
   auto r = callDetect(request, path);
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(std::numeric_limits<uint32_t>::max() - 1, r.apiVersion);
-  EXPECT_EQ("/path", r.remaining);
+  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(path, r.remaining);
 }
 
 // Test: Check that default API version constant is accessible and is 0
@@ -289,17 +262,16 @@ TEST_F(ApiVersionDetectionTest, NewRequestHasDefaultVersion) {
   EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
 }
 
-// Test: API version exceeding uint32_t max should be rejected
-TEST_F(ApiVersionDetectionTest, VersionExceedsUint32Max) {
+// Test: Version exceeding uint32_t max - unsupported, not stripped
+TEST_F(ApiVersionDetectionTest, UnsupportedVersionExceedsUint32Max) {
   HttpRequest request(ci, 1);
   uint64_t tooLarge =
       static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1;
   std::string path = "/_arango/v" + std::to_string(tooLarge) + "/path";
   auto r = callDetect(request, path);
-  EXPECT_FALSE(r.ok);
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_TRUE(r.ok);
   EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
-  EXPECT_NE(std::string::npos, r.errorMessage.find("too large"));
+  EXPECT_EQ(path, r.remaining);
 }
 
 // Test: Version with leading zero should be rejected (v01)
@@ -382,16 +354,15 @@ TEST_F(ApiVersionDetectionTest, VersionExceedsUint64Max) {
   EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }
 
-// Test: Version number at uint64_t max boundary
-TEST_F(ApiVersionDetectionTest, VersionAtUint64Max) {
+// Test: uint64_t max - parses fine but unsupported, not stripped
+TEST_F(ApiVersionDetectionTest, UnsupportedVersionAtUint64Max) {
   HttpRequest request(ci, 1);
   // uint64_t max is 18446744073709551615 - exceeds uint32_t max
   std::string path = "/_arango/v18446744073709551615/path";
   auto r = callDetect(request, path);
-  EXPECT_FALSE(r.ok);
-  EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
+  EXPECT_TRUE(r.ok);
   EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
-  EXPECT_NE(std::string::npos, r.errorMessage.find("too large"));
+  EXPECT_EQ(path, r.remaining);
 }
 
 // Test: Version number slightly above uint64_t max

--- a/tests/js/client/shell/api/multi/http.js
+++ b/tests/js/client/shell/api/multi/http.js
@@ -423,14 +423,6 @@ function API_versioningSuite () {
       assertCspHeaders(doc);
     },
 
-    test_checks_version_endpoint_with_v1_prefix: function() {
-      let cmd = "/_arango/v1/_api/version";
-      let doc = arango.GET_RAW(cmd);
-
-      assertEqual(doc.code, 200);
-      assertCspHeaders(doc);
-    },
-
     test_checks_version_endpoint_with_v0_prefix: function() {
       let cmd = "/_arango/v0/_api/version";
       let doc = arango.GET_RAW(cmd);
@@ -459,24 +451,6 @@ function API_versioningSuite () {
       assertCspHeaders(doc);
     },
 
-    test_checks_version_endpoint_with_v1_prefix_POST: function() {
-      let cmd = "/_arango/v1/_api/version";
-      let doc = arango.POST_RAW(cmd, {});
-
-      // POST should also work with versioned prefix
-      assertEqual(doc.code, 200);
-      assertCspHeaders(doc);
-    },
-
-    test_checks_version_endpoint_with_v1_prefix_HEAD: function() {
-      let cmd = "/_arango/v1/_api/version";
-      let doc = arango.HEAD_RAW(cmd);
-
-      // HEAD should also work with versioned prefix
-      assertEqual(doc.code, 200);
-      assertCspHeaders(doc);
-    },
-
     test_checks_version_endpoint_reports_requested_api_version_v0: function() {
       let cmd = "/_arango/v0/_api/version";
       let doc = arango.GET_RAW(cmd);
@@ -484,16 +458,6 @@ function API_versioningSuite () {
       assertEqual(doc.code, 200);
       assertTrue(doc.parsedBody.hasOwnProperty('requestedApiVersion'));
       assertEqual(doc.parsedBody.requestedApiVersion, "v0");
-      assertCspHeaders(doc);
-    },
-
-    test_checks_version_endpoint_reports_requested_api_version_v1: function() {
-      let cmd = "/_arango/v1/_api/version";
-      let doc = arango.GET_RAW(cmd);
-
-      assertEqual(doc.code, 200);
-      assertTrue(doc.parsedBody.hasOwnProperty('requestedApiVersion'));
-      assertEqual(doc.parsedBody.requestedApiVersion, "v1");
       assertCspHeaders(doc);
     },
 

--- a/tests/js/client/shell/api/openapi.js
+++ b/tests/js/client/shell/api/openapi.js
@@ -57,8 +57,23 @@ function openapi_endpointsSuite() {
       assertEqual(typeof response.paths, 'object');
     },
 
-    test_retrieves_openapi_v1: function() {
+    test_openapi_v1_does_not_exist: function () {
       let doc = arango.GET_RAW("/_arango/v1/openapi.json");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.errorNum, 404);
+
+    },
+
+    test_openapi_v2_does_not_exist: function () {
+      let doc = arango.GET_RAW("/_arango/v2/openapi.json");
+
+      assertEqual(doc.code, 404);
+      assertEqual(doc.errorNum, 404);
+    },
+
+    test_retrieves_openapi_experimental: function () {
+      let doc = arango.GET_RAW("/_arango/experimental/openapi.json");
 
       assertEqual(doc.code, 200);
       assertEqual(doc.headers['content-type'], "application/json");
@@ -76,24 +91,24 @@ function openapi_endpointsSuite() {
       assertEqual(typeof response.paths, 'object');
     },
 
-    test_openapi_v0_and_v1_differ: function() {
+    test_openapi_v0_and_experimental_differ: function () {
       let docV0 = arango.GET_RAW("/_arango/v0/openapi.json");
-      let docV1 = arango.GET_RAW("/_arango/v1/openapi.json");
+      let docExp = arango.GET_RAW("/_arango/experimental/openapi.json");
 
       assertEqual(docV0.code, 200);
-      assertEqual(docV1.code, 200);
+      assertEqual(docExp.code, 200);
 
       let v0 = docV0.parsedBody;
-      let v1 = docV1.parsedBody;
+      let exp = docExp.parsedBody;
 
       // Both should be valid OpenAPI documents
       assertNotUndefined(v0.openapi);
-      assertNotUndefined(v1.openapi);
+      assertNotUndefined(exp.openapi);
 
       // They should potentially differ in content
       // (At minimum, they should have different version info or paths)
       assertNotUndefined(v0.paths);
-      assertNotUndefined(v1.paths);
+      assertNotUndefined(exp.paths);
     }
   };
 }


### PR DESCRIPTION
### Scope & Purpose

Disable v1 API routes and fix parsing of API version.

Forward port of #22431

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**
  - [x] **integration tests**