### PR TITLE
save java driver collectionname log

### DIFF
--- a/js/client/modules/@arangodb/testsuites/java.js
+++ b/js/client/modules/@arangodb/testsuites/java.js
@@ -146,6 +146,13 @@ arangodb.acquireHostList=true
     if (rc.exit !== 0) {
       status = false;
     }
+    let txtfile = fs.join(cwd, "test-functional/target/unicode_names.txt");
+    if (fs.exists(txtfile)) {
+      print(`copying ${txtfile}`);
+      fs.copyFile(txtfile, this.instanceManager.rootDir);
+    } else {
+      print(`${txtfile} not found!`);
+    }
     this.getAllureResults(testResultsDir, results, status, 'javadriver');
     return results;
   }


### PR DESCRIPTION


### Scope & Purpose

copy the java driver tests collection name log to a directory that is copied into the result report

- [x] :pizza: New feature
