### PR TITLE
Fix for the flakiness of testIndexProgressIsReported

### DIFF
--- a/tests/js/client/shell/large/shell-index-visibility-nocov-fp.js
+++ b/tests/js/client/shell/large/shell-index-visibility-nocov-fp.js
@@ -35,6 +35,10 @@ let IM = global.instanceManager;
 
 const filter = isCluster ? instanceRole.dbServer: instanceRole.single;
 
+function logMessage(msg) {
+  internal.print(`${new Date().toISOString()} ${msg}`);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite: basics
 ////////////////////////////////////////////////////////////////////////////////
@@ -98,6 +102,7 @@ function IndexSuite() {
       count = 0;
       let progress_flow = [];
       while (true) {
+        logMessage(`testIndexProgressIsReported: progress_flow: ${progress_flow}`);
         idxs = arango.GET(`/_api/index?collection=${cn}&withHidden=true`);
         assertTrue(idxs.hasOwnProperty("indexes"), idxs);
         idxs = idxs.indexes;
@@ -120,7 +125,7 @@ function IndexSuite() {
           break;
         }
           
-        sleep(0.1);
+        sleep(0.15);
         if (++count > 4000) {
           // Value intentionally high for ASAN runs, this is 100x slower
           // than observed on an old machine with debug build!


### PR DESCRIPTION
### Scope & Purpose

The test `testIndexProgressIsReported` creates a persistent index over a collection with a large no. of documents and asserts that the index creation progress is continuously reported. To ensure that the index creation has indeed progressed the test has a `sleep(0.1)` after each iteration of inspecting the reported progress. However, in rare cases the sleep duration proves to be too little for the index creation progress to be updated.
When the test sees that the current progress percentage is the same as the one last reported, it declares that no progress was reported.
I simply increased the intermediate sleep duration to fix the issue and added a log entry to see the progress flow if the test fails again.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-434
- [ ] Design document: 
