### PR TITLE
Lower file descriptor limit when running with sanitizers.

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -366,6 +366,13 @@ commands:
               export SAN_MODE=tsan
             fi
 
+            if [ "$SAN_MODE" != "" ]; then
+              # When running with sanitizer we have to LOWER the number of file descriptors!
+              # The sanitizer forks off a separate process to handle the symbolization of stack traces,
+              # and the fork operation iterates over all file descriptors, making this extremely expensive.
+              ulimit -n 65536
+            fi
+
             # check if promtool is available and if so set the environment variable to enable the according tests
             if command -v promtool &> /dev/null; then
               export PROMTOOL_PATH=`command -v promtool`


### PR DESCRIPTION
### Scope & Purpose

When running with sanitizer we have to LOWER the number of file descriptors!
The sanitizer forks off a separate process to handle the symbolization of stack traces, and the fork operation iterates over all file descriptors, making this extremely expensive. With the default settings on AWS this takes ~80-100 seconds!

The fork operation blocks while the newly forked process is walking through the file descriptors. The problem is that during that time this thread holds a tsan internal mutex that protects some shared data (like the pipes to the symbolizer process). As a result, any other tsan operation that needs to access that data is blocked on that mutex. And that's why the whole process seems to be stalled, because almost every tsan verification needs to access this mutex, including signal handlers which are also interjected by tsan.