### PR TITLE
[COR-443] Add api version to internal requests

### DIFF
--- a/3rdParty/fuerte/include/fuerte/ApiVersion.h
+++ b/3rdParty/fuerte/include/fuerte/ApiVersion.h
@@ -23,6 +23,8 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
+#include <string_view>
 
 namespace arangodb { namespace fuerte { namespace api_version {
 inline namespace v1 {
@@ -32,5 +34,16 @@ inline namespace v1 {
 /// lib/Rest/ApiVersion.h re-exports this enum.
 
 enum class ApiVersion { V0 = 0, V1, Experimental };
+
+constexpr auto from(std::string_view s) -> std::optional<ApiVersion> {
+  if (s == "v0") {
+    return ApiVersion::V0;
+  } else if (s == "v1") {
+    return ApiVersion::V1;
+  } else if (s == "experimental") {
+    return ApiVersion::Experimental;
+  }
+  return std::nullopt;
+}
 
 }}}}  // namespace arangodb::fuerte::api_version::v1

--- a/3rdParty/fuerte/include/fuerte/ApiVersion.h
+++ b/3rdParty/fuerte/include/fuerte/ApiVersion.h
@@ -24,13 +24,13 @@
 
 #include <cstdint>
 
-namespace arangodb {
-namespace fuerte {
+namespace arangodb { namespace fuerte { namespace api_version {
 inline namespace v1 {
 
 /// @brief API version constants shared between fuerte and the ArangoDB server.
 /// Defined here (in fuerte) so that fuerte does not need to include server
 /// headers.  lib/Rest/ApiVersion.h re-exports these values.
+
 struct ApiVersion {
   /// Version used when no /_arango/vX prefix is present
   static constexpr uint32_t defaultApiVersion = 0;
@@ -39,6 +39,4 @@ struct ApiVersion {
   static constexpr uint32_t experimentalApiVersion = 2;
 };
 
-}  // namespace v1
-}  // namespace fuerte
-}  // namespace arangodb
+}}}}  // namespace arangodb::fuerte::api_version::v1

--- a/3rdParty/fuerte/include/fuerte/ApiVersion.h
+++ b/3rdParty/fuerte/include/fuerte/ApiVersion.h
@@ -27,16 +27,10 @@
 namespace arangodb { namespace fuerte { namespace api_version {
 inline namespace v1 {
 
-/// @brief API version constants shared between fuerte and the ArangoDB server.
-/// Defined here (in fuerte) so that fuerte does not need to include server
-/// headers.  lib/Rest/ApiVersion.h re-exports these values.
+/// ApiVersion is also used by ArangoDB server but is defined here (in fuerte)
+/// so that fuerte does not need to include server headers.
+/// lib/Rest/ApiVersion.h re-exports this enum.
 
-struct ApiVersion {
-  /// Version used when no /_arango/vX prefix is present
-  static constexpr uint32_t defaultApiVersion = 0;
-
-  /// Version accessed via /_arango/experimental
-  static constexpr uint32_t experimentalApiVersion = 2;
-};
+enum class ApiVersion { V0 = 0, V1, Experimental };
 
 }}}}  // namespace arangodb::fuerte::api_version::v1

--- a/3rdParty/fuerte/include/fuerte/ApiVersion.h
+++ b/3rdParty/fuerte/include/fuerte/ApiVersion.h
@@ -24,6 +24,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <string>
 #include <string_view>
 
 namespace arangodb { namespace fuerte { namespace api_version {
@@ -44,6 +45,17 @@ constexpr auto from(std::string_view s) -> std::optional<ApiVersion> {
     return ApiVersion::Experimental;
   }
   return std::nullopt;
+}
+
+constexpr auto to_string(ApiVersion v) -> std::string {
+  switch (v) {
+    case ApiVersion::V0:
+      return "v0";
+    case ApiVersion::V1:
+      return "v1";
+    case ApiVersion::Experimental:
+      return "experimental";
+  }
 }
 
 }}}}  // namespace arangodb::fuerte::api_version::v1

--- a/3rdParty/fuerte/include/fuerte/message.h
+++ b/3rdParty/fuerte/include/fuerte/message.h
@@ -25,7 +25,6 @@
 #ifndef ARANGO_CXX_DRIVER_MESSAGE
 #define ARANGO_CXX_DRIVER_MESSAGE
 
-#include <fuerte/ApiVersion.h>
 #include <fuerte/asio_ns.h>
 #include <fuerte/types.h>
 #include <velocypack/Buffer.h>
@@ -37,9 +36,7 @@
 #include <string_view>
 #include <vector>
 
-namespace arangodb {
-namespace fuerte {
-inline namespace v1 {
+namespace arangodb { namespace fuerte { inline namespace v1 {
 const std::string fu_accept_key("accept");
 const std::string fu_authorization_key("authorization");
 const std::string fu_content_length_key("content-length");
@@ -49,7 +46,7 @@ const std::string fu_keep_alive_key("keep-alive");
 
 struct MessageHeader {
   // Header metadata helpers#
-  template<typename K, typename V>
+  template <typename K, typename V>
   void addMeta(K&& key, V&& value) {
     if (fu_accept_key == key) {
       _acceptType = to_ContentType(value);
@@ -92,7 +89,7 @@ struct MessageHeader {
   }
 
  protected:
-  StringMap _meta;     /// Header meta data (equivalent to HTTP headers)
+  StringMap _meta;  /// Header meta data (equivalent to HTTP headers)
   ContentType _contentType = ContentType::Unset;
   ContentType _acceptType = ContentType::VPack;
   ContentEncoding _contentEncoding = ContentEncoding::Identity;
@@ -329,7 +326,5 @@ class Response : public Message {
   velocypack::Buffer<uint8_t> _payload;
   std::size_t _payloadOffset;
 };
-}  // namespace v1
-}  // namespace fuerte
-}  // namespace arangodb
+}}}  // namespace arangodb::fuerte::v1
 #endif

--- a/3rdParty/fuerte/include/fuerte/message.h
+++ b/3rdParty/fuerte/include/fuerte/message.h
@@ -22,10 +22,10 @@
 /// @author Simon Grätzer
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
-#include "fuerte/ApiVersion.h"
 #ifndef ARANGO_CXX_DRIVER_MESSAGE
 #define ARANGO_CXX_DRIVER_MESSAGE
 
+#include <fuerte/ApiVersion.h>
 #include <fuerte/asio_ns.h>
 #include <fuerte/types.h>
 #include <velocypack/Buffer.h>
@@ -37,7 +37,7 @@
 #include <string_view>
 #include <vector>
 
-namespace arangodb { namespace fuerte { inline namespace v1 {
+namespace arangodb::fuerte { inline namespace v1 {
 const std::string fu_accept_key("accept");
 const std::string fu_authorization_key("authorization");
 const std::string fu_content_length_key("content-length");
@@ -327,5 +327,5 @@ class Response : public Message {
   velocypack::Buffer<uint8_t> _payload;
   std::size_t _payloadOffset;
 };
-}}}  // namespace arangodb::fuerte::v1
+}}  // namespace arangodb::fuerte::v1
 #endif

--- a/3rdParty/fuerte/include/fuerte/message.h
+++ b/3rdParty/fuerte/include/fuerte/message.h
@@ -22,6 +22,7 @@
 /// @author Simon Grätzer
 ////////////////////////////////////////////////////////////////////////////////
 #pragma once
+#include "fuerte/ApiVersion.h"
 #ifndef ARANGO_CXX_DRIVER_MESSAGE
 #define ARANGO_CXX_DRIVER_MESSAGE
 
@@ -110,7 +111,7 @@ struct RequestHeader final : public MessageHeader {
 
   /// @brief API version, if specified via /_arango/vX or /_arango/experimental.
   /// std::nullopt means no prefix was present; appendPath will not add one.
-  std::optional<std::string> apiVersion = std::nullopt;
+  std::optional<api_version::ApiVersion> apiVersion = std::nullopt;
 
   // accept header accessors
   ContentType acceptType() const { return _acceptType; }

--- a/3rdParty/fuerte/src/http.cpp
+++ b/3rdParty/fuerte/src/http.cpp
@@ -134,7 +134,7 @@ void appendPath(Request const& req, std::string& target) {
   // Prepend /_arango/vX or /_arango/experimental if an API version was set
   if (req.header.apiVersion.has_value()) {
     target.append("/_arango/");
-    target.append(req.header.apiVersion.value());
+    target.append(to_string(req.header.apiVersion.value()));
   }
 
   // construct request path ("/_db/<name>/" prefix)

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -24,9 +24,11 @@
 #include <fuerte/message.h>
 #include <velocypack/Validator.h>
 
+#include <ranges>
 #include <sstream>
 
 #include "debugging.h"
+#include "fuerte/ApiVersion.h"
 
 namespace {
 static std::string const emptyString;
@@ -44,9 +46,7 @@ inline int hex2int(char ch, int errorCode) {
 }
 }  // namespace
 
-namespace arangodb {
-namespace fuerte {
-inline namespace v1 {
+namespace arangodb { namespace fuerte { inline namespace v1 {
 
 ///////////////////////////////////////////////
 // class MessageHeader
@@ -87,6 +87,42 @@ void RequestHeader::acceptType(std::string const& type) {
   addMeta(fu_accept_key, type);
 }
 
+namespace {
+// returns version and rest of path
+auto splitPathByVersion(std::string_view path)
+    -> std::optional<std::pair<std::string_view, std::string_view>> {
+  auto split = path | std::views::split('/');
+  auto it = split.begin();
+
+  // first suffix is empty because the path starts with '/'
+  if (it == split.end() || not(*it).empty()) {
+    return std::nullopt;
+  }
+  ++it;
+
+  // second ("_arango")
+  if (it == split.end() &&
+      std::string_view{(*it).begin(), (*it).end()} != "_arango") {
+    return std::nullopt;
+  }
+  ++it;
+
+  // third (version)
+  if (it == split.end()) {
+    return std::nullopt;
+  }
+  auto version = std::string_view{(*it).begin(), (*it).end()};
+  ++it;
+
+  // rest
+  if (it == split.end()) {
+    return {{version, "/"}};
+  }
+  size_t offset = std::distance(path.begin(), (*it).begin());
+  return {{version, path.substr(offset)}};
+}
+}  // namespace
+
 /// @brief analyze path and split into components
 /// strips /_arango/vX (or /_arango/experimental) prefix, then /_db/<name>
 /// prefix; sets apiVersion, database, path, and fills parameters
@@ -97,31 +133,24 @@ void RequestHeader::parseArangoPath(std::string_view p) {
   // Detect and strip /_arango/vX or /_arango/experimental prefix.
   // This must come before /_db/<name>.
   {
-    constexpr std::string_view arangoPrefix = "/_arango/";
-    constexpr std::string_view experimentalSuffix = "experimental";
-    if (this->path.size() >= arangoPrefix.size() &&
-        std::string_view(this->path).substr(0, arangoPrefix.size()) ==
-            arangoPrefix) {
-      std::string_view remainder =
-          std::string_view(this->path).substr(arangoPrefix.size());
-      bool recognized = false;
-      if (remainder.starts_with(experimentalSuffix)) {
-        size_t suffixEnd = experimentalSuffix.size();
-        if (suffixEnd == remainder.size() || remainder[suffixEnd] == '/') {
-          this->apiVersion = experimentalSuffix;
-          this->path = suffixEnd < remainder.size()
-                           ? std::string(remainder.substr(suffixEnd))
-                           : "/";
-          recognized = true;
-        }
-      } else if (!remainder.empty() && remainder[0] == 'v') {
-        std::string_view afterV = remainder.substr(1);
+    auto maybe_splitPath = splitPathByVersion(this->path);
+    if (maybe_splitPath != std::nullopt) {
+      auto& [version_string, rest] = *maybe_splitPath;
+      if (auto maybe_v = fuerte::api_version::from(version_string);
+          maybe_v != std::nullopt) {
+        this->apiVersion =
+            version_string;  // TODO will be an ApiVersion: *maybe_v
+        this->path = rest;
+      } else if (version_string.starts_with('v')) {
+        //  check for additional zeros after v
+
+        std::string_view afterV = version_string.substr(1);
         size_t numEnd = 0;
         while (numEnd < afterV.size() &&
                (afterV[numEnd] >= '0' && afterV[numEnd] <= '9')) {
           ++numEnd;
         }
-        if (numEnd > 0 && (numEnd == afterV.size() || afterV[numEnd] == '/')) {
+        if (numEnd > 0 && numEnd == afterV.size()) {
           // parse version number (reject leading zeros except bare "0")
           if (!(afterV[0] == '0' && numEnd > 1)) {
             uint32_t version = 0;
@@ -136,15 +165,11 @@ void RequestHeader::parseArangoPath(std::string_view p) {
             }
             if (!overflow) {
               this->apiVersion = "v" + std::to_string(version);
-              this->path = numEnd < afterV.size()
-                               ? std::string(afterV.substr(numEnd))
-                               : "/";
-              recognized = true;
+              this->path = rest;
             }
           }
         }
-      }
-      if (!recognized) {
+      } else {
         // /_arango/ present but not a valid prefix — leave path unchanged,
         // apiVersion stays nullopt
       }
@@ -353,6 +378,4 @@ std::shared_ptr<velocypack::Buffer<uint8_t>> Response::stealPayload() {
   _payloadOffset = 0;
   return buffer;
 }
-}  // namespace v1
-}  // namespace fuerte
-}  // namespace arangodb
+}}}  // namespace arangodb::fuerte::v1

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -88,9 +88,13 @@ void RequestHeader::acceptType(std::string const& type) {
 }
 
 namespace {
-// returns version and rest of path
-auto splitPathByVersion(std::string_view path)
-    -> std::optional<std::pair<std::string_view, std::string_view>> {
+using VersionString = std::string_view;
+using PathRest = std::string_view;
+
+/// split paths /_arango/version/some/other/rest
+/// into version and some/other/rest
+auto extractVersionFromPath(std::string_view path)
+    -> std::optional<std::pair<VersionString, PathRest>> {
   auto split = path | std::views::split('/');
   auto it = split.begin();
 
@@ -133,18 +137,17 @@ void RequestHeader::parseArangoPath(std::string_view p) {
   // Detect and strip /_arango/vX or /_arango/experimental prefix.
   // This must come before /_db/<name>.
   {
-    auto maybe_splitPath = splitPathByVersion(this->path);
+    auto maybe_splitPath = extractVersionFromPath(this->path);
     if (maybe_splitPath != std::nullopt) {
-      auto& [version_string, rest] = *maybe_splitPath;
-      if (auto maybe_v = fuerte::api_version::from(version_string);
+      auto& [versionString, pathRest] = *maybe_splitPath;
+      if (auto maybe_v = fuerte::api_version::from(versionString);
           maybe_v != std::nullopt) {
-        this->apiVersion =
-            version_string;  // TODO will be an ApiVersion: *maybe_v
-        this->path = rest;
-      } else if (version_string.starts_with('v')) {
+        this->apiVersion = *maybe_v;
+        this->path = pathRest;
+      } else if (versionString.starts_with('v')) {
         //  check for additional zeros after v
 
-        std::string_view afterV = version_string.substr(1);
+        std::string_view afterV = versionString.substr(1);
         size_t numEnd = 0;
         while (numEnd < afterV.size() &&
                (afterV[numEnd] >= '0' && afterV[numEnd] <= '9')) {
@@ -164,8 +167,12 @@ void RequestHeader::parseArangoPath(std::string_view p) {
               version = version * 10 + d;
             }
             if (!overflow) {
-              this->apiVersion = "v" + std::to_string(version);
-              this->path = rest;
+              if (auto maybe_v =
+                      fuerte::api_version::from(std::to_string(version));
+                  maybe_v != std::nullopt) {
+                this->apiVersion = *maybe_v;
+                this->path = pathRest;
+              }
             }
           }
         }

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -95,35 +95,22 @@ using PathRest = std::string_view;
 /// into version and some/other/rest
 auto extractVersionFromPath(std::string_view path)
     -> std::optional<std::pair<VersionString, PathRest>> {
-  auto split = path | std::views::split('/');
-  auto it = split.begin();
-
-  // first suffix is empty because the path starts with '/'
-  if (it == split.end() || not(*it).empty()) {
+  constexpr std::string_view kPrefix = "/_arango/";
+  if (!path.starts_with(kPrefix)) {
     return std::nullopt;
   }
-  ++it;
-
-  // second ("_arango")
-  if (it == split.end() ||
-      std::string_view{(*it).begin(), (*it).end()} != "_arango") {
+  auto const tail = path.substr(kPrefix.size());
+  auto const slash = tail.find('/');
+  if (slash == std::string_view::npos) {
+    if (tail.empty()) {
+      return std::nullopt;
+    }
+    return {{tail, PathRest{"/"}}};
+  }
+  if (slash == 0) {
     return std::nullopt;
   }
-  ++it;
-
-  // third (version)
-  if (it == split.end()) {
-    return std::nullopt;
-  }
-  auto version = std::string_view{(*it).begin(), (*it).end()};
-  ++it;
-
-  // rest
-  if (it == split.end()) {
-    return {{version, "/"}};
-  }
-  size_t offset = std::distance(path.begin(), (*it).begin());
-  return {{version, path.substr(offset)}};
+  return {{tail.substr(0, slash), tail.substr(slash)}};
 }
 }  // namespace
 
@@ -144,43 +131,9 @@ void RequestHeader::parseArangoPath(std::string_view p) {
           maybe_v != std::nullopt) {
         this->apiVersion = *maybe_v;
         this->path = pathRest;
-      } else if (versionString.starts_with('v')) {
-        //  check for additional zeros after v
-
-        std::string_view afterV = versionString.substr(1);
-        size_t numEnd = 0;
-        while (numEnd < afterV.size() &&
-               (afterV[numEnd] >= '0' && afterV[numEnd] <= '9')) {
-          ++numEnd;
-        }
-        if (numEnd > 0 && numEnd == afterV.size()) {
-          // parse version number (reject leading zeros except bare "0")
-          if (!(afterV[0] == '0' && numEnd > 1)) {
-            uint32_t version = 0;
-            bool overflow = false;
-            for (size_t i = 0; i < numEnd; ++i) {
-              uint32_t d = afterV[i] - '0';
-              if (version > (UINT32_MAX - d) / 10) {
-                overflow = true;
-                break;
-              }
-              version = version * 10 + d;
-            }
-            if (!overflow) {
-              if (auto maybe_v =
-                      fuerte::api_version::from(std::to_string(version));
-                  maybe_v != std::nullopt) {
-                this->apiVersion = *maybe_v;
-                this->path = pathRest;
-              }
-            }
-          }
-        }
-      } else {
-        // /_arango/ present but not a valid prefix — leave path unchanged,
-        // apiVersion stays nullopt
       }
     }
+    // in any other case: leave path unchanged, apiVersion stays nullopt
   }
 
   // extract database prefix /_db/<name>/

--- a/3rdParty/fuerte/src/message.cpp
+++ b/3rdParty/fuerte/src/message.cpp
@@ -20,6 +20,7 @@
 /// @author Jan Christoph Uhde
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <fuerte/ApiVersion.h>
 #include <fuerte/helper.h>
 #include <fuerte/message.h>
 #include <velocypack/Validator.h>
@@ -28,7 +29,6 @@
 #include <sstream>
 
 #include "debugging.h"
-#include "fuerte/ApiVersion.h"
 
 namespace {
 static std::string const emptyString;
@@ -46,7 +46,7 @@ inline int hex2int(char ch, int errorCode) {
 }
 }  // namespace
 
-namespace arangodb { namespace fuerte { inline namespace v1 {
+namespace arangodb::fuerte { inline namespace v1 {
 
 ///////////////////////////////////////////////
 // class MessageHeader
@@ -105,7 +105,7 @@ auto extractVersionFromPath(std::string_view path)
   ++it;
 
   // second ("_arango")
-  if (it == split.end() &&
+  if (it == split.end() ||
       std::string_view{(*it).begin(), (*it).end()} != "_arango") {
     return std::nullopt;
   }
@@ -385,4 +385,4 @@ std::shared_ptr<velocypack::Buffer<uint8_t>> Response::stealPayload() {
   _payloadOffset = 0;
   return buffer;
 }
-}}}  // namespace arangodb::fuerte::v1
+}}  // namespace arangodb::fuerte::v1

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -419,7 +419,7 @@ void GeneralServerFeature::prepare() {
   // this initial factory only knows a few selected RestHandlers.
   // we will later create another RestHandlerFactory that knows
   // all routes.
-  auto hf = std::make_shared<RestHandlerFactory>(ApiVersion::maxApiVersion());
+  auto hf = std::make_shared<RestHandlerFactory>(api_version::maxApiVersion());
   defineInitialHandlers(*hf);
   // make handler-factory read-only
   hf->seal();
@@ -448,7 +448,7 @@ void GeneralServerFeature::start() {
   // create the full RestHandlerFactory that knows all the routes.
   // this will replace the previous, stripped-down RestHandlerFactory
   // instance.
-  auto hf = std::make_shared<RestHandlerFactory>(ApiVersion::maxApiVersion());
+  auto hf = std::make_shared<RestHandlerFactory>(api_version::maxApiVersion());
 
   defineInitialHandlers(*hf);
   defineRemainingHandlers(*hf);
@@ -858,7 +858,7 @@ void GeneralServerFeature::defineRemainingHandlers(
   f.addPrefixHandler(
       "/_admin/activities",
       RestHandlerCreator<arangodb::activities::RestHandler>::createNoData,
-      {ApiVersion::experimentalApiVersion});
+      {api_version::experimentalApiVersion});
 
   f.addPrefixHandler(
       "/_admin/cluster",

--- a/arangod/GeneralServer/GeneralServerFeature.h
+++ b/arangod/GeneralServer/GeneralServerFeature.h
@@ -47,10 +47,6 @@ class RestServerThread;
 class GeneralServerFeature final
     : public application_features::ApplicationFeature {
  public:
-  // API Version Configuration - use the centralized ApiVersion struct
-  // See Rest/ApiVersion.h for configuration details
-  using ApiVersion = arangodb::ApiVersion;
-
   static constexpr std::string_view name() noexcept { return "GeneralServer"; }
 
   explicit GeneralServerFeature(application_features::ApplicationServer& server,

--- a/arangod/GeneralServer/RestHandlerFactory.cpp
+++ b/arangod/GeneralServer/RestHandlerFactory.cpp
@@ -175,8 +175,8 @@ void RestHandlerFactory::addHandler(std::string const& path, create_fptr func,
   TRI_ASSERT(!_sealed);
 
   for (uint32_t apiVersion : apiVersions) {
-    if (!ApiVersion::isApiVersionSupported(apiVersion) &&
-        apiVersion != ApiVersion::experimentalApiVersion) {
+    if (!api_version::isApiVersionSupported(apiVersion) &&
+        apiVersion != api_version::experimentalApiVersion) {
       // version 1 has been removed from the list of supported versions, but we
       // did not change the version list in the handler factory, so we need to
       // ignore attempts to register handlers for version 1
@@ -206,8 +206,8 @@ void RestHandlerFactory::addPrefixHandler(
   addHandler(path, func, apiVersions, data);
 
   for (uint32_t apiVersion : apiVersions) {
-    if (!ApiVersion::isApiVersionSupported(apiVersion) &&
-        apiVersion != ApiVersion::experimentalApiVersion) {
+    if (!api_version::isApiVersionSupported(apiVersion) &&
+        apiVersion != api_version::experimentalApiVersion) {
       // version 1 has been removed from the list of supported versions, but we
       // did not change the version list in the handler factory, so we need to
       // ignore attempts to register handlers for version 1

--- a/arangod/Network/Methods.cpp
+++ b/arangod/Network/Methods.cpp
@@ -172,6 +172,7 @@ auto prepareRequest(ConnectionPool* pool, RestVerb type, std::string path,
 
   req->header.database = options.database;
   req->header.setMeta(std::move(headers));
+  req->header.apiVersion = options.apiVersion;
 
   if (!options.contentType.empty()) {
     req->header.contentType(options.contentType);

--- a/arangod/Network/RequestOptions.h
+++ b/arangod/Network/RequestOptions.h
@@ -25,6 +25,7 @@
 #include "Assertions/Assert.h"
 #include "GeneralServer/RequestLane.h"
 #include "Network/types.h"
+#include "fuerte/ApiVersion.h"
 
 #include <fuerte/types.h>
 
@@ -61,6 +62,8 @@ struct RequestOptions {
   // the leader, but rather to the server given here. This is read for
   // the "allowDirtyReads" options when we want to read from followers.
   std::string overrideDestination;
+
+  std::optional<fuerte::api_version::ApiVersion> apiVersion;
 
   template<typename K, typename V>
   RequestOptions& param(K&& key, V&& val) {

--- a/arangod/Network/RequestOptions.h
+++ b/arangod/Network/RequestOptions.h
@@ -25,8 +25,8 @@
 #include "Assertions/Assert.h"
 #include "GeneralServer/RequestLane.h"
 #include "Network/types.h"
-#include "fuerte/ApiVersion.h"
 
+#include <fuerte/ApiVersion.h>
 #include <fuerte/types.h>
 
 #include <string>

--- a/arangod/RestHandler/RestOpenApiHandler.cpp
+++ b/arangod/RestHandler/RestOpenApiHandler.cpp
@@ -58,7 +58,7 @@ std::string_view RestOpenApiHandler::getOpenApiSpec(uint32_t apiVersion) const {
     case 1:
       return std::string_view(reinterpret_cast<char const*>(kOpenApiV1),
                               sizeof(kOpenApiV1));
-    case ApiVersion::experimentalApiVersion:
+    case api_version::experimentalApiVersion:
       return std::string_view(reinterpret_cast<char const*>(kOpenApiV2),
                               sizeof(kOpenApiV2));
     default:

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -41,8 +41,8 @@ using namespace arangodb::rest;
 static void addApiVersions(VPackBuilder& result) {
   // Collect all supported versions and sort in descending order
   std::vector<uint32_t> versions;
-  for (size_t i = 0; i < ApiVersion::numSupportedApiVersions(); ++i) {
-    versions.push_back(ApiVersion::supportedApiVersions[i]);
+  for (size_t i = 0; i < api_version::numSupportedApiVersions(); ++i) {
+    versions.push_back(api_version::supportedApiVersions[i]);
   }
   std::sort(versions.begin(), versions.end(), std::greater<uint32_t>());
 
@@ -55,10 +55,11 @@ static void addApiVersions(VPackBuilder& result) {
 
   // Collect deprecated versions and sort in descending order
   std::vector<uint32_t> deprecatedVersions;
-  constexpr size_t numDeprecated = sizeof(ApiVersion::deprecatedApiVersions) /
-                                   sizeof(ApiVersion::deprecatedApiVersions[0]);
+  constexpr size_t numDeprecated =
+      sizeof(api_version::deprecatedApiVersions) /
+      sizeof(api_version::deprecatedApiVersions[0]);
   for (size_t i = 0; i < numDeprecated; ++i) {
-    deprecatedVersions.push_back(ApiVersion::deprecatedApiVersions[i]);
+    deprecatedVersions.push_back(api_version::deprecatedApiVersions[i]);
   }
   std::sort(deprecatedVersions.begin(), deprecatedVersions.end(),
             std::greater<uint32_t>());

--- a/arangod/SystemMonitor/Activities/RestHandler.cpp
+++ b/arangod/SystemMonitor/Activities/RestHandler.cpp
@@ -61,7 +61,7 @@ auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
   }
 
   switch (_request->requestedApiVersion()) {
-    case ApiVersion::experimentalApiVersion: {
+    case api_version::experimentalApiVersion: {
       VPackBuilder builder;
       builder.openObject();
       builder.add("activities", _feature.getData().slice());

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -1592,7 +1592,7 @@ static void JS_VersionServer(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_GET_SERVER_GLOBALS(ArangodServer);
   VPackBuilder builder;
   arangodb::RestVersionHandler::getVersion(v8g->server(), true, true, builder,
-                                           ApiVersion::defaultApiVersion);
+                                           api_version::defaultApiVersion);
 
   TRI_V8_RETURN(TRI_VPackToV8(isolate, builder.slice()));
   TRI_V8_TRY_CATCH_END

--- a/lib/Rest/ApiVersion.h
+++ b/lib/Rest/ApiVersion.h
@@ -28,67 +28,69 @@
 
 #include <fuerte/ApiVersion.h>
 
-namespace arangodb {
+namespace arangodb::api_version {
+
+// reexport fuerte items.
+using namespace arangodb::fuerte::api_version;
 
 /// @brief Central configuration for API versioning
-struct ApiVersion {
-  // The list of all supported API versions (both stable and deprecated)
-  static constexpr uint32_t supportedApiVersions[] = {0};
 
-  // The list of deprecated API versions (subset of supportedApiVersions)
-  static constexpr uint32_t deprecatedApiVersions[] = {};
+// The list of all supported API versions (both stable and deprecated)
+static constexpr uint32_t supportedApiVersions[] = {0};
 
-  // The default API version used when no /_arango/vX prefix is specified.
-  // Value is defined in fuerte so that fuerte can use it without depending on
-  // server headers.
-  static constexpr uint32_t defaultApiVersion =
-      fuerte::ApiVersion::defaultApiVersion;
+// The list of deprecated API versions (subset of supportedApiVersions)
+static constexpr uint32_t deprecatedApiVersions[] = {};
 
-  // The experimental API version (accessed via /_arango/experimental).
-  // Value is defined in fuerte so that fuerte can use it without depending on
-  // server headers.
-  static constexpr uint32_t experimentalApiVersion =
-      fuerte::ApiVersion::experimentalApiVersion;
+// The default API version used when no /_arango/vX prefix is specified.
+// Value is defined in fuerte so that fuerte can use it without depending on
+// server headers.
+static constexpr uint32_t defaultApiVersion =
+    fuerte::api_version::ApiVersion::defaultApiVersion;
 
-  // Helper function to get the number of supported API versions
-  static constexpr size_t numSupportedApiVersions() {
-    return sizeof(supportedApiVersions) / sizeof(supportedApiVersions[0]);
-  }
+// The experimental API version (accessed via /_arango/experimental).
+// Value is defined in fuerte so that fuerte can use it without depending on
+// server headers.
+static constexpr uint32_t experimentalApiVersion =
+    fuerte::api_version::ApiVersion::experimentalApiVersion;
 
-  // Helper function to check if an API version is supported
-  static constexpr bool isApiVersionSupported(uint32_t version) {
-    for (size_t i = 0; i < numSupportedApiVersions(); ++i) {
-      if (supportedApiVersions[i] == version) {
-        return true;
-      }
+// Helper function to get the number of supported API versions
+static constexpr size_t numSupportedApiVersions() {
+  return sizeof(supportedApiVersions) / sizeof(supportedApiVersions[0]);
+}
+
+// Helper function to check if an API version is supported
+static constexpr bool isApiVersionSupported(uint32_t version) {
+  for (size_t i = 0; i < numSupportedApiVersions(); ++i) {
+    if (supportedApiVersions[i] == version) {
+      return true;
     }
-    return false;
   }
+  return false;
+}
 
-  // Helper function to check if an API version is deprecated
-  static constexpr bool isApiVersionDeprecated(uint32_t version) {
-    constexpr size_t numDeprecated =
-        sizeof(deprecatedApiVersions) / sizeof(deprecatedApiVersions[0]);
-    for (size_t i = 0; i < numDeprecated; ++i) {
-      if (deprecatedApiVersions[i] == version) {
-        return true;
-      }
+// Helper function to check if an API version is deprecated
+static constexpr bool isApiVersionDeprecated(uint32_t version) {
+  constexpr size_t numDeprecated =
+      sizeof(deprecatedApiVersions) / sizeof(deprecatedApiVersions[0]);
+  for (size_t i = 0; i < numDeprecated; ++i) {
+    if (deprecatedApiVersions[i] == version) {
+      return true;
     }
-    return false;
   }
+  return false;
+}
 
-  // Helper function to get the maximum API version
-  // This is the maximum of all supported/deprecated versions and the
-  // experimental version
-  static constexpr uint32_t maxApiVersion() {
-    uint32_t maxVersion = experimentalApiVersion;
-    for (size_t i = 0; i < numSupportedApiVersions(); ++i) {
-      if (supportedApiVersions[i] > maxVersion) {
-        maxVersion = supportedApiVersions[i];
-      }
+// Helper function to get the maximum API version
+// This is the maximum of all supported/deprecated versions and the
+// experimental version
+static constexpr uint32_t maxApiVersion() {
+  uint32_t maxVersion = experimentalApiVersion;
+  for (size_t i = 0; i < numSupportedApiVersions(); ++i) {
+    if (supportedApiVersions[i] > maxVersion) {
+      maxVersion = supportedApiVersions[i];
     }
-    return maxVersion;
   }
-};
+  return maxVersion;
+}
 
-}  // namespace arangodb
+}  // namespace arangodb::api_version

--- a/lib/Rest/ApiVersion.h
+++ b/lib/Rest/ApiVersion.h
@@ -45,13 +45,13 @@ static constexpr uint32_t deprecatedApiVersions[] = {};
 // Value is defined in fuerte so that fuerte can use it without depending on
 // server headers.
 static constexpr uint32_t defaultApiVersion =
-    fuerte::api_version::ApiVersion::defaultApiVersion;
+    static_cast<uint32_t>(fuerte::api_version::ApiVersion::V0);
 
 // The experimental API version (accessed via /_arango/experimental).
 // Value is defined in fuerte so that fuerte can use it without depending on
 // server headers.
 static constexpr uint32_t experimentalApiVersion =
-    fuerte::api_version::ApiVersion::experimentalApiVersion;
+    static_cast<uint32_t>(fuerte::api_version::ApiVersion::Experimental);
 
 // Helper function to get the number of supported API versions
 static constexpr size_t numSupportedApiVersions() {

--- a/lib/Rest/GeneralRequest.cpp
+++ b/lib/Rest/GeneralRequest.cpp
@@ -69,7 +69,7 @@ GeneralRequest::GeneralRequest(ConnectionInfo const& connectionInfo,
       _tokenExpiry(0.0),
       _memoryUsage(0),
       _authenticationMethod(rest::AuthenticationMethod::NONE),
-      _requestedApiVersion(ApiVersion::defaultApiVersion),
+      _requestedApiVersion(api_version::defaultApiVersion),
       _type(RequestType::ILLEGAL),
       _contentType(ContentType::UNSET),
       _contentTypeResponse(ContentType::UNSET),
@@ -441,7 +441,7 @@ void GeneralRequest::detectAndStripApiVersion(char const*& start,
   if (remainder.starts_with(experimentalSuffix)) {
     size_t suffixEnd = experimentalSuffix.size();
     if (suffixEnd == remainder.size() || remainder[suffixEnd] == '/') {
-      _requestedApiVersion = ApiVersion::experimentalApiVersion;
+      _requestedApiVersion = api_version::experimentalApiVersion;
       isExperimental = true;
       start = p + suffixEnd;  // advance past "/_arango/experimental"
       return;
@@ -488,7 +488,7 @@ void GeneralRequest::detectAndStripApiVersion(char const*& start,
     // _requestedApiVersion or strip the prefix. This will cause the handler
     // lookup to fail and return a 404 Not Found
     if (version < std::numeric_limits<uint32_t>::max() &&
-        (ApiVersion::isApiVersionSupported(version) || isExperimental)) {
+        (api_version::isApiVersionSupported(version) || isExperimental)) {
       _requestedApiVersion = static_cast<uint32_t>(version);
       start = p + 1 + numEnd;  // advance past "/_arango/vX"
     }

--- a/tests/Fuerte/CMakeLists.txt
+++ b/tests/Fuerte/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(fuertetest
   ConnectionTimeoutsTest.cpp
 #    test_10000_writes.cpp
   main.cpp
+  RequestHeaderParsingTest.cpp
 )
 
 target_link_libraries(fuertetest

--- a/tests/Fuerte/RequestHeaderParsingTest.cpp
+++ b/tests/Fuerte/RequestHeaderParsingTest.cpp
@@ -4,6 +4,7 @@
 #include <fuerte/message.h>
 
 using namespace arangodb::fuerte;
+using namespace arangodb::fuerte::api_version;
 
 // TODO write tests with parameters in path
 
@@ -20,14 +21,15 @@ TEST(RequestHeaderParsingTest, strips_version_number) {
   auto header = RequestHeader{};
   header.parseArangoPath("/_arango/v0/something/else");
   ASSERT_EQ(header.path, "/something/else");
-  ASSERT_EQ(header.apiVersion, "v0");
+  ASSERT_EQ(header.apiVersion, std::optional<ApiVersion>(ApiVersion::V0));
 }
 
 TEST(RequestHeaderParsingTest, strips_experimental_version) {
   auto header = RequestHeader{};
   header.parseArangoPath("/_arango/experimental/something/else");
   ASSERT_EQ(header.path, "/something/else");
-  ASSERT_EQ(header.apiVersion, "experimental");
+  ASSERT_EQ(header.apiVersion,
+            std::optional<ApiVersion>(ApiVersion::Experimental));
 }
 
 TEST(RequestHeaderParsingTest,
@@ -41,14 +43,14 @@ TEST(RequestHeaderParsingTest, strips_version_when_there_is_only_slash_left) {
   auto header = RequestHeader{};
   header.parseArangoPath("/_arango/v0/");
   ASSERT_EQ(header.path, "/");
-  ASSERT_EQ(header.apiVersion, "v0");
+  ASSERT_EQ(header.apiVersion, std::optional<ApiVersion>(ApiVersion::V0));
 }
 
 TEST(RequestHeaderParsingTest, strips_version_when_there_is_nothing_else_left) {
   auto header = RequestHeader{};
   header.parseArangoPath("/_arango/v0");
   ASSERT_EQ(header.path, "/");
-  ASSERT_EQ(header.apiVersion, "v0");
+  ASSERT_EQ(header.apiVersion, std::optional<ApiVersion>(ApiVersion::V0));
 }
 
 TEST(RequestHeaderParsingTest, ignores_versions_with_leading_zeros) {
@@ -58,13 +60,10 @@ TEST(RequestHeaderParsingTest, ignores_versions_with_leading_zeros) {
   ASSERT_EQ(header.apiVersion, std::nullopt);
 }
 
-TEST(RequestHeaderParsingTest, parses_more_digit_version_numbers) {
+TEST(RequestHeaderParsingTest,
+     ignores_version_when_given_version_does_not_exist) {
   auto header = RequestHeader{};
-  header.parseArangoPath("/_arango/v11/path");
-  ASSERT_EQ(header.path, "/path");
-  ASSERT_EQ(header.apiVersion, "v11");
-
-  header.parseArangoPath("/_arango/v909/path");
-  ASSERT_EQ(header.path, "/path");
-  ASSERT_EQ(header.apiVersion, "v909");
+  header.parseArangoPath("/_arango/v999/something/else");
+  ASSERT_EQ(header.path, "/_arango/v999/something/else");
+  ASSERT_EQ(header.apiVersion, std::nullopt);
 }

--- a/tests/Fuerte/RequestHeaderParsingTest.cpp
+++ b/tests/Fuerte/RequestHeaderParsingTest.cpp
@@ -1,0 +1,70 @@
+#include "fuerte/ApiVersion.h"
+#include "gtest/gtest.h"
+
+#include <fuerte/message.h>
+
+using namespace arangodb::fuerte;
+
+// TODO write tests with parameters in path
+
+TEST(RequestHeaderParsingTest, sets_path) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/123/456");
+  ASSERT_EQ(header.path, "/123/456");
+
+  header.parseArangoPath("/123/456/");
+  ASSERT_EQ(header.path, "/123/456/");
+}
+
+TEST(RequestHeaderParsingTest, strips_version_number) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/v0/something/else");
+  ASSERT_EQ(header.path, "/something/else");
+  ASSERT_EQ(header.apiVersion, "v0");
+}
+
+TEST(RequestHeaderParsingTest, strips_experimental_version) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/experimental/something/else");
+  ASSERT_EQ(header.path, "/something/else");
+  ASSERT_EQ(header.apiVersion, "experimental");
+}
+
+TEST(RequestHeaderParsingTest,
+     does_not_strip_arangostring_when_no_version_comes_after) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/something/else");
+  ASSERT_EQ(header.path, "/_arango/something/else");
+}
+
+TEST(RequestHeaderParsingTest, strips_version_when_there_is_only_slash_left) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/v0/");
+  ASSERT_EQ(header.path, "/");
+  ASSERT_EQ(header.apiVersion, "v0");
+}
+
+TEST(RequestHeaderParsingTest, strips_version_when_there_is_nothing_else_left) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/v0");
+  ASSERT_EQ(header.path, "/");
+  ASSERT_EQ(header.apiVersion, "v0");
+}
+
+TEST(RequestHeaderParsingTest, ignores_versions_with_leading_zeros) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/v0001/path");
+  ASSERT_EQ(header.path, "/_arango/v0001/path");
+  ASSERT_EQ(header.apiVersion, std::nullopt);
+}
+
+TEST(RequestHeaderParsingTest, parses_more_digit_version_numbers) {
+  auto header = RequestHeader{};
+  header.parseArangoPath("/_arango/v11/path");
+  ASSERT_EQ(header.path, "/path");
+  ASSERT_EQ(header.apiVersion, "v11");
+
+  header.parseArangoPath("/_arango/v909/path");
+  ASSERT_EQ(header.path, "/path");
+  ASSERT_EQ(header.apiVersion, "v909");
+}

--- a/tests/Rest/GeneralRequestTest.cpp
+++ b/tests/Rest/GeneralRequestTest.cpp
@@ -74,7 +74,7 @@ TEST_F(ApiVersionDetectionTest, NoApiVersionPrefix) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_api/version");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_api/version", r.remaining);
 }
 
@@ -83,7 +83,7 @@ TEST_F(ApiVersionDetectionTest, RegularPath) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/some/random/path");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/some/random/path", r.remaining);
 }
 
@@ -91,7 +91,7 @@ TEST_F(ApiVersionDetectionTest, UnsupportedVersionNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v1/_api/version");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/v1/_api/version", r.remaining);
 }
 
@@ -100,7 +100,7 @@ TEST_F(ApiVersionDetectionTest, ExperimentalApiVersion) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/experimental/_api/new-feature");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::experimentalApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::experimentalApiVersion, r.apiVersion);
   EXPECT_EQ("/_api/new-feature", r.remaining);
 }
 
@@ -118,7 +118,7 @@ TEST_F(ApiVersionDetectionTest, PathEndingAtExperimental) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/experimental");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::experimentalApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::experimentalApiVersion, r.apiVersion);
   EXPECT_EQ("", r.remaining);
 }
 
@@ -128,7 +128,8 @@ TEST_F(ApiVersionDetectionTest, InvalidExactlyArango) {
   auto r = callDetect(request, "/_arango/");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);  // unchanged on error
+  EXPECT_EQ(api_version::defaultApiVersion,
+            r.apiVersion);  // unchanged on error
 }
 
 // Test: Invalid - missing v prefix
@@ -137,7 +138,7 @@ TEST_F(ApiVersionDetectionTest, InvalidMissingVPrefix) {
   auto r = callDetect(request, "/_arango/1/path");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
 }
 
 // Test: v without number - unrecognized, not stripped
@@ -145,7 +146,7 @@ TEST_F(ApiVersionDetectionTest, VWithoutNumberNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v/path");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/v/path", r.remaining);
 }
 
@@ -154,7 +155,7 @@ TEST_F(ApiVersionDetectionTest, VWithAlphaNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/vabc/path");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/vabc/path", r.remaining);
 }
 
@@ -164,7 +165,7 @@ TEST_F(ApiVersionDetectionTest, InvalidRandomText) {
   auto r = callDetect(request, "/_arango/invalid/path");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
 }
 
 // Test: Invalid - experimental typo
@@ -173,7 +174,7 @@ TEST_F(ApiVersionDetectionTest, InvalidExperimentalTypo) {
   auto r = callDetect(request, "/_arango/experimenta/path");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
 }
 
 // Test: Edge case - v0 is valid
@@ -191,7 +192,7 @@ TEST_F(ApiVersionDetectionTest, VersionFollowedByAlphaNotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v1abc/path");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/v1abc/path", r.remaining);
 }
 
@@ -208,7 +209,7 @@ TEST_F(ApiVersionDetectionTest, UnsupportedVersionWithMultipleSlashes) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v1///path");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/v1///path", r.remaining);
 }
 
@@ -217,7 +218,7 @@ TEST_F(ApiVersionDetectionTest, RootPath) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/", r.remaining);
 }
 
@@ -226,7 +227,7 @@ TEST_F(ApiVersionDetectionTest, UnsupportedVersionWithNestedPath) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v3/_api/collection/test/document/123");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/v3/_api/collection/test/document/123", r.remaining);
 }
 
@@ -235,7 +236,7 @@ TEST_F(ApiVersionDetectionTest, UnsupportedVersionV7NotStripped) {
   HttpRequest request(ci, 1);
   auto r = callDetect(request, "/_arango/v7/_api/cursor");
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ("/_arango/v7/_api/cursor", r.remaining);
 }
 
@@ -247,19 +248,19 @@ TEST_F(ApiVersionDetectionTest, UnsupportedLargeVersionNotStripped) {
                      "/path";
   auto r = callDetect(request, path);
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ(path, r.remaining);
 }
 
 // Test: Check that default API version constant is accessible and is 0
 TEST_F(ApiVersionDetectionTest, DefaultApiVersionConstant) {
-  EXPECT_EQ(0u, ApiVersion::defaultApiVersion);
+  EXPECT_EQ(0u, api_version::defaultApiVersion);
 }
 
 // Test: Verify default version is applied to new requests
 TEST_F(ApiVersionDetectionTest, NewRequestHasDefaultVersion) {
   HttpRequest request(ci, 1);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, request.requestedApiVersion());
+  EXPECT_EQ(api_version::defaultApiVersion, request.requestedApiVersion());
 }
 
 // Test: Version exceeding uint32_t max - unsupported, not stripped
@@ -270,7 +271,7 @@ TEST_F(ApiVersionDetectionTest, UnsupportedVersionExceedsUint32Max) {
   std::string path = "/_arango/v" + std::to_string(tooLarge) + "/path";
   auto r = callDetect(request, path);
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ(path, r.remaining);
 }
 
@@ -280,7 +281,7 @@ TEST_F(ApiVersionDetectionTest, InvalidVersionLeadingZeroV01) {
   auto r = callDetect(request, "/_arango/v01/path");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
@@ -290,7 +291,7 @@ TEST_F(ApiVersionDetectionTest, InvalidVersionLeadingZeroV007) {
   auto r = callDetect(request, "/_arango/v007/path");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
@@ -300,7 +301,7 @@ TEST_F(ApiVersionDetectionTest, InvalidVersionLeadingZeroV0123) {
   auto r = callDetect(request, "/_arango/v0123/_api/version");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
@@ -310,7 +311,7 @@ TEST_F(ApiVersionDetectionTest, InvalidVersionV00) {
   auto r = callDetect(request, "/_arango/v00/path");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
@@ -320,7 +321,7 @@ TEST_F(ApiVersionDetectionTest, InvalidVersionV000) {
   auto r = callDetect(request, "/_arango/v000");
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("leading zeros"));
 }
 
@@ -350,7 +351,7 @@ TEST_F(ApiVersionDetectionTest, VersionExceedsUint64Max) {
   auto r = callDetect(request, path);
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }
 
@@ -361,7 +362,7 @@ TEST_F(ApiVersionDetectionTest, UnsupportedVersionAtUint64Max) {
   std::string path = "/_arango/v18446744073709551615/path";
   auto r = callDetect(request, path);
   EXPECT_TRUE(r.ok);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_EQ(path, r.remaining);
 }
 
@@ -372,7 +373,7 @@ TEST_F(ApiVersionDetectionTest, VersionSlightlyAboveUint64Max) {
   auto r = callDetect(request, path);
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }
 
@@ -384,6 +385,6 @@ TEST_F(ApiVersionDetectionTest, VersionExcessivelyLongNumber) {
   auto r = callDetect(request, path);
   EXPECT_FALSE(r.ok);
   EXPECT_EQ(TRI_ERROR_HTTP_BAD_PARAMETER, r.errorNumber);
-  EXPECT_EQ(ApiVersion::defaultApiVersion, r.apiVersion);
+  EXPECT_EQ(api_version::defaultApiVersion, r.apiVersion);
   EXPECT_NE(std::string::npos, r.errorMessage.find("failed to parse"));
 }


### PR DESCRIPTION
This PR adds the optional parameter `apiVersion` to the `RestOptions`. This parameter is given to fuerte which knows how to send a request with a specific api version.

In order to not add fuerte-specific information in `arangod/Network` and to clean up the api version code, this PR does some refactorings as well:
- Change the arango-struct `ApiVersion` (in `lib/Rest/ApiVersion.h`) into the namespace `api_version` because it only includes static variables and functions.
- Change the fuerte-struct `ApiVersion` (in `3rdParty/fuerte/include/fuerte/ApiVersion.h`) into an enum class to make it a real object - before it also included only static variables.
- Use the enum type `ApiVersion` for the `apiVersion` member in the fuerte `RequestHeader` (instead of a string) to add some type-safety and be able to define the specific version string at one place - the enum class `ApiVersion` in fuerte.

Side-note: In the future it would probably be beneficial to use the enum class `ApiVersion` also in the arango code where we currently use  `uint32_t` for the version (see `lib/Rest/ApiVersion.h`).