### PR TITLE
Fix community build regressions in graph queue aliases and authentication options

### DIFF
--- a/arangod/GeneralServer/AuthenticationOptions.h
+++ b/arangod/GeneralServer/AuthenticationOptions.h
@@ -42,10 +42,8 @@ struct AuthenticationOptions {
   std::string jwtSecretFolderProgramOption;
   bool jwtSecretIsES256 = false;  // true if the active secret uses ES256
 
-#ifdef USE_ENTERPRISE
   /// verification only secrets
   std::vector<std::string> jwtPassiveSecrets;
-#endif
 };
 
 }  // namespace arangodb

--- a/arangod/Graph/algorithm-aliases.h
+++ b/arangod/Graph/algorithm-aliases.h
@@ -105,6 +105,15 @@ template<class Provider>
 using WeightedKShortestPathsEnumerator =
     TwoSidedEnumeratorWithProviderWeighted<Provider>;
 
+template<class ProviderType>
+struct uses_unbatched_traversal_queue : std::false_type {};
+
+#ifdef USE_ENTERPRISE
+template<>
+struct uses_unbatched_traversal_queue<
+    enterprise::SmartGraphProvider<ClusterProviderStep>> : std::true_type {};
+#endif
+
 template<class ProviderType, VertexUniquenessLevel vertexUniqueness,
          EdgeUniquenessLevel edgeUniqueness>
 struct BFSConfiguration {
@@ -115,8 +124,7 @@ struct BFSConfiguration {
   // need to be implemented
   // using Queue = FifoQueue<Step>;
   using Queue = typename std::conditional<
-      std::is_same_v<ProviderType,
-                     enterprise::SmartGraphProvider<ClusterProviderStep>>,
+      uses_unbatched_traversal_queue<ProviderType>::value,
       FifoQueue<Step>,
       CursorFifoQueue<Step, typename ProviderType::NeighbourCursor>>::type;
   using Store = PathStore<Step>;
@@ -133,8 +141,7 @@ struct DFSConfiguration {
   // for that, SmartGraphProvider fns addExpansionIterator and
   // expandToNextBatch need to be implemented
   using Queue = typename std::conditional<
-      std::is_same_v<ProviderType,
-                     enterprise::SmartGraphProvider<ClusterProviderStep>>,
+      uses_unbatched_traversal_queue<ProviderType>::value,
       LifoQueue<Step>,
       CursorLifoQueue<Step, typename ProviderType::NeighbourCursor>>::type;
   using Store = PathStore<Step>;
@@ -151,8 +158,7 @@ struct WeightedConfiguration {
   // for that, SmartGraphProvider fns addExpansionIterator and
   // expandToNextBatch need to be implemented
   using Queue = typename std::conditional<
-      std::is_same_v<ProviderType,
-                     enterprise::SmartGraphProvider<ClusterProviderStep>>,
+      uses_unbatched_traversal_queue<ProviderType>::value,
       WeightedQueue<Step>,
       CursorWeightedQueue<Step, typename ProviderType::NeighbourCursor>>::type;
   using Store = PathStore<Step>;


### PR DESCRIPTION
### Scope & Purpose

  I let codex build a dev-container for me to make PRs possible for arangodb. Codex found 2 issue while building the arangod target. With these fixes my dev-container builds the arangod target just fine. I let it fix it and this is the result:

  The first problem is in `arangod/Graph/algorithm-aliases.h`. The queue aliases use `enterprise::SmartGraphProvider<ClusterProviderStep>` inside `std::conditional`, but that enterprise type is referenced unconditionally. In a community build this breaks compilation even though the enterprise code path should not be used.

  The second problem is in `arangod/GeneralServer/AuthenticationOptions.h`. `AuthenticationFeature.cpp` uses `_options.jwtPassiveSecrets` unconditionally, and `TokenCache` already supports passive JWT secrets unconditionally, but the field in `AuthenticationOptions` was only declared behind `#ifdef USE_ENTERPRISE`. That makes the community build
  fail later in the server build.

  This PR fixes both issues with the smallest possible changes:
  - add a small trait in `algorithm-aliases.h` so the enterprise-specific queue special-case is only instantiated when the enterprise type is actually available
  - make `jwtPassiveSecrets` available in `AuthenticationOptions` consistently with its existing use in community code

  Without these fixes, a fresh community build on `devel` failed for me while building `arangod`. With these changes in place, `arangod` builds and runs in my local dev setup.

  - [x] :hankey: Bugfix
  - [ ] :pizza: New feature
  - [ ] :fire: Performance improvement
  - [ ] :hammer: Refactoring/simplification


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build/compile fixes: exposes `jwtPassiveSecrets` consistently and avoids referencing enterprise-only graph provider types in community builds.
> 
> **Overview**
> Fixes community build regressions by **making `AuthenticationOptions::jwtPassiveSecrets` always available** (it was previously behind `USE_ENTERPRISE` despite being used unconditionally).
> 
> Updates graph traversal queue alias selection in `algorithm-aliases.h` to **avoid unconditionally instantiating enterprise-only `SmartGraphProvider` types**, using a small trait (`uses_unbatched_traversal_queue`) to keep the enterprise special-case while compiling cleanly without enterprise headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff4577719979a1161bf71cfcefdebba7340ea765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->