### PR TITLE
[COR-444] Vector index training dataset sampling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* COR-444: Vector index training now draws a uniformly random training set
+  via reservoir sampling (Algorithm L) over a full iteration of the
+  collection, instead of keeping the first `nLists * 256` documents.
+
 * COR-415: Fix vector index catch-up phase to use the proper
   `fillIndexBackground` path via `RocksDBBuilderIndex`. This ensures that
   WAL entries written during training are correctly ingested, preventing

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -37,7 +37,6 @@
 #include <cstdint>
 #include <format>
 #include <functional>
-#include <optional>
 #include <string>
 #include <thread>
 
@@ -218,6 +217,15 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
                                            std::stop_token stopToken) const {
   auto const& def = _index.getDefinition();
   bool const sparseScaling = _index.sparse() && isNListsScaling(def.nLists);
+
+  // Empty collection: resolveNLists would reject this in scaling mode, but the
+  // situation is "no vectors to train on", not a parameter error.
+  if (numDocsHint == 0) {
+    return Result{TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
+                  "For the vector index to be created documents "
+                  "must be present in the respective collection for the "
+                  "training process."};
+  }
 
   // Size the reservoir from numDocsHint. For sparse+scaling this is an upper
   // bound on the valid vector count; the post-iteration resize below shrinks

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -352,10 +352,9 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
   ReservoirSampler sampler{def.dimension, reservoirCapacity, rng};
   std::vector<float> input;
   input.reserve(def.dimension);
-  std::size_t iterationCounter{0};
 
   while (it.Valid()) {
-    if (iterationCounter % 1000 == 0 && stopToken.stop_requested()) {
+    if (stopToken.stop_requested()) {
       return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                     "vector training aborted"};
     }
@@ -366,7 +365,6 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
         res.fail()) {
       if (res.is(TRI_ERROR_BAD_PARAMETER) && _index.sparse()) {
         it.Next();
-        ++iterationCounter;
         continue;
       }
       return Result{
@@ -379,7 +377,6 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
     sampler.consume(input);
     input.clear();
     it.Next();
-    ++iterationCounter;
   }
 
   std::size_t const validSeen = sampler.itemsSeen();

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -213,100 +213,6 @@ std::shared_ptr<faiss::IndexIVF> VectorIndexTrainer::createFaissIndex(
 
 namespace {
 
-// Reservoir sampler implementing Algorithm L (Li 1994) for uniform-without-
-// replacement sampling over a stream of unknown-but-bounded length. Each
-// slot holds `dimension` consecutive floats. With no capacity set, consume()
-// just appends — useful when we don't know an upper bound on the stream size.
-class ReservoirSampler {
- public:
-  ReservoirSampler(std::size_t dimension, std::optional<std::size_t> capacity,
-                   std::mt19937_64& rng)
-      : _dimension{dimension}, _capacity{capacity}, _rng{rng} {
-    if (_capacity.has_value()) {
-      _data.reserve(*_capacity * _dimension);
-    }
-  }
-
-  void consume(std::vector<float> const& vector) {
-    TRI_ASSERT(vector.size() == _dimension);
-    if (!_capacity.has_value() || _itemsSeen < *_capacity) {
-      _data.insert(_data.end(), vector.begin(), vector.end());
-      ++_itemsSeen;
-      if (_capacity.has_value() && _itemsSeen == *_capacity) {
-        primeSampler();
-      }
-      return;
-    }
-    if (_itemsSeen == _nextReplacement) {
-      std::size_t const k = *_capacity;
-      std::uniform_int_distribution<std::size_t> slotDist{0, k - 1};
-      std::size_t const slot = slotDist(_rng);
-      std::copy(vector.begin(), vector.end(),
-                _data.begin() + slot * _dimension);
-      _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
-      TRI_ASSERT(_w > 0.0 && _w < 1.0);
-      _nextReplacement += 1 + skipCount(_w);
-    }
-    ++_itemsSeen;
-  }
-
-  // Uniformly subsample down to `newCapacity` slots via a partial
-  // Fisher–Yates shuffle. No-op if the reservoir already fits.
-  void resize(std::size_t newCapacity) {
-    std::size_t const current = _data.size() / _dimension;
-    if (newCapacity >= current) {
-      return;
-    }
-    for (std::size_t i = 0; i < newCapacity; ++i) {
-      std::uniform_int_distribution<std::size_t> dist{i, current - 1};
-      std::size_t const j = dist(_rng);
-      if (i != j) {
-        std::swap_ranges(_data.begin() + i * _dimension,
-                         _data.begin() + (i + 1) * _dimension,
-                         _data.begin() + j * _dimension);
-      }
-    }
-    _data.resize(newCapacity * _dimension);
-  }
-
-  std::vector<float> release() && { return std::move(_data); }
-  std::size_t itemsSeen() const noexcept { return _itemsSeen; }
-
- private:
-  // Draws u ∈ (0, 1); rejects 0 so std::log(u) stays finite.
-  double sampleOpenUnit() {
-    std::uniform_real_distribution<double> dist;
-    double u;
-    do {
-      u = dist(_rng);
-    } while (u <= 0.0);
-    return u;
-  }
-
-  // Geometric skip count: floor(log(U) / log(1 - w)). Uses log1p for
-  // numerical stability when w is close to 0.
-  std::size_t skipCount(double w) {
-    return static_cast<std::size_t>(
-        std::floor(std::log(sampleOpenUnit()) / std::log1p(-w)));
-  }
-
-  void primeSampler() {
-    std::size_t const k = *_capacity;
-    TRI_ASSERT(k > 0);
-    _w = std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
-    TRI_ASSERT(_w > 0.0 && _w < 1.0);
-    _nextReplacement = k + skipCount(_w);
-  }
-
-  std::size_t _dimension;
-  std::optional<std::size_t> _capacity;
-  std::mt19937_64& _rng;
-  std::size_t _itemsSeen{0};
-  double _w{0.0};
-  std::size_t _nextReplacement{0};
-  std::vector<float> _data;
-};
-
 std::uint64_t makeSeed() {
   std::random_device rd;
   return (static_cast<std::uint64_t>(rd()) << 32) |
@@ -338,7 +244,6 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
   }
 
   std::uint64_t const seed = makeSeed();
-  std::mt19937_64 rng{seed};
 
   LOG_TOPIC("b161b", INFO, Logger::ENGINES) << std::format(
       "[shard={}, index={}] Collecting training data dimension {} for {} "
@@ -349,7 +254,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
                                     : std::string{"unbounded"},
       seed);
 
-  ReservoirSampler sampler{def.dimension, reservoirCapacity, rng};
+  VectorIndexTrainingSampler sampler{def.dimension, reservoirCapacity, seed};
   std::vector<float> input;
   input.reserve(def.dimension);
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -38,7 +38,6 @@
 #include <format>
 #include <functional>
 #include <optional>
-#include <random>
 #include <string>
 #include <thread>
 
@@ -49,6 +48,7 @@
 #include "Basics/voc-errors.h"
 #include "Indexes/Index.h"
 #include "Logger/LogMacros.h"
+#include "Random/RandomGenerator.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "RocksDBEngine/RocksDBColumnFamilyManager.h"
 #include "RocksDBEngine/RocksDBCommon.h"
@@ -211,16 +211,6 @@ std::shared_ptr<faiss::IndexIVF> VectorIndexTrainer::createFaissIndex(
   }
 }
 
-namespace {
-
-std::uint64_t makeSeed() {
-  std::random_device rd;
-  return (static_cast<std::uint64_t>(rd()) << 32) |
-         static_cast<std::uint64_t>(rd());
-}
-
-}  // namespace
-
 ResultT<VectorIndexTrainer::TrainingDataset>
 VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
                                            rocksdb::Slice upper,
@@ -243,7 +233,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
     reservoirCapacity = resolved.get() * kMaxTrainingSizePerNLists;
   }
 
-  std::uint64_t const seed = makeSeed();
+  auto const seed = RandomDevice::seed64();
 
   LOG_TOPIC("b161b", INFO, Logger::ENGINES) << std::format(
       "[shard={}, index={}] Collecting training data dimension {} for {} "
@@ -283,9 +273,8 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
 
   std::size_t const validSeen = sampler.itemsSeen();
 
-  // Sparse+scaling: resize the reservoir to the k implied by the actual
-  // valid-vector count. A uniform subsample of a uniform sample stays
-  // uniform, so this preserves the Algorithm L guarantee.
+  // Sparse+scaling: we need to resize after full iteration since we cannot
+  // calculate the
   if (sparseScaling && validSeen > 0) {
     auto resolved = resolveNLists(validSeen);
     if (resolved.fail()) {
@@ -459,8 +448,7 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
 
       if constexpr (returnsResult) {
         setResult(fn());
-      }
-      else {
+      } else {
         fn();
       }
     } catch (basics::Exception const& e) {

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -37,6 +37,8 @@
 #include <cstdint>
 #include <format>
 #include <functional>
+#include <optional>
+#include <random>
 #include <string>
 #include <thread>
 
@@ -57,6 +59,7 @@
 #include "RocksDBEngine/RocksDBValue.h"
 #include "RocksDBEngine/RocksDBVectorIndexList.h"
 #include "Transaction/Helpers.h"
+#include "VectorIndex/VectorIndexTrainingSampler.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <rocksdb/db.h>
@@ -74,10 +77,6 @@
 #include "faiss/utils/distances.h"
 
 namespace arangodb::vector {
-
-// Minimum vectors to collect unconditionally before applying the adaptive cap
-// in the sparse+scaling path.
-constexpr std::size_t kSparseScalingBootstrapVectors{1000};
 
 Result readDocumentVectorData(
     velocypack::Slice doc,
@@ -212,41 +211,150 @@ std::shared_ptr<faiss::IndexIVF> VectorIndexTrainer::createFaissIndex(
   }
 }
 
+namespace {
+
+// Reservoir sampler implementing Algorithm L (Li 1994) for uniform-without-
+// replacement sampling over a stream of unknown-but-bounded length. Each
+// slot holds `dimension` consecutive floats. With no capacity set, consume()
+// just appends — useful when we don't know an upper bound on the stream size.
+class ReservoirSampler {
+ public:
+  ReservoirSampler(std::size_t dimension, std::optional<std::size_t> capacity,
+                   std::mt19937_64& rng)
+      : _dimension{dimension}, _capacity{capacity}, _rng{rng} {
+    if (_capacity.has_value()) {
+      _data.reserve(*_capacity * _dimension);
+    }
+  }
+
+  void consume(std::vector<float> const& vector) {
+    TRI_ASSERT(vector.size() == _dimension);
+    if (!_capacity.has_value() || _itemsSeen < *_capacity) {
+      _data.insert(_data.end(), vector.begin(), vector.end());
+      ++_itemsSeen;
+      if (_capacity.has_value() && _itemsSeen == *_capacity) {
+        primeSampler();
+      }
+      return;
+    }
+    if (_itemsSeen == _nextReplacement) {
+      std::size_t const k = *_capacity;
+      std::uniform_int_distribution<std::size_t> slotDist{0, k - 1};
+      std::size_t const slot = slotDist(_rng);
+      std::copy(vector.begin(), vector.end(),
+                _data.begin() + slot * _dimension);
+      _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
+      TRI_ASSERT(_w > 0.0 && _w < 1.0);
+      _nextReplacement += 1 + skipCount(_w);
+    }
+    ++_itemsSeen;
+  }
+
+  // Uniformly subsample down to `newCapacity` slots via a partial
+  // Fisher–Yates shuffle. No-op if the reservoir already fits.
+  void resize(std::size_t newCapacity) {
+    std::size_t const current = _data.size() / _dimension;
+    if (newCapacity >= current) {
+      return;
+    }
+    for (std::size_t i = 0; i < newCapacity; ++i) {
+      std::uniform_int_distribution<std::size_t> dist{i, current - 1};
+      std::size_t const j = dist(_rng);
+      if (i != j) {
+        std::swap_ranges(_data.begin() + i * _dimension,
+                         _data.begin() + (i + 1) * _dimension,
+                         _data.begin() + j * _dimension);
+      }
+    }
+    _data.resize(newCapacity * _dimension);
+  }
+
+  std::vector<float> release() && { return std::move(_data); }
+  std::size_t itemsSeen() const noexcept { return _itemsSeen; }
+
+ private:
+  // Draws u ∈ (0, 1); rejects 0 so std::log(u) stays finite.
+  double sampleOpenUnit() {
+    std::uniform_real_distribution<double> dist;
+    double u;
+    do {
+      u = dist(_rng);
+    } while (u <= 0.0);
+    return u;
+  }
+
+  // Geometric skip count: floor(log(U) / log(1 - w)). Uses log1p for
+  // numerical stability when w is close to 0.
+  std::size_t skipCount(double w) {
+    return static_cast<std::size_t>(
+        std::floor(std::log(sampleOpenUnit()) / std::log1p(-w)));
+  }
+
+  void primeSampler() {
+    std::size_t const k = *_capacity;
+    TRI_ASSERT(k > 0);
+    _w = std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
+    TRI_ASSERT(_w > 0.0 && _w < 1.0);
+    _nextReplacement = k + skipCount(_w);
+  }
+
+  std::size_t _dimension;
+  std::optional<std::size_t> _capacity;
+  std::mt19937_64& _rng;
+  std::size_t _itemsSeen{0};
+  double _w{0.0};
+  std::size_t _nextReplacement{0};
+  std::vector<float> _data;
+};
+
+std::uint64_t makeSeed() {
+  std::random_device rd;
+  return (static_cast<std::uint64_t>(rd()) << 32) |
+         static_cast<std::uint64_t>(rd());
+}
+
+}  // namespace
+
 ResultT<VectorIndexTrainer::TrainingDataset>
 VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
                                            rocksdb::Slice upper,
                                            std::uint64_t numDocsHint,
                                            std::stop_token stopToken) const {
   auto const& def = _index.getDefinition();
-  std::vector<float> trainingData;
-  std::vector<float> input;
-  input.reserve(def.dimension);
-  std::optional<std::size_t> maxVectors;
+  bool const sparseScaling = _index.sparse() && isNListsScaling(def.nLists);
 
-  LOG_TOPIC("b161b", INFO, Logger::ENGINES) << std::format(
-      "[shard={}, index={}] Collecting training data "
-      "dimension {} for training for {} index with the numDocsHint: {}.",
-      _index.collection().name(), _index.id().id(), def.dimension,
-      _index.sparse() ? "sparse" : "non-sparse", numDocsHint);
-
-  // We need to do a full iteration to properly resolve the number of nLists
-  bool const shouldDoFullIteration =
-      _index.sparse() && isNListsScaling(def.nLists);
-  if (!shouldDoFullIteration) {
+  // Size the reservoir from numDocsHint. For sparse+scaling this is an upper
+  // bound on the valid vector count, so we may subsample further once the
+  // actual count is known. If numDocsHint is 0 in sparse+scaling mode we have
+  // no upper bound and fall back to an unbounded reservoir; the subsample at
+  // the end still produces a uniform sample.
+  std::optional<std::size_t> reservoirCapacity;
+  if (!sparseScaling || numDocsHint > 0) {
     auto resolved = resolveNLists(numDocsHint);
     if (resolved.fail()) {
       return std::move(resolved).result();
     }
-    maxVectors = resolved.get() * kMaxTrainingSizePerNLists;
+    reservoirCapacity = resolved.get() * kMaxTrainingSizePerNLists;
   }
-  // only one of these can be true
-  TRI_ASSERT(shouldDoFullIteration ^ maxVectors.has_value());
 
-  std::size_t trainingDatasetCounter{0};
+  std::uint64_t const seed = makeSeed();
+  std::mt19937_64 rng{seed};
+
+  LOG_TOPIC("b161b", INFO, Logger::ENGINES) << std::format(
+      "[shard={}, index={}] Collecting training data dimension {} for {} "
+      "index with numDocsHint: {}, reservoir capacity: {}, sampler seed: {}.",
+      _index.collection().name(), _index.id().id(), def.dimension,
+      _index.sparse() ? "sparse" : "non-sparse", numDocsHint,
+      reservoirCapacity.has_value() ? std::to_string(*reservoirCapacity)
+                                    : std::string{"unbounded"},
+      seed);
+
+  ReservoirSampler sampler{def.dimension, reservoirCapacity, rng};
+  std::vector<float> input;
+  input.reserve(def.dimension);
   std::size_t iterationCounter{0};
-  while (it.Valid() &&
-         (shouldDoFullIteration ||
-          (maxVectors.has_value() && trainingDatasetCounter < *maxVectors))) {
+
+  while (it.Valid()) {
     if (iterationCounter % 1000 == 0 && stopToken.stop_requested()) {
       return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND,
                     "vector training aborted"};
@@ -258,6 +366,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
         res.fail()) {
       if (res.is(TRI_ERROR_BAD_PARAMETER) && _index.sparse()) {
         it.Next();
+        ++iterationCounter;
         continue;
       }
       return Result{
@@ -267,37 +376,29 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
               "embeddings are in a wrong format and index is not sparse: {}",
               res.errorMessage())};
     }
-
-    if (!shouldDoFullIteration) {
-      trainingData.insert(trainingData.end(), input.begin(), input.end());
-      ++trainingDatasetCounter;
-    } else {
-      // We collect only in case when we are below minimum 1000 docs or when we
-      // have do not have enough docs for the currently projected nLists value
-      bool shouldCollect =
-          trainingDatasetCounter < kSparseScalingBootstrapVectors;
-      if (!shouldCollect) {
-        auto resolved = resolveNLists(trainingDatasetCounter);
-        if (resolved.fail()) {
-          return std::move(resolved).result();
-        }
-        shouldCollect =
-            trainingDatasetCounter < resolved.get() * kMaxTrainingSizePerNLists;
-      }
-      if (shouldCollect) {
-        trainingData.insert(trainingData.end(), input.begin(), input.end());
-        ++trainingDatasetCounter;
-      }
-    }
+    sampler.consume(input);
     input.clear();
-
     it.Next();
     ++iterationCounter;
   }
 
+  std::size_t const validSeen = sampler.itemsSeen();
+
+  // Sparse+scaling: resize the reservoir to the k implied by the actual
+  // valid-vector count. A uniform subsample of a uniform sample stays
+  // uniform, so this preserves the Algorithm L guarantee.
+  if (sparseScaling && validSeen > 0) {
+    auto resolved = resolveNLists(validSeen);
+    if (resolved.fail()) {
+      return std::move(resolved).result();
+    }
+    sampler.resize(resolved.get() * kMaxTrainingSizePerNLists);
+  }
+
+  auto trainingData = std::move(sampler).release();
+  std::size_t const finalCount = trainingData.size() / def.dimension;
   if (def.metric == SimilarityMetric::kCosine) {
-    faiss::fvec_renorm_L2(def.dimension, trainingDatasetCounter,
-                          trainingData.data());
+    faiss::fvec_renorm_L2(def.dimension, finalCount, trainingData.data());
   }
 
   if (trainingData.empty()) {
@@ -308,7 +409,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
                   "training process."};
   }
 
-  return ResultT<TrainingDataset>({std::move(trainingData), iterationCounter});
+  return ResultT<TrainingDataset>({std::move(trainingData), validSeen});
 }
 
 ResultT<std::size_t> VectorIndexTrainer::resolveNLists(

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -255,8 +255,6 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
       seed);
 
   VectorIndexTrainingSampler sampler{def.dimension, reservoirCapacity, seed};
-  std::vector<float> input;
-  input.reserve(def.dimension);
 
   while (it.Valid()) {
     if (stopToken.stop_requested()) {
@@ -265,8 +263,8 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
     }
     TRI_ASSERT(it.key().compare(upper) < 0);
     auto doc = VPackSlice(reinterpret_cast<uint8_t const*>(it.value().data()));
-    if (auto const res =
-            readDocumentVectorData(doc, _index.fields(), def.dimension, input);
+    if (auto const res = readDocumentVectorData(
+            doc, _index.fields(), def.dimension, sampler.inputBuffer());
         res.fail()) {
       if (res.is(TRI_ERROR_BAD_PARAMETER) && _index.sparse()) {
         it.Next();
@@ -279,8 +277,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
               "embeddings are in a wrong format and index is not sparse: {}",
               res.errorMessage())};
     }
-    sampler.consume(input);
-    input.clear();
+    sampler.consume();
     it.Next();
   }
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -77,6 +77,18 @@
 
 namespace arangodb::vector {
 
+// Shallow field-presence probe; ingestion already rejects malformed vectors.
+bool hasVectorField(
+    velocypack::Slice doc,
+    std::vector<std::vector<basics::AttributeName>> const& fields) {
+  TRI_ASSERT(fields.size() >= 1);
+  try {
+    return !rocksutils::accessDocumentPath(doc, fields[0]).isNone();
+  } catch (velocypack::Exception const&) {
+    return false;
+  }
+}
+
 Result readDocumentVectorData(
     velocypack::Slice doc,
     std::vector<std::vector<basics::AttributeName>> const& fields,
@@ -261,6 +273,19 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
     }
     TRI_ASSERT(it.key().compare(upper) < 0);
     auto doc = VPackSlice(reinterpret_cast<uint8_t const*>(it.value().data()));
+
+    if (!sampler.wantsItem()) {
+      // Sparse mode: rows without the vector field must not count toward
+      // itemsSeen, preserving the Algorithm L invariant over valid vectors.
+      if (_index.sparse() && !hasVectorField(doc, _index.fields())) {
+        it.Next();
+        continue;
+      }
+      sampler.skip();
+      it.Next();
+      continue;
+    }
+
     if (auto const res = readDocumentVectorData(
             doc, _index.fields(), def.dimension, sampler.inputBuffer());
         res.fail()) {

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -265,6 +265,8 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
       seed);
 
   VectorIndexTrainingSampler sampler{def.dimension, reservoirCapacity, seed};
+  std::vector<float> inputBuffer;
+  inputBuffer.reserve(def.dimension);
 
   while (it.Valid()) {
     if (stopToken.stop_requested()) {
@@ -286,8 +288,9 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
       continue;
     }
 
-    if (auto const res = readDocumentVectorData(
-            doc, _index.fields(), def.dimension, sampler.inputBuffer());
+    inputBuffer.clear();
+    if (auto const res = readDocumentVectorData(doc, _index.fields(),
+                                                def.dimension, inputBuffer);
         res.fail()) {
       if (res.is(TRI_ERROR_BAD_PARAMETER) && _index.sparse()) {
         it.Next();
@@ -300,7 +303,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
               "embeddings are in a wrong format and index is not sparse: {}",
               res.errorMessage())};
     }
-    sampler.consume();
+    sampler.consume(inputBuffer);
     it.Next();
   }
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -226,8 +226,14 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
   if (resolved.fail()) {
     return std::move(resolved).result();
   }
-  std::size_t const reservoirCapacity =
-      resolved.get() * kMaxTrainingSizePerNLists;
+  std::size_t const reservoirCapacity = std::invoke([&] {
+    auto const capacity = resolved.get() * kMaxTrainingSizePerNLists;
+    if (_index.sparse()) {
+      return capacity;
+    }
+
+    return std::min(capacity, numDocsHint);
+  });
 
   auto const seed = RandomDevice::seed64();
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -220,18 +220,14 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
   bool const sparseScaling = _index.sparse() && isNListsScaling(def.nLists);
 
   // Size the reservoir from numDocsHint. For sparse+scaling this is an upper
-  // bound on the valid vector count, so we may subsample further once the
-  // actual count is known. If numDocsHint is 0 in sparse+scaling mode we have
-  // no upper bound and fall back to an unbounded reservoir; the subsample at
-  // the end still produces a uniform sample.
-  std::optional<std::size_t> reservoirCapacity;
-  if (!sparseScaling || numDocsHint > 0) {
-    auto resolved = resolveNLists(numDocsHint);
-    if (resolved.fail()) {
-      return std::move(resolved).result();
-    }
-    reservoirCapacity = resolved.get() * kMaxTrainingSizePerNLists;
+  // bound on the valid vector count; the post-iteration resize below shrinks
+  // it to the true k once the valid-vector count is known.
+  auto resolved = resolveNLists(numDocsHint);
+  if (resolved.fail()) {
+    return std::move(resolved).result();
   }
+  std::size_t const reservoirCapacity =
+      resolved.get() * kMaxTrainingSizePerNLists;
 
   auto const seed = RandomDevice::seed64();
 
@@ -239,9 +235,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
       "[shard={}, index={}] Collecting training data dimension {} for {} "
       "index with numDocsHint: {}, reservoir capacity: {}, sampler seed: {}.",
       _index.collection().name(), _index.id().id(), def.dimension,
-      _index.sparse() ? "sparse" : "non-sparse", numDocsHint,
-      reservoirCapacity.has_value() ? std::to_string(*reservoirCapacity)
-                                    : std::string{"unbounded"},
+      _index.sparse() ? "sparse" : "non-sparse", numDocsHint, reservoirCapacity,
       seed);
 
   VectorIndexTrainingSampler sampler{def.dimension, reservoirCapacity, seed};
@@ -448,7 +442,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
 
       if constexpr (returnsResult) {
         setResult(fn());
-      } else {
+      }
+      else {
         fn();
       }
     } catch (basics::Exception const& e) {

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -274,7 +274,9 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
   std::size_t const validSeen = sampler.itemsSeen();
 
   // Sparse+scaling: we need to resize after full iteration since we cannot
-  // calculate the
+  // calculate the true k from numDocsHint (which over-counts by the number of
+  // docs without the vector field). A uniform subsample of a uniform sample
+  // stays uniform, so this preserves the Algorithm L guarantee.
   if (sparseScaling && validSeen > 0) {
     auto resolved = resolveNLists(validSeen);
     if (resolved.fail()) {
@@ -290,8 +292,8 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
   }
 
   if (trainingData.empty()) {
-    // This should never happen
-    return Result{TRI_ERROR_NOT_IMPLEMENTED,
+    // Reachable in sparse mode when no document carries the vector field.
+    return Result{TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
                   "For the vector index to be created documents "
                   "must be present in the respective collection for the "
                   "training process."};
@@ -329,7 +331,7 @@ ResultT<std::shared_ptr<faiss::IndexIVF>> VectorIndexTrainer::train(
     return numDocsHint;
   });
   if (numberOfVectors == 0) {
-    return Result{TRI_ERROR_NOT_IMPLEMENTED,
+    return Result{TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
                   std::format("Vector index requires at least {} "
                               "vectors for training, "
                               "but none were found.",
@@ -347,7 +349,7 @@ ResultT<std::shared_ptr<faiss::IndexIVF>> VectorIndexTrainer::train(
 
   if (numOfTrainingVectors < _index.trainingThreshold()) {
     return Result{
-        TRI_ERROR_NOT_IMPLEMENTED,
+        TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
         std::format("Vector index requires at least {} "
                     "vectors for training, "
                     "but only {} were found.",

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -41,23 +41,17 @@ VectorIndexTrainingSampler::VectorIndexTrainingSampler(std::size_t dimension,
   TRI_ASSERT(_capacity > 0);
   TRI_ASSERT(_dimension > 0);
   _data.reserve(_capacity * _dimension);
-  _input.reserve(_dimension);
-}
-
-std::vector<float>& VectorIndexTrainingSampler::inputBuffer() noexcept {
-  _input.clear();
-  return _input;
 }
 
 bool VectorIndexTrainingSampler::wantsItem() const noexcept {
   return _itemsSeen < _capacity || _itemsSeen == _nextReplacement;
 }
 
-void VectorIndexTrainingSampler::consume() {
+void VectorIndexTrainingSampler::consume(std::span<float const> vector) {
   TRI_ASSERT(wantsItem());
-  TRI_ASSERT(_input.size() == _dimension);
+  TRI_ASSERT(vector.size() == _dimension);
   if (_itemsSeen < _capacity) {
-    _data.insert(_data.end(), _input.begin(), _input.end());
+    _data.insert(_data.end(), vector.begin(), vector.end());
     ++_itemsSeen;
     if (_itemsSeen == _capacity) {
       primeSampler();
@@ -65,7 +59,7 @@ void VectorIndexTrainingSampler::consume() {
     return;
   }
   std::size_t const slot = _slotDist(_rng);
-  std::ranges::copy(_input, _data.begin() + slot * _dimension);
+  std::ranges::copy(vector, _data.begin() + slot * _dimension);
   _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(_capacity));
   TRI_ASSERT(_w > 0.0 && _w < 1.0);
   _nextReplacement += 1 + skipCount(_w);

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -1,0 +1,116 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jure Bajic
+////////////////////////////////////////////////////////////////////////////////
+
+#include "VectorIndex/VectorIndexTrainingSampler.h"
+
+#include "Assertions/Assert.h"
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace arangodb::vector {
+
+VectorIndexTrainingSampler::VectorIndexTrainingSampler(
+    std::size_t dimension, std::optional<std::size_t> capacity,
+    std::uint64_t seed)
+    : _dimension{dimension}, _capacity{capacity}, _rng{seed} {
+  if (_capacity.has_value()) {
+    _data.reserve(*_capacity * _dimension);
+  }
+}
+
+void VectorIndexTrainingSampler::consume(std::vector<float> const& vector) {
+  TRI_ASSERT(vector.size() == _dimension);
+  if (!_capacity.has_value() || _itemsSeen < *_capacity) {
+    _data.insert(_data.end(), vector.begin(), vector.end());
+    ++_itemsSeen;
+    if (_capacity.has_value() && _itemsSeen == *_capacity) {
+      primeSampler();
+    }
+    return;
+  }
+  if (_itemsSeen == _nextReplacement) {
+    std::size_t const k = *_capacity;
+    std::uniform_int_distribution<std::size_t> slotDist{0, k - 1};
+    std::size_t const slot = slotDist(_rng);
+    std::copy(vector.begin(), vector.end(),
+              _data.begin() + slot * _dimension);
+    _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
+    TRI_ASSERT(_w > 0.0 && _w < 1.0);
+    _nextReplacement += 1 + skipCount(_w);
+  }
+  ++_itemsSeen;
+}
+
+void VectorIndexTrainingSampler::resize(std::size_t newCapacity) {
+  std::size_t const current = _data.size() / _dimension;
+  if (newCapacity >= current) {
+    return;
+  }
+  for (std::size_t i = 0; i < newCapacity; ++i) {
+    std::uniform_int_distribution<std::size_t> dist{i, current - 1};
+    std::size_t const j = dist(_rng);
+    if (i != j) {
+      std::swap_ranges(_data.begin() + i * _dimension,
+                       _data.begin() + (i + 1) * _dimension,
+                       _data.begin() + j * _dimension);
+    }
+  }
+  _data.resize(newCapacity * _dimension);
+}
+
+std::vector<float> VectorIndexTrainingSampler::release() && {
+  return std::move(_data);
+}
+
+std::size_t VectorIndexTrainingSampler::itemsSeen() const noexcept {
+  return _itemsSeen;
+}
+
+// Draws u ∈ (0, 1); rejects 0 so std::log(u) stays finite.
+double VectorIndexTrainingSampler::sampleOpenUnit() {
+  std::uniform_real_distribution<double> dist;
+  double u;
+  do {
+    u = dist(_rng);
+  } while (u <= 0.0);
+  return u;
+}
+
+// Geometric skip count: floor(log(U) / log(1 - w)). Uses log1p for
+// numerical stability when w is close to 0.
+std::size_t VectorIndexTrainingSampler::skipCount(double w) {
+  return static_cast<std::size_t>(
+      std::floor(std::log(sampleOpenUnit()) / std::log1p(-w)));
+}
+
+void VectorIndexTrainingSampler::primeSampler() {
+  std::size_t const k = *_capacity;
+  TRI_ASSERT(k > 0);
+  _w = std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
+  TRI_ASSERT(_w > 0.0 && _w < 1.0);
+  _nextReplacement = k + skipCount(_w);
+}
+
+}  // namespace arangodb::vector

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -49,7 +49,12 @@ std::vector<float>& VectorIndexTrainingSampler::inputBuffer() noexcept {
   return _input;
 }
 
+bool VectorIndexTrainingSampler::wantsItem() const noexcept {
+  return _itemsSeen < _capacity || _itemsSeen == _nextReplacement;
+}
+
 void VectorIndexTrainingSampler::consume() {
+  TRI_ASSERT(wantsItem());
   TRI_ASSERT(_input.size() == _dimension);
   if (_itemsSeen < _capacity) {
     _data.insert(_data.end(), _input.begin(), _input.end());
@@ -59,13 +64,16 @@ void VectorIndexTrainingSampler::consume() {
     }
     return;
   }
-  if (_itemsSeen == _nextReplacement) {
-    std::size_t const slot = _slotDist(_rng);
-    std::copy(_input.begin(), _input.end(), _data.begin() + slot * _dimension);
-    _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(_capacity));
-    TRI_ASSERT(_w > 0.0 && _w < 1.0);
-    _nextReplacement += 1 + skipCount(_w);
-  }
+  std::size_t const slot = _slotDist(_rng);
+  std::ranges::copy(_input, _data.begin() + slot * _dimension);
+  _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(_capacity));
+  TRI_ASSERT(_w > 0.0 && _w < 1.0);
+  _nextReplacement += 1 + skipCount(_w);
+  ++_itemsSeen;
+}
+
+void VectorIndexTrainingSampler::skip() noexcept {
+  TRI_ASSERT(!wantsItem());
   ++_itemsSeen;
 }
 

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -38,12 +38,18 @@ VectorIndexTrainingSampler::VectorIndexTrainingSampler(
   if (_capacity.has_value()) {
     _data.reserve(*_capacity * _dimension);
   }
+  _input.reserve(_dimension);
 }
 
-void VectorIndexTrainingSampler::consume(std::vector<float> const& vector) {
-  TRI_ASSERT(vector.size() == _dimension);
+std::vector<float>& VectorIndexTrainingSampler::inputBuffer() noexcept {
+  _input.clear();
+  return _input;
+}
+
+void VectorIndexTrainingSampler::consume() {
+  TRI_ASSERT(_input.size() == _dimension);
   if (!_capacity.has_value() || _itemsSeen < *_capacity) {
-    _data.insert(_data.end(), vector.begin(), vector.end());
+    _data.insert(_data.end(), _input.begin(), _input.end());
     ++_itemsSeen;
     if (_capacity.has_value() && _itemsSeen == *_capacity) {
       primeSampler();
@@ -54,8 +60,7 @@ void VectorIndexTrainingSampler::consume(std::vector<float> const& vector) {
     std::size_t const k = *_capacity;
     std::uniform_int_distribution<std::size_t> slotDist{0, k - 1};
     std::size_t const slot = slotDist(_rng);
-    std::copy(vector.begin(), vector.end(),
-              _data.begin() + slot * _dimension);
+    std::copy(_input.begin(), _input.end(), _data.begin() + slot * _dimension);
     _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
     TRI_ASSERT(_w > 0.0 && _w < 1.0);
     _nextReplacement += 1 + skipCount(_w);

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -34,7 +34,10 @@ namespace arangodb::vector {
 VectorIndexTrainingSampler::VectorIndexTrainingSampler(std::size_t dimension,
                                                        std::size_t capacity,
                                                        std::uint64_t seed)
-    : _dimension{dimension}, _capacity{capacity}, _rng{seed} {
+    : _dimension{dimension},
+      _capacity{capacity},
+      _rng{seed},
+      _slotDist{0, capacity - 1} {
   TRI_ASSERT(_capacity > 0);
   _data.reserve(_capacity * _dimension);
   _input.reserve(_dimension);
@@ -56,8 +59,7 @@ void VectorIndexTrainingSampler::consume() {
     return;
   }
   if (_itemsSeen == _nextReplacement) {
-    std::uniform_int_distribution<std::size_t> slotDist{0, _capacity - 1};
-    std::size_t const slot = slotDist(_rng);
+    std::size_t const slot = _slotDist(_rng);
     std::copy(_input.begin(), _input.end(), _data.begin() + slot * _dimension);
     _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(_capacity));
     TRI_ASSERT(_w > 0.0 && _w < 1.0);
@@ -71,9 +73,9 @@ void VectorIndexTrainingSampler::resize(std::size_t newCapacity) {
   if (newCapacity >= current) {
     return;
   }
+  using param_t = std::uniform_int_distribution<std::size_t>::param_type;
   for (std::size_t i = 0; i < newCapacity; ++i) {
-    std::uniform_int_distribution<std::size_t> dist{i, current - 1};
-    std::size_t const j = dist(_rng);
+    std::size_t const j = _slotDist(_rng, param_t{i, current - 1});
     if (i != j) {
       std::swap_ranges(_data.begin() + i * _dimension,
                        _data.begin() + (i + 1) * _dimension,
@@ -93,10 +95,9 @@ std::size_t VectorIndexTrainingSampler::itemsSeen() const noexcept {
 
 // Draws u ∈ (0, 1); rejects 0 so std::log(u) stays finite.
 double VectorIndexTrainingSampler::sampleOpenUnit() {
-  std::uniform_real_distribution<double> dist;
   double u;
   do {
-    u = dist(_rng);
+    u = _unitDist(_rng);
   } while (u <= 0.0);
   return u;
 }

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -39,6 +39,7 @@ VectorIndexTrainingSampler::VectorIndexTrainingSampler(std::size_t dimension,
       _rng{seed},
       _slotDist{0, capacity - 1} {
   TRI_ASSERT(_capacity > 0);
+  TRI_ASSERT(_dimension > 0);
   _data.reserve(_capacity * _dimension);
   _input.reserve(_dimension);
 }

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.cpp
@@ -31,13 +31,12 @@
 
 namespace arangodb::vector {
 
-VectorIndexTrainingSampler::VectorIndexTrainingSampler(
-    std::size_t dimension, std::optional<std::size_t> capacity,
-    std::uint64_t seed)
+VectorIndexTrainingSampler::VectorIndexTrainingSampler(std::size_t dimension,
+                                                       std::size_t capacity,
+                                                       std::uint64_t seed)
     : _dimension{dimension}, _capacity{capacity}, _rng{seed} {
-  if (_capacity.has_value()) {
-    _data.reserve(*_capacity * _dimension);
-  }
+  TRI_ASSERT(_capacity > 0);
+  _data.reserve(_capacity * _dimension);
   _input.reserve(_dimension);
 }
 
@@ -48,20 +47,19 @@ std::vector<float>& VectorIndexTrainingSampler::inputBuffer() noexcept {
 
 void VectorIndexTrainingSampler::consume() {
   TRI_ASSERT(_input.size() == _dimension);
-  if (!_capacity.has_value() || _itemsSeen < *_capacity) {
+  if (_itemsSeen < _capacity) {
     _data.insert(_data.end(), _input.begin(), _input.end());
     ++_itemsSeen;
-    if (_capacity.has_value() && _itemsSeen == *_capacity) {
+    if (_itemsSeen == _capacity) {
       primeSampler();
     }
     return;
   }
   if (_itemsSeen == _nextReplacement) {
-    std::size_t const k = *_capacity;
-    std::uniform_int_distribution<std::size_t> slotDist{0, k - 1};
+    std::uniform_int_distribution<std::size_t> slotDist{0, _capacity - 1};
     std::size_t const slot = slotDist(_rng);
     std::copy(_input.begin(), _input.end(), _data.begin() + slot * _dimension);
-    _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
+    _w *= std::exp(std::log(sampleOpenUnit()) / static_cast<double>(_capacity));
     TRI_ASSERT(_w > 0.0 && _w < 1.0);
     _nextReplacement += 1 + skipCount(_w);
   }
@@ -111,11 +109,9 @@ std::size_t VectorIndexTrainingSampler::skipCount(double w) {
 }
 
 void VectorIndexTrainingSampler::primeSampler() {
-  std::size_t const k = *_capacity;
-  TRI_ASSERT(k > 0);
-  _w = std::exp(std::log(sampleOpenUnit()) / static_cast<double>(k));
+  _w = std::exp(std::log(sampleOpenUnit()) / static_cast<double>(_capacity));
   TRI_ASSERT(_w > 0.0 && _w < 1.0);
-  _nextReplacement = k + skipCount(_w);
+  _nextReplacement = _capacity + skipCount(_w);
 }
 
 }  // namespace arangodb::vector

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -44,10 +44,19 @@ class VectorIndexTrainingSampler {
   // `dimension` floats before calling consume().
   std::vector<float>& inputBuffer() noexcept;
 
-  // Consumes the current scratch buffer (must hold `dimension` floats). Runs
-  // one step of Algorithm L: either grows the reservoir, replaces a slot, or
-  // skips the item.
+  // True iff the next observed item must be consumed — either the reservoir
+  // is still filling, or we have reached the next replacement position. Lets
+  // the caller avoid decoding vectors that the sampler would discard.
+  bool wantsItem() const noexcept;
+
+  // Preconditions: wantsItem() returned true and inputBuffer() was filled
+  // with exactly `dimension` floats. Grows the reservoir or replaces a slot
+  // per Algorithm L.
   void consume();
+
+  // Precondition: wantsItem() returned false. Counts one valid item as seen
+  // without touching the reservoir.
+  void skip() noexcept;
 
   // Uniformly subsample down to `newCapacity` slots via a partial
   // Fisher–Yates shuffle. No-op if the reservoir already fits.

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -42,6 +42,7 @@ class VectorIndexTrainingSampler {
   // Hands out the internal scratch buffer for the next vector. The buffer is
   // empty on return; the caller is expected to fill it with exactly
   // `dimension` floats before calling consume().
+  // TODO(jbajic) Generalize this so it can be used in other cases
   std::vector<float>& inputBuffer() noexcept;
 
   // True iff the next observed item must be consumed — either the reservoir

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -64,6 +64,8 @@ class VectorIndexTrainingSampler {
   std::size_t _dimension;
   std::size_t _capacity;
   std::mt19937_64 _rng;
+  std::uniform_int_distribution<std::size_t> _slotDist;
+  std::uniform_real_distribution<double> _unitDist;
   std::size_t _itemsSeen{0};
   double _w{0.0};
   std::size_t _nextReplacement{0};

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jure Bajic
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <random>
+#include <vector>
+
+namespace arangodb::vector {
+
+// Reservoir sampler implementing Algorithm L (Li 1994) for uniform-without-
+// replacement sampling over a stream of unknown-but-bounded length. Each
+// slot holds `dimension` consecutive floats. With no capacity set, consume()
+// just appends — useful when no upper bound on the stream size is known; a
+// subsequent resize() call can still produce a uniform sample.
+class VectorIndexTrainingSampler {
+ public:
+  VectorIndexTrainingSampler(std::size_t dimension,
+                             std::optional<std::size_t> capacity,
+                             std::uint64_t seed);
+
+  void consume(std::vector<float> const& vector);
+
+  // Uniformly subsample down to `newCapacity` slots via a partial
+  // Fisher–Yates shuffle. No-op if the reservoir already fits.
+  void resize(std::size_t newCapacity);
+
+  std::vector<float> release() &&;
+  std::size_t itemsSeen() const noexcept;
+
+ private:
+  double sampleOpenUnit();
+  std::size_t skipCount(double w);
+  void primeSampler();
+
+  std::size_t _dimension;
+  std::optional<std::size_t> _capacity;
+  std::mt19937_64 _rng;
+  std::size_t _itemsSeen{0};
+  double _w{0.0};
+  std::size_t _nextReplacement{0};
+  std::vector<float> _data;
+};
+
+}  // namespace arangodb::vector

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -25,7 +25,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <random>
 #include <vector>
 
@@ -33,13 +32,11 @@ namespace arangodb::vector {
 
 // Reservoir sampler implementing Algorithm L (Li 1994) for uniform-without-
 // replacement sampling over a stream of unknown-but-bounded length. Each
-// slot holds `dimension` consecutive floats. With no capacity set, consume()
-// just appends — useful when no upper bound on the stream size is known; a
-// subsequent resize() call can still produce a uniform sample.
+// slot holds `dimension` consecutive floats. The reservoir is bounded at
+// `capacity` slots and never grows past it; resize() can only shrink it.
 class VectorIndexTrainingSampler {
  public:
-  VectorIndexTrainingSampler(std::size_t dimension,
-                             std::optional<std::size_t> capacity,
+  VectorIndexTrainingSampler(std::size_t dimension, std::size_t capacity,
                              std::uint64_t seed);
 
   // Hands out the internal scratch buffer for the next vector. The buffer is
@@ -65,7 +62,7 @@ class VectorIndexTrainingSampler {
   void primeSampler();
 
   std::size_t _dimension;
-  std::optional<std::size_t> _capacity;
+  std::size_t _capacity;
   std::mt19937_64 _rng;
   std::size_t _itemsSeen{0};
   double _w{0.0};

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <random>
+#include <span>
 #include <vector>
 
 namespace arangodb::vector {
@@ -39,21 +40,14 @@ class VectorIndexTrainingSampler {
   VectorIndexTrainingSampler(std::size_t dimension, std::size_t capacity,
                              std::uint64_t seed);
 
-  // Hands out the internal scratch buffer for the next vector. The buffer is
-  // empty on return; the caller is expected to fill it with exactly
-  // `dimension` floats before calling consume().
-  // TODO(jbajic) Generalize this so it can be used in other cases
-  std::vector<float>& inputBuffer() noexcept;
-
   // True iff the next observed item must be consumed — either the reservoir
   // is still filling, or we have reached the next replacement position. Lets
   // the caller avoid decoding vectors that the sampler would discard.
   bool wantsItem() const noexcept;
 
-  // Preconditions: wantsItem() returned true and inputBuffer() was filled
-  // with exactly `dimension` floats. Grows the reservoir or replaces a slot
-  // per Algorithm L.
-  void consume();
+  // Preconditions: wantsItem() returned true and `vector.size() == dimension`.
+  // Grows the reservoir or replaces a slot per Algorithm L.
+  void consume(std::span<float const> vector);
 
   // Precondition: wantsItem() returned false. Counts one valid item as seen
   // without touching the reservoir.
@@ -80,7 +74,6 @@ class VectorIndexTrainingSampler {
   double _w{0.0};
   std::size_t _nextReplacement{0};
   std::vector<float> _data;
-  std::vector<float> _input;
 };
 
 }  // namespace arangodb::vector

--- a/arangod/VectorIndex/VectorIndexTrainingSampler.h
+++ b/arangod/VectorIndex/VectorIndexTrainingSampler.h
@@ -42,7 +42,15 @@ class VectorIndexTrainingSampler {
                              std::optional<std::size_t> capacity,
                              std::uint64_t seed);
 
-  void consume(std::vector<float> const& vector);
+  // Hands out the internal scratch buffer for the next vector. The buffer is
+  // empty on return; the caller is expected to fill it with exactly
+  // `dimension` floats before calling consume().
+  std::vector<float>& inputBuffer() noexcept;
+
+  // Consumes the current scratch buffer (must hold `dimension` floats). Runs
+  // one step of Algorithm L: either grows the reservoir, replaces a slot, or
+  // skips the item.
+  void consume();
 
   // Uniformly subsample down to `newCapacity` slots via a partial
   // Fisher–Yates shuffle. No-op if the reservoir already fits.
@@ -63,6 +71,7 @@ class VectorIndexTrainingSampler {
   double _w{0.0};
   std::size_t _nextReplacement{0};
   std::vector<float> _data;
+  std::vector<float> _input;
 };
 
 }  // namespace arangodb::vector

--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -158,6 +158,7 @@ add_library(arangoserver STATIC
   RestServer/UpgradeFeature.cpp
   VectorIndex/VectorIndexFeature.cpp
   VectorIndex/VectorIndexBuildManager.cpp
+  VectorIndex/VectorIndexTrainingSampler.cpp
   RestServer/ViewTypesFeature.cpp
   RestServer/VocbaseContext.cpp
   Sharding/ShardDistributionReporter.cpp

--- a/lib/Random/RandomGenerator.cpp
+++ b/lib/Random/RandomGenerator.cpp
@@ -73,6 +73,12 @@ unsigned long RandomDevice::seed() {
   return (unsigned long)(dev + tid + now);
 }
 
+std::uint64_t RandomDevice::seed64() {
+  std::random_device rd;
+  return (static_cast<std::uint64_t>(rd()) << 32) |
+         static_cast<std::uint64_t>(rd());
+}
+
 int32_t RandomDevice::interval(int32_t left, int32_t right) {
   return random(left, right);
 }

--- a/lib/Random/RandomGenerator.h
+++ b/lib/Random/RandomGenerator.h
@@ -50,6 +50,8 @@ class RandomDevice {
 
   static unsigned long seed();
 
+  static std::uint64_t seed64();
+
   int32_t random(int32_t left, int32_t right);
 
  private:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -264,6 +264,7 @@ set(ARANGODB_TESTS_SOURCES
   Utils/ExecContextTest.cpp
   Utils/NameValidatorTest.cpp
   Utils/QuickGen.cpp
+  VectorIndex/VectorIndexTrainingSamplerTest.cpp
   VocBase/ComputedValuesTest.cpp
   VocBase/KeyGeneratorTest.cpp
   VocBase/LogicalDataSourceTest.cpp

--- a/tests/VectorIndex/VectorIndexTrainingSamplerTest.cpp
+++ b/tests/VectorIndex/VectorIndexTrainingSamplerTest.cpp
@@ -23,6 +23,7 @@
 
 #include "VectorIndex/VectorIndexTrainingSampler.h"
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
@@ -38,13 +39,11 @@ using namespace arangodb::vector;
 namespace {
 
 // Feeds one vector through the sampler. Mirrors the production caller: only
-// decode into the buffer when the sampler wants the item; otherwise advance
-// the seen-counter via skip().
+// consume when the sampler wants the item; otherwise advance the seen-counter
+// via skip().
 void feed(VectorIndexTrainingSampler& s, std::vector<float> const& vector) {
   if (s.wantsItem()) {
-    auto& buf = s.inputBuffer();
-    buf.insert(buf.end(), vector.begin(), vector.end());
-    s.consume();
+    s.consume(vector);
   } else {
     s.skip();
   }
@@ -251,22 +250,6 @@ TEST(VectorIndexTrainingSamplerTest, resize_on_undersized_reservoir_is_noop) {
   }
 }
 
-// -----------------------------------------------------------------------------
-// inputBuffer() semantics
-// -----------------------------------------------------------------------------
-
-TEST(VectorIndexTrainingSamplerTest, input_buffer_is_cleared_each_call) {
-  VectorIndexTrainingSampler s{/*dimension=*/3, /*capacity=*/4, kFixedSeed};
-  auto& a = s.inputBuffer();
-  EXPECT_TRUE(a.empty());
-  a.push_back(1.0f);
-  a.push_back(2.0f);
-  // Request the buffer again without consume — must come back empty.
-  auto& b = s.inputBuffer();
-  EXPECT_TRUE(b.empty());
-  EXPECT_EQ(&a, &b) << "inputBuffer() should return a stable reference";
-}
-
 TEST(VectorIndexTrainingSamplerTest, itemsSeen_counts_every_consumed_vector) {
   // itemsSeen must count every consumed vector regardless of whether
   // Algorithm L kept or evicted it.
@@ -308,9 +291,8 @@ TEST(VectorIndexTrainingSamplerTest,
   for (std::size_t i = 0; i < n; ++i) {
     bool const wanted = s.wantsItem();
     if (wanted) {
-      auto& buf = s.inputBuffer();
-      buf.push_back(static_cast<float>(i));
-      s.consume();
+      std::array<float, dim> const buf{static_cast<float>(i)};
+      s.consume(buf);
       ++consumed;
     } else {
       s.skip();

--- a/tests/VectorIndex/VectorIndexTrainingSamplerTest.cpp
+++ b/tests/VectorIndex/VectorIndexTrainingSamplerTest.cpp
@@ -37,12 +37,17 @@ using namespace arangodb::vector;
 
 namespace {
 
-// Feeds one vector through the sampler via its public inputBuffer()/consume()
-// pair.
+// Feeds one vector through the sampler. Mirrors the production caller: only
+// decode into the buffer when the sampler wants the item; otherwise advance
+// the seen-counter via skip().
 void feed(VectorIndexTrainingSampler& s, std::vector<float> const& vector) {
-  auto& buf = s.inputBuffer();
-  buf.insert(buf.end(), vector.begin(), vector.end());
-  s.consume();
+  if (s.wantsItem()) {
+    auto& buf = s.inputBuffer();
+    buf.insert(buf.end(), vector.begin(), vector.end());
+    s.consume();
+  } else {
+    s.skip();
+  }
 }
 
 // Builds a 1-D vector holding the single float `v`. Handy for tests that
@@ -272,4 +277,49 @@ TEST(VectorIndexTrainingSamplerTest, itemsSeen_counts_every_consumed_vector) {
     feed(s, scalar(static_cast<float>(i)));
   }
   EXPECT_EQ(s.itemsSeen(), n);
+}
+
+// -----------------------------------------------------------------------------
+// wantsItem() / skip() semantics
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, wants_item_true_through_fill_phase) {
+  // Every position in the fill phase must request the item; otherwise the
+  // reservoir would end up short and Algorithm L's invariant would break.
+  constexpr std::size_t k = 8;
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+  for (std::size_t i = 0; i < k; ++i) {
+    EXPECT_TRUE(s.wantsItem()) << "wantsItem() false at fill index " << i;
+    feed(s, scalar(static_cast<float>(i)));
+  }
+}
+
+TEST(VectorIndexTrainingSamplerTest,
+     wants_item_decides_whether_skip_or_consume_runs) {
+  // Past capacity, wantsItem() must be true exactly at positions where
+  // feed() actually mutates the reservoir, and false everywhere else.
+  constexpr std::size_t dim = 1;
+  constexpr std::size_t k = 4;
+  constexpr std::size_t n = 200;
+  VectorIndexTrainingSampler s{dim, k, kFixedSeed};
+
+  std::size_t consumed = 0;
+  std::size_t skipped = 0;
+  for (std::size_t i = 0; i < n; ++i) {
+    bool const wanted = s.wantsItem();
+    if (wanted) {
+      auto& buf = s.inputBuffer();
+      buf.push_back(static_cast<float>(i));
+      s.consume();
+      ++consumed;
+    } else {
+      s.skip();
+      ++skipped;
+    }
+  }
+  EXPECT_EQ(consumed + skipped, n);
+  EXPECT_EQ(s.itemsSeen(), n);
+  // Past the fill phase the replacement schedule is sparse, so most items
+  // must have been skipped rather than consumed.
+  EXPECT_GT(skipped, consumed);
 }

--- a/tests/VectorIndex/VectorIndexTrainingSamplerTest.cpp
+++ b/tests/VectorIndex/VectorIndexTrainingSamplerTest.cpp
@@ -1,0 +1,275 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jure Bajic
+////////////////////////////////////////////////////////////////////////////////
+
+#include "VectorIndex/VectorIndexTrainingSampler.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+using namespace arangodb;
+using namespace arangodb::vector;
+
+namespace {
+
+// Feeds one vector through the sampler via its public inputBuffer()/consume()
+// pair.
+void feed(VectorIndexTrainingSampler& s, std::vector<float> const& vector) {
+  auto& buf = s.inputBuffer();
+  buf.insert(buf.end(), vector.begin(), vector.end());
+  s.consume();
+}
+
+// Builds a 1-D vector holding the single float `v`. Handy for tests that
+// identify items by a scalar id.
+std::vector<float> scalar(float v) { return {v}; }
+
+// Returns the i-th slot (a `dimension`-sized span starting at i * dimension)
+// as a vector.
+std::vector<float> slotAt(std::vector<float> const& reservoir,
+                          std::size_t dimension, std::size_t i) {
+  return std::vector<float>(reservoir.begin() + i * dimension,
+                            reservoir.begin() + (i + 1) * dimension);
+}
+
+constexpr std::uint64_t kFixedSeed = 0xABCDEF0123456789ULL;
+
+}  // namespace
+
+// -----------------------------------------------------------------------------
+// Fill phase
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, below_capacity_keeps_everything) {
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/10, kFixedSeed};
+  for (int i = 0; i < 5; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  EXPECT_EQ(s.itemsSeen(), 5u);
+  auto data = std::move(s).release();
+  ASSERT_EQ(data.size(), 5u);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(data[i], static_cast<float>(i));
+  }
+}
+
+TEST(VectorIndexTrainingSamplerTest, at_capacity_keeps_everything) {
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/5, kFixedSeed};
+  for (int i = 0; i < 5; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  EXPECT_EQ(s.itemsSeen(), 5u);
+  auto data = std::move(s).release();
+  ASSERT_EQ(data.size(), 5u);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(data[i], static_cast<float>(i));
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Replace phase
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, over_capacity_size_matches_capacity) {
+  constexpr std::size_t k = 10;
+  constexpr std::size_t n = 1000;
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+  for (std::size_t i = 0; i < n; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  EXPECT_EQ(s.itemsSeen(), n);
+  auto data = std::move(s).release();
+  EXPECT_EQ(data.size(), k);
+}
+
+TEST(VectorIndexTrainingSamplerTest, reservoir_is_subset_of_distinct_inputs) {
+  // Feed N distinct scalar inputs; reservoir must contain k distinct values,
+  // each drawn from the input stream.
+  constexpr std::size_t k = 16;
+  constexpr std::size_t n = 500;
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+  for (std::size_t i = 0; i < n; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  auto data = std::move(s).release();
+  ASSERT_EQ(data.size(), k);
+
+  std::unordered_set<int> kept;
+  for (float f : data) {
+    int const idx = static_cast<int>(f);
+    EXPECT_GE(idx, 0);
+    EXPECT_LT(idx, static_cast<int>(n));
+    kept.insert(idx);
+  }
+  EXPECT_EQ(kept.size(), k) << "reservoir contains duplicate slots";
+}
+
+// -----------------------------------------------------------------------------
+// Multi-dimensional slot layout
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, multi_dimensional_slots_are_contiguous) {
+  constexpr std::size_t dim = 4;
+  constexpr std::size_t k = 8;
+  constexpr std::size_t n = 200;
+  VectorIndexTrainingSampler s{dim, /*capacity=*/k, kFixedSeed};
+
+  // Feed items where each i maps to the vector (i, i+1, i+2, i+3) so we can
+  // identify which input produced a slot.
+  for (std::size_t i = 0; i < n; ++i) {
+    std::vector<float> v(dim);
+    for (std::size_t d = 0; d < dim; ++d) {
+      v[d] = static_cast<float>(i + d);
+    }
+    feed(s, v);
+  }
+  auto data = std::move(s).release();
+  ASSERT_EQ(data.size(), k * dim);
+
+  for (std::size_t i = 0; i < k; ++i) {
+    auto slot = slotAt(data, dim, i);
+    ASSERT_EQ(slot.size(), dim);
+    float const base = slot[0];
+    for (std::size_t d = 0; d < dim; ++d) {
+      EXPECT_EQ(slot[d], base + static_cast<float>(d))
+          << "slot " << i << " at dim " << d << " is not a contiguous input";
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Determinism
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, fixed_seed_is_deterministic) {
+  constexpr std::size_t k = 32;
+  constexpr std::size_t n = 1000;
+  auto run = [&] {
+    VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+    for (std::size_t i = 0; i < n; ++i) {
+      feed(s, scalar(static_cast<float>(i)));
+    }
+    return std::move(s).release();
+  };
+  EXPECT_EQ(run(), run());
+}
+
+TEST(VectorIndexTrainingSamplerTest, different_seeds_diverge) {
+  constexpr std::size_t k = 32;
+  constexpr std::size_t n = 1000;
+  auto run = [&](std::uint64_t seed) {
+    VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, seed};
+    for (std::size_t i = 0; i < n; ++i) {
+      feed(s, scalar(static_cast<float>(i)));
+    }
+    return std::move(s).release();
+  };
+  auto a = run(1);
+  auto b = run(2);
+  EXPECT_NE(a, b);
+}
+
+// -----------------------------------------------------------------------------
+// resize()
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, resize_smaller_shrinks_reservoir) {
+  constexpr std::size_t k = 20;
+  constexpr std::size_t n = 200;
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+  for (std::size_t i = 0; i < n; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  s.resize(5);
+  auto data = std::move(s).release();
+  EXPECT_EQ(data.size(), 5u);
+
+  // Every value must still come from the input stream.
+  for (float f : data) {
+    auto const idx = static_cast<int>(f);
+    EXPECT_GE(idx, 0);
+    EXPECT_LT(idx, static_cast<int>(n));
+  }
+}
+
+TEST(VectorIndexTrainingSamplerTest, resize_larger_is_noop) {
+  constexpr std::size_t k = 10;
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+  for (std::size_t i = 0; i < k; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  s.resize(100);  // larger than current size
+  auto data = std::move(s).release();
+  ASSERT_EQ(data.size(), k);
+  for (std::size_t i = 0; i < k; ++i) {
+    EXPECT_EQ(data[i], static_cast<float>(i));
+  }
+}
+
+TEST(VectorIndexTrainingSamplerTest, resize_on_undersized_reservoir_is_noop) {
+  // Reservoir never filled past 5 items; resize(10) should leave all 5 in
+  // place (new capacity >= current size).
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/20, kFixedSeed};
+  for (std::size_t i = 0; i < 5; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  s.resize(10);
+  auto data = std::move(s).release();
+  ASSERT_EQ(data.size(), 5u);
+  for (std::size_t i = 0; i < 5; ++i) {
+    EXPECT_EQ(data[i], static_cast<float>(i));
+  }
+}
+
+// -----------------------------------------------------------------------------
+// inputBuffer() semantics
+// -----------------------------------------------------------------------------
+
+TEST(VectorIndexTrainingSamplerTest, input_buffer_is_cleared_each_call) {
+  VectorIndexTrainingSampler s{/*dimension=*/3, /*capacity=*/4, kFixedSeed};
+  auto& a = s.inputBuffer();
+  EXPECT_TRUE(a.empty());
+  a.push_back(1.0f);
+  a.push_back(2.0f);
+  // Request the buffer again without consume — must come back empty.
+  auto& b = s.inputBuffer();
+  EXPECT_TRUE(b.empty());
+  EXPECT_EQ(&a, &b) << "inputBuffer() should return a stable reference";
+}
+
+TEST(VectorIndexTrainingSamplerTest, itemsSeen_counts_every_consumed_vector) {
+  // itemsSeen must count every consumed vector regardless of whether
+  // Algorithm L kept or evicted it.
+  constexpr std::size_t k = 5;
+  constexpr std::size_t n = 123;
+  VectorIndexTrainingSampler s{/*dimension=*/1, /*capacity=*/k, kFixedSeed};
+  for (std::size_t i = 0; i < n; ++i) {
+    feed(s, scalar(static_cast<float>(i)));
+  }
+  EXPECT_EQ(s.itemsSeen(), n);
+}


### PR DESCRIPTION
### Scope & Purpose

Adds a sampler based on  Algorithm L so that the training dataset is sampled properly. We calculate the maximum capacity of the training dataset, same as FAISS `nLists * 256`, and try to fill that with training vectors. After doing that, we use a sampler to determine which ones to keep and which ones to throw away.
There are 4 possible scenarios for determining the training dataset:
| Sparse              | Scaling nLists | Training dataset capacity |
| :---------------- | :------: | ----: |
| FALSE        |   FALSE   | `trainingDatasetSize = std::min(nLists * 256, numberOfDocsHint)` |
| FALSE           |   TRUE   | `trainingDatasetSize = std::min(nLists * 256, numberOfDocsHint)` |
| TRUE    |  FALSE   | `trainingDatasetSize = nLists * 256`  |
| TRUE |  TRUE   | `trainingDatasetSize = resolveNLists(numberOfDocsHint) * 256` |

When we have a non-sparse index and scaling or non-scaling nLists, we can always determine the nLists parameter, either by having it explicitly defined or by calculating it via the scaling function, since we only need the number of documents, and that is correct in this case.
In case when we have a sparse index, we do not know the number of documents, and the `numberOfDocsHint` is the worst case; therefore, for capacity in case when we do not have scalining nLists we cannot minimize the capacity of training set, but in the even worst case when we have scaling and sparse index we have to assume that `numberOfDocsHint` is the number of docs since we do not have better information.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-444
- [ ] Design document: 
