### PR TITLE
[COR-428] Backport: Fix counters in ingestVectors tsan race

### DIFF
--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -30,6 +30,7 @@
 #include "RocksDBEngine/RocksDBIndex.h"
 #include "RocksDBEngine/RocksDBVectorIndex.h"
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -332,10 +333,10 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
   };
 
   struct BlockCounters {
-    uint64_t readProduceBlocked{0};
-    uint64_t encodeProduceBlocked{0};
-    uint64_t encodeConsumeBlocked{0};
-    uint64_t writeConsumeBlocked{0};
+    std::atomic<uint64_t> readProduceBlocked{0};
+    std::atomic<uint64_t> encodeProduceBlocked{0};
+    std::atomic<uint64_t> encodeConsumeBlocked{0};
+    std::atomic<uint64_t> writeConsumeBlocked{0};
   } counters;
 
   BoundedChannel<DocumentVectors> documentChannel{5};
@@ -434,7 +435,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
                                   batch->vectors.data());
           }
           auto [shouldStop, blocked] = documentChannel.push(std::move(batch));
-          counters.readProduceBlocked += blocked;
+          counters.readProduceBlocked.fetch_add(blocked,
+                                                std::memory_order_relaxed);
 
           if (shouldStop) {
             return;
@@ -463,7 +465,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
 
       bool shouldStop = false;
       errorExceptionHandler([&] {
-        counters.encodeConsumeBlocked += blocked;
+        counters.encodeConsumeBlocked.fetch_add(blocked,
+                                                std::memory_order_relaxed);
         auto n = item->docIds.size();
         countBatches += 1;
         countDocuments += n;
@@ -491,7 +494,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
         bool pushBlocked = false;
         std::tie(shouldStop, pushBlocked) =
             encodedChannel.push(std::move(encoded));
-        counters.encodeProduceBlocked += pushBlocked;
+        counters.encodeProduceBlocked.fetch_add(pushBlocked,
+                                                std::memory_order_relaxed);
       });
       if (shouldStop) {
         break;
@@ -508,7 +512,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
       }
 
       errorExceptionHandler([&] {
-        counters.writeConsumeBlocked += blocked;
+        counters.writeConsumeBlocked.fetch_add(blocked,
+                                               std::memory_order_relaxed);
         batch.Clear();
 
         RocksDBKey key;


### PR DESCRIPTION
### Scope & Purpose

Backport of https://github.com/arangodb/arangodb/pull/22624

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
