### PR TITLE
Remove duplicate arangod call in entrypoint script

### DIFF
--- a/scripts/docker/deploy/entrypoint.sh
+++ b/scripts/docker/deploy/entrypoint.sh
@@ -88,7 +88,7 @@ if [ "$1" = 'arangod' ]; then
         echo "Initializing database...Hang on..."
         echo "PARAMETERS: "
         echo "$@"
-        $NUMACTL arangod "$@" --config /tmp/arangod.conf \
+        $NUMACTL "$@" --config /tmp/arangod.conf \
                 --server.endpoint tcp://127.0.0.1:$ARANGO_INIT_PORT \
                 --server.authentication false \
 		--log.file /tmp/init-log \


### PR DESCRIPTION
### Scope & Purpose

While attempting to run ArangoDB as a non-root user I ran into an issue where the initial run of the entrypoint script would time out, but a subsequent start of the pod would then work. I traced the issue down to this section where we are calling the arangod binary. The entrypoint script requires either `arangod` or a variable `--server.endpoint 8922` to be passed in which has `arangod` prepended. When it reaches the the invovation `$NUMACTL arangod "$@" --config /tmp/arangod.conf \` it results in duplicate `arangod`. Removing the duplication resolved my issue using a non-root user.

-  :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change limited to the init-time `arangod` startup command; main impact is how container args are passed during initial DB initialization.
> 
> **Overview**
> Fixes the Docker `entrypoint.sh` initialization startup by removing the hardcoded `arangod` from the init-time launch command and executing `"$@"` directly.
> 
> This prevents accidental `arangod arangod ...` invocation when the script has already prepended `arangod` to option-only commands, improving reliability (notably for non-root runs) during first-time database initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ab5b49bb06e3aa03349fcfae3e05393ed1c5f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->