### PR TITLE
[cor-510]-replace-legacy-fileutils-functions-with-std-filesystem-equivalents-part4

### DIFF
--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -132,10 +132,15 @@ std::string buildFilename(char const* path, char const* name) {
 }
 
 std::string buildFilename(std::string const& path, std::string const& name) {
-  std::filesystem::path base(path);
+  namespace fs = std::filesystem;
+  fs::path result;
 
-  std::filesystem::path result = (base / name).lexically_normal();
-  return result.make_preferred().string();
+  if (!fs::path(path).empty())
+    result = (fs::path(path) / fs::path(name).relative_path());
+  else
+    result = fs::path(name);
+
+  return result.lexically_normal().make_preferred().string();
 }
 
 static void throwFileReadError(std::string const& filename) {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -135,11 +135,11 @@ std::string buildFilename(std::string const& path, std::string const& name) {
   namespace fs = std::filesystem;
   fs::path result;
 
-  if (!fs::path(path).empty())
+  if (!fs::path(path).empty()) {
     result = (fs::path(path) / fs::path(name).relative_path());
-  else
+  } else {
     result = fs::path(name);
-
+  }
   return result.lexically_normal().make_preferred().string();
 }
 

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -128,48 +128,42 @@ namespace arangodb::basics::FileUtils {
 std::string buildFilename(char const* path, char const* name) {
   TRI_ASSERT(path != nullptr);
   TRI_ASSERT(name != nullptr);
-
-  std::string result(path);
-
-  if (!result.empty()) {
-    std::filesystem::path sourcepath{result};
-    result = sourcepath.lexically_normal().string();
-    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
-      result += TRI_DIR_SEPARATOR_CHAR;
-    }
-  }
-
-  if (!result.empty() && *name == TRI_DIR_SEPARATOR_CHAR) {
-    // skip initial forward slash in name to avoid having two forward slashes in
-    // result
-    result.append(name + 1);
-  } else {
-    result.append(name);
-  }
-
-  return std::filesystem::path(result).make_preferred().string();
+  return buildFilename(std::string(path), std::string(name));
 }
-
+/*
 std::string buildFilename(std::string const& path, std::string const& name) {
-  std::string result(path);
+  if (path.empty()) {
+    return std::filesystem::path(name).make_preferred().string();
+  }
+  std::filesystem::path const base =
+      std::filesystem::path(path).lexically_normal();
+  std::string const baseStr = base.string();
 
-  if (!result.empty()) {
-    std::filesystem::path sourcepath{result};
-    result = sourcepath.lexically_normal().string();
-    if (result.length() != 1 || result[0] != TRI_DIR_SEPARATOR_CHAR) {
-      result += TRI_DIR_SEPARATOR_CHAR;
+  std::string nameToJoin = name;
+  if (!nameToJoin.empty() && nameToJoin.front() == TRI_DIR_SEPARATOR_CHAR) {
+    nameToJoin.erase(0, 1);
+  }
+  if (nameToJoin.empty()) {
+    std::string out = baseStr;
+    if (out.size() != 1 || out[0] != TRI_DIR_SEPARATOR_CHAR) {
+      out += TRI_DIR_SEPARATOR_CHAR;
     }
+    return std::filesystem::path(out).make_preferred().string();
+  }
+  return (base / nameToJoin).make_preferred().string();
+}
+*/
+std::string buildFilename(std::string const& path, std::string const& name) {
+  std::filesystem::path base(path);
+
+  // If name starts with a separator, strip it so it's treated as relative
+  std::string nameToJoin = name;
+  if (!nameToJoin.empty() && nameToJoin.front() == TRI_DIR_SEPARATOR_CHAR) {
+    nameToJoin.erase(0, 1);
   }
 
-  if (!result.empty() && !name.empty() && name[0] == TRI_DIR_SEPARATOR_CHAR) {
-    // skip initial forward slash in name to avoid having two forward slashes in
-    // result
-    result.append(name.c_str() + 1, name.size() - 1);
-  } else {
-    result.append(name);
-  }
-
-  return std::filesystem::path(result).make_preferred().string();
+  std::filesystem::path result = (base / nameToJoin).lexically_normal();
+  return result.make_preferred().string();
 }
 
 static void throwFileReadError(std::string const& filename) {

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -134,13 +134,7 @@ std::string buildFilename(char const* path, char const* name) {
 std::string buildFilename(std::string const& path, std::string const& name) {
   std::filesystem::path base(path);
 
-  // If name starts with a separator, strip it so it's treated as relative
-  std::string nameToJoin = name;
-  if (!nameToJoin.empty() && nameToJoin.front() == TRI_DIR_SEPARATOR_CHAR) {
-    nameToJoin.erase(0, 1);
-  }
-
-  std::filesystem::path result = (base / nameToJoin).lexically_normal();
+  std::filesystem::path result = (base / name).lexically_normal();
   return result.make_preferred().string();
 }
 

--- a/lib/Basics/FileUtils.cpp
+++ b/lib/Basics/FileUtils.cpp
@@ -130,29 +130,7 @@ std::string buildFilename(char const* path, char const* name) {
   TRI_ASSERT(name != nullptr);
   return buildFilename(std::string(path), std::string(name));
 }
-/*
-std::string buildFilename(std::string const& path, std::string const& name) {
-  if (path.empty()) {
-    return std::filesystem::path(name).make_preferred().string();
-  }
-  std::filesystem::path const base =
-      std::filesystem::path(path).lexically_normal();
-  std::string const baseStr = base.string();
 
-  std::string nameToJoin = name;
-  if (!nameToJoin.empty() && nameToJoin.front() == TRI_DIR_SEPARATOR_CHAR) {
-    nameToJoin.erase(0, 1);
-  }
-  if (nameToJoin.empty()) {
-    std::string out = baseStr;
-    if (out.size() != 1 || out[0] != TRI_DIR_SEPARATOR_CHAR) {
-      out += TRI_DIR_SEPARATOR_CHAR;
-    }
-    return std::filesystem::path(out).make_preferred().string();
-  }
-  return (base / nameToJoin).make_preferred().string();
-}
-*/
 std::string buildFilename(std::string const& path, std::string const& name) {
   std::filesystem::path base(path);
 


### PR DESCRIPTION
Replaced legacy FileUtils functions with std::filesystem equivalents. In this task have addressed buildFilename()