### PR TITLE
[COR-468] Remove POST /_api/edges/{coll}

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
 
+* COR-468: Removed POST method to endpoint _api/edges/{collection}, which was used by Aardvark.
+
 * COR-442: Renamed the startup options of the `--ssl.*` group into `--tls.*`,
   but still accept the old naming pattern as an alias to the new one.
   Config files using `[ssl]` sections are remapped automatically as well.

--- a/arangod/RestHandler/RestEdgesHandler.cpp
+++ b/arangod/RestHandler/RestEdgesHandler.cpp
@@ -24,19 +24,14 @@
 #include "RestEdgesHandler.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Aql/AstNode.h"
 #include "Aql/Query.h"
 #include "Aql/QueryString.h"
-#include "Aql/Variable.h"
 #include "Basics/StringUtils.h"
 #include "StorageEngine/TransactionState.h"
-#include "Transaction/Helpers.h"
 #include "Transaction/OperationOrigin.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/CollectionNameResolver.h"
 #include "VocBase/LogicalCollection.h"
-
-#include <velocypack/Iterator.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -60,9 +55,6 @@ RestStatus RestEdgesHandler::execute() {
   switch (type) {
     case rest::RequestType::GET:
       readEdges();
-      break;
-    case rest::RequestType::POST:
-      readEdgesForMultipleVertices();
       break;
     default:
       generateNotImplemented("ILLEGAL " + EDGES_PATH);
@@ -233,111 +225,6 @@ bool RestEdgesHandler::readEdges() {
   // and generate a response
   generateResult(rest::ResponseCode::OK, std::move(buffer),
                  queryResult.context);
-
-  return true;
-}
-
-// Internal function to receive all edges for a list of vertices
-// Not publicly documented on purpose.
-// NOTE: It ONLY except _id strings. Nothing else
-bool RestEdgesHandler::readEdgesForMultipleVertices() {
-  std::vector<std::string> const& suffixes = _request->decodedSuffixes();
-
-  if (suffixes.size() != 1) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  "expected POST " + EDGES_PATH +
-                      "/<collection-identifier>?direction=<direction>");
-    return false;
-  }
-
-  bool parseSuccess = false;
-  VPackSlice body = this->parseVPackBody(parseSuccess);
-
-  if (!parseSuccess) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  "expected POST " + EDGES_PATH +
-                      "/<collection-identifier>?direction=<direction>");
-    // A body is required
-    return false;
-  }
-
-  if (!body.isArray()) {
-    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER,
-                  "Expected an array of vertex _id's in body parameter");
-    return false;
-  }
-
-  std::string const& collectionName = suffixes[0];
-  if (!validateCollection(collectionName)) {
-    return false;
-  }
-
-  TRI_edge_direction_e direction;
-  if (!parseDirection(direction)) {
-    return false;
-  }
-
-  VPackBuffer<uint8_t> buffer;
-  VPackBuilder resultBuilder(buffer);
-  resultBuilder.openObject();
-  // build edges
-  resultBuilder.add("edges", VPackValue(VPackValueType::Array));
-
-  std::unordered_set<std::string> foundEdges;
-
-  // Check if dirty reads are allowed:
-  bool found = false;
-  std::string const& val =
-      _request->header(StaticStrings::AllowDirtyReads, found);
-  bool allowDirtyReads = false;
-  if (found && StringUtils::boolean(val)) {
-    // This will be used in `createTransaction` below, if that creates
-    // a new transaction. Otherwise, we use the default given by the
-    // existing transaction.
-    allowDirtyReads = true;
-  }
-
-  std::shared_ptr<transaction::Context> ctx;
-  for (VPackSlice it : VPackArrayIterator(body)) {
-    std::string startVertex = it.copyString();
-    auto queryResult = ::queryEdges(_vocbase, collectionName, direction,
-                                    startVertex, allowDirtyReads);
-
-    if (queryResult.result.fail()) {
-      if (queryResult.result.is(TRI_ERROR_REQUEST_CANCELED) ||
-          (queryResult.result.is(TRI_ERROR_QUERY_KILLED))) {
-        generateError(rest::ResponseCode::GONE, TRI_ERROR_REQUEST_CANCELED);
-        return false;
-      }
-      THROW_ARANGO_EXCEPTION_MESSAGE(
-          queryResult.result.errorNumber(),
-          StringUtils::concatT("Error executing edges query ",
-                               queryResult.result.errorMessage()));
-    }
-
-    VPackSlice edges = queryResult.data->slice();
-    for (VPackSlice edge : VPackArrayIterator(edges)) {
-      if (foundEdges
-              .emplace(transaction::helpers::extractKeyFromDocument(edge)
-                           .copyString())
-              .second) {
-        resultBuilder.add(edge);
-      }
-    }
-    ctx = queryResult.context;
-  }
-  resultBuilder.close();  // </edges>
-
-  resultBuilder.add(StaticStrings::Error, VPackValue(false));
-  resultBuilder.add(StaticStrings::Code, VPackValue(200));
-  resultBuilder.close();
-
-  // and generate a response
-  if (ctx) {
-    generateResult(rest::ResponseCode::OK, std::move(buffer), ctx);
-  } else {
-    generateResult(rest::ResponseCode::OK, std::move(buffer));
-  }
 
   return true;
 }

--- a/arangod/RestHandler/RestEdgesHandler.h
+++ b/arangod/RestHandler/RestEdgesHandler.h
@@ -25,18 +25,7 @@
 
 #include "RestHandler/RestVocbaseBaseHandler.h"
 
-#include <velocypack/Builder.h>
-
 namespace arangodb {
-class LocalDocumentId;
-namespace transaction {
-class Methods;
-}
-
-namespace aql {
-struct AstNode;
-struct Variable;
-}  // namespace aql
 
 class RestEdgesHandler : public RestVocbaseBaseHandler {
  public:
@@ -54,22 +43,6 @@ class RestEdgesHandler : public RestVocbaseBaseHandler {
   //////////////////////////////////////////////////////////////////////////////
 
   bool readEdges();
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief reads all edges in given direction for a list of vertices
-  //////////////////////////////////////////////////////////////////////////////
-
-  bool readEdgesForMultipleVertices();
-
-  //////////////////////////////////////////////////////////////////////////////
-  /// @brief get all edges for a given vertex. Independent from the request
-  //////////////////////////////////////////////////////////////////////////////
-
-  bool getEdgesForVertex(std::string const& id, DataSourceId cid,
-                         std::string const& collectionName,
-                         TRI_edge_direction_e direction,
-                         transaction::Methods& trx,
-                         std::function<void(LocalDocumentId)> const& cb);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief Parse the direction parameter

--- a/js/client/modules/@arangodb/arango-collection.js
+++ b/js/client/modules/@arangodb/arango-collection.js
@@ -192,13 +192,24 @@ ArangoCollection.prototype._edgesQuery = function (vertex, direction) {
     return v;
   });
 
-  // get the edges
-  let url = '/_api/edges/' + encodeURIComponent(this.name())
-    + (direction ? '?direction=' + encodeURIComponent(direction) : '');
+  const baseUrl = '/_api/edges/' + encodeURIComponent(this.name());
+  const dirParam = direction ? '&direction=' + encodeURIComponent(direction) : '';
+  const seen = new Set();
+  const edges = [];
 
-  let requestResult = this._database._connection.POST(this._prefixurl(url), vertex);
-  arangosh.checkRequestResult(requestResult);
-  return requestResult.edges;
+  for (const v of vertex) {
+    const url = baseUrl + '?vertex=' + encodeURIComponent(v) + dirParam;
+    const requestResult = this._database._connection.GET(this._prefixurl(url));
+    arangosh.checkRequestResult(requestResult);
+    for (const edge of requestResult.edges) {
+      if (!seen.has(edge._id)) {
+        seen.add(edge._id);
+        edges.push(edge);
+      }
+    }
+  }
+
+  return edges;
 };
 
 ArangoCollection.prototype.shards = function (details) {


### PR DESCRIPTION
ATTENTION: I'm closing this PR because I was told it's used by the JS driver, so we can't remove it yet

### Scope & Purpose

This PR implements ticket https://arangodb.atlassian.net/browse/COR-468, it removes the undocumented POST /_api/edges/{collection} endpoint, which existed solely for internal use by Aardvark. 
No CHANGELOG entry because, though accessible, the method POST to this endpoint is said to be undocumented on purpose.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [x] Docs PR: https://arangodb.atlassian.net/browse/COR-468 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
