### PR TITLE
[cor-431] Replace legacy FileUtils functions with std::filesystem equivalents part3

### DIFF
--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -128,8 +128,7 @@ void ServerState::findHost(std::string const& fallback) {
 
   // Now look at the contents of the file /etc/machine-id, if it exists:
   std::string name = "/etc/machine-id";
-  std::error_code existsEc;
-  if (std::filesystem::exists(name, existsEc)) {
+  if (std::filesystem::exists(name)) {
     try {
       _host = arangodb::basics::FileUtils::slurp(name);
       while (!_host.empty() && (_host.back() == '\r' || _host.back() == '\n' ||
@@ -617,9 +616,7 @@ std::string ServerState::getUuidFilename() const {
 }
 
 bool ServerState::hasPersistedId() {
-  std::string uuidFilename = getUuidFilename();
-  std::error_code existsEc;
-  return std::filesystem::exists(uuidFilename, existsEc);
+  return std::filesystem::exists(getUuidFilename());
 }
 
 bool ServerState::writePersistedId(std::string const& id) {

--- a/arangod/Cluster/ServerState.cpp
+++ b/arangod/Cluster/ServerState.cpp
@@ -128,7 +128,8 @@ void ServerState::findHost(std::string const& fallback) {
 
   // Now look at the contents of the file /etc/machine-id, if it exists:
   std::string name = "/etc/machine-id";
-  if (arangodb::basics::FileUtils::exists(name)) {
+  std::error_code existsEc;
+  if (std::filesystem::exists(name, existsEc)) {
     try {
       _host = arangodb::basics::FileUtils::slurp(name);
       while (!_host.empty() && (_host.back() == '\r' || _host.back() == '\n' ||
@@ -617,7 +618,8 @@ std::string ServerState::getUuidFilename() const {
 
 bool ServerState::hasPersistedId() {
   std::string uuidFilename = getUuidFilename();
-  return FileUtils::exists(uuidFilename);
+  std::error_code existsEc;
+  return std::filesystem::exists(uuidFilename, existsEc);
 }
 
 bool ServerState::writePersistedId(std::string const& id) {

--- a/arangod/GeneralServer/AcceptorUnixDomain.cpp
+++ b/arangod/GeneralServer/AcceptorUnixDomain.cpp
@@ -41,8 +41,7 @@ using namespace arangodb::rest;
 
 void AcceptorUnixDomain::open() {
   std::string path(((EndpointUnixDomain*)_endpoint)->path());
-  std::error_code existsEc;
-  if (std::filesystem::exists(path, existsEc)) {
+  if (std::filesystem::exists(path)) {
     // socket file already exists
     LOG_TOPIC("e0ae1", WARN, arangodb::Logger::FIXME)
         << "socket file '" << path << "' already exists.";
@@ -54,10 +53,10 @@ void AcceptorUnixDomain::open() {
     if (!ec && deleted) {
       LOG_TOPIC("2b5b6", WARN, arangodb::Logger::FIXME)
           << "deleted previously existing socket file '" << path << "'";
-    } else {
+    } else if (ec) {
       LOG_TOPIC("f6012", ERR, arangodb::Logger::FIXME)
-          << "unable to delete previously existing socket file '" << path
-          << "'";
+          << "unable to delete previously existing socket file '" << path << "'"
+          << "Error:" << ec.message();
     }
   }
 
@@ -120,7 +119,8 @@ void AcceptorUnixDomain::close() {
           std::filesystem::remove(std::filesystem::path(path), ec);
       if (ec || !deleted) {
         LOG_TOPIC("56b89", TRACE, arangodb::Logger::FIXME)
-            << "unable to remove socket file '" << path << "'";
+            << "unable to remove socket file '" << path << "'"
+            << "Error:" << ec.message();
       }
     });
   }

--- a/arangod/GeneralServer/AcceptorUnixDomain.cpp
+++ b/arangod/GeneralServer/AcceptorUnixDomain.cpp
@@ -23,6 +23,8 @@
 
 #include "GeneralServer/AcceptorUnixDomain.h"
 
+#include <filesystem>
+
 #include "Basics/Exceptions.h"
 #include "Basics/FileUtils.h"
 #include "Endpoint/ConnectionInfo.h"
@@ -39,13 +41,17 @@ using namespace arangodb::rest;
 
 void AcceptorUnixDomain::open() {
   std::string path(((EndpointUnixDomain*)_endpoint)->path());
-  if (basics::FileUtils::exists(path)) {
+  std::error_code existsEc;
+  if (std::filesystem::exists(path, existsEc)) {
     // socket file already exists
     LOG_TOPIC("e0ae1", WARN, arangodb::Logger::FIXME)
         << "socket file '" << path << "' already exists.";
 
     // delete previously existing socket file
-    if (basics::FileUtils::remove(path) == TRI_ERROR_NO_ERROR) {
+    std::error_code ec;
+    bool const deleted =
+        std::filesystem::remove(std::filesystem::path(path), ec);
+    if (!ec && deleted) {
       LOG_TOPIC("2b5b6", WARN, arangodb::Logger::FIXME)
           << "deleted previously existing socket file '" << path << "'";
     } else {
@@ -109,7 +115,10 @@ void AcceptorUnixDomain::close() {
     _ctx.io_context.wrap([this]() {
       _acceptor.close();
       std::string path = static_cast<EndpointUnixDomain*>(_endpoint)->path();
-      if (basics::FileUtils::remove(path) != TRI_ERROR_NO_ERROR) {
+      std::error_code ec;
+      bool const deleted =
+          std::filesystem::remove(std::filesystem::path(path), ec);
+      if (ec || !deleted) {
         LOG_TOPIC("56b89", TRACE, arangodb::Logger::FIXME)
             << "unable to remove socket file '" << path << "'";
       }

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -276,8 +276,7 @@ void SslServerFeature::verifySslOptions() {
   LOG_TOPIC("47161", DEBUG, arangodb::Logger::SSL)
       << "using SSL protocol version '"
       << protocolName(SslProtocol(_options.sslProtocol)) << "'";
-  std::error_code existsEc;
-  if (std::filesystem::exists(_options.keyfile, existsEc)) {
+  if (!std::filesystem::exists(_options.keyfile)) {
     LOG_TOPIC("51cf0", FATAL, arangodb::Logger::SSL)
         << "unable to find SSL keyfile '" << _options.keyfile << "'";
     FATAL_ERROR_EXIT();

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -276,8 +276,8 @@ void SslServerFeature::verifySslOptions() {
   LOG_TOPIC("47161", DEBUG, arangodb::Logger::SSL)
       << "using SSL protocol version '"
       << protocolName(SslProtocol(_options.sslProtocol)) << "'";
-
-  if (!FileUtils::exists(_options.keyfile)) {
+  std::error_code existsEc;
+  if (std::filesystem::exists(_options.keyfile, existsEc)) {
     LOG_TOPIC("51cf0", FATAL, arangodb::Logger::SSL)
         << "unable to find SSL keyfile '" << _options.keyfile << "'";
     FATAL_ERROR_EXIT();

--- a/arangod/RestServer/DaemonFeature.cpp
+++ b/arangod/RestServer/DaemonFeature.cpp
@@ -163,7 +163,8 @@ void DaemonFeature::unprepare() {
   std::filesystem::remove(_options.pidFile, removeEc);
   if (removeEc) {
     LOG_TOPIC("1b46c", ERR, arangodb::Logger::FIXME)
-        << "cannot remove pid file '" << _options.pidFile << "'";
+        << "cannot remove pid file '" << _options.pidFile << "'"
+        << "Error:" << removeEc.message();
   }
 }
 
@@ -175,7 +176,13 @@ void DaemonFeature::checkPidFile() {
       LOG_TOPIC("6b3c0", FATAL, arangodb::Logger::FIXME)
           << "pid-file '" << _options.pidFile << "' is a directory";
       FATAL_ERROR_EXIT();
-    } else if (std::filesystem::exists(_options.pidFile, dirEc) &&
+    } else if (dirEc) {
+      LOG_TOPIC("6b3c1", FATAL, arangodb::Logger::FIXME)
+          << "pid-file '" << _options.pidFile
+          << "' Path does not exist or insufficient permissions"
+          << "Error:" << dirEc.message();
+      FATAL_ERROR_EXIT();
+    } else if (std::filesystem::exists(_options.pidFile) &&
                std::filesystem::file_size(_options.pidFile) > 0) {
       LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
           << "pid-file '" << _options.pidFile
@@ -231,7 +238,8 @@ void DaemonFeature::checkPidFile() {
             LOG_TOPIC("fddfc", FATAL, arangodb::Logger::FIXME)
                 << "pid-file '" << _options.pidFile
                 << "' exists, no process with pid " << oldPid
-                << " exists, but pid-file cannot be removed";
+                << " exists, but pid-file cannot be removed"
+                << "Error:" << removeEc.message();
             FATAL_ERROR_EXIT();
           }
 

--- a/arangod/RestServer/DaemonFeature.cpp
+++ b/arangod/RestServer/DaemonFeature.cpp
@@ -31,7 +31,6 @@
 #include <filesystem>
 #include <stdexcept>
 #include <thread>
-#include <filesystem>
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
@@ -160,7 +159,9 @@ void DaemonFeature::unprepare() {
   }
 
   // remove pid file
-  if (FileUtils::remove(_options.pidFile) != TRI_ERROR_NO_ERROR) {
+  std::error_code removeEc;
+  std::filesystem::remove(_options.pidFile, removeEc);
+  if (removeEc) {
     LOG_TOPIC("1b46c", ERR, arangodb::Logger::FIXME)
         << "cannot remove pid file '" << _options.pidFile << "'";
   }
@@ -169,11 +170,12 @@ void DaemonFeature::unprepare() {
 void DaemonFeature::checkPidFile() {
   // check if the pid-file exists
   if (!_options.pidFile.empty()) {
-    if (FileUtils::isDirectory(_options.pidFile)) {
+    std::error_code dirEc;
+    if (std::filesystem::is_directory(_options.pidFile, dirEc)) {
       LOG_TOPIC("6b3c0", FATAL, arangodb::Logger::FIXME)
           << "pid-file '" << _options.pidFile << "' is a directory";
       FATAL_ERROR_EXIT();
-    } else if (FileUtils::exists(_options.pidFile) &&
+    } else if (std::filesystem::exists(_options.pidFile, dirEc) &&
                std::filesystem::file_size(_options.pidFile) > 0) {
       LOG_TOPIC("cf10a", INFO, Logger::STARTUP)
           << "pid-file '" << _options.pidFile
@@ -223,7 +225,9 @@ void DaemonFeature::checkPidFile() {
               << "pid-file '" << _options.pidFile
               << " exists, but no process with pid " << oldPid << " exists";
 
-          if (FileUtils::remove(_options.pidFile) != TRI_ERROR_NO_ERROR) {
+          std::error_code removeEc;
+          std::filesystem::remove(_options.pidFile, removeEc);
+          if (removeEc) {
             LOG_TOPIC("fddfc", FATAL, arangodb::Logger::FIXME)
                 << "pid-file '" << _options.pidFile
                 << "' exists, no process with pid " << oldPid

--- a/arangod/RestServer/DatabasePathFeature.cpp
+++ b/arangod/RestServer/DatabasePathFeature.cpp
@@ -23,6 +23,8 @@
 
 #include "DatabasePathFeature.h"
 
+#include <filesystem>
+
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/GreetingsFeaturePhase.h"
 #include "ApplicationFeatures/LanguageFeature.h"
@@ -154,7 +156,8 @@ void DatabasePathFeature::prepare() {
   }
 
   if (_options.requiredDirectoryState == "non-existing") {
-    if (basics::FileUtils::isDirectory(_options.directory)) {
+    std::error_code dirEc;
+    if (std::filesystem::is_directory(_options.directory, dirEc)) {
       LOG_TOPIC("25452", FATAL, arangodb::Logger::STARTUP)
           << "database directory '" << _options.directory
           << "' already exists, but option "
@@ -165,7 +168,8 @@ void DatabasePathFeature::prepare() {
   }
 
   // existing, empty, populated when we get here
-  if (!basics::FileUtils::isDirectory(_options.directory)) {
+  std::error_code dirEc;
+  if (!std::filesystem::is_directory(_options.directory, dirEc)) {
     LOG_TOPIC("3b1df", FATAL, arangodb::Logger::STARTUP)
         << "database directory '" << _options.directory
         << "' does not exist, but option '--database.required-directory-state' "
@@ -181,7 +185,8 @@ void DatabasePathFeature::prepare() {
 
   std::vector<std::string> files;
   for (auto const& it : basics::FileUtils::listFiles(_options.directory)) {
-    if (it.empty() || basics::FileUtils::isDirectory(it)) {
+    std::error_code entryDirEc;
+    if (it.empty() || std::filesystem::is_directory(it, entryDirEc)) {
       continue;
     }
 
@@ -214,7 +219,8 @@ void DatabasePathFeature::prepare() {
 
 void DatabasePathFeature::start() {
   // create base directory if it does not exist
-  if (!basics::FileUtils::isDirectory(_options.directory)) {
+  std::error_code dirEc;
+  if (!std::filesystem::is_directory(_options.directory, dirEc)) {
     std::string systemErrorStr;
     long errorNo;
 

--- a/arangod/RestServer/DatabasePathFeature.cpp
+++ b/arangod/RestServer/DatabasePathFeature.cpp
@@ -185,8 +185,7 @@ void DatabasePathFeature::prepare() {
 
   std::vector<std::string> files;
   for (auto const& it : basics::FileUtils::listFiles(_options.directory)) {
-    std::error_code entryDirEc;
-    if (it.empty() || std::filesystem::is_directory(it, entryDirEc)) {
+    if (it.empty() || std::filesystem::is_directory(it)) {
       continue;
     }
 
@@ -219,8 +218,7 @@ void DatabasePathFeature::prepare() {
 
 void DatabasePathFeature::start() {
   // create base directory if it does not exist
-  std::error_code dirEc;
-  if (!std::filesystem::is_directory(_options.directory, dirEc)) {
+  if (!std::filesystem::is_directory(_options.directory)) {
     std::string systemErrorStr;
     long errorNo;
 

--- a/arangod/RestServer/DatabasePathFeature.cpp
+++ b/arangod/RestServer/DatabasePathFeature.cpp
@@ -156,8 +156,7 @@ void DatabasePathFeature::prepare() {
   }
 
   if (_options.requiredDirectoryState == "non-existing") {
-    std::error_code dirEc;
-    if (std::filesystem::is_directory(_options.directory, dirEc)) {
+    if (std::filesystem::is_directory(_options.directory)) {
       LOG_TOPIC("25452", FATAL, arangodb::Logger::STARTUP)
           << "database directory '" << _options.directory
           << "' already exists, but option "

--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -104,8 +104,7 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const versionFilename("/proc/version");
 
-    std::error_code existsEc;
-    if (std::filesystem::exists(versionFilename, existsEc)) {
+    if (std::filesystem::exists(versionFilename)) {
       _operatingSystem =
           basics::StringUtils::trim(basics::FileUtils::slurp(versionFilename));
     }
@@ -122,8 +121,7 @@ void EnvironmentFeature::prepare() {
       std::string const procFilename =
           absl::StrCat("/proc/", parentId, "/stat");
 
-      std::error_code existsEc;
-      if (std::filesystem::exists(procFilename, existsEc)) {
+      if (std::filesystem::exists(procFilename)) {
         std::string content = basics::FileUtils::slurp(procFilename);
         std::string_view procName = ::trimProcName(content);
         if (!procName.empty()) {
@@ -172,8 +170,7 @@ void EnvironmentFeature::prepare() {
 
     std::string const filename("/proc/cpu/alignment");
     try {
-      std::error_code existsEc;
-      if (std::filesystem::exists(filename, existsEc)) {
+      if (std::filesystem::exists(filename)) {
         std::string const cpuAlignment = basics::FileUtils::slurp(filename);
         auto start = cpuAlignment.find("User faults:");
 
@@ -233,8 +230,7 @@ void EnvironmentFeature::prepare() {
 
     std::string const cpuInfoFilename("/proc/cpuinfo");
     try {
-      std::error_code existsEc;
-      if (std::filesystem::exists(cpuInfoFilename, existsEc)) {
+      if (std::filesystem::exists(cpuInfoFilename)) {
         std::string const cpuInfo = basics::FileUtils::slurp(cpuInfoFilename);
         auto start = cpuInfo.find("ARMv6");
 
@@ -304,8 +300,7 @@ void EnvironmentFeature::prepare() {
       //   policy that attempts to prevent any overcommit of memory.
       std::string const ratioFilename("/proc/sys/vm/overcommit_ratio");
 
-      std::error_code existsEc;
-      if (std::filesystem::exists(ratioFilename, existsEc)) {
+      if (std::filesystem::exists(ratioFilename)) {
         content = basics::FileUtils::slurp(ratioFilename);
         uint64_t r = basics::StringUtils::uint64(content);
         // from https://www.kernel.org/doc/Documentation/sysctl/vm.txt:
@@ -371,8 +366,7 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const portFilename("/proc/sys/net/ipv4/ip_local_port_range");
 
-    std::error_code existsEc;
-    if (std::filesystem::exists(portFilename, existsEc)) {
+    if (std::filesystem::exists(portFilename)) {
       std::string content = basics::FileUtils::slurp(portFilename);
       auto parts = basics::StringUtils::split(content, '\t');
       if (parts.size() == 2) {
@@ -404,8 +398,7 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const recycleFilename("/proc/sys/net/ipv4/tcp_tw_recycle");
 
-    std::error_code existsEc;
-    if (std::filesystem::exists(recycleFilename, existsEc)) {
+    if (std::filesystem::exists(recycleFilename)) {
       std::string content = basics::FileUtils::slurp(recycleFilename);
       uint64_t v = basics::StringUtils::uint64(content);
       if (v != 0) {
@@ -440,8 +433,7 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const reclaimFilename("/proc/sys/vm/zone_reclaim_mode");
 
-    std::error_code existsEc;
-    if (std::filesystem::exists(reclaimFilename, existsEc)) {
+    if (std::filesystem::exists(reclaimFilename)) {
       std::string content = basics::FileUtils::slurp(reclaimFilename);
       uint64_t v = basics::StringUtils::uint64(content);
       if (v != 0) {
@@ -470,8 +462,7 @@ void EnvironmentFeature::prepare() {
 
   for (auto const& file : paths) {
     try {
-      std::error_code existsEc;
-      if (std::filesystem::exists(file, existsEc)) {
+      if (std::filesystem::exists(file)) {
         std::string value = basics::FileUtils::slurp(file);
         size_t start = value.find('[');
         size_t end = value.find(']');
@@ -499,8 +490,7 @@ void EnvironmentFeature::prepare() {
     try {
       std::string const mapsFilename("/proc/self/numa_maps");
 
-      std::error_code existsEc;
-      if (std::filesystem::exists(mapsFilename, existsEc)) {
+      if (std::filesystem::exists(mapsFilename)) {
         std::string content = basics::FileUtils::slurp(mapsFilename);
         auto values = basics::StringUtils::split(content, '\n');
 
@@ -526,8 +516,7 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const settingsFilename("/proc/sys/kernel/randomize_va_space");
 
-    std::error_code existsEc;
-    if (std::filesystem::exists(settingsFilename, existsEc)) {
+    if (std::filesystem::exists(settingsFilename)) {
       std::string content = basics::FileUtils::slurp(settingsFilename);
       uint64_t v = basics::StringUtils::uint64(content);
       // from man proc:

--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -40,6 +40,7 @@
 #include <array>
 #include <atomic>
 #include <cmath>
+#include <filesystem>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
@@ -103,7 +104,8 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const versionFilename("/proc/version");
 
-    if (basics::FileUtils::exists(versionFilename)) {
+    std::error_code existsEc;
+    if (std::filesystem::exists(versionFilename, existsEc)) {
       _operatingSystem =
           basics::StringUtils::trim(basics::FileUtils::slurp(versionFilename));
     }
@@ -120,7 +122,8 @@ void EnvironmentFeature::prepare() {
       std::string const procFilename =
           absl::StrCat("/proc/", parentId, "/stat");
 
-      if (basics::FileUtils::exists(procFilename)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(procFilename, existsEc)) {
         std::string content = basics::FileUtils::slurp(procFilename);
         std::string_view procName = ::trimProcName(content);
         if (!procName.empty()) {
@@ -169,7 +172,8 @@ void EnvironmentFeature::prepare() {
 
     std::string const filename("/proc/cpu/alignment");
     try {
-      if (basics::FileUtils::exists(filename)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(filename, existsEc)) {
         std::string const cpuAlignment = basics::FileUtils::slurp(filename);
         auto start = cpuAlignment.find("User faults:");
 
@@ -229,7 +233,8 @@ void EnvironmentFeature::prepare() {
 
     std::string const cpuInfoFilename("/proc/cpuinfo");
     try {
-      if (basics::FileUtils::exists(cpuInfoFilename)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(cpuInfoFilename, existsEc)) {
         std::string const cpuInfo = basics::FileUtils::slurp(cpuInfoFilename);
         auto start = cpuInfo.find("ARMv6");
 
@@ -299,7 +304,8 @@ void EnvironmentFeature::prepare() {
       //   policy that attempts to prevent any overcommit of memory.
       std::string const ratioFilename("/proc/sys/vm/overcommit_ratio");
 
-      if (basics::FileUtils::exists(ratioFilename)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(ratioFilename, existsEc)) {
         content = basics::FileUtils::slurp(ratioFilename);
         uint64_t r = basics::StringUtils::uint64(content);
         // from https://www.kernel.org/doc/Documentation/sysctl/vm.txt:
@@ -352,7 +358,8 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const ipV6Filename("/proc/net/if_inet6");
 
-    if (!basics::FileUtils::exists(ipV6Filename)) {
+    std::error_code existsEc;
+    if (!std::filesystem::exists(ipV6Filename, existsEc)) {
       LOG_TOPIC("0f48d", INFO, arangodb::Logger::COMMUNICATION)
           << "IPv6 support seems to be disabled";
     }
@@ -364,7 +371,8 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const portFilename("/proc/sys/net/ipv4/ip_local_port_range");
 
-    if (basics::FileUtils::exists(portFilename)) {
+    std::error_code existsEc;
+    if (std::filesystem::exists(portFilename, existsEc)) {
       std::string content = basics::FileUtils::slurp(portFilename);
       auto parts = basics::StringUtils::split(content, '\t');
       if (parts.size() == 2) {
@@ -396,7 +404,8 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const recycleFilename("/proc/sys/net/ipv4/tcp_tw_recycle");
 
-    if (basics::FileUtils::exists(recycleFilename)) {
+    std::error_code existsEc;
+    if (std::filesystem::exists(recycleFilename, existsEc)) {
       std::string content = basics::FileUtils::slurp(recycleFilename);
       uint64_t v = basics::StringUtils::uint64(content);
       if (v != 0) {
@@ -431,7 +440,8 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const reclaimFilename("/proc/sys/vm/zone_reclaim_mode");
 
-    if (basics::FileUtils::exists(reclaimFilename)) {
+    std::error_code existsEc;
+    if (std::filesystem::exists(reclaimFilename, existsEc)) {
       std::string content = basics::FileUtils::slurp(reclaimFilename);
       uint64_t v = basics::StringUtils::uint64(content);
       if (v != 0) {
@@ -460,7 +470,8 @@ void EnvironmentFeature::prepare() {
 
   for (auto const& file : paths) {
     try {
-      if (basics::FileUtils::exists(file)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(file, existsEc)) {
         std::string value = basics::FileUtils::slurp(file);
         size_t start = value.find('[');
         size_t end = value.find(']');
@@ -483,13 +494,13 @@ void EnvironmentFeature::prepare() {
     }
   }
 
-  bool numa = FileUtils::exists("/sys/devices/system/node/node1");
-
-  if (numa) {
+  std::error_code existsEc;
+  if (std::filesystem::exists("/sys/devices/system/node/node1", existsEc)) {
     try {
       std::string const mapsFilename("/proc/self/numa_maps");
 
-      if (basics::FileUtils::exists(mapsFilename)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(mapsFilename, existsEc)) {
         std::string content = basics::FileUtils::slurp(mapsFilename);
         auto values = basics::StringUtils::split(content, '\n');
 
@@ -515,7 +526,8 @@ void EnvironmentFeature::prepare() {
   try {
     std::string const settingsFilename("/proc/sys/kernel/randomize_va_space");
 
-    if (basics::FileUtils::exists(settingsFilename)) {
+    std::error_code existsEc;
+    if (std::filesystem::exists(settingsFilename, existsEc)) {
       std::string content = basics::FileUtils::slurp(settingsFilename);
       uint64_t v = basics::StringUtils::uint64(content);
       // from man proc:

--- a/arangod/RestServer/EnvironmentFeature.cpp
+++ b/arangod/RestServer/EnvironmentFeature.cpp
@@ -356,7 +356,7 @@ void EnvironmentFeature::prepare() {
     std::error_code existsEc;
     if (!std::filesystem::exists(ipV6Filename, existsEc)) {
       LOG_TOPIC("0f48d", INFO, arangodb::Logger::COMMUNICATION)
-          << "IPv6 support seems to be disabled";
+          << "IPv6 support seems to be disabled" << existsEc.message();
     }
   } catch (...) {
     // file not found
@@ -510,6 +510,10 @@ void EnvironmentFeature::prepare() {
     } catch (...) {
       // file not found
     }
+  } else if (existsEc) {
+    LOG_TOPIC("c7d92", DEBUG, Logger::MEMORY)
+        << "unable to check for NUMA node '/sys/devices/system/node/node1': "
+        << existsEc.message();
   }
 
   // check kernel ASLR settings

--- a/arangod/RestServer/IOHeartbeatThread.cpp
+++ b/arangod/RestServer/IOHeartbeatThread.cpp
@@ -23,7 +23,8 @@
 
 #include "IOHeartbeatThread.h"
 
-#include "Basics/ErrorCode.h"
+#include <filesystem>
+
 #include "Basics/FileUtils.h"
 #include "Logger/LogMacros.h"
 #include "Metrics/CounterBuilder.h"
@@ -66,7 +67,8 @@ void IOHeartbeatThread::run() {
   LOG_TOPIC("66665", DEBUG, Logger::ENGINES) << "IOHeartbeatThread: running...";
   // File might be left if previous run has crashed.
   // That will trigger an error in spit.
-  std::ignore = basics::FileUtils::remove(testFilePath);
+  // std::error_code removeStartupEc;
+  std::filesystem::remove(testFilePath);
   while (true) {
     try {  // protect thread against any exceptions
       if (isStopping()) {
@@ -138,11 +140,13 @@ void IOHeartbeatThread::run() {
 
         // And remove it again:
         start = std::chrono::steady_clock::now();
-        ErrorCode err = basics::FileUtils::remove(testFilePath);
-        if (err != TRI_ERROR_NO_ERROR) {
+        std::error_code removeEc;
+        std::filesystem::remove(testFilePath, removeEc);
+        if (removeEc) {
           ++_failures;
           LOG_TOPIC("66670", INFO, Logger::ENGINES)
-              << "IOHeartbeat: error when removing test file: " << err;
+              << "IOHeartbeat: error when removing test file: "
+              << removeEc.message();
           trouble = true;
         }
         finish = std::chrono::steady_clock::now();

--- a/arangod/RestServer/InitDatabaseFeature.cpp
+++ b/arangod/RestServer/InitDatabaseFeature.cpp
@@ -166,21 +166,51 @@ void InitDatabaseFeature::checkEmptyDatabase() {
   std::error_code dirEc;
   if (std::filesystem::exists(path, dirEc)) {
     if (!std::filesystem::is_directory(path, dirEc)) {
+      if (dirEc) {
+        message =
+            "error checking database path '" + path + "': " + dirEc.message();
+        code = TRI_EXIT_CODE_RESOLVING_FAILED;
+        goto doexit;
+      }
       message = "database path '" + path + "' is not a directory";
       code = EXIT_FAILURE;
       goto doexit;
     }
 
     if (std::filesystem::exists(serverFile, dirEc)) {
+      if (dirEc) {
+        message = "error checking database SERVER marker '" + serverFile +
+                  "': " + dirEc.message();
+        code = TRI_EXIT_CODE_RESOLVING_FAILED;
+        goto doexit;
+      }
       if (std::filesystem::is_directory(serverFile, dirEc)) {
         message = "database SERVER '" + serverFile + "' is not a file";
         code = EXIT_FAILURE;
         goto doexit;
       }
+      if (dirEc) {
+        message = "error checking database SERVER marker '" + serverFile +
+                  "': " + dirEc.message();
+        code = TRI_EXIT_CODE_RESOLVING_FAILED;
+        goto doexit;
+      }
     } else {
+      if (dirEc) {
+        message = "error checking database SERVER marker '" + serverFile +
+                  "': " + dirEc.message();
+        code = TRI_EXIT_CODE_RESOLVING_FAILED;
+        goto doexit;
+      }
       empty = true;
     }
   } else {
+    if (dirEc) {
+      message =
+          "error checking database path '" + path + "': " + dirEc.message();
+      code = TRI_EXIT_CODE_RESOLVING_FAILED;
+      goto doexit;
+    }
     empty = true;
   }
 

--- a/arangod/RestServer/InitDatabaseFeature.cpp
+++ b/arangod/RestServer/InitDatabaseFeature.cpp
@@ -24,6 +24,7 @@
 #include "InitDatabaseFeature.h"
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <thread>
 
@@ -162,16 +163,16 @@ void InitDatabaseFeature::checkEmptyDatabase() {
   bool empty = false;
   std::string message;
   int code = TRI_EXIT_CODE_RESOLVING_FAILED;
-
-  if (FileUtils::exists(path)) {
-    if (!FileUtils::isDirectory(path)) {
+  std::error_code dirEc;
+  if (std::filesystem::exists(path, dirEc)) {
+    if (!std::filesystem::is_directory(path, dirEc)) {
       message = "database path '" + path + "' is not a directory";
       code = EXIT_FAILURE;
       goto doexit;
     }
 
-    if (FileUtils::exists(serverFile)) {
-      if (FileUtils::isDirectory(serverFile)) {
+    if (std::filesystem::exists(serverFile, dirEc)) {
+      if (std::filesystem::is_directory(serverFile, dirEc)) {
         message = "database SERVER '" + serverFile + "' is not a file";
         code = EXIT_FAILURE;
         goto doexit;

--- a/arangod/RestServer/TemporaryStorageFeature.cpp
+++ b/arangod/RestServer/TemporaryStorageFeature.cpp
@@ -21,8 +21,6 @@
 /// @author Julia Puget
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <filesystem>
-
 #include "TemporaryStorageFeature.h"
 
 #include <filesystem>
@@ -33,7 +31,6 @@
 #include "StorageEngine/StorageEngineFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "Basics/Exceptions.h"
-#include "Basics/FileUtils.h"
 #include "Basics/StringUtils.h"
 #include "Basics/Thread.h"
 #include "Basics/application-exit.h"
@@ -264,7 +261,8 @@ void TemporaryStorageFeature::prepare() {
     return;
   }
 
-  if (basics::FileUtils::isDirectory(_options.basePath)) {
+  std::error_code dirEc;
+  if (std::filesystem::is_directory(_options.basePath, dirEc)) {
     // intentionally do not set _cleanedUpDirectory flag here
     cleanupDirectory();
   } else {

--- a/arangod/RestServer/TemporaryStorageFeature.cpp
+++ b/arangod/RestServer/TemporaryStorageFeature.cpp
@@ -261,8 +261,7 @@ void TemporaryStorageFeature::prepare() {
     return;
   }
 
-  std::error_code dirEc;
-  if (std::filesystem::is_directory(_options.basePath, dirEc)) {
+  if (std::filesystem::is_directory(_options.basePath)) {
     // intentionally do not set _cleanedUpDirectory flag here
     cleanupDirectory();
   } else {

--- a/arangod/RestServer/TimeZoneFeature.cpp
+++ b/arangod/RestServer/TimeZoneFeature.cpp
@@ -84,7 +84,8 @@ void TimeZoneFeature::prepareTimeZoneData(
     LOG_TOPIC("67bdc", FATAL, arangodb::Logger::STARTUP)
         << "failed to locate timezone data " << tz_path
         << ". please set the TZ_DATA environment variable to the "
-        << "tzdata directory in case you are running an unusual setup";
+        << "tzdata directory in case you are running an unusual setup"
+        << dirEc.message();
     FATAL_ERROR_EXIT_CODE(TRI_EXIT_TZDATA_INITIALIZATION_FAILED);
   }
 

--- a/arangod/RestServer/TimeZoneFeature.cpp
+++ b/arangod/RestServer/TimeZoneFeature.cpp
@@ -62,7 +62,8 @@ void TimeZoneFeature::prepareTimeZoneData(
     std::string test_exe =
         FileUtils::buildFilename(binaryExecutionPath, "tzdata");
 
-    if (FileUtils::isDirectory(test_exe)) {
+    std::error_code dirEc;
+    if (std::filesystem::is_directory(test_exe, dirEc)) {
       test_exe = basics::FileUtils::absolutePath(test_exe).string();
       tz_path = std::filesystem::path(test_exe).make_preferred().string();
     } else {
@@ -77,7 +78,8 @@ void TimeZoneFeature::prepareTimeZoneData(
     }
   }
 
-  if (FileUtils::isDirectory(tz_path)) {
+  std::error_code dirEc;
+  if (std::filesystem::is_directory(tz_path, dirEc)) {
     date::set_install(tz_path);
   } else {
     LOG_TOPIC("67bdc", FATAL, arangodb::Logger::STARTUP)

--- a/arangod/RestServer/TimeZoneFeature.cpp
+++ b/arangod/RestServer/TimeZoneFeature.cpp
@@ -62,8 +62,7 @@ void TimeZoneFeature::prepareTimeZoneData(
     std::string test_exe =
         FileUtils::buildFilename(binaryExecutionPath, "tzdata");
 
-    std::error_code dirEc;
-    if (std::filesystem::is_directory(test_exe, dirEc)) {
+    if (std::filesystem::is_directory(test_exe)) {
       test_exe = basics::FileUtils::absolutePath(test_exe).string();
       tz_path = std::filesystem::path(test_exe).make_preferred().string();
     } else {

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -23,6 +23,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "RocksDBEngine.h"
+
+#include <filesystem>
+
 #include "Agency/AgencyFeature.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/LanguageFeature.h"
@@ -1000,7 +1003,8 @@ void RocksDBEngine::start() {
   _path = _databasePathFeature.subdirectoryName("engine-rocksdb");
 
   [[maybe_unused]] bool createdEngineDir = false;
-  if (!basics::FileUtils::isDirectory(_path)) {
+  std::error_code engineDirEc;
+  if (!std::filesystem::is_directory(_path, engineDirEc)) {
     std::string systemErrorStr;
     long errorNo;
 
@@ -1049,7 +1053,8 @@ void RocksDBEngine::start() {
 
 #ifdef USE_SST_INGESTION
   _idxPath = basics::FileUtils::buildFilename(_path, "tmp-idx-creation");
-  if (basics::FileUtils::isDirectory(_idxPath)) {
+  std::error_code idxDirEc;
+  if (std::filesystem::is_directory(_idxPath, idxDirEc)) {
     for (auto const& fileName : TRI_FullTreeDirectory(_idxPath.c_str())) {
       TRI_UnlinkFile(basics::FileUtils::buildFilename(path, fileName).data());
     }
@@ -2862,8 +2867,10 @@ void RocksDBEngine::pruneWalFiles() {
       LOG_TOPIC("68e4a", DEBUG, Logger::ENGINES)
           << "deleting RocksDB WAL file '" << (*it).first << "'";
       rocksdb::Status s;
-      if (basics::FileUtils::exists(basics::FileUtils::buildFilename(
-              _dbOptions.wal_dir, (*it).first))) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(
+              basics::FileUtils::buildFilename(_dbOptions.wal_dir, (*it).first),
+              existsEc)) {
         // only attempt file deletion if the file actually exists.
         // otherwise RocksDB may complain about non-existing files and log a
         // big error message

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -1003,8 +1003,7 @@ void RocksDBEngine::start() {
   _path = _databasePathFeature.subdirectoryName("engine-rocksdb");
 
   [[maybe_unused]] bool createdEngineDir = false;
-  std::error_code engineDirEc;
-  if (!std::filesystem::is_directory(_path, engineDirEc)) {
+  if (!std::filesystem::is_directory(_path)) {
     std::string systemErrorStr;
     long errorNo;
 
@@ -1053,8 +1052,7 @@ void RocksDBEngine::start() {
 
 #ifdef USE_SST_INGESTION
   _idxPath = basics::FileUtils::buildFilename(_path, "tmp-idx-creation");
-  std::error_code idxDirEc;
-  if (std::filesystem::is_directory(_idxPath, idxDirEc)) {
+  if (std::filesystem::is_directory(_idxPath)) {
     for (auto const& fileName : TRI_FullTreeDirectory(_idxPath.c_str())) {
       TRI_UnlinkFile(basics::FileUtils::buildFilename(path, fileName).data());
     }

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -655,8 +655,8 @@ void V8DealerFeature::copyInstallationFiles() {
     // check if for some reason we will be trying to remove the entire database
     // directory...
     std::error_code copyExistsEc;
-    if (std::filesystem::exists(
-            FileUtils::buildFilename(copyJSPath, "ENGINE"), copyExistsEc)) {
+    if (std::filesystem::exists(FileUtils::buildFilename(copyJSPath, "ENGINE"),
+                                copyExistsEc)) {
       LOG_TOPIC("214d1", FATAL, Logger::V8)
           << "JS installation path '" << copyJSPath << "' seems to be invalid";
       FATAL_ERROR_EXIT();

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -451,14 +451,16 @@ void V8DealerFeature::start() {
     std::string const commonPath = FileUtils::buildFilename(dbJSPath, "common");
     std::string const nodeModulesPath =
         FileUtils::buildFilename(dbJSPath, "node", "node_modules");
-    if (FileUtils::isDirectory(dbJSPath) && FileUtils::exists(checksumFile) &&
-        FileUtils::isDirectory(serverPath) &&
-        FileUtils::isDirectory(commonPath)) {
+    std::error_code dirEc;
+    if (std::filesystem::is_directory(dbJSPath, dirEc) &&
+        std::filesystem::exists(checksumFile, dirEc) &&
+        std::filesystem::is_directory(serverPath, dirEc) &&
+        std::filesystem::is_directory(commonPath, dirEc)) {
       // js directory inside database directory looks good. now use it!
       _options.startupDirectory = dbJSPath;
       // older versions didn't copy node_modules. so check if it exists inside
       // the database directory or not.
-      if (FileUtils::isDirectory(nodeModulesPath)) {
+      if (std::filesystem::is_directory(nodeModulesPath, dirEc)) {
         _nodeModulesDirectory = nodeModulesPath;
       } else {
         _nodeModulesDirectory = _options.startupDirectory;
@@ -508,7 +510,8 @@ void V8DealerFeature::start() {
       paths.push_back(std::string("application '" + _options.appPath + "'"));
 
       // create app directory if it does not exist
-      if (!basics::FileUtils::isDirectory(_options.appPath)) {
+      std::error_code appDirEc;
+      if (!std::filesystem::is_directory(_options.appPath, appDirEc)) {
         std::string systemErrorStr;
         long errorNo;
 
@@ -630,8 +633,10 @@ void V8DealerFeature::copyInstallationFiles() {
       FileUtils::buildFilename(copyJSPath, StaticStrings::checksumFileJs);
 
   bool overwriteCopy = false;
-  if (!FileUtils::exists(copyJSPath) || !FileUtils::exists(checksumFile) ||
-      !FileUtils::exists(copyChecksumFile)) {
+  std::error_code existsEc;
+  if (!std::filesystem::exists(copyJSPath, existsEc) ||
+      !std::filesystem::exists(checksumFile, existsEc) ||
+      !std::filesystem::exists(copyChecksumFile, existsEc)) {
     overwriteCopy = true;
   } else {
     try {
@@ -649,7 +654,9 @@ void V8DealerFeature::copyInstallationFiles() {
     // basic security checks before removing an existing directory:
     // check if for some reason we will be trying to remove the entire database
     // directory...
-    if (FileUtils::exists(FileUtils::buildFilename(copyJSPath, "ENGINE"))) {
+    std::error_code copyExistsEc;
+    if (std::filesystem::exists(
+            FileUtils::buildFilename(copyJSPath, "ENGINE"), copyExistsEc)) {
       LOG_TOPIC("214d1", FATAL, Logger::V8)
           << "JS installation path '" << copyJSPath << "' seems to be invalid";
       FATAL_ERROR_EXIT();
@@ -659,7 +666,7 @@ void V8DealerFeature::copyInstallationFiles() {
         << "Copying JS installation files from '" << _options.startupDirectory
         << "' to '" << copyJSPath << "'";
     auto res = TRI_ERROR_NO_ERROR;
-    if (FileUtils::exists(copyJSPath)) {
+    if (std::filesystem::exists(copyJSPath, copyExistsEc)) {
       res = TRI_RemoveDirectory(copyJSPath.c_str());
       if (res != TRI_ERROR_NO_ERROR) {
         LOG_TOPIC("1a20d", FATAL, Logger::V8)
@@ -732,7 +739,8 @@ void V8DealerFeature::copyInstallationFiles() {
     std::string const enterpriseJs = basics::FileUtils::buildFilename(
         _options.startupDirectory, "..", "enterprise", "js");
 
-    if (FileUtils::isDirectory(enterpriseJs)) {
+    std::error_code entDirEc;
+    if (std::filesystem::is_directory(enterpriseJs, entDirEc)) {
       std::function<bool(std::string const&)> const passAllFilter =
           [](std::string const&) { return false; };
       if (!FileUtils::copyRecursive(enterpriseJs, copyJSPath, passAllFilter,

--- a/arangod/V8Server/V8DealerFeature.cpp
+++ b/arangod/V8Server/V8DealerFeature.cpp
@@ -451,16 +451,16 @@ void V8DealerFeature::start() {
     std::string const commonPath = FileUtils::buildFilename(dbJSPath, "common");
     std::string const nodeModulesPath =
         FileUtils::buildFilename(dbJSPath, "node", "node_modules");
-    std::error_code dirEc;
-    if (std::filesystem::is_directory(dbJSPath, dirEc) &&
-        std::filesystem::exists(checksumFile, dirEc) &&
-        std::filesystem::is_directory(serverPath, dirEc) &&
-        std::filesystem::is_directory(commonPath, dirEc)) {
+
+    if (std::filesystem::is_directory(dbJSPath) &&
+        std::filesystem::exists(checksumFile) &&
+        std::filesystem::is_directory(serverPath) &&
+        std::filesystem::is_directory(commonPath)) {
       // js directory inside database directory looks good. now use it!
       _options.startupDirectory = dbJSPath;
       // older versions didn't copy node_modules. so check if it exists inside
       // the database directory or not.
-      if (std::filesystem::is_directory(nodeModulesPath, dirEc)) {
+      if (std::filesystem::is_directory(nodeModulesPath)) {
         _nodeModulesDirectory = nodeModulesPath;
       } else {
         _nodeModulesDirectory = _options.startupDirectory;
@@ -510,8 +510,8 @@ void V8DealerFeature::start() {
       paths.push_back(std::string("application '" + _options.appPath + "'"));
 
       // create app directory if it does not exist
-      std::error_code appDirEc;
-      if (!std::filesystem::is_directory(_options.appPath, appDirEc)) {
+
+      if (!std::filesystem::is_directory(_options.appPath)) {
         std::string systemErrorStr;
         long errorNo;
 
@@ -633,10 +633,9 @@ void V8DealerFeature::copyInstallationFiles() {
       FileUtils::buildFilename(copyJSPath, StaticStrings::checksumFileJs);
 
   bool overwriteCopy = false;
-  std::error_code existsEc;
-  if (!std::filesystem::exists(copyJSPath, existsEc) ||
-      !std::filesystem::exists(checksumFile, existsEc) ||
-      !std::filesystem::exists(copyChecksumFile, existsEc)) {
+  if (!std::filesystem::exists(copyJSPath) ||
+      !std::filesystem::exists(checksumFile) ||
+      !std::filesystem::exists(copyChecksumFile)) {
     overwriteCopy = true;
   } else {
     try {
@@ -666,7 +665,7 @@ void V8DealerFeature::copyInstallationFiles() {
         << "Copying JS installation files from '" << _options.startupDirectory
         << "' to '" << copyJSPath << "'";
     auto res = TRI_ERROR_NO_ERROR;
-    if (std::filesystem::exists(copyJSPath, copyExistsEc)) {
+    if (std::filesystem::exists(copyJSPath)) {
       res = TRI_RemoveDirectory(copyJSPath.c_str());
       if (res != TRI_ERROR_NO_ERROR) {
         LOG_TOPIC("1a20d", FATAL, Logger::V8)
@@ -739,8 +738,7 @@ void V8DealerFeature::copyInstallationFiles() {
     std::string const enterpriseJs = basics::FileUtils::buildFilename(
         _options.startupDirectory, "..", "enterprise", "js");
 
-    std::error_code entDirEc;
-    if (std::filesystem::is_directory(enterpriseJs, entDirEc)) {
+    if (std::filesystem::is_directory(enterpriseJs)) {
       std::function<bool(std::string const&)> const passAllFilter =
           [](std::string const&) { return false; };
       if (!FileUtils::copyRecursive(enterpriseJs, copyJSPath, passAllFilter,

--- a/arangod/VocBase/Methods/Version.cpp
+++ b/arangod/VocBase/Methods/Version.cpp
@@ -105,7 +105,8 @@ VersionResult Version::check(TRI_vocbase_t* vocbase) {
   std::error_code existsEc;
   if (!std::filesystem::exists(versionFile, existsEc)) {
     LOG_TOPIC("fde3f", DEBUG, Logger::STARTUP)
-        << "VERSION file '" << versionFile << "' not found";
+        << "VERSION file '" << versionFile << "' not found"
+        << existsEc.message();
     return VersionResult{VersionResult::NO_VERSION_FILE, 0, 0, {}};
   }
   std::string versionInfo = basics::FileUtils::slurp(versionFile);

--- a/arangod/VocBase/Methods/Version.cpp
+++ b/arangod/VocBase/Methods/Version.cpp
@@ -102,7 +102,8 @@ VersionResult Version::check(TRI_vocbase_t* vocbase) {
   }
 
   std::string versionFile = vocbase->engine().versionFilename(vocbase->id());
-  if (!basics::FileUtils::exists(versionFile)) {
+  std::error_code existsEc;
+  if (!std::filesystem::exists(versionFile, existsEc)) {
     LOG_TOPIC("fde3f", DEBUG, Logger::STARTUP)
         << "VERSION file '" << versionFile << "' not found";
     return VersionResult{VersionResult::NO_VERSION_FILE, 0, 0, {}};

--- a/client-tools/Benchmark/BenchFeature.cpp
+++ b/client-tools/Benchmark/BenchFeature.cpp
@@ -359,7 +359,7 @@ void BenchFeature::start() {
       std::filesystem::exists(_jsonReportFile, existsEc)) {
     LOG_TOPIC("ee2a4", FATAL, arangodb::Logger::BENCH)
         << "file already exists: '" << _jsonReportFile
-        << "' - won't overwrite it.";
+        << "' - won't overwrite it." << existsEc.message();
     FATAL_ERROR_EXIT();
   }
   ClientFeature& client =

--- a/client-tools/Benchmark/BenchFeature.cpp
+++ b/client-tools/Benchmark/BenchFeature.cpp
@@ -354,8 +354,9 @@ void BenchFeature::prepare() { logLGPLNotice(); }
 
 void BenchFeature::start() {
   std::sort(_percentiles.begin(), _percentiles.end());
-
-  if (!_jsonReportFile.empty() && FileUtils::exists(_jsonReportFile)) {
+  std::error_code existsEc;
+  if (!_jsonReportFile.empty() &&
+      std::filesystem::exists(_jsonReportFile, existsEc)) {
     LOG_TOPIC("ee2a4", FATAL, arangodb::Logger::BENCH)
         << "file already exists: '" << _jsonReportFile
         << "' - won't overwrite it.";

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -67,6 +67,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <regex>
 #include <string>
 #include <string_view>
@@ -1156,7 +1157,8 @@ std::vector<RestoreFeature::DatabaseInfo> RestoreFeature::determineDatabaseList(
     for (auto const& it : basics::FileUtils::listFiles(_options.inputPath)) {
       std::string path =
           basics::FileUtils::buildFilename(_options.inputPath, it);
-      if (basics::FileUtils::isDirectory(path)) {
+      std::error_code dirEc;
+      if (std::filesystem::is_directory(path, dirEc)) {
         EncryptionFeature* encryption{};
 #ifdef USE_ENTERPRISE
         TRI_ASSERT(server().hasFeature<EncryptionFeature>());
@@ -2509,7 +2511,8 @@ void RestoreFeature::start() {
     _exitCode = EXIT_FAILURE;
   } else {
     for (auto const& fn : filesToClean) {
-      [[maybe_unused]] auto result = basics::FileUtils::remove(fn);
+      // std::error_code removeEc;
+      std::filesystem::remove(fn);
     }
   }
 

--- a/client-tools/Restore/RestoreFeature.cpp
+++ b/client-tools/Restore/RestoreFeature.cpp
@@ -1157,8 +1157,7 @@ std::vector<RestoreFeature::DatabaseInfo> RestoreFeature::determineDatabaseList(
     for (auto const& it : basics::FileUtils::listFiles(_options.inputPath)) {
       std::string path =
           basics::FileUtils::buildFilename(_options.inputPath, it);
-      std::error_code dirEc;
-      if (std::filesystem::is_directory(path, dirEc)) {
+      if (std::filesystem::is_directory(path)) {
         EncryptionFeature* encryption{};
 #ifdef USE_ENTERPRISE
         TRI_ASSERT(server().hasFeature<EncryptionFeature>());

--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -2045,7 +2045,8 @@ static void ClientConnection_httpSendFile(
 
   std::string const infile = TRI_ObjectToString(isolate, args[1]);
 
-  if (!FileUtils::exists(infile)) {
+  std::error_code existsEc;
+  if (!std::filesystem::exists(infile, existsEc)) {
     TRI_V8_THROW_EXCEPTION(TRI_ERROR_FILE_NOT_FOUND);
   }
 
@@ -3017,7 +3018,8 @@ bool setRequestBody(fu::Request& request, v8::Isolate* isolate,
 
   if (isFile) {
     std::string const inFile = TRI_ObjectToString(isolate, body);
-    if (!FileUtils::exists(inFile)) {
+    std::error_code existsEc;
+    if (!std::filesystem::exists(inFile, existsEc)) {
       std::string err =
           absl::StrCat("file to load for body doesn't exist: ", inFile);
       TRI_V8_SET_EXCEPTION_MESSAGE(TRI_ERROR_BAD_PARAMETER, err);

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -288,8 +288,7 @@ void V8ShellFeature::copyInstallationFiles() {
       << _copyDirectory << "'";
 
   _nodeModulesDirectory = _startupDirectory;
-  std::error_code ec;
-  if (std::filesystem::exists(_copyDirectory, ec)) {
+  if (std::filesystem::exists(_copyDirectory)) {
     auto res = TRI_ERROR_NO_ERROR;
     res = TRI_RemoveDirectory(_copyDirectory.c_str());
     if (res != TRI_ERROR_NO_ERROR) {
@@ -1068,8 +1067,7 @@ void V8ShellFeature::initGlobals() {
   LOG_TOPIC("5095d", DEBUG, Logger::V8)
       << "checking for existence of version-specific startup-directory '"
       << versionedPath << "'";
-  std::error_code dirEc;
-  if (std::filesystem::is_directory(versionedPath, dirEc)) {
+  if (std::filesystem::is_directory(versionedPath)) {
     // version-specific js path exists!
     _startupDirectory = versionedPath;
   }
@@ -1081,8 +1079,7 @@ void V8ShellFeature::initGlobals() {
     LOG_TOPIC("2abe3", DEBUG, Logger::V8)
         << "checking for existence of version-specific module-directory '"
         << versionedPath << "'";
-    std::error_code moduleDirEc;
-    if (std::filesystem::is_directory(versionedPath, moduleDirEc)) {
+    if (std::filesystem::is_directory(versionedPath)) {
       // version-specific js path exists!
       it = versionedPath;
     }

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -653,7 +653,8 @@ bool V8ShellFeature::runScript(std::vector<std::string> const& files,
     std::error_code ec;
     if (!std::filesystem::exists(file, ec)) {
       LOG_TOPIC("4beec", ERR, arangodb::Logger::FIXME)
-          << "error: JavaScript file not found: '" << file << "'";
+          << "error: JavaScript file not found: '" << file << "'"
+          << ec.message();
       ok = false;
       continue;
     }
@@ -794,7 +795,8 @@ bool V8ShellFeature::runUnitTests(std::vector<std::string> const& files,
     std::error_code ec;
     if (!std::filesystem::exists(file, ec)) {
       LOG_TOPIC("51bdb", ERR, arangodb::Logger::FIXME)
-          << "error: JavaScript file not found: '" << file << "'";
+          << "error: JavaScript file not found: '" << file << "'"
+          << ec.message();
       ok = false;
       continue;
     }

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -288,8 +288,8 @@ void V8ShellFeature::copyInstallationFiles() {
       << _copyDirectory << "'";
 
   _nodeModulesDirectory = _startupDirectory;
-
-  if (FileUtils::exists(_copyDirectory)) {
+  std::error_code ec;
+  if (std::filesystem::exists(_copyDirectory, ec)) {
     auto res = TRI_ERROR_NO_ERROR;
     res = TRI_RemoveDirectory(_copyDirectory.c_str());
     if (res != TRI_ERROR_NO_ERROR) {
@@ -651,7 +651,8 @@ bool V8ShellFeature::runScript(std::vector<std::string> const& files,
   bool ok = true;
 
   for (auto const& file : files) {
-    if (!FileUtils::exists(file)) {
+    std::error_code ec;
+    if (!std::filesystem::exists(file, ec)) {
       LOG_TOPIC("4beec", ERR, arangodb::Logger::FIXME)
           << "error: JavaScript file not found: '" << file << "'";
       ok = false;
@@ -791,7 +792,8 @@ bool V8ShellFeature::runUnitTests(std::vector<std::string> const& files,
   uint32_t i = 0;
 
   for (auto const& file : files) {
-    if (!FileUtils::exists(file)) {
+    std::error_code ec;
+    if (!std::filesystem::exists(file, ec)) {
       LOG_TOPIC("51bdb", ERR, arangodb::Logger::FIXME)
           << "error: JavaScript file not found: '" << file << "'";
       ok = false;
@@ -1066,7 +1068,8 @@ void V8ShellFeature::initGlobals() {
   LOG_TOPIC("5095d", DEBUG, Logger::V8)
       << "checking for existence of version-specific startup-directory '"
       << versionedPath << "'";
-  if (basics::FileUtils::isDirectory(versionedPath)) {
+  std::error_code dirEc;
+  if (std::filesystem::is_directory(versionedPath, dirEc)) {
     // version-specific js path exists!
     _startupDirectory = versionedPath;
   }
@@ -1078,7 +1081,8 @@ void V8ShellFeature::initGlobals() {
     LOG_TOPIC("2abe3", DEBUG, Logger::V8)
         << "checking for existence of version-specific module-directory '"
         << versionedPath << "'";
-    if (basics::FileUtils::isDirectory(versionedPath)) {
+    std::error_code moduleDirEc;
+    if (std::filesystem::is_directory(versionedPath, moduleDirEc)) {
       // version-specific js path exists!
       it = versionedPath;
     }

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -117,7 +117,8 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
 
   // always prefer an explicitly given config file
   if (!_options.file.empty()) {
-    if (!FileUtils::exists(_options.file)) {
+    std::error_code existsEc;
+    if (!std::filesystem::exists(_options.file, existsEc)) {
       LOG_TOPIC("f21f9", FATAL, Logger::CONFIG)
           << "cannot read config file '" << _options.file << "'";
       FATAL_ERROR_EXIT_CODE(TRI_EXIT_CONFIG_NOT_FOUND);
@@ -199,7 +200,8 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
     LOG_TOPIC("393e7", TRACE, Logger::CONFIG)
         << "checking config file '" << name << "'";
 
-    if (FileUtils::exists(name)) {
+    std::error_code existsEc;
+    if (std::filesystem::exists(name, existsEc)) {
       LOG_TOPIC("e6bd8", DEBUG, Logger::CONFIG)
           << "found config file '" << name << "'";
       filename = name;
@@ -210,7 +212,8 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
       name = FileUtils::buildFilename(location, "arangoimp.conf");
       LOG_TOPIC("b629e", TRACE, Logger::CONFIG)
           << "checking config file '" << name << "'";
-      if (FileUtils::exists(name)) {
+      std::error_code existsEc;
+      if (std::filesystem::exists(name, existsEc)) {
         LOG_TOPIC("fc54e", DEBUG, Logger::CONFIG)
             << "found config file '" << name << "'";
         filename = name;

--- a/lib/ApplicationFeatures/ConfigFeature.cpp
+++ b/lib/ApplicationFeatures/ConfigFeature.cpp
@@ -119,9 +119,18 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
   if (!_options.file.empty()) {
     std::error_code existsEc;
     if (!std::filesystem::exists(_options.file, existsEc)) {
-      LOG_TOPIC("f21f9", FATAL, Logger::CONFIG)
-          << "cannot read config file '" << _options.file << "'";
-      FATAL_ERROR_EXIT_CODE(TRI_EXIT_CONFIG_NOT_FOUND);
+      if (existsEc) {
+        // An actual error occurred (permissions, I/O, invalid path, etc.
+        LOG_TOPIC("f21fa", FATAL, Logger::CONFIG)
+            << "error checking config file '" << _options.file
+            << "': " << existsEc.message();
+        FATAL_ERROR_EXIT_CODE(TRI_EXIT_CONFIG_NOT_FOUND);
+      } else {
+        // File simply does not exist
+        LOG_TOPIC("f21f9", FATAL, Logger::CONFIG)
+            << "cannot read config file '" << _options.file << "'";
+        FATAL_ERROR_EXIT_CODE(TRI_EXIT_CONFIG_NOT_FOUND);
+      }
     }
 
     auto local = _options.file + ".local";
@@ -206,6 +215,15 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
           << "found config file '" << name << "'";
       filename = name;
       break;
+    } else if (existsEc) {
+      // An error occurred while checking the file
+      LOG_TOPIC("e6bd9", ERR, Logger::CONFIG)
+          << "error checking config file '" << name
+          << "': " << existsEc.message();
+    } else {
+      // File simply does not exist
+      LOG_TOPIC("e6bda", DEBUG, Logger::CONFIG)
+          << "config file '" << name << "' does not exist";
     }
 
     if (checkArangoImp) {
@@ -218,6 +236,15 @@ void ConfigFeature::loadConfigFile(std::shared_ptr<ProgramOptions> options,
             << "found config file '" << name << "'";
         filename = name;
         break;
+      } else if (existsEc) {
+        // An error occurred while checking the file
+        LOG_TOPIC("fc54f", ERR, Logger::CONFIG)
+            << "error checking config file '" << name
+            << "': " << existsEc.message();
+      } else {
+        // File simply does not exist
+        LOG_TOPIC("fc550", DEBUG, Logger::CONFIG)
+            << "config file '" << name << "' does not exist";
       }
     }
   }

--- a/lib/Basics/ArangoGlobalContext.cpp
+++ b/lib/Basics/ArangoGlobalContext.cpp
@@ -115,10 +115,11 @@ void ArangoGlobalContext::normalizePath(std::string& path,
   StringUtils::rTrimInPlace(path, TRI_DIR_SEPARATOR_STR);
 
   path = std::filesystem::path(path).make_preferred().string();
-  if (!arangodb::basics::FileUtils::exists(path)) {
+  std::error_code ec;
+  if (!std::filesystem::exists(path, ec)) {
     std::string directory =
         arangodb::basics::FileUtils::buildFilename(_runRoot, path);
-    if (!arangodb::basics::FileUtils::exists(directory)) {
+    if (!std::filesystem::exists(directory, ec)) {
       if (!fatal) {
         return;
       }

--- a/lib/Basics/ArangoGlobalContext.cpp
+++ b/lib/Basics/ArangoGlobalContext.cpp
@@ -115,11 +115,10 @@ void ArangoGlobalContext::normalizePath(std::string& path,
   StringUtils::rTrimInPlace(path, TRI_DIR_SEPARATOR_STR);
 
   path = std::filesystem::path(path).make_preferred().string();
-  std::error_code ec;
-  if (!std::filesystem::exists(path, ec)) {
+  if (!std::filesystem::exists(path)) {
     std::string directory =
         arangodb::basics::FileUtils::buildFilename(_runRoot, path);
-    if (!std::filesystem::exists(directory, ec)) {
+    if (!std::filesystem::exists(directory)) {
       if (!fatal) {
         return;
       }

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -88,15 +88,6 @@ StatResultType statResultType(TRI_stat_t const& stbuf) {
   return StatResultType::Other;
 }
 
-StatResultType statResultType(std::string const& path) {
-  TRI_stat_t stbuf;
-  int res = TRI_STAT(path.c_str(), &stbuf);
-  if (res != 0) {
-    return StatResultType::Error;
-  }
-  return statResultType(stbuf);
-}
-
 void processFiles(std::string const& directory,
                   std::function<void(std::string const&)> const& cb) {
   std::filesystem::path const dir{directory};
@@ -137,48 +128,32 @@ namespace arangodb::basics::FileUtils {
 std::string buildFilename(char const* path, char const* name) {
   TRI_ASSERT(path != nullptr);
   TRI_ASSERT(name != nullptr);
-
-  std::string result(path);
-
-  if (!result.empty()) {
-    std::filesystem::path sourcepath{result};
-    result = sourcepath.lexically_normal().string();
-    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
-      result += TRI_DIR_SEPARATOR_CHAR;
-    }
-  }
-
-  if (!result.empty() && *name == TRI_DIR_SEPARATOR_CHAR) {
-    // skip initial forward slash in name to avoid having two forward slashes in
-    // result
-    result.append(name + 1);
-  } else {
-    result.append(name);
-  }
-
-  return std::filesystem::path(result).make_preferred().string();
+  return buildFilename(std::string(path), std::string(name));
 }
 
 std::string buildFilename(std::string const& path, std::string const& name) {
-  std::string result(path);
+  if (path.empty()) {
+    return std::filesystem::path(name).make_preferred().string();
+  }
 
-  if (!result.empty()) {
-    std::filesystem::path sourcepath{result};
-    result = sourcepath.lexically_normal().string();
-    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
-      result += TRI_DIR_SEPARATOR_CHAR;
+  std::filesystem::path const base =
+      std::filesystem::path(path).lexically_normal();
+  std::string const baseStr = base.string();
+
+  std::string nameToJoin = name;
+  if (!nameToJoin.empty() && nameToJoin.front() == TRI_DIR_SEPARATOR_CHAR) {
+    nameToJoin.erase(0, 1);
+  }
+
+  if (nameToJoin.empty()) {
+    std::string out = baseStr;
+    if (out.size() != 1 || out[0] != TRI_DIR_SEPARATOR_CHAR) {
+      out += TRI_DIR_SEPARATOR_CHAR;
     }
+    return std::filesystem::path(out).make_preferred().string();
   }
 
-  if (!result.empty() && !name.empty() && name[0] == TRI_DIR_SEPARATOR_CHAR) {
-    // skip initial forward slash in name to avoid having two forward slashes in
-    // result
-    result.append(name.c_str() + 1, name.size() - 1);
-  } else {
-    result.append(name);
-  }
-
-  return std::filesystem::path(result).make_preferred().string();
+  return (base / nameToJoin).make_preferred().string();
 }
 
 static void throwFileReadError(std::string const& filename) {
@@ -326,16 +301,6 @@ void appendToFile(std::string const& filename, std::string_view s, bool sync) {
   appendToFile(filename, s.data(), s.size(), sync);
 }
 
-ErrorCode remove(std::string const& fileName) {
-  auto const success = 0 == std::remove(fileName.c_str());
-
-  if (!success) {
-    return TRI_set_errno(TRI_ERROR_SYS_ERROR);
-  }
-
-  return TRI_ERROR_NO_ERROR;
-}
-
 /// @brief will not copy files/directories for which the filter function
 /// returns true (now wrapper for version below with TRI_copy_recursive_e
 /// filter)
@@ -358,7 +323,8 @@ bool copyRecursive(
     std::string const& source, std::string const& target,
     std::function<TRI_copy_recursive_e(std::string const&)> const& filter,
     std::string& error) {
-  if (isDirectory(source)) {
+  std::error_code ec;
+  if (std::filesystem::is_directory(source, ec)) {
     return copyDirectoryRecursive(source, target, filter, error);
   }
 
@@ -489,14 +455,6 @@ std::vector<std::string> listFiles(std::string const& directory) {
   });
 
   return result;
-}
-
-bool isDirectory(std::string const& path) {
-  return ::statResultType(path) == ::StatResultType::Directory;
-}
-
-bool exists(std::string const& path) {
-  return ::statResultType(path) != ::StatResultType::Error;
 }
 
 std::string stripExtension(std::string const& path,

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -128,32 +128,48 @@ namespace arangodb::basics::FileUtils {
 std::string buildFilename(char const* path, char const* name) {
   TRI_ASSERT(path != nullptr);
   TRI_ASSERT(name != nullptr);
-  return buildFilename(std::string(path), std::string(name));
+
+  std::string result(path);
+
+  if (!result.empty()) {
+    std::filesystem::path sourcepath{result};
+    result = sourcepath.lexically_normal().string();
+    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
+      result += TRI_DIR_SEPARATOR_CHAR;
+    }
+  }
+
+  if (!result.empty() && *name == TRI_DIR_SEPARATOR_CHAR) {
+    // skip initial forward slash in name to avoid having two forward slashes in
+    // result
+    result.append(name + 1);
+  } else {
+    result.append(name);
+  }
+
+  return std::filesystem::path(result).make_preferred().string();
 }
 
 std::string buildFilename(std::string const& path, std::string const& name) {
-  if (path.empty()) {
-    return std::filesystem::path(name).make_preferred().string();
-  }
+  std::string result(path);
 
-  std::filesystem::path const base =
-      std::filesystem::path(path).lexically_normal();
-  std::string const baseStr = base.string();
-
-  std::string nameToJoin = name;
-  if (!nameToJoin.empty() && nameToJoin.front() == TRI_DIR_SEPARATOR_CHAR) {
-    nameToJoin.erase(0, 1);
-  }
-
-  if (nameToJoin.empty()) {
-    std::string out = baseStr;
-    if (out.size() != 1 || out[0] != TRI_DIR_SEPARATOR_CHAR) {
-      out += TRI_DIR_SEPARATOR_CHAR;
+  if (!result.empty()) {
+    std::filesystem::path sourcepath{result};
+    result = sourcepath.lexically_normal().string();
+    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
+      result += TRI_DIR_SEPARATOR_CHAR;
     }
-    return std::filesystem::path(out).make_preferred().string();
   }
 
-  return (base / nameToJoin).make_preferred().string();
+  if (!result.empty() && !name.empty() && name[0] == TRI_DIR_SEPARATOR_CHAR) {
+    // skip initial forward slash in name to avoid having two forward slashes in
+    // result
+    result.append(name.c_str() + 1, name.size() - 1);
+  } else {
+    result.append(name);
+  }
+
+  return std::filesystem::path(result).make_preferred().string();
 }
 
 static void throwFileReadError(std::string const& filename) {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -323,8 +323,7 @@ bool copyRecursive(
     std::string const& source, std::string const& target,
     std::function<TRI_copy_recursive_e(std::string const&)> const& filter,
     std::string& error) {
-  std::error_code ec;
-  if (std::filesystem::is_directory(source, ec)) {
+  if (std::filesystem::is_directory(source)) {
     return copyDirectoryRecursive(source, target, filter, error);
   }
 

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -78,7 +78,6 @@ void appendToFile(std::string const& filename, std::string_view s,
 
 // if a file could be removed returns TRI_ERROR_NO_ERROR.
 // otherwise, returns TRI_ERROR_SYS_ERROR and sets LastError.
-[[nodiscard]] ErrorCode remove(std::string const& fileName);
 
 /// @brief copies directories / files recursive
 /// will not copy files/directories for which the filter function
@@ -109,12 +108,6 @@ bool copyDirectoryRecursive(
 // does not recurse into subdirectories. will throw an exception in
 // case the directory cannot be opened for iteration.
 std::vector<std::string> listFiles(std::string const& directory);
-
-// checks if path is a directory
-bool isDirectory(std::string const& path);
-
-// checks if path exists
-bool exists(std::string const& path);
 
 // strip extension
 std::string stripExtension(std::string const& path,

--- a/lib/Basics/FileUtils.h
+++ b/lib/Basics/FileUtils.h
@@ -76,9 +76,6 @@ void appendToFile(std::string const& filename, char const* ptr, size_t len,
 void appendToFile(std::string const& filename, std::string_view s,
                   bool sync = false);
 
-// if a file could be removed returns TRI_ERROR_NO_ERROR.
-// otherwise, returns TRI_ERROR_SYS_ERROR and sets LastError.
-
 /// @brief copies directories / files recursive
 /// will not copy files/directories for which the filter function
 /// returns true (now wrapper for version below with TRI_copy_recursive_e

--- a/lib/Basics/NumberOfCores.cpp
+++ b/lib/Basics/NumberOfCores.cpp
@@ -80,8 +80,9 @@ std::size_t numberOfEffectiveCoresImpl() {
     }
     case cgroup::Version::V1: {
       try {
-        if (basics::FileUtils::exists(kCgroupV1CpuQuotaPath) &&
-            basics::FileUtils::exists(kCgroupV1CpuPeriodPath)) {
+        std::error_code existsEc;
+        if (std::filesystem::exists(kCgroupV1CpuQuotaPath, existsEc) &&
+            std::filesystem::exists(kCgroupV1CpuPeriodPath, existsEc)) {
           auto quota =
               basics::FileUtils::readCgroupFileValue(kCgroupV1CpuQuotaPath);
           auto period =
@@ -106,7 +107,8 @@ std::size_t numberOfEffectiveCoresImpl() {
     }
     case cgroup::Version::V2: {
       try {
-        if (basics::FileUtils::exists(kCgroupV2CpuMaxPath)) {
+        std::error_code existsEc;
+        if (std::filesystem::exists(kCgroupV2CpuMaxPath, existsEc)) {
           std::string content = basics::FileUtils::slurp(kCgroupV2CpuMaxPath);
           std::istringstream stream(content);
           std::string quotaStr, periodStr;

--- a/lib/Basics/NumberOfCores.cpp
+++ b/lib/Basics/NumberOfCores.cpp
@@ -80,9 +80,8 @@ std::size_t numberOfEffectiveCoresImpl() {
     }
     case cgroup::Version::V1: {
       try {
-        std::error_code existsEc;
-        if (std::filesystem::exists(kCgroupV1CpuQuotaPath, existsEc) &&
-            std::filesystem::exists(kCgroupV1CpuPeriodPath, existsEc)) {
+        if (std::filesystem::exists(kCgroupV1CpuQuotaPath) &&
+            std::filesystem::exists(kCgroupV1CpuPeriodPath)) {
           auto quota =
               basics::FileUtils::readCgroupFileValue(kCgroupV1CpuQuotaPath);
           auto period =
@@ -107,8 +106,7 @@ std::size_t numberOfEffectiveCoresImpl() {
     }
     case cgroup::Version::V2: {
       try {
-        std::error_code existsEc;
-        if (std::filesystem::exists(kCgroupV2CpuMaxPath, existsEc)) {
+        if (std::filesystem::exists(kCgroupV2CpuMaxPath)) {
           std::string content = basics::FileUtils::slurp(kCgroupV2CpuMaxPath);
           std::istringstream stream(content);
           std::string quotaStr, periodStr;

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -104,8 +104,7 @@ uint64_t effectivePhysicalMemoryImpl() {
     }
     case cgroup::Version::V1: {
       try {
-        std::error_code existsEc;
-        if (std::filesystem::exists(kCgroupV1MemoryLimitPath, existsEc)) {
+        if (std::filesystem::exists(kCgroupV1MemoryLimitPath)) {
           if (auto const limit = basics::FileUtils::readCgroupFileValue(
                   kCgroupV1MemoryLimitPath);
               limit) {
@@ -129,8 +128,7 @@ uint64_t effectivePhysicalMemoryImpl() {
     }
     case cgroup::Version::V2: {
       try {
-        std::error_code existsEc;
-        if (std::filesystem::exists(kCgroupV2MemoryMaxPath, existsEc)) {
+        if (std::filesystem::exists(kCgroupV2MemoryMaxPath)) {
           if (auto const limit = basics::FileUtils::readCgroupFileValue(
                   kCgroupV2MemoryMaxPath);
               limit) {

--- a/lib/Basics/PhysicalMemory.cpp
+++ b/lib/Basics/PhysicalMemory.cpp
@@ -104,7 +104,8 @@ uint64_t effectivePhysicalMemoryImpl() {
     }
     case cgroup::Version::V1: {
       try {
-        if (basics::FileUtils::exists(kCgroupV1MemoryLimitPath)) {
+        std::error_code existsEc;
+        if (std::filesystem::exists(kCgroupV1MemoryLimitPath, existsEc)) {
           if (auto const limit = basics::FileUtils::readCgroupFileValue(
                   kCgroupV1MemoryLimitPath);
               limit) {
@@ -128,7 +129,8 @@ uint64_t effectivePhysicalMemoryImpl() {
     }
     case cgroup::Version::V2: {
       try {
-        if (basics::FileUtils::exists(kCgroupV2MemoryMaxPath)) {
+        std::error_code existsEc;
+        if (std::filesystem::exists(kCgroupV2MemoryMaxPath, existsEc)) {
           if (auto const limit = basics::FileUtils::readCgroupFileValue(
                   kCgroupV2MemoryMaxPath);
               limit) {

--- a/lib/Endpoint/EndpointUnixDomain.cpp
+++ b/lib/Endpoint/EndpointUnixDomain.cpp
@@ -29,18 +29,15 @@
 #include <stdio.h>
 #include <sys/un.h>
 #include <cstring>
+#include <filesystem>
 
-#include "Basics/FileUtils.h"
 #include "Basics/debugging.h"
-#include "Basics/error.h"
-#include "Basics/voc-errors.h"
 #include "Endpoint/Endpoint.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 
 using namespace arangodb;
-using namespace arangodb::basics;
 
 EndpointUnixDomain::EndpointUnixDomain(EndpointType type, int listenBacklog,
                                        std::string const& path)
@@ -144,10 +141,12 @@ void EndpointUnixDomain::disconnect() {
     TRI_invalidatesocket(&_socket);
 
     if (_type == EndpointType::SERVER) {
-      if (FileUtils::remove(_path) != TRI_ERROR_NO_ERROR) {
+      std::error_code removeEc;
+      std::filesystem::remove(_path, removeEc);
+      if (removeEc) {
         LOG_TOPIC("9a8d6", TRACE, arangodb::Logger::FIXME)
             << "unable to remove socket file '" << _path
-            << "': " << TRI_last_error();
+            << "': " << removeEc.message();
       }
     }
   }

--- a/lib/Logger/LogAppenderFile.cpp
+++ b/lib/Logger/LogAppenderFile.cpp
@@ -25,9 +25,9 @@
 
 #include <fcntl.h>
 #include <cstring>
+#include <filesystem>
 
 #include "Basics/Exceptions.h"
-#include "Basics/FileUtils.h"
 #include "Basics/files.h"
 #include "Basics/operating-system.h"
 #include "Logger/Logger.h"
@@ -159,7 +159,8 @@ void LogAppenderFileFactory::reopenAll() {
     std::string backup(filename);
     backup.append(".old");
 
-    std::ignore = basics::FileUtils::remove(backup);
+    // std::error_code removeOldEc;
+    std::filesystem::remove(backup);
     TRI_RenameFile(filename.c_str(), backup.c_str());
 
     // open new log file
@@ -184,7 +185,8 @@ void LogAppenderFileFactory::reopenAll() {
 #endif
 
     if (!Logger::_keepLogRotate) {
-      std::ignore = basics::FileUtils::remove(backup);
+      // std::error_code removeEc;
+      std::filesystem::remove(backup);
     }
 
     // and also tell the appender of the file descriptor change

--- a/tests/Basics/FilesTest.cpp
+++ b/tests/Basics/FilesTest.cpp
@@ -116,13 +116,12 @@ TEST_F(FilesTest, tst_copyfile) {
   EXPECT_EQ("", FileUtils::slurp(dest));
 
   // copy over an existing target file
-  std::error_code removeEc;
-  std::filesystem::remove(source, removeEc);
+  std::filesystem::remove(source);
   FileUtils::spit(source, std::string("foobar"), false);
   EXPECT_FALSE(TRI_CopyFile(source, dest, error));
 
-  std::filesystem::remove(source, removeEc);
-  std::filesystem::remove(dest, removeEc);
+  std::filesystem::remove(source);
+  std::filesystem::remove(dest);
   FileUtils::spit(source, std::string("foobar"), false);
   EXPECT_TRUE(TRI_CopyFile(source, dest, error));
   EXPECT_EQ("foobar", FileUtils::slurp(dest));
@@ -133,8 +132,8 @@ TEST_F(FilesTest, tst_copyfile) {
     value += value;
   }
 
-  std::filesystem::remove(source, removeEc);
-  std::filesystem::remove(dest, removeEc);
+  std::filesystem::remove(source);
+  std::filesystem::remove(dest);
   FileUtils::spit(source, value, false);
   EXPECT_TRUE(TRI_CopyFile(source, dest, error));
   EXPECT_EQ(value, FileUtils::slurp(dest));
@@ -142,8 +141,8 @@ TEST_F(FilesTest, tst_copyfile) {
 
   // copy file slightly larger than copy buffer
   std::string value2(128 * 1024 + 1, 'x');
-  std::filesystem::remove(source, removeEc);
-  std::filesystem::remove(dest, removeEc);
+  std::filesystem::remove(source);
+  std::filesystem::remove(dest);
   FileUtils::spit(source, value2, false);
   EXPECT_TRUE(TRI_CopyFile(source, dest, error));
   EXPECT_EQ(value2, FileUtils::slurp(dest));

--- a/tests/Basics/FilesTest.cpp
+++ b/tests/Basics/FilesTest.cpp
@@ -116,12 +116,13 @@ TEST_F(FilesTest, tst_copyfile) {
   EXPECT_EQ("", FileUtils::slurp(dest));
 
   // copy over an existing target file
-  std::ignore = FileUtils::remove(source);
+  std::error_code removeEc;
+  std::filesystem::remove(source, removeEc);
   FileUtils::spit(source, std::string("foobar"), false);
   EXPECT_FALSE(TRI_CopyFile(source, dest, error));
 
-  std::ignore = FileUtils::remove(source);
-  std::ignore = FileUtils::remove(dest);
+  std::filesystem::remove(source, removeEc);
+  std::filesystem::remove(dest, removeEc);
   FileUtils::spit(source, std::string("foobar"), false);
   EXPECT_TRUE(TRI_CopyFile(source, dest, error));
   EXPECT_EQ("foobar", FileUtils::slurp(dest));
@@ -132,8 +133,8 @@ TEST_F(FilesTest, tst_copyfile) {
     value += value;
   }
 
-  std::ignore = FileUtils::remove(source);
-  std::ignore = FileUtils::remove(dest);
+  std::filesystem::remove(source, removeEc);
+  std::filesystem::remove(dest, removeEc);
   FileUtils::spit(source, value, false);
   EXPECT_TRUE(TRI_CopyFile(source, dest, error));
   EXPECT_EQ(value, FileUtils::slurp(dest));
@@ -141,8 +142,8 @@ TEST_F(FilesTest, tst_copyfile) {
 
   // copy file slightly larger than copy buffer
   std::string value2(128 * 1024 + 1, 'x');
-  std::ignore = FileUtils::remove(source);
-  std::ignore = FileUtils::remove(dest);
+  std::filesystem::remove(source, removeEc);
+  std::filesystem::remove(dest, removeEc);
   FileUtils::spit(source, value2, false);
   EXPECT_TRUE(TRI_CopyFile(source, dest, error));
   EXPECT_EQ(value2, FileUtils::slurp(dest));

--- a/tests/Basics/LoggerTest.cpp
+++ b/tests/Basics/LoggerTest.cpp
@@ -36,6 +36,7 @@
 #include <date/date.h>
 #include <format>
 
+#include <filesystem>
 #include <regex>
 #include <sstream>
 
@@ -85,8 +86,9 @@ class LoggerTest : public ::testing::Test {
         path(TRI_GetTempPath()),
         logfile1(path + "logfile1"),
         logfile2(path + "logfile2") {
-    std::ignore = FileUtils::remove(logfile1);
-    std::ignore = FileUtils::remove(logfile2);
+    std::error_code removeEc;
+    std::filesystem::remove(logfile1, removeEc);
+    std::filesystem::remove(logfile2, removeEc);
     // remove any previous loggers
     LogAppenderFileFactory::closeAll();
   }
@@ -96,8 +98,9 @@ class LoggerTest : public ::testing::Test {
     LogAppenderFileFactory::setAppenders(backup);
     LogAppenderFileFactory::reopenAll();
 
-    std::ignore = FileUtils::remove(logfile1);
-    std::ignore = FileUtils::remove(logfile2);
+    std::error_code removeEc;
+    std::filesystem::remove(logfile1, removeEc);
+    std::filesystem::remove(logfile2, removeEc);
   }
 };
 

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -482,16 +482,14 @@ static void findIResearchTestResources() {
     // environment variable not set, so try to auto-detect the location
     testResourceDir = ".";
     do {
-      std::error_code dirEc;
       if (std::filesystem::is_directory(
-              basics::FileUtils::buildFilename(testResourceDir, toBeFound),
-              dirEc)) {
+              basics::FileUtils::buildFilename(testResourceDir, toBeFound))) {
         testResourceDir =
             basics::FileUtils::buildFilename(testResourceDir, toBeFound);
         return;
       }
       testResourceDir = basics::FileUtils::buildFilename(testResourceDir, "..");
-      if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
+      if (!std::filesystem::is_directory(testResourceDir)) {
         testResourceDir = IResearch_test_resource_dir;
         break;
       }

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -470,33 +470,41 @@ std::string const AnalyzerCollectionName("_analyzers");
 std::string testResourceDir;
 
 static void findIResearchTestResources() {
-  std::string toBeFound =
-      basics::FileUtils::buildFilename("iresearch", "tests", "resources");
-
   // peek into environment variable first
   char const* dir = getenv("IRESEARCH_TEST_RESOURCE_DIR");
   if (dir != nullptr) {
     // environment variable set, so use it
     testResourceDir = std::string(dir);
+    return;
+  }
+
+  std::filesystem::path const toBeFound =
+      std::filesystem::path("iresearch") / "tests" / "resources";
+
+  std::error_code ec;
+  std::filesystem::path probe = std::filesystem::current_path(ec);
+  if (ec) {
+    testResourceDir = IResearch_test_resource_dir;
   } else {
-    // environment variable not set, so try to auto-detect the location
-    testResourceDir = ".";
-    do {
-      std::error_code dirEc;
-      if (std::filesystem::is_directory(
-              basics::FileUtils::buildFilename(testResourceDir, toBeFound),
-              dirEc)) {
-        testResourceDir =
-            basics::FileUtils::buildFilename(testResourceDir, toBeFound);
+    constexpr int kMaxWalk = 128;
+    for (int i = 0; i < kMaxWalk; ++i) {
+      std::filesystem::path const candidate = probe / toBeFound;
+      if (std::filesystem::is_directory(candidate)) {
+        testResourceDir = std::filesystem::weakly_canonical(candidate).string();
         return;
       }
-      testResourceDir = basics::FileUtils::buildFilename(testResourceDir, "..");
-      if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
-        testResourceDir = IResearch_test_resource_dir;
+      if (!probe.has_parent_path()) {
         break;
       }
-    } while (true);
+      std::filesystem::path const parent = probe.parent_path();
+      if (parent == probe) {
+        break;
+      }
+      probe = parent;
+    }
+    testResourceDir = IResearch_test_resource_dir;
   }
+
   std::error_code dirEc;
   if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
     LOG_TOPIC("45f9d", ERR, Logger::FIXME)

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -482,25 +482,41 @@ static void findIResearchTestResources() {
     // environment variable not set, so try to auto-detect the location
     testResourceDir = ".";
     do {
+      std::error_code dirEc;
       if (std::filesystem::is_directory(
-              basics::FileUtils::buildFilename(testResourceDir, toBeFound))) {
+              basics::FileUtils::buildFilename(testResourceDir, toBeFound),
+              dirEc)) {
         testResourceDir =
             basics::FileUtils::buildFilename(testResourceDir, toBeFound);
         return;
+      } else if (dirEc) {
+        LOG_TOPIC("45f9a", ERR, Logger::FIXME)
+            << "testResourceDir is not a directory"
+               "Error:"
+            << dirEc.message();
       }
       testResourceDir = basics::FileUtils::buildFilename(testResourceDir, "..");
-      if (!std::filesystem::is_directory(testResourceDir)) {
+      if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
         testResourceDir = IResearch_test_resource_dir;
+        LOG_TOPIC("45f9b", ERR, Logger::FIXME)
+            << "testResourceDir is not a directory"
+               "Error:"
+            << dirEc.message();
         break;
       }
     } while (true);
   }
-
   std::error_code dirEc;
   if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
-    LOG_TOPIC("45f9d", ERR, Logger::FIXME)
-        << "unable to find directory for IResearch test resources. use "
-           "environment variable IRESEARCH_TEST_RESOURCE_DIR to set it";
+    if (dirEc) {
+      LOG_TOPIC("45f9d", ERR, Logger::FIXME)
+          << "Error checking directory: " << dirEc.message() << " (code "
+          << dirEc.value() << ")";
+    } else {
+      LOG_TOPIC("45f9d", ERR, Logger::FIXME)
+          << "Path exists but is not a directory. "
+          << "Use environment variable IRESEARCH_TEST_RESOURCE_DIR to set it.";
+    }
   }
 }
 

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -482,41 +482,23 @@ static void findIResearchTestResources() {
     // environment variable not set, so try to auto-detect the location
     testResourceDir = ".";
     do {
-      std::error_code dirEc;
       if (std::filesystem::is_directory(
-              basics::FileUtils::buildFilename(testResourceDir, toBeFound),
-              dirEc)) {
+              basics::FileUtils::buildFilename(testResourceDir, toBeFound))) {
         testResourceDir =
             basics::FileUtils::buildFilename(testResourceDir, toBeFound);
         return;
-      } else if (dirEc) {
-        LOG_TOPIC("45f9a", ERR, Logger::FIXME)
-            << "testResourceDir is not a directory"
-               "Error:"
-            << dirEc.message();
       }
       testResourceDir = basics::FileUtils::buildFilename(testResourceDir, "..");
-      if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
+      if (!std::filesystem::is_directory(testResourceDir)) {
         testResourceDir = IResearch_test_resource_dir;
-        LOG_TOPIC("45f9b", ERR, Logger::FIXME)
-            << "testResourceDir is not a directory"
-               "Error:"
-            << dirEc.message();
         break;
       }
     } while (true);
   }
-  std::error_code dirEc;
-  if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
-    if (dirEc) {
-      LOG_TOPIC("45f9d", ERR, Logger::FIXME)
-          << "Error checking directory: " << dirEc.message() << " (code "
-          << dirEc.value() << ")";
-    } else {
-      LOG_TOPIC("45f9d", ERR, Logger::FIXME)
-          << "Path exists but is not a directory. "
-          << "Use environment variable IRESEARCH_TEST_RESOURCE_DIR to set it.";
-    }
+  if (!std::filesystem::is_directory(testResourceDir)) {
+    LOG_TOPIC("45f9d", ERR, Logger::FIXME)
+        << "unable to find directory for IResearch test resources. use "
+           "environment variable IRESEARCH_TEST_RESOURCE_DIR to set it";
   }
 }
 

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -482,23 +482,27 @@ static void findIResearchTestResources() {
     // environment variable not set, so try to auto-detect the location
     testResourceDir = ".";
     do {
+      std::error_code dirEc;
       if (std::filesystem::is_directory(
-              basics::FileUtils::buildFilename(testResourceDir, toBeFound))) {
+              basics::FileUtils::buildFilename(testResourceDir, toBeFound),
+              dirEc)) {
         testResourceDir =
             basics::FileUtils::buildFilename(testResourceDir, toBeFound);
         return;
       }
       testResourceDir = basics::FileUtils::buildFilename(testResourceDir, "..");
-      if (!std::filesystem::is_directory(testResourceDir)) {
+      if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
         testResourceDir = IResearch_test_resource_dir;
         break;
       }
     } while (true);
   }
-  if (!std::filesystem::is_directory(testResourceDir)) {
+  std::error_code dirEc;
+  if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
     LOG_TOPIC("45f9d", ERR, Logger::FIXME)
         << "unable to find directory for IResearch test resources. use "
-           "environment variable IRESEARCH_TEST_RESOURCE_DIR to set it";
+           "environment variable IRESEARCH_TEST_RESOURCE_DIR to set it"
+        << dirEc.message();
   }
 }
 

--- a/tests/IResearch/common.cpp
+++ b/tests/IResearch/common.cpp
@@ -482,21 +482,24 @@ static void findIResearchTestResources() {
     // environment variable not set, so try to auto-detect the location
     testResourceDir = ".";
     do {
-      if (basics::FileUtils::isDirectory(
-              basics::FileUtils::buildFilename(testResourceDir, toBeFound))) {
+      std::error_code dirEc;
+      if (std::filesystem::is_directory(
+              basics::FileUtils::buildFilename(testResourceDir, toBeFound),
+              dirEc)) {
         testResourceDir =
             basics::FileUtils::buildFilename(testResourceDir, toBeFound);
         return;
       }
       testResourceDir = basics::FileUtils::buildFilename(testResourceDir, "..");
-      if (!basics::FileUtils::isDirectory(testResourceDir)) {
+      if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
         testResourceDir = IResearch_test_resource_dir;
         break;
       }
     } while (true);
   }
 
-  if (!basics::FileUtils::isDirectory(testResourceDir)) {
+  std::error_code dirEc;
+  if (!std::filesystem::is_directory(testResourceDir, dirEc)) {
     LOG_TOPIC("45f9d", ERR, Logger::FIXME)
         << "unable to find directory for IResearch test resources. use "
            "environment variable IRESEARCH_TEST_RESOURCE_DIR to set it";


### PR DESCRIPTION
Replaced legacy FileUtils functions with std::filesystem equivalents. In this task we have updated below functions.

remove()
isDirectory()
exists()


Please consider Enterprise PR also: https://github.com/arangodb/enterprise/pull/1642
