### PR TITLE
[COR-463] Remove `EngineSelectorFeature`

### DIFF
--- a/arangod/StorageEngine/StorageEngineFeature.cpp
+++ b/arangod/StorageEngine/StorageEngineFeature.cpp
@@ -1,0 +1,99 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Jan Steemann
+////////////////////////////////////////////////////////////////////////////////
+
+#include "StorageEngineFeature.h"
+
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Cluster/ServerState.h"
+#include "ClusterEngine/ClusterEngine.h"
+#include "FeaturePhases/BasicFeaturePhaseServer.h"
+#include "Logger/Logger.h"
+#include "RocksDBEngine/RocksDBEngine.h"
+#include "StorageEngine/StorageEngine.h"
+
+namespace arangodb {
+
+StorageEngineFeature::StorageEngineFeature(
+    application_features::ApplicationServer& server)
+    : ApplicationFeature(server, typeid(StorageEngineFeature), name()) {
+  setOptional(false);
+  startsAfter<application_features::BasicFeaturePhaseServer>();
+}
+
+template<typename As, typename std::enable_if<std::is_base_of<StorageEngine, As>::value, int>::type>
+As& StorageEngineFeature::engine() {
+    TRI_ASSERT(dynamic_cast<As*>(_engine) != nullptr);
+    return *static_cast<As*>(_engine);
+}
+
+template ClusterEngine& StorageEngineFeature::engine<ClusterEngine>();
+template RocksDBEngine& StorageEngineFeature::engine<RocksDBEngine>();
+
+void StorageEngineFeature::prepare() {
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  if (_selected.load()) {
+    // already set in the test code
+    return;
+  }
+#endif
+
+  if (ServerState::instance()->isCoordinator()) {
+    auto& clusterEngine = server().getFeature<ClusterEngine>();
+    auto& rocksDBEngine = server().getFeature<RocksDBEngine>();
+
+    rocksDBEngine.disable();
+    clusterEngine.setActualEngine(&rocksDBEngine);
+    _engine = &clusterEngine;
+  } else {
+    auto& rocksDBEngine = server().getFeature<RocksDBEngine>();
+    rocksDBEngine.enable();
+    _engine = &rocksDBEngine;
+  }
+
+  TRI_ASSERT(_engine != nullptr);
+  _selected.store(true);
+}
+
+void StorageEngineFeature::unprepare() {
+  _selected.store(false);
+  _engine = nullptr;
+  if (ServerState::instance()->isCoordinator()) {
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+    if (!arangodb::ClusterEngine::Mocking) {
+#endif
+      server().getFeature<ClusterEngine>().setActualEngine(nullptr);
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+    }
+#endif
+  }
+}
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+void StorageEngineFeature::setEngineTesting(StorageEngine* input) {
+    TRI_ASSERT((input == nullptr) != (_engine == nullptr));
+    _selected.store(input != nullptr);
+    _engine = input;
+}
+#endif
+
+}  // namespace arangodb

--- a/arangod/StorageEngine/StorageEngineFeature.h
+++ b/arangod/StorageEngine/StorageEngineFeature.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -28,6 +28,9 @@
 #include "FeaturePhases/BasicFeaturePhaseServer.h"
 
 namespace arangodb {
+class ClusterEngine;
+class RocksDBEngine;
+class StorageEngine;
 
 // a stub class that other features can use to check whether a storage
 // engine (no matter what type) is ready
@@ -36,11 +39,28 @@ class StorageEngineFeature final
  public:
   static constexpr std::string_view name() noexcept { return "StorageEngine"; }
 
-  explicit StorageEngineFeature(application_features::ApplicationServer& server)
-      : ApplicationFeature(server, typeid(StorageEngineFeature), name()) {
-    setOptional(false);
-    startsAfter<application_features::BasicFeaturePhaseServer>();
-  }
+  explicit StorageEngineFeature(application_features::ApplicationServer& server);
+
+  StorageEngine& engine();
+  template<typename As,
+           typename std::enable_if<std::is_base_of<StorageEngine, As>::value,
+                                   int>::type = 0>
+  As& engine();
+
+  std::string_view engineName() const;
+  static std::string_view defaultEngine();
+  bool isRocksDB();
+  bool selected() const { return _selected.load(); }
+  void prepare() override final;
+  void unprepare() override final;
+
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  void setEngineTesting(StorageEngine*);
+#endif
+
+ private:
+  StorageEngine* _engine{nullptr};
+  std::atomic<bool> _selected{false};
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
### Scope & Purpose

1. Move the existing fields and methods in `EngineSelectorFeature` to `StorageEngineFeature`.
We can’t simply delete `EngineSelectorFeature` replace existing use with `RocksDBEngine` because coordinators still use `ClusterEngine` while DB servers and single servers use `RocksDBEngine`. That choice is made at runtime from the server's state. So, this polymorphic accessor will go to a new home: `StorageEngineFeature`.

2. Move other selector responsibilities. 
3. Rewrite call sites:
`server.getFeature<EngineSelectorFeature>().engine()`
becomes
`server.getFeature<StorageEngineFeature>().engine()`.
`server.getFeature<EngineSelectorFeature>().engine<RocksDBEngine>()`
becomes
`server.getFeature<StorageEngineFeature>().engine<RocksDBEngine>()` or `server.getFeature<RocksDBEngine>()`.

4. Delete `EngineSelectorFeature`.
5. Change tests.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
