### PR TITLE
[COR-436] Add additional logging for flaky `testFetchLargeNumberOfDocsWithMaxNProbe`

### DIFF
--- a/arangod/Aql/Executor/EnumerateNearVectorExecutor.cpp
+++ b/arangod/Aql/Executor/EnumerateNearVectorExecutor.cpp
@@ -27,6 +27,8 @@
 #include "Aql/ExecutionState.h"
 #include "Assertions/Assert.h"
 #include "Basics/Exceptions.h"
+#include "Logger/LogMacros.h"
+#include "Logger/Logger.h"
 #include "RocksDBEngine/RocksDBVectorIndex.h"
 #include "Aql/ExecutionBlockImpl.tpp"
 
@@ -109,6 +111,15 @@ void EnumerateNearVectorsExecutor::searchResults() {
       _infos.isCoveredByStoredValues);
   _currentProcessedResultCount = 0;
   TRI_ASSERT(hasResults());
+
+  auto validCount = std::count_if(_labels.begin(), _labels.end(),
+                                  [](auto const& l) { return l != -1; });
+  LOG_TOPIC("f1a2b", WARN, Logger::ENGINES) << std::format(
+      "EnumerateNearVectors::searchResults: requested={}, returned={}, "
+      "validLabels={}, collectionCount={}",
+      _infos.getNumberOfResults(), _labels.size(), validCount,
+      _collectionCount);
+
   LOG_INTERNAL << "Results: " << _labels << " and distances: " << _distances;
 }
 
@@ -217,14 +228,13 @@ EnumerateNearVectorsExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
     skipped += remainingRows * _collectionCount;
     call.didSkip(skipped);
 
-    LOG_INTERNAL << ADB_HERE
-                 << std::format(
-                        ": skipped={}, remainingRows={}, currentProcessed={}, "
-                        "nr={}, state={}, "
-                        "hasResults={}, call={}, colCount={}",
-                        skipped, remainingRows, _currentProcessedResultCount,
-                        _infos.getNumberOfResults(), state(), hasResults(),
-                        to_string(call), _collectionCount);
+    LOG_TOPIC("f1a2c", DEBUG, Logger::ENGINES) << std::format(
+        "EnumerateNearVectors::skipRowsRange(fullCount): skipped={}, "
+        "remainingRows={}, currentProcessed={}, nr={}, state={}, "
+        "hasResults={}, call={}, colCount={}",
+        skipped, remainingRows, _currentProcessedResultCount,
+        _infos.getNumberOfResults(), state(), hasResults(), to_string(call),
+        _collectionCount);
 
     auto upstreamCall = AqlCall{};
 

--- a/tests/js/client/aql/vector/aql-vector-full-count.js
+++ b/tests/js/client/aql/vector/aql-vector-full-count.js
@@ -476,7 +476,7 @@ function VectorIndexLargeLimitTestSuite() {
                 assertEqual(limit, uniqueResults.size,
                     "All " + limit + " returned documents should be unique");
 
-                assertEqual(queryResults.count(), limit);
+                assertEqual(queryResults.count(), limit, `The count assertion failed on query: ${JSON.stringify(query)}`);
 
                 const stats = queryResults.getExtra().stats;
                 assertEqual(stats.fullCount, largeLimitNumberOfDocs, `The fullCount failed on query: ${JSON.stringify(query)}`);

--- a/tests/js/client/aql/vector/aql-vector-full-count.js
+++ b/tests/js/client/aql/vector/aql-vector-full-count.js
@@ -460,6 +460,10 @@ function VectorIndexLargeLimitTestSuite() {
         testFetchLargeNumberOfDocsWithMaxNProbe: function() {
             const limits = [1500, 3000, 4000, largeLimitNumberOfDocs];
 
+            const actualCollectionCount = collection.count();
+            assertEqual(actualCollectionCount, largeLimitNumberOfDocs,
+                `Collection count mismatch: actual=${actualCollectionCount} vs expected=${largeLimitNumberOfDocs}`);
+
             for (const limit of limits) {
                 const query = aql`
                   FOR d IN ${collection}
@@ -469,17 +473,26 @@ function VectorIndexLargeLimitTestSuite() {
 
                 const queryResults = db._query(query, {count: true}, {fullCount: true});
                 const results = queryResults.toArray();
-                assertEqual(limit, results.length,
-                    "Expected " + limit + " results");
 
                 const uniqueResults = new Set(results);
-                assertEqual(limit, uniqueResults.size,
-                    "All " + limit + " returned documents should be unique");
-
-                assertEqual(queryResults.count(), limit, `The count assertion failed on query: ${JSON.stringify(query)}`);
-
                 const stats = queryResults.getExtra().stats;
-                assertEqual(stats.fullCount, largeLimitNumberOfDocs, `The fullCount failed on query: ${JSON.stringify(query)}`);
+
+                const diag = `limit=${limit}, results.length=${results.length}, ` +
+                    `unique=${uniqueResults.size}, count=${queryResults.count()}, ` +
+                    `fullCount=${stats.fullCount}, expectedFullCount=${largeLimitNumberOfDocs}, ` +
+                    `collectionCount=${actualCollectionCount}, nLists=${nLists}`;
+
+                assertEqual(limit, results.length,
+                    `Expected ${limit} results. ${diag}`);
+
+                assertEqual(limit, uniqueResults.size,
+                    `All ${limit} returned documents should be unique. ${diag}`);
+
+                assertEqual(queryResults.count(), limit,
+                    `Count mismatch. ${diag}`);
+
+                assertEqual(stats.fullCount, largeLimitNumberOfDocs,
+                    `FullCount mismatch. ${diag}`);
             }
         },
     };

--- a/tests/js/client/aql/vector/aql-vector-full-count.js
+++ b/tests/js/client/aql/vector/aql-vector-full-count.js
@@ -405,7 +405,7 @@ function VectorIndexLargeLimitTestSuite() {
     let collection;
     let randomPoint;
     const largeLimitDimension = 128;
-    const largeLimitNumberOfDocs = 4500;
+    const largeLimitNumberOfDocs = 5000;
     const nLists = 32;
     const seed = generateSeed();
 
@@ -458,7 +458,7 @@ function VectorIndexLargeLimitTestSuite() {
         },
 
         testFetchLargeNumberOfDocsWithMaxNProbe: function() {
-            const limits = [1500, 3000, 4000];
+            const limits = [1500, 3000, 4000, largeLimitNumberOfDocs];
 
             for (const limit of limits) {
                 const query = aql`
@@ -479,7 +479,7 @@ function VectorIndexLargeLimitTestSuite() {
                 assertEqual(queryResults.count(), limit);
 
                 const stats = queryResults.getExtra().stats;
-                assertEqual(stats.fullCount, largeLimitNumberOfDocs);
+                assertEqual(stats.fullCount, largeLimitNumberOfDocs, `The fullCount failed on query: ${JSON.stringify(query)}`);
             }
         },
     };


### PR DESCRIPTION
### Scope & Purpose

Add additional logging

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-436
- [ ] Design document: 
