### PR TITLE
[COR-376] Remove --server.authentication-system-only

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
 
+* COR-376: Removed startup option `--server.authentication-system-only`. It's
+  now considered a legacy option, so it will be silently ignored on startup.
+
 * COR-295: Removed `StatisticsFeature`. The `--server.statistics-all-databases` and
   `--server.statistics-history` startup options are now obsolete and ignored.
 

--- a/js/client/modules/@arangodb/testsuites/authentication.js
+++ b/js/client/modules/@arangodb/testsuites/authentication.js
@@ -78,7 +78,6 @@ function authenticationClient (options) {
 
 const authTestExpectRC = [
   [401, 401, 401, 401, 401, 401, 401],
-  [401, 401, 401, 401, 401, 404, 404],
   [404, 404, 200, 301, 301, 404, 404]
 ];
 
@@ -94,19 +93,13 @@ const authTestUrls = [
 
 const authTestNames = [
   'Full',
-  'SystemAuth',
   'None'
 ];
 
 const authTestServerParams = [{
-  'server.authentication': 'true',
-  'server.authentication-system-only': 'false'
+  'server.authentication': 'true'
 }, {
-  'server.authentication': 'true',
-  'server.authentication-system-only': 'true'
-}, {
-  'server.authentication': 'false',
-  'server.authentication-system-only': 'true'
+  'server.authentication': 'false'
 }];
 
 function checkBodyForJsonToParse (request) {
@@ -140,7 +133,7 @@ function authenticationParameters (options) {
   let continueTesting = true;
   let results = {};
 
-  for (let test = 0; test < 3; test++) {
+  for (let test = 0; test < 2; test++) {
     let cleanup = true;
 
     let instanceManager = new im.instanceManager('tcp', options,

--- a/js/client/modules/@arangodb/testsuites/queryCacheAuthorization.js
+++ b/js/client/modules/@arangodb/testsuites/queryCacheAuthorization.js
@@ -65,8 +65,7 @@ function queryCacheAuthorization (options) {
   }
 
   const conf = {
-    'server.authentication': true,
-    'server.authentication-system-only': false
+    'server.authentication': true
   };
 
   print(CYAN + 'queryCacheAuthorization tests...' + RESET);

--- a/js/client/modules/@arangodb/testsuites/readOnly.js
+++ b/js/client/modules/@arangodb/testsuites/readOnly.js
@@ -64,11 +64,7 @@ function readOnly (options) {
     };
   }
 
-  const conf = Object.assign(
-    {},
-    tu.testServerAuthInfo, {
-      'server.authentication-system-only': false
-    });
+  const conf = Object.assign({}, tu.testServerAuthInfo);
 
   print(CYAN + 'readOnly tests...' + RESET);
   


### PR DESCRIPTION
### Scope & Purpose

This PR implements https://arangodb.atlassian.net/browse/COR-376. It removes startup option `--serever.authentication-systems-only`. Actually, it's still accepted for rolling upgrades, but it's treated as a legacy option and is silently ignored.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information


- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket:  https://arangodb.atlassian.net/browse/COR-376
- [ ] Design document: 
