### PR TITLE
[COR-403] ExecutionNode Annotations

### DIFF
--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -76,6 +76,7 @@
 #include <velocypack/Iterator.h>
 
 #include <algorithm>
+#include <utility>
 
 using namespace arangodb;
 using namespace arangodb::aql;
@@ -605,6 +606,12 @@ ExecutionNode::ExecutionNode(ExecutionPlan* plan, velocypack::Slice slice)
   if (isAsyncPrefetchEnabled()) {
     plan->getAst()->setContainsAsyncPrefetch();
   }
+
+  if (auto annotations = slice.get("annotations"); annotations.isObject()) {
+    for (auto [key, value] : VPackObjectIterator(annotations)) {
+      _annotations.emplace(key.copyString(), VPackString{value});
+    }
+  }
 }
 
 ExecutionNode::ExecutionNode(ExecutionPlan& plan, ExecutionNode const& other)
@@ -667,6 +674,8 @@ void ExecutionNode::cloneWithoutRegisteringAndDependencies(
   other._varsUsedLaterStack = _varsUsedLaterStack;
   other._varsValidStack = _varsValidStack;
   other._registerPlan = _registerPlan;
+
+  other._annotations = _annotations;
 }
 
 /// @brief helper for cloning, use virtual clone methods for dependencies
@@ -1121,6 +1130,13 @@ void ExecutionNode::toVelocyPack(velocypack::Builder& builder,
     builder.add("isCallstackSplitEnabled", VPackValue(true));
   }
 
+  if (!_annotations.empty()) {
+    VPackObjectBuilder guard(&builder, "annotations");
+    for (auto const& [name, value] : _annotations) {
+      builder.add(name, value.slice());
+    }
+  }
+
   TRI_ASSERT(builder.isOpenObject());
   doToVelocyPack(builder, flags);
 }
@@ -1335,6 +1351,25 @@ auto ExecutionNode::getRegsToKeepStack() const -> RegIdSetStack {
         _varsUsedLaterStack, _varsValidStack, getVariablesSetHere());
   }
   return _regsToKeepStack;
+}
+
+auto ExecutionNode::getAnnotation(std::string_view name) const noexcept
+    -> VPackSlice {
+  if (auto it = _annotations.find(name); it != _annotations.end()) {
+    return it->second;
+  }
+  return VPackSlice::nullSlice();
+}
+
+auto ExecutionNode::getAnnotatedString(std::string_view name) const noexcept
+    -> std::optional<std::string_view> {
+  if (auto it = _annotations.find(name); it != _annotations.end()) {
+    ADB_PROD_ASSERT(it->second.isString())
+        << "annotation `" << name << "` expected to be a string, found "
+        << it->second.typeName();
+    return it->second.stringView();
+  }
+  return std::nullopt;
 }
 
 RegisterCount ExecutionNode::getNrOutputRegisters() const {
@@ -1557,6 +1592,26 @@ bool ExecutionNode::isVarUsedLater(Variable const* variable) const noexcept {
 }
 
 bool ExecutionNode::isInInnerLoop() const { return getLoop() != nullptr; }
+
+void ExecutionNode::setAnnotation(std::string name, VPackString value) {
+  _annotations.insert_or_assign(std::move(name), std::move(value));
+}
+
+void ExecutionNode::setAnnotation(std::string name, VPackSlice value) {
+  VPackString str{value};
+  setAnnotation(std::move(name), std::move(str));
+}
+
+void ExecutionNode::setAnnotation(std::string name, VPackValue value) {
+  VPackBuilder builder;
+  builder.add(value);
+  setAnnotation(std::move(name), builder.slice());
+}
+
+void ExecutionNode::setAnnotatedString(std::string name,
+                                       std::string_view value) {
+  setAnnotation(std::move(name), VPackValue(value));
+}
 
 void ExecutionNode::setId(ExecutionNodeId id) { _id = id; }
 

--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -69,6 +69,7 @@
 #include "Aql/types.h"
 #include "Basics/TypeTraits.h"
 #include "Containers/HashSet.h"
+#include "velocypack/String.h"
 
 namespace arangodb {
 namespace velocypack {
@@ -495,6 +496,49 @@ class ExecutionNode {
 
   auto getRegsToKeepStack() const -> RegIdSetStack;
 
+  /// @brief read an annotation. Returns a none-slice if the annotation is not
+  /// found. Probably you want to use some typed alternatives.
+  auto getAnnotation(std::string_view) const noexcept -> VPackSlice;
+
+  /// @brief returns the string stored for the given annotation. Returns nullopt
+  /// if no such annotation exists. It's a hard error if no string value
+  /// was found.
+  auto getAnnotatedString(std::string_view) const noexcept
+      -> std::optional<std::string_view>;
+
+  /// @brief returns the number stored for the given annotation. Returns nullopt
+  /// if no such annotation exists. It's a hard error if no numeric value
+  /// was found.
+  template<std::integral T>
+  auto getAnnotatedNumber(std::string_view name) const noexcept
+      -> std::optional<T> {
+    auto s = getAnnotation(name);
+    if (s.isNone()) {
+      return std::nullopt;
+    }
+    ADB_PROD_ASSERT(s.isNumber<T>())
+        << "annotation `" << name << "` expected to be a number, found "
+        << s.typeName();
+    return s.getNumericValue<T>();
+  }
+
+  /// @brief sets an annotation with the given name and value. An existing
+  /// annotation with the same name is overwritten.
+  void setAnnotation(std::string name, VPackString value);
+  void setAnnotation(std::string name, VPackSlice value);
+  void setAnnotation(std::string name, VPackValue value);
+
+  /// @brief sets an annotation with the given name and integral value.
+  /// An existing annotation with the same name is overwritten.
+  template<std::integral T>
+  void setAnnotatedNumber(std::string name, T value) {
+    setAnnotation(std::move(name), VPackValue(value));
+  }
+
+  /// @brief sets an annotation with the given name and string value.
+  /// An existing annotation with the same name is overwritten.
+  void setAnnotatedString(std::string name, std::string_view value);
+
  protected:
   /// @brief serialize this ExecutionNode to VelocyPack.
   /// This function is called as part of `toVelocyPack` and must be overriden in
@@ -580,6 +624,10 @@ class ExecutionNode {
   /// This is computed during the static analysis for each node using the
   /// variable usage in the plan.
   RegIdSetStack _regsToKeepStack;
+
+  /// @brief contains node metadata information that is produced and consumed
+  /// by different parts of the optimizer or query engine.
+  absl::flat_hash_map<std::string, VPackString> _annotations;
 
  public:
   /// @brief used as "type traits" for ExecutionNodes and derived classes

--- a/tests/Aql/ExecutionNode/ExecutionNodeTest.cpp
+++ b/tests/Aql/ExecutionNode/ExecutionNodeTest.cpp
@@ -238,8 +238,8 @@ TEST_F(ExecutionNodeTest, annotations) {
             "some-annotated-value");
   EXPECT_EQ(node1->getAnnotatedString("does-not-exist"), std::nullopt);
 
-  // check is the cloned node has the same annotations
-  auto node2 = std::unique_ptr<ExecutionNode>{node1->clone(&plan, false)};
+  // check is the cloned node has the same annotations (plan is owner)
+  auto node2 = node1->clone(&plan, false);
   EXPECT_EQ(node2->getAnnotatedString("my-annotation-1"),
             "some-annotated-value");
   EXPECT_EQ(node2->getAnnotatedString("does-not-exist"), std::nullopt);
@@ -257,7 +257,10 @@ TEST_F(ExecutionNodeTest, annotations) {
 
   // check that annotations are serialized to velocypack
   VPackBuilder builder;
-  node1->toVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS | ExecutionNode::SERIALIZE_REGISTER_INFORMATION);
+  node1->setVarsUsedLater({{}});
+  node1->setVarsValid({{}});
+  node1->setRegsToKeep({{}});
+  node1->toVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS);
   auto annotations = builder.slice().get("annotations");
   EXPECT_TRUE(annotations.isObject());
   EXPECT_EQ(annotations.get("my-annotation-1").stringView(),

--- a/tests/Aql/ExecutionNode/ExecutionNodeTest.cpp
+++ b/tests/Aql/ExecutionNode/ExecutionNodeTest.cpp
@@ -226,4 +226,53 @@ TEST_F(ExecutionNodeTest, end_node_not_equal_outvariable_differ) {
   ASSERT_FALSE(node2->isEqualTo(*node1));
 }
 
+TEST_F(ExecutionNodeTest, annotations) {
+  std::unique_ptr<SubqueryEndNode> node1;
+
+  Variable outvar("name", 1, false, resourceMonitor);
+  node1 = std::make_unique<SubqueryEndNode>(&plan, ExecutionNodeId{0}, nullptr,
+                                            &outvar);
+
+  node1->setAnnotatedString("my-annotation-1", "some-annotated-value");
+  EXPECT_EQ(node1->getAnnotatedString("my-annotation-1"),
+            "some-annotated-value");
+  EXPECT_EQ(node1->getAnnotatedString("does-not-exist"), std::nullopt);
+
+  // check is the cloned node has the same annotations
+  auto node2 = std::unique_ptr<ExecutionNode>{node1->clone(&plan, false)};
+  EXPECT_EQ(node2->getAnnotatedString("my-annotation-1"),
+            "some-annotated-value");
+  EXPECT_EQ(node2->getAnnotatedString("does-not-exist"), std::nullopt);
+
+  // check if modifying the cloned nodes annotations does not alter the original
+  // node
+  node2->setAnnotatedString("my-annotation-1", "some-other-annotated-value");
+  EXPECT_EQ(node2->getAnnotatedString("my-annotation-1"),
+            "some-other-annotated-value");
+  EXPECT_EQ(node1->getAnnotatedString("my-annotation-1"),
+            "some-annotated-value");
+  EXPECT_EQ(node2->getAnnotatedString("does-not-exist"), std::nullopt);
+
+  node1->setAnnotatedNumber("some-number", 12);
+
+  // check that annotations are serialized to velocypack
+  VPackBuilder builder;
+  node1->toVelocyPack(builder, ExecutionNode::SERIALIZE_DETAILS | ExecutionNode::SERIALIZE_REGISTER_INFORMATION);
+  auto annotations = builder.slice().get("annotations");
+  EXPECT_TRUE(annotations.isObject());
+  EXPECT_EQ(annotations.get("my-annotation-1").stringView(),
+            "some-annotated-value");
+  EXPECT_EQ(annotations.get("some-number").getInt(), 12);
+  EXPECT_TRUE(annotations.get("does-not-exist").isNone());
+
+  // check if restoring from velocypack restores the annotations
+  auto node3 = std::unique_ptr<ExecutionNode>{
+      ExecutionNode::fromVPackFactory(&plan, builder.slice())};
+
+  EXPECT_EQ(node3->getAnnotatedString("my-annotation-1"),
+            "some-annotated-value");
+  EXPECT_EQ(node3->getAnnotatedNumber<int>("some-number"), 12);
+  EXPECT_EQ(node3->getAnnotatedString("does-not-exist"), std::nullopt);
+}
+
 }  // namespace arangodb::tests::aql


### PR DESCRIPTION
### Scope & Purpose
Multiple times in the past I felt the need to attach additional information to a ExecutionNode during optimization. However, adding a member to the `ExecutionNode` class felt wrong, because
1. This field has meaning to two or three optimizer rules only. There is no need to make everyone aware of my data structures.
2. Most of the time, this field has no meaning and would remain empty. There are a lot of examples of fields that or only valid occasionally, but cause confusion always.

Adding annotations is a quick escape hatch. This is also a very common approach in the LLVM codebase, where Instructions can have arbitrary annotations (called Metadata) which are used to communicate information between two or more optimizer stages/rules. A annotation that is used almost everywhere is a good indicator for when a new member should be introduced.

A annotation uses a string key and can store arbitrary velocypack. However, convenience functions have been added for integral types and strings. Further helper functions can be added in future.