### PR TITLE
[cor-386] Replace legacy fileutils functions with std filesystem equivalents

### DIFF
--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -625,8 +625,8 @@ bool ServerState::writePersistedId(std::string const& id) {
   // try to create underlying directory
 
   auto ec = std::error_code{};
-  std::ignore =
-      std::filesystem::create_directory(FileUtils::dirname(uuidFilename), ec);
+  std::ignore = std::filesystem::create_directory(
+      std::filesystem::path(uuidFilename).parent_path(), ec);
   if (ec) {
     LOG_TOPIC("f2f71", FATAL, arangodb::Logger::FIXME)
         << "Cannot create UUID directory '" << uuidFilename

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -570,9 +570,10 @@ Result AuthenticationFeature::loadJwtSecretFolder() try {
                    if (file.ends_with(".tmp")) {
                      return true;
                    }
-                   auto p = basics::FileUtils::buildFilename(
-                       _options.jwtSecretFolderProgramOption, file);
-                   if (std::filesystem::is_symlink(std::filesystem::path(p))) {
+                   auto p =
+                       std::filesystem::path(basics::FileUtils::buildFilename(
+                           _options.jwtSecretFolderProgramOption, file));
+                   if (std::filesystem::is_symlink(p)) {
                      return true;
                    }
                    return false;

--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -45,6 +45,7 @@
 #include <openssl/bio.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
+#include <filesystem>
 
 using namespace arangodb::options;
 
@@ -560,21 +561,22 @@ Result AuthenticationFeature::loadJwtSecretFolder() try {
       basics::FileUtils::listFiles(_options.jwtSecretFolderProgramOption);
 
   // filter out empty filenames, hidden files, tmp files and symlinks
-  list.erase(std::remove_if(list.begin(), list.end(),
-                            [this](std::string const& file) {
-                              if (file.empty() || file[0] == '.') {
-                                return true;
-                              }
-                              if (file.ends_with(".tmp")) {
-                                return true;
-                              }
-                              auto p = basics::FileUtils::buildFilename(
-                                  _options.jwtSecretFolderProgramOption, file);
-                              if (basics::FileUtils::isSymbolicLink(p)) {
-                                return true;
-                              }
-                              return false;
-                            }),
+  list.erase(std::remove_if(
+                 list.begin(), list.end(),
+                 [this](std::string const& file) {
+                   if (file.empty() || file[0] == '.') {
+                     return true;
+                   }
+                   if (file.ends_with(".tmp")) {
+                     return true;
+                   }
+                   auto p = basics::FileUtils::buildFilename(
+                       _options.jwtSecretFolderProgramOption, file);
+                   if (std::filesystem::is_symlink(std::filesystem::path(p))) {
+                     return true;
+                   }
+                   return false;
+                 }),
              list.end());
 
   if (list.empty()) {

--- a/arangod/RestServer/DaemonFeature.cpp
+++ b/arangod/RestServer/DaemonFeature.cpp
@@ -174,10 +174,9 @@ void DaemonFeature::checkPidFile() {
           << "pid-file '" << _options.pidFile << "' is a directory";
       FATAL_ERROR_EXIT();
     } else if (FileUtils::exists(_options.pidFile)) {
-      std::error_code sizeEc;
       std::uintmax_t const pidFileSize =
-          std::filesystem::file_size(_options.pidFile, sizeEc);
-      if (!sizeEc && pidFileSize > 0) {
+          std::filesystem::file_size(_options.pidFile);
+      if (pidFileSize > 0) {
         LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
             << "pid-file '" << _options.pidFile
             << "' already exists, verifying pid";

--- a/arangod/RestServer/DaemonFeature.cpp
+++ b/arangod/RestServer/DaemonFeature.cpp
@@ -173,80 +173,84 @@ void DaemonFeature::checkPidFile() {
       LOG_TOPIC("6b3c0", FATAL, arangodb::Logger::FIXME)
           << "pid-file '" << _options.pidFile << "' is a directory";
       FATAL_ERROR_EXIT();
-    } else if (FileUtils::exists(_options.pidFile) &&
-               FileUtils::size(_options.pidFile) > 0) {
-      LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
-          << "pid-file '" << _options.pidFile
-          << "' already exists, verifying pid";
-      std::string oldPidS;
-      try {
-        oldPidS = arangodb::basics::FileUtils::slurp(_options.pidFile);
-      } catch (arangodb::basics::Exception const& ex) {
-        LOG_TOPIC("4aadd", FATAL, arangodb::Logger::FIXME)
-            << "Couldn't read PID file '" << _options.pidFile << "' - "
-            << ex.what();
-        FATAL_ERROR_EXIT();
-      }
-
-      basics::StringUtils::trimInPlace(oldPidS);
-
-      if (!oldPidS.empty()) {
-        TRI_pid_t oldPid;
-
+    } else if (FileUtils::exists(_options.pidFile)) {
+      std::error_code sizeEc;
+      std::uintmax_t const pidFileSize =
+          std::filesystem::file_size(_options.pidFile, sizeEc);
+      if (!sizeEc && pidFileSize > 0) {
+        LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
+            << "pid-file '" << _options.pidFile
+            << "' already exists, verifying pid";
+        std::string oldPidS;
         try {
-          oldPid = std::stol(oldPidS);
-        } catch (std::invalid_argument const&) {
-          LOG_TOPIC("bd20c", FATAL, arangodb::Logger::FIXME)
-              << "pid-file '" << _options.pidFile
-              << "' doesn't contain a number.";
-          FATAL_ERROR_EXIT();
-        }
-        if (oldPid == 0) {
-          LOG_TOPIC("aef5d", FATAL, arangodb::Logger::FIXME)
-              << "pid-file '" << _options.pidFile << "' is unreadable";
+          oldPidS = arangodb::basics::FileUtils::slurp(_options.pidFile);
+        } catch (arangodb::basics::Exception const& ex) {
+          LOG_TOPIC("4aadd", FATAL, arangodb::Logger::FIXME)
+              << "Couldn't read PID file '" << _options.pidFile << "' - "
+              << ex.what();
           FATAL_ERROR_EXIT();
         }
 
-        LOG_TOPIC("ecac1", DEBUG, Logger::STARTUP)
-            << "found old pid: " << oldPid;
+        basics::StringUtils::trimInPlace(oldPidS);
 
-        int r = kill(oldPid, 0);
+        if (!oldPidS.empty()) {
+          TRI_pid_t oldPid;
 
-        if (r == 0 || errno == EPERM) {
-          LOG_TOPIC("5fa62", FATAL, arangodb::Logger::FIXME)
-              << "pid-file '" << _options.pidFile
-              << "' exists and process with pid " << oldPid
-              << " is still running, refusing to start twice";
-          FATAL_ERROR_EXIT();
-        } else if (errno == ESRCH) {
-          LOG_TOPIC("a9576", ERR, Logger::STARTUP)
-              << "pid-file '" << _options.pidFile
-              << " exists, but no process with pid " << oldPid << " exists";
-
-          if (FileUtils::remove(_options.pidFile) != TRI_ERROR_NO_ERROR) {
-            LOG_TOPIC("fddfc", FATAL, arangodb::Logger::FIXME)
+          try {
+            oldPid = std::stol(oldPidS);
+          } catch (std::invalid_argument const&) {
+            LOG_TOPIC("bd20c", FATAL, arangodb::Logger::FIXME)
                 << "pid-file '" << _options.pidFile
-                << "' exists, no process with pid " << oldPid
-                << " exists, but pid-file cannot be removed";
+                << "' doesn't contain a number.";
+            FATAL_ERROR_EXIT();
+          }
+          if (oldPid == 0) {
+            LOG_TOPIC("aef5d", FATAL, arangodb::Logger::FIXME)
+                << "pid-file '" << _options.pidFile << "' is unreadable";
             FATAL_ERROR_EXIT();
           }
 
-          LOG_TOPIC("1f3e6", INFO, Logger::STARTUP)
-              << "removed stale pid-file '" << _options.pidFile << "'";
-        } else {
-          LOG_TOPIC("180c0", FATAL, arangodb::Logger::FIXME)
-              << "pid-file '" << _options.pidFile << "' exists and kill "
-              << oldPid << " failed";
+          LOG_TOPIC("ecac1", DEBUG, Logger::STARTUP)
+              << "found old pid: " << oldPid;
+
+          int r = kill(oldPid, 0);
+
+          if (r == 0 || errno == EPERM) {
+            LOG_TOPIC("5fa62", FATAL, arangodb::Logger::FIXME)
+                << "pid-file '" << _options.pidFile
+                << "' exists and process with pid " << oldPid
+                << " is still running, refusing to start twice";
+            FATAL_ERROR_EXIT();
+          } else if (errno == ESRCH) {
+            LOG_TOPIC("a9576", ERR, Logger::STARTUP)
+                << "pid-file '" << _options.pidFile
+                << " exists, but no process with pid " << oldPid << " exists";
+
+            if (FileUtils::remove(_options.pidFile) != TRI_ERROR_NO_ERROR) {
+              LOG_TOPIC("fddfc", FATAL, arangodb::Logger::FIXME)
+                  << "pid-file '" << _options.pidFile
+                  << "' exists, no process with pid " << oldPid
+                  << " exists, but pid-file cannot be removed";
+              FATAL_ERROR_EXIT();
+            }
+
+            LOG_TOPIC("1f3e6", INFO, Logger::STARTUP)
+                << "removed stale pid-file '" << _options.pidFile << "'";
+          } else {
+            LOG_TOPIC("180c0", FATAL, arangodb::Logger::FIXME)
+                << "pid-file '" << _options.pidFile << "' exists and kill "
+                << oldPid << " failed";
+            FATAL_ERROR_EXIT();
+          }
+        }
+
+        // failed to open file
+        else {
+          LOG_TOPIC("ab3fe", FATAL, arangodb::Logger::FIXME)
+              << "pid-file '" << _options.pidFile
+              << "' exists, but cannot be opened";
           FATAL_ERROR_EXIT();
         }
-      }
-
-      // failed to open file
-      else {
-        LOG_TOPIC("ab3fe", FATAL, arangodb::Logger::FIXME)
-            << "pid-file '" << _options.pidFile
-            << "' exists, but cannot be opened";
-        FATAL_ERROR_EXIT();
       }
     }
 

--- a/arangod/RestServer/DaemonFeature.cpp
+++ b/arangod/RestServer/DaemonFeature.cpp
@@ -173,83 +173,80 @@ void DaemonFeature::checkPidFile() {
       LOG_TOPIC("6b3c0", FATAL, arangodb::Logger::FIXME)
           << "pid-file '" << _options.pidFile << "' is a directory";
       FATAL_ERROR_EXIT();
-    } else if (FileUtils::exists(_options.pidFile)) {
-      std::uintmax_t const pidFileSize =
-          std::filesystem::file_size(_options.pidFile);
-      if (pidFileSize > 0) {
-        LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
-            << "pid-file '" << _options.pidFile
-            << "' already exists, verifying pid";
-        std::string oldPidS;
+    } else if (FileUtils::exists(_options.pidFile) &&
+               std::filesystem::file_size(_options.pidFile) > 0) {
+      LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
+          << "pid-file '" << _options.pidFile
+          << "' already exists, verifying pid";
+      std::string oldPidS;
+      try {
+        oldPidS = arangodb::basics::FileUtils::slurp(_options.pidFile);
+      } catch (arangodb::basics::Exception const& ex) {
+        LOG_TOPIC("4aadd", FATAL, arangodb::Logger::FIXME)
+            << "Couldn't read PID file '" << _options.pidFile << "' - "
+            << ex.what();
+        FATAL_ERROR_EXIT();
+      }
+
+      basics::StringUtils::trimInPlace(oldPidS);
+
+      if (!oldPidS.empty()) {
+        TRI_pid_t oldPid;
+
         try {
-          oldPidS = arangodb::basics::FileUtils::slurp(_options.pidFile);
-        } catch (arangodb::basics::Exception const& ex) {
-          LOG_TOPIC("4aadd", FATAL, arangodb::Logger::FIXME)
-              << "Couldn't read PID file '" << _options.pidFile << "' - "
-              << ex.what();
-          FATAL_ERROR_EXIT();
-        }
-
-        basics::StringUtils::trimInPlace(oldPidS);
-
-        if (!oldPidS.empty()) {
-          TRI_pid_t oldPid;
-
-          try {
-            oldPid = std::stol(oldPidS);
-          } catch (std::invalid_argument const&) {
-            LOG_TOPIC("bd20c", FATAL, arangodb::Logger::FIXME)
-                << "pid-file '" << _options.pidFile
-                << "' doesn't contain a number.";
-            FATAL_ERROR_EXIT();
-          }
-          if (oldPid == 0) {
-            LOG_TOPIC("aef5d", FATAL, arangodb::Logger::FIXME)
-                << "pid-file '" << _options.pidFile << "' is unreadable";
-            FATAL_ERROR_EXIT();
-          }
-
-          LOG_TOPIC("ecac1", DEBUG, Logger::STARTUP)
-              << "found old pid: " << oldPid;
-
-          int r = kill(oldPid, 0);
-
-          if (r == 0 || errno == EPERM) {
-            LOG_TOPIC("5fa62", FATAL, arangodb::Logger::FIXME)
-                << "pid-file '" << _options.pidFile
-                << "' exists and process with pid " << oldPid
-                << " is still running, refusing to start twice";
-            FATAL_ERROR_EXIT();
-          } else if (errno == ESRCH) {
-            LOG_TOPIC("a9576", ERR, Logger::STARTUP)
-                << "pid-file '" << _options.pidFile
-                << " exists, but no process with pid " << oldPid << " exists";
-
-            if (FileUtils::remove(_options.pidFile) != TRI_ERROR_NO_ERROR) {
-              LOG_TOPIC("fddfc", FATAL, arangodb::Logger::FIXME)
-                  << "pid-file '" << _options.pidFile
-                  << "' exists, no process with pid " << oldPid
-                  << " exists, but pid-file cannot be removed";
-              FATAL_ERROR_EXIT();
-            }
-
-            LOG_TOPIC("1f3e6", INFO, Logger::STARTUP)
-                << "removed stale pid-file '" << _options.pidFile << "'";
-          } else {
-            LOG_TOPIC("180c0", FATAL, arangodb::Logger::FIXME)
-                << "pid-file '" << _options.pidFile << "' exists and kill "
-                << oldPid << " failed";
-            FATAL_ERROR_EXIT();
-          }
-        }
-
-        // failed to open file
-        else {
-          LOG_TOPIC("ab3fe", FATAL, arangodb::Logger::FIXME)
+          oldPid = std::stol(oldPidS);
+        } catch (std::invalid_argument const&) {
+          LOG_TOPIC("bd20c", FATAL, arangodb::Logger::FIXME)
               << "pid-file '" << _options.pidFile
-              << "' exists, but cannot be opened";
+              << "' doesn't contain a number.";
           FATAL_ERROR_EXIT();
         }
+        if (oldPid == 0) {
+          LOG_TOPIC("aef5d", FATAL, arangodb::Logger::FIXME)
+              << "pid-file '" << _options.pidFile << "' is unreadable";
+          FATAL_ERROR_EXIT();
+        }
+
+        LOG_TOPIC("ecac1", DEBUG, Logger::STARTUP)
+            << "found old pid: " << oldPid;
+
+        int r = kill(oldPid, 0);
+
+        if (r == 0 || errno == EPERM) {
+          LOG_TOPIC("5fa62", FATAL, arangodb::Logger::FIXME)
+              << "pid-file '" << _options.pidFile
+              << "' exists and process with pid " << oldPid
+              << " is still running, refusing to start twice";
+          FATAL_ERROR_EXIT();
+        } else if (errno == ESRCH) {
+          LOG_TOPIC("a9576", ERR, Logger::STARTUP)
+              << "pid-file '" << _options.pidFile
+              << " exists, but no process with pid " << oldPid << " exists";
+
+          if (FileUtils::remove(_options.pidFile) != TRI_ERROR_NO_ERROR) {
+            LOG_TOPIC("fddfc", FATAL, arangodb::Logger::FIXME)
+                << "pid-file '" << _options.pidFile
+                << "' exists, no process with pid " << oldPid
+                << " exists, but pid-file cannot be removed";
+            FATAL_ERROR_EXIT();
+          }
+
+          LOG_TOPIC("1f3e6", INFO, Logger::STARTUP)
+              << "removed stale pid-file '" << _options.pidFile << "'";
+        } else {
+          LOG_TOPIC("180c0", FATAL, arangodb::Logger::FIXME)
+              << "pid-file '" << _options.pidFile << "' exists and kill "
+              << oldPid << " failed";
+          FATAL_ERROR_EXIT();
+        }
+      }
+
+      // failed to open file
+      else {
+        LOG_TOPIC("ab3fe", FATAL, arangodb::Logger::FIXME)
+            << "pid-file '" << _options.pidFile
+            << "' exists, but cannot be opened";
+        FATAL_ERROR_EXIT();
       }
     }
 

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -46,6 +46,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <filesystem>
 
 using namespace arangodb::application_features;
 using namespace arangodb::basics;
@@ -117,7 +118,18 @@ uint64_t FileDescriptorsFeature::limit() const noexcept {
 
 void FileDescriptorsFeature::countOpenFiles() {
   try {
-    size_t numFiles = FileUtils::countFiles("/proc/self/fd");
+    std::filesystem::path fdPath{"/proc/self/fd"};
+    size_t numFiles = 0;
+
+    std::error_code ec;
+    if (std::filesystem::exists(fdPath, ec)) {
+      for (auto const& entry :
+           std::filesystem::directory_iterator(fdPath, ec)) {
+        (void)entry;  // explicitly ignore
+        ++numFiles;
+      }
+    }
+
     _fileDescriptorsCurrent.store(numFiles, std::memory_order_relaxed);
   } catch (std::exception const& ex) {
     LOG_TOPIC("bee41", DEBUG, Logger::SYSCALL)

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -121,7 +121,6 @@ void FileDescriptorsFeature::countOpenFiles() {
     std::filesystem::path fdPath{"/proc/self/fd"};
     size_t numFiles = 0;
 
-    std::error_code ec;
     if (std::filesystem::exists(fdPath)) {
       for (auto const& entry : std::filesystem::directory_iterator(fdPath)) {
         // The intent is simply to increment numFiles for each entry in

--- a/arangod/RestServer/FileDescriptorsFeature.cpp
+++ b/arangod/RestServer/FileDescriptorsFeature.cpp
@@ -122,9 +122,11 @@ void FileDescriptorsFeature::countOpenFiles() {
     size_t numFiles = 0;
 
     std::error_code ec;
-    if (std::filesystem::exists(fdPath, ec)) {
-      for (auto const& entry :
-           std::filesystem::directory_iterator(fdPath, ec)) {
+    if (std::filesystem::exists(fdPath)) {
+      for (auto const& entry : std::filesystem::directory_iterator(fdPath)) {
+        // The intent is simply to increment numFiles for each entry in
+        // fdPath, not to inspect the entries themselves. Hence Ignore
+        // entry
         (void)entry;  // explicitly ignore
         ++numFiles;
       }

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1594,12 +1594,8 @@ void DumpFeature::start() {
         auto f = absl::StrCat(
             basics::FileUtils::buildFilename(_options.outputPath, it));
         if (basics::FileUtils::isRegularFile(f)) {
-          std::error_code ec;
-          auto fileSize =
-              std::filesystem::file_size(std::filesystem::path(f), ec);
-          if (ec) {
-            fileSize = 0;
-          }
+          auto fileSize = std::filesystem::file_size(std::filesystem::path(f));
+
           totalSize += fileSize;
         }
       }

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -1594,7 +1594,13 @@ void DumpFeature::start() {
         auto f = absl::StrCat(
             basics::FileUtils::buildFilename(_options.outputPath, it));
         if (basics::FileUtils::isRegularFile(f)) {
-          totalSize += basics::FileUtils::size(f);
+          std::error_code ec;
+          auto fileSize =
+              std::filesystem::file_size(std::filesystem::path(f), ec);
+          if (ec) {
+            fileSize = 0;
+          }
+          totalSize += fileSize;
         }
       }
     } catch (...) {

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -679,13 +679,10 @@ bool V8ShellFeature::runScript(std::vector<std::string> const& files,
           current->Get(context, TRI_V8_ASCII_STRING(_isolate, "__dirname"))
               .FromMaybe(v8::Handle<v8::Value>());
 
-      std::filesystem::path dirPath =
+      std::string const dirname =
           std::filesystem::path(TRI_ObjectToString(isolate, filename))
-              .parent_path();
-      if (dirPath.empty()) {
-        dirPath = ".";
-      }
-      std::string const dirname = dirPath.string();
+              .parent_path()
+              .string();
 
       current
           ->Set(context, TRI_V8_ASCII_STRING(_isolate, "__dirname"),

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -679,7 +679,13 @@ bool V8ShellFeature::runScript(std::vector<std::string> const& files,
           current->Get(context, TRI_V8_ASCII_STRING(_isolate, "__dirname"))
               .FromMaybe(v8::Handle<v8::Value>());
 
-      auto dirname = FileUtils::dirname(TRI_ObjectToString(isolate, filename));
+      std::filesystem::path dirPath =
+          std::filesystem::path(TRI_ObjectToString(isolate, filename))
+              .parent_path();
+      if (dirPath.empty()) {
+        dirPath = ".";
+      }
+      std::string const dirname = dirPath.string();
 
       current
           ->Set(context, TRI_V8_ASCII_STRING(_isolate, "__dirname"),

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -137,21 +137,6 @@ void processFiles(std::string const& directory,
 namespace arangodb::basics::FileUtils {
 
 ////////////////////////////////////////////////////////////////////////////////
-/// @brief removes trailing path separators from path
-///
-/// path will be modified in-place
-////////////////////////////////////////////////////////////////////////////////
-
-std::string removeTrailingSeparator(std::string const& name) {
-  size_t endpos = name.find_last_not_of(TRI_DIR_SEPARATOR_CHAR);
-  if (endpos != std::string::npos) {
-    return name.substr(0, endpos + 1);
-  }
-
-  return name;
-}
-
-////////////////////////////////////////////////////////////////////////////////
 /// @brief normalizes path
 ///
 /// path will be modified in-place
@@ -172,7 +157,8 @@ std::string buildFilename(char const* path, char const* name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result);
+    std::filesystem::path sourcepath{result};
+    result = sourcepath.lexically_normal().string();
     if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
       result += TRI_DIR_SEPARATOR_CHAR;
     }
@@ -194,7 +180,8 @@ std::string buildFilename(std::string const& path, std::string const& name) {
   std::string result(path);
 
   if (!result.empty()) {
-    result = removeTrailingSeparator(result);
+    std::filesystem::path sourcepath{result};
+    result = sourcepath.lexically_normal().string();
     if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
       result += TRI_DIR_SEPARATOR_CHAR;
     }
@@ -522,21 +509,8 @@ std::vector<std::string> listFiles(std::string const& directory) {
   return result;
 }
 
-size_t countFiles(std::string const& directory) {
-  size_t result = 0;
-
-  ::processFiles(directory,
-                 [&result](std::string const& filename) { ++result; });
-
-  return result;
-}
-
 bool isDirectory(std::string const& path) {
   return ::statResultType(path) == ::StatResultType::Directory;
-}
-
-bool isSymbolicLink(std::string const& path) {
-  return ::statResultType(path) == ::StatResultType::SymLink;
 }
 
 bool isRegularFile(std::string const& path) {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -521,16 +521,6 @@ bool exists(std::string const& path) {
   return ::statResultType(path) != ::StatResultType::Error;
 }
 
-off_t size(std::string const& path) {
-  int64_t result = TRI_SizeFile(path.c_str());
-
-  if (result < 0) {
-    return (off_t)0;
-  }
-
-  return (off_t)result;
-}
-
 std::string stripExtension(std::string const& path,
                            std::string const& extension) {
   size_t pos = path.rfind(extension);
@@ -557,8 +547,6 @@ std::string configDirectory(char const* binaryPath) {
 
   return dir;
 }
-
-std::string dirname(std::string const& name) { return TRI_Dirname(name); }
 
 void makePathAbsolute(std::string& path) {
   std::string const cwd = std::filesystem::current_path();

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -121,10 +121,6 @@ bool isRegularFile(std::string const& path);
 // checks if path exists
 bool exists(std::string const& path);
 
-// returns the size of a file. will return 0 for non-existing files
-/// the caller should check first if the file exists via the exists() method
-off_t size(std::string const& path);
-
 // strip extension
 std::string stripExtension(std::string const& path,
                            std::string const& extension);
@@ -134,9 +130,6 @@ std::string homeDirectory();
 
 // returns the config directory
 std::string configDirectory(char const* binaryPath);
-
-// returns the dir name of a path
-std::string dirname(std::string const&);
 
 // returns the output of a program
 std::string slurpProgram(std::string const& program);

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -44,9 +44,6 @@
 
 namespace arangodb::basics::FileUtils {
 
-// removes trailing path separators from path, path will be modified in-place
-std::string removeTrailingSeparator(std::string const& name);
-
 // normalizes path, path will be modified in-place
 void normalizePath(std::string& name);
 
@@ -115,16 +112,8 @@ bool copyDirectoryRecursive(
 // case the directory cannot be opened for iteration.
 std::vector<std::string> listFiles(std::string const& directory);
 
-// returns the number of files / subdirectories / links in a directory.
-// does not recurse into subdirectories. will throw an exception in
-// case the directory cannot be opened for iteration.
-size_t countFiles(std::string const& directory);
-
 // checks if path is a directory
 bool isDirectory(std::string const& path);
-
-// checks if path is a symbolic link
-bool isSymbolicLink(std::string const& path);
 
 // checks if path is a regular file
 bool isRegularFile(std::string const& path);

--- a/lib/ProgramOptions/IniFileParser.cpp
+++ b/lib/ProgramOptions/IniFileParser.cpp
@@ -145,12 +145,8 @@ bool IniFileParser::parseContent(std::string const& filename,
       _seen.insert(include);
 
       if (!basics::FileUtils::isRegularFile(include)) {
-        std::filesystem::path dirPath =
-            std::filesystem::path(filename).parent_path();
-        if (dirPath.empty()) {
-          dirPath = ".";
-        }
-        include = basics::FileUtils::buildFilename(dirPath.string(), include);
+        include = basics::FileUtils::buildFilename(
+            std::filesystem::path(filename).parent_path().string(), include);
       }
 
       LOG_TOPIC("36d6b", DEBUG, Logger::CONFIG)

--- a/lib/ProgramOptions/IniFileParser.cpp
+++ b/lib/ProgramOptions/IniFileParser.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <cstddef>
+#include <filesystem>
 #include <map>
 #include <sstream>
 
@@ -144,8 +145,12 @@ bool IniFileParser::parseContent(std::string const& filename,
       _seen.insert(include);
 
       if (!basics::FileUtils::isRegularFile(include)) {
-        auto dn = basics::FileUtils::dirname(filename);
-        include = basics::FileUtils::buildFilename(dn, include);
+        std::filesystem::path dirPath =
+            std::filesystem::path(filename).parent_path();
+        if (dirPath.empty()) {
+          dirPath = ".";
+        }
+        include = basics::FileUtils::buildFilename(dirPath.string(), include);
       }
 
       LOG_TOPIC("36d6b", DEBUG, Logger::CONFIG)

--- a/tests/Basics/FilesTest.cpp
+++ b/tests/Basics/FilesTest.cpp
@@ -541,27 +541,3 @@ TEST_F(FilesTest, tst_listfiles) {
   std::sort(found.begin(), found.end());
   EXPECT_EQ(names, found);
 }
-
-TEST_F(FilesTest, tst_countfiles) {
-  constexpr std::string_view content = "piffpaffpuff";
-
-  constexpr size_t n = 16;
-  // create subdirs
-  for (size_t i = 0; i < n; ++i) {
-    std::string name =
-        absl::StrCat(_directory, TRI_DIR_SEPARATOR_STR, "tmp-", ++counter);
-    long unused1;
-    std::string unused2;
-    auto res = TRI_CreateDirectory(name.c_str(), unused1, unused2);
-    EXPECT_EQ(TRI_ERROR_NO_ERROR, res);
-  }
-  // create a few files on top
-  for (size_t i = 0; i < 5; ++i) {
-    std::string name =
-        absl::StrCat(_directory, TRI_DIR_SEPARATOR_STR, "tmp-", ++counter);
-    FileUtils::spit(name, content.data(), content.size(), false);
-  }
-
-  size_t found = FileUtils::countFiles(_directory);
-  EXPECT_EQ(n + 5, found);
-}


### PR DESCRIPTION
### Scope & Purpose
In This PR we are addressing below functions. Removed these functions and replaced with std::filesystem apis.
removeTrailingSeparator()
isSymbolicLink()
countFiles()
size()
dirname()

Please review this PR along with 
- [X] Enterprise PR: https://github.com/arangodb/enterprise/pull/1632


