### PR TITLE
[COR-452] Fix using regular variables in `FILTER` statement with vector index search

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* COR -452: Vector search filters may now reference variables from outside the FOR
+  loop (subquery results, LET bindings, bind parameters).
+
 * COR-444: Vector index training now draws a uniformly random training set
   via reservoir sampling (Algorithm L) over a full iteration of the
   collection, instead of keeping the first `nLists * 256` documents.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
-* COR -452: Vector search filters may now reference variables from outside the FOR
+* COR-452: Vector search filters may now reference variables from outside the FOR
   loop (subquery results, LET bindings, bind parameters).
 
 * COR-444: Vector index training now draws a uniformly random training set

--- a/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
@@ -178,6 +178,15 @@ CostEstimate EnumerateNearVectorNode::estimateCost() const {
 
 void EnumerateNearVectorNode::getVariablesUsedHere(VarSet& vars) const {
   vars.emplace(_inVariable);
+  if (_filterExpression != nullptr) {
+    Ast::getReferencedVariables(_filterExpression->node(), vars);
+    // the filter expression is evaluated inside the vector index search
+    // path, which reconstructs the document itself (either from the
+    // materialized doc downstream or from stored values). the filter's
+    // document variable is therefore not read from an input register, so
+    // remove it to keep the register planner honest.
+    vars.erase(_oldDocumentVariable);
+  }
 }
 
 std::vector<const Variable*> EnumerateNearVectorNode::getVariablesSetHere()

--- a/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
+++ b/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
@@ -41,8 +41,10 @@
 #include "Aql/Optimizer/Utils/VectorIndexHelpers.h"
 #include "Aql/OptimizerUtils.h"
 #include "Aql/QueryContext.h"
+#include "Assertions/Assert.h"
 #include "Basics/Exceptions.h"
 #include "Indexes/Index.h"
+#include "VocBase/vocbase.h"
 
 namespace arangodb::aql {
 
@@ -53,10 +55,13 @@ using EN = ExecutionNode;
 #define LOG_RULE LOG_RULE_IF(true)
 
 std::unique_ptr<Expression> tryRemoveFilterNode(
-    ExecutionNode* maybeFilterNode, std::unique_ptr<ExecutionPlan> const& plan,
+    ExecutionNode* filterExecutionNode,
+    std::unique_ptr<ExecutionPlan> const& plan,
     Variable const* distanceOutVariable) {
+  TRI_ASSERT(filterExecutionNode != nullptr &&
+             filterExecutionNode->getType() == EN::FILTER);
   auto const* filterNode =
-      ExecutionNode::castTo<FilterNode const*>(maybeFilterNode);
+      ExecutionNode::castTo<FilterNode const*>(filterExecutionNode);
   auto const* filterInVar = filterNode->inVariable();
 
   // Find the calculation node that populates the filter variable

--- a/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
+++ b/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
@@ -22,6 +22,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "PushFilterIntoEnumerateNear.h"
+#include <memory>
 
 #include "Aql/Ast.h"
 #include "Aql/AstHelper.h"
@@ -29,6 +30,7 @@
 #include "Aql/Condition.h"
 #include "Aql/ExecutionNode/EnumerateNearVectorNode.h"
 #include "Aql/ExecutionNode/EnumerateCollectionNode.h"
+#include "Aql/ExecutionNode/ExecutionNode.h"
 #include "Aql/Expression.h"
 #include "Aql/ExecutionNode/CalculationNode.h"
 #include "Aql/ExecutionNode/MaterializeRocksDBNode.h"
@@ -51,7 +53,8 @@ using EN = ExecutionNode;
 #define LOG_RULE LOG_RULE_IF(true)
 
 std::unique_ptr<Expression> tryRemoveFilterNode(
-    auto* maybeFilterNode, auto& plan, Variable const* distanceOutVariable) {
+    ExecutionNode* maybeFilterNode, std::unique_ptr<ExecutionPlan> const& plan,
+    Variable const* distanceOutVariable) {
   auto const* filterNode =
       ExecutionNode::castTo<FilterNode const*>(maybeFilterNode);
   auto const* filterInVar = filterNode->inVariable();

--- a/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
+++ b/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<Expression> tryRemoveFilterNode(
   // referenced by any other node. EnumerateNearVectorNode advertises the
   // filter's variables through getVariablesUsedHere, so the register planner
   // keeps them alive up to this node.
-  plan->unlinkNode(maybeFilterNode);
+  plan->unlinkNode(filterExecutionNode);
 
   return filterExpression;
 }

--- a/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
+++ b/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
@@ -50,8 +50,8 @@ using EN = ExecutionNode;
 #define LOG_RULE_IF(cond) LOG_DEVEL_IF((LOG_RULE_ENABLED) && (cond))
 #define LOG_RULE LOG_RULE_IF(true)
 
-std::unique_ptr<Expression> tryRemoveFilterNode(auto* maybeFilterNode,
-                                                auto& plan) {
+std::unique_ptr<Expression> tryRemoveFilterNode(
+    auto* maybeFilterNode, auto& plan, Variable const* distanceOutVariable) {
   auto const* filterNode =
       ExecutionNode::castTo<FilterNode const*>(maybeFilterNode);
   auto const* filterInVar = filterNode->inVariable();
@@ -67,6 +67,16 @@ std::unique_ptr<Expression> tryRemoveFilterNode(auto* maybeFilterNode,
       ExecutionNode::castTo<CalculationNode const*>(maybeCalculationNode);
 
   auto filterExpression = calculationNode->expression()->clone(plan->getAst());
+
+  // TODO this will be resolved in the ticket COR-461
+  VarSet filterVars;
+  filterExpression->variables(filterVars);
+  if (filterVars.contains(distanceOutVariable)) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_QUERY_VECTOR_SEARCH_NOT_APPLIED,
+        "filter on the distance variable cannot be pushed into the vector "
+        "search; the distance is produced by the search itself");
+  }
 
   // CalculationNode will be removed by the subsequent rule if it is not
   // referenced by any other node. EnumerateNearVectorNode advertises the
@@ -185,8 +195,8 @@ void pushFilterIntoEnumerateNear(Optimizer* opt,
 
     // If there is a FilterNode it comes with CalculationNode, we remove it
     // and handle it in EnumerateNearVectorNode
-    std::unique_ptr<Expression> filterExpression =
-        tryRemoveFilterNode(filterNode, plan);
+    std::unique_ptr<Expression> filterExpression = tryRemoveFilterNode(
+        filterNode, plan, enumerateNearVectorNode->distanceOutVariable());
     if (!filterExpression) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_QUERY_VECTOR_SEARCH_NOT_APPLIED,

--- a/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
+++ b/arangod/Aql/Optimizer/Rule/PushFilterIntoEnumerateNear.cpp
@@ -50,9 +50,8 @@ using EN = ExecutionNode;
 #define LOG_RULE_IF(cond) LOG_DEVEL_IF((LOG_RULE_ENABLED) && (cond))
 #define LOG_RULE LOG_RULE_IF(true)
 
-std::unique_ptr<Expression> tryRemoveFilterNode(
-    auto* maybeFilterNode, auto& plan,
-    auto const* enumerateNearVectorOutputDocument) {
+std::unique_ptr<Expression> tryRemoveFilterNode(auto* maybeFilterNode,
+                                                auto& plan) {
   auto const* filterNode =
       ExecutionNode::castTo<FilterNode const*>(maybeFilterNode);
   auto const* filterInVar = filterNode->inVariable();
@@ -67,23 +66,12 @@ std::unique_ptr<Expression> tryRemoveFilterNode(
   auto const* calculationNode =
       ExecutionNode::castTo<CalculationNode const*>(maybeCalculationNode);
 
-  // Check that all variables used in filterExpression can be handled in
-  // EnumerateNearVector node
-  VarSet calculationVars;
   auto filterExpression = calculationNode->expression()->clone(plan->getAst());
-  filterExpression->variables(calculationVars);
-
-  for (auto const* calcVar : calculationVars) {
-    if (calcVar->type() != Variable::Type::Regular) {
-      continue;
-    }
-    if (calcVar != enumerateNearVectorOutputDocument) {
-      return nullptr;
-    }
-  }
 
   // CalculationNode will be removed by the subsequent rule if it is not
-  // referenced by any other node
+  // referenced by any other node. EnumerateNearVectorNode advertises the
+  // filter's variables through getVariablesUsedHere, so the register planner
+  // keeps them alive up to this node.
   plan->unlinkNode(maybeFilterNode);
 
   return filterExpression;
@@ -197,8 +185,8 @@ void pushFilterIntoEnumerateNear(Optimizer* opt,
 
     // If there is a FilterNode it comes with CalculationNode, we remove it
     // and handle it in EnumerateNearVectorNode
-    std::unique_ptr<Expression> filterExpression = tryRemoveFilterNode(
-        filterNode, plan, enumerateNearVectorNode->documentOutVariable());
+    std::unique_ptr<Expression> filterExpression =
+        tryRemoveFilterNode(filterNode, plan);
     if (!filterExpression) {
       THROW_ARANGO_EXCEPTION_MESSAGE(
           TRI_ERROR_QUERY_VECTOR_SEARCH_NOT_APPLIED,

--- a/tests/js/client/aql/vector/aql-vector-filter.js
+++ b/tests/js/client/aql/vector/aql-vector-filter.js
@@ -590,7 +590,7 @@ function VectorIndexL2FilterTestSuite() {
 
             const results = db._query(query, bindVars).toArray();
 
-            assertEqual(results.length, 5);
+            assertEqual(5, results.length);
         },
 
         testApproxL2WithMultipleFilterClauses: function() {
@@ -753,7 +753,7 @@ function VectorIndexL2FilterTestMultipleCollectionsSuite() {
 
             const results = db._query(query, bindVars).toArray();
 
-            assertEqual(results.length, 5);
+            assertEqual(5, results.length, 5);
         },
 
         testApproxL2FilterNotAppliedReversedLoop: function() {

--- a/tests/js/client/aql/vector/aql-vector-filter.js
+++ b/tests/js/client/aql/vector/aql-vector-filter.js
@@ -570,6 +570,29 @@ function VectorIndexL2FilterTestSuite() {
             verifyResultsMatchFilter(results, (r) => r.outerKey !== undefined);
         },
 
+        testApproxL2WithFilterInOperator: function() {
+            const query = `
+            LET CATEGORIES = (FOR d IN ${collection.name()} RETURN DISTINCT d.category)
+            FOR d IN ${collection.name()}
+            FILTER d.category IN CATEGORIES
+            LET dist = APPROX_NEAR_L2(@qp, d.vector)
+            SORT dist LIMIT 5
+            RETURN d`;
+
+            const bindVars = {
+                qp: randomPoint
+            };
+            const plan = db._createStatement({
+                query,
+                bindVars
+            }).explain().plan;
+            verifyVectorIndexUsed(plan);
+
+            const results = db._query(query, bindVars).toArray();
+
+            assertEq(results.length, 5);
+        },
+
         testApproxL2WithMultipleFilterClauses: function() {
             const query = `FOR d IN ${collection.name()}
               FILTER d.val >= 5

--- a/tests/js/client/aql/vector/aql-vector-filter.js
+++ b/tests/js/client/aql/vector/aql-vector-filter.js
@@ -590,7 +590,7 @@ function VectorIndexL2FilterTestSuite() {
 
             const results = db._query(query, bindVars).toArray();
 
-            assertEq(results.length, 5);
+            assertEqual(results.length, 5);
         },
 
         testApproxL2WithMultipleFilterClauses: function() {
@@ -636,7 +636,7 @@ function VectorIndexL2FilterTestSuite() {
               LET dist = APPROX_NEAR_L2(@qp, d.vector)
               FILTER dist < 0.5
               SORT dist LIMIT 5
-              RETURN d  `;
+              RETURN d`;
 
             const bindVars = {
                 qp: randomPoint
@@ -733,7 +733,7 @@ function VectorIndexL2FilterTestMultipleCollectionsSuite() {
             db._dropDatabase(dbName);
         },
 
-        testApproxL2FilterNotApplied: function() {
+        testApproxL2FilterDoubleLoop: function() {
             const query = `FOR d1 IN ${collection2.name()}
               FOR d2 IN ${collection1.name()}
               FILTER d2.val < 5 OR d1.val < 5
@@ -745,11 +745,15 @@ function VectorIndexL2FilterTestMultipleCollectionsSuite() {
                 qp: randomPoint
             };
 
-            assertQueryError(
-                errors.ERROR_QUERY_VECTOR_SEARCH_NOT_APPLIED.code,
+            const plan = db._createStatement({
                 query,
-                bindVars,
-            );
+                bindVars
+            }).explain().plan;
+            verifyVectorIndexUsed(plan);
+
+            const results = db._query(query, bindVars).toArray();
+
+            assertEqual(results.length, 5);
         },
 
         testApproxL2FilterNotAppliedReversedLoop: function() {


### PR DESCRIPTION
### Scope & Purpose

Enables the vector search when using regular variables in the FILTER statement. Queries like these were not possible before:
```aql
LET CATEGORIES = (FOR d IN col RETURN DISTINCT d.category)
FOR d IN col
LET dist = APPROX_NEAR_L2(@qp, d.vector)
FILTER d.category IN CATEGORIES
SORT dist LIMIT 5
RETURN d
```
And now they are.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-452
- [ ] Design document: 
