### PR TITLE
Return vocbase path if NOT a Coordinator

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 3.12.9-devel (XXXX-XX-XX)
 -------------------------
 
+* Fixed a bug that prevented the `GET /_api/database/current` endpoint and
+  `db._path()` from returning the actual database directory `path` for
+  DB-Servers and single servers. They returned `"none"`, which is only expected
+  from Coordinators that generally don't store data.
+
 * Updated ArangoDB Starter to v0.19.19.
 
 * Create coredumps with correct CPU context.

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1491,9 +1491,9 @@ void TRI_vocbase_t::toVelocyPack(VPackBuilder& result) const {
   VPackObjectBuilder b(&result);
   _info.toVelocyPack(result);
   if (ServerState::instance()->isCoordinator()) {
-    result.add("path", VPackValue(path()));
-  } else {
     result.add("path", VPackValue("none"));
+  } else {
+    result.add("path", VPackValue(path()));
   }
 }
 


### PR DESCRIPTION
### Scope & Purpose

According to Claude's analysis, the returned database path is `"none"` when reading from the Agency cache / asking a Coordinator in a cluster, where "none" makes sense because there is no database.

In case of a DB-Server or single server, a path could be returned.
However, this returns "none" as well in the server server case (and probably for DB-Servers, too), potentially because of a bug. In the toVelocyPack function, the logic seems inverted, returning `"none"` when NOT asking a Coordinator.

Can we closed if we remove the database "path": https://github.com/arangodb/arangodb/pull/22560

- [x] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
