### PR TITLE
[COR-411] Introduce optimizer rule replace-any-eq-with-in

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@
 
 * COR-411: Introduced optimizer rule `replace-any-eq-with-in` that maps filter
   nodes of the form FILTER [exp1] ANY == exp2 into FILTER exp2 IN [exp1] to
-  make them visible to downstream optimizer rules, such as use-indexes.
+  make them visible to downstream optimizer rules, including use-indexes,
+  optimize-traversals, and sort-in-values.
 
 * COR-435: Fix a TOCTOU race in the Agency leader's sendAppendEntriesRPC that
   could crash a follower agent. The leader read log entries and the compaction

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* COR-411: Introduced optimizer rule `replace-any-eq-with-in` that maps filter
+  nodes of the form FILTER [exp1] ANY == exp2 into FILTER exp2 IN [exp1] to
+  make them visible to downstream optimizer rules, such as use-indexes.
+
 * COR-435: Fix a TOCTOU race in the Agency leader's sendAppendEntriesRPC that
   could crash a follower agent. The leader read log entries and the compaction
   snapshot in two non-atomic operations; compaction could advance the snapshot

--- a/arangod/Aql/Optimizer/Rule/CMakeLists.txt
+++ b/arangod/Aql/Optimizer/Rule/CMakeLists.txt
@@ -43,6 +43,7 @@ target_sources(arango_aql PRIVATE
   RemoveUnnecessaryCalculations.cpp
   RemoveUnnecessaryFilters.cpp
   RemoveUnnecessaryRemoteScatter.cpp
+  ReplaceAnyEqWithIn.cpp
   ReplaceEntriesWithObjectIteration.cpp
   ReplaceEqualAttributeAccess.cpp
   ReplaceLastAccessOnGraphPath.cpp

--- a/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.cpp
+++ b/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.cpp
@@ -57,6 +57,10 @@ struct AnySimplifier {
       return nullptr;
     }
 
+    // We don't apply the rule for UNARY_NOT as in NOT (lhs ANY == rhs), as,
+    // though it's equivalent to rhs NOT IN lhs, it's less useful for index and
+    // ReplaceOrWithIn, which is a rule that also maps to rhs IN lhs, also
+    // doesn't apply it.
     if (node->type == NODE_TYPE_OPERATOR_BINARY_AND ||
         node->type == NODE_TYPE_OPERATOR_BINARY_OR) {
       auto* lhs = node->getMember(0);

--- a/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.cpp
+++ b/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.cpp
@@ -1,0 +1,138 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Puget
+////////////////////////////////////////////////////////////////////////////////
+
+#include "ReplaceAnyEqWithIn.h"
+
+#include "Aql/Ast.h"
+#include "Aql/ExecutionNode/CalculationNode.h"
+#include "Aql/ExecutionNode/ExecutionNode.h"
+#include "Aql/ExecutionNode/FilterNode.h"
+#include "Aql/ExecutionPlan.h"
+#include "Aql/Expression.h"
+#include "Aql/Optimizer.h"
+#include "Aql/Quantifier.h"
+#include "Aql/TypedAstNodes.h"
+#include "Containers/SmallVector.h"
+
+#include <memory>
+
+namespace arangodb::aql {
+using EN = ExecutionNode;
+
+namespace {
+
+/// @brief rewrites ANY == comparisons into IN expressions
+///
+/// Example:
+///   ['Alice', 'Bob'] ANY == x.name  →  x.name IN ['Alice', 'Bob']
+///
+/// This enables index lookups that are unavailable for ANY == expressions.
+struct AnySimplifier {
+  Ast* ast;
+
+  explicit AnySimplifier(Ast* ast) : ast(ast) {}
+
+  AstNode* simplify(AstNode const* node) const {
+    if (node == nullptr) {
+      return nullptr;
+    }
+
+    if (node->type == NODE_TYPE_OPERATOR_BINARY_AND ||
+        node->type == NODE_TYPE_OPERATOR_BINARY_OR) {
+      auto* lhs = node->getMember(0);
+      auto* rhs = node->getMember(1);
+      auto* lhsNew = simplify(lhs);
+      auto* rhsNew = simplify(rhs);
+      if (lhs != lhsNew || rhs != rhsNew) {
+        return ast->createNodeBinaryOperator(node->type, lhsNew, rhsNew);
+      }
+      return const_cast<AstNode*>(node);
+    }
+
+    return simplifyAnyEq(node);
+  }
+
+ private:
+  AstNode* simplifyAnyEq(AstNode const* node) const {
+    if (node->type != NODE_TYPE_OPERATOR_BINARY_ARRAY_EQ) {
+      return const_cast<AstNode*>(node);
+    }
+
+    TRI_ASSERT(node->numMembers() == 3);
+
+    auto* quantifierNode = node->getMember(2);
+    if (quantifierNode == nullptr ||
+        quantifierNode->type != NODE_TYPE_QUANTIFIER) {
+      return const_cast<AstNode*>(node);
+    }
+
+    ast::QuantifierNode quantifier(quantifierNode);
+    if (!quantifier.isAny()) {
+      return const_cast<AstNode*>(node);
+    }
+
+    // grammar guarantees member(0) is array
+    // `lhs ANY == rhs`  →  `rhs IN lhs`
+    auto* lhs = node->getMember(0);
+    auto* rhs = node->getMember(1);
+
+    return ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_IN, rhs,
+                                         lhs);
+  }
+};
+
+}  // namespace
+
+void replaceAnyEqWithInRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
+                            OptimizerRule const& rule) {
+  containers::SmallVector<ExecutionNode*, 8> nodes;
+  plan->findNodesOfType(nodes, EN::FILTER, true);
+
+  bool modified = false;
+  for (auto const& n : nodes) {
+    auto* fn = ExecutionNode::castTo<FilterNode const*>(n);
+    auto* setter = plan->getVarSetBy(fn->inVariable()->id);
+
+    if (setter == nullptr || setter->getType() != EN::CALCULATION) {
+      continue;
+    }
+
+    auto* cn = ExecutionNode::castTo<CalculationNode*>(setter);
+    auto* root = cn->expression()->node();
+
+    AnySimplifier simplifier(plan->getAst());
+    auto* newRoot = simplifier.simplify(root);
+
+    if (newRoot != root) {
+      auto* outVar = cn->outVariable();
+      auto expr = std::make_unique<Expression>(plan->getAst(), newRoot);
+      ExecutionNode* newNode = plan->createNode<CalculationNode>(
+          plan.get(), plan->nextId(), std::move(expr), outVar);
+      plan->replaceNode(cn, newNode);
+      modified = true;
+    }
+  }
+
+  opt->addPlan(std::move(plan), rule, modified);
+}
+}  // namespace arangodb::aql

--- a/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.cpp
+++ b/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.cpp
@@ -57,10 +57,9 @@ struct AnySimplifier {
       return nullptr;
     }
 
-    // We don't apply the rule for UNARY_NOT as in NOT (lhs ANY == rhs), as,
-    // though it's equivalent to rhs NOT IN lhs, it's less useful for index and
-    // ReplaceOrWithIn, which is a rule that also maps to rhs IN lhs, also
-    // doesn't apply it.
+    // NOT (lhs ANY == rhs) is equivalent to rhs NOT IN lhs, but we skip it:
+    // NOT IN is not index-eligible, and replace-or-with-in doesn't fire on it
+    // either.
     if (node->type == NODE_TYPE_OPERATOR_BINARY_AND ||
         node->type == NODE_TYPE_OPERATOR_BINARY_OR) {
       auto* lhs = node->getMember(0);

--- a/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.h
+++ b/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.h
@@ -23,10 +23,12 @@
 
 #pragma once
 
-#include "Aql/ExecutionPlan.h"
+#include <memory>
 
 namespace arangodb::aql {
+class ExecutionPlan;
 class Optimizer;
+struct OptimizerRule;
 
 /// @brief replace ANY == array comparisons with IN expressions
 void replaceAnyEqWithInRule(Optimizer*, std::unique_ptr<ExecutionPlan>,

--- a/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.h
+++ b/arangod/Aql/Optimizer/Rule/ReplaceAnyEqWithIn.h
@@ -1,0 +1,35 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Julia Puget
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/ExecutionPlan.h"
+
+namespace arangodb::aql {
+class Optimizer;
+
+/// @brief replace ANY == array comparisons with IN expressions
+void replaceAnyEqWithInRule(Optimizer*, std::unique_ptr<ExecutionPlan>,
+                            OptimizerRule const&);
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -459,6 +459,16 @@ struct OptimizerRule {
       "Also constrained sort rule now does not expects any late "
       "materialization variables replacement");
 
+  static_assert(replaceAnyEqWithInRule < useIndexesRule,
+                "replaceAnyEqWithInRule must run before useIndexesRule so the "
+                "rewritten IN expressions are visible to index selection");
+
+  static_assert(
+      replaceAnyEqWithInRule < removeUnnecessaryFiltersRule2,
+      "replaceAnyEqWithInRule must run before removeUnnecessaryFiltersRule2 "
+      "so constant-false IN expressions produced by the rewrite can be "
+      "eliminated");
+
   static_assert(useVectorIndexForSort < useIndexesRule,
                 "useVectorIndexForSort must happen before useIndexesRule rule, "
                 "otherwise the forcing of vector index hint does not work");

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -464,12 +464,6 @@ struct OptimizerRule {
                 "rewritten IN expressions are visible to index selection");
 
   static_assert(
-      replaceAnyEqWithInRule < removeUnnecessaryFiltersRule2,
-      "replaceAnyEqWithInRule must run before removeUnnecessaryFiltersRule2 "
-      "so the ordering is preserved if filter elimination is later extended "
-      "to constant-fold IN expressions produced by the rewrite");
-
-  static_assert(
       replaceAnyEqWithInRule < optimizeTraversalsRule,
       "replaceAnyEqWithInRule must run before optimizeTraversalsRule "
       "so rewritten IN edge conditions can be pushed into TraversalNode");

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -469,6 +469,11 @@ struct OptimizerRule {
       "so constant-false IN expressions produced by the rewrite can be "
       "eliminated");
 
+  static_assert(
+      replaceAnyEqWithInRule < optimizeTraversalsRule,
+      "replaceAnyEqWithInRule must run before optimizeTraversalsRule "
+      "so rewritten IN edge conditions can be pushed into TraversalNode");
+
   static_assert(useVectorIndexForSort < useIndexesRule,
                 "useVectorIndexForSort must happen before useIndexesRule rule, "
                 "otherwise the forcing of vector index hint does not work");

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -466,8 +466,8 @@ struct OptimizerRule {
   static_assert(
       replaceAnyEqWithInRule < removeUnnecessaryFiltersRule2,
       "replaceAnyEqWithInRule must run before removeUnnecessaryFiltersRule2 "
-      "so constant-false IN expressions produced by the rewrite can be "
-      "eliminated");
+      "so the ordering is preserved if filter elimination is later extended "
+      "to constant-fold IN expressions produced by the rewrite");
 
   static_assert(
       replaceAnyEqWithInRule < optimizeTraversalsRule,

--- a/arangod/Aql/OptimizerRule.h
+++ b/arangod/Aql/OptimizerRule.h
@@ -193,6 +193,9 @@ struct OptimizerRule {
     // replace simple OR conditions with IN
     replaceOrWithInRule,
 
+    // replace ANY == array comparisons with IN
+    replaceAnyEqWithInRule,
+
     // remove redundant OR conditions
     removeRedundantOrRule,
 

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -68,6 +68,7 @@
 #include "Aql/Optimizer/Rule/RemoveUnnecessaryCalculations.h"
 #include "Aql/Optimizer/Rule/RemoveUnnecessaryFilters.h"
 #include "Aql/Optimizer/Rule/RemoveUnnecessaryRemoteScatter.h"
+#include "Aql/Optimizer/Rule/ReplaceAnyEqWithIn.h"
 #include "Aql/Optimizer/Rule/ReplaceEntriesWithObjectIteration.h"
 #include "Aql/Optimizer/Rule/ReplaceEqualAttributeAccess.h"
 #include "Aql/Optimizer/Rule/ReplaceLastAccessOnGraphPath.h"
@@ -396,6 +397,14 @@ are not used in data modification queries.)");
                OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
                R"(Combine multiple `OR` equality conditions on the same
 variable or attribute with an `IN` condition.)");
+
+  // try to replace ANY == array comparisons with IN
+  registerRule(
+      "replace-any-eq-with-in", replaceAnyEqWithInRule,
+      OptimizerRule::replaceAnyEqWithInRule,
+      OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
+      R"(Replace `ANY ==` array comparison expressions with equivalent `IN`
+expressions to enable further optimizations and index usage.)");
 
   // try to remove redundant OR conditions
   registerRule("remove-redundant-or", removeRedundantOrRule,

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -185,7 +185,7 @@ describe('Single Traversal Optimizer', function () {
       // replace-any-eq-with-in rewrites `e.bar[*] ANY == 2` into `2 IN e.bar[*]`,
       // which optimize-traversals can then push into the TraversalNode, so both
       // filters are covered and no FilterNode remains.
-      it('on p.edges[*].foo ALL > 3 AND e.bar[*] ANY == 3', () => {
+      it('on p.edges[*].foo ALL > 3 AND e.bar[*] ANY == 2', () => {
         let query = `WITH @@vertices
                        FOR v, e, p IN OUTBOUND @start @@edges
                        FILTER p.edges[*].foo ALL > 3
@@ -203,7 +203,6 @@ describe('Single Traversal Optimizer', function () {
         const disableOurRule = { optimizer: { rules: [ "+all", "-replace-any-eq-with-in" ] } };
         let planWithoutOurRule = db._createStatement({query: query, bindVars: bindVars, options: disableOurRule}).explain();
         hasFilterNode(planWithoutOurRule);
-        validateResult(query, bindVars);
       });
     });
   });

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -182,6 +182,9 @@ describe('Single Traversal Optimizer', function () {
         validateResult(query, bindVars);
       });
 
+      // replace-any-eq-with-in rewrites `e.bar[*] ANY == 2` into `2 IN e.bar[*]`,
+      // which optimize-traversals can then push into the TraversalNode, so both
+      // filters are covered and no FilterNode remains.
       it('on p.edges[*].foo ALL > 3 AND e.bar[*] ANY == 3', () => {
         let query = `WITH @@vertices
                        FOR v, e, p IN OUTBOUND @start @@edges
@@ -190,7 +193,7 @@ describe('Single Traversal Optimizer', function () {
                        RETURN v`;
         let plan = db._createStatement({query: query, bindVars:  bindVars, options:  activateOptimizer}).explain();
 
-        hasFilterNode(plan);
+        hasNoFilterNode(plan);
         validateResult(query, bindVars);
       });
     });

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -191,9 +191,18 @@ describe('Single Traversal Optimizer', function () {
                        FILTER p.edges[*].foo ALL > 3
                        FILTER e.bar[*] ANY == 2
                        RETURN v`;
-        let plan = db._createStatement({query: query, bindVars:  bindVars, options:  activateOptimizer}).explain();
 
-        hasNoFilterNode(plan);
+        // With all rules on: our rewrite fires, optimize-traversals pushes both
+        // conditions into the TraversalNode, no FilterNode remains.
+        let planAllRules = db._createStatement({query: query, bindVars: bindVars, options: activateOptimizer}).explain();
+        hasNoFilterNode(planAllRules);
+        validateResult(query, bindVars);
+
+        // Gate test: disable only replace-any-eq-with-in. The BINARY_ARRAY_EQ ANY ==
+        // form is not pushed by optimize-traversals, so the FilterNode stays.
+        const disableOurRule = { optimizer: { rules: [ "+all", "-replace-any-eq-with-in" ] } };
+        let planWithoutOurRule = db._createStatement({query: query, bindVars: bindVars, options: disableOurRule}).explain();
+        hasFilterNode(planWithoutOurRule);
         validateResult(query, bindVars);
       });
     });

--- a/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
+++ b/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
@@ -80,7 +80,7 @@ function NewAqlReplaceAnyWithINTestSuite() {
         var calcNodesWith = findExecutionNodes(planWithRule, "CalculationNode");
         var calcNodesWithout = findExecutionNodes(planWithoutRule, "CalculationNode");
 
-        assertTrue(calcNodesWith.length > 0 || calcNodesWithout.length > 0,
+        assertTrue(calcNodesWith.length > 0 && calcNodesWithout.length > 0,
             "Plans should have calculation nodes: " + query);
 
         assertTrue(planWithRule.nodes.length > 0, "Plan with rule should have nodes");
@@ -399,7 +399,10 @@ function NewAqlReplaceAnyWithINTestSuite() {
 
             var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
             assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
-            assertEqual(0, executeWithRule(query, {}).length);
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(0, withRule.length);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
         },
 
         testFiresNonDeterministicLhs: function () {
@@ -424,7 +427,10 @@ function NewAqlReplaceAnyWithINTestSuite() {
 
             var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
             assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
-            assertEqual(40, executeWithRule(query, {}).length);
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(40, withRule.length);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
         },
 
         testFiresBothConstantArrays: function () {
@@ -436,7 +442,10 @@ function NewAqlReplaceAnyWithINTestSuite() {
 
             var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
             assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
-            assertEqual(0, executeWithRule(query, {}).length);
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(0, withRule.length);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
         },
 
         testSkipsAnyNe: function () {
@@ -631,16 +640,16 @@ function NewAqlReplaceAnyWithINTestSuite() {
         testAnyOrBranchesOnSameAttribute: function () {
             var query = "FOR doc IN " + replace.name() +
                 " FILTER [5] ANY == doc.value OR [15] ANY == doc.value RETURN doc";
-            
-            var result = db._query(query).toArray();
-            assertEqual(2, result.length, "Should return 2 documents with value 5 or 15");
-            
-            var values = result.map(d => d.value).sort((a, b) => a - b);
+
+            var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(2, withRule.length, "Should return 2 documents with value 5 or 15");
+            var values = withRule.map(d => d.value).sort((a, b) => a - b);
             assertEqual([5, 15], values);
-            
-            var plan = db._createStatement({query: query}).explain();
-            var foundRule = plan.plan.rules.indexOf("replace-any-eq-with-in") !== -1;
-            assertTrue(foundRule, "replace-any-eq-with-in rule should fire");
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
         }
     };
 }

--- a/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
+++ b/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
@@ -345,6 +345,27 @@ function NewAqlReplaceAnyWithINTestSuite() {
             ruleIsNotUsed(query, {});
         },
 
+        testSkipsNoneQuantifier: function () {
+            const query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] NONE == x.name RETURN x.value";
+
+            ruleIsNotUsed(query, {});
+        },
+
+        testSkipsNot: function () {
+            // NOT (lhs ANY == rhs) is equivalent to rhs NOT IN lhs,
+            // but the rule deliberately does not rewrite it (NOT IN is less useful for indexes).
+            const query =
+                "FOR x IN " + replace.name() +
+                " FILTER NOT (['Alice', 'Bob'] ANY == x.name) RETURN x.value";
+
+            ruleIsNotUsed(query, {});
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
         testFiresScalarLhs: function () {
             // lhs='Alice' is not an array → rule fires, x.name IN 'Alice' → false → 0 docs.
             var query =
@@ -572,6 +593,166 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withoutRule = executeWithoutRule(query, {});
 
             assertEqual(expected, withRule);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresBothAnyEqArmsOfAnd: function () {
+            // Both arms of AND contain ANY == — simplify() recurses into each arm
+            // and rewrites both. Verifies the recursive descent through BINARY_AND.
+            const query =
+                "FOR v IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == v.name AND [1, 2, 3] ANY == v.value" +
+                " SORT v.value RETURN v.value";
+
+            const plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1,
+                "Rule should fire on both ANY == arms of AND");
+
+            // Alice values are 1–10, Bob values are 11–20. Only Alice has values 1, 2, 3.
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
+            assertEqual([1, 2, 3], withRule);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresBothAnyEqArmsOfOr: function () {
+            // Both arms of OR contain ANY == on different attributes — simplify() recurses
+            // into each arm and rewrites both independently. Verifies BINARY_OR descent.
+            const query =
+                "FOR v IN " + replace.name() +
+                " FILTER ['Alice'] ANY == v.name OR [11, 12] ANY == v.value" +
+                " SORT v.value RETURN v.value";
+
+            const plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1,
+                "Rule should fire on both ANY == arms of OR");
+
+            // Alice docs: values 1–10. Bob(11) and Bob(12) match the value arm.
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
+            assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], withRule);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresNestedAndOrRecursion: function () {
+            // AND( ANY ==, OR( ANY ==, ANY == ) ) — three ANY == nodes in a mixed tree.
+            // Verifies that simplify() recurses correctly through both BINARY_AND and BINARY_OR.
+            const query =
+                "FOR v IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == v.name" +
+                "     AND ([1, 5] ANY == v.value OR [11, 15] ANY == v.value)" +
+                " SORT v.value RETURN v.value";
+
+            const plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1,
+                "Rule should fire on all three ANY == nodes in the nested tree");
+
+            // name IN ['Alice','Bob'] AND (value IN [1,5] OR value IN [11,15])
+            // → Alice(1), Alice(5), Bob(11), Bob(15)
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
+            assertEqual([1, 5, 11, 15], withRule);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresDuplicateArrayValues: function () {
+            // Duplicate values in the array are harmless: ['Alice', 'Alice', 'Bob'] ANY == v.name
+            // rewrites to v.name IN ['Alice', 'Alice', 'Bob'] and returns the same results.
+            const query =
+                "FOR v IN " + replace.name() +
+                " FILTER ['Alice', 'Alice', 'Bob'] ANY == v.name SORT v.value RETURN v.value";
+
+            const plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
+            // Alice values 1–10 and Bob values 11–20
+            assertEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+                         11, 12, 13, 14, 15, 16, 17, 18, 19, 20], withRule);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testRemoveFilterCoveredByIndexInteraction: function () {
+            // replace-any-eq-with-in gates the remove-filter-covered-by-index cascade:
+            // the rewrite produces BINARY_IN, which use-indexes can match to an index,
+            // after which remove-filter-covered-by-index drops the now-redundant FilterNode.
+            // Without the rewrite, BINARY_ARRAY_EQ ANY == is not index-eligible, FilterNode stays.
+            const query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == x.name SORT x.value RETURN x.value";
+
+            // WITH replace-any-eq-with-in: FilterNode is removed by the cascade.
+            const planWithRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: [
+                    "-all",
+                    "+replace-any-eq-with-in",
+                    "+use-indexes",
+                    "+remove-filter-covered-by-index"
+                ]}}
+            }).explain();
+
+            assertTrue(planWithRule.plan.rules.indexOf(ruleName) !== -1,
+                "replace-any-eq-with-in should fire");
+            assertEqual(0, findExecutionNodes(planWithRule, "FilterNode").length,
+                "FilterNode should be removed: index covers the rewritten IN condition");
+
+            // WITHOUT replace-any-eq-with-in: BINARY_ARRAY_EQ ANY == is not index-eligible,
+            // FilterNode remains.
+            const planWithoutRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: [
+                    "-all",
+                    "+use-indexes",
+                    "+remove-filter-covered-by-index"
+                ]}}
+            }).explain();
+
+            assertTrue(findExecutionNodes(planWithoutRule, "FilterNode").length > 0,
+                "FilterNode should remain without replace-any-eq-with-in");
+
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results should match");
+        },
+
+        testSortInValuesInteraction: function () {
+            // replace-any-eq-with-in gates sort-in-values: the rewrite produces BINARY_IN,
+            // which sort-in-values wraps in SORTED_UNIQUE() for arrays with >= 8 elements.
+            // Without the rewrite there is no BINARY_IN node, so sort-in-values never fires.
+            const query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob', 'Carol', 'David', " +
+                "         'Eve', 'Frank', 'Grace', 'Henry'] " +
+                " ANY == x.name SORT x.value RETURN x.value";
+
+            // WITH replace-any-eq-with-in: rewrite produces BINARY_IN → sort-in-values fires.
+            const planWithRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+sort-in-values"]}}
+            }).explain();
+
+            assertTrue(planWithRule.plan.rules.indexOf(ruleName) !== -1,
+                "replace-any-eq-with-in should fire");
+            assertTrue(planWithRule.plan.rules.indexOf("sort-in-values") !== -1,
+                "sort-in-values should fire on the rewritten IN expression with >= 8 values");
+
+            // WITHOUT replace-any-eq-with-in: no BINARY_IN → sort-in-values does not fire.
+            const planWithoutRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+sort-in-values"]}}
+            }).explain();
+
+            assertTrue(planWithoutRule.plan.rules.indexOf("sort-in-values") === -1,
+                "sort-in-values should not fire without replace-any-eq-with-in");
+
+            const withRule = executeWithRule(query, {});
+            const withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
         },
 

--- a/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
+++ b/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertTrue, fail */
+/*global assertEqual, assertTrue */
 
 var internal = require("internal");
 var jsunity = require("jsunity");
@@ -431,120 +431,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             ruleIsNotUsed(query, {});
         },
 
-        testIndexOptimizationWithNameIndex: function () {
-            var query =
-                "FOR x IN " + replace.name() +
-                " FILTER ['Alice', 'Bob'] ANY == x.name SORT x.value RETURN x.value";
-
-            var explainWithRule = db._createStatement({
-                query: query,
-                bindVars: {},
-                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+use-indexes"]}}
-            }).explain();
-
-            var explainWithoutRule = db._createStatement({
-                query: query,
-                bindVars: {},
-                options: {optimizer: {rules: ["-all", "+use-indexes"]}}
-            }).explain();
-
-            var planWithRule = explainWithRule.plan;
-            var planWithoutRule = explainWithoutRule.plan;
-
-            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
-                "Plan with rule should contain replace-any-eq-with-in");
-            assertTrue(planWithRule.rules.indexOf("use-indexes") !== -1,
-                "Plan with rule should contain use-indexes");
-
-            var indexNodesWith = findExecutionNodes(planWithRule, "IndexNode");
-            var enumNodesWith = findExecutionNodes(planWithRule, "EnumerateCollectionNode");
-            var indexNodesWithout = findExecutionNodes(planWithoutRule, "IndexNode");
-            var enumNodesWithout = findExecutionNodes(planWithoutRule, "EnumerateCollectionNode");
-
-            assertTrue(indexNodesWith.length > 0,
-                "Plan with replace-any-eq-with-in should use IndexNode. " +
-                "Rules: " + JSON.stringify(planWithRule.rules));
-            assertTrue(enumNodesWith.length === 0,
-                "Plan with replace-any-eq-with-in should NOT use EnumerateCollectionNode");
-
-            if (indexNodesWithout.length === 0) {
-                assertTrue(enumNodesWithout.length > 0,
-                    "Plan without replace-any-eq-with-in should use EnumerateCollectionNode");
-            }
-
-            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
-            var withRule = executeWithRule(query, {});
-            var withoutRule = executeWithoutRule(query, {});
-
-            assertEqual(expected, withRule);
-            assertEqual(withRule, withoutRule, "Results should match");
-        },
-
-        testIndexOptimizationWithNestedAttributeIndex: function () {
-            var query =
-                "FOR x IN " + replace.name() +
-                " FILTER [1, 2] ANY == x.a.b SORT x.a.b RETURN x.a.b";
-
-            var explainWithRule = db._createStatement({
-                query: query,
-                bindVars: {},
-                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+use-indexes"]}}
-            }).explain();
-
-            var planWithRule = explainWithRule.plan;
-
-            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
-                "Plan with rule should contain replace-any-eq-with-in");
-            assertTrue(planWithRule.rules.indexOf("use-indexes") !== -1,
-                "Plan with rule should contain use-indexes");
-
-            var indexNodesWith = findExecutionNodes(planWithRule, "IndexNode");
-            var enumNodesWith = findExecutionNodes(planWithRule, "EnumerateCollectionNode");
-
-            assertTrue(indexNodesWith.length > 0,
-                "Plan with replace-any-eq-with-in should use IndexNode for nested attribute");
-            assertTrue(enumNodesWith.length === 0,
-                "Plan with replace-any-eq-with-in should NOT use EnumerateCollectionNode");
-
-            var expected = [1, 2];
-            var withRule = executeWithRule(query, {});
-            var withoutRule = executeWithoutRule(query, {});
-
-            assertEqual(expected, withRule);
-            assertEqual(withRule, withoutRule, "Results should match");
-        },
-
-        testIndexOptimizationMultipleConditions: function () {
-            var query =
-                "FOR x IN " + replace.name() +
-                " FILTER ['Alice'] ANY == x.name && x.value <= 10 SORT x.value RETURN x.value";
-
-            var explainWithRule = db._createStatement({
-                query: query,
-                bindVars: {},
-                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+use-indexes"]}}
-            }).explain();
-
-            var planWithRule = explainWithRule.plan;
-
-            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
-                "Plan with rule should contain replace-any-eq-with-in");
-            assertTrue(planWithRule.rules.indexOf("use-indexes") !== -1,
-                "Plan with rule should contain use-indexes");
-
-            var indexNodesWith = findExecutionNodes(planWithRule, "IndexNode");
-
-            assertTrue(indexNodesWith.length > 0,
-                "Plan with replace-any-eq-with-in should use IndexNode even with multiple conditions");
-
-            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-            var withRule = executeWithRule(query, {});
-            var withoutRule = executeWithoutRule(query, {});
-
-            assertEqual(expected, withRule);
-            assertEqual(withRule, withoutRule, "Results should match");
-        },
-
         testFiresSpecialCharacters: function () {
             var query = "FOR x IN " + replace.name() +
                 " FILTER ['Alice', 'O\\'Brien', 'test\"quote', 'new\\nline'] ANY == x.name SORT x.value RETURN x.value";
@@ -570,29 +456,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
 
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
-            assertEqual(withRule, withoutRule, "Results with and without rule should match");
-        },
-
-        testSingleValueOptimization: function () {
-            var query = "FOR x IN " + replace.name() +
-                " FILTER ['Alice'] ANY == x.name SORT x.value RETURN x.value";
-
-            var explainWithRule = db._createStatement({
-                query: query,
-                bindVars: {},
-                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in"]}}
-            }).explain();
-
-            var planWithRule = explainWithRule.plan;
-
-            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
-                "Plan with rule should contain replace-any-eq-with-in");
-
-            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-            var withRule = executeWithRule(query, {});
-            var withoutRule = executeWithoutRule(query, {});
-
-            assertEqual(expected, withRule);
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
         },
 

--- a/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
+++ b/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
@@ -1,0 +1,651 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertTrue, fail */
+
+var internal = require("internal");
+var jsunity = require("jsunity");
+var helper = require("@arangodb/aql-helper");
+var getQueryResults = helper.getQueryResults;
+var findExecutionNodes = helper.findExecutionNodes;
+const db = require('internal').db;
+let IM = global.instanceManager;
+
+function NewAqlReplaceAnyWithINTestSuite() {
+    var replace;
+    var ruleName = "replace-any-eq-with-in";
+
+    var getPlan = function (query, params, options) {
+        return db._createStatement({query: query, bindVars: params, options: options}).explain().plan;
+    };
+
+    var ruleIsNotUsed = function (query, params) {
+        var plan = getPlan(query, params, {optimizer: {rules: ["-all", "+" + ruleName]}});
+        assertTrue(plan.rules.indexOf(ruleName) === -1, "Rule should not be used: " + query);
+    };
+
+    var executeWithRule = function (query, params) {
+        return db._query(query, params, {optimizer: {rules: ["-all", "+" + ruleName]}}).toArray();
+    };
+
+    var executeWithoutRule = function (query, params) {
+        return db._query(query, params, {optimizer: {rules: ["-all"]}}).toArray();
+    };
+
+    var executeWithOrRule = function (query, params) {
+        return db._query(query, params, {optimizer: {rules: ["-all", "+replace-or-with-in"]}}).toArray();
+    };
+
+    var verifyExecutionPlan = function (query, params) {
+        var explainWithRule = db._createStatement({
+            query: query,
+            bindVars: params || {},
+            options: {optimizer: {rules: ["-all", "+" + ruleName]}}
+        }).explain();
+
+        var explainWithoutRule = db._createStatement({
+            query: query,
+            bindVars: params || {},
+            options: {optimizer: {rules: ["-all"]}}
+        }).explain();
+
+        var planWithRule = explainWithRule.plan;
+        var planWithoutRule = explainWithoutRule.plan;
+
+        assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
+            "Plan with rule enabled should contain rule '" + ruleName + "': " + query);
+        assertTrue(planWithoutRule.rules.indexOf(ruleName) === -1,
+            "Plan without rule should NOT contain rule '" + ruleName + "': " + query);
+
+        var filterNodesWith = findExecutionNodes(planWithRule, "FilterNode");
+        var filterNodesWithout = findExecutionNodes(planWithoutRule, "FilterNode");
+        var calcNodesWith = findExecutionNodes(planWithRule, "CalculationNode");
+        var calcNodesWithout = findExecutionNodes(planWithoutRule, "CalculationNode");
+
+        assertTrue(filterNodesWith.length > 0 && filterNodesWithout.length > 0,
+            "Plans should have FilterNodes: " + query);
+        assertTrue(calcNodesWith.length > 0 && calcNodesWithout.length > 0,
+            "Plans should have CalculationNodes: " + query);
+
+        assertTrue(planWithRule.nodes.length > 0, "Plan with rule should have nodes: " + query);
+        assertTrue(planWithoutRule.nodes.length > 0, "Plan without rule should have nodes: " + query);
+
+        return {withRule: planWithRule, withoutRule: planWithoutRule};
+    };
+
+    var verifyPlansDifferent = function (planWithRule, planWithoutRule, query) {
+        assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
+            "Plan with rule enabled should contain the rule: " + query);
+        assertTrue(planWithoutRule.rules.indexOf(ruleName) === -1,
+            "Plan without rule should not contain the rule: " + query);
+
+        var calcNodesWith = findExecutionNodes(planWithRule, "CalculationNode");
+        var calcNodesWithout = findExecutionNodes(planWithoutRule, "CalculationNode");
+
+        assertTrue(calcNodesWith.length > 0 || calcNodesWithout.length > 0,
+            "Plans should have calculation nodes: " + query);
+
+        assertTrue(planWithRule.nodes.length > 0, "Plan with rule should have nodes");
+        assertTrue(planWithoutRule.nodes.length > 0, "Plan without rule should have nodes");
+    };
+
+    return {
+
+        setUpAll: function () {
+            IM.debugClearFailAt();
+            internal.db._drop("UnitTestsNewAqlReplaceAnyWithINTestSuite");
+            replace = internal.db._create("UnitTestsNewAqlReplaceAnyWithINTestSuite");
+
+            let docs = [];
+            for (var i = 1; i <= 10; ++i) {
+                docs.push({"value": i, "name": "Alice", "tags": ["a", "b"], "categories": ["x", "y"]});
+                docs.push({"value": i + 10, "name": "Bob", "tags": ["b", "c"], "categories": ["y", "z"]});
+                docs.push({"value": i + 20, "name": "Carol", "tags": ["c", "d"], "categories": ["z"]});
+                docs.push({"a": {"b": i}});
+            }
+            replace.insert(docs);
+
+            replace.ensureIndex({type: "persistent", fields: ["name"]});
+            replace.ensureIndex({type: "persistent", fields: ["a.b"]});
+        },
+
+        tearDownAll: function () {
+            IM.debugClearFailAt();
+            internal.db._drop("UnitTestsNewAqlReplaceAnyWithINTestSuite");
+            replace = null;
+        },
+
+        setUp: function () {
+            IM.debugClearFailAt();
+        },
+
+        tearDown: function () {
+            IM.debugClearFailAt();
+        },
+
+        testFiresBasic: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == x.name SORT x.value RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresSingleValue: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER ['Alice'] ANY == x.name SORT x.value RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "FOR x IN " + replace.name() +
+                " FILTER x.name == 'Alice' SORT x.value RETURN x.value";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresEmptyArray: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER [] ANY == x.name RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var inQuery = "FOR x IN " + replace.name() +
+                " FILTER x.name IN [] RETURN x.value";
+            var inResult = executeWithOrRule(inQuery, {});
+            assertEqual(withRule, inResult, "Results with ANY == should match IN query");
+        },
+
+        testFiresVariableArray: function () {
+            // lhs is a computed (non-literal) array — rule still fires
+            var query = "FOR x IN " + replace.name() +
+                " FILTER [x.value, x.value + 1] ANY == 5 SORT x.value RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+            // x.value==4: [4,5] ANY == 5 is true; x.value==5: [5,6] ANY == 5 is true
+            assertTrue(withRule.indexOf(4) !== -1, "value 4 should match");
+            assertTrue(withRule.indexOf(5) !== -1, "value 5 should match");
+        },
+
+        testFiresArrayOfArrays: function () {
+            // lhs is an array of arrays — rule fires, element comparison is deep
+            // [['ALICE'], ['BOB']] ANY == ['Bob'] → ['Bob'] IN [['ALICE'], ['BOB']]
+            // 'BOB' != 'Bob' (case-sensitive) → false → 0 docs
+            var query = "FOR x IN " + replace.name() +
+                " FILTER [['ALICE'], ['BOB']] ANY == ['Bob'] RETURN x.value";
+
+            var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(0, withRule.length);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresManyValues: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob', 'Carol', 'David', " +
+                "         'Eve', 'Frank', 'Grace', 'Henry'] " +
+                " ANY == x.name SORT x.value RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+                            16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "FOR x IN " + replace.name() +
+                " FILTER x.name == 'Alice' || x.name == 'Bob' || x.name == 'Carol' || x.name == 'David' ||" +
+                "        x.name == 'Eve' || x.name == 'Frank' || x.name == 'Grace' || x.name == 'Henry' " +
+                " SORT x.value RETURN x.value";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresNestedAttribute: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER [1, 2] ANY == x.a.b SORT x.a.b RETURN x.a.b";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "FOR x IN " + replace.name() +
+                " FILTER x.a.b == 1 || x.a.b == 2 SORT x.a.b RETURN x.a.b";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresBind: function () {
+            var query =
+                "FOR v IN " + replace.name()
+                + " FILTER @names ANY == v.name SORT v.value RETURN v.value";
+            var params = {"names": ["Alice", "Bob"]};
+
+            var plans = verifyExecutionPlan(query, params);
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            var actual = getQueryResults(query, params);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, params);
+            var withoutRule = executeWithoutRule(query, params);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "FOR v IN " + replace.name()
+                + " FILTER v.name == 'Alice' || v.name == 'Bob' SORT v.value RETURN v.value";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresVariables: function () {
+            var query =
+                "LET names = ['Alice', 'Bob'] FOR v IN " + replace.name()
+                + " FILTER names ANY == v.name SORT v.value RETURN v.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            var actual = getQueryResults(query, {});
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "LET names = ['Alice', 'Bob'] FOR v IN " + replace.name()
+                + " FILTER v.name == 'Alice' || v.name == 'Bob' SORT v.value RETURN v.value";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresMultipleAnyEq: function () {
+            var query =
+                "FOR v IN " + replace.name()
+                + " FILTER ['Alice', 'Bob'] ANY == v.name && v.value <= 20 SORT v.value RETURN v.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            var actual = getQueryResults(query, {});
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "FOR v IN " + replace.name()
+                + " FILTER (v.name == 'Alice' || v.name == 'Bob') && v.value <= 20 SORT v.value RETURN v.value";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresMultipleAnyEqDifferentAttributes: function () {
+            var query =
+                "FOR v IN " + replace.name()
+                + " FILTER ['Alice'] ANY == v.name && v.value <= 10 SORT v.value RETURN v.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var actual = getQueryResults(query, {});
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var orQuery = "FOR v IN " + replace.name()
+                + " FILTER v.name == 'Alice' && v.value <= 10 SORT v.value RETURN v.value";
+            var orResult = executeWithOrRule(orQuery, {});
+            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
+        },
+
+        testFiresNoCollection: function () {
+            var query =
+                "FOR x in 1..10 LET doc = {name: 'Alice', value: x} FILTER ['Alice', 'Bob'] " +
+                "ANY == doc.name SORT doc.value RETURN doc.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testFiresNestedInSubquery: function () {
+            var query =
+                "FOR outer IN " + replace.name() +
+                " LET sub = (FOR inner IN " + replace.name() +
+                " FILTER ['Alice'] ANY == inner.name RETURN inner.value)" +
+                " FILTER ['Alice'] ANY == outer.name RETURN outer.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var actual = getQueryResults(query, {});
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+        },
+
+        testSkipsAllQuantifier: function () {
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ALL == x.name RETURN x.value";
+
+            ruleIsNotUsed(query, {});
+        },
+
+        testFiresScalarLhs: function () {
+            // lhs='Alice' is not an array → rule fires, x.name IN 'Alice' → false → 0 docs.
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER 'Alice' ANY == x.name RETURN x.value";
+
+            var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+            assertEqual(0, executeWithRule(query, {}).length);
+        },
+
+        testFiresNonDeterministicLhs: function () {
+            // lhs=NOOPT([...]) is non-deterministic → rule fires, results match ANY ==.
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER NOOPT(['Alice', 'Bob']) ANY == x.name RETURN x.value";
+
+            var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withoutRule.length, withRule.length);
+        },
+
+        testFiresConstantRhs: function () {
+            // ['Alice', 'Bob'] ANY == 'Alice' → 'Alice' IN ['Alice', 'Bob'] = true constant.
+            // All 40 docs are returned.
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == 'Alice' RETURN x.value";
+
+            var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+            assertEqual(40, executeWithRule(query, {}).length);
+        },
+
+        testFiresBothConstantArrays: function () {
+            // ['Alice'] ANY == ['Bob'] → ['Bob'] IN ['Alice'] = false constant.
+            // 0 docs are returned.
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice'] ANY == ['Bob'] RETURN x.value";
+
+            var plan = getPlan(query, {}, {optimizer: {rules: ["-all", "+" + ruleName]}});
+            assertTrue(plan.rules.indexOf(ruleName) !== -1, "Rule should fire");
+            assertEqual(0, executeWithRule(query, {}).length);
+        },
+
+        testSkipsAnyNe: function () {
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY != x.name RETURN x.value";
+
+            ruleIsNotUsed(query, {});
+        },
+
+        testIndexOptimizationWithNameIndex: function () {
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == x.name SORT x.value RETURN x.value";
+
+            var explainWithRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+use-indexes"]}}
+            }).explain();
+
+            var explainWithoutRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+use-indexes"]}}
+            }).explain();
+
+            var planWithRule = explainWithRule.plan;
+            var planWithoutRule = explainWithoutRule.plan;
+
+            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
+                "Plan with rule should contain replace-any-eq-with-in");
+            assertTrue(planWithRule.rules.indexOf("use-indexes") !== -1,
+                "Plan with rule should contain use-indexes");
+
+            var indexNodesWith = findExecutionNodes(planWithRule, "IndexNode");
+            var enumNodesWith = findExecutionNodes(planWithRule, "EnumerateCollectionNode");
+            var indexNodesWithout = findExecutionNodes(planWithoutRule, "IndexNode");
+            var enumNodesWithout = findExecutionNodes(planWithoutRule, "EnumerateCollectionNode");
+
+            assertTrue(indexNodesWith.length > 0,
+                "Plan with replace-any-eq-with-in should use IndexNode. " +
+                "Rules: " + JSON.stringify(planWithRule.rules));
+            assertTrue(enumNodesWith.length === 0,
+                "Plan with replace-any-eq-with-in should NOT use EnumerateCollectionNode");
+
+            if (indexNodesWithout.length === 0) {
+                assertTrue(enumNodesWithout.length > 0,
+                    "Plan without replace-any-eq-with-in should use EnumerateCollectionNode");
+            }
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+
+            assertEqual(expected, withRule);
+            assertEqual(withRule, withoutRule, "Results should match");
+        },
+
+        testIndexOptimizationWithNestedAttributeIndex: function () {
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER [1, 2] ANY == x.a.b SORT x.a.b RETURN x.a.b";
+
+            var explainWithRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+use-indexes"]}}
+            }).explain();
+
+            var planWithRule = explainWithRule.plan;
+
+            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
+                "Plan with rule should contain replace-any-eq-with-in");
+            assertTrue(planWithRule.rules.indexOf("use-indexes") !== -1,
+                "Plan with rule should contain use-indexes");
+
+            var indexNodesWith = findExecutionNodes(planWithRule, "IndexNode");
+            var enumNodesWith = findExecutionNodes(planWithRule, "EnumerateCollectionNode");
+
+            assertTrue(indexNodesWith.length > 0,
+                "Plan with replace-any-eq-with-in should use IndexNode for nested attribute");
+            assertTrue(enumNodesWith.length === 0,
+                "Plan with replace-any-eq-with-in should NOT use EnumerateCollectionNode");
+
+            var expected = [1, 2];
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+
+            assertEqual(expected, withRule);
+            assertEqual(withRule, withoutRule, "Results should match");
+        },
+
+        testIndexOptimizationMultipleConditions: function () {
+            var query =
+                "FOR x IN " + replace.name() +
+                " FILTER ['Alice'] ANY == x.name && x.value <= 10 SORT x.value RETURN x.value";
+
+            var explainWithRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in", "+use-indexes"]}}
+            }).explain();
+
+            var planWithRule = explainWithRule.plan;
+
+            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
+                "Plan with rule should contain replace-any-eq-with-in");
+            assertTrue(planWithRule.rules.indexOf("use-indexes") !== -1,
+                "Plan with rule should contain use-indexes");
+
+            var indexNodesWith = findExecutionNodes(planWithRule, "IndexNode");
+
+            assertTrue(indexNodesWith.length > 0,
+                "Plan with replace-any-eq-with-in should use IndexNode even with multiple conditions");
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+
+            assertEqual(expected, withRule);
+            assertEqual(withRule, withoutRule, "Results should match");
+        },
+
+        testFiresSpecialCharacters: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'O\\'Brien', 'test\"quote', 'new\\nline'] ANY == x.name SORT x.value RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var actual = getQueryResults(query);
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var inQuery = "FOR x IN " + replace.name() +
+                " FILTER x.name IN ['Alice', 'O\\'Brien', 'test\"quote', 'new\\nline'] SORT x.value RETURN x.value";
+            var inResult = executeWithOrRule(inQuery, {});
+            assertEqual(withRule, inResult, "Results with ANY == should match IN query");
+        },
+
+        testFiresIndexedAccess: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER ['Alice', 'Bob'] ANY == x['name'] SORT x.value RETURN x.value";
+
+            var plans = verifyExecutionPlan(query, {});
+            verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+            var actual = getQueryResults(query);
+            assertEqual(expected, actual);
+
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var inQuery = "FOR x IN " + replace.name() +
+                " FILTER x['name'] IN ['Alice', 'Bob'] SORT x.value RETURN x.value";
+            var inResult = executeWithOrRule(inQuery, {});
+            assertEqual(withRule, inResult, "Results with ANY == should match IN query");
+        },
+
+        testSingleValueOptimization: function () {
+            var query = "FOR x IN " + replace.name() +
+                " FILTER ['Alice'] ANY == x.name SORT x.value RETURN x.value";
+
+            var explainWithRule = db._createStatement({
+                query: query,
+                bindVars: {},
+                options: {optimizer: {rules: ["-all", "+replace-any-eq-with-in"]}}
+            }).explain();
+
+            var planWithRule = explainWithRule.plan;
+
+            assertTrue(planWithRule.rules.indexOf(ruleName) !== -1,
+                "Plan with rule should contain replace-any-eq-with-in");
+
+            var expected = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+            var withRule = executeWithRule(query, {});
+            var withoutRule = executeWithoutRule(query, {});
+
+            assertEqual(expected, withRule);
+            assertEqual(withRule, withoutRule, "Results with and without rule should match");
+
+            var eqQuery = "FOR x IN " + replace.name() +
+                " FILTER x.name == 'Alice' SORT x.value RETURN x.value";
+            var eqResult = db._query(eqQuery).toArray();
+            assertEqual(withRule, eqResult, "Single-value ANY == should match == query");
+        },
+
+        testAnyOrBranchesOnSameAttribute: function () {
+            var query = "FOR doc IN " + replace.name() +
+                " FILTER [5] ANY == doc.value OR [15] ANY == doc.value RETURN doc";
+            
+            var result = db._query(query).toArray();
+            assertEqual(2, result.length, "Should return 2 documents with value 5 or 15");
+            
+            var values = result.map(d => d.value).sort((a, b) => a - b);
+            assertEqual([5, 15], values);
+            
+            var plan = db._createStatement({query: query}).explain();
+            var foundRule = plan.plan.rules.indexOf("replace-any-eq-with-in") !== -1;
+            assertTrue(foundRule, "replace-any-eq-with-in rule should fire");
+        }
+    };
+}
+
+jsunity.run(NewAqlReplaceAnyWithINTestSuite);
+
+return jsunity.done();
+

--- a/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
+++ b/tests/js/client/aql/aql-optimizer-rule-replace-any-with-in.js
@@ -30,10 +30,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
         return db._query(query, params, {optimizer: {rules: ["-all"]}}).toArray();
     };
 
-    var executeWithOrRule = function (query, params) {
-        return db._query(query, params, {optimizer: {rules: ["-all", "+replace-or-with-in"]}}).toArray();
-    };
-
     var verifyExecutionPlan = function (query, params) {
         var explainWithRule = db._createStatement({
             query: query,
@@ -151,11 +147,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "FOR x IN " + replace.name() +
-                " FILTER x.name == 'Alice' SORT x.value RETURN x.value";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresEmptyArray: function () {
@@ -172,11 +163,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var inQuery = "FOR x IN " + replace.name() +
-                " FILTER x.name IN [] RETURN x.value";
-            var inResult = executeWithOrRule(inQuery, {});
-            assertEqual(withRule, inResult, "Results with ANY == should match IN query");
         },
 
         testFiresVariableArray: function () {
@@ -228,13 +214,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "FOR x IN " + replace.name() +
-                " FILTER x.name == 'Alice' || x.name == 'Bob' || x.name == 'Carol' || x.name == 'David' ||" +
-                "        x.name == 'Eve' || x.name == 'Frank' || x.name == 'Grace' || x.name == 'Henry' " +
-                " SORT x.value RETURN x.value";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresNestedAttribute: function () {
@@ -251,11 +230,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "FOR x IN " + replace.name() +
-                " FILTER x.a.b == 1 || x.a.b == 2 SORT x.a.b RETURN x.a.b";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresBind: function () {
@@ -274,11 +248,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, params);
             var withoutRule = executeWithoutRule(query, params);
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "FOR v IN " + replace.name()
-                + " FILTER v.name == 'Alice' || v.name == 'Bob' SORT v.value RETURN v.value";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresVariables: function () {
@@ -296,11 +265,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "LET names = ['Alice', 'Bob'] FOR v IN " + replace.name()
-                + " FILTER v.name == 'Alice' || v.name == 'Bob' SORT v.value RETURN v.value";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresMultipleAnyEq: function () {
@@ -318,11 +282,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "FOR v IN " + replace.name()
-                + " FILTER (v.name == 'Alice' || v.name == 'Bob') && v.value <= 20 SORT v.value RETURN v.value";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresMultipleAnyEqDifferentAttributes: function () {
@@ -340,11 +299,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var orQuery = "FOR v IN " + replace.name()
-                + " FILTER v.name == 'Alice' && v.value <= 10 SORT v.value RETURN v.value";
-            var orResult = executeWithOrRule(orQuery, {});
-            assertEqual(withRule, orResult, "Results with ANY == should match OR query");
         },
 
         testFiresNoCollection: function () {
@@ -577,15 +531,9 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var plans = verifyExecutionPlan(query, {});
             verifyPlansDifferent(plans.withRule, plans.withoutRule, query);
 
-            var actual = getQueryResults(query);
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var inQuery = "FOR x IN " + replace.name() +
-                " FILTER x.name IN ['Alice', 'O\\'Brien', 'test\"quote', 'new\\nline'] SORT x.value RETURN x.value";
-            var inResult = executeWithOrRule(inQuery, {});
-            assertEqual(withRule, inResult, "Results with ANY == should match IN query");
         },
 
         testFiresIndexedAccess: function () {
@@ -602,11 +550,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
             var withRule = executeWithRule(query, {});
             var withoutRule = executeWithoutRule(query, {});
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var inQuery = "FOR x IN " + replace.name() +
-                " FILTER x['name'] IN ['Alice', 'Bob'] SORT x.value RETURN x.value";
-            var inResult = executeWithOrRule(inQuery, {});
-            assertEqual(withRule, inResult, "Results with ANY == should match IN query");
         },
 
         testSingleValueOptimization: function () {
@@ -630,11 +573,6 @@ function NewAqlReplaceAnyWithINTestSuite() {
 
             assertEqual(expected, withRule);
             assertEqual(withRule, withoutRule, "Results with and without rule should match");
-
-            var eqQuery = "FOR x IN " + replace.name() +
-                " FILTER x.name == 'Alice' SORT x.value RETURN x.value";
-            var eqResult = db._query(eqQuery).toArray();
-            assertEqual(withRule, eqResult, "Single-value ANY == should match == query");
         },
 
         testAnyOrBranchesOnSameAttribute: function () {


### PR DESCRIPTION
### Scope & Purpose

This PR is an independent branch that implements the main optimization introduced in https://github.com/arangodb/arangodb/pull/22164. The rule maps filter nodes in the format FILTER expr1 ANY == expr2 to FILTER expr2 IN expr1.                                                                                  
                                                                                                                                                              
   Example:                                                                                                                                                   
  ` FILTER ['Alice', 'Bob'] ANY == doc.name
  becomes:                                                                                                                                                   
  FILTER doc.name IN ['Alice', 'Bob'] `
  Here, the two forms are semantically equivalent, and the grammar already makes sure exp1 is an array.
  
The BINARY_ARRAY_EQ operator used in the ANY == format expression is invisible to the downstream optimizer rules, so such filters won't take advantage of them, rules such as use-indexes  (when exp2 is an attribute access, for applying a persistent index on an attribute on the right hand side expression of the ANY ==) and removeUnnecessaryFiltersRule. For the latter, we need to let expr2 be generic, not obligating it to be a non-constant, hence, in the code, there's no guard to check if exp2 is an attribute access, accepting other types of expressions such as constants. 
    

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-411
- [ ] Design document: 
