### PR TITLE
Reduce amount of UPSERTs in test to make tsan-suite more stable.

### DIFF
--- a/tests/js/client/shell/shell-iterators.inc
+++ b/tests/js/client/shell/shell-iterators.inc
@@ -545,13 +545,13 @@ function IteratorWriteSuite(permuteConfigs) {
       permute((ctx, opts) => {
         const tc = ctx.collection(cn);
         // full scan
-        let result = ctx.query('FOR i IN 1..2000 UPSERT { v: "dummy" } INSERT { v: "dummy", cnt: 1, idx: i } UPDATE { cnt: OLD.cnt + 1 } IN @@c RETURN OLD', { '@c': cn }, opts).toArray();
+        let result = ctx.query('FOR i IN 1..1200 UPSERT { v: "dummy" } INSERT { v: "dummy", cnt: 1, idx: i } UPDATE { cnt: OLD.cnt + 1 } IN @@c RETURN OLD', { '@c': cn }, opts).toArray();
         assertEqual(5000 + 1, tc.count());
-        assertEqual(2000, result.length);
+        assertEqual(1200, result.length);
 
         let values = ctx.query('FOR doc in @@c FILTER doc.v == "dummy" RETURN doc', { '@c': cn }, opts).toArray();
         assertEqual(1, values.length);
-        assertEqual(2000, values[0].cnt);
+        assertEqual(1200, values[0].cnt);
       });
     },
 


### PR DESCRIPTION
### Scope & Purpose

We recently introduced a timeout of 240 seconds for instrumented runs. But we have some tests that take longer than that with the TSan build.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2320
- [ ] Design document: 
