### PR TITLE
[COR-415] Backport-3.12.9: Fix vector index catch up

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,14 @@
-3.12.9 (2026-04-03)
--------------------
+3.12.9.1 (XXXX-XX-XX)
+---------------------
+
 * COR-415: Fix vector index catch-up phase to use the proper
   `fillIndexBackground` path via `RocksDBBuilderIndex`. This ensures that
   WAL entries written during training are correctly ingested, preventing
   missed documents after index creation.
 
+
+3.12.9 (2026-04-03)
+-------------------
 * Bump lodash from 4.17.21 to 4.18.1.
 
 * Bump @xmldom/xmldom from 0.8.10 to 0.8.12.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 3.12.9 (2026-04-03)
 -------------------
+* COR-415: Fix vector index catch-up phase to use the proper
+  `fillIndexBackground` path via `RocksDBBuilderIndex`. This ensures that
+  WAL entries written during training are correctly ingested, preventing
+  missed documents after index creation.
 
 * Bump lodash from 4.17.21 to 4.18.1.
 

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -25,12 +25,8 @@
 
 #include "Indexes/Index.h"
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/FileUtils.h"
-#include "Basics/VelocyPackHelper.h"
 #include "Basics/application-exit.h"
 #include "Basics/debugging.h"
-#include "Basics/files.h"
-#include "Containers/HashSet.h"
 #include "RocksDBEngine/RocksDBFormat.h"
 #include "RocksDBEngine/RocksDBVectorIndex.h"
 #include "RocksDBEngine/RocksDBVectorIndexBuilder.h"
@@ -354,7 +350,7 @@ static Result fillIndex(
   if (ridx.type() == Index::TRI_IDX_TYPE_VECTOR_INDEX) {
     auto& vecIdx = static_cast<RocksDBVectorIndex&>(ridx);
     it->Seek(bounds.start());
-    auto res = vector::ingestVectors(vecIdx, rootDB, std::move(it));
+    res = vector::ingestVectors(vecIdx, rootDB, std::move(it));
     if (res.ok()) {
       res = trx.commit();
     }

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -143,6 +143,8 @@ class RocksDBBuilderIndex final : public RocksDBIndex {
   }
   void recalculateEstimates() override { _wrapped->recalculateEstimates(); }
 
+  RocksDBIndex const& wrapped() const noexcept { return *_wrapped; }
+
   /// @brief Validates existing documents before the index is persisted.
   /// Creates a snapshot and iterator, then delegates to _wrapped->prepareIndex.
   Result beforeCreate();

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -452,6 +452,13 @@ void RocksDBCollection::duringAddIndex(std::shared_ptr<Index> idx) {
   }
 }
 
+void RocksDBCollection::swapIndex(std::shared_ptr<Index> const& oldIdx,
+                                  std::shared_ptr<Index> const& newIdx) {
+  RECURSIVE_WRITE_LOCKER(_indexesLock, _indexesLockWriteOwner);
+  removeIndex(_indexes, oldIdx->id());
+  _indexes.emplace(newIdx);
+}
+
 futures::Future<std::shared_ptr<Index>> RocksDBCollection::createIndex(
     VPackSlice info, bool restore, bool& created,
     std::shared_ptr<std::function<arangodb::Result(double)>> progress,

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -74,6 +74,12 @@ class RocksDBCollection final : public RocksDBMetaCollection {
       std::shared_ptr<std::function<arangodb::Result(double)>> = nullptr,
       Replication2Callback replicationCb = nullptr) override;
 
+  /// @brief Atomically replace one index with another in _indexes.
+  ///        Used by VectorIndexBuilder to swap the RocksDBBuilderIndex
+  ///        wrapper in/out during the fill+catchup phase.
+  void swapIndex(std::shared_ptr<Index> const& oldIdx,
+                 std::shared_ptr<Index> const& newIdx);
+
   std::unique_ptr<IndexIterator> getAllIterator(
       transaction::Methods* trx, ReadOwnWrites readOwnWrites) const override;
   std::unique_ptr<IndexIterator> getAnyIterator(

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -266,8 +266,8 @@ bool RocksDBVectorIndex::isVectorIndexReady() const noexcept {
          VectorIndexTrainingState::kReady;
 }
 
-Result RocksDBVectorIndex::readDocumentVectorData(velocypack::Slice const doc,
-                                                  std::vector<float>& output) {
+Result RocksDBVectorIndex::readDocumentVectorData(
+    velocypack::Slice const doc, std::vector<float>& output) const {
   return vector::readDocumentVectorData(doc, _fields, _definition.dimension,
                                         output);
 }
@@ -337,13 +337,8 @@ void RocksDBVectorIndex::truncateCommit(TruncateGuard&& guard,
   RocksDBIndex::truncateCommit(std::move(guard), tick, trx);
 }
 
-/// @brief inserts a document into the index
-Result RocksDBVectorIndex::insert(transaction::Methods& trx,
-                                  RocksDBMethods* methods,
-                                  LocalDocumentId documentId,
-                                  velocypack::Slice doc,
-                                  OperationOptions const& /*options*/,
-                                  bool /*performChecks*/) {
+ResultT<std::vector<float>> RocksDBVectorIndex::preModificationCheck(
+    std::string_view operation, velocypack::Slice doc) const {
   std::vector<float> input;
   input.reserve(_definition.dimension);
   if (auto const res = readDocumentVectorData(doc, input); res.fail()) {
@@ -364,11 +359,40 @@ Result RocksDBVectorIndex::insert(transaction::Methods& trx,
   }
   TRI_ASSERT(_faissIndex != nullptr);
 
+  if (auto const state = _trainingState.load(std::memory_order_acquire);
+      state == VectorIndexTrainingState::kUnusable ||
+      state == VectorIndexTrainingState::kTraining) {
+    LOG_TOPIC("d1e0a", DEBUG, Logger::ENGINES) << std::format(
+        "vector index {} not yet trained, skipping {}", _iid.id(), operation);
+
+    // Not an error but the result is ignored
+    return {};
+  }
+
   if (_definition.metric == SimilarityMetric::kCosine) {
     faiss::fvec_renorm_L2(_definition.dimension, 1, input.data());
   }
 
-  // Trained: normal FAISS path
+  return {std::move(input)};
+}
+
+/// @brief inserts a document into the index
+Result RocksDBVectorIndex::insert(transaction::Methods& trx,
+                                  RocksDBMethods* methods,
+                                  LocalDocumentId documentId,
+                                  velocypack::Slice doc,
+                                  OperationOptions const& /*options*/,
+                                  bool /*performChecks*/) {
+  auto res = preModificationCheck("insert", doc);
+  if (res.fail()) {
+    return {res.errorNumber(), res.errorMessage()};
+  }
+  auto input = std::move(res.get());
+  if (input.empty()) {
+    // sparse or index or indexes in unusable/training state
+    return {};
+  }
+
   faiss::idx_t listId{0};
   TRI_ASSERT(_faissIndex->quantizer != nullptr);
   _faissIndex->quantizer->assign(1, input.data(), &listId);
@@ -409,23 +433,14 @@ Result RocksDBVectorIndex::remove(transaction::Methods& /*trx*/,
                                   LocalDocumentId documentId,
                                   velocypack::Slice doc,
                                   OperationOptions const& /*options*/) {
-  std::vector<float> input;
-  input.reserve(_definition.dimension);
-  if (auto const res = readDocumentVectorData(doc, input); res.fail()) {
-    if (_sparse && res.is(TRI_ERROR_BAD_PARAMETER)) {
-      return {};
-    }
-    return res;
+  auto res = preModificationCheck("remove", doc);
+  if (res.fail()) {
+    return res.result();
   }
-
-  if (auto const state = _trainingState.load();
-      state == VectorIndexTrainingState::kUnusable ||
-      state == VectorIndexTrainingState::kTraining) {
+  auto input = std::move(res.get());
+  if (input.empty()) {
+    // sparse or index or indexes in unusable/training state
     return {};
-  }
-
-  if (_definition.metric == SimilarityMetric::kCosine) {
-    faiss::fvec_renorm_L2(_definition.dimension, 1, input.data());
   }
 
   faiss::idx_t listId{0};

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -99,7 +99,7 @@ class RocksDBVectorIndex final : public RocksDBIndex {
   bool isVectorIndexReady() const noexcept override;
 
   Result readDocumentVectorData(velocypack::Slice doc,
-                                std::vector<float>& vector);
+                                std::vector<float>& vector) const;
 
   std::shared_ptr<faiss::IndexIVF> const& faissIndex() const noexcept {
     return _faissIndex;
@@ -132,6 +132,9 @@ class RocksDBVectorIndex final : public RocksDBIndex {
   void resetTrainingState() noexcept;
 
  protected:
+  ResultT<std::vector<float>> preModificationCheck(std::string_view operation,
+                                                   velocypack::Slice doc) const;
+
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,
                 LocalDocumentId documentId, velocypack::Slice doc,
                 OperationOptions const& options, bool performChecks) override;

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -144,6 +144,19 @@ std::shared_ptr<faiss::IndexIVF> VectorIndexTrainer::restoreFromTrainedData(
   return faissIndex;
 }
 
+BoundedDocumentIterator::BoundedDocumentIterator(RocksDBKeyBounds bounds,
+                                                 rocksdb::DB* db,
+                                                 rocksdb::Snapshot const* snap)
+    : bounds(std::move(bounds)), upper(this->bounds.end()), ro(false, false) {
+  ro.prefix_same_as_start = true;
+  ro.iterate_upper_bound = &upper;
+  ro.snapshot = snap;
+  auto* docCF = RocksDBColumnFamilyManager::get(
+      RocksDBColumnFamilyManager::Family::Documents);
+  it.reset(db->NewIterator(ro, docCF));
+  it->Seek(this->bounds.start());
+}
+
 VectorIndexTrainer::VectorIndexTrainer(
     UserVectorIndexDefinition const& definition, bool isSparse,
     std::vector<std::vector<basics::AttributeName>> const& fields,
@@ -307,6 +320,12 @@ ResultT<std::shared_ptr<faiss::IndexIVF>> VectorIndexTrainer::train(
 Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
                      std::unique_ptr<rocksdb::Iterator> documentIterator,
                      std::stop_token stopToken) {
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  while (TRI_ShouldFailDebugging("RocksDBVectorIndex::pauseDuringIngestion")) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+#endif
+
   auto const& definition = index.getDefinition();
   auto const dim = definition.dimension;
   auto const& fields = index.fields();
@@ -595,44 +614,64 @@ VectorIndexBuildManager::VectorIndexBuildManager(RocksDBVectorIndex& index)
       _rcoll(static_cast<RocksDBCollection*>(index.collection().getPhysical())),
       _bounds(_rcoll->bounds()) {}
 
+Result VectorIndexBuildManager::persistTrainedData(
+    TrainedData const& trainedData) {
+  velocypack::Builder builder;
+  velocypack::serialize(builder, trainedData);
+
+  RocksDBKey key;
+  key.constructVectorIndexTrainedData(_index.objectId());
+  auto value = RocksDBValue::VectorIndexValue(builder.slice());
+
+  auto* vectorCF = RocksDBColumnFamilyManager::get(
+      RocksDBColumnFamilyManager::Family::VectorIndex);
+  rocksdb::WriteOptions wo;
+  auto status = _rootDB->Put(wo, vectorCF, key.string(), value.string());
+  if (!status.ok()) {
+    return Result{
+        TRI_ERROR_INTERNAL,
+        std::string{"Failed to persist trained data: "} + status.ToString()};
+  }
+  return {};
+}
+
 Result VectorIndexBuildManager::build(
     std::shared_ptr<RocksDBIndex> indexPtr,
     metrics::Histogram<metrics::LogScale<double>>& trainingDuration,
     metrics::Histogram<metrics::LogScale<double>>& ingestionDuration,
     std::stop_token stopToken) {
+  auto const shouldAbort = [&]() -> bool {
+    return stopToken.stop_requested() || _index.collection().deleted();
+  };
+
   if (!_index.setTrainingState(VectorIndexTrainingState::kUnusable,
                                VectorIndexTrainingState::kTraining)) {
     return Result{TRI_ERROR_INTERNAL, "vector index is not in unusable state"};
   }
 
-  auto shouldAbort = [&]() -> bool {
-    return stopToken.stop_requested() || _index.collection().deleted();
-  };
-
-  if (shouldAbort()) {
-    _index.resetTrainingState();
-    return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  while (TRI_ShouldFailDebugging("RocksDBVectorIndex::pauseBeforeTraining")) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    if (shouldAbort()) {
+      break;
+    }
   }
+#endif
 
-  rocksdb::Slice upper(_bounds.end());
-  rocksdb::ReadOptions ro(false, false);
-  ro.prefix_same_as_start = true;
-  ro.iterate_upper_bound = &upper;
-
-  auto* docCF = RocksDBColumnFamilyManager::get(
-      RocksDBColumnFamilyManager::Family::Documents);
+  // TRAINING PHASE
+  auto const numDocsHint = _rcoll->meta().numberDocuments();
   VectorIndexTrainer trainer(_index.getDefinition(), _index.sparse(),
                              _index.fields(), _index.collection().name(),
                              _index.id().id(), _index.trainingThreshold());
+
+  BoundedDocumentIterator docIt(_bounds, _rootDB);
 
   auto const trainStart = std::chrono::steady_clock::now();
   if (shouldAbort()) {
     _index.resetTrainingState();
     return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
   }
-  std::unique_ptr<rocksdb::Iterator> trainIt(_rootDB->NewIterator(ro, docCF));
-  trainIt->Seek(_bounds.start());
-  auto faissIndexResult = trainer.train(*trainIt, upper, stopToken);
+  auto faissIndexResult = trainer.train(*docIt.it, docIt.upper, stopToken);
   auto const trainEnd = std::chrono::steady_clock::now();
   if (faissIndexResult.fail()) {
     _index.resetTrainingState();
@@ -654,60 +693,75 @@ Result VectorIndexBuildManager::build(
 
   auto trainedData = serializeIndex(*faissIndex);
 
-  // Persist trained data to the vector CF so it survives restarts.
-  {
-    velocypack::Builder builder;
-    velocypack::serialize(builder, trainedData);
-
-    RocksDBKey key;
-    key.constructVectorIndexTrainedData(_index.objectId());
-    auto value = RocksDBValue::VectorIndexValue(builder.slice());
-
-    auto* vectorCF = RocksDBColumnFamilyManager::get(
-        RocksDBColumnFamilyManager::Family::VectorIndex);
-    rocksdb::WriteOptions wo;
-    auto status = _rootDB->Put(wo, vectorCF, key.string(), value.string());
-    if (!status.ok()) {
-      _index.resetTrainingState();
-      return Result{
-          TRI_ERROR_INTERNAL,
-          std::string{"Failed to persist trained data: "} + status.ToString()};
-    }
+  if (auto res = persistTrainedData(trainedData); res.fail()) {
+    _index.resetTrainingState();
+    return res;
   }
 
   _index.applyTrainingResult(std::move(faissIndex), std::move(trainedData));
   _index.setTrainingState(VectorIndexTrainingState::kTraining,
                           VectorIndexTrainingState::kIngesting);
 
-  auto const ingestStart = std::chrono::steady_clock::now();
-
-  std::unique_ptr<rocksdb::Iterator> ingestIt(_rootDB->NewIterator(ro, docCF));
-  ingestIt->Seek(_bounds.start());
-
   TRI_IF_FAILURE("RocksDBVectorIndex::buildWrongDimension") {
     _index.resetTrainingState();
     return Result{TRI_ERROR_DEBUG};
   }
 
-  Result res = ingestVectors(_index, _rootDB, std::move(ingestIt), stopToken);
+  // INGESTION PHASE
+  auto const ingestStart = std::chrono::steady_clock::now();
+
+  // Create RocksDBBuilderIndex wrapper
+  auto buildIdx = std::make_shared<RocksDBBuilderIndex>(
+      indexPtr, numDocsHint, IndexFactory::kMaxParallelism);
+
+  _rcoll->swapIndex(indexPtr, buildIdx);
+  auto swapGuard = ScopeGuard([&]() noexcept {
+    // On any exit, ensure the real index is back in _indexes.
+    _rcoll->swapIndex(buildIdx, indexPtr);
+  });
+
+#ifdef ARANGODB_ENABLE_FAILURE_TESTS
+  while (TRI_ShouldFailDebugging("RocksDBVectorIndex::pauseBeforeIngestion")) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    if (shouldAbort()) {
+      break;
+    }
+  }
+#endif
+
+  RocksDBBuilderIndex::Locker locker(_rcoll);
+  if (!locker.lock().waitAndGet()) {
+    _index.resetTrainingState();
+    return Result{TRI_ERROR_LOCK_TIMEOUT,
+                  "failed to acquire lock for vector index build"};
+  }
+
+  // This solves all our problems with catching up with WAL entries
+  auto res = buildIdx->fillIndexBackground(locker).waitAndGet();
   auto const ingestEnd = std::chrono::steady_clock::now();
 
   if (res.fail()) {
     LOG_TOPIC("e166b", ERR, Logger::ENGINES)
         << "[shard=" << _index.collection().name()
         << ", index=" << _index.id().id() << "] "
-        << "Vector ingestion failed: " << res.errorMessage();
+        << "Vector index fill + WAL catch-up failed: " << res.errorMessage();
     _index.resetTrainingState();
-  } else {
-    ingestionDuration.count(
-        std::chrono::duration<double>(ingestEnd - ingestStart).count());
-    LOG_TOPIC("e165b", INFO, Logger::ENGINES)
-        << "[shard=" << _index.collection().name()
-        << ", index=" << _index.id().id() << "] "
-        << "Ingestion completed.";
-    _index.setTrainingState(VectorIndexTrainingState::kIngesting,
-                            VectorIndexTrainingState::kReady);
+    return res;
   }
+
+  ingestionDuration.count(
+      std::chrono::duration<double>(ingestEnd - ingestStart).count());
+
+  // fillIndexBackground returns with the exclusive lock still held.
+  // Swap the real index back and transition to kReady before releasing.
+  swapGuard.fire();
+  _index.setTrainingState(VectorIndexTrainingState::kIngesting,
+                          VectorIndexTrainingState::kReady);
+
+  LOG_TOPIC("e169c", INFO, Logger::ENGINES)
+      << "[shard=" << _index.collection().name()
+      << ", index=" << _index.id().id() << "] "
+      << "Vector index build completed (fill + WAL catch-up).";
 
   return res;
 }

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -30,6 +30,7 @@
 #include "RocksDBEngine/RocksDBIndex.h"
 #include "RocksDBEngine/RocksDBVectorIndex.h"
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -332,10 +333,10 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
   };
 
   struct BlockCounters {
-    uint64_t readProduceBlocked{0};
-    uint64_t encodeProduceBlocked{0};
-    uint64_t encodeConsumeBlocked{0};
-    uint64_t writeConsumeBlocked{0};
+    std::atomic<uint64_t> readProduceBlocked{0};
+    std::atomic<uint64_t> encodeProduceBlocked{0};
+    std::atomic<uint64_t> encodeConsumeBlocked{0};
+    std::atomic<uint64_t> writeConsumeBlocked{0};
   } counters;
 
   BoundedChannel<DocumentVectors> documentChannel{5};
@@ -434,7 +435,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
                                   batch->vectors.data());
           }
           auto [shouldStop, blocked] = documentChannel.push(std::move(batch));
-          counters.readProduceBlocked += blocked;
+          counters.readProduceBlocked.fetch_add(blocked,
+                                                std::memory_order_relaxed);
 
           if (shouldStop) {
             return;
@@ -463,7 +465,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
 
       bool shouldStop = false;
       errorExceptionHandler([&] {
-        counters.encodeConsumeBlocked += blocked;
+        counters.encodeConsumeBlocked.fetch_add(blocked,
+                                                std::memory_order_relaxed);
         auto n = item->docIds.size();
         countBatches += 1;
         countDocuments += n;
@@ -491,7 +494,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
         bool pushBlocked = false;
         std::tie(shouldStop, pushBlocked) =
             encodedChannel.push(std::move(encoded));
-        counters.encodeProduceBlocked += pushBlocked;
+        counters.encodeProduceBlocked.fetch_add(pushBlocked,
+                                                std::memory_order_relaxed);
       });
       if (shouldStop) {
         break;
@@ -508,7 +512,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
       }
 
       errorExceptionHandler([&] {
-        counters.writeConsumeBlocked += blocked;
+        counters.writeConsumeBlocked.fetch_add(blocked,
+                                               std::memory_order_relaxed);
         batch.Clear();
 
         RocksDBKey key;

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
@@ -65,9 +65,16 @@ Result readDocumentVectorData(
     std::vector<std::vector<basics::AttributeName>> const& fields,
     std::size_t dimension, std::vector<float>& output);
 
-/// Encapsulates FAISS index creation and the training pipeline.
-/// Holds the immutable configuration that is shared across operations,
-/// keeping individual method signatures clean.
+struct BoundedDocumentIterator {
+  RocksDBKeyBounds bounds;
+  rocksdb::Slice upper;
+  rocksdb::ReadOptions ro;
+  std::unique_ptr<rocksdb::Iterator> it;
+
+  explicit BoundedDocumentIterator(RocksDBKeyBounds bounds, rocksdb::DB* db,
+                                   rocksdb::Snapshot const* snap = nullptr);
+};
+
 class VectorIndexTrainer {
  public:
   VectorIndexTrainer(
@@ -133,6 +140,8 @@ class VectorIndexBuildManager {
                std::stop_token stopToken = {});
 
  private:
+  Result persistTrainedData(TrainedData const& trainedData);
+
   RocksDBVectorIndex& _index;
   RocksDBEngine& _engine;
   rocksdb::DB* _rootDB;

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -795,10 +795,14 @@ Result LogicalCollection::appendVPack(velocypack::Builder& build,
                                   Index::Serialize::Maintenance);
   }
 
-  auto filter = [indexFlags, forPersistence, showInProgress](
-                    Index const* idx, decltype(Index::makeFlags())& flags) {
+  auto const filter = [indexFlags, forPersistence, forMaintance,
+                       showInProgress](Index const* idx,
+                                       decltype(Index::makeFlags())& flags) {
     if ((forPersistence || !idx->isHidden()) &&
-        (showInProgress || !idx->inProgress())) {
+        (showInProgress || !idx->inProgress() ||
+         // We do this since we need trainingState of the vector index in agency
+         // so we can report it to the end user
+         (forMaintance && idx->type() == Index::TRI_IDX_TYPE_VECTOR_INDEX))) {
       flags = indexFlags;
       return true;
     }

--- a/js/common/modules/@arangodb/testutils/vector-index-common.js
+++ b/js/common/modules/@arangodb/testutils/vector-index-common.js
@@ -269,10 +269,9 @@ function vectorIndexesMatchState(indexes, state, indexName) {
 // If indexName is provided, only that single index is checked.
 function waitForState(collection, state, timeoutSec, indexName) {
     const internal = require("internal");
-    const isCluster = internal.isCluster();
     const iterations = Math.floor(timeoutSec / sleepIntervalSec);
     for (let i = 0; i < iterations; i++) {
-        const indexes = isCluster ? collection.indexes(true, true) : collection.indexes();
+        const indexes = collection.indexes(false, true);
         if (vectorIndexesMatchState(indexes, state, indexName)) {
             return true;
         }

--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -35,6 +35,8 @@ const {
 const {
     insertDocsAndEnsureIndex,
     waitForAllVectorIndexesState,
+    generateDocs,
+    waitForVectorIndexState,
     VectorIndexTrainingState,
 } = require("@arangodb/testutils/vector-index-common");
 const isCluster = require("internal").isCluster();
@@ -750,9 +752,80 @@ function VectorIndexStoredValuesTestSuite() {
 }
 
 
+function VectorIndexInsertDuringTrainingSuite() {
+    const IM = global.instanceManager;
+    const dim = 500;
+    const nLists = 10;
+    const seed = generateSeed();
+    let collection;
+
+    return {
+        setUp: function() {
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+            db._createDatabase(dbName);
+            db._useDatabase(dbName);
+            collection = db._create(collName, {numberOfShards: 1});
+
+            const gen = randomNumberGeneratorFloat(seed);
+            const numDocs = isCluster ? nLists * 3 + 500 : nLists + 500;
+            const docs = generateDocs(gen, numDocs, dim);
+            collection.insert(docs);
+        },
+
+        tearDown: function() {
+            if (IM && IM.debugCanUseFailAt()) {
+                IM.debugClearFailAt();
+            }
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+        },
+
+        testInsertWithoutVectorFieldFailsDuringTrainingDense: function() {
+            if (!IM || !IM.debugCanUseFailAt()) {
+                return;
+            }
+
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseBeforeTraining");
+
+            collection.ensureIndex({
+                name: "vec_l2",
+                type: "vector",
+                fields: ["vector"],
+                inBackground: true,
+                sparse: false,
+                params: {
+                    metric: "l2",
+                    dimension: dim,
+                    nLists: nLists,
+                    trainingIterations: 10,
+                },
+            });
+
+            assertTrue(
+                waitForVectorIndexState(
+                    collection, "vec_l2",
+                    VectorIndexTrainingState.kTraining, 30),
+                "Index should reach training state"
+            );
+
+            // For a dense index the insert must be rejected even while
+            // the index is still training — the vector field is mandatory.
+            try {
+                collection.insert({name: "no_vector_doc"});
+                fail("Insert of document without vector field should fail " +
+                     "for a dense index during training");
+            } catch (e) {
+                assertEqual(errors.ERROR_BAD_PARAMETER.code, e.errorNum);
+            }
+        },
+    };
+}
+
 jsunity.run(VectorIndexCreateAndRemoveTestSuite);
 jsunity.run(VectorIndexStoredValuesTestSuite);
 
 jsunity.run(VectorIndexTestCreationWithVectors);
+jsunity.run(VectorIndexInsertDuringTrainingSuite);
 
 return jsunity.done();

--- a/tests/js/client/aql/vector/aql-vector-wal-catchup-fp.js
+++ b/tests/js/client/aql/vector/aql-vector-wal-catchup-fp.js
@@ -1,0 +1,314 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertTrue, assertFalse */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+/// @author Jure Bajic
+// //////////////////////////////////////////////////////////////////////////////
+
+/// Tests that concurrent DML during vector index build is correctly picked up
+/// via the WAL catch-up mechanism. Three failure points pause the build at
+/// different phases; while paused, a special document is inserted or removed
+/// from the client side. After the build completes, a full-scan vector query
+/// (nProbe = nLists) verifies the document is present or absent.
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const db = internal.db;
+const IM = global.instanceManager;
+const {
+    randomNumberGeneratorFloat,
+    generateSeed,
+} = require("@arangodb/testutils/seededRandom");
+const {
+    VectorIndexTrainingState,
+    waitForVectorIndexState,
+    generateDocs,
+} = require("@arangodb/testutils/vector-index-common");
+
+const dbName = "vectorWalCatchupDB";
+const collName = "vectorColl";
+const dimension = 100;
+const nLists = 10;
+const numInitialDocs = 3000;
+const indexName = "vec_l2";
+const specialKey = "special_doc";
+const specialVector = Array.from({length: dimension}, () => 0.5);
+
+////////////////////////////////////////////////////////////////////////////////
+/// Helpers
+////////////////////////////////////////////////////////////////////////////////
+
+function createVectorIndex(collection) {
+    collection.ensureIndex({
+        name: indexName,
+        type: "vector",
+        fields: ["vector"],
+        inBackground: true,
+        params: {metric: "l2", dimension, nLists},
+    });
+}
+
+function specialDocFound(collection) {
+    const results = db._query(
+        `FOR d IN @@coll
+         SORT APPROX_NEAR_L2(d.vector, @qp, {nProbe: @nProbe})
+         LIMIT @limit
+         RETURN d._key`,
+        {"@coll": collection.name(), qp: specialVector, nProbe: nLists,
+         limit: numInitialDocs + 10}
+    ).toArray();
+    return results.includes(specialKey);
+}
+
+function insertInitialDocs(collection, gen) {
+    const docs = generateDocs(gen, numInitialDocs, dimension);
+    const batchSize = 500;
+    for (let i = 0; i < docs.length; i += batchSize) {
+        collection.insert(docs.slice(i, i + batchSize));
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Insert suite: insert a special document during each build phase and verify
+/// it is found after the index reaches ready state.
+////////////////////////////////////////////////////////////////////////////////
+
+function VectorIndexWalCatchupInsertSuite() {
+    const seed = generateSeed();
+    let gen;
+    let collection;
+
+    return {
+        setUp: function () {
+            gen = randomNumberGeneratorFloat(seed);
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+            db._createDatabase(dbName);
+            db._useDatabase(dbName);
+            collection = db._create(collName, {numberOfShards: 1});
+            insertInitialDocs(collection, gen);
+        },
+
+        tearDown: function () {
+            IM.debugClearFailAt();
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+        },
+
+        testInsertDuringTraining: function () {
+            if (!IM.debugCanUseFailAt()) {
+                return;
+            }
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseBeforeTraining");
+            createVectorIndex(collection);
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kTraining, 30),
+                "Index should reach training state"
+            );
+
+            collection.insert({_key: specialKey, vector: specialVector});
+
+            IM.debugClearFailAt();
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kReady, 120),
+                "Index should reach ready state"
+            );
+            assertTrue(specialDocFound(collection),
+                "Special doc inserted during training should be found");
+        },
+
+        testInsertBeforeIngestion: function () {
+            if (!IM.debugCanUseFailAt()) {
+                return;
+            }
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseBeforeIngestion");
+            createVectorIndex(collection);
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kIngesting, 60),
+                "Index should reach ingesting state"
+            );
+
+            collection.insert({_key: specialKey, vector: specialVector});
+
+            IM.debugClearFailAt();
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kReady, 120),
+                "Index should reach ready state"
+            );
+            assertTrue(specialDocFound(collection),
+                "Special doc inserted before ingestion should be found");
+        },
+
+        testInsertDuringIngestion: function () {
+            if (!IM.debugCanUseFailAt()) {
+                return;
+            }
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseDuringIngestion");
+            createVectorIndex(collection);
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kIngesting, 60),
+                "Index should reach ingesting state"
+            );
+            // Allow time for fillIndexBackground to take a snapshot and call
+            // ingestVectors, which then hits the failure point.
+            internal.sleep(3);
+
+            collection.insert({_key: specialKey, vector: specialVector});
+
+            IM.debugClearFailAt();
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kReady, 120),
+                "Index should reach ready state"
+            );
+            assertTrue(specialDocFound(collection),
+                "Special doc inserted during ingestion should be found " +
+                "via WAL catch-up");
+        },
+    };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+/// Remove suite: insert a special document with the initial data, remove it
+/// during each build phase, and verify it is absent after the index reaches
+/// ready state.
+////////////////////////////////////////////////////////////////////////////////
+
+function VectorIndexWalCatchupRemoveSuite() {
+    const seed = generateSeed();
+    let gen;
+    let collection;
+
+    return {
+        setUp: function () {
+            gen = randomNumberGeneratorFloat(seed);
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+            db._createDatabase(dbName);
+            db._useDatabase(dbName);
+            collection = db._create(collName, {numberOfShards: 1});
+            insertInitialDocs(collection, gen);
+            collection.insert({_key: specialKey, vector: specialVector});
+        },
+
+        tearDown: function () {
+            IM.debugClearFailAt();
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+        },
+
+        testRemoveDuringTraining: function () {
+            if (!IM.debugCanUseFailAt()) {
+                return;
+            }
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseBeforeTraining");
+            createVectorIndex(collection);
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kTraining, 30),
+                "Index should reach training state"
+            );
+
+            collection.remove(specialKey);
+
+            IM.debugClearFailAt();
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kReady, 120),
+                "Index should reach ready state"
+            );
+            assertFalse(specialDocFound(collection),
+                "Special doc removed during training should not be found");
+        },
+
+        testRemoveBeforeIngestion: function () {
+            if (!IM.debugCanUseFailAt()) {
+                return;
+            }
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseBeforeIngestion");
+            createVectorIndex(collection);
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kIngesting, 60),
+                "Index should reach ingesting state"
+            );
+
+            collection.remove(specialKey);
+
+            IM.debugClearFailAt();
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kReady, 120),
+                "Index should reach ready state"
+            );
+            assertFalse(specialDocFound(collection),
+                "Special doc removed before ingestion should not be found");
+        },
+
+        testRemoveDuringIngestion: function () {
+            if (!IM.debugCanUseFailAt()) {
+                return;
+            }
+            IM.debugSetFailAt("RocksDBVectorIndex::pauseDuringIngestion");
+            createVectorIndex(collection);
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kIngesting, 60),
+                "Index should reach ingesting state"
+            );
+            internal.sleep(3);
+
+            collection.remove(specialKey);
+
+            IM.debugClearFailAt();
+
+            assertTrue(
+                waitForVectorIndexState(collection, indexName,
+                    VectorIndexTrainingState.kReady, 120),
+                "Index should reach ready state"
+            );
+            assertFalse(specialDocFound(collection),
+                "Special doc removed during ingestion should not be found " +
+                "via WAL catch-up");
+        },
+    };
+}
+
+jsunity.run(VectorIndexWalCatchupInsertSuite);
+jsunity.run(VectorIndexWalCatchupRemoveSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Cherry-picked PRs https://github.com/arangodb/arangodb/pull/22610 and https://github.com/arangodb/arangodb/pull/22624

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
