### PR TITLE
[COR-442] Rename --ssl.* startup options to --tls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
 
-* COR-442: Renamed the startup options of the --ssl.* group into --tls.*,
-  but still accept the old naming pattern as alias to the new one.
+* COR-442: Renamed the startup options of the `--ssl.*` group into `--tls.*`,
+  but still accept the old naming pattern as an alias to the new one.
+  Config files using `[ssl]` sections are remapped automatically as well.
 
 * COR-376: Removed startup option `--server.authentication-system-only`. It's
   now considered a legacy option, so it will be silently ignored on startup.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
 
+* COR-442: Renamed the startup options of the --ssl.* group into --tls.*,
+  but still accept the old naming pattern as alias to the new one.
+
 * COR-376: Removed startup option `--server.authentication-system-only`. It's
   now considered a legacy option, so it will be silently ignored on startup.
 

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -71,16 +71,6 @@ SslServerFeature::SslServerFeature(
 void SslServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
   options->addSection("tls", "TLS communication");
 
-  options->addOldOption("--ssl.cafile", "--tls.cafile");
-  options->addOldOption("--ssl.keyfile", "--tls.keyfile");
-  options->addOldOption("--ssl.session-cache", "--tls.session-cache");
-  options->addOldOption("--ssl.cipher-list", "--tls.cipher-list");
-  options->addOldOption("--ssl.protocol", "--tls.protocol");
-  options->addOldOption("--ssl.options", "--tls.options");
-  options->addOldOption("--ssl.ecdh-curve", "--tls.ecdh-curve");
-  options->addOldOption("--ssl.prefer-http1-in-alpn",
-                        "--tls.prefer-http1-in-alpn");
-
   options
       ->addOption("--tls.cafile", "The CA file used for secure connections.",
                   new StringParameter(&_options.cafile))
@@ -152,7 +142,7 @@ the certificate.)");
 
   options
       ->addOption("--tls.cipher-list",
-                  "The SSL ciphers to use. See the OpenSSL documentation.",
+                  "The TLS ciphers to use. See the OpenSSL documentation.",
                   new StringParameter(&_options.cipherList))
       .setLongDescription(R"(You can use this option to restrict the server to
 certain SSL ciphers only, and to define the relative usage preference of SSL
@@ -192,7 +182,7 @@ the startup.)");
 
   options
       ->addOption("--tls.options",
-                  "The SSL connection options. See the OpenSSL documentation.",
+                  "The TLS connection options. See the OpenSSL documentation.",
                   new UInt64Parameter(&_options.sslOptions),
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
@@ -220,13 +210,23 @@ http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html))");
 
   options->addOption(
       "--tls.ecdh-curve",
-      "The SSL ECDH curve, see the output of \"openssl ecparam -list_curves\".",
+      "The TLS ECDH curve, see the output of \"openssl ecparam -list_curves\".",
       new StringParameter(&_options.ecdhCurve));
 
   options->addOption("--tls.prefer-http1-in-alpn",
                      "Allows to let the server prefer HTTP/1.1 over HTTP/2 in "
                      "ALPN protocol negotiations",
                      new BooleanParameter(&_options.preferHttp11InAlpn));
+
+  options->addOldOption("--ssl.cafile", "--tls.cafile");
+  options->addOldOption("--ssl.keyfile", "--tls.keyfile");
+  options->addOldOption("--ssl.session-cache", "--tls.session-cache");
+  options->addOldOption("--ssl.cipher-list", "--tls.cipher-list");
+  options->addOldOption("--ssl.protocol", "--tls.protocol");
+  options->addOldOption("--ssl.options", "--tls.options");
+  options->addOldOption("--ssl.ecdh-curve", "--tls.ecdh-curve");
+  options->addOldOption("--ssl.prefer-http1-in-alpn",
+                        "--tls.prefer-http1-in-alpn");
 }
 
 void SslServerFeature::validateOptions(
@@ -246,7 +246,7 @@ void SslServerFeature::prepare() {
 
   if (!_options.cipherList.empty()) {
     LOG_TOPIC("9b126", INFO, arangodb::Logger::SSL)
-        << "using SSL cipher-list '" << _options.cipherList << "'";
+        << "using TLS cipher-list '" << _options.cipherList << "'";
   }
 
   UniformCharacter r(
@@ -271,18 +271,18 @@ void SslServerFeature::verifySslOptions() {
   // cppcheck-suppress unsignedLessThanZero
   if (_options.sslProtocol <= SSL_UNKNOWN || _options.sslProtocol >= SSL_LAST) {
     LOG_TOPIC("1f48b", FATAL, arangodb::Logger::SSL)
-        << "invalid SSL protocol version specified. Please use a valid "
+        << "invalid TLS protocol version specified. Please use a valid "
            "value for '--tls.protocol'";
     FATAL_ERROR_EXIT();
   }
 
   LOG_TOPIC("47161", DEBUG, arangodb::Logger::SSL)
-      << "using SSL protocol version '"
+      << "using TLS protocol version '"
       << protocolName(SslProtocol(_options.sslProtocol)) << "'";
 
   if (!FileUtils::exists(_options.keyfile)) {
     LOG_TOPIC("51cf0", FATAL, arangodb::Logger::SSL)
-        << "unable to find SSL keyfile '" << _options.keyfile << "'";
+        << "unable to find TLS keyfile '" << _options.keyfile << "'";
     FATAL_ERROR_EXIT();
   }
 

--- a/arangod/GeneralServer/SslServerFeature.cpp
+++ b/arangod/GeneralServer/SslServerFeature.cpp
@@ -69,10 +69,20 @@ SslServerFeature::SslServerFeature(
 }
 
 void SslServerFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("ssl", "SSL communication");
+  options->addSection("tls", "TLS communication");
+
+  options->addOldOption("--ssl.cafile", "--tls.cafile");
+  options->addOldOption("--ssl.keyfile", "--tls.keyfile");
+  options->addOldOption("--ssl.session-cache", "--tls.session-cache");
+  options->addOldOption("--ssl.cipher-list", "--tls.cipher-list");
+  options->addOldOption("--ssl.protocol", "--tls.protocol");
+  options->addOldOption("--ssl.options", "--tls.options");
+  options->addOldOption("--ssl.ecdh-curve", "--tls.ecdh-curve");
+  options->addOldOption("--ssl.prefer-http1-in-alpn",
+                        "--tls.prefer-http1-in-alpn");
 
   options
-      ->addOption("--ssl.cafile", "The CA file used for secure connections.",
+      ->addOption("--tls.cafile", "The CA file used for secure connections.",
                   new StringParameter(&_options.cafile))
       .setLongDescription(R"(You can use this option to specify a file with
 CA certificates that are sent to the client whenever the server requests a
@@ -83,7 +93,7 @@ you want clients to be able to connect without specific certificates.
 The certificates in the file must be PEM-formatted.)");
 
   options
-      ->addOption("--ssl.keyfile",
+      ->addOption("--tls.keyfile",
                   "The path to a PEM file (server certificate + private key) "
                   "to use for secure connections.",
                   new StringParameter(&_options.keyfile))
@@ -136,12 +146,12 @@ above commands should create a valid keyfile with a structure like this:
 For further information please check the manuals of the tools you use to create
 the certificate.)");
 
-  options->addOption("--ssl.session-cache",
+  options->addOption("--tls.session-cache",
                      "Enable the session cache for connections.",
                      new BooleanParameter(&_options.sessionCache));
 
   options
-      ->addOption("--ssl.cipher-list",
+      ->addOption("--tls.cipher-list",
                   "The SSL ciphers to use. See the OpenSSL documentation.",
                   new StringParameter(&_options.cipherList))
       .setLongDescription(R"(You can use this option to restrict the server to
@@ -168,7 +178,7 @@ Mac=SHA1
   std::unordered_set<uint64_t> const sslProtocols = availableSslProtocols();
 
   options
-      ->addOption("--ssl.protocol", availableSslProtocolsDescription(),
+      ->addOption("--tls.protocol", availableSslProtocolsDescription(),
                   new DiscreteValuesParameter<UInt64Parameter>(
                       &_options.sslProtocol, sslProtocols))
       .setLongDescription(R"(Use this option to specify the default encryption
@@ -181,7 +191,7 @@ security vulnerabilities in this protocol. Selecting SSLv2 as protocol aborts
 the startup.)");
 
   options
-      ->addOption("--ssl.options",
+      ->addOption("--tls.options",
                   "The SSL connection options. See the OpenSSL documentation.",
                   new UInt64Parameter(&_options.sslOptions),
                   arangodb::options::makeDefaultFlags(
@@ -209,11 +219,11 @@ A description of the options can be found online in the OpenSSL documentation:
 http://www.openssl.org/docs/ssl/SSL_CTX_set_options.html))");
 
   options->addOption(
-      "--ssl.ecdh-curve",
+      "--tls.ecdh-curve",
       "The SSL ECDH curve, see the output of \"openssl ecparam -list_curves\".",
       new StringParameter(&_options.ecdhCurve));
 
-  options->addOption("--ssl.prefer-http1-in-alpn",
+  options->addOption("--tls.prefer-http1-in-alpn",
                      "Allows to let the server prefer HTTP/1.1 over HTTP/2 in "
                      "ALPN protocol negotiations",
                      new BooleanParameter(&_options.preferHttp11InAlpn));
@@ -253,7 +263,7 @@ void SslServerFeature::verifySslOptions() {
   // check keyfile
   if (_options.keyfile.empty()) {
     LOG_TOPIC("f0dca", FATAL, arangodb::Logger::SSL)
-        << "no value specified for '--ssl.keyfile'";
+        << "no value specified for '--tls.keyfile'";
     FATAL_ERROR_EXIT();
   }
 
@@ -262,7 +272,7 @@ void SslServerFeature::verifySslOptions() {
   if (_options.sslProtocol <= SSL_UNKNOWN || _options.sslProtocol >= SSL_LAST) {
     LOG_TOPIC("1f48b", FATAL, arangodb::Logger::SSL)
         << "invalid SSL protocol version specified. Please use a valid "
-           "value for '--ssl.protocol'";
+           "value for '--tls.protocol'";
     FATAL_ERROR_EXIT();
   }
 

--- a/arangod/RestServer/EndpointFeature.cpp
+++ b/arangod/RestServer/EndpointFeature.cpp
@@ -74,12 +74,12 @@ If a TCP/IP endpoint is specified without a port number, then the default port
 (8529) is used.
 
 If you use SSL-encrypted endpoints, you must also supply the path to a server
-certificate using the `--ssl.keyfile` option.
+certificate using the `--tls.keyfile` option.
 
 ```bash
 arangod --server.endpoint tcp://127.0.0.1:8529 \
         --server.endpoint ssl://127.0.0.1:8530 \
-        --ssl.keyfile server.pem /tmp/data-dir
+        --tls.keyfile server.pem /tmp/data-dir
 
 ...
 2022-11-07T10:39:30Z [1] INFO [6ea38] {general} using endpoint 'http+ssl://0.0.0.0:8530' for ssl-encrypted requests

--- a/client-tools/Shell/ClientFeature.cpp
+++ b/client-tools/Shell/ClientFeature.cpp
@@ -208,8 +208,9 @@ arangosh without connecting to a server.)");
 
   std::unordered_set<uint64_t> const sslProtocols = availableSslProtocols();
 
-  options->addSection("ssl", "SSL communication");
-  options->addOption("--ssl.protocol", availableSslProtocolsDescription(),
+  options->addSection("tls", "TLS communication");
+  options->addOldOption("--ssl.protocol", "--tls.protocol");
+  options->addOption("--tls.protocol", availableSslProtocolsDescription(),
                      new DiscreteValuesParameter<UInt64Parameter>(
                          &_sslProtocol, sslProtocols));
   options

--- a/etc/testing/arangod-auth.conf
+++ b/etc/testing/arangod-auth.conf
@@ -25,7 +25,7 @@ block-cache-jemalloc-allocator = true
 authentication = true
 telemetrics-api = false
 
-[ssl]
+[tls]
 keyfile = @TOP_DIR@/UnitTests/server.pem
 
 [http]

--- a/etc/testing/arangod-common.conf
+++ b/etc/testing/arangod-common.conf
@@ -25,7 +25,7 @@ block-cache-jemalloc-allocator = true
 authentication = false
 telemetrics-api = false
 
-[ssl]
+[tls]
 keyfile = @TOP_DIR@/UnitTests/server.pem
 
 [http]

--- a/lib/ApplicationFeatures/OptionsCheckFeature.cpp
+++ b/lib/ApplicationFeatures/OptionsCheckFeature.cpp
@@ -41,7 +41,7 @@ void OptionsCheckFeature::prepare() {
     for (auto const& it : modernizedOptions) {
       LOG_TOPIC("3e342", WARN, Logger::STARTUP)
           << "please note that the specified option '--" << it.first
-          << " has been renamed to '--" << it.second << "'";
+          << "' has been renamed to '--" << it.second << "'";
     }
 
     LOG_TOPIC("27c9c", INFO, Logger::STARTUP)

--- a/scripts/startLocalCluster.sh
+++ b/scripts/startLocalCluster.sh
@@ -118,7 +118,7 @@ else
 fi
 
 if [ "$TRANSPORT" == "ssl" ]; then
-  SSLKEYFILE="--ssl.keyfile etc/testing/server.pem"
+  SSLKEYFILE="--tls.keyfile etc/testing/server.pem"
   CURL="curl --insecure $CURL_AUTHENTICATION -s -f -X GET https:"
 else
   SSLKEYFILE=""

--- a/scripts/startStandAloneAgency.sh
+++ b/scripts/startStandAloneAgency.sh
@@ -133,7 +133,7 @@ if [ "$LOG_LEVEL" == "" ];  then
 fi
 
 if [ "$TRANSPORT" == "ssl" ]; then
-  SSLKEYFILE="--ssl.keyfile etc/testing/server.pem"
+  SSLKEYFILE="--tls.keyfile etc/testing/server.pem"
   CURL="curl --insecure -ks https://"
 else
   SSLKEYFILE=""


### PR DESCRIPTION
### Scope & Purpose

This PR implements https://arangodb.atlassian.net/browse/COR-442, in which we rename the startup options of the group `--ssl.*` into `--tls.*`. As ssl v2 and v3 are no longer gonna be supported because they’re broken, the remainder protocols to choose from are TLS variants, as ssl ended in v3, and TLS has been used as the standard ever since. 
Enterprise companion https://github.com/arangodb/enterprise/pull/1643

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information


- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1643
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-442
- [ ] Design document: 
