### PR TITLE
[cor-416] Replace legacy FileUtils functions with std::filesystem equivalents part2

### DIFF
--- a/arangod/RestServer/DatabasePathFeature.cpp
+++ b/arangod/RestServer/DatabasePathFeature.cpp
@@ -124,15 +124,24 @@ void DatabasePathFeature::validateOptions(
 void DatabasePathFeature::prepare() {
   // check if temporary directory and database directory are identical
   {
-    std::string directoryCopy = _options.directory;
-    basics::FileUtils::makePathAbsolute(directoryCopy);
+    std::string const cwd = std::filesystem::current_path();
+    std::string directoryCopy =
+        _options.directory.empty()
+            ? cwd
+            : std::filesystem::absolute(std::filesystem::path(cwd) /
+                                        _options.directory)
+                  .string();
 
     if (server().hasFeature<TempFeature>()) {
       auto& tf = server().getFeature<TempFeature>();
       // the feature is not present in unit tests, so make the execution depend
       // on whether the feature is available
       std::string tempPathCopy = tf.path();
-      basics::FileUtils::makePathAbsolute(tempPathCopy);
+      tempPathCopy = tempPathCopy.empty()
+                         ? cwd
+                         : std::filesystem::absolute(
+                               std::filesystem::path(cwd) / tempPathCopy)
+                               .string();
       tempPathCopy =
           basics::StringUtils::rTrim(tempPathCopy, TRI_DIR_SEPARATOR_STR);
 

--- a/arangod/RestServer/DatabasePathFeature.cpp
+++ b/arangod/RestServer/DatabasePathFeature.cpp
@@ -124,24 +124,16 @@ void DatabasePathFeature::validateOptions(
 void DatabasePathFeature::prepare() {
   // check if temporary directory and database directory are identical
   {
-    std::string const cwd = std::filesystem::current_path();
     std::string directoryCopy =
-        _options.directory.empty()
-            ? cwd
-            : std::filesystem::absolute(std::filesystem::path(cwd) /
-                                        _options.directory)
-                  .string();
+        basics::FileUtils::absolutePath(_options.directory).string();
 
     if (server().hasFeature<TempFeature>()) {
       auto& tf = server().getFeature<TempFeature>();
       // the feature is not present in unit tests, so make the execution depend
       // on whether the feature is available
-      std::string tempPathCopy = tf.path();
-      tempPathCopy = tempPathCopy.empty()
-                         ? cwd
-                         : std::filesystem::absolute(
-                               std::filesystem::path(cwd) / tempPathCopy)
-                               .string();
+
+      std::string tempPathCopy =
+          basics::FileUtils::absolutePath(tf.path()).string();
       tempPathCopy =
           basics::StringUtils::rTrim(tempPathCopy, TRI_DIR_SEPARATOR_STR);
 

--- a/arangod/RestServer/TimeZoneFeature.cpp
+++ b/arangod/RestServer/TimeZoneFeature.cpp
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <stdexcept>
 
+#include <filesystem>
+
 #include "TimeZoneFeature.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -61,9 +63,14 @@ void TimeZoneFeature::prepareTimeZoneData(
         FileUtils::buildFilename(binaryExecutionPath, "tzdata");
 
     if (FileUtils::isDirectory(test_exe)) {
-      FileUtils::makePathAbsolute(test_exe);
-      FileUtils::normalizePath(test_exe);
-      tz_path = test_exe;
+      std::string const cwd = std::filesystem::current_path();
+      test_exe =
+          test_exe.empty()
+              ? cwd
+              : std::filesystem::absolute(std::filesystem::path(cwd) / test_exe)
+                    .string();
+
+      tz_path = std::filesystem::path(test_exe).make_preferred().string();
     } else {
       std::string argv0 =
           FileUtils::buildFilename(binaryExecutionPath, binaryName);
@@ -71,9 +78,13 @@ void TimeZoneFeature::prepareTimeZoneData(
           TRI_LocateInstallDirectory(argv0.c_str(), binaryPath.c_str());
       path =
           FileUtils::buildFilename(path, ICU_DESTINATION_DIRECTORY, "tzdata");
-      FileUtils::makePathAbsolute(path);
-      FileUtils::normalizePath(path);
-      tz_path = path;
+      std::string const cwd = std::filesystem::current_path();
+      path = path.empty()
+                 ? cwd
+                 : std::filesystem::absolute(std::filesystem::path(cwd) / path)
+                       .string();
+
+      tz_path = std::filesystem::path(path).make_preferred().string();
     }
   }
 

--- a/arangod/RestServer/TimeZoneFeature.cpp
+++ b/arangod/RestServer/TimeZoneFeature.cpp
@@ -63,13 +63,7 @@ void TimeZoneFeature::prepareTimeZoneData(
         FileUtils::buildFilename(binaryExecutionPath, "tzdata");
 
     if (FileUtils::isDirectory(test_exe)) {
-      std::string const cwd = std::filesystem::current_path();
-      test_exe =
-          test_exe.empty()
-              ? cwd
-              : std::filesystem::absolute(std::filesystem::path(cwd) / test_exe)
-                    .string();
-
+      test_exe = basics::FileUtils::absolutePath(test_exe).string();
       tz_path = std::filesystem::path(test_exe).make_preferred().string();
     } else {
       std::string argv0 =
@@ -78,12 +72,7 @@ void TimeZoneFeature::prepareTimeZoneData(
           TRI_LocateInstallDirectory(argv0.c_str(), binaryPath.c_str());
       path =
           FileUtils::buildFilename(path, ICU_DESTINATION_DIRECTORY, "tzdata");
-      std::string const cwd = std::filesystem::current_path();
-      path = path.empty()
-                 ? cwd
-                 : std::filesystem::absolute(std::filesystem::path(cwd) / path)
-                       .string();
-
+      path = basics::FileUtils::absolutePath(path).string();
       tz_path = std::filesystem::path(path).make_preferred().string();
     }
   }

--- a/arangod/StorageEngine/EngineSelectorFeature.cpp
+++ b/arangod/StorageEngine/EngineSelectorFeature.cpp
@@ -23,6 +23,8 @@
 
 #include "EngineSelectorFeature.h"
 
+#include <filesystem>
+
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/FileUtils.h"
 #include "Basics/StringUtils.h"
@@ -110,7 +112,7 @@ void EngineSelectorFeature::prepare() {
 
   // fail if engine value in file does not match command-line option
   if (!ServerState::instance()->isCoordinator() &&
-      basics::FileUtils::isRegularFile(_engineFilePath)) {
+      std::filesystem::is_regular_file(_engineFilePath)) {
     LOG_TOPIC("98b5c", DEBUG, Logger::STARTUP)
         << "looking for previously selected engine in file '" << _engineFilePath
         << "'";
@@ -171,7 +173,7 @@ void EngineSelectorFeature::prepare() {
              "engine.";
 
       if (!ServerState::instance()->isCoordinator() &&
-          !basics::FileUtils::isRegularFile(_engineFilePath) &&
+          !std::filesystem::is_regular_file(_engineFilePath) &&
           !_allowDeprecatedDeployments) {
         LOG_TOPIC("ca0a7", FATAL, Logger::STARTUP)
             << "The " << _options.engineName
@@ -245,7 +247,7 @@ void EngineSelectorFeature::start() {
 
   // write engine File
   if (!ServerState::instance()->isCoordinator() &&
-      !basics::FileUtils::isRegularFile(_engineFilePath)) {
+      !std::filesystem::is_regular_file(_engineFilePath)) {
     try {
       basics::FileUtils::spit(_engineFilePath, _options.engineName, true);
     } catch (std::exception const& ex) {

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -704,8 +704,8 @@ void V8DealerFeature::copyInstallationFiles() {
         return true;
       }
 
-      std::string normalized = filename;
-      FileUtils::normalizePath(normalized);
+      std::string const normalized =
+          std::filesystem::path(filename).make_preferred().string();
       if (normalized.ends_with(uiNodeModulesPath)) {
         // filter it out!
         return true;

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -54,6 +54,7 @@
 #include "VocBase/Properties/DatabaseConfiguration.h"
 #include "VocBase/vocbase.h"
 
+#include <filesystem>
 #include <velocypack/Collection.h>
 
 using namespace arangodb;
@@ -612,8 +613,8 @@ Result UpgradeTasks::renameReplicationApplierStateFiles(
   std::string const source = arangodb::basics::FileUtils::buildFilename(
       path, "REPLICATION-APPLIER-STATE");
 
-  if (!basics::FileUtils::isRegularFile(source)) {
-    // source file does not exist
+  if (!std::filesystem::is_regular_file(source)) {
+    // source file does not exist (or not a regular file)
     return {};
   }
 

--- a/client-tools/Dump/DumpFeature.cpp
+++ b/client-tools/Dump/DumpFeature.cpp
@@ -57,6 +57,7 @@
 #include "Utils/ManagedDirectory.h"
 
 #include <chrono>
+#include <filesystem>
 #include <thread>
 #include <unordered_map>
 
@@ -1593,7 +1594,7 @@ void DumpFeature::start() {
       for (auto const& it : list) {
         auto f = absl::StrCat(
             basics::FileUtils::buildFilename(_options.outputPath, it));
-        if (basics::FileUtils::isRegularFile(f)) {
+        if (std::filesystem::is_regular_file(f)) {
           auto fileSize = std::filesystem::file_size(std::filesystem::path(f));
 
           totalSize += fileSize;

--- a/client-tools/Import/ImportFeature.cpp
+++ b/client-tools/Import/ImportFeature.cpp
@@ -25,7 +25,6 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/GreetingsFeature.h"
-#include "Basics/FileUtils.h"
 #include "Basics/NumberOfCores.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Utf8Helper.h"
@@ -46,6 +45,7 @@
 #ifdef USE_ENTERPRISE
 #include "Enterprise/Encryption/EncryptionFeature.h"
 #endif
+#include <filesystem>
 #include <iostream>
 #include <regex>
 
@@ -371,11 +371,12 @@ void ImportFeature::start() {
     FATAL_ERROR_EXIT();
   }
 
-  if (_filename != "-" && !FileUtils::isRegularFile(_filename)) {
-    if (!FileUtils::exists(_filename)) {
+  std::error_code fsEc;
+  if (_filename != "-" && !std::filesystem::is_regular_file(_filename, fsEc)) {
+    if (!std::filesystem::exists(_filename, fsEc)) {
       LOG_TOPIC("6f83e", FATAL, arangodb::Logger::FIXME)
           << "Cannot open file '" << _filename << "'. File not found.";
-    } else if (FileUtils::isDirectory(_filename)) {
+    } else if (std::filesystem::is_directory(_filename, fsEc)) {
       LOG_TOPIC("70dac", FATAL, arangodb::Logger::FIXME)
           << "Specified file '" << _filename
           << "' is a directory. Please use a regular file.";

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -337,8 +337,8 @@ void V8ShellFeature::copyInstallationFiles() {
       return true;
     }
 
-    std::string normalized = filename;
-    FileUtils::normalizePath(normalized);
+    std::string const normalized =
+        std::filesystem::path(filename).make_preferred().string();
     if (filterPath(normalized, nodeModulesPath) ||
         filterPath(normalized, nodeModulesPathVersioned) ||
         filterPath(normalized, jsAppsPath) ||

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -127,7 +127,8 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
 
     IniFileParser parser(options.get());
 
-    if (FileUtils::exists(local) && FileUtils::isRegularFile(local)) {
+    std::error_code pathEc;
+    if (std::filesystem::is_regular_file(local, pathEc)) {
       LOG_TOPIC("9b20a", DEBUG, Logger::CONFIG)
           << "loading override '" << local << "'";
 
@@ -228,7 +229,8 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
   LOG_TOPIC("f6420", TRACE, Logger::CONFIG)
       << "checking override '" << local << "'";
 
-  if (FileUtils::exists(local) && FileUtils::isRegularFile(local)) {
+  std::error_code pathEc;
+  if (std::filesystem::is_regular_file(local, pathEc)) {
     LOG_TOPIC("3d2d0", DEBUG, Logger::CONFIG)
         << "loading override '" << local << "'";
 

--- a/lib/ApplicationFeatures/LanguageFeature.cpp
+++ b/lib/ApplicationFeatures/LanguageFeature.cpp
@@ -218,12 +218,7 @@ std::string LanguageFeature::prepareIcu(std::string const& binaryPath,
       FATAL_ERROR_EXIT_CODE(TRI_EXIT_ICU_INITIALIZATION_FAILED);
     } else {
       std::string icu_path = path.substr(0, path.length() - fn.length());
-      std::string const cwd = std::filesystem::current_path();
-      icu_path =
-          icu_path.empty()
-              ? cwd
-              : std::filesystem::absolute(std::filesystem::path(cwd) / icu_path)
-                    .string();
+      icu_path = basics::FileUtils::absolutePath(icu_path).string();
       icu_path = std::filesystem::path(icu_path).make_preferred().string();
       setenv("ICU_DATA_LEGACY", icu_path.c_str(), 1);
     }

--- a/lib/ApplicationFeatures/LanguageFeature.cpp
+++ b/lib/ApplicationFeatures/LanguageFeature.cpp
@@ -218,8 +218,13 @@ std::string LanguageFeature::prepareIcu(std::string const& binaryPath,
       FATAL_ERROR_EXIT_CODE(TRI_EXIT_ICU_INITIALIZATION_FAILED);
     } else {
       std::string icu_path = path.substr(0, path.length() - fn.length());
-      FileUtils::makePathAbsolute(icu_path);
-      FileUtils::normalizePath(icu_path);
+      std::string const cwd = std::filesystem::current_path();
+      icu_path =
+          icu_path.empty()
+              ? cwd
+              : std::filesystem::absolute(std::filesystem::path(cwd) / icu_path)
+                    .string();
+      icu_path = std::filesystem::path(icu_path).make_preferred().string();
       setenv("ICU_DATA_LEGACY", icu_path.c_str(), 1);
     }
   }

--- a/lib/ApplicationFeatures/TempFeature.cpp
+++ b/lib/ApplicationFeatures/TempFeature.cpp
@@ -63,8 +63,7 @@ void TempFeature::validateOptions(std::shared_ptr<ProgramOptions> /*options*/) {
     // replace $PID in basepath with current process id
     _options.path = basics::StringUtils::replace(
         _options.path, "$PID", std::to_string(Thread::currentProcessId()));
-
-    basics::FileUtils::makePathAbsolute(_options.path);
+    std::filesystem::absolute(_options.path).string();
   }
 }
 

--- a/lib/Basics/ArangoGlobalContext.cpp
+++ b/lib/Basics/ArangoGlobalContext.cpp
@@ -22,6 +22,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "ArangoGlobalContext.h"
+
+#include <filesystem>
+
 #include "Basics/FileUtils.h"
 #include "Basics/StringUtils.h"
 #include "Basics/VelocyPackHelper.h"
@@ -111,7 +114,7 @@ void ArangoGlobalContext::normalizePath(std::string& path,
                                         char const* whichPath, bool fatal) {
   StringUtils::rTrimInPlace(path, TRI_DIR_SEPARATOR_STR);
 
-  arangodb::basics::FileUtils::normalizePath(path);
+  path = std::filesystem::path(path).make_preferred().string();
   if (!arangodb::basics::FileUtils::exists(path)) {
     std::string directory =
         arangodb::basics::FileUtils::buildFilename(_runRoot, path);
@@ -125,11 +128,16 @@ void ArangoGlobalContext::normalizePath(std::string& path,
           << directory << "'";
       FATAL_ERROR_EXIT();
     }
-    arangodb::basics::FileUtils::normalizePath(directory);
+    directory =
+        std::filesystem::path(directory).make_preferred().string();
     path = directory;
   } else {
     if (!std::filesystem::path(path).is_absolute()) {
-      arangodb::basics::FileUtils::makePathAbsolute(path);
+      std::string const cwd = std::filesystem::current_path();
+      path = path.empty()
+                 ? cwd
+                 : std::filesystem::absolute(std::filesystem::path(cwd) / path)
+                       .string();
     }
   }
 }

--- a/lib/Basics/ArangoGlobalContext.cpp
+++ b/lib/Basics/ArangoGlobalContext.cpp
@@ -128,16 +128,11 @@ void ArangoGlobalContext::normalizePath(std::string& path,
           << directory << "'";
       FATAL_ERROR_EXIT();
     }
-    directory =
-        std::filesystem::path(directory).make_preferred().string();
+    directory = std::filesystem::path(directory).make_preferred().string();
     path = directory;
   } else {
     if (!std::filesystem::path(path).is_absolute()) {
-      std::string const cwd = std::filesystem::current_path();
-      path = path.empty()
-                 ? cwd
-                 : std::filesystem::absolute(std::filesystem::path(cwd) / path)
-                       .string();
+      path = basics::FileUtils::absolutePath(path).string();
     }
   }
 }

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -31,7 +31,6 @@
 #include <functional>
 #include <memory>
 #include <utility>
-#include <filesystem>
 
 #include "FileUtils.h"
 
@@ -100,51 +99,36 @@ StatResultType statResultType(std::string const& path) {
 
 void processFiles(std::string const& directory,
                   std::function<void(std::string const&)> const& cb) {
-  DIR* d = opendir(directory.c_str());
-
-  if (d == nullptr) {
+  std::filesystem::path const dir{directory};
+  std::error_code ec;
+  std::filesystem::directory_iterator iter(dir, ec);
+  if (ec) {
     auto res = TRI_set_errno(TRI_ERROR_SYS_ERROR);
-
     auto message = arangodb::basics::StringUtils::concatT(
         "failed to enumerate files in directory '", directory,
-        "': ", TRI_last_error());
+        "': ", ec.message());
     THROW_ARANGO_EXCEPTION_MESSAGE(res, std::move(message));
   }
-
-  auto guard = arangodb::scopeGuard([&]() noexcept { closedir(d); });
-
-  std::string rcs;
-  dirent* de = readdir(d);
-
-  while (de != nullptr) {
-    // stringify filename (convert to std::string). we take this performance
-    // hit because we will need to strlen anyway and need to pass it to a
-    // function that will likely use its stringified value anyway
-    rcs.assign(de->d_name);
-
-    if (rcs != "." && rcs != "..") {
-      // run callback function
-      cb(rcs);
+  std::filesystem::directory_iterator const end;
+  while (iter != end) {
+    std::string const name = iter->path().filename().string();
+    if (name != "." && name != "..") {
+      cb(name);
     }
-
-    // advance to next entry
-    de = readdir(d);
+    iter.increment(ec);
+    if (ec) {
+      auto res = TRI_set_errno(TRI_ERROR_SYS_ERROR);
+      auto message = arangodb::basics::StringUtils::concatT(
+          "failed to enumerate files in directory '", directory,
+          "': ", ec.message());
+      THROW_ARANGO_EXCEPTION_MESSAGE(res, std::move(message));
+    }
   }
 }
 
 }  // namespace
 
 namespace arangodb::basics::FileUtils {
-
-////////////////////////////////////////////////////////////////////////////////
-/// @brief normalizes path
-///
-/// path will be modified in-place
-////////////////////////////////////////////////////////////////////////////////
-
-void normalizePath(std::string& name) {
-  std::replace(name.begin(), name.end(), '/', TRI_DIR_SEPARATOR_CHAR);
-}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief creates a filename
@@ -171,9 +155,8 @@ std::string buildFilename(char const* path, char const* name) {
   } else {
     result.append(name);
   }
-  normalizePath(result);  // in place
 
-  return result;
+  return std::filesystem::path(result).make_preferred().string();
 }
 
 std::string buildFilename(std::string const& path, std::string const& name) {
@@ -194,9 +177,8 @@ std::string buildFilename(std::string const& path, std::string const& name) {
   } else {
     result.append(name);
   }
-  normalizePath(result);  // in place
 
-  return result;
+  return std::filesystem::path(result).make_preferred().string();
 }
 
 static void throwFileReadError(std::string const& filename) {
@@ -513,10 +495,6 @@ bool isDirectory(std::string const& path) {
   return ::statResultType(path) == ::StatResultType::Directory;
 }
 
-bool isRegularFile(std::string const& path) {
-  return ::statResultType(path) == ::StatResultType::File;
-}
-
 bool exists(std::string const& path) {
   return ::statResultType(path) != ::StatResultType::Error;
 }
@@ -546,16 +524,6 @@ std::string configDirectory(char const* binaryPath) {
   }
 
   return dir;
-}
-
-void makePathAbsolute(std::string& path) {
-  std::string const cwd = std::filesystem::current_path();
-  if (path.empty()) {
-    path = cwd;
-  } else {
-    path =
-        std::filesystem::absolute(std::filesystem::path(cwd) / path).string();
-  }
 }
 
 namespace {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -576,6 +576,13 @@ std::string slurpProgramInternal(std::string const& program,
 
 }  // namespace
 
+auto absolutePath(std::filesystem::path path) -> std::filesystem::path {
+  if (path.empty()) {
+    return std::filesystem::current_path();
+  }
+  return std::filesystem::absolute(path);
+}
+
 std::string slurpProgram(std::string const& program) {
   std::vector<std::string> moreArgs{std::string("version")};
   return slurpProgramInternal(program, moreArgs);

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -28,6 +28,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include "Basics/FileResult.h"
 #include "Basics/FileResultString.h"
@@ -44,7 +45,8 @@
 
 namespace arangodb::basics::FileUtils {
 
-// normalizes path, path will be modified in-place
+// makes a path absolute
+std::filesystem::path absolutePath(std::filesystem::path path);
 
 // creates a filename
 std::string buildFilename(char const* path, char const* name);

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -45,10 +45,6 @@
 namespace arangodb::basics::FileUtils {
 
 // normalizes path, path will be modified in-place
-void normalizePath(std::string& name);
-
-// makes a path absolute, path will be modified in-place
-void makePathAbsolute(std::string& path);
 
 // creates a filename
 std::string buildFilename(char const* path, char const* name);
@@ -114,9 +110,6 @@ std::vector<std::string> listFiles(std::string const& directory);
 
 // checks if path is a directory
 bool isDirectory(std::string const& path);
-
-// checks if path is a regular file
-bool isRegularFile(std::string const& path);
 
 // checks if path exists
 bool exists(std::string const& path);

--- a/lib/ProgramOptions/IniFileParser.cpp
+++ b/lib/ProgramOptions/IniFileParser.cpp
@@ -144,7 +144,7 @@ bool IniFileParser::parseContent(std::string const& filename,
 
       _seen.insert(include);
 
-      if (!basics::FileUtils::isRegularFile(include)) {
+      if (!std::filesystem::is_regular_file(include)) {
         include = basics::FileUtils::buildFilename(
             std::filesystem::path(filename).parent_path().string(), include);
       }

--- a/lib/V8/V8PlatformFeature.cpp
+++ b/lib/V8/V8PlatformFeature.cpp
@@ -346,12 +346,7 @@ std::string V8PlatformFeature::determineICUDataPath() {
 
     if (TRI_IsRegularFile(path.c_str())) {
       std::string icu_path = path.substr(0, path.length() - fn.length());
-      std::string const cwd = std::filesystem::current_path();
-      icu_path =
-          icu_path.empty()
-              ? cwd
-              : std::filesystem::absolute(std::filesystem::path(cwd) / icu_path)
-                    .string();
+      icu_path = basics::FileUtils::absolutePath(icu_path).string();
       icu_path = std::filesystem::path(icu_path).make_preferred().string();
       setenv("ICU_DATA", icu_path.c_str(), 1);
     }

--- a/lib/V8/V8PlatformFeature.cpp
+++ b/lib/V8/V8PlatformFeature.cpp
@@ -23,6 +23,8 @@
 
 #include "V8PlatformFeature.h"
 
+#include <filesystem>
+
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/ArangoGlobalContext.h"
 #include "Basics/FileUtils.h"
@@ -344,8 +346,13 @@ std::string V8PlatformFeature::determineICUDataPath() {
 
     if (TRI_IsRegularFile(path.c_str())) {
       std::string icu_path = path.substr(0, path.length() - fn.length());
-      FileUtils::makePathAbsolute(icu_path);
-      FileUtils::normalizePath(icu_path);
+      std::string const cwd = std::filesystem::current_path();
+      icu_path =
+          icu_path.empty()
+              ? cwd
+              : std::filesystem::absolute(std::filesystem::path(cwd) / icu_path)
+                    .string();
+      icu_path = std::filesystem::path(icu_path).make_preferred().string();
       setenv("ICU_DATA", icu_path.c_str(), 1);
     }
   }

--- a/tests/Basics/FilesTest.cpp
+++ b/tests/Basics/FilesTest.cpp
@@ -350,34 +350,6 @@ TEST_F(FilesTest, tst_normalizepath) {
 #endif
 }
 
-TEST_F(FilesTest, tst_normalize) {
-  std::string path;
-
-  path = "/foo/bar/baz";
-  FileUtils::normalizePath(path);
-  EXPECT_EQ(std::string("/foo/bar/baz"), path);
-
-  path = "\\foo\\bar\\baz";
-  FileUtils::normalizePath(path);
-  EXPECT_EQ(std::string("\\foo\\bar\\baz"), path);
-
-  path = "/foo/bar\\baz";
-  FileUtils::normalizePath(path);
-  EXPECT_EQ(std::string("/foo/bar\\baz"), path);
-
-  path = "/foo/bar/\\baz";
-  FileUtils::normalizePath(path);
-  EXPECT_EQ(std::string("/foo/bar/\\baz"), path);
-
-  path = "//foo\\/bar/\\baz";
-  FileUtils::normalizePath(path);
-  EXPECT_EQ(std::string("//foo\\/bar/\\baz"), path);
-
-  path = "\\\\foo\\/bar/\\baz";
-  FileUtils::normalizePath(path);
-  EXPECT_EQ(std::string("\\\\foo\\/bar/\\baz"), path);
-}
-
 TEST_F(FilesTest, tst_getfilename) {
   EXPECT_EQ("", TRI_GetFilename(""));
   EXPECT_EQ(".", TRI_GetFilename("."));


### PR DESCRIPTION
Replaced legacy FileUtils functions with std::filesystem equivalents. Updated below functions.

listFiles()
isRegularFile()
makePathAbsolute()
normalizePath()

Along this PR consider Enterprise PR : https://github.com/arangodb/enterprise/pull/1640