### PR TITLE
enable vector index for python drivers

### DIFF
--- a/js/client/modules/@arangodb/testsuites/python-arango.js
+++ b/js/client/modules/@arangodb/testsuites/python-arango.js
@@ -78,6 +78,7 @@ class runInPythonTest extends runWithAllureReport {
       // need by Python tests to query the options API
       'server.options-api': 'admin',
       'backup.api-enabled': true,
+      "vector-index": "true",
     };
     //opts['arangodConfig'] = 'arangod-auth.conf';
     _.defaults(opts, options);


### PR DESCRIPTION
### Scope & Purpose

the python driver now also tests the vector index, enable it. 

- [x] :pizza: New feature
