### PR TITLE
Ignore error on index creation

### DIFF
--- a/js/common/modules/@arangodb/testutils/vector-index-common.js
+++ b/js/common/modules/@arangodb/testutils/vector-index-common.js
@@ -301,7 +301,14 @@ function insertDocsAndEnsureIndex({collection, docs, seed, ensureIndex,
 
     for (let i = 0; i < numBatches; i++) {
         if (i === ensureIndexSlot) {
-            ensureIndex();
+            try {
+                ensureIndex();
+            } catch (e) {
+                // Index creation may fail if not enough data is present yet
+                // (e.g. vector index training threshold not met on a shard).
+                // The index still exists in unusable state and the background
+                // build manager will retry once enough data arrives.
+            }
         }
         const start = i * batchSize;
         const end = Math.min(start + batchSize, docs.length);

--- a/js/common/modules/@arangodb/testutils/vector-index-common.js
+++ b/js/common/modules/@arangodb/testutils/vector-index-common.js
@@ -284,31 +284,42 @@ function waitForState(collection, state, timeoutSec, indexName) {
 /**
  * Inserts docs in batches, calling ensureIndex() at a random batch slot
  * determined by the seed. This tests that index creation works regardless of
- * whether it happens before, during, or after data insertion.
+ * whether it happens before, during, or after data insertion. After all docs
+ * are inserted, waits for the vector index to reach the ready state.
  *
  * @param {object} opts
  * @param {ArangoCollection} opts.collection
  * @param {Array} opts.docs - documents to insert
  * @param {number} opts.seed - random seed (used to pick ensureIndex slot)
- * @param {function} opts.ensureIndex - callback that creates the index(es)
+ * @param {object} opts.indexDef - index definition passed to ensureIndex()
+ * @param {string} opts.indexName - name of the vector index to assert ready
  * @param {number} [opts.batchSize=100]
  * @param {function} [opts.onBatchInserted] - called with insert result per batch
+ * @param {number} [opts.readyTimeoutSec=60] - timeout for waiting until the
+ *   vector index reaches the ready state
  */
-function insertDocsAndEnsureIndex({collection, docs, seed, ensureIndex,
-                                    batchSize = 100, onBatchInserted}) {
+function insertDocsAndAssertIndex({collection, docs, seed, indexDef,
+                                    indexName, batchSize = 100,
+                                    onBatchInserted,
+                                    readyTimeoutSec = 60}) {
     const numBatches = Math.ceil(docs.length / batchSize);
     const ensureIndexSlot = Math.abs(seed) % (numBatches + 1);
+    const fullIndexDef = {name: indexName, ...indexDef};
+
+    const tryEnsureIndex = () => {
+        try {
+            collection.ensureIndex(fullIndexDef);
+        } catch (e) {
+            // Index creation may fail if not enough data is present yet
+            // (e.g. vector index training threshold not met on a shard).
+            // The index still exists in unusable state and the background
+            // build manager will retry once enough data arrives.
+        }
+    };
 
     for (let i = 0; i < numBatches; i++) {
         if (i === ensureIndexSlot) {
-            try {
-                ensureIndex();
-            } catch (e) {
-                // Index creation may fail if not enough data is present yet
-                // (e.g. vector index training threshold not met on a shard).
-                // The index still exists in unusable state and the background
-                // build manager will retry once enough data arrives.
-            }
+            tryEnsureIndex();
         }
         const start = i * batchSize;
         const end = Math.min(start + batchSize, docs.length);
@@ -318,7 +329,16 @@ function insertDocsAndEnsureIndex({collection, docs, seed, ensureIndex,
         }
     }
     if (ensureIndexSlot === numBatches) {
-        ensureIndex();
+        collection.ensureIndex(fullIndexDef);
+    }
+    const ready = waitForVectorIndexState(
+        collection, indexName, VectorIndexTrainingState.kReady,
+        readyTimeoutSec);
+    if (!ready) {
+        throw new Error(
+            `Vector index '${indexName}' on collection ` +
+            `'${collection.name()}' did not reach ready state ` +
+            `within ${readyTimeoutSec}s`);
     }
 }
 
@@ -371,4 +391,4 @@ exports.DistanceFunctions = DistanceFunctions;
 exports.VectorIndexTrainingState = VectorIndexTrainingState;
 exports.waitForVectorIndexState = waitForVectorIndexState;
 exports.waitForAllVectorIndexesState = waitForAllVectorIndexesState;
-exports.insertDocsAndEnsureIndex = insertDocsAndEnsureIndex;
+exports.insertDocsAndAssertIndex = insertDocsAndAssertIndex;

--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -33,9 +33,7 @@ const {
     generateSeed,
 } = require("@arangodb/testutils/seededRandom");
 const {
-    insertDocsAndEnsureIndex,
-    waitForAllVectorIndexesState,
-    VectorIndexTrainingState,
+    insertDocsAndAssertIndex,
 } = require("@arangodb/testutils/vector-index-common");
 const isCluster = require("internal").isCluster();
 
@@ -85,10 +83,11 @@ function VectorIndexCreateAndRemoveTestSuite() {
                 });
             }
             insertedDocs = [];
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                readyTimeoutSec: 120,
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -97,14 +96,9 @@ function VectorIndexCreateAndRemoveTestSuite() {
                         dimension,
                         nLists: 10
                     },
-                }),
+                },
                 onBatchInserted: (result) => insertedDocs.push(...result),
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 120),
-                "Expected index to become ready with " + insertedDocsCount + " docs"
-            );
         },
 
         tearDown: function() {
@@ -540,10 +534,11 @@ function VectorIndexStoredValuesTestSuite() {
                 });
             }
             insertedDocs = [];
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2_stored",
+                readyTimeoutSec: 120,
+                indexName: "vector_l2_stored",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -553,14 +548,9 @@ function VectorIndexStoredValuesTestSuite() {
                         dimension,
                         nLists: 1
                     },
-                }),
+                },
                 onBatchInserted: (result) => insertedDocs.push(...result),
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 120),
-                "Expected index to become ready with " + insertedDocsCount + " docs"
-            );
         },
 
         tearDown: function() {

--- a/tests/js/client/aql/vector/aql-vector-filter.js
+++ b/tests/js/client/aql/vector/aql-vector-filter.js
@@ -37,7 +37,7 @@ const {
     generateSeed,
 } = require("@arangodb/testutils/seededRandom");
 const {
-    insertDocsAndEnsureIndex,
+    insertDocsAndAssertIndex,
     waitForAllVectorIndexesState,
     VectorIndexTrainingState,
 } = require("@arangodb/testutils/vector-index-common");
@@ -155,10 +155,10 @@ function VectorIndexL2FilterTestSuite() {
                 });
             }
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -169,13 +169,8 @@ function VectorIndexL2FilterTestSuite() {
                         trainingIterations: 10,
                         defaultNProbe: nProbeAndNlists,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {
@@ -797,10 +792,10 @@ function VectorIndexL2FilterStoredValuesTestSuite() {
                     floatField: i + 0.5
                 });
             }
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2_stored_values",
+                indexName: "vector_l2_stored_values",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -812,13 +807,8 @@ function VectorIndexL2FilterStoredValuesTestSuite() {
                         defaultNProbe: nProbeAndNlists,
                     },
                     storedValues: ["val", "stringField", "boolField", "floatField"]
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {

--- a/tests/js/client/aql/vector/aql-vector-full-count.js
+++ b/tests/js/client/aql/vector/aql-vector-full-count.js
@@ -34,9 +34,7 @@ const {
     generateSeed,
 } = require("@arangodb/testutils/seededRandom");
 const {
-    insertDocsAndEnsureIndex,
-    waitForAllVectorIndexesState,
-    VectorIndexTrainingState,
+    insertDocsAndAssertIndex,
 } = require("@arangodb/testutils/vector-index-common");
 const isCluster = require("internal").isCluster();
 
@@ -80,10 +78,10 @@ function VectorIndexFullCountTestSuite() {
                     vector,
                 });
             }
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -94,13 +92,8 @@ function VectorIndexFullCountTestSuite() {
                         trainingIterations: 10,
                         defaultNProbe: nLists,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {
@@ -269,10 +262,10 @@ function VectorIndexFullCountWithNotEnoughNListsTestSuite() {
                 });
             }
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -282,13 +275,8 @@ function VectorIndexFullCountWithNotEnoughNListsTestSuite() {
                         nLists: 10,
                         trainingIterations: 10,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {
@@ -359,10 +347,10 @@ function VectorIndexFullCountCollectionWithSmallAmountOfDocs() {
                 });
             }
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -372,13 +360,8 @@ function VectorIndexFullCountCollectionWithSmallAmountOfDocs() {
                         nLists: 1,
                         trainingIterations: 10,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {
@@ -449,13 +432,14 @@ function VectorIndexLargeLimitTestSuite() {
                 });
             }
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection,
                 docs,
                 seed,
                 batchSize: 1000,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                readyTimeoutSec: 120,
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -464,13 +448,8 @@ function VectorIndexLargeLimitTestSuite() {
                         dimension: largeLimitDimension,
                         nLists: nLists,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 120),
-                "Expected index to become ready with " + largeLimitNumberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {

--- a/tests/js/client/aql/vector/aql-vector-nprobe.js
+++ b/tests/js/client/aql/vector/aql-vector-nprobe.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertNotEqual, assertTrue */
+/*global assertEqual, assertNotEqual */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -32,9 +32,7 @@ const {
     generateSeed,
 } = require("@arangodb/testutils/seededRandom");
 const {
-    insertDocsAndEnsureIndex,
-    waitForAllVectorIndexesState,
-    VectorIndexTrainingState,
+    insertDocsAndAssertIndex,
 } = require("@arangodb/testutils/vector-index-common");
 const isCluster = require("internal").isCluster();
 const dbName = "vectorDB";
@@ -77,10 +75,10 @@ function VectorIndexL2NprobeTestSuite() {
                     vector
                 });
             }
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -89,13 +87,8 @@ function VectorIndexL2NprobeTestSuite() {
                         dimension: dimension,
                         nLists: 300,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected vector index to become trained"
-            );
         },
 
         tearDownAll: function() {

--- a/tests/js/client/aql/vector/aql-vector.js
+++ b/tests/js/client/aql/vector/aql-vector.js
@@ -39,7 +39,7 @@ const {
 const {
     createVectorGenerator,
     DistanceFunctions,
-    insertDocsAndEnsureIndex,
+    insertDocsAndAssertIndex,
     waitForAllVectorIndexesState,
     VectorIndexTrainingState,
 } = require("@arangodb/testutils/vector-index-common");
@@ -86,10 +86,10 @@ function VectorIndexL2TestSuite() {
             const vectorData = vectorGenerator.generateAllVectors();
             randomPoint = vectorData.randomPoint;
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs: vectorData.docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_l2",
+                indexName: "vector_l2",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     inBackground: false,
@@ -99,13 +99,8 @@ function VectorIndexL2TestSuite() {
                         nLists: 10,
                         trainingIterations: 10,
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {
@@ -563,10 +558,10 @@ function VectorIndexCosineTestSuite() {
             const vectorData = vectorGenerator.generateAllVectors();
             randomPoint = vectorData.randomPoint;
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs: vectorData.docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_cosine",
+                indexName: "vector_cosine",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     params: {
@@ -574,13 +569,8 @@ function VectorIndexCosineTestSuite() {
                         dimension: dimension,
                         nLists: 10
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {
@@ -748,10 +738,10 @@ function VectorIndexInnerProductTestSuite() {
             const vectorData = vectorGenerator.generateAllVectors();
             randomPoint = vectorData.randomPoint;
 
-            insertDocsAndEnsureIndex({
+            insertDocsAndAssertIndex({
                 collection, docs: vectorData.docs, seed,
-                ensureIndex: () => collection.ensureIndex({
-                    name: "vector_inner_product",
+                indexName: "vector_inner_product",
+                indexDef: {
                     type: "vector",
                     fields: ["vector"],
                     params: {
@@ -759,13 +749,8 @@ function VectorIndexInnerProductTestSuite() {
                         dimension: dimension,
                         nLists: 10
                     },
-                }),
+                },
             });
-
-            assertTrue(
-                waitForAllVectorIndexesState(collection, VectorIndexTrainingState.kReady, 60),
-                "Expected index to become ready with " + numberOfDocs + " docs"
-            );
         },
 
         tearDownAll: function() {


### PR DESCRIPTION
### Scope & Purpose

Ignore the error on index creation since later on, the assertion verifies that the index is in the ready state

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
