### PR TITLE
[COR-509] Remove `EngineSelectorFeature` 1

### DIFF
--- a/arangod/Cluster/CreateDatabase.cpp
+++ b/arangod/Cluster/CreateDatabase.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -34,6 +34,7 @@
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
 #include "RestServer/DatabaseFeature.h"
+#include "RocksDBEngine/RocksDBEngine.h"
 #include "Utils/DatabaseGuard.h"
 #include "Utils/OperationOptions.h"
 #include "VocBase/Methods/Databases.h"
@@ -90,7 +91,8 @@ bool CreateDatabase::first() {
 
     // Assertion in constructor makes sure that we have DATABASE.
     auto& server = _feature.server();
-    res = Databases::create(server, ExecContext::current(),
+    auto& rocksdbEngine = server.getFeature<RocksDBEngine>();
+    res = Databases::create(server, rocksdbEngine, ExecContext::current(),
                             _description.get(DATABASE), users, properties());
     result(res);
     if (res.fail() && res.isNot(TRI_ERROR_ARANGO_DUPLICATE_NAME)) {

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -73,7 +73,6 @@
 #include "RestServer/ViewTypesFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "RocksDBEngine/RocksDBLogValue.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/TransactionState.h"

--- a/arangod/IResearch/IResearchFeature.cpp
+++ b/arangod/IResearch/IResearchFeature.cpp
@@ -322,7 +322,6 @@ Result upgradeArangoSearchLinkCollectionName(
       !vocbase.server().getFeature<ClusterFeature>().isEnabled()) {
     return {};  // not applicable for other ServerState roles
   }
-  auto& selector = vocbase.server().getFeature<EngineSelectorFeature>();
   auto& clusterInfo =
       vocbase.server().getFeature<ClusterFeature>().clusterInfo();
   // persist collection names in links
@@ -376,8 +375,8 @@ Result upgradeArangoSearchLinkCollectionName(
             LOG_TOPIC("b269d", INFO, arangodb::iresearch::TOPIC)
                 << "Setting collection name '" << clusterCollectionName
                 << "' for link " << id;
-            if (selector.engineName() == RocksDBEngine::kEngineName) {
-              auto& engine = selector.engine<RocksDBEngine>();
+            if (vocbase.engine().typeName() == RocksDBEngine::kEngineName) {
+              auto& engine = static_cast<RocksDBEngine&>(vocbase.engine());
               auto builder = collection->toVelocyPackIgnore(
                   {"path"},
                   LogicalDataSource::Serialization::PersistenceWithInProgress);
@@ -393,13 +392,13 @@ Result upgradeArangoSearchLinkCollectionName(
               }
 #ifdef ARANGODB_USE_GOOGLE_TESTS
               // for unit tests just ignore write to storage
-            } else if (selector.engineName() != "Mock") {
+            } else if (vocbase.engine().typeName() != "Mock") {
 #else
             } else {
 #endif
               TRI_ASSERT(false);
               LOG_TOPIC("d6edc", WARN, arangodb::iresearch::TOPIC)
-                  << "Unsupported engine '" << selector.engineName()
+                  << "Unsupported engine '" << vocbase.engine().typeName()
                   << "' for link upgrade task";
             }
           }

--- a/arangod/Replication/GlobalInitialSyncer.cpp
+++ b/arangod/Replication/GlobalInitialSyncer.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -32,6 +32,7 @@
 #include "Replication/DatabaseInitialSyncer.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
+#include "RocksDBEngine/RocksDBEngine.h"
 #include "SimpleHttpClient/SimpleHttpClient.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
 #include "VocBase/LogicalCollection.h"
@@ -280,8 +281,10 @@ Result GlobalInitialSyncer::updateServerInventory(
 
     if (vocbase == nullptr) {
       // database is missing. we need to create it now
+      auto& server = _state.applier._server;
+      auto& rocksdbEngine = server.getFeature<RocksDBEngine>();
       Result r = methods::Databases::create(
-          _state.applier._server, ExecContext::current(), dbName,
+          server, rocksdbEngine, ExecContext::current(), dbName,
           VPackSlice::emptyArraySlice(), VPackSlice::emptyObjectSlice());
       if (r.fail()) {
         LOG_TOPIC("cf124", WARN, Logger::REPLICATION)

--- a/arangod/Replication/GlobalReplicationApplier.cpp
+++ b/arangod/Replication/GlobalReplicationApplier.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");

--- a/arangod/Replication/TailingSyncer.cpp
+++ b/arangod/Replication/TailingSyncer.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -44,9 +44,9 @@
 #include "Rest/HttpRequest.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
+#include "RocksDBEngine/RocksDBEngine.h"
 #include "SimpleHttpClient/SimpleHttpClient.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/Hints.h"
 #include "Utils/CollectionGuard.h"
@@ -351,8 +351,10 @@ Result TailingSyncer::processDBMarker(TRI_replication_operation_e type,
       }
     }
 
+    auto& server = _state.applier._server;
+    auto& rocksdbEngine = server.getFeature<RocksDBEngine>();
     VPackSlice users = VPackSlice::emptyArraySlice();
-    Result res = methods::Databases::create(_state.applier._server,
+    Result res = methods::Databases::create(server, rocksdbEngine,
                                             ExecContext::current(), name, users,
                                             VPackSlice::emptyObjectSlice());
 

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -58,6 +58,7 @@
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
 #include "Replication2/ReplicatedLog/AgencySpecificationInspectors.h"
+#include "RocksDBEngine/RocksDBEngine.h"
 #include "Scheduler/SchedulerFeature.h"
 #include "Sharding/ShardDistributionReporter.h"
 #include "StorageEngine/VPackSortMigration.h"
@@ -1708,7 +1709,9 @@ async<void> RestAdminClusterHandler::setDBServerMaintenance(
     auto result = co_await sendTransaction();
     if (result.ok() && result.statusCode() == 200) {
       VPackBuilder builder;
-      { VPackObjectBuilder obj(&builder); }
+      {
+        VPackObjectBuilder obj(&builder);
+      }
       generateOk(rest::ResponseCode::OK, builder);
       co_await waitForDBServerMaintenance(serverId, isMaintenanceMode);
     } else {
@@ -2998,14 +3001,23 @@ async<void> RestAdminClusterHandler::handleVPackSortMigration(
   VPackBuilder result;
   Result res;
   if (!ServerState::instance()->isCoordinator()) {
-    if (request()->requestType() == rest::RequestType::GET) {
-      if (subCommand == VPackSortMigrationCheck) {
-        res = ::analyzeVPackIndexSorting(_vocbase, result);
-      } else {
-        res = ::statusVPackIndexSorting(_vocbase, result);
+    auto& storageEngine = _vocbase.engine();
+    if (storageEngine.typeName() != RocksDBEngine::kEngineName) {
+      res = Result(TRI_ERROR_NOT_IMPLEMENTED,
+                   "VPack sorting migration is unnecessary for storage engines "
+                   "other than RocksDB");
+    } else {
+      auto& rocksDBEngine = static_cast<RocksDBEngine&>(storageEngine);
+
+      if (request()->requestType() == rest::RequestType::GET) {
+        if (subCommand == VPackSortMigrationCheck) {
+          res = ::analyzeVPackIndexSorting(_vocbase, result);
+        } else {
+          res = ::statusVPackIndexSorting(rocksDBEngine, result);
+        }
+      } else {  // PUT
+        res = ::migrateVPackIndexSorting(rocksDBEngine, result);
       }
-    } else {  // PUT
-      res = ::migrateVPackIndexSorting(_vocbase, result);
     }
   } else {
     // Coordinators from here:

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -3011,7 +3011,9 @@ async<void> RestAdminClusterHandler::handleVPackSortMigration(
 
       if (request()->requestType() == rest::RequestType::GET) {
         if (subCommand == VPackSortMigrationCheck) {
-          res = ::analyzeVPackIndexSorting(_vocbase, result);
+          res = ::analyzeVPackIndexSorting(
+              rocksDBEngine, _vocbase.server().getFeature<DatabaseFeature>(),
+              result);
         } else {
           res = ::statusVPackIndexSorting(rocksDBEngine, result);
         }

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");

--- a/arangod/RestHandler/RestDatabaseHandler.cpp
+++ b/arangod/RestHandler/RestDatabaseHandler.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -29,6 +29,7 @@
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
+#include "RocksDBEngine/RocksDBEngine.h"
 #include "Utils/Events.h"
 #include "VocBase/Methods/Databases.h"
 
@@ -148,8 +149,9 @@ RestStatus RestDatabaseHandler::createDatabase() {
   VPackSlice options = body.get("options");
   VPackSlice users = body.get("users");
 
-  Result res =
-      methods::Databases::create(server(), _context, dbName, users, options);
+  auto& rocksdbEngine = server().getFeature<RocksDBEngine>();
+  Result res = methods::Databases::create(server(), rocksdbEngine, _context,
+                                          dbName, users, options);
   if (res.ok()) {
     generateOk(rest::ResponseCode::CREATED, VPackSlice::trueSlice());
   } else {

--- a/arangod/RestHandler/RestDocumentHandler.cpp
+++ b/arangod/RestHandler/RestDocumentHandler.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -30,7 +30,6 @@
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/ServerState.h"
 #include "Random/RandomGenerator.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/TransactionState.h"
 #include "Transaction/Helpers.h"
@@ -887,10 +886,7 @@ void RestDocumentHandler::handleFillIndexCachesValue(
   RefillIndexCaches ric = RefillIndexCaches::kDefault;
 
   if (!options.isSynchronousReplicationFrom.empty() &&
-      !_vocbase.server()
-           .getFeature<EngineSelectorFeature>()
-           .engine()
-           .autoRefillIndexCachesOnFollowers()) {
+      !_vocbase.engine().autoRefillIndexCachesOnFollowers()) {
     // do not refill caches on followers if this is intentionally turned off
     ric = RefillIndexCaches::kDontRefill;
   } else {

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -355,7 +355,7 @@ void DatabaseFeature::initCalculationVocbase(
     application_features::ApplicationServer& server) {
   auto& df = server.getFeature<DatabaseFeature>();
   calculationVocbase = std::make_unique<TRI_vocbase_t>(
-      createExpressionVocbaseInfo(server), df.versionTracker(),
+      createExpressionVocbaseInfo(server), df.engine(), df.versionTracker(),
       df.extendedNames(), /*isInternal*/ true);
 }
 

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -174,6 +174,11 @@ class DatabaseFeature final : public application_features::ApplicationFeature {
       std::function<void(TRI_vocbase_t& vocbase)> const& func);
   std::string translateCollectionName(std::string_view dbName,
                                       std::string_view collectionName);
+
+  StorageEngine& engine() const noexcept {
+    TRI_ASSERT(_engine != nullptr);
+    return *_engine;
+  }
 
   bool ignoreDatafileErrors() const noexcept {
     return _options.ignoreDatafileErrors;

--- a/arangod/StorageEngine/StorageEngine.cpp
+++ b/arangod/StorageEngine/StorageEngine.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -68,7 +68,7 @@ std::unique_ptr<TRI_vocbase_t> StorageEngine::createDatabase(
     CreateDatabaseInfo&& info) {
   DatabaseFeature& databaseFeature =
       info.server().getFeature<DatabaseFeature>();
-  return std::make_unique<TRI_vocbase_t>(std::move(info),
+  return std::make_unique<TRI_vocbase_t>(std::move(info), databaseFeature.engine(),
                                          databaseFeature.versionTracker(),
                                          databaseFeature.extendedNames());
 }

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -44,8 +44,13 @@ namespace arangodb {
 
 // On dbservers, agents and single servers:
 Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
-  TRI_ASSERT(vocbase.engine().typeName() == RocksDBEngine::kEngineName);
-  auto& engine = vocbase.engine<RocksDBEngine>();
+  auto& storageEngine = vocbase.engine();
+  if (storageEngine.typeName() != RocksDBEngine::kEngineName) {
+    return Result(TRI_ERROR_NOT_IMPLEMENTED,
+                  "VPack sorting migration is unnecessary for storage engines "
+                  "other than RocksDB");
+  }
+  auto& engine = static_cast<RocksDBEngine&>(storageEngine);
   auto* db = engine.db();
 
   using IndexType = arangodb::Index::IndexType;
@@ -167,11 +172,9 @@ Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
   return {};
 }
 
-Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
+Result migrateVPackIndexSorting(RocksDBEngine& engine, VPackBuilder& result) {
   result.clear();
 
-  TRI_ASSERT(vocbase.engine().typeName() == RocksDBEngine::kEngineName);
-  auto& engine = vocbase.engine<RocksDBEngine>();
   Result res = engine.writeSortingFile(
       arangodb::basics::VelocyPackHelper::SortingMethod::Correct);
 
@@ -186,9 +189,7 @@ Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
   return res;
 }
 
-Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
-  TRI_ASSERT(vocbase.engine().typeName() == RocksDBEngine::kEngineName);
-  auto& engine = vocbase.engine<RocksDBEngine>();
+Result statusVPackIndexSorting(RocksDBEngine& engine, VPackBuilder& result) {
   auto sortingFileMethod = engine.readSortingFile();
   {
     VPackObjectBuilder guard(&result);

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -29,7 +29,6 @@
 #include "RocksDBEngine/RocksDBComparator.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "RocksDBEngine/RocksDBIndex.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "Utils/SingleCollectionTransaction.h"
 #include "Transaction/StandaloneContext.h"
@@ -45,6 +44,7 @@ namespace arangodb {
 
 // On dbservers, agents and single servers:
 Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
+  TRI_ASSERT(vocbase.engine().typeName() == RocksDBEngine::kEngineName);
   auto& engine = vocbase.engine<RocksDBEngine>();
   auto* db = engine.db();
 
@@ -170,6 +170,7 @@ Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
 Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
   result.clear();
 
+  TRI_ASSERT(vocbase.engine().typeName() == RocksDBEngine::kEngineName);
   auto& engine = vocbase.engine<RocksDBEngine>();
   Result res = engine.writeSortingFile(
       arangodb::basics::VelocyPackHelper::SortingMethod::Correct);
@@ -186,6 +187,7 @@ Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
 }
 
 Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
+  TRI_ASSERT(vocbase.engine().typeName() == RocksDBEngine::kEngineName);
   auto& engine = vocbase.engine<RocksDBEngine>();
   auto sortingFileMethod = engine.readSortingFile();
   {

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -43,19 +43,12 @@
 namespace arangodb {
 
 // On dbservers, agents and single servers:
-Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
-  auto& storageEngine = vocbase.engine();
-  if (storageEngine.typeName() != RocksDBEngine::kEngineName) {
-    return Result(TRI_ERROR_NOT_IMPLEMENTED,
-                  "VPack sorting migration is unnecessary for storage engines "
-                  "other than RocksDB");
-  }
-  auto& engine = static_cast<RocksDBEngine&>(storageEngine);
+Result analyzeVPackIndexSorting(RocksDBEngine& engine,
+                                DatabaseFeature& databaseFeature,
+                                VPackBuilder& result) {
   auto* db = engine.db();
 
   using IndexType = arangodb::Index::IndexType;
-  DatabaseFeature& databaseFeature =
-      vocbase.server().getFeature<DatabaseFeature>();
   auto newComparator = RocksDBVPackComparator<
       arangodb::basics::VelocyPackHelper::SortingMethod::Correct>();
 

--- a/arangod/StorageEngine/VPackSortMigration.cpp
+++ b/arangod/StorageEngine/VPackSortMigration.cpp
@@ -45,17 +45,7 @@ namespace arangodb {
 
 // On dbservers, agents and single servers:
 Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
-  // Just for the sake of completeness, restrict ourselves to the RocksDB
-  // storage engine:
-  auto& engineSelectorFeature =
-      vocbase.server().getFeature<EngineSelectorFeature>();
-  if (!engineSelectorFeature.isRocksDB()) {
-    return Result(TRI_ERROR_NOT_IMPLEMENTED,
-                  "VPack sorting migration is unnecessary for storage engines "
-                  "other than RocksDB");
-  }
-
-  auto& engine = engineSelectorFeature.engine<RocksDBEngine>();
+  auto& engine = vocbase.engine<RocksDBEngine>();
   auto* db = engine.db();
 
   using IndexType = arangodb::Index::IndexType;
@@ -178,18 +168,9 @@ Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
 }
 
 Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
-  // Just for the sake of completeness, restrict ourselves to the RocksDB
-  // storage engine:
   result.clear();
-  auto& engineSelectorFeature =
-      vocbase.server().getFeature<EngineSelectorFeature>();
-  if (!engineSelectorFeature.isRocksDB()) {
-    return Result(TRI_ERROR_NOT_IMPLEMENTED,
-                  "VPack sorting migration is unnecessary for storage engines "
-                  "other than RocksDB");
-  }
 
-  auto& engine = engineSelectorFeature.engine<RocksDBEngine>();
+  auto& engine = vocbase.engine<RocksDBEngine>();
   Result res = engine.writeSortingFile(
       arangodb::basics::VelocyPackHelper::SortingMethod::Correct);
 
@@ -205,17 +186,7 @@ Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
 }
 
 Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result) {
-  // Just for the sake of completeness, restrict ourselves to the RocksDB
-  // storage engine:
-  auto& engineSelectorFeature =
-      vocbase.server().getFeature<EngineSelectorFeature>();
-  if (!engineSelectorFeature.isRocksDB()) {
-    return Result(TRI_ERROR_NOT_IMPLEMENTED,
-                  "VPack sorting migration is unnecessary for storage engines "
-                  "other than RocksDB");
-  }
-
-  auto& engine = engineSelectorFeature.engine<RocksDBEngine>();
+  auto& engine = vocbase.engine<RocksDBEngine>();
   auto sortingFileMethod = engine.readSortingFile();
   {
     VPackObjectBuilder guard(&result);

--- a/arangod/StorageEngine/VPackSortMigration.h
+++ b/arangod/StorageEngine/VPackSortMigration.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
 /// you may not use this file except in compliance with the License.
@@ -26,11 +26,12 @@
 #include "VocBase/vocbase.h"
 
 namespace arangodb {
+class RocksDBEngine;
 
 // On dbservers, agents and single servers:
 Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
-Result migrateVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
-Result statusVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
+Result migrateVPackIndexSorting(RocksDBEngine& engine, VPackBuilder& result);
+Result statusVPackIndexSorting(RocksDBEngine& engine, VPackBuilder& result);
 
 // On coordinators:
 async<Result> fanOutRequests(TRI_vocbase_t& vocbase, fuerte::RestVerb verb,

--- a/arangod/StorageEngine/VPackSortMigration.h
+++ b/arangod/StorageEngine/VPackSortMigration.h
@@ -29,7 +29,9 @@ namespace arangodb {
 class RocksDBEngine;
 
 // On dbservers, agents and single servers:
-Result analyzeVPackIndexSorting(TRI_vocbase_t& vocbase, VPackBuilder& result);
+Result analyzeVPackIndexSorting(RocksDBEngine& engine,
+                                DatabaseFeature& databaseFeature,
+                                VPackBuilder& result);
 Result migrateVPackIndexSorting(RocksDBEngine& engine, VPackBuilder& result);
 Result statusVPackIndexSorting(RocksDBEngine& engine, VPackBuilder& result);
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -46,7 +46,6 @@
 #include "Replication2/StateMachines/Document/DocumentStateMachine.h"
 #include "RestServer/DatabaseFeature.h"
 #include "Sharding/ShardingInfo.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/Helpers.h"
@@ -944,8 +943,7 @@ Result LogicalCollection::properties(velocypack::Slice slice) {
         "failed to find feature 'Database' while updating collection");
   }
 
-  if (!vocbase().server().hasFeature<EngineSelectorFeature>() ||
-      !vocbase().server().getFeature<EngineSelectorFeature>().selected()) {
+  if (vocbase().engine().typeName().empty()) {
     return Result(TRI_ERROR_INTERNAL,
                   "failed to find a storage engine while updating collection");
   }
@@ -1408,13 +1406,14 @@ auto LogicalCollection::getDocumentStateLeader() -> std::shared_ptr<
     replication2::replicated_state::document::DocumentLeaderState> {
   auto stateMachine = getDocumentState();
 
-  static constexpr auto throwUnavailable = []<typename... Args>(
-      basics::SourceLocation location, std::format_string<Args...> formatString,
-      Args && ... args) {
-    throw basics::Exception(
-        TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_AVAILABLE,
-        std::format(formatString, std::forward<Args>(args)...), location);
-  };
+  static constexpr auto throwUnavailable =
+      []<typename... Args>(basics::SourceLocation location,
+                           std::format_string<Args...> formatString,
+                           Args&&... args) {
+        throw basics::Exception(
+            TRI_ERROR_REPLICATION_REPLICATED_STATE_NOT_AVAILABLE,
+            std::format(formatString, std::forward<Args>(args)...), location);
+      };
 
   auto leader = stateMachine->getLeader();
   if (leader == nullptr) {

--- a/arangod/VocBase/LogicalView.cpp
+++ b/arangod/VocBase/LogicalView.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -366,15 +366,14 @@ Result drop(LogicalView const& view) noexcept {
 
 Result properties(LogicalView const& view, bool safe) noexcept {
   auto& vocbase = view.vocbase();
-  auto& server = vocbase.server();
-  if (!server.hasFeature<EngineSelectorFeature>()) {
+  auto& engine = vocbase.engine();
+  if (engine.typeName().empty()) {
     return {
         TRI_ERROR_INTERNAL,
         "failed to find storage engine while updating definition of view '" +
             view.name() + "' in database '" + vocbase.name() + "'"};
   }
   return safeCall([&]() -> Result {
-    auto& engine = vocbase.engine();
     if (engine.inRecovery()) {
       return {};
     }

--- a/arangod/VocBase/LogicalView.cpp
+++ b/arangod/VocBase/LogicalView.cpp
@@ -33,7 +33,6 @@
 #include "Logger/Logger.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/ViewTypesFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Utils/Events.h"
 #include "Utils/ExecContext.h"

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -858,18 +858,7 @@ void Collections::applySystemCollectionProperties(
   // This implements some stunt to figure out if we are in a mock environment.
   // If that is the case we may not have all System collections.
   // So we better not enforce distributeShardsLike.
-  bool isMock = false;
-  if (vocbase.server().hasFeature<EngineSelectorFeature>()) {
-    StorageEngine& engine =
-        vocbase.server().getFeature<EngineSelectorFeature>().engine();
-
-    isMock = (engine.typeName() == "Mock");
-  } else {
-    // We do not even have a full server, can only be a mock.
-    isMock = true;
-  }
-
-  if (isMock) {
+  if (vocbase.engine().typeName() == "Mock") {
     designatedLeaderName = col.name;
   }
 #endif

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -52,7 +52,6 @@
 #include "Scheduler/SchedulerFeature.h"
 #include "Sharding/ShardingFeature.h"
 #include "Sharding/ShardingInfo.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/Helpers.h"

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -261,7 +261,7 @@ Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
   // This vocbase is needed for the call to methods::Upgrade::createDB, but
   // is just a placeholder
   CreateDatabaseInfo tempInfo = info;
-  TRI_vocbase_t vocbase(std::move(tempInfo), databaseFeature.versionTracker(),
+  TRI_vocbase_t vocbase(std::move(tempInfo), databaseFeature.engine(), databaseFeature.versionTracker(),
                         databaseFeature.extendedNames());
 
   // Now create *all* system collections for the database,

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -43,7 +43,6 @@
 #include "RestServer/SystemDatabaseFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "Sharding/ShardingInfo.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Utils/Events.h"
 #include "Utils/ExecContext.h"
 #include "Utilities/NameValidator.h"
@@ -345,8 +344,9 @@ Result Databases::createOther(CreateDatabaseInfo const& info) {
 }
 
 Result Databases::create(application_features::ApplicationServer& server,
-                         ExecContext const& exec, std::string const& dbName,
-                         velocypack::Slice users, velocypack::Slice options) {
+                         RocksDBEngine& rocksdbEngine, ExecContext const& exec,
+                         std::string const& dbName, velocypack::Slice users,
+                         velocypack::Slice options) {
   Result res = basics::catchToResult([&]() {
     Result res;
 
@@ -403,9 +403,7 @@ Result Databases::create(application_features::ApplicationServer& server,
         return Result(TRI_ERROR_NOT_IMPLEMENTED, message);
       }
 
-      auto& selector = server.getFeature<EngineSelectorFeature>();
-      auto& engine = selector.engine<RocksDBEngine>();
-      if (engine.syncThread() == nullptr) {
+      if (rocksdbEngine.syncThread() == nullptr) {
         return Result(TRI_ERROR_CLUSTER_COULD_NOT_CREATE_DATABASE,
                       "Automatic syncing must be enabled for replication "
                       "version 2. Please make sure the --rocksdb.sync-interval "

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");

--- a/arangod/VocBase/Methods/Databases.h
+++ b/arangod/VocBase/Methods/Databases.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -40,6 +40,7 @@ class ApplicationServer;
 class DatabaseFeature;
 class ClusterFeature;
 struct OperationOptions;
+class RocksDBEngine;
 namespace methods {
 
 struct Databases {
@@ -51,8 +52,9 @@ struct Databases {
                                        std::string const& user = "");
   static Result info(TRI_vocbase_t* vocbase, velocypack::Builder& result);
   static Result create(application_features::ApplicationServer& server,
-                       ExecContext const& context, std::string const& dbName,
-                       velocypack::Slice users, velocypack::Slice options);
+                       RocksDBEngine& rocksdbEngine, ExecContext const& context,
+                       std::string const& dbName, velocypack::Slice users,
+                       velocypack::Slice options);
   static Result drop(ExecContext const& context, TRI_vocbase_t* systemVocbase,
                      std::string const& dbName);
 

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -783,7 +783,12 @@ Result UpgradeTasks::migrateHashSkiplistToPersistent(
     auto& clusterFeature = vocbase.server().getFeature<ClusterFeature>();
     return convertHashSkiplistIndexesInPlanCoordinator(vocbase, clusterFeature);
   }
-  return convertHashSkiplistInDefinitionsColumnFamily(vocbase.engine<RocksDBEngine>());
+  auto& storageEngine = vocbase.engine();
+  if (storageEngine.typeName() != RocksDBEngine::kEngineName) {
+    return {};
+  }
+  return convertHashSkiplistInDefinitionsColumnFamily(
+      static_cast<RocksDBEngine&>(storageEngine));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -624,12 +624,7 @@ std::optional<velocypack::Builder> rewriteIndexTypesInArray(
   return out;
 }
 
-Result convertHashSkiplistInDefinitionsColumnFamily(TRI_vocbase_t& vocbase) {
-  auto& selectorFeature = vocbase.server().getFeature<EngineSelectorFeature>();
-  if (!selectorFeature.isRocksDB()) {
-    return {};
-  }
-  auto& engine = selectorFeature.engine<RocksDBEngine>();
+Result convertHashSkiplistInDefinitionsColumnFamily(RocksDBEngine& engine) {
   rocksdb::TransactionDB* db = engine.db();
   auto* cf = RocksDBColumnFamilyManager::get(
       RocksDBColumnFamilyManager::Family::Definitions);
@@ -788,7 +783,7 @@ Result UpgradeTasks::migrateHashSkiplistToPersistent(
     auto& clusterFeature = vocbase.server().getFeature<ClusterFeature>();
     return convertHashSkiplistIndexesInPlanCoordinator(vocbase, clusterFeature);
   }
-  return convertHashSkiplistInDefinitionsColumnFamily(vocbase);
+  return convertHashSkiplistInDefinitionsColumnFamily(vocbase.engine<RocksDBEngine>());
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/VocBase/Methods/UpgradeTasks.cpp
+++ b/arangod/VocBase/Methods/UpgradeTasks.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -67,7 +67,6 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Scheduler/SchedulerFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/ClusterUtils.h"
@@ -1354,17 +1353,18 @@ Result TRI_vocbase_t::dropView(DataSourceId cid, bool allowDropSystem) {
   return {};
 }
 
-TRI_vocbase_t::TRI_vocbase_t(arangodb::CreateDatabaseInfo&& info)
+TRI_vocbase_t::TRI_vocbase_t(arangodb::CreateDatabaseInfo&& info,
+                             arangodb::StorageEngine& engine)
     : TRI_vocbase_t(
-          std::move(info),
+          std::move(info), engine,
           info.server().getFeature<DatabaseFeature>().versionTracker(),
           info.server().getFeature<DatabaseFeature>().extendedNames()) {}
 
-TRI_vocbase_t::TRI_vocbase_t(CreateDatabaseInfo&& info,
+TRI_vocbase_t::TRI_vocbase_t(CreateDatabaseInfo&& info, StorageEngine& engine,
                              VersionTracker& versionTracker, bool extendedNames,
                              bool isInternal)
     : _server(info.server()),
-      _engine(_server.getFeature<arangodb::EngineSelectorFeature>().engine()),
+      _engine(engine),
       _versionTracker(versionTracker),
       _extendedNames(extendedNames),
       _info(std::move(info)) {

--- a/arangod/VocBase/vocbase.cpp
+++ b/arangod/VocBase/vocbase.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");

--- a/arangod/VocBase/vocbase.h
+++ b/arangod/VocBase/vocbase.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -122,7 +122,8 @@ inline constexpr auto TRI_INDEX_HANDLE_SEPARATOR_STR = "/";
 struct TRI_vocbase_t {
   friend class arangodb::StorageEngine;
 
-  explicit TRI_vocbase_t(arangodb::CreateDatabaseInfo&& info);
+  explicit TRI_vocbase_t(arangodb::CreateDatabaseInfo&& info,
+                         arangodb::StorageEngine& engine);
 
   // note: isInternal=true is currently only used for the special internal
   // vocbase object that is used to execute IResearchAqlAnalyzer computations,
@@ -132,6 +133,7 @@ struct TRI_vocbase_t {
   // internal vocbase object, which does not use the MetricsFeature, because
   // it can outlive the entire ApplicationServer stack.
   TRI_vocbase_t(arangodb::CreateDatabaseInfo&& info,
+                arangodb::StorageEngine& engine,
                 arangodb::VersionTracker& versionTracker, bool extendedNames,
                 bool isInternal = false);
   TEST_VIRTUAL ~TRI_vocbase_t();
@@ -206,7 +208,8 @@ struct TRI_vocbase_t {
 
   template<typename As>
   As& engine() const noexcept
-      requires(std::derived_from<As, arangodb::StorageEngine>) {
+    requires(std::derived_from<As, arangodb::StorageEngine>)
+  {
     return static_cast<As&>(_engine);
   }
 

--- a/tests/Aql/ExecutionNode/IndexNodeTest.cpp
+++ b/tests/Aql/ExecutionNode/IndexNodeTest.cpp
@@ -88,7 +88,7 @@ arangodb::aql::QueryResult executeQuery(
 }
 
 TEST_F(IndexNodeTest, objectQuery) {
-  TRI_vocbase_t vocbase(createInfo(server.server()));
+  TRI_vocbase_t vocbase(createInfo(server.server()), server.engine());
   // create a collection
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
       "{\"name\": \"testCollection\", \"id\": 42}");
@@ -169,7 +169,7 @@ TEST_F(IndexNodeTest, objectQuery) {
 }
 
 TEST_F(IndexNodeTest, expansionQuery) {
-  TRI_vocbase_t vocbase(createInfo(server.server()));
+  TRI_vocbase_t vocbase(createInfo(server.server()), server.engine());
   // create a collection
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
       "{\"name\": \"testCollection\", \"id\": 42}");
@@ -224,7 +224,7 @@ TEST_F(IndexNodeTest, expansionQuery) {
 }
 
 TEST_F(IndexNodeTest, expansionIndexAndNotExpansionDocumentQuery) {
-  TRI_vocbase_t vocbase(createInfo(server.server()));
+  TRI_vocbase_t vocbase(createInfo(server.server()), server.engine());
   // create a collection
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
       "{\"name\": \"testCollection\", \"id\": 42}");
@@ -268,7 +268,7 @@ TEST_F(IndexNodeTest, expansionIndexAndNotExpansionDocumentQuery) {
 }
 
 TEST_F(IndexNodeTest, lastExpansionQuery) {
-  TRI_vocbase_t vocbase(createInfo(server.server()));
+  TRI_vocbase_t vocbase(createInfo(server.server()), server.engine());
   // create a collection
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
       "{\"name\": \"testCollection\", \"id\": 42}");
@@ -329,7 +329,7 @@ TEST_F(IndexNodeTest, lastExpansionQuery) {
 }
 
 TEST_F(IndexNodeTest, constructIndexNode) {
-  TRI_vocbase_t vocbase(createInfo(server.server()));
+  TRI_vocbase_t vocbase(createInfo(server.server()), server.engine());
   // create a collection
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
       "{\"name\": \"testCollection\", \"id\": 42}");
@@ -590,7 +590,7 @@ TEST_F(IndexNodeTest, constructIndexNode) {
 }
 
 TEST_F(IndexNodeTest, invalidLateMaterializedJSON) {
-  TRI_vocbase_t vocbase(createInfo(server.server()));
+  TRI_vocbase_t vocbase(createInfo(server.server()), server.engine());
   // create a collection
   auto collectionJson = arangodb::velocypack::Parser::fromJson(
       "{\"name\": \"testCollection\", \"id\": 42}");

--- a/tests/Aql/Function/InRangeFunctionTest.cpp
+++ b/tests/Aql/Function/InRangeFunctionTest.cpp
@@ -62,7 +62,7 @@ class InRangeFunctionTest : public ::testing::Test {
             warnings->insert(static_cast<int>(c));
           }
         });
-    TRI_vocbase_t mockVocbase(testDBInfo(server.server()));
+    TRI_vocbase_t mockVocbase(testDBInfo(server.server()), server.engine());
     auto trx = server.createFakeTransaction();
     fakeit::When(Method(expressionContextMock, trx))
         .AlwaysDo([&trx]() -> transaction::Methods& { return *trx; });

--- a/tests/Aql/Function/NgramPosSimilarityFunctionTest.cpp
+++ b/tests/Aql/Function/NgramPosSimilarityFunctionTest.cpp
@@ -61,7 +61,7 @@ class NgramPosSimilarityFunctionTest : public ::testing::Test {
             warnings->insert(static_cast<int>(c));
           }
         });
-    TRI_vocbase_t mockVocbase(testDBInfo(server.server()));
+    TRI_vocbase_t mockVocbase(testDBInfo(server.server()), server.engine());
     auto trx = server.createFakeTransaction();
     fakeit::When(Method(expressionContextMock, trx))
         .AlwaysDo([&]() -> transaction::Methods& { return *trx; });

--- a/tests/Aql/Function/NgramSimilarityFunctionTest.cpp
+++ b/tests/Aql/Function/NgramSimilarityFunctionTest.cpp
@@ -61,7 +61,7 @@ class NgramSimilarityFunctionTest : public ::testing::Test {
             warnings->insert(static_cast<int>(c));
           }
         });
-    TRI_vocbase_t mockVocbase(testDBInfo(server.server()));
+    TRI_vocbase_t mockVocbase(testDBInfo(server.server()), server.engine());
     auto trx = server.createFakeTransaction();
     fakeit::When(Method(expressionContextMock, trx))
         .AlwaysDo([&]() -> transaction::Methods& { return *trx; });

--- a/tests/Aql/QueryLimitsTest.cpp
+++ b/tests/Aql/QueryLimitsTest.cpp
@@ -70,7 +70,7 @@ TEST_F(AqlQueryLimitsTest, testManyNodes) {
   arangodb::CreateDatabaseInfo testDBInfo(server.server(),
                                           arangodb::ExecContext::current());
   testDBInfo.load("testVocbase", 2);
-  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  TRI_vocbase_t vocbase(std::move(testDBInfo), server.engine());
 
   std::string query("LET x = NOOPT('testi')\n");
   size_t cnt = arangodb::aql::ExecutionPlan::maxPlanNodes -
@@ -93,7 +93,7 @@ TEST_F(AqlQueryLimitsTest, testTooManyNodes) {
   arangodb::CreateDatabaseInfo testDBInfo(server.server(),
                                           arangodb::ExecContext::current());
   testDBInfo.load("testVocbase", 2);
-  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  TRI_vocbase_t vocbase(std::move(testDBInfo), server.engine());
 
   std::string query("LET x = NOOPT('testi')\n");
   size_t cnt = arangodb::aql::ExecutionPlan::maxPlanNodes;
@@ -112,7 +112,7 @@ TEST_F(AqlQueryLimitsTest, testDeepRecursion) {
   arangodb::CreateDatabaseInfo testDBInfo(server.server(),
                                           arangodb::ExecContext::current());
   testDBInfo.load("testVocbase", 2);
-  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  TRI_vocbase_t vocbase(std::move(testDBInfo), server.engine());
 
   std::string query("RETURN 0");
   size_t cnt = arangodb::aql::Ast::maxExpressionNesting - 2;
@@ -134,7 +134,7 @@ TEST_F(AqlQueryLimitsTest, testTooDeepRecursion) {
   arangodb::CreateDatabaseInfo testDBInfo(server.server(),
                                           arangodb::ExecContext::current());
   testDBInfo.load("testVocbase", 2);
-  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  TRI_vocbase_t vocbase(std::move(testDBInfo), server.engine());
 
   std::string query("RETURN 0");
   size_t cnt = arangodb::aql::Ast::maxExpressionNesting;

--- a/tests/Aql/SortLimitTest.cpp
+++ b/tests/Aql/SortLimitTest.cpp
@@ -85,8 +85,7 @@ class SortLimitTest
         arangodb::RandomGenerator::RandomType::MERSENNE);
 
     vocbase = std::make_unique<TRI_vocbase_t>(
-
-        testDBInfo(server.server()));
+        testDBInfo(server.server()), server.engine());
 
     CreateCollection();
   }

--- a/tests/Basics/FixedSizeAllocatorTest.cpp
+++ b/tests/Basics/FixedSizeAllocatorTest.cpp
@@ -265,7 +265,7 @@ TEST(FixedSizeAllocatorTest, test_AstNodesRollbackDuringCreation) {
   arangodb::CreateDatabaseInfo testDBInfo(server.server(),
                                           arangodb::ExecContext::current());
   testDBInfo.load("testVocbase", 2);
-  TRI_vocbase_t vocbase(std::move(testDBInfo));
+  TRI_vocbase_t vocbase(std::move(testDBInfo), server.engine());
   auto query = arangodb::aql::Query::create(
       arangodb::transaction::StandaloneContext::create(
           vocbase, arangodb::transaction::OperationOriginTestCase{}),

--- a/tests/Graph/GenericGraphProviderTest.cpp
+++ b/tests/Graph/GenericGraphProviderTest.cpp
@@ -91,7 +91,7 @@ class GraphProviderTest : public ::testing::Test {
     if constexpr (std::is_same_v<ProviderType, MockGraphProvider>) {
       s = std::make_unique<GraphTestSetup>();
       singleServer =
-          std::make_unique<MockGraphDatabase>(s->server, "testVocbase");
+          std::make_unique<MockGraphDatabase>(s->server, s->engine, "testVocbase");
       singleServer->addGraph(graph);
 
       // We now have collections "v" and "e"
@@ -107,7 +107,7 @@ class GraphProviderTest : public ::testing::Test {
                                                    SingleServerProviderStep>>) {
       s = std::make_unique<GraphTestSetup>();
       singleServer =
-          std::make_unique<MockGraphDatabase>(s->server, "testVocbase");
+          std::make_unique<MockGraphDatabase>(s->server, s->engine, "testVocbase");
       singleServer->addGraph(graph);
 
       // We now have collections "v" and "e"

--- a/tests/Graph/GraphTestTools.cpp
+++ b/tests/Graph/GraphTestTools.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -79,7 +79,7 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
           server.getFeature<arangodb::metrics::MetricsFeature>()),
       false);  // must be first
   system = std::make_unique<TRI_vocbase_t>(
-      systemDBInfo(server),
+      systemDBInfo(server), engine,
       server.getFeature<DatabaseFeature>().versionTracker(), true);
   features.emplace_back(
       server.addFeature<arangodb::SystemDatabaseFeature>(system.get()),

--- a/tests/Graph/GraphTestTools.h
+++ b/tests/Graph/GraphTestTools.h
@@ -88,8 +88,8 @@ struct MockGraphDatabase {
   TRI_vocbase_t vocbase;
   VersionTracker versionTracker;
 
-  MockGraphDatabase(ArangodServer& server, std::string name)
-      : vocbase(createInfo(server, name, 1), versionTracker, true) {}
+  MockGraphDatabase(ArangodServer& server, StorageEngine& engine, std::string name)
+      : vocbase(createInfo(server, name, 1), engine, versionTracker, true) {}
 
   ~MockGraphDatabase() {}
 

--- a/tests/Graph/SingleServerProviderTest.cpp
+++ b/tests/Graph/SingleServerProviderTest.cpp
@@ -88,7 +88,7 @@ class SingleServerProviderTest : public ::testing::Test {
     // Setup code for each provider type
     s = std::make_unique<GraphTestSetup>();
     singleServer =
-        std::make_unique<MockGraphDatabase>(s->server, "testVocbase");
+        std::make_unique<MockGraphDatabase>(s->server, s->engine, "testVocbase");
     singleServer->addGraph(graph);
 
     // We now have collections "v" and "e"

--- a/tests/Graph/TraverserCacheTest.cpp
+++ b/tests/Graph/TraverserCacheTest.cpp
@@ -71,7 +71,7 @@ class TraverserCacheTest : public ::testing::Test {
   arangodb::aql::Projections _vertexProjections{};
   arangodb::aql::Projections _edgeProjections{};
 
-  TraverserCacheTest() : gdb(s.server, "testVocbase") {
+  TraverserCacheTest() : gdb(s.server, s.engine, "testVocbase") {
     stats = std::make_shared<arangodb::aql::TraversalStats>();
     query = gdb.getQuery("RETURN 1", std::vector<std::string>{});
     queryContext = query.get()->newTrxContext();

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -274,7 +274,7 @@ struct IResearchExpressionFilterTest
         server.addFeature<arangodb::QueryRegistryFeature>(
             server.getFeature<arangodb::metrics::MetricsFeature>()),
         false);  // must be first
-    system = std::make_unique<TRI_vocbase_t>(systemDBInfo(server));
+    system = std::make_unique<TRI_vocbase_t>(systemDBInfo(server), engine);
     features.emplace_back(
         server.addFeature<arangodb::SystemDatabaseFeature>(system.get()),
         false);  // required for IResearchAnalyzerFeature
@@ -414,7 +414,7 @@ TEST_F(IResearchExpressionFilterTest, test) {
   }
 
   // setup ArangoDB database
-  TRI_vocbase_t vocbase(testDBInfo(server));
+  TRI_vocbase_t vocbase(testDBInfo(server), engine);
 
   // create view
   {

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -509,13 +509,13 @@ class IResearchAnalyzerFeatureTest
 // -----------------------------------------------------------------------------
 
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_no_auth) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   EXPECT_TRUE(arangodb::iresearch::IResearchAnalyzerFeature::canUse(
       vocbase, arangodb::auth::Level::RW));
 }
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_no_vocbase_read) {
   // no vocbase read access
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::NONE, arangodb::auth::Level::NONE);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -526,7 +526,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_no_vocbase_read) {
 // no collection read access (vocbase read access, no user)
 TEST_F(IResearchAnalyzerFeatureTest,
        test_auth_vocbase_none_collection_read_no_user) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::NONE, arangodb::auth::Level::RO);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -536,7 +536,7 @@ TEST_F(IResearchAnalyzerFeatureTest,
 
 // no collection read access (vocbase read access)
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_none) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::RO, arangodb::auth::Level::NONE);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -550,7 +550,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_none) {
 }
 
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_ro) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::RO, arangodb::auth::Level::RO);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -561,7 +561,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_ro) {
 }
 
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_rw) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::RO, arangodb::auth::Level::RW);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -572,7 +572,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_ro_collection_rw) {
 }
 
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_rw_collection_ro) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::RW, arangodb::auth::Level::RO);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -585,7 +585,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_rw_collection_ro) {
 }
 
 TEST_F(IResearchAnalyzerFeatureTest, test_auth_vocbase_rw_collection_rw) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   userSetAccessLevel(arangodb::auth::Level::RW, arangodb::auth::Level::RW);
   auto ctxt = getLoggedInContext();
   arangodb::ExecContextScope execContextScope(ctxt);
@@ -1687,8 +1687,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_identity_registered) {
 // -----------------------------------------------------------------------------
 
 TEST_F(IResearchAnalyzerFeatureTest, test_normalize) {
-  TRI_vocbase_t active(testDBInfo(server.server(), "active", 2));
-  TRI_vocbase_t system(systemDBInfo(server.server()));
+  TRI_vocbase_t active(testDBInfo(server.server(), "active", 2), server.engine());
+  TRI_vocbase_t system(systemDBInfo(server.server()), server.engine());
 
   // normalize 'identity' (with prefix)
   {

--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -1419,7 +1419,7 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1_no_directory) {
   ASSERT_TRUE((arangodb::basics::VelocyPackHelper::velocyPackToFile(
       StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_NE(logicalCollection, nullptr);
   auto logicalView0 = vocbase.createView(viewJson->slice(), false);
@@ -1527,7 +1527,7 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1_with_directory) {
   ASSERT_TRUE((arangodb::basics::VelocyPackHelper::velocyPackToFile(
       StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_FALSE(!logicalCollection);
   auto logicalView0 = vocbase.createView(viewJson->slice(), false);
@@ -2240,7 +2240,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_no_directory) {
       .agencyCache()
       .applyTestTransaction(bogus.slice());
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_FALSE(!logicalCollection);
   auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2339,7 +2339,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_with_directory) {
       .agencyCache()
       .applyTestTransaction(bogus.slice());
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_FALSE(!logicalCollection);
   auto logicalView = vocbase.createView(viewJson->slice(), false);

--- a/tests/IResearch/IResearchFilterArrayInTest.cpp
+++ b/tests/IResearch/IResearchFilterArrayInTest.cpp
@@ -1702,7 +1702,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryIn) {
           << queryString);
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(
@@ -1805,7 +1805,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryIn) {
           << queryString);
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(
@@ -1924,7 +1924,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryIn) {
           << queryString);
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(
@@ -2039,7 +2039,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryIn) {
           << queryString);
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(
@@ -3567,7 +3567,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryNotIn) {
       SCOPED_TRACE(testing::Message("Query: ") << queryString);
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(
@@ -3712,7 +3712,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryNotIn) {
 
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(
@@ -3857,7 +3857,7 @@ TEST_F(IResearchFilterArrayInTest, BinaryNotIn) {
       SCOPED_TRACE(testing::Message("Query:") << queryString);
       std::string const refName = "d";
 
-      TRI_vocbase_t vocbase(testDBInfo(server.server()));
+      TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
       auto query = arangodb::aql::Query::create(
           arangodb::transaction::StandaloneContext::create(

--- a/tests/IResearch/IResearchFilterBooleanTest.cpp
+++ b/tests/IResearch/IResearchFilterBooleanTest.cpp
@@ -1415,7 +1415,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
         "collection FILTER not "
         "(d[a].b[c].e[offsetInt].f[offsetDbl].g[_FORWARD_(3)].g[_NONDETERM_('a'"
         ")] == '1') RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1515,7 +1515,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
         "collection FILTER not ('1' < "
         "d[a].b[c].e[offsetInt].f[offsetDbl].g[_FORWARD_(3)].g[_NONDETERM_('a')"
         "]) RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1612,7 +1612,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
     std::string const& refName = "d";
     std::string const& queryString =
         "FOR d IN collection FILTER not (d.a < _NONDETERM_('1')) RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1708,7 +1708,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
     std::string const& queryString =
         "FOR d IN collection FILTER BOOST(not (d.a < _NONDETERM_('1')), 2.5) "
         "RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1807,7 +1807,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
     std::string const& queryString =
         "LET k={} FOR d IN collection FILTER not (k.a < _NONDETERM_('1')) "
         "RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1903,7 +1903,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
     std::string const& queryString =
         "LET k={} FOR d IN collection FILTER not BOOST(k.a < _NONDETERM_('1'), "
         "1.5) RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -2002,7 +2002,7 @@ TEST_F(IResearchFilterBooleanTest, UnaryNot) {
     std::string const& refName = "d";
     std::string const& queryString =
         "FOR d IN collection FILTER not (d.a < 1+d.b) RETURN d";
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -3039,7 +3039,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryOr) {
 
   // noneterministic expression -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -3144,7 +3144,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryOr) {
 
   // noneterministic expression -> wrap it, boost
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -3521,7 +3521,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryAnd) {
 
   // expression is not supported by IResearch -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -3959,7 +3959,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryAnd) {
 
   // expression is not supported by IResearch -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -4059,7 +4059,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryAnd) {
 
   // expression is not supported by IResearch -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -4434,7 +4434,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryAnd) {
 
   // expression is not supported by IResearch -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -4625,7 +4625,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryAnd) {
 
   // expression is not supported by IResearch -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =
@@ -6725,7 +6725,7 @@ TEST_F(IResearchFilterBooleanTest, BinaryAnd) {
 
   // noneterministic expression -> wrap it
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     std::string const refName = "d";
     std::string const queryString =

--- a/tests/IResearch/IResearchFilterInTest.cpp
+++ b/tests/IResearch/IResearchFilterInTest.cpp
@@ -992,7 +992,7 @@ TEST_F(IResearchFilterInTest, BinaryIn) {
         "d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1119,7 +1119,7 @@ TEST_F(IResearchFilterInTest, BinaryIn) {
         "FOR d IN collection FILTER d.a.b.c.e.f in [ '1', d, '3' ] RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1247,7 +1247,7 @@ TEST_F(IResearchFilterInTest, BinaryIn) {
         "RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1375,7 +1375,7 @@ TEST_F(IResearchFilterInTest, BinaryIn) {
         "d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1503,7 +1503,7 @@ TEST_F(IResearchFilterInTest, BinaryIn) {
         "RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -1617,7 +1617,7 @@ TEST_F(IResearchFilterInTest, BinaryIn) {
         "FOR d IN collection FILTER 4 in [ 1, d.b.a, 4 ] RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4157,7 +4157,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4292,7 +4292,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4427,7 +4427,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4562,7 +4562,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "], 1.5) RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4698,7 +4698,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "] RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4833,7 +4833,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(
@@ -4951,7 +4951,7 @@ TEST_F(IResearchFilterInTest, BinaryNotIn) {
         "FOR d IN collection FILTER 4 not in [ 1, d.b.a, 4 ] RETURN d";
     std::string const refName = "d";
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
     auto query = arangodb::aql::Query::create(
         arangodb::transaction::StandaloneContext::create(

--- a/tests/IResearch/IResearchIndexTest.cpp
+++ b/tests/IResearch/IResearchIndexTest.cpp
@@ -525,7 +525,7 @@ TEST_F(IResearchIndexTest, test_async_index) {
       "{ \"name\": \"testCollection1\" }");
   auto createView = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collection0 = vocbase.createCollection(createCollection0->slice());
   ASSERT_NE(nullptr, collection0);
   auto collection1 = vocbase.createCollection(createCollection1->slice());
@@ -880,7 +880,7 @@ TEST_F(IResearchIndexTest, test_fields) {
       "{ \"name\": \"testCollection1\" }");
   auto createView = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collection0 = vocbase.createCollection(createCollection0->slice());
   ASSERT_NE(nullptr, collection0);
   auto collection1 = vocbase.createCollection(createCollection1->slice());
@@ -980,7 +980,7 @@ TEST_F(IResearchIndexTest, test_pkCached) {
   auto createView = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", "
       "\"primaryKeyCache\":true }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10000000);
   auto collection0 = vocbase.createCollection(createCollection0->slice());
@@ -1043,7 +1043,7 @@ TEST_F(IResearchIndexTest, test_pkCached) {
 TEST_F(IResearchIndexTest, test_pkCachedInverted) {
   auto createCollection0 = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testCollection0\" }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10000000);
   auto collection0 = vocbase.createCollection(createCollection0->slice());
@@ -1104,7 +1104,7 @@ TEST_F(IResearchIndexTest, test_pkCachedRestricted) {
   auto createView = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", "
       "\"primaryKeyCache\":true }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10);
   auto collection0 = vocbase.createCollection(createCollection0->slice());
@@ -1176,7 +1176,7 @@ TEST_F(IResearchIndexTest, test_sortCached) {
         \"primarySort\":[{\"field\":\"X\", \"direction\":\"asc\" }]}");
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10000000);
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collection0 = vocbase.createCollection(createCollection0->slice());
   ASSERT_NE(nullptr, collection0);
   auto collection1 = vocbase.createCollection(createCollection1->slice());
@@ -1237,7 +1237,7 @@ TEST_F(IResearchIndexTest, test_sortCached) {
 TEST_F(IResearchIndexTest, test_sortCachedInverted) {
   auto createCollection0 = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testCollection0\" }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10000000);
   auto collection0 = vocbase.createCollection(createCollection0->slice());
@@ -1302,7 +1302,7 @@ TEST_F(IResearchIndexTest, test_sortCachedRestricted) {
         \"primarySort\":[{\"field\":\"X\", \"direction\":\"asc\" }]}");
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10);
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collection0 = vocbase.createCollection(createCollection0->slice());
   ASSERT_NE(nullptr, collection0);
   auto collection1 = vocbase.createCollection(createCollection1->slice());
@@ -1367,7 +1367,7 @@ TEST_F(IResearchIndexTest, test_geoCached) {
   auto createView = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", "
       "\"primaryKeyCache\":false }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10000000);
   auto collection0 = vocbase.createCollection(createCollection0->slice());
@@ -1431,7 +1431,7 @@ TEST_F(IResearchIndexTest, test_geoCachedInverted) {
   auto createView = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", "
       "\"primaryKeyCache\":false }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   feature.setCacheUsageLimit(10000000);
   auto collection0 = vocbase.createCollection(createCollection0->slice());
@@ -1504,7 +1504,7 @@ class IResearchCacheOnlyFollowersTest : public ::testing::Test {
 TEST_F(IResearchCacheOnlyFollowersTest, test_PkInverted) {
   auto createCollection0 = arangodb::velocypack::Parser::fromJson(
       "{\"id\":1, \"name\": \"s1337\" }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   auto collection0 = vocbase.createCollection(createCollection0->slice());
   ASSERT_NE(nullptr, collection0);
@@ -1581,7 +1581,7 @@ TEST_F(IResearchCacheOnlyFollowersTest, test_PkInverted) {
 TEST_F(IResearchCacheOnlyFollowersTest, test_PkInverted_InitialLeader) {
   auto createCollection0 = arangodb::velocypack::Parser::fromJson(
       "{\"id\":1, \"name\": \"s1337\" }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& feature = server.getFeature<arangodb::iresearch::IResearchFeature>();
   auto collection0 = vocbase.createCollection(createCollection0->slice());
   ASSERT_NE(nullptr, collection0);
@@ -1665,7 +1665,7 @@ TEST_F(IResearchIndexTest, test_emptyPrimarySortFieldInView) {
         ]})";
 
   auto createView = arangodb::velocypack::Parser::fromJson(viewDef);
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   try {
     vocbase.createView(createView->slice(), false);
     FAIL() << "View creation did not fail";
@@ -1685,7 +1685,7 @@ TEST_F(IResearchIndexTest, test_emptyPrimarySortFieldInView) {
 TEST_F(IResearchIndexTest, test_emptyPrimarySortFieldInInvertedIndex) {
   auto collectionJson =
       arangodb::velocypack::Parser::fromJson(R"({"id":1, "name": "coll" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collection = vocbase.createCollection(collectionJson->slice());
 
   auto invIndexDef = R"({

--- a/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
@@ -42,12 +42,13 @@ using namespace std::literals;
 
 namespace {
 void serializationChecker(ArangodServer& server,
+                          arangodb::StorageEngine& engine,
                           std::string_view jsonAsString) {
   auto json = VPackParser::fromJson({jsonAsString.data(), jsonAsString.size()});
 
   arangodb::iresearch::IResearchInvertedIndexMeta metaLhs, metaRhs;
   std::string errorString;
-  TRI_vocbase_t vocbase(testDBInfo(server));
+  TRI_vocbase_t vocbase(testDBInfo(server), engine);
   auto res = metaLhs.init(server, json->slice(), true, errorString,
                           std::string_view(vocbase.name()));
   {
@@ -471,7 +472,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testWrongDefinitions) {
 
     arangodb::iresearch::IResearchInvertedIndexMeta meta;
     std::string errorString;
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto res = meta.init(server.server(), json->slice(), true, errorString,
                          std::string_view(vocbase.name()));
     {
@@ -624,7 +625,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testCorrectDefinitions) {
 
     arangodb::iresearch::IResearchInvertedIndexMeta meta;
     std::string errorString;
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto res = meta.init(server.server(), json->slice(), true, errorString,
                          std::string_view(vocbase.name()));
     {
@@ -632,7 +633,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testCorrectDefinitions) {
       ASSERT_TRUE(res);
       ASSERT_TRUE(errorString.empty());
     }
-    serializationChecker(server.server(), jsonD);
+    serializationChecker(server.server(), server.engine(), jsonD);
   }
 }
 
@@ -663,7 +664,7 @@ TEST_F(IResearchInvertedIndexMetaTest,
 
   arangodb::iresearch::IResearchInvertedIndexMeta meta;
   std::string errorString;
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto res = meta.init(server.server(), json->slice(), false, errorString,
                        std::string_view(vocbase.name()));
   ASSERT_FALSE(res);
@@ -696,7 +697,7 @@ TEST_F(IResearchInvertedIndexMetaTest,
 
   arangodb::iresearch::IResearchInvertedIndexMeta meta;
   std::string errorString;
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto res = meta.init(server.server(), json->slice(), false, errorString,
                        std::string_view(vocbase.name()));
   ASSERT_FALSE(res);
@@ -739,7 +740,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testIgnoreAnalyzerDefinitions) {
                                       kDefinitionWithAnalyzers.size());
 
     std::string errorString;
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto res = metaLhs.init(server.server(), json->slice(), false, errorString,
                             std::string_view(vocbase.name()));
     {
@@ -766,7 +767,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testIgnoreAnalyzerDefinitions) {
                                       kDefinitionWithoutAnalyzers.size());
 
     std::string errorString;
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto res = metaRhs.init(server.server(), json->slice(), false, errorString,
                             std::string_view(vocbase.name()));
     {
@@ -893,7 +894,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testReadDefaults) {
   {
     arangodb::iresearch::IResearchInvertedIndexMeta meta;
     std::string errorString;
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     ASSERT_TRUE(meta.init(server.server(), json->slice(), false, errorString,
                           std::string_view(vocbase.name())));
     ASSERT_TRUE(errorString.empty());
@@ -942,7 +943,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testDataStoreMetaFields) {
 
   arangodb::iresearch::IResearchInvertedIndexMeta meta;
   std::string errorString;
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto res = meta.init(server.server(), json->slice(), true, errorString,
                        std::string_view(vocbase.name()));
   {
@@ -1003,7 +1004,7 @@ TEST_F(IResearchInvertedIndexMetaTest, testmatchesFieldsDefinition) {
 
   arangodb::iresearch::IResearchInvertedIndexMeta meta;
   std::string errorString;
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto res = meta.init(server.server(), json->slice(), true, errorString,
                        std::string_view(vocbase.name()));
   {

--- a/tests/IResearch/IResearchLinkMetaTest.cpp
+++ b/tests/IResearch/IResearchLinkMetaTest.cpp
@@ -224,7 +224,7 @@ TEST_F(IResearchLinkMetaTest, test_readDefaults) {
 
   // with active vocbase
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::iresearch::IResearchLinkMeta meta;
     std::string tmpString;
     EXPECT_TRUE(
@@ -279,7 +279,7 @@ TEST_F(IResearchLinkMetaTest, test_readCustomizedValues) {
     std::unordered_set<std::string> expectedOverrides = {"default", "all",
                                                          "some", "none"};
     std::unordered_set<std::string> expectedAnalyzers = {"empty", "identity"};
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::iresearch::IResearchLinkMeta meta;
     std::string tmpString;
     EXPECT_TRUE(
@@ -440,7 +440,7 @@ TEST_F(IResearchLinkMetaTest, test_readCustomizedValuesCluster) {
     std::unordered_set<std::string> expectedOverrides = {"default", "all",
                                                          "some", "none"};
     std::unordered_set<std::string> expectedAnalyzers = {"empty", "identity"};
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::iresearch::IResearchLinkMeta meta;
     std::string tmpString;
     EXPECT_TRUE(
@@ -631,7 +631,7 @@ TEST_F(IResearchLinkMetaTest, test_writeDefaults) {
 
   // with active vocbase (not fullAnalyzerDefinition)
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::iresearch::IResearchLinkMeta meta;
     arangodb::velocypack::Builder builder;
     arangodb::velocypack::Slice tmpSlice;
@@ -660,7 +660,7 @@ TEST_F(IResearchLinkMetaTest, test_writeDefaults) {
 
   // with active vocbase (with fullAnalyzerDefinition)
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::iresearch::IResearchLinkMeta meta;
     arangodb::velocypack::Builder builder;
     arangodb::velocypack::Slice tmpSlice;
@@ -1070,7 +1070,7 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
                                                               "some", "none"};
     std::unordered_set<std::string_view> expectedAnalyzers = {"::empty",
                                                               "identity"};
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::velocypack::Builder builder;
     arangodb::velocypack::Slice tmpSlice;
 
@@ -1189,7 +1189,7 @@ TEST_F(IResearchLinkMetaTest, test_writeCustomizedValues) {
              VPackParser::fromJson("{\"args\":\"en\"}")->slice().toString()},
             {"identity", VPackSlice::emptyObjectSlice().toString()},
         };
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::velocypack::Builder builder;
     arangodb::velocypack::Slice tmpSlice;
 
@@ -1574,7 +1574,7 @@ TEST_F(IResearchLinkMetaTest, test_writeMaskNone) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_readAnalyzerDefinitions) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   // missing analyzer (name only)
   {
@@ -2612,7 +2612,7 @@ TEST_F(IResearchLinkMetaTest, test_readAnalyzerDefinitions) {
 // https://github.com/arangodb/backlog/issues/581
 // (ArangoSearch view doesn't validate uniqueness of analyzers)
 TEST_F(IResearchLinkMetaTest, test_addNonUniqueAnalyzers) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto& analyzers =
       server.getFeature<arangodb::iresearch::IResearchAnalyzerFeature>();
 
@@ -2760,7 +2760,7 @@ class IResearchLinkMetaTestNoSystem
 };
 
 TEST_F(IResearchLinkMetaTestNoSystem, test_readAnalyzerDefinitions) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   ASSERT_EQ(nullptr,
             server.getFeature<arangodb::SystemDatabaseFeature>().use());
@@ -3735,7 +3735,7 @@ TEST_F(IResearchLinkMetaTest, test_collectioNameComparison) {
 
 #ifdef USE_ENTERPRISE
 TEST_F(IResearchLinkMetaTest, test_withNested) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   arangodb::iresearch::IResearchLinkMeta meta;
   auto json = arangodb::velocypack::Parser::fromJson(
       R"({
@@ -3982,7 +3982,7 @@ TEST_F(IResearchLinkMetaTest, test_withNested) {
     "analyzers": [ "identity" ]
   })");
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string errorField;
   ASSERT_FALSE(
       meta.init(server.server(), json->slice(), errorField, vocbase.name()));
@@ -3993,7 +3993,7 @@ TEST_F(IResearchLinkMetaTest, test_withNested) {
 #ifdef USE_ENTERPRISE
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumnsDefinitions) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4036,7 +4036,7 @@ TEST_F(IResearchLinkMetaTest, test_cachedColumnsDefinitions) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumnsDefinitionsGlobalCache) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4080,7 +4080,7 @@ TEST_F(IResearchLinkMetaTest, test_cachedColumnsDefinitionsGlobalCache) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumnsDefinitionsSortCache) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4234,7 +4234,7 @@ void makeCachedColumnsTest(std::vector<irs::field_meta> const& mockedFields,
 }
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumns) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4365,7 +4365,7 @@ TEST_F(IResearchLinkMetaTest, test_cachedColumns) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumnsIncludeAllFields) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4441,7 +4441,7 @@ TEST_F(IResearchLinkMetaTest, test_cachedColumnsIncludeAllFields) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumnsWithNested) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4515,7 +4515,7 @@ TEST_F(IResearchLinkMetaTest, test_cachedColumnsWithNested) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_cachedColumnsOnlyNested) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({
@@ -4588,7 +4588,7 @@ TEST_F(IResearchLinkMetaTest, test_cachedColumnsOnlyNested) {
 }
 
 TEST_F(IResearchLinkMetaTest, test_withSmartSort) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   auto json = VPackParser::fromJson(
       R"({

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -145,7 +145,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testCollection" })");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -166,7 +166,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testCollection" })");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -182,7 +182,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         R"({ "type": "arangosearch", "view": "42" })");
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -260,7 +260,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         R"({ "type": "arangosearch", "view": "42", "version":1 })");
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -338,7 +338,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         R"({ "type": "arangosearch", "view": "42" })");
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -447,7 +447,7 @@ TEST_F(IResearchLinkTest, test_init) {
         R"({ "type": "arangosearch", "view": "42" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -526,7 +526,7 @@ TEST_F(IResearchLinkTest, test_init) {
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"id\": 43, \"type\": \"arangosearch\", "
         "\"collections\": [ 101 ] }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -614,7 +614,7 @@ TEST_F(IResearchLinkTest, test_self_token) {
         arangodb::velocypack::Parser::fromJson(R"({ "view": "testView" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "type":"arangosearch" })");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -649,7 +649,7 @@ TEST_F(IResearchLinkTest, test_drop) {
         R"({ "type": "arangosearch", "view": "42" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -760,7 +760,7 @@ TEST_F(IResearchLinkTest, test_unload) {
         R"({ "type": "arangosearch", "view": "42" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -842,7 +842,7 @@ TEST_F(IResearchLinkTest, test_unload) {
 TEST_F(IResearchLinkTest, test_write_index_creation_version_0) {
   static std::vector<std::string> const kEmpty;
   auto doc0 = arangodb::velocypack::Parser::fromJson(R"({ "abc": "def" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -910,7 +910,7 @@ TEST_F(IResearchLinkTest, test_write_index_creation_version_0) {
 TEST_F(IResearchLinkTest, test_write_index_creation_version_1) {
   static std::vector<std::string> const kEmpty;
   auto doc0 = arangodb::velocypack::Parser::fromJson(R"({ "abc": "def" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -978,7 +978,7 @@ TEST_F(IResearchLinkTest, test_write) {
   static std::vector<std::string> const kEmpty;
   auto doc0 = arangodb::velocypack::Parser::fromJson(R"({ "abc": "def" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(R"({ "ghi": "jkl" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1075,7 +1075,7 @@ TEST_F(IResearchLinkTest, test_write_with_custom_compression_nondefault_sole) {
   auto doc0 = arangodb::velocypack::Parser::fromJson(
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps"  })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(R"({ "ghi": "jkl" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1183,7 +1183,7 @@ TEST_F(IResearchLinkTest,
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps"  })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(
       R"({ "ghi": "jkl", "sort":"pp" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1297,7 +1297,7 @@ TEST_F(IResearchLinkTest, test_write_with_custom_compression_nondefault_mixed) {
   auto doc0 = arangodb::velocypack::Parser::fromJson(
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(R"({ "ghi": "jkl" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1409,7 +1409,7 @@ TEST_F(IResearchLinkTest,
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(
       R"({ "ghi": "jkl", "sort":"pp" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1535,7 +1535,7 @@ TEST_F(
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(
       R"({ "ghi": "jkl", "sort":"pp" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1680,7 +1680,7 @@ TEST_F(IResearchLinkTest, test_maintenance_disabled_at_creation) {
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_1));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collectionJson = VPackParser::fromJson(R"({
     "name": "testCollection" })");
   auto linkJson = VPackParser::fromJson(R"({
@@ -1789,7 +1789,7 @@ TEST_F(IResearchLinkTest, test_maintenance_consolidation) {
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_1));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collectionJson = VPackParser::fromJson(R"({
     "name": "testCollection" })");
   auto linkJson = VPackParser::fromJson(R"({
@@ -2020,7 +2020,7 @@ TEST_F(IResearchLinkTest, test_maintenance_commit) {
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_1));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto collectionJson = VPackParser::fromJson(R"({
     "name": "testCollection" })");
   auto linkJson = VPackParser::fromJson(R"({
@@ -2234,7 +2234,7 @@ static std::vector<std::string> const kEmpty;
 
 class IResearchLinkMetricsTest : public IResearchLinkTest {
  protected:
-  TRI_vocbase_t _vocbase{testDBInfo(server.server())};
+  TRI_vocbase_t _vocbase{testDBInfo(server.server()), server.engine()};
   std::array<std::shared_ptr<arangodb::velocypack::Builder>, 3> _docs;
   std::shared_ptr<arangodb::LogicalCollection> _logicalCollection;
   uint64_t _cleanupIntervalStep = 0;
@@ -2844,7 +2844,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":true})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2890,7 +2890,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":false, "fields":{"_id":{}}})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2936,7 +2936,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":false, "fields":{"value":{}, "_id":{}}})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2982,7 +2982,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":false, "fields":{"value":{}}})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -3029,7 +3029,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest, test_init_in_recovery) {
         R"({ "type": "arangosearch", "view": "42", "collectionName":"testCollection" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -120,13 +120,14 @@ struct dummy_scorer final : public irs::ScorerBase<void> {
 REGISTER_SCORER_JSON(dummy_scorer, dummy_scorer::make);
 
 void assertOrder(
-    arangodb::application_features::ApplicationServer& server, bool parseOk,
-    bool execOk, std::string const& queryString,
+    arangodb::application_features::ApplicationServer& server,
+    arangodb::StorageEngine& engine, bool parseOk, bool execOk,
+    std::string const& queryString,
     std::span<irs::Scorer::ptr const> expected,
     arangodb::aql::ExpressionContext* exprCtx = nullptr,
     std::shared_ptr<arangodb::velocypack::Builder> bindVars = nullptr,
     std::string const& refName = "d") {
-  TRI_vocbase_t vocbase(testDBInfo(server));
+  TRI_vocbase_t vocbase(testDBInfo(server), engine);
 
   auto query = arangodb::aql::Query::create(
       arangodb::transaction::StandaloneContext::create(
@@ -218,38 +219,40 @@ void assertOrder(
 
 void assertOrderSuccess(
     arangodb::application_features::ApplicationServer& server,
-    std::string const& queryString, std::span<const irs::Scorer::ptr> expected,
+    arangodb::StorageEngine& engine, std::string const& queryString,
+    std::span<const irs::Scorer::ptr> expected,
     arangodb::aql::ExpressionContext* exprCtx = nullptr,
     std::shared_ptr<arangodb::velocypack::Builder> bindVars = nullptr,
     std::string const& refName = "d") {
-  return assertOrder(server, true, true, queryString, expected, exprCtx,
+  return assertOrder(server, engine, true, true, queryString, expected, exprCtx,
                      bindVars, refName);
 }
 
 void assertOrderFail(
     arangodb::application_features::ApplicationServer& server,
-    std::string const& queryString,
+    arangodb::StorageEngine& engine, std::string const& queryString,
     arangodb::aql::ExpressionContext* exprCtx = nullptr,
     std::shared_ptr<arangodb::velocypack::Builder> bindVars = nullptr,
     std::string const& refName = "d") {
-  return assertOrder(server, false, false, queryString, {}, exprCtx, bindVars,
-                     refName);
+  return assertOrder(server, engine, false, false, queryString, {}, exprCtx,
+                     bindVars, refName);
 }
 
 void assertOrderExecutionFail(
     arangodb::application_features::ApplicationServer& server,
-    std::string const& queryString,
+    arangodb::StorageEngine& engine, std::string const& queryString,
     arangodb::aql::ExpressionContext* exprCtx = nullptr,
     std::shared_ptr<arangodb::velocypack::Builder> bindVars = nullptr,
     std::string const& refName = "d") {
-  return assertOrder(server, true, false, queryString, {}, exprCtx, bindVars,
-                     refName);
+  return assertOrder(server, engine, true, false, queryString, {}, exprCtx,
+                     bindVars, refName);
 }
 
 void assertOrderParseFail(
     arangodb::application_features::ApplicationServer& server,
-    std::string const& queryString, ErrorCode parseCode) {
-  TRI_vocbase_t vocbase(testDBInfo(server));
+    arangodb::StorageEngine& engine, std::string const& queryString,
+    ErrorCode parseCode) {
+  TRI_vocbase_t vocbase(testDBInfo(server), engine);
 
   auto query = arangodb::aql::Query::create(
       arangodb::transaction::StandaloneContext::create(
@@ -379,7 +382,7 @@ TEST_F(IResearchOrderTest, test_FCall) {
     std::string query =
         "FOR d IN collection FILTER '1' SORT invalid(d) RETURN d";
 
-    assertOrderParseFail(server, query, TRI_ERROR_NO_ERROR);
+    assertOrderParseFail(server, engine, query, TRI_ERROR_NO_ERROR);
   }
 
   // undefined function (not a function registered with ArangoDB)
@@ -387,7 +390,7 @@ TEST_F(IResearchOrderTest, test_FCall) {
     std::string query =
         "FOR d IN collection FILTER '1' SORT undefined(d) RETURN d";
 
-    assertOrderParseFail(server, query, TRI_ERROR_QUERY_FUNCTION_NAME_UNKNOWN);
+    assertOrderParseFail(server, engine, query, TRI_ERROR_QUERY_FUNCTION_NAME_UNKNOWN);
   }
 }
 
@@ -398,7 +401,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::array expected{irs::scorers::get(
         "tfidf", irs::type<irs::text_format::json>::get(), std::string_view{})};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // tfidf ASC
@@ -408,7 +411,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::array expected{irs::scorers::get(
         "tfidf", irs::type<irs::text_format::json>::get(), std::string_view{})};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // tfidf DESC
@@ -418,7 +421,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::array expected{irs::scorers::get(
         "tfidf", irs::type<irs::text_format::json>::get(), std::string_view{})};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // tfidf with norms
@@ -428,7 +431,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::array expected{irs::scorers::get(
         "tfidf", irs::type<irs::text_format::json>::get(), "[ true ]")};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // reference as an argument
@@ -444,7 +447,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     ctx.vars.emplace("withNorms", arangodb::aql::AqlValue(
                                       arangodb::aql::AqlValueHintBool{true}));
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // deterministic expression as an argument
@@ -459,7 +462,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     ctx.vars.emplace(
         "x", arangodb::aql::AqlValue(arangodb::aql::AqlValueHintInt{5}));
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // non-deterministic expression as an argument
@@ -471,7 +474,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::string query =
         "LET x=5 FOR d IN collection FILTER '1' SORT tfidf(d, RAND()+x > 3) "
         "DESC RETURN d";
-    assertOrderFail(server, query, &ctx);
+    assertOrderFail(server, engine, query, &ctx);
   }
 
   // invalid number of arguments function
@@ -479,7 +482,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::string query =
         "FOR d IN collection FILTER '1' SORT tfidf(d, true, false) RETURN d";
 
-    assertOrderExecutionFail(server, query);
+    assertOrderExecutionFail(server, engine, query);
   }
 
   // invalid reference (invalid output variable reference)
@@ -492,7 +495,7 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::string query =
         "LET c={} FOR d IN collection FILTER '1' SORT tfidf(c) RETURN d";
 
-    assertOrderFail(server, query, &ctx);
+    assertOrderFail(server, engine, query, &ctx);
   }
 
   // invalid function (invalid 1st argument)
@@ -500,14 +503,14 @@ TEST_F(IResearchOrderTest, test_FCall_tfidf) {
     std::string query =
         "FOR d IN collection FILTER '1' SORT tfidf('d') RETURN d";
 
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // invalid function (no 1st parameter output variable reference)
   {
     std::string query = "FOR d IN collection FILTER '1' SORT tfidf() RETURN d";
 
-    assertOrderParseFail(server, query,
+    assertOrderParseFail(server, engine, query,
                          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
   }
 }
@@ -519,7 +522,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), std::string_view{})};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // bm25 ASC
@@ -529,7 +532,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), std::string_view{})};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // bm25 DESC
@@ -539,7 +542,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), std::string_view{})};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // bm25 with k coefficient
@@ -549,7 +552,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99 ]")};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // reference as k coefficient
@@ -564,7 +567,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99 ]")};
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // deterministic expression as k coefficient
@@ -579,7 +582,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99 ]")};
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // non-deterministic expression as k coefficient
@@ -591,7 +594,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::string query =
         "LET x=0.97 FOR d IN collection FILTER '1' SORT bm25(d, RAND()+x) DESC "
         "RETURN d";
-    assertOrderFail(server, query, &ctx);
+    assertOrderFail(server, engine, query, &ctx);
   }
 
   // bm25 with k coefficient, b coefficient
@@ -601,7 +604,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99, 1.2 ]")};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // reference as k,b coefficients
@@ -618,7 +621,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.97, 1.2 ]")};
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // deterministic expressions as k,b coefficients
@@ -635,7 +638,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99, 1.2 ]")};
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // non-deterministic expression as b coefficient
@@ -647,7 +650,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::string query =
         "LET x=0.97 FOR d IN collection FILTER '1' SORT bm25(d, x, RAND()) "
         "DESC RETURN d";
-    assertOrderFail(server, query, &ctx);
+    assertOrderFail(server, engine, query, &ctx);
   }
 
   // bm25 with k coefficient, b coefficient
@@ -657,7 +660,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99, 1.2 ]")};
 
-    assertOrderSuccess(server, query, expected);
+    assertOrderSuccess(server, engine, query, expected);
   }
 
   // reference as k,b coefficients
@@ -676,7 +679,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.97, 1.2 ]")};
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // deterministic expressions as k,b coefficients
@@ -693,7 +696,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::array expected{irs::scorers::get(
         "bm25", irs::type<irs::text_format::json>::get(), "[ 0.99, 1.1 ]")};
 
-    assertOrderSuccess(server, query, expected, &ctx);
+    assertOrderSuccess(server, engine, query, expected, &ctx);
   }
 
   // non-deterministic expression as b coefficient
@@ -705,7 +708,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::string query =
         "LET x=0.97 FOR d IN collection FILTER '1' SORT bm25(d, x, x, RAND() > "
         "0.5) DESC RETURN d";
-    assertOrderFail(server, query, &ctx);
+    assertOrderFail(server, engine, query, &ctx);
   }
 
   // invalid number of arguments function
@@ -714,7 +717,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
         "FOR d IN collection FILTER '1' SORT bm25(d, 0.97, 0.07, false) RETURN "
         "d";
 
-    assertOrderParseFail(server, query, TRI_ERROR_NO_ERROR);
+    assertOrderParseFail(server, engine, query, TRI_ERROR_NO_ERROR);
   }
 
   // invalid reference (invalid output variable reference)
@@ -727,7 +730,7 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::string query =
         "LET c={} FOR d IN collection FILTER '1' SORT bm25(c) RETURN d";
 
-    assertOrderFail(server, query, &ctx);
+    assertOrderFail(server, engine, query, &ctx);
   }
 
   // invalid function (invalid 1st argument)
@@ -735,14 +738,14 @@ TEST_F(IResearchOrderTest, test_FCall_bm25) {
     std::string query =
         "FOR d IN collection FILTER '1' SORT bm25('d') RETURN d";
 
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // invalid function (no 1st parameter output variable reference)
   {
     std::string query = "FOR d IN collection FILTER '1' SORT bm25() RETURN d";
 
-    assertOrderParseFail(server, query,
+    assertOrderParseFail(server, engine, query,
                          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH);
   }
 }
@@ -751,38 +754,38 @@ TEST_F(IResearchOrderTest, test_StringValue) {
   // simple field
   {
     std::string query = "FOR d IN collection FILTER '1' SORT 'a' RETURN d";
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // simple field ASC
   {
     std::string query = "FOR d IN collection FILTER '1' SORT 'a' ASC RETURN d";
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // simple field DESC
   {
     std::string query = "FOR d IN collection FILTER '1' SORT 'a' DESC RETURN d";
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // nested field
   {
     std::string query = "FOR d IN collection FILTER '1' SORT 'a.b.c' RETURN d";
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // nested field ASC
   {
     std::string query =
         "FOR d IN collection FILTER '1' SORT 'a.b.c' ASC RETURN d";
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 
   // nested field DESC
   {
     std::string query =
         "FOR d IN collection FILTER '1' SORT 'a.b.c' DESC RETURN d";
-    assertOrderFail(server, query);
+    assertOrderFail(server, engine, query);
   }
 }

--- a/tests/IResearch/IResearchPrimaryKeyReuseTest.cpp
+++ b/tests/IResearch/IResearchPrimaryKeyReuseTest.cpp
@@ -55,7 +55,7 @@ class IResearchPrimaryKeyReuse : public IResearchQueryTest {};
 ////////////////////////////////////////////////////////////////////////////////
 
 TEST_F(IResearchPrimaryKeyReuse, test_multiple_transactions_sequential) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::vector<arangodb::velocypack::Builder> insertedDocs;
   arangodb::LogicalView* view;
   std::shared_ptr<arangodb::LogicalCollection> collection;
@@ -184,7 +184,7 @@ TEST_F(IResearchPrimaryKeyReuse, test_multiple_transactions_sequential) {
 }
 
 TEST_F(IResearchPrimaryKeyReuse, test_multiple_transactions_interleaved) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::vector<arangodb::velocypack::Builder> insertedDocs;
   std::vector<arangodb::velocypack::Builder> extraDocs;
   arangodb::LogicalView* view;
@@ -351,7 +351,7 @@ TEST_F(IResearchPrimaryKeyReuse, test_multiple_transactions_interleaved) {
 }
 
 TEST_F(IResearchPrimaryKeyReuse, test_single_transaction) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::vector<arangodb::velocypack::Builder> insertedDocs;
   arangodb::LogicalView* view;
   std::shared_ptr<arangodb::LogicalCollection> collection;

--- a/tests/IResearch/IResearchQueryCommon.h
+++ b/tests/IResearch/IResearchQueryCommon.h
@@ -138,7 +138,7 @@ class QueryTest : public IResearchQueryTest {
     return it.size() == expectedCount && errorCount == 0;
   }
 
-  TRI_vocbase_t _vocbase{testDBInfo(server.server())};
+  TRI_vocbase_t _vocbase{testDBInfo(server.server()), server.engine()};
   std::vector<velocypack::Builder> _insertedDocs;
 
  private:

--- a/tests/IResearch/IResearchViewCoordinatorTest.cpp
+++ b/tests/IResearch/IResearchViewCoordinatorTest.cpp
@@ -137,7 +137,7 @@ TEST_F(IResearchViewCoordinatorTest, test_rename) {
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": \"1\", "
       "\"collections\": [1,2,3] }");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   arangodb::LogicalView::ptr view;
   ASSERT_TRUE(
       (arangodb::LogicalView::instantiate(view, vocbase, json->slice(), false)
@@ -258,7 +258,7 @@ TEST_F(IResearchViewCoordinatorTest, test_defaults) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": \"1\" "
         "}");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE(
         (arangodb::LogicalView::instantiate(view, vocbase, json->slice(), false)

--- a/tests/IResearch/IResearchViewDBServerTest.cpp
+++ b/tests/IResearch/IResearchViewDBServerTest.cpp
@@ -344,7 +344,7 @@ TEST_F(IResearchViewDBServerTest, test_make) {
         1;  // +1 because LogicalView creation will generate a new ID
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -371,7 +371,7 @@ TEST_F(IResearchViewDBServerTest, test_open) {
   {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -399,7 +399,7 @@ TEST_F(IResearchViewDBServerTest, test_open) {
         "{ \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_FALSE(!logicalCollection);
     arangodb::LogicalView::ptr view;
@@ -762,7 +762,7 @@ TEST_F(IResearchViewDBServerTest, test_rename) {
         "{ \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_FALSE(!logicalCollection);
     arangodb::LogicalView::ptr view;
@@ -821,7 +821,7 @@ TEST_F(IResearchViewDBServerTest, test_rename) {
         1);  // +1 because LogicalView creation will generate a new ID
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_FALSE(!logicalCollection);
     arangodb::LogicalView::ptr view;
@@ -879,7 +879,7 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"unusedKey\": "
         "\"unusedValue\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -916,7 +916,7 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
         "\"unusedValue\", \"storedValues\":[[], [\"\"], [\"\"], { "
         "\"fields\":[\"test.t\"], \"compression\":\"none\"}, [\"a.a\", "
         "\"b.b\"]] }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -959,7 +959,7 @@ TEST_F(IResearchViewDBServerTest, test_toVelocyPack) {
         "\"unusedValue\", \"storedValues\":[[], [\"\"], [\"\"], { "
         "\"fields\":[\"test.t\"], \"compression\":\"none\"}, [\"a.a\", "
         "\"b.b\"]] }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -1783,7 +1783,7 @@ TEST_F(IResearchViewDBServerTest, test_visitCollections) {
   {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     ASSERT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -1808,7 +1808,7 @@ TEST_F(IResearchViewDBServerTest, test_visitCollections) {
         1);  // +1 because LogicalView creation will generate a new ID
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_FALSE(!logicalCollection);
     arangodb::LogicalView::ptr view;

--- a/tests/IResearch/IResearchViewNodeTest.cpp
+++ b/tests/IResearch/IResearchViewNodeTest.cpp
@@ -128,7 +128,7 @@ struct MockQuery final : arangodb::aql::Query {
 }  // namespace
 
 TEST_F(IResearchViewNodeTest, constructSortedView) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   // create view
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ "
@@ -286,7 +286,7 @@ TEST_F(IResearchViewNodeTest, constructSortedView) {
 }
 
 TEST_F(IResearchViewNodeTest, construct) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   // create view
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
@@ -897,7 +897,7 @@ TEST_F(IResearchViewNodeTest, construct) {
 }
 
 TEST_F(IResearchViewNodeTest, constructFromVPackSingleServer) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   // create view
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
@@ -1973,7 +1973,7 @@ TEST_F(IResearchViewNodeTest, constructFromVPackSingleServer) {
 //}
 
 TEST_F(IResearchViewNodeTest, clone) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   // create view
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
@@ -2433,7 +2433,7 @@ TEST_F(IResearchViewNodeTest, clone) {
 }
 
 TEST_F(IResearchViewNodeTest, serialize) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   // create view
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
@@ -3019,7 +3019,7 @@ TEST_F(IResearchViewNodeTest, serialize) {
 }
 
 TEST_F(IResearchViewNodeTest, serializeSortedView) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   // create view
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"primarySort\" : "
@@ -3297,7 +3297,7 @@ TEST_F(IResearchViewNodeTest, serializeSortedView) {
 }
 
 TEST_F(IResearchViewNodeTest, collections) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
 
   std::shared_ptr<arangodb::LogicalCollection> collection0;
   std::shared_ptr<arangodb::LogicalCollection> collection1;
@@ -3389,7 +3389,7 @@ TEST_F(IResearchViewNodeTest, collections) {
 }
 
 TEST_F(IResearchViewNodeTest, createBlockSingleServer) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
   auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -3534,7 +3534,7 @@ TEST_F(IResearchViewNodeTest, createBlockSingleServer) {
 //}
 
 TEST_F(IResearchViewNodeTest, createBlockCoordinator) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
   auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -3592,7 +3592,7 @@ TEST_F(IResearchViewNodeTest, createBlockCoordinator) {
 }
 
 TEST_F(IResearchViewNodeTest, createBlockCoordinatorLateMaterialize) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server(), "testVocbase", 1));
+  TRI_vocbase_t vocbase(testDBInfo(server.server(), "testVocbase", 1), server.engine());
   auto createJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
   auto logicalView = vocbase.createView(createJson->slice(), false);

--- a/tests/IResearch/IResearchViewSortedTest.cpp
+++ b/tests/IResearch/IResearchViewSortedTest.cpp
@@ -150,7 +150,7 @@ TEST_P(IResearchViewSortedTest, SingleField) {
     \"primarySort\": [ { \"field\" : \"seq\", \"direction\": \"desc\" } ] \
   }");
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::shared_ptr<arangodb::LogicalCollection> logicalCollection1;
   std::shared_ptr<arangodb::LogicalCollection> logicalCollection2;
 
@@ -456,7 +456,7 @@ TEST_P(IResearchViewSortedTest, MultipleFields) {
     \"primarySort\": [ { \"field\": \"same\", \"asc\": true }, { \"field\": \"same\", \"asc\": false }, { \"field\" : \"seq\", \"direction\": \"desc\" }, { \"field\" : \"name\", \"direction\": \"asc\" } ] \
   }");
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::shared_ptr<arangodb::LogicalCollection> logicalCollection1;
   std::shared_ptr<arangodb::LogicalCollection> logicalCollection2;
 

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -215,7 +215,7 @@ TEST_F(IResearchViewTest, test_defaults) {
 
   // view definition with LogicalView (for persistence)
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, json->slice(), true)
@@ -253,7 +253,7 @@ TEST_F(IResearchViewTest, test_defaults) {
 
   // view definition with LogicalView
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE(arangodb::iresearch::IResearchView::factory()
                     .create(view, vocbase, json->slice(), true)
@@ -294,7 +294,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 101, "
         "\"links\": { \"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     EXPECT_TRUE((true == !vocbase.lookupView("testView")));
     arangodb::LogicalView::ptr view;
     auto res = arangodb::iresearch::IResearchView::factory().create(
@@ -311,7 +311,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 101, "
         "\"links\": { \"testCollection\": 42 } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     EXPECT_TRUE((nullptr != logicalCollection));
     EXPECT_TRUE((true == !vocbase.lookupView("testView")));
@@ -332,7 +332,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"links\": { "
         "\"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
 
@@ -367,7 +367,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 101, "
         "\"links\": { \"testCollection\": {} } }");
 
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     EXPECT_TRUE((nullptr != logicalCollection));
     EXPECT_TRUE((true == !vocbase.lookupView("testView")));
@@ -433,7 +433,7 @@ TEST_F(IResearchViewTest, test_properties_user_request) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -789,7 +789,7 @@ TEST_F(IResearchViewTest, test_properties_user_request_explicit_version) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1141,7 +1141,7 @@ TEST_F(IResearchViewTest, test_properties_internal_request) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1494,7 +1494,7 @@ TEST_F(IResearchViewTest, test_properties_internal_request_explicit_version) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1846,7 +1846,7 @@ TEST_F(IResearchViewTest, test_vocbase_inventory) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1918,7 +1918,7 @@ TEST_F(IResearchViewTest, test_cleanup) {
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\":\"arangosearch\", "
       "\"cleanupIntervalStep\":1, \"consolidationIntervalMsec\": 1000 }");
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_TRUE((false == !logicalCollection));
   auto logicalView = vocbase.createView(json->slice(), false);
@@ -1983,7 +1983,7 @@ TEST_F(IResearchViewTest, test_consolidate) {
   auto viewCreateJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\":\"arangosearch\", "
       "\"consolidationIntervalMsec\": 1000 }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
   ASSERT_TRUE((false == !logicalView));
   // FIXME TODO write test to check that long-running consolidation aborts on
@@ -1996,7 +1996,7 @@ TEST_F(IResearchViewTest, test_consolidate) {
 }
 
 TEST_F(IResearchViewTest, test_drop) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -2037,7 +2037,7 @@ TEST_F(IResearchViewTest, test_drop) {
 }
 
 TEST_F(IResearchViewTest, test_drop_with_link) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -2156,7 +2156,7 @@ TEST_F(IResearchViewTest, test_drop_collection) {
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
   auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
       "{ \"links\": { \"testCollection\": { \"includeAllFields\": true } } }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_TRUE((false == !logicalCollection));
   auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -2195,7 +2195,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
         "{ \"view\": \"testView\", \"includeAllFields\": true }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2278,7 +2278,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2361,7 +2361,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2469,7 +2469,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2569,7 +2569,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2718,7 +2718,7 @@ TEST_F(IResearchViewTest, test_instantiate) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"version\": 1 "
         "}");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -2731,7 +2731,7 @@ TEST_F(IResearchViewTest, test_instantiate) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"version\": 0 "
         "}");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE(arangodb::iresearch::IResearchView::factory()
                     .instantiate(view, vocbase, json->slice(), false)
@@ -2744,7 +2744,7 @@ TEST_F(IResearchViewTest, test_instantiate) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"version\": "
         "123456789 }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((!arangodb::iresearch::IResearchView::factory()
                       .instantiate(view, vocbase, json->slice(), false)
@@ -2765,7 +2765,7 @@ TEST_F(IResearchViewTest, test_truncate_cid) {
         "{ \"view\": \"testView\", \"includeAllFields\": true }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2848,7 +2848,7 @@ TEST_F(IResearchViewTest, test_truncate_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2932,7 +2932,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3010,7 +3010,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3086,7 +3086,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\"  }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3169,7 +3169,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3241,7 +3241,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3347,7 +3347,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // in recovery (skip operations before or at recovery tick)
   {
     auto before = StorageEngineMock::recoveryStateResult;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3421,7 +3421,7 @@ TEST_F(IResearchViewTest, test_insert) {
     auto before = StorageEngineMock::recoveryStateResult;
     StorageEngineMock::recoveryStateResult =
         arangodb::RecoveryState::IN_PROGRESS;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
 
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
@@ -3505,7 +3505,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3562,7 +3562,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3621,7 +3621,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery : single operation transaction
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3672,7 +3672,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery batch (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3729,7 +3729,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery batch (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3796,7 +3796,7 @@ TEST_F(IResearchViewTest, test_remove_within_trx) {
   auto json = velocypack::Parser::fromJson(
       R"({ "name": "testView", "type":"arangosearch", "cleanupIntervalStep":0, "commitIntervalMsec": 0, "consolidationIntervalMsec" : 0 })");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_NE(nullptr, logicalCollection);
   auto logicalView = vocbase.createView(json->slice(), true);
@@ -3878,7 +3878,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // in recovery (skip operations before or at recovery tick)
   {
     auto before = StorageEngineMock::recoveryStateResult;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3960,7 +3960,7 @@ TEST_F(IResearchViewTest, test_remove) {
     auto before = StorageEngineMock::recoveryStateResult;
     StorageEngineMock::recoveryStateResult =
         arangodb::RecoveryState::IN_PROGRESS;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4043,7 +4043,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4100,7 +4100,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4159,7 +4159,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery : single operation transaction
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4210,7 +4210,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery batch (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4267,7 +4267,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery batch (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4325,7 +4325,7 @@ TEST_F(IResearchViewTest, test_remove) {
 TEST_F(IResearchViewTest, test_open) {
   // default data path
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     std::string dataPath =
         ((((std::filesystem::path() /= testFilesystemPath) /=
            std::string("databases")) /=
@@ -4361,7 +4361,7 @@ TEST_F(IResearchViewTest, test_query) {
 
   // no filter/order provided, means "RETURN *"
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     auto* view =
@@ -4385,7 +4385,7 @@ TEST_F(IResearchViewTest, test_query) {
         "{ \"name\": \"testCollection\" }");
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         "{ \"view\": \"testView\", \"includeAllFields\": true }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -4442,7 +4442,7 @@ TEST_F(IResearchViewTest, test_query) {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
 
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     std::vector<std::string> collections{logicalCollection->name()};
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -4535,7 +4535,7 @@ TEST_F(IResearchViewTest, test_query) {
         "{ \"links\": { \"testCollection\": { \"includeAllFields\": true } } "
         "}");
     ASSERT_TRUE(server.server().hasFeature<arangodb::FlushFeature>());
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
@@ -4609,7 +4609,7 @@ TEST_F(IResearchViewTest, test_register_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson0->slice(), false);
@@ -4690,7 +4690,7 @@ TEST_F(IResearchViewTest, test_register_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson0->slice(), false);
@@ -4788,7 +4788,7 @@ TEST_F(IResearchViewTest, test_register_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson1->slice(), false);
@@ -4930,7 +4930,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5053,7 +5053,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5168,7 +5168,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
@@ -5207,7 +5207,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
 
     {
@@ -5282,7 +5282,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
     auto& engine = *static_cast<StorageEngineMock*>(
         &server.getFeature<arangodb::EngineSelectorFeature>().engine());
     engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, viewJson->slice(), true)
@@ -5309,7 +5309,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
     engine.views.clear();
     auto updateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     arangodb::LogicalView::ptr logicalView;
@@ -5357,7 +5357,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
         "{ \"links\": { \"testCollection\": { } } }");
     auto updateJson1 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     arangodb::LogicalView::ptr logicalView;
@@ -5424,7 +5424,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 102 "
         "}");
     ASSERT_TRUE(server.server().hasFeature<arangodb::FlushFeature>());
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -5462,7 +5462,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
     auto createJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 102 "
         "}");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     auto* viewImpl =
@@ -5486,7 +5486,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
     engine.views.clear();
     auto updateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5522,7 +5522,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
         "{ \"links\": { \"testCollection\": { } } }");
     auto updateJson1 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5587,7 +5587,7 @@ TEST_F(IResearchViewTest, test_overwrite_immutable_properties) {
       "]"
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalView =
       vocbase.createView(viewJson->slice(), false);  // create view
   ASSERT_TRUE(nullptr != logicalView);
@@ -5698,7 +5698,7 @@ TEST_F(IResearchViewTest, test_transaction_registration) {
       "{ \"name\": \"testCollection1\" }");
   auto viewJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection0 = vocbase.createCollection(collectionJson0->slice());
   ASSERT_TRUE((nullptr != logicalCollection0));
   auto logicalCollection1 = vocbase.createCollection(collectionJson1->slice());
@@ -6060,7 +6060,7 @@ TEST_F(IResearchViewTest, test_transaction_snapshot) {
   auto viewJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", "
       "\"commitIntervalMsec\": 0 }");
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_TRUE((false == !logicalCollection));
   auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -6285,7 +6285,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // modify meta params
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
 
@@ -6440,7 +6440,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
   // test rollback on meta modification failure (as an example invalid value for
   // 'cleanupIntervalStep')
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -6522,7 +6522,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // modify meta params with links to missing collections
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -6611,7 +6611,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -6704,7 +6704,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -6887,7 +6887,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // overwrite links
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson0 = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection0\" }");
     auto collectionJson1 = arangodb::velocypack::Parser::fromJson(
@@ -7103,7 +7103,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // update existing link (full update)
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -7247,7 +7247,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         "{ \"cleanupIntervalStep\": 62, \"links\": { \"testCollection\": {} } "
         "}");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7362,7 +7362,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7410,7 +7410,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7508,7 +7508,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {}, \"testCollection1\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -7627,7 +7627,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -7746,7 +7746,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7844,7 +7844,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {}, \"testCollection1\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -7964,7 +7964,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -8091,7 +8091,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // modify meta params
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
     ASSERT_TRUE(view->category() ==
@@ -8171,7 +8171,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
   // test rollback on meta modification failure (as an example invalid value for
   // 'cleanupIntervalStep')
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -8250,7 +8250,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // modify meta params with links to missing collections
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -8336,7 +8336,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -8426,7 +8426,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -8633,7 +8633,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add a new link (in recovery)
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -8711,7 +8711,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add a new link
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -8817,7 +8817,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add a new link to a collection with documents
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -8941,7 +8941,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add new link to non-existant collection
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
     ASSERT_TRUE(view->category() ==
@@ -9023,7 +9023,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove link (in recovery)
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9112,7 +9112,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove link
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9271,7 +9271,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove link from non-existant collection
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
 
@@ -9351,7 +9351,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove non-existant link
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9433,7 +9433,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove + add link to same collection (reindex)
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9575,7 +9575,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // update existing link (partial update)
   {
-    Vocbase vocbase(testDBInfo(server.server()));
+    Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -10034,7 +10034,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"cleanupIntervalStep\": 62 }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -10149,7 +10149,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -10197,7 +10197,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -10295,7 +10295,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection1\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -10415,7 +10415,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection1\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -10788,7 +10788,7 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
         "    [\"obj.c\", \"\", \"obj.d\"], [\"obj.e\", \"obj.f.f1\", "
         "\"obj.g\"] ] "
         "} ");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, json->slice(), true)
@@ -10853,7 +10853,7 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
         "    [\"obj.d\"], [\"obj.c.c1\", \"obj.c\", \"obj.c\", \"obj.d\", "
         "\"obj.c.c2\"], [\"obj.b\", \"obj.b\"] ] "
         "} ");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, json->slice(), true)
@@ -10918,7 +10918,7 @@ TEST_F(IResearchViewTest, create_view_with_stored_value_with_compression) {
       "    {\"fields\":[\"obj.a\"], \"compression\":\"none\"} , "
       "{\"fields\":[\"obj.b.b1\"], \"compression\":\"lz4\"} ] "
       "} ");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()));
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
   arangodb::LogicalView::ptr view;
   EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                    .create(view, vocbase, json->slice(), true)

--- a/tests/Mocks/Servers.h
+++ b/tests/Mocks/Servers.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -32,6 +32,7 @@
 #include "Cluster/ServerState.h"
 #include "IResearch/IResearchCommon.h"
 #include "Logger/LogMacros.h"
+#include "Mocks/StorageEngineMock.h"
 #include "Transaction/Hints.h"
 #include "VocBase/Identifiers/DataSourceId.h"
 
@@ -120,6 +121,8 @@ class MockServer {
 
   // Implementation knows the place when all features are included
   virtual void startFeatures();
+
+  StorageEngineMock& engine() { return *_engine; }
 
  private:
   // Will be called by destructor

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -438,8 +438,8 @@ std::unique_ptr<TRI_vocbase_t> StorageEngineMock::openDatabase(
   auto new_info = info;
   new_info.setId(++vocbaseCount);
 
-  return std::make_unique<TRI_vocbase_t>(std::move(new_info), _versionTracker,
-                                         true);
+  return std::make_unique<TRI_vocbase_t>(std::move(new_info), *this,
+                                         _versionTracker, true);
 }
 
 TRI_voc_tick_t StorageEngineMock::releasedTick() const {

--- a/tests/RestHandler/RestAnalyzerHandlerTest.cpp
+++ b/tests/RestHandler/RestAnalyzerHandlerTest.cpp
@@ -869,7 +869,7 @@ TEST_F(RestAnalyzerHandlerTest,
   grantOnDb(arangodb::StaticStrings::SystemDatabase, arangodb::auth::Level::RO);
 
   // TODO
-  TRI_vocbase_t vocbase(unknownDBInfo(server.server()));
+  TRI_vocbase_t vocbase(unknownDBInfo(server.server()), server.engine());
   auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
   auto& request = *requestPtr;
   auto responcePtr = std::make_unique<GeneralResponseMock>();
@@ -906,7 +906,7 @@ TEST_F(RestAnalyzerHandlerTest,
             arangodb::auth::Level::NONE);
 
   // TODO
-  TRI_vocbase_t vocbase(unknownDBInfo(server.server()));
+  TRI_vocbase_t vocbase(unknownDBInfo(server.server()), server.engine());
   auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
   auto& request = *requestPtr;
   auto responcePtr = std::make_unique<GeneralResponseMock>();

--- a/tests/RestHandler/RestViewHandlerTest.cpp
+++ b/tests/RestHandler/RestViewHandlerTest.cpp
@@ -149,7 +149,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
     auto* authFeature = arangodb::AuthenticationFeature::instance();
     auto* userManager = authFeature->userManager();
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
     auto& request = *requestPtr;
     auto responcePtr = std::make_unique<GeneralResponseMock>();
@@ -268,7 +268,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
   {
     auto createViewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"testViewType\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createViewJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
@@ -385,7 +385,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
   {
     auto createViewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"testViewType\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createViewJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
@@ -561,7 +561,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
   {
     auto createViewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"testViewType\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createViewJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
@@ -838,7 +838,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
   {
     auto createViewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"testViewType\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createViewJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
@@ -1020,7 +1020,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
   {
     auto createViewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"testViewType\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView = vocbase.createView(createViewJson->slice(), false);
     ASSERT_FALSE(!logicalView);
     auto requestPtr = std::make_unique<GeneralRequestMock>(vocbase);
@@ -1204,7 +1204,7 @@ TEST_F(RestViewHandlerTest, test_auth) {
         "{ \"name\": \"testView1\", \"type\": \"testViewType\" }");
     auto createView2Json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView2\", \"type\": \"testViewType\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()));
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto logicalView1 = vocbase.createView(createView1Json->slice(), false);
     ASSERT_FALSE(!logicalView1);
     auto logicalView2 = vocbase.createView(createView2Json->slice(), false);

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -226,7 +226,7 @@ class ShardDistributionReporterTest
       f.first.prepare();
     }
 
-    vocbase = std::make_unique<TRI_vocbase_t>(testDBInfo(server));
+    vocbase = std::make_unique<TRI_vocbase_t>(testDBInfo(server), engine);
     col = std::make_unique<arangodb::LogicalCollection>(*vocbase, json->slice(),
                                                         true);
 

--- a/tests/StorageEngine/PhysicalCollectionTest.cpp
+++ b/tests/StorageEngine/PhysicalCollectionTest.cpp
@@ -108,7 +108,7 @@ class PhysicalCollectionTest
 // -----------------------------------------------------------------------------
 
 TEST_F(PhysicalCollectionTest, test_new_object_for_insert) {
-  TRI_vocbase_t vocbase(testDBInfo(server));
+  TRI_vocbase_t vocbase(testDBInfo(server), engine);
 
   auto json = arangodb::velocypack::Parser::fromJson("{ \"name\": \"test\" }");
   auto collection = vocbase.createCollection(json->slice());
@@ -242,7 +242,7 @@ class MockIndex : public Index {
 };
 
 TEST_F(PhysicalCollectionTest, test_index_ordeing) {
-  TRI_vocbase_t vocbase(testDBInfo(server));
+  TRI_vocbase_t vocbase(testDBInfo(server), engine);
   auto json = arangodb::velocypack::Parser::fromJson("{ \"name\": \"test\" }");
   auto collection = vocbase.createCollection(json->slice());
   std::vector<std::vector<arangodb::basics::AttributeName>> dummyFields;

--- a/tests/Transaction/ContextTest.cpp
+++ b/tests/Transaction/ContextTest.cpp
@@ -51,7 +51,8 @@ class TransactionContextTest : public ::testing::Test {
   arangodb::tests::mocks::TransactionManagerSetup setup;
   TRI_vocbase_t vocbase;
 
-  TransactionContextTest() : vocbase(testDBInfo(setup.server.server())) {}
+  TransactionContextTest()
+      : vocbase(testDBInfo(setup.server.server()), setup.server.engine()) {}
 };
 
 TEST_F(TransactionContextTest, StandaloneSmartContext) {

--- a/tests/Transaction/ManagerTest.cpp
+++ b/tests/Transaction/ManagerTest.cpp
@@ -67,7 +67,7 @@ class TransactionManagerTest : public ::testing::Test {
   TransactionId tid;
 
   TransactionManagerTest()
-      : vocbase(testDBInfo(setup.server.server())),
+      : vocbase(testDBInfo(setup.server.server()), setup.server.engine()),
         mgr(transaction::ManagerFeature::manager()),
         tid(TransactionId::createLeader()) {}
 

--- a/tests/Transaction/RestTransactionHandlerTest.cpp
+++ b/tests/Transaction/RestTransactionHandlerTest.cpp
@@ -65,7 +65,7 @@ class RestTransactionHandlerTest : public ::testing::Test {
   velocypack::Parser parser;
 
   RestTransactionHandlerTest()
-      : vocbase(testDBInfo(setup.server.server())),
+      : vocbase(testDBInfo(setup.server.server()), setup.server.engine()),
         mgr(transaction::ManagerFeature::manager()),
         requestPtr(std::make_unique<GeneralRequestMock>(vocbase)),
         request(*requestPtr),

--- a/tests/Utils/CollectionNameResolverTest.cpp
+++ b/tests/Utils/CollectionNameResolverTest.cpp
@@ -108,7 +108,7 @@ TEST_F(CollectionNameResolverTest, test_getDataSource) {
   auto viewJson = arangodb::velocypack::Parser::fromJson(
       "{ \"id\": 200, \"name\": \"testView\", \"type\": \"testViewType\" "
       "}");  // any arbitrary view type
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
   arangodb::CollectionNameResolver resolver(vocbase);
 
   // not present collection (no datasource)

--- a/tests/VocBase/LogicalDataSourceTest.cpp
+++ b/tests/VocBase/LogicalDataSourceTest.cpp
@@ -140,7 +140,7 @@ class LogicalDataSourceTest : public ::testing::Test {
 TEST_F(LogicalDataSourceTest, test_category) {
   // LogicalCollection
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     arangodb::LogicalCollection instance(vocbase, json->slice(), true);
@@ -151,7 +151,7 @@ TEST_F(LogicalDataSourceTest, test_category) {
 
   // LogicalView
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto json =
         arangodb::velocypack::Parser::fromJson("{ \"name\": \"testView\" }");
     LogicalViewImpl instance(vocbase, json->slice());
@@ -164,7 +164,7 @@ TEST_F(LogicalDataSourceTest, test_category) {
 TEST_F(LogicalDataSourceTest, test_construct) {
   // LogicalCollection
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"id\": 1, \"planId\": 2, \"globallyUniqueId\": \"abc\", \"name\": "
         "\"testCollection\" }");
@@ -177,7 +177,7 @@ TEST_F(LogicalDataSourceTest, test_construct) {
 
   // LogicalView
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"id\": 1, \"planId\": 2, \"globallyUniqueId\": \"abc\", \"name\": "
         "\"testView\" }");
@@ -192,7 +192,7 @@ TEST_F(LogicalDataSourceTest, test_construct) {
 TEST_F(LogicalDataSourceTest, test_defaults) {
   // LogicalCollection
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     arangodb::LogicalCollection instance(vocbase, json->slice(), true);
@@ -204,7 +204,7 @@ TEST_F(LogicalDataSourceTest, test_defaults) {
 
   // LogicalView
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto json =
         arangodb::velocypack::Parser::fromJson("{ \"name\": \"testView\" }");
     LogicalViewImpl instance(vocbase, json->slice());

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -183,14 +183,14 @@ TEST_F(LogicalViewTest, test_auth) {
 
   // no ExecContext
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     EXPECT_TRUE(logicalView->canUse(arangodb::auth::Level::RW));
   }
 
   // no read access
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
@@ -206,7 +206,7 @@ TEST_F(LogicalViewTest, test_auth) {
 
   // no write access
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()
@@ -224,7 +224,7 @@ TEST_F(LogicalViewTest, test_auth) {
   // write access (view access is db access as per
   // https://github.com/arangodb/backlog/issues/459)
   {
-    TRI_vocbase_t vocbase(testDBInfo(server));
+    TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     struct ExecContext : public arangodb::ExecContext {
       ExecContext()

--- a/tests/VocBase/VocbaseTest.cpp
+++ b/tests/VocBase/VocbaseTest.cpp
@@ -109,7 +109,7 @@ TEST_F(VocbaseTest, test_lookupDataSource) {
   auto viewJson = arangodb::velocypack::Parser::fromJson(
       "{ \"id\": 200, \"name\": \"testView\", \"type\": \"testViewType\" "
       "}");  // any arbitrary view type
-  Vocbase vocbase(testDBInfo(server.server()));
+  Vocbase vocbase(testDBInfo(server.server()), server.engine());
 
   // not present collection (no datasource)
   {


### PR DESCRIPTION
### Scope & Purpose

This PR removes `EngineSelectorFeature` from these call sites; Replace them a dependency
- injectiStorageEngine/VPackSortMigration.cpp
- VocBase/Methods/UpgradeTasks.cpp
- VocBase/Methods/Collections.cpp
- VocBase/Methods/Databases.cpp
- VocBase/LogicalCollection.cpp
- VocBase/LogicalView.cpp
- VocBase/vocbase.cpp 
- RestHandler/RestDocumentHandler.cpp 
- Replication/GlobalReplicationApplier.cpp
- IResearch/IResearchFeature.cpp 

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
