### PR TITLE
COR-432: Fix flaky MaintenanceFeatureTest

### DIFF
--- a/tests/Maintenance/MaintenanceFeatureMock.h
+++ b/tests/Maintenance/MaintenanceFeatureMock.h
@@ -104,6 +104,13 @@ class TestMaintenanceFeature : public arangodb::MaintenanceFeature {
 
   virtual ~TestMaintenanceFeature() = default;
 
+  void collectOptions(
+      std::shared_ptr<arangodb::options::ProgramOptions> options) override {
+    arangodb::MaintenanceFeature::collectOptions(options);
+    _options.maintenanceThreadsMax = 0;
+    _options.maintenanceThreadsSlowMax = 0;
+  }
+
   void validateOptions(
       std::shared_ptr<arangodb::options::ProgramOptions> options) override {}
 


### PR DESCRIPTION
### Scope & Purpose

The failure was in `TEST_F(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate)`. The test launches ArangodServer on a thread with the `TestMaintenanceFeature` enabled. `TestMaintenanceFeature` sets the max worker threads to 0 in its constructor, so the expectation is that no worker threads will be running until we explicitly call `TestMaintenanceFeature::setMaintenanceThreadsMax`. Meanwhile the test adds actions (in READY state) and expects them to remain in READY state since there are no workers running yet that would pick these actions items for execution and transition them into different states. However, every once in a while it found these actions in EXECUTING state before it created the workers.

The reason was that even if TestMaintenanceFeature set the max worker threads to 0 in its constructor, the base class implementation of `collectOptions()` would set the thread count to a non-zero value and override the values set by the constructor. The call hierarchy is `ArangodServer::run() -> ApplicationServer::run() -> ApplicationServer::collectOptions() -> TestMaintenanceFeature::collectOptions -> MaintenanceFeature::collectOptions() -> set max threads to non-zero value`. This would launch the worker threads as soon as the ArangodServer starts running and the threads would sometimes pick the action items already added by the test and start executing them. Most of the times the test would get to execute the assertion on line 571 before the workers started executing the action items. But once in a while the worker threads would start executing earlier. That is why the test was flaky.

- [X] :hankey: Bug fix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [X] Tests
  - [ ] **Regression tests**
  - [X] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-432
- [ ] Design document: 
