### PR TITLE
[COR-523] Remove EngineSelectorFeature (2)

### DIFF
--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -71,7 +71,6 @@
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
 #include "Scheduler/SchedulerFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/TransactionState.h"
@@ -1085,7 +1084,6 @@ IResearchAnalyzerFeature::Dependencies::fromServer(
     application_features::ApplicationServer& server) {
   return {
       .databaseFeature = server.getFeature<DatabaseFeature>(),
-      .engineSelector = server.getFeature<EngineSelectorFeature>(),
       .systemDatabase = server.getFeature<SystemDatabaseFeature>(),
       .networkFeature = server.hasFeature<NetworkFeature>()
                             ? &server.getFeature<NetworkFeature>()
@@ -1106,7 +1104,6 @@ IResearchAnalyzerFeature::IResearchAnalyzerFeature(
     application_features::ApplicationServer& server, Dependencies deps)
     : ApplicationFeature{server, *this},
       _clusterFeature(deps.clusterFeature),
-      _engineSelector(deps.engineSelector),
       _systemDatabase(deps.systemDatabase),
       _databaseFeature(deps.databaseFeature),
       _networkFeature(deps.networkFeature),
@@ -1429,7 +1426,6 @@ Result IResearchAnalyzerFeature::emplace(
       return res;
     }
 
-    auto& engine = _engineSelector.engine();
     bool erase = emplaceRes.second;  // an insertion took place
     irs::Finally cleanup = [&erase, this, &emplaceRes]() noexcept {
       if (erase) {
@@ -1451,7 +1447,7 @@ Result IResearchAnalyzerFeature::emplace(
       }
 
       // persist only on coordinator and single-server while not in recovery
-      if ((!engine.inRecovery())  // do not persist during recovery
+      if ((!engine().inRecovery())  // do not persist during recovery
           && (ServerState::instance()->isCoordinator()          // coordinator
               || ServerState::instance()->isSingleServer())) {  // single-server
         res = storeAnalyzer(*pool, operationOrigin);
@@ -1990,10 +1986,9 @@ Result IResearchAnalyzerFeature::cleanupAnalyzersCollection(
     AnalyzersRevision::Revision buildingRevision,
     transaction::OperationOrigin operationOrigin) {
   if (ServerState::instance()->isCoordinator()) {
-    auto& engine = _engineSelector.engine();
     auto vocbase = _databaseFeature.useDatabase(database);
     if (!vocbase) {
-      if (engine.inRecovery()) {
+      if (engine().inRecovery()) {
         return {};  // database might not have come up yet
       }
       return {TRI_ERROR_INTERNAL,
@@ -2155,12 +2150,11 @@ Result IResearchAnalyzerFeature::loadAnalyzers(
     // .........................................................................
 
     // database key used in '_lastLoad'
-    auto& engine = _engineSelector.engine();
     auto itr = _lastLoad.find(database);
 
     auto vocbase = _databaseFeature.useDatabase(database);
     if (!vocbase) {
-      if (engine.inRecovery()) {
+      if (engine().inRecovery()) {
         return {};  // database might not have come up yet
       }
       if (itr != _lastLoad.end()) {
@@ -2176,7 +2170,7 @@ Result IResearchAnalyzerFeature::loadAnalyzers(
     AnalyzersRevision::Revision loadingRevision{
         getAnalyzersRevision(*vocbase, true)->getRevision()};
 
-    if (engine.inRecovery()) {
+    if (engine().inRecovery()) {
       // always load if inRecovery since collection contents might have changed
       // unless on db-server which does not store analyzer definitions in
       // collections
@@ -2667,10 +2661,8 @@ Result IResearchAnalyzerFeature::remove(
                        "' while removing arangosearch analyzer '", name, "'")};
     }
 
-    auto& engine = _engineSelector.engine();
-
     // do not allow persistence while in recovery
-    if (engine.inRecovery()) {
+    if (engine().inRecovery()) {
       return {TRI_ERROR_INTERNAL,
               absl::StrCat("failure to remove arangosearch analyzer '", name,
                            "' configuration while storage engine in recovery")};
@@ -2830,10 +2822,8 @@ Result IResearchAnalyzerFeature::storeAnalyzer(
                            pool.name(), "' configuration with 'null' type")};
     }
 
-    auto& engine = _engineSelector.engine();
-
     // do not allow persistence while in recovery
-    if (engine.inRecovery()) {
+    if (engine().inRecovery()) {
       return {TRI_ERROR_INTERNAL,
               absl::StrCat("failure to persist arangosearch analyzer '",
                            pool.name(),

--- a/arangod/IResearch/IResearchAnalyzerFeature.h
+++ b/arangod/IResearch/IResearchAnalyzerFeature.h
@@ -49,6 +49,7 @@
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "IResearch/IResearchAnalyzerValueTypeAttribute.h"
 #include "IResearch/IResearchCommon.h"
+#include "RestServer/DatabaseFeature.h"
 #include "Scheduler/Scheduler.h"
 #include "Transaction/OperationOrigin.h"
 
@@ -60,9 +61,9 @@ class ApplicationServer;
 }
 class ClusterFeature;
 class DatabaseFeature;
-class EngineSelectorFeature;
 class NetworkFeature;
 class SchedulerFeature;
+class StorageEngine;
 class SystemDatabaseFeature;
 
 namespace aql {
@@ -292,7 +293,6 @@ class IResearchAnalyzerFeature final
 
   struct Dependencies {
     DatabaseFeature& databaseFeature;
-    EngineSelectorFeature& engineSelector;
     SystemDatabaseFeature& systemDatabase;
     NetworkFeature* networkFeature;
     ClusterFeature* clusterFeature;
@@ -606,12 +606,13 @@ class IResearchAnalyzerFeature final
   Result storeAnalyzer(AnalyzerPool& pool,
                        transaction::OperationOrigin operationOrigin);
 
+  StorageEngine& engine() const noexcept { return _databaseFeature.engine(); }
+
   /// @brief dangling analyzer revisions collector
   std::function<void(bool)> _gcfunc;
   std::mutex _workItemMutex;
   Scheduler::WorkHandle _workItem;
   ClusterFeature* _clusterFeature;
-  EngineSelectorFeature& _engineSelector;
   SystemDatabaseFeature& _systemDatabase;
   DatabaseFeature& _databaseFeature;
   NetworkFeature* _networkFeature;

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -40,10 +40,10 @@
 #include "Metrics/Metric.h"
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
+#include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "Statistics/StatisticsFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 namespace arangodb::metrics {
 
@@ -52,15 +52,15 @@ MetricsFeature::MetricsFeature(
     LazyApplicationFeatureReference<QueryRegistryFeature>
         lazyQueryRegistryFeatureRef,
     LazyApplicationFeatureReference<StatisticsFeature> lazyStatisticsFeatureRef,
-    LazyApplicationFeatureReference<EngineSelectorFeature>
-        lazyEngineSelectorFeatureRef,
+    LazyApplicationFeatureReference<DatabaseFeature>
+        lazyDatabaseFeatureRef,
     LazyApplicationFeatureReference<ClusterMetricsFeature>
         lazyClusterMetricsFeatureRef,
     LazyApplicationFeatureReference<ClusterFeature> lazyClusterFeatureRef)
     : ApplicationFeature{server, *this},
       _lazyQueryRegistryFeatureRef(std::move(lazyQueryRegistryFeatureRef)),
       _lazyStatisticsFeatureRef(std::move(lazyStatisticsFeatureRef)),
-      _lazyEngineSelectorFeatureRef(std::move(lazyEngineSelectorFeatureRef)),
+      _lazyDatabaseFeatureRef(std::move(lazyDatabaseFeatureRef)),
       _lazyClusterMetricsFeatureRef(std::move(lazyClusterMetricsFeatureRef)),
       _lazyClusterFeatureRef(std::move(lazyClusterFeatureRef)) {
   setOptional(false);
@@ -283,7 +283,7 @@ void MetricsFeature::toPrometheus(std::string& result,
                                      _options.ensureWhitespace);
 
     // Storage engine only provides standard metrics
-    auto& es = _engineSelectorFeature->engine();
+    auto& es = _databaseFeature->engine();
     if (es.typeName() == RocksDBEngine::kEngineName) {
       es.toPrometheus(result, _globals, _options.ensureWhitespace);
     }
@@ -402,7 +402,7 @@ void MetricsFeature::batchRemove(std::string_view name,
 void MetricsFeature::prepare() {
   _queryRegistryFeature = std::move(_lazyQueryRegistryFeatureRef).get();
   _statisticsFeature = std::move(_lazyStatisticsFeatureRef).get();
-  _engineSelectorFeature = std::move(_lazyEngineSelectorFeatureRef).get();
+  _databaseFeature = std::move(_lazyDatabaseFeatureRef).get();
   _clusterMetricsFeature = std::move(_lazyClusterMetricsFeatureRef).get();
   _clusterFeature = std::move(_lazyClusterFeatureRef).get();
 }

--- a/arangod/Metrics/MetricsFeature.cpp
+++ b/arangod/Metrics/MetricsFeature.cpp
@@ -52,8 +52,7 @@ MetricsFeature::MetricsFeature(
     LazyApplicationFeatureReference<QueryRegistryFeature>
         lazyQueryRegistryFeatureRef,
     LazyApplicationFeatureReference<StatisticsFeature> lazyStatisticsFeatureRef,
-    LazyApplicationFeatureReference<DatabaseFeature>
-        lazyDatabaseFeatureRef,
+    LazyApplicationFeatureReference<DatabaseFeature> lazyDatabaseFeatureRef,
     LazyApplicationFeatureReference<ClusterMetricsFeature>
         lazyClusterMetricsFeatureRef,
     LazyApplicationFeatureReference<ClusterFeature> lazyClusterFeatureRef)

--- a/arangod/Metrics/MetricsFeature.h
+++ b/arangod/Metrics/MetricsFeature.h
@@ -44,7 +44,7 @@
 namespace arangodb {
 class QueryRegistryFeature;
 class StatisticsFeature;
-class EngineSelectorFeature;
+class DatabaseFeature;
 class ClusterFeature;
 }  // namespace arangodb
 namespace arangodb::metrics {
@@ -64,8 +64,8 @@ class MetricsFeature final : public application_features::ApplicationFeature {
           lazyQueryRegistryFeatureRef,
       LazyApplicationFeatureReference<StatisticsFeature>
           lazyStatisticsFeatureRef,
-      LazyApplicationFeatureReference<EngineSelectorFeature>
-          lazyEngineSelectorFeatureRef,
+      LazyApplicationFeatureReference<DatabaseFeature>
+          lazyDatabaseFeatureRef,
       LazyApplicationFeatureReference<ClusterMetricsFeature>
           lazyClusterMetricsFeatureRef,
       LazyApplicationFeatureReference<ClusterFeature> lazyClusterFeatureRef);
@@ -145,15 +145,15 @@ class MetricsFeature final : public application_features::ApplicationFeature {
   LazyApplicationFeatureReference<QueryRegistryFeature>
       _lazyQueryRegistryFeatureRef;
   LazyApplicationFeatureReference<StatisticsFeature> _lazyStatisticsFeatureRef;
-  LazyApplicationFeatureReference<EngineSelectorFeature>
-      _lazyEngineSelectorFeatureRef;
+  LazyApplicationFeatureReference<DatabaseFeature>
+      _lazyDatabaseFeatureRef;
   LazyApplicationFeatureReference<ClusterMetricsFeature>
       _lazyClusterMetricsFeatureRef;
   LazyApplicationFeatureReference<ClusterFeature> _lazyClusterFeatureRef;
 
   QueryRegistryFeature* _queryRegistryFeature = nullptr;
   StatisticsFeature* _statisticsFeature = nullptr;
-  EngineSelectorFeature* _engineSelectorFeature = nullptr;
+  DatabaseFeature* _databaseFeature = nullptr;
   ClusterMetricsFeature* _clusterMetricsFeature = nullptr;
   ClusterFeature* _clusterFeature = nullptr;
 

--- a/arangod/Metrics/MetricsFeature.h
+++ b/arangod/Metrics/MetricsFeature.h
@@ -64,8 +64,7 @@ class MetricsFeature final : public application_features::ApplicationFeature {
           lazyQueryRegistryFeatureRef,
       LazyApplicationFeatureReference<StatisticsFeature>
           lazyStatisticsFeatureRef,
-      LazyApplicationFeatureReference<DatabaseFeature>
-          lazyDatabaseFeatureRef,
+      LazyApplicationFeatureReference<DatabaseFeature> lazyDatabaseFeatureRef,
       LazyApplicationFeatureReference<ClusterMetricsFeature>
           lazyClusterMetricsFeatureRef,
       LazyApplicationFeatureReference<ClusterFeature> lazyClusterFeatureRef);
@@ -145,8 +144,7 @@ class MetricsFeature final : public application_features::ApplicationFeature {
   LazyApplicationFeatureReference<QueryRegistryFeature>
       _lazyQueryRegistryFeatureRef;
   LazyApplicationFeatureReference<StatisticsFeature> _lazyStatisticsFeatureRef;
-  LazyApplicationFeatureReference<DatabaseFeature>
-      _lazyDatabaseFeatureRef;
+  LazyApplicationFeatureReference<DatabaseFeature> _lazyDatabaseFeatureRef;
   LazyApplicationFeatureReference<ClusterMetricsFeature>
       _lazyClusterMetricsFeatureRef;
   LazyApplicationFeatureReference<ClusterFeature> _lazyClusterFeatureRef;

--- a/arangod/Network/NetworkFeature.cpp
+++ b/arangod/Network/NetworkFeature.cpp
@@ -43,7 +43,6 @@
 #include "ProgramOptions/ProgramOptions.h"
 #include "RestServer/ServerFeature.h"
 #include "Scheduler/SchedulerFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 #include <fuerte/connection.h>
 
@@ -332,7 +331,6 @@ NetworkFeature::NetworkFeature(application_features::ApplicationServer& server,
   startsAfter<ClusterFeature>();
   startsAfter<SchedulerFeature>();
   startsAfter<ServerFeature>();
-  startsAfter<EngineSelectorFeature>();
 }
 
 NetworkFeature::~NetworkFeature() {

--- a/arangod/RestHandler/RestDumpHandler.cpp
+++ b/arangod/RestHandler/RestDumpHandler.cpp
@@ -35,7 +35,6 @@
 #include "Inspection/VPack.h"
 #include "RocksDBEngine/RocksDBDumpManager.h"
 #include "RocksDBEngine/RocksDBEngine.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Utils/ExecContext.h"
 
 #include <absl/strings/str_cat.h>
@@ -55,9 +54,7 @@ RestDumpHandler::RestDumpHandler(
       _clusterInfo(server.getFeature<ClusterFeature>().clusterInfo()) {
   if (ServerState::instance()->isDBServer() ||
       ServerState::instance()->isSingleServer()) {
-    _dumpManager = server.getFeature<EngineSelectorFeature>()
-                       .engine<RocksDBEngine>()
-                       .dumpManager();
+    _dumpManager = _vocbase.engine<RocksDBEngine>().dumpManager();
   }
 }
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -64,7 +64,6 @@
 #include "VectorIndex/VectorIndexFeature.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "Sharding/ShardingInfo.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/TransactionState.h"
@@ -391,7 +390,6 @@ RestReplicationHandler::RestReplicationHandler(
     GeneralResponse* response)
     : RestVocbaseBaseHandler(server, request, response),
       _clusterFeature(server.getFeature<ClusterFeature>()),
-      _engineSelectorFeature(server.getFeature<EngineSelectorFeature>()),
       _replicationFeature(server.getFeature<ReplicationFeature>()),
       _databaseFeature(server.getFeature<DatabaseFeature>()) {}
 
@@ -2933,8 +2931,7 @@ RestReplicationHandler::handleCommandHoldReadLockCollection() {
     // than the tick of the transaction created above, but it still can be
     // used by a follower as an upper bound until which to tail the WAL _at
     // most_.
-    TRI_ASSERT(server().hasFeature<EngineSelectorFeature>());
-    StorageEngine& engine = _engineSelectorFeature.engine();
+    auto& engine = _vocbase.engine();
     b.add("lastLogTick", VPackValue(engine.currentTick()));
   }
 
@@ -3014,8 +3011,7 @@ void RestReplicationHandler::handleCommandGetIdForReadLockCollection() {
 }
 
 void RestReplicationHandler::handleCommandLoggerState() {
-  TRI_ASSERT(server().hasFeature<EngineSelectorFeature>());
-  StorageEngine& engine = _engineSelectorFeature.engine();
+  auto& engine = _vocbase.engine();
 
   VPackBuilder builder;
   auto res = engine.createLoggerState(&_vocbase, builder);
@@ -3039,7 +3035,7 @@ void RestReplicationHandler::handleCommandLoggerState() {
 //////////////////////////////////////////////////////////////////////////////
 void RestReplicationHandler::handleCommandLoggerFirstTick() {
   TRI_voc_tick_t tick = UINT64_MAX;
-  Result res = _engineSelectorFeature.engine().firstTick(tick);
+  Result res = _vocbase.engine().firstTick(tick);
 
   VPackBuilder b;
   b.add(VPackValue(VPackValueType::Object));
@@ -3064,7 +3060,7 @@ void RestReplicationHandler::handleCommandLoggerLast() {
   auto tickStart = _request->parsedValue("tickStart", uint64_t(0));
   auto tickEnd = _request->parsedValue("tickEnd", uint64_t(0xbadbadbadbadULL));
 
-  Result res = server().getFeature<EngineSelectorFeature>().engine().lastLogger(
+  Result res = _vocbase.engine().lastLogger(
       _vocbase, tickStart, tickEnd, builder);
   generateResult(rest::ResponseCode::OK, builder.slice());
 }
@@ -3080,8 +3076,8 @@ void RestReplicationHandler::handleCommandLoggerLast() {
 //////////////////////////////////////////////////////////////////////////////
 
 void RestReplicationHandler::handleCommandLoggerTickRanges() {
-  TRI_ASSERT(server().hasFeature<EngineSelectorFeature>());
-  StorageEngine& engine = _engineSelectorFeature.engine();
+  TRI_ASSERT(!_vocbase.engine().typeName().empty());
+  auto& engine = _vocbase.engine();
   VPackBuilder b;
   Result res = engine.createTickRanges(b);
   if (res.ok()) {

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3076,7 +3076,6 @@ void RestReplicationHandler::handleCommandLoggerLast() {
 //////////////////////////////////////////////////////////////////////////////
 
 void RestReplicationHandler::handleCommandLoggerTickRanges() {
-  TRI_ASSERT(!_vocbase.engine().typeName().empty());
   auto& engine = _vocbase.engine();
   VPackBuilder b;
   Result res = engine.createTickRanges(b);

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3060,8 +3060,8 @@ void RestReplicationHandler::handleCommandLoggerLast() {
   auto tickStart = _request->parsedValue("tickStart", uint64_t(0));
   auto tickEnd = _request->parsedValue("tickEnd", uint64_t(0xbadbadbadbadULL));
 
-  Result res = _vocbase.engine().lastLogger(
-      _vocbase, tickStart, tickEnd, builder);
+  Result res =
+      _vocbase.engine().lastLogger(_vocbase, tickStart, tickEnd, builder);
   generateResult(rest::ResponseCode::OK, builder.slice());
 }
 

--- a/arangod/RestHandler/RestReplicationHandler.h
+++ b/arangod/RestHandler/RestReplicationHandler.h
@@ -39,7 +39,6 @@ class ClusterFeature;
 class ClusterInfo;
 class CollectionNameResolver;
 class DatabaseFeature;
-class EngineSelectorFeature;
 class LogicalCollection;
 class ReplicationApplier;
 class ReplicationFeature;
@@ -435,7 +434,6 @@ class RestReplicationHandler : public RestVocbaseBaseHandler {
   //////////////////////////////////////////////////////////////////////////////
 
   ClusterFeature& _clusterFeature;
-  EngineSelectorFeature& _engineSelectorFeature;
   ReplicationFeature& _replicationFeature;
   DatabaseFeature& _databaseFeature;
 

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -38,11 +38,11 @@
 #include "Basics/application-exit.h"
 #include "Cache/CacheManagerFeature.h"
 #include "Cluster/ServerState.h"
+#include "ClusterEngine/ClusterEngine.h"
 #include "FeaturePhases/BasicFeaturePhaseServer.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "IResearch/IResearchAnalyzerFeature.h"
 #include "IResearch/IResearchFeature.h"
-#include "RestServer/InitDatabaseFeature.h"
 #include "Logger/LogMacros.h"
 #include "Logger/Logger.h"
 #include "Logger/LoggerStream.h"
@@ -57,8 +57,9 @@
 #include "RestServer/FileDescriptorsFeature.h"
 #include "RestServer/IOHeartbeatThread.h"
 #include "RestServer/QueryRegistryFeature.h"
+#include "RestServer/InitDatabaseFeature.h"
+#include "RocksDBEngine/RocksDBEngine.h"
 #include "Scheduler/SchedulerFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/StorageEngineFeature.h"
 #include "Transaction/OperationOrigin.h"
@@ -278,7 +279,8 @@ DatabaseFeature::DatabaseFeature(
 
   startsAfter<AuthenticationFeature>();
   startsAfter<CacheManagerFeature>();
-  startsAfter<EngineSelectorFeature>();
+  startsAfter<ClusterEngine>();
+  startsAfter<RocksDBEngine>();
   startsAfter<InitDatabaseFeature>();
   startsAfter<StorageEngineFeature>();
   startsAfter<metrics::MetricsFeature>();
@@ -629,7 +631,18 @@ void DatabaseFeature::unprepare() {
 }
 
 void DatabaseFeature::prepare() {
-  _engine = &server().getFeature<EngineSelectorFeature>().engine();
+  if (ServerState::instance()->isCoordinator()) {
+    auto& ce = server().getFeature<ClusterEngine>();
+    auto& rocksdb = server().getFeature<RocksDBEngine>();
+    rocksdb.disable();
+    ce.setActualEngine(&rocksdb);
+    _engine = &ce;
+  } else {
+    auto& rocksdb = server().getFeature<RocksDBEngine>();
+    rocksdb.enable();
+    _engine = &rocksdb;
+  }
+
   if (server().hasFeature<ReplicationFeature>()) {
     _replicationFeature = &server().getFeature<ReplicationFeature>();
   }

--- a/arangod/RestServer/DatabaseFeature.cpp
+++ b/arangod/RestServer/DatabaseFeature.cpp
@@ -631,17 +631,24 @@ void DatabaseFeature::unprepare() {
 }
 
 void DatabaseFeature::prepare() {
-  if (ServerState::instance()->isCoordinator()) {
-    auto& ce = server().getFeature<ClusterEngine>();
-    auto& rocksdb = server().getFeature<RocksDBEngine>();
-    rocksdb.disable();
-    ce.setActualEngine(&rocksdb);
-    _engine = &ce;
-  } else {
-    auto& rocksdb = server().getFeature<RocksDBEngine>();
-    rocksdb.enable();
-    _engine = &rocksdb;
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+  if (_engine == nullptr) {
+    // engine not injected by test code, inject it now
+#endif
+    if (ServerState::instance()->isCoordinator()) {
+      auto& ce = server().getFeature<ClusterEngine>();
+      auto& rocksdb = server().getFeature<RocksDBEngine>();
+      rocksdb.disable();
+      ce.setActualEngine(&rocksdb);
+      _engine = &ce;
+    } else {
+      auto& rocksdb = server().getFeature<RocksDBEngine>();
+      rocksdb.enable();
+      _engine = &rocksdb;
+    }
+#ifdef ARANGODB_USE_GOOGLE_TESTS
   }
+#endif
 
   if (server().hasFeature<ReplicationFeature>()) {
     _replicationFeature = &server().getFeature<ReplicationFeature>();

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -120,6 +120,7 @@ class DatabaseFeature final : public application_features::ApplicationFeature {
 
   // used by unit tests
 #ifdef ARANGODB_USE_GOOGLE_TESTS
+  void setEngineTesting(StorageEngine* engine) noexcept { _engine = engine; }
   ErrorCode loadDatabases(velocypack::Slice databases) {
     return iterateDatabases(databases);
   }

--- a/arangod/RestServer/DatabaseFeature.h
+++ b/arangod/RestServer/DatabaseFeature.h
@@ -51,6 +51,8 @@ class IOHeartbeatThread;
 class LogicalCollection;
 class ReplicationFeature;
 class StorageEngine;
+class ClusterEngine;
+class RocksDBEngine;
 class V8DealerFeature;
 
 namespace metrics {

--- a/arangod/RestServer/FlushFeature.cpp
+++ b/arangod/RestServer/FlushFeature.cpp
@@ -32,7 +32,7 @@
 #include "Metrics/GaugeBuilder.h"
 #include "Metrics/MetricsFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
-#include "StorageEngine/EngineSelectorFeature.h"
+#include "RestServer/DatabaseFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "StorageEngine/StorageEngineFeature.h"
 
@@ -84,7 +84,7 @@ void FlushFeature::registerFlushSubscription(
 }
 
 std::tuple<size_t, size_t, TRI_voc_tick_t> FlushFeature::releaseUnusedTicks() {
-  auto& engine = server().getFeature<EngineSelectorFeature>().engine();
+  auto& engine = server().getFeature<DatabaseFeature>().engine();
   auto const initialTick = engine.currentTick();
 
   size_t stale = 0;

--- a/arangod/RestServer/UpgradeFeature.cpp
+++ b/arangod/RestServer/UpgradeFeature.cpp
@@ -47,7 +47,6 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/InitDatabaseFeature.h"
 #include "RestServer/RestartAction.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngine.h"
 #include "VocBase/Methods/Upgrade.h"
 #include "VocBase/vocbase.h"
@@ -390,8 +389,7 @@ Result UpgradeFeature::performFullCompaction() {
   LOG_TOPIC("e8f45", INFO, arangodb::Logger::ENGINES)
       << "starting full RocksDB compaction after upgrade";
 
-  TRI_ASSERT(server().hasFeature<EngineSelectorFeature>());
-  StorageEngine& engine = server().getFeature<EngineSelectorFeature>().engine();
+  StorageEngine& engine = server().getFeature<DatabaseFeature>().engine();
 
   // Perform full compaction with both changeLevel and compactBottomMostLevel
   // enabled This matches the behavior of the /_admin/compact API with

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -216,7 +216,6 @@ void ArangodServer::addFeatures(
   addFeature<iresearch::IResearchAnalyzerFeature>(
       iresearch::IResearchAnalyzerFeature::Dependencies{
           .databaseFeature = database,
-          .engineSelector = engineSelectorFeature,
           .systemDatabase = systemDatabaseFeature,
           .networkFeature = &networkFeature,
           .clusterFeature = &clusterFeature,

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -83,7 +83,7 @@ void ArangodServer::addFeatures(
   auto& metrics = addFeature<metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(*this),
       LazyApplicationFeatureReference<StatisticsFeature>(*this),
-      LazyApplicationFeatureReference<EngineSelectorFeature>(*this),
+      LazyApplicationFeatureReference<DatabaseFeature>(*this),
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(*this),
       LazyApplicationFeatureReference<ClusterFeature>(*this));
   addFeature<metrics::ClusterMetricsFeature>();

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -68,9 +68,7 @@ RocksDBRestReplicationHandler::RocksDBRestReplicationHandler(
     application_features::ApplicationServer& server, GeneralRequest* request,
     GeneralResponse* response)
     : RestReplicationHandler(server, request, response),
-      _manager(server.getFeature<EngineSelectorFeature>()
-                   .engine<RocksDBEngine>()
-                   .replicationManager()),
+      _manager(_vocbase.engine<RocksDBEngine>().replicationManager()),
       _quickKeysNumDocsLimit(
           server.getFeature<ReplicationFeature>().quickKeysLimit()) {
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
@@ -106,8 +104,7 @@ RocksDBRestReplicationHandler::handleCommandBatch() {
     // create transaction+snapshot, ttl will be default if `ttl == 0``
     auto ttl = VelocyPackHelper::getNumericValue<double>(
         body, "ttl", replutils::BatchInfo::DefaultTimeout);
-    auto& engine =
-        server().getFeature<EngineSelectorFeature>().engine<RocksDBEngine>();
+    auto& engine = _vocbase.engine<RocksDBEngine>();
     auto ctx =
         _manager->createContext(engine, ttl, syncerId, clientId, patchCount);
 

--- a/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp
@@ -43,7 +43,6 @@
 #include "RocksDBEngine/RocksDBReplicationContextGuard.h"
 #include "RocksDBEngine/RocksDBReplicationManager.h"
 #include "RocksDBEngine/RocksDBReplicationTailing.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "StorageEngine/StorageEngine.h"
 #include "Transaction/StandaloneContext.h"

--- a/tests/Activities/ActivitiesSchedulerTest.cpp
+++ b/tests/Activities/ActivitiesSchedulerTest.cpp
@@ -38,7 +38,7 @@ struct ActivitiesSchedulerTest : ::testing::Test {
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<
-                arangodb::EngineSelectorFeature>(nullptr),
+                arangodb::DatabaseFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/Graph/GraphTestTools.cpp
+++ b/tests/Graph/GraphTestTools.cpp
@@ -62,7 +62,7 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
   auto& metrics = server.addFeature<arangodb::metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(server),
       LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-      LazyApplicationFeatureReference<EngineSelectorFeature>(server),
+      LazyApplicationFeatureReference<DatabaseFeature>(server),
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
       LazyApplicationFeatureReference<ClusterFeature>(nullptr));
   features.emplace_back(metrics, false);
@@ -75,6 +75,7 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
   features.emplace_back(server.addFeature<arangodb::EngineSelectorFeature>(),
                         false);
   server.getFeature<EngineSelectorFeature>().setEngineTesting(&engine);
+  databaseFeature.setEngineTesting(&engine);
   features.emplace_back(
       server.addFeature<arangodb::QueryRegistryFeature>(
           server.getFeature<arangodb::metrics::MetricsFeature>()),
@@ -113,7 +114,7 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
 GraphTestSetup::~GraphTestSetup() {
   system.reset();                       // destroy before reseting the 'ENGINE'
   arangodb::AqlFeature(server).stop();  // unset singleton instance
-  server.getFeature<EngineSelectorFeature>().setEngineTesting(nullptr);
+  server.getFeature<DatabaseFeature>().setEngineTesting(nullptr);
 
   // destroy application features
   for (auto& f : features) {

--- a/tests/Graph/GraphTestTools.cpp
+++ b/tests/Graph/GraphTestTools.cpp
@@ -67,10 +67,12 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
       LazyApplicationFeatureReference<ClusterFeature>(nullptr));
   features.emplace_back(metrics, false);
-  auto& databaseFeature = server.addFeature<arangodb::DatabaseFeature>();
-  features.emplace_back(databaseFeature, false);
+  features.emplace_back(server.addFeature<arangodb::DatabasePathFeature>(),
+                        false);
   features.emplace_back(
       server.addFeature<arangodb::transaction::ManagerFeature>(metrics), false);
+  auto& databaseFeature = server.addFeature<arangodb::DatabaseFeature>();
+  features.emplace_back(databaseFeature, false);
   features.emplace_back(server.addFeature<arangodb::EngineSelectorFeature>(),
                         false);
   server.getFeature<EngineSelectorFeature>().setEngineTesting(&engine);

--- a/tests/Graph/GraphTestTools.cpp
+++ b/tests/Graph/GraphTestTools.cpp
@@ -39,6 +39,7 @@
 #include "RestServer/QueryRegistryFeature.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "Statistics/StatisticsFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "Transaction/ManagerFeature.h"
 #include "GraphTestTools.h"
@@ -66,12 +67,10 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
       LazyApplicationFeatureReference<ClusterFeature>(nullptr));
   features.emplace_back(metrics, false);
-  features.emplace_back(server.addFeature<arangodb::DatabasePathFeature>(),
-                        false);
-  features.emplace_back(
-      server.addFeature<arangodb::transaction::ManagerFeature>(metrics), false);
   auto& databaseFeature = server.addFeature<arangodb::DatabaseFeature>();
   features.emplace_back(databaseFeature, false);
+  features.emplace_back(
+      server.addFeature<arangodb::transaction::ManagerFeature>(metrics), false);
   features.emplace_back(server.addFeature<arangodb::EngineSelectorFeature>(),
                         false);
   server.getFeature<EngineSelectorFeature>().setEngineTesting(&engine);
@@ -114,6 +113,7 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
 GraphTestSetup::~GraphTestSetup() {
   system.reset();                       // destroy before reseting the 'ENGINE'
   arangodb::AqlFeature(server).stop();  // unset singleton instance
+  server.getFeature<EngineSelectorFeature>().setEngineTesting(nullptr);
   server.getFeature<DatabaseFeature>().setEngineTesting(nullptr);
 
   // destroy application features

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -335,8 +335,7 @@ struct IResearchExpressionFilterTest
   ~IResearchExpressionFilterTest() {
     system.reset();  // destroy before reseting the 'ENGINE'
     arangodb::AqlFeature(server).stop();  // unset singleton instance
-    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
-        nullptr);
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features
     for (auto& f : features) {
@@ -365,7 +364,7 @@ struct FilterCtx : irs::attribute_provider {
 
   arangodb::iresearch::ExpressionExecutionContext*
       _execCtx;  // expression execution context
-};               // FilterCtx
+};  // FilterCtx
 
 }  // namespace
 

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -72,7 +72,6 @@
 #include "RestServer/SystemDatabaseFeature.h"
 #include "RestServer/ViewTypesFeature.h"
 #include "Sharding/ShardingFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
@@ -256,15 +255,14 @@ struct IResearchExpressionFilterTest
     features.emplace_back(
         server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
 
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    features.emplace_back(selector, false);
-    selector.setEngineTesting(&engine);
+    databaseFeature.setEngineTesting(&engine);
     auto& metrics = server.addFeature<arangodb::metrics::MetricsFeature>(
         arangodb::LazyApplicationFeatureReference<
             arangodb::QueryRegistryFeature>(server),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        selector,
+        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+            databaseFeature),
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -337,7 +335,7 @@ struct IResearchExpressionFilterTest
   ~IResearchExpressionFilterTest() {
     system.reset();  // destroy before reseting the 'ENGINE'
     arangodb::AqlFeature(server).stop();  // unset singleton instance
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         nullptr);
 
     // destroy application features

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -369,7 +369,7 @@ struct FilterCtx : irs::attribute_provider {
 
   arangodb::iresearch::ExpressionExecutionContext*
       _execCtx;  // expression execution context
-};  // FilterCtx
+};               // FilterCtx
 
 }  // namespace
 

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -72,6 +72,7 @@
 #include "RestServer/SystemDatabaseFeature.h"
 #include "RestServer/ViewTypesFeature.h"
 #include "Sharding/ShardingFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "ProgramOptions/ProgramOptions.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
@@ -255,6 +256,9 @@ struct IResearchExpressionFilterTest
     features.emplace_back(
         server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
 
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    features.emplace_back(selector, false);
+    selector.setEngineTesting(&engine);
     databaseFeature.setEngineTesting(&engine);
     auto& metrics = server.addFeature<arangodb::metrics::MetricsFeature>(
         arangodb::LazyApplicationFeatureReference<
@@ -335,6 +339,8 @@ struct IResearchExpressionFilterTest
   ~IResearchExpressionFilterTest() {
     system.reset();  // destroy before reseting the 'ENGINE'
     arangodb::AqlFeature(server).stop();  // unset singleton instance
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+        nullptr);
     server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features
@@ -364,7 +370,7 @@ struct FilterCtx : irs::attribute_provider {
 
   arangodb::iresearch::ExpressionExecutionContext*
       _execCtx;  // expression execution context
-};  // FilterCtx
+};               // FilterCtx
 
 }  // namespace
 

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -265,8 +265,7 @@ struct IResearchExpressionFilterTest
             arangodb::QueryRegistryFeature>(server),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
-            databaseFeature),
+        databaseFeature,
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -370,7 +369,7 @@ struct FilterCtx : irs::attribute_provider {
 
   arangodb::iresearch::ExpressionExecutionContext*
       _execCtx;  // expression execution context
-};               // FilterCtx
+};  // FilterCtx
 
 }  // namespace
 

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -2693,8 +2693,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
             .metrics =
                 arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
                     metrics, "mock")});
-    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
+    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     StorageEngineMock engine(newServer);
     selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
@@ -2797,8 +2797,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
             .metrics =
                 arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
                     metrics, "mock")});
-    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
+    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     StorageEngineMock engine(newServer);
     selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
@@ -4394,8 +4394,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
   };
 
   arangodb::ArangodServer newServer(nullptr, nullptr);
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
   selector.setEngineTesting(&engine);
   dbFeature.setEngineTesting(&engine);
@@ -4404,8 +4404,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
           newServer),
       arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
           nullptr),
-      arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
-          dbFeature),
+      dbFeature,
       arangodb::LazyApplicationFeatureReference<
           arangodb::metrics::ClusterMetricsFeature>(nullptr),
       arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -4745,8 +4744,8 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_toVelocyPack) {
   // features cannot use the existing server since its features already have
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
   selector.setEngineTesting(&engine);
   dbFeature.setEngineTesting(&engine);
@@ -4900,8 +4899,8 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_vpack_create) {
   // features cannot use the existing server since its features already have
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
   selector.setEngineTesting(&engine);
   dbFeature.setEngineTesting(&engine);

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -69,6 +69,7 @@
 #include "RestServer/SystemDatabaseFeature.h"
 #include "Sharding/ShardingFeature.h"
 #include "Statistics/StatisticsFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/ExecContext.h"
 #include "Utils/OperationOptions.h"
@@ -2692,8 +2693,10 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
             .metrics =
                 arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
                     metrics, "mock")});
+    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
     StorageEngineMock engine(newServer);
+    selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
     newServer.addFeature<arangodb::ShardingFeature>();
     auto& sysDatabase = newServer.addFeature<arangodb::SystemDatabaseFeature>();
@@ -2794,8 +2797,10 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
             .metrics =
                 arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
                     metrics, "mock")});
+    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
     StorageEngineMock engine(newServer);
+    selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
     newServer.addFeature<arangodb::QueryRegistryFeature>(metrics);
     newServer.addFeature<arangodb::ShardingFeature>();
@@ -3303,7 +3308,9 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
   // features cannot use the existing server since its features already have
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
+  selector.setEngineTesting(&engine);
   auto& dbfeature = newServer.addFeature<arangodb::DatabaseFeature>();
   dbfeature.setEngineTesting(&engine);
   auto& functions = newServer.addFeature<arangodb::aql::AqlFunctionFeature>();
@@ -4387,8 +4394,10 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
   };
 
   arangodb::ArangodServer newServer(nullptr, nullptr);
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
   StorageEngineMock engine(newServer);
+  selector.setEngineTesting(&engine);
   dbFeature.setEngineTesting(&engine);
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(
@@ -4736,8 +4745,10 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_toVelocyPack) {
   // features cannot use the existing server since its features already have
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
   StorageEngineMock engine(newServer);
+  selector.setEngineTesting(&engine);
   dbFeature.setEngineTesting(&engine);
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(
@@ -4889,8 +4900,10 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_vpack_create) {
   // features cannot use the existing server since its features already have
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
+  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
   StorageEngineMock engine(newServer);
+  selector.setEngineTesting(&engine);
   dbFeature.setEngineTesting(&engine);
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -69,7 +69,6 @@
 #include "RestServer/SystemDatabaseFeature.h"
 #include "Sharding/ShardingFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/StandaloneContext.h"
 #include "Utils/ExecContext.h"
 #include "Utils/OperationOptions.h"
@@ -1567,9 +1566,7 @@ TEST_F(IResearchAnalyzerFeatureCoordinatorTest, test_ensure_index_add_factory) {
     };
     static const IndexTypeFactory indexTypeFactory(server.server());
     auto& indexFactory = const_cast<arangodb::IndexFactory&>(
-        server.getFeature<arangodb::EngineSelectorFeature>()
-            .engine()
-            .indexFactory());
+        server.getFeature<arangodb::DatabaseFeature>().engine().indexFactory());
     indexFactory.emplace("testType", indexTypeFactory);
   }
 
@@ -2682,8 +2679,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
             arangodb::QueryRegistryFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        arangodb::LazyApplicationFeatureReference<
-            arangodb::EngineSelectorFeature>(newServer),
+        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+            newServer),
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -2696,9 +2693,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
                 arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
                     metrics, "mock")});
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
-    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     StorageEngineMock engine(newServer);
-    selector.setEngineTesting(&engine);
+    dbFeature.setEngineTesting(&engine);
     newServer.addFeature<arangodb::ShardingFeature>();
     auto& sysDatabase = newServer.addFeature<arangodb::SystemDatabaseFeature>();
 #ifdef USE_V8
@@ -2785,8 +2781,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
             arangodb::QueryRegistryFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        arangodb::LazyApplicationFeatureReference<
-            arangodb::EngineSelectorFeature>(newServer),
+        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+            newServer),
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -2799,9 +2795,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
                 arangodb::network::ConnectionPool::Metrics::fromMetricsFeature(
                     metrics, "mock")});
     auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
-    auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
     StorageEngineMock engine(newServer);
-    selector.setEngineTesting(&engine);
+    dbFeature.setEngineTesting(&engine);
     newServer.addFeature<arangodb::QueryRegistryFeature>(metrics);
     newServer.addFeature<arangodb::ShardingFeature>();
     auto& sysDatabase = newServer.addFeature<arangodb::SystemDatabaseFeature>();
@@ -3308,18 +3303,17 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
   // features cannot use the existing server since its features already have
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
-  selector.setEngineTesting(&engine);
   auto& dbfeature = newServer.addFeature<arangodb::DatabaseFeature>();
+  dbfeature.setEngineTesting(&engine);
   auto& functions = newServer.addFeature<arangodb::aql::AqlFunctionFeature>();
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(
           newServer),
       arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
           nullptr),
-      arangodb::LazyApplicationFeatureReference<
-          arangodb::EngineSelectorFeature>(nullptr),
+      arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+          newServer),
       arangodb::LazyApplicationFeatureReference<
           arangodb::metrics::ClusterMetricsFeature>(nullptr),
       arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -4394,15 +4388,15 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
 
   arangodb::ArangodServer newServer(nullptr, nullptr);
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
-  selector.setEngineTesting(&engine);
+  dbFeature.setEngineTesting(&engine);
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(
           newServer),
       arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
           nullptr),
-      selector,
+      arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+          dbFeature),
       arangodb::LazyApplicationFeatureReference<
           arangodb::metrics::ClusterMetricsFeature>(nullptr),
       arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -4743,16 +4737,15 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_toVelocyPack) {
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
-  selector.setEngineTesting(&engine);
+  dbFeature.setEngineTesting(&engine);
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(
           newServer),
       arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
           nullptr),
-      arangodb::LazyApplicationFeatureReference<
-          arangodb::EngineSelectorFeature>(nullptr),
+      arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+          newServer),
       arangodb::LazyApplicationFeatureReference<
           arangodb::metrics::ClusterMetricsFeature>(nullptr),
       arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -4897,16 +4890,15 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_vpack_create) {
   // some state
   arangodb::ArangodServer newServer(nullptr, nullptr);
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
-  auto& selector = newServer.addFeature<arangodb::EngineSelectorFeature>();
   StorageEngineMock engine(newServer);
-  selector.setEngineTesting(&engine);
+  dbFeature.setEngineTesting(&engine);
   auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
       arangodb::LazyApplicationFeatureReference<arangodb::QueryRegistryFeature>(
           newServer),
       arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
           nullptr),
-      arangodb::LazyApplicationFeatureReference<
-          arangodb::EngineSelectorFeature>(nullptr),
+      arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+          newServer),
       arangodb::LazyApplicationFeatureReference<
           arangodb::metrics::ClusterMetricsFeature>(nullptr),
       arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -4416,7 +4416,6 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
   newServer.addFeature<arangodb::AqlFeature>();
   arangodb::iresearch::IResearchAnalyzerFeature feature(
       newServer, {.databaseFeature = dbFeature,
-                  .engineSelector = selector,
                   .systemDatabase = sysDatabase,
                   .networkFeature = nullptr,
                   .clusterFeature = nullptr,
@@ -4767,7 +4766,6 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_toVelocyPack) {
   newServer.addFeature<arangodb::AqlFeature>();
   arangodb::iresearch::IResearchAnalyzerFeature feature(
       newServer, {.databaseFeature = dbFeature,
-                  .engineSelector = selector,
                   .systemDatabase = sysDatabase,
                   .networkFeature = nullptr,
                   .clusterFeature = nullptr,
@@ -4922,7 +4920,6 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_vpack_create) {
   newServer.addFeature<arangodb::AqlFeature>();
   arangodb::iresearch::IResearchAnalyzerFeature feature(
       newServer, {.databaseFeature = dbFeature,
-                  .engineSelector = selector,
                   .systemDatabase = sysDatabase,
                   .networkFeature = nullptr,
                   .clusterFeature = nullptr,

--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -2325,10 +2325,12 @@ class IResearchFeatureTestCoordinator
                                             arangodb::LogLevel::FATAL> {
  protected:
   arangodb::tests::mocks::MockCoordinator server;
+  StorageEngineMock& _engine;
 
  private:
  protected:
-  IResearchFeatureTestCoordinator() : server("CRDN_0001", false) {
+  IResearchFeatureTestCoordinator()
+      : server("CRDN_0001", false), _engine(server.engine()) {
     arangodb::tests::init();
 
     arangodb::ServerState::instance()->setRebootId(
@@ -2454,10 +2456,9 @@ TEST_F(IResearchFeatureTestCoordinator, test_upgrade0_1) {
   server.getFeature<arangodb::DatabaseFeature>()
       .enableUpgrade();  // skip IResearchView validation
 
-  auto& engine = server.getFeature<arangodb::DatabaseFeature>().engine();
   auto& factory = server.getFeature<arangodb::iresearch::IResearchFeature>()
                       .factory<arangodb::ClusterEngine>();
-  const_cast<arangodb::IndexFactory&>(engine.indexFactory())
+  const_cast<arangodb::IndexFactory&>(_engine.indexFactory())
       .emplace(
           std::string{arangodb::iresearch::StaticStrings::ViewArangoSearchType},
           factory);

--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -93,10 +93,12 @@ class IResearchFeatureTest
                                             arangodb::LogLevel::FATAL> {
  protected:
   arangodb::tests::mocks::MockV8Server server;
+  StorageEngineMock& _engine;
   arangodb::metrics::MetricsFeature& _metrics;
 
   IResearchFeatureTest()
       : server(false),
+        _engine(server.engine()),
         _metrics(server.getFeature<arangodb::metrics::MetricsFeature>()) {
     arangodb::tests::init();
 
@@ -1862,7 +1864,7 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1_no_directory) {
   ASSERT_TRUE((arangodb::basics::VelocyPackHelper::velocyPackToFile(
       StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_NE(logicalCollection, nullptr);
   auto logicalView0 = vocbase.createView(viewJson->slice(), false);
@@ -1971,7 +1973,7 @@ TEST_F(IResearchFeatureTest, test_upgrade0_1_with_directory) {
   ASSERT_TRUE((arangodb::basics::VelocyPackHelper::velocyPackToFile(
       StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_FALSE(!logicalCollection);
   auto logicalView0 = vocbase.createView(viewJson->slice(), false);
@@ -2590,10 +2592,12 @@ class IResearchFeatureTestDBServer
                                             arangodb::LogLevel::FATAL> {
  protected:
   arangodb::tests::mocks::MockDBServer server;
+  StorageEngineMock& _engine;
 
  private:
  protected:
-  IResearchFeatureTestDBServer() : server("PRMR_0001", false) {
+  IResearchFeatureTestDBServer()
+      : server("PRMR_0001", false), _engine(server.engine()) {
     arangodb::tests::init();
 
     arangodb::ServerState::instance()->setRebootId(
@@ -2688,7 +2692,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_no_directory) {
       .agencyCache()
       .applyTestTransaction(bogus.slice());
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_FALSE(!logicalCollection);
   auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2767,9 +2771,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_with_directory) {
   ASSERT_TRUE((arangodb::basics::VelocyPackHelper::velocyPackToFile(
       StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
-  auto& engine = *static_cast<StorageEngineMock*>(
-      &server.getFeature<arangodb::DatabaseFeature>().engine());
-  engine.views.clear();
+  _engine.views.clear();
 
   VPackBuilder bogus;
   {
@@ -2787,7 +2789,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_with_directory) {
       .agencyCache()
       .applyTestTransaction(bogus.slice());
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_FALSE(!logicalCollection);
   auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2872,9 +2874,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade1_link_collectionName) {
   ASSERT_TRUE(irs::file_utils::mkdir(
       std::filesystem::path(dbPathFeature.directory()).c_str(), true));
 
-  auto& engine = *static_cast<StorageEngineMock*>(
-      &server.getFeature<arangodb::DatabaseFeature>().engine());
-  engine.views.clear();
+  _engine.views.clear();
 
   TRI_vocbase_t* vocbase;
   createTestDatabase(vocbase);

--- a/tests/IResearch/IResearchFeatureTest.cpp
+++ b/tests/IResearch/IResearchFeatureTest.cpp
@@ -71,7 +71,6 @@
 #include "RestServer/UpgradeFeature.h"
 #include "RestServer/ViewTypesFeature.h"
 #include "Sharding/ShardingFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/Methods/Indexes.h"
@@ -2453,7 +2452,7 @@ TEST_F(IResearchFeatureTestCoordinator, test_upgrade0_1) {
   server.getFeature<arangodb::DatabaseFeature>()
       .enableUpgrade();  // skip IResearchView validation
 
-  auto& engine = server.getFeature<arangodb::EngineSelectorFeature>().engine();
+  auto& engine = server.getFeature<arangodb::DatabaseFeature>().engine();
   auto& factory = server.getFeature<arangodb::iresearch::IResearchFeature>()
                       .factory<arangodb::ClusterEngine>();
   const_cast<arangodb::IndexFactory&>(engine.indexFactory())
@@ -2769,7 +2768,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade0_1_with_directory) {
       StorageEngineMock::versionFilenameResult, versionJson->slice(), false)));
 
   auto& engine = *static_cast<StorageEngineMock*>(
-      &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+      &server.getFeature<arangodb::DatabaseFeature>().engine());
   engine.views.clear();
 
   VPackBuilder bogus;
@@ -2874,7 +2873,7 @@ TEST_F(IResearchFeatureTestDBServer, test_upgrade1_link_collectionName) {
       std::filesystem::path(dbPathFeature.directory()).c_str(), true));
 
   auto& engine = *static_cast<StorageEngineMock*>(
-      &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+      &server.getFeature<arangodb::DatabaseFeature>().engine());
   engine.views.clear();
 
   TRI_vocbase_t* vocbase;

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -51,7 +51,6 @@
 #include "Mocks/StorageEngineMock.h"
 #include "RestServer/DatabasePathFeature.h"
 #include "RestServer/FlushFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
@@ -144,7 +143,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
   // no view specified
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -165,7 +164,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
   // Agency yet)
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -181,7 +180,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
   // valid link creation
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto linkJson = arangodb::velocypack::Parser::fromJson(
@@ -259,7 +258,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
   // valid link creation (explicit version)
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto linkJson = arangodb::velocypack::Parser::fromJson(
@@ -337,7 +336,7 @@ TEST_F(IResearchLinkTest, test_defaults) {
   // ensure jSON is still valid after unload()
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
     auto linkJson = arangodb::velocypack::Parser::fromJson(

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -83,9 +83,10 @@ class IResearchLinkTest
  protected:
   static constexpr size_t kEncBlockSize{13};
   arangodb::tests::mocks::MockAqlServer server;
+  StorageEngineMock& _engine;
   std::string testFilesystemPath;
 
-  IResearchLinkTest() : server(false) {
+  IResearchLinkTest() : server(false), _engine(server.engine()) {
     arangodb::tests::init();
 
     // ensure ArangoSearch start 1 maintenance for each group
@@ -142,10 +143,8 @@ static_assert("1_5simd" == getFormat(arangodb::iresearch::LinkVersion::MAX));
 TEST_F(IResearchLinkTest, test_defaults) {
   // no view specified
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testCollection" })");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -163,10 +162,8 @@ TEST_F(IResearchLinkTest, test_defaults) {
   // no view can be found (e.g. db-server coming up with view not available from
   // Agency yet)
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testCollection" })");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -179,10 +176,8 @@ TEST_F(IResearchLinkTest, test_defaults) {
 
   // valid link creation
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         R"({ "type": "arangosearch", "view": "42" })");
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -257,10 +252,8 @@ TEST_F(IResearchLinkTest, test_defaults) {
 
   // valid link creation (explicit version)
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         R"({ "type": "arangosearch", "view": "42", "version":1 })");
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -335,10 +328,8 @@ TEST_F(IResearchLinkTest, test_defaults) {
 
   // ensure jSON is still valid after unload()
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         R"({ "type": "arangosearch", "view": "42" })");
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
@@ -447,7 +438,7 @@ TEST_F(IResearchLinkTest, test_init) {
         R"({ "type": "arangosearch", "view": "42" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -526,7 +517,7 @@ TEST_F(IResearchLinkTest, test_init) {
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"id\": 43, \"type\": \"arangosearch\", "
         "\"collections\": [ 101 ] }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -614,7 +605,7 @@ TEST_F(IResearchLinkTest, test_self_token) {
         arangodb::velocypack::Parser::fromJson(R"({ "view": "testView" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "type":"arangosearch" })");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -649,7 +640,7 @@ TEST_F(IResearchLinkTest, test_drop) {
         R"({ "type": "arangosearch", "view": "42" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -760,7 +751,7 @@ TEST_F(IResearchLinkTest, test_unload) {
         R"({ "type": "arangosearch", "view": "42" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -842,7 +833,7 @@ TEST_F(IResearchLinkTest, test_unload) {
 TEST_F(IResearchLinkTest, test_write_index_creation_version_0) {
   static std::vector<std::string> const kEmpty;
   auto doc0 = arangodb::velocypack::Parser::fromJson(R"({ "abc": "def" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -910,7 +901,7 @@ TEST_F(IResearchLinkTest, test_write_index_creation_version_0) {
 TEST_F(IResearchLinkTest, test_write_index_creation_version_1) {
   static std::vector<std::string> const kEmpty;
   auto doc0 = arangodb::velocypack::Parser::fromJson(R"({ "abc": "def" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -978,7 +969,7 @@ TEST_F(IResearchLinkTest, test_write) {
   static std::vector<std::string> const kEmpty;
   auto doc0 = arangodb::velocypack::Parser::fromJson(R"({ "abc": "def" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(R"({ "ghi": "jkl" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1075,7 +1066,7 @@ TEST_F(IResearchLinkTest, test_write_with_custom_compression_nondefault_sole) {
   auto doc0 = arangodb::velocypack::Parser::fromJson(
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps"  })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(R"({ "ghi": "jkl" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1183,7 +1174,7 @@ TEST_F(IResearchLinkTest,
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps"  })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(
       R"({ "ghi": "jkl", "sort":"pp" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1297,7 +1288,7 @@ TEST_F(IResearchLinkTest, test_write_with_custom_compression_nondefault_mixed) {
   auto doc0 = arangodb::velocypack::Parser::fromJson(
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(R"({ "ghi": "jkl" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1409,7 +1400,7 @@ TEST_F(IResearchLinkTest,
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(
       R"({ "ghi": "jkl", "sort":"pp" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1535,7 +1526,7 @@ TEST_F(
       R"({ "abc": "def", "abc2":"aaa", "sort":"ps" })");
   auto doc1 = arangodb::velocypack::Parser::fromJson(
       R"({ "ghi": "jkl", "sort":"pp" })");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -1680,7 +1671,7 @@ TEST_F(IResearchLinkTest, test_maintenance_disabled_at_creation) {
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_1));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto collectionJson = VPackParser::fromJson(R"({
     "name": "testCollection" })");
   auto linkJson = VPackParser::fromJson(R"({
@@ -1789,7 +1780,7 @@ TEST_F(IResearchLinkTest, test_maintenance_consolidation) {
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_1));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto collectionJson = VPackParser::fromJson(R"({
     "name": "testCollection" })");
   auto linkJson = VPackParser::fromJson(R"({
@@ -2020,7 +2011,7 @@ TEST_F(IResearchLinkTest, test_maintenance_commit) {
   ASSERT_EQ(std::make_tuple(size_t(0), size_t(0), size_t(1)),
             feature.stats(ThreadGroup::_1));
 
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto collectionJson = VPackParser::fromJson(R"({
     "name": "testCollection" })");
   auto linkJson = VPackParser::fromJson(R"({
@@ -2234,7 +2225,7 @@ static std::vector<std::string> const kEmpty;
 
 class IResearchLinkMetricsTest : public IResearchLinkTest {
  protected:
-  TRI_vocbase_t _vocbase{testDBInfo(server.server()), server.engine()};
+  TRI_vocbase_t _vocbase{testDBInfo(server.server()), _engine};
   std::array<std::shared_ptr<arangodb::velocypack::Builder>, 3> _docs;
   std::shared_ptr<arangodb::LogicalCollection> _logicalCollection;
   uint64_t _cleanupIntervalStep = 0;
@@ -2783,10 +2774,11 @@ class IResearchLinkInRecoveryDBServerOnUpgradeTest
  protected:
   static constexpr size_t kEncBlockSize{13};
   arangodb::tests::mocks::MockDBServer server;
+  StorageEngineMock& _engine;
   std::string testFilesystemPath;
 
   IResearchLinkInRecoveryDBServerOnUpgradeTest()
-      : server("PRMR_0001", false, true) {
+      : server("PRMR_0001", false, true), _engine(server.engine()) {
     arangodb::tests::init();
 
     // ensure ArangoSearch start 1 maintenance for each group
@@ -2844,7 +2836,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":true})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2890,7 +2882,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":false, "fields":{"_id":{}}})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2936,7 +2928,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":false, "fields":{"value":{}, "_id":{}}})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -2982,7 +2974,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
         R"({ "type": "arangosearch", "view": "42", "includeAllFields":false, "fields":{"value":{}}})");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -3029,7 +3021,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest, test_init_in_recovery) {
         R"({ "type": "arangosearch", "view": "42", "collectionName":"testCollection" })");
     auto viewJson = arangodb::velocypack::Parser::fromJson(
         R"({ "name": "testView", "id": 42, "type": "arangosearch" })");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -57,7 +57,6 @@
 #include "RestServer/ViewTypesFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "Statistics/StatisticsWorker.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 
@@ -290,15 +289,16 @@ class IResearchOrderTest
     arangodb::tests::init();
 
     // setup required application features
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    selector.setEngineTesting(&engine);
-    features.emplace_back(selector, false);
+    auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
+    dbFeature.setEngineTesting(&engine);
+    features.emplace_back(dbFeature, false);  // required for calculationVocbase
     auto& metrics = server.addFeature<arangodb::metrics::MetricsFeature>(
         arangodb::LazyApplicationFeatureReference<
             arangodb::QueryRegistryFeature>(server),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        selector,
+        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+            dbFeature),
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -313,11 +313,9 @@ class IResearchOrderTest
         server.addFeature<arangodb::aql::AqlFunctionFeature>(), true);
     features.emplace_back(
         server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
-    auto& databaseFeature = server.addFeature<arangodb::DatabaseFeature>();
-    features.emplace_back(databaseFeature,
-                          false);  // required for calculationVocbase
+
     features.emplace_back(
-        server.addFeature<arangodb::VectorIndexFeature>(databaseFeature),
+        server.addFeature<arangodb::VectorIndexFeature>(dbFeature),
         false);
     {
       auto& feature =
@@ -359,8 +357,7 @@ class IResearchOrderTest
     arangodb::aql::AqlFunctionFeature(server)
         .unprepare();                     // unset singleton instance
     arangodb::AqlFeature(server).stop();  // unset singleton instance
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
-        nullptr);
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features
     for (auto& f : features) {

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -301,8 +301,7 @@ class IResearchOrderTest
             arangodb::QueryRegistryFeature>(server),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
-            dbFeature),
+        dbFeature,
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -317,8 +317,7 @@ class IResearchOrderTest
     features.emplace_back(
         server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
     features.emplace_back(
-        server.addFeature<arangodb::VectorIndexFeature>(dbFeature),
-        false);
+        server.addFeature<arangodb::VectorIndexFeature>(dbFeature), false);
     {
       auto& feature =
           features

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -57,6 +57,7 @@
 #include "RestServer/ViewTypesFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "Statistics/StatisticsWorker.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 
@@ -289,6 +290,9 @@ class IResearchOrderTest
     arangodb::tests::init();
 
     // setup required application features
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    selector.setEngineTesting(&engine);
+    features.emplace_back(selector, false);
     auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
     dbFeature.setEngineTesting(&engine);
     features.emplace_back(dbFeature, false);  // required for calculationVocbase
@@ -357,6 +361,8 @@ class IResearchOrderTest
     arangodb::aql::AqlFunctionFeature(server)
         .unprepare();                     // unset singleton instance
     arangodb::AqlFeature(server).stop();  // unset singleton instance
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+        nullptr);
     server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -316,7 +316,6 @@ class IResearchOrderTest
         server.addFeature<arangodb::aql::AqlFunctionFeature>(), true);
     features.emplace_back(
         server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
-
     features.emplace_back(
         server.addFeature<arangodb::VectorIndexFeature>(dbFeature),
         false);

--- a/tests/IResearch/IResearchViewMetaTest.cpp
+++ b/tests/IResearch/IResearchViewMetaTest.cpp
@@ -37,6 +37,7 @@
 #include "Basics/VelocyPackHelper.h"
 #include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 
 class IResearchViewMetaTest : public ::testing::Test {
  protected:
@@ -44,11 +45,15 @@ class IResearchViewMetaTest : public ::testing::Test {
   StorageEngineMock engine;
 
   IResearchViewMetaTest() : server(nullptr, nullptr), engine(server) {
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    selector.setEngineTesting(&engine);
     auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
     dbFeature.setEngineTesting(&engine);
   }
 
   ~IResearchViewMetaTest() {
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+        nullptr);
     server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
   }
 };

--- a/tests/IResearch/IResearchViewMetaTest.cpp
+++ b/tests/IResearch/IResearchViewMetaTest.cpp
@@ -32,11 +32,11 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "IResearch/IResearchViewMeta.h"
 #include "IResearch/VelocyPackHelper.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "velocypack/Iterator.h"
 #include "velocypack/Parser.h"
 #include "Basics/VelocyPackHelper.h"
 #include "RestServer/arangod.h"
+#include "RestServer/DatabaseFeature.h"
 
 class IResearchViewMetaTest : public ::testing::Test {
  protected:
@@ -44,12 +44,12 @@ class IResearchViewMetaTest : public ::testing::Test {
   StorageEngineMock engine;
 
   IResearchViewMetaTest() : server(nullptr, nullptr), engine(server) {
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    selector.setEngineTesting(&engine);
+    auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
+    dbFeature.setEngineTesting(&engine);
   }
 
   ~IResearchViewMetaTest() {
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         nullptr);
   }
 };

--- a/tests/IResearch/IResearchViewMetaTest.cpp
+++ b/tests/IResearch/IResearchViewMetaTest.cpp
@@ -49,8 +49,7 @@ class IResearchViewMetaTest : public ::testing::Test {
   }
 
   ~IResearchViewMetaTest() {
-    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
-        nullptr);
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
   }
 };
 

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -136,12 +136,13 @@ class IResearchViewTest
                                             arangodb::LogLevel::FATAL> {
  protected:
   arangodb::tests::mocks::MockAqlServer server;
+  StorageEngineMock& _engine;
   std::unique_ptr<TRI_vocbase_t> system;
   std::string testFilesystemPath;
   arangodb::GlobalResourceMonitor global{};
   arangodb::ResourceMonitor resourceMonitor{global};
 
-  IResearchViewTest() : server(false) {
+  IResearchViewTest() : server(false), _engine(server.engine()) {
     arangodb::tests::init();
 
     auto& metrics = server.getFeature<arangodb::metrics::MetricsFeature>();
@@ -218,7 +219,7 @@ TEST_F(IResearchViewTest, test_defaults) {
 
   // view definition with LogicalView (for persistence)
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, json->slice(), true)
@@ -256,7 +257,7 @@ TEST_F(IResearchViewTest, test_defaults) {
 
   // view definition with LogicalView
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE(arangodb::iresearch::IResearchView::factory()
                     .create(view, vocbase, json->slice(), true)
@@ -297,7 +298,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 101, "
         "\"links\": { \"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     EXPECT_TRUE((true == !vocbase.lookupView("testView")));
     arangodb::LogicalView::ptr view;
     auto res = arangodb::iresearch::IResearchView::factory().create(
@@ -314,7 +315,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 101, "
         "\"links\": { \"testCollection\": 42 } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     EXPECT_TRUE((nullptr != logicalCollection));
     EXPECT_TRUE((true == !vocbase.lookupView("testView")));
@@ -335,7 +336,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"links\": { "
         "\"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
 
@@ -370,7 +371,7 @@ TEST_F(IResearchViewTest, test_defaults) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 101, "
         "\"links\": { \"testCollection\": {} } }");
 
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     EXPECT_TRUE((nullptr != logicalCollection));
     EXPECT_TRUE((true == !vocbase.lookupView("testView")));
@@ -436,7 +437,7 @@ TEST_F(IResearchViewTest, test_properties_user_request) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -792,7 +793,7 @@ TEST_F(IResearchViewTest, test_properties_user_request_explicit_version) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1144,7 +1145,7 @@ TEST_F(IResearchViewTest, test_properties_internal_request) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1497,7 +1498,7 @@ TEST_F(IResearchViewTest, test_properties_internal_request_explicit_version) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1849,7 +1850,7 @@ TEST_F(IResearchViewTest, test_vocbase_inventory) {
       "  } "
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   EXPECT_NE(nullptr, logicalCollection);
   EXPECT_EQ(nullptr, vocbase.lookupView("testView"));
@@ -1921,7 +1922,7 @@ TEST_F(IResearchViewTest, test_cleanup) {
   auto json = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\":\"arangosearch\", "
       "\"cleanupIntervalStep\":1, \"consolidationIntervalMsec\": 1000 }");
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_TRUE((false == !logicalCollection));
   auto logicalView = vocbase.createView(json->slice(), false);
@@ -1986,7 +1987,7 @@ TEST_F(IResearchViewTest, test_consolidate) {
   auto viewCreateJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\":\"arangosearch\", "
       "\"consolidationIntervalMsec\": 1000 }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
   ASSERT_TRUE((false == !logicalView));
   // FIXME TODO write test to check that long-running consolidation aborts on
@@ -1999,7 +2000,7 @@ TEST_F(IResearchViewTest, test_consolidate) {
 }
 
 TEST_F(IResearchViewTest, test_drop) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -2040,7 +2041,7 @@ TEST_F(IResearchViewTest, test_drop) {
 }
 
 TEST_F(IResearchViewTest, test_drop_with_link) {
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   std::string dataPath =
       ((((std::filesystem::path() /= testFilesystemPath) /=
          std::string("databases")) /=
@@ -2159,7 +2160,7 @@ TEST_F(IResearchViewTest, test_drop_collection) {
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
   auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
       "{ \"links\": { \"testCollection\": { \"includeAllFields\": true } } }");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_TRUE((false == !logicalCollection));
   auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -2198,7 +2199,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
         "{ \"view\": \"testView\", \"includeAllFields\": true }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2281,7 +2282,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2364,7 +2365,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2472,7 +2473,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2572,7 +2573,7 @@ TEST_F(IResearchViewTest, test_drop_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2721,7 +2722,7 @@ TEST_F(IResearchViewTest, test_instantiate) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"version\": 1 "
         "}");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .instantiate(view, vocbase, json->slice(), false)
@@ -2734,7 +2735,7 @@ TEST_F(IResearchViewTest, test_instantiate) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"version\": 0 "
         "}");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE(arangodb::iresearch::IResearchView::factory()
                     .instantiate(view, vocbase, json->slice(), false)
@@ -2747,7 +2748,7 @@ TEST_F(IResearchViewTest, test_instantiate) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"version\": "
         "123456789 }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((!arangodb::iresearch::IResearchView::factory()
                       .instantiate(view, vocbase, json->slice(), false)
@@ -2768,7 +2769,7 @@ TEST_F(IResearchViewTest, test_truncate_cid) {
         "{ \"view\": \"testView\", \"includeAllFields\": true }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2851,7 +2852,7 @@ TEST_F(IResearchViewTest, test_truncate_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -2935,7 +2936,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\", \"collections\": "
         "[ 42 ] }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3013,7 +3014,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3089,7 +3090,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\"  }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3172,7 +3173,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3244,7 +3245,7 @@ TEST_F(IResearchViewTest, test_emplace_cid) {
         "{ \"id\": 42, \"name\": \"testCollection\" }");
     auto json = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\":\"arangosearch\" }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(json->slice(), false);
@@ -3350,7 +3351,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // in recovery (skip operations before or at recovery tick)
   {
     auto before = StorageEngineMock::recoveryStateResult;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3424,7 +3425,7 @@ TEST_F(IResearchViewTest, test_insert) {
     auto before = StorageEngineMock::recoveryStateResult;
     StorageEngineMock::recoveryStateResult =
         arangodb::RecoveryState::IN_PROGRESS;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
 
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
@@ -3508,7 +3509,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3565,7 +3566,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3624,7 +3625,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery : single operation transaction
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3675,7 +3676,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery batch (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3732,7 +3733,7 @@ TEST_F(IResearchViewTest, test_insert) {
   // not in recovery batch (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3799,7 +3800,7 @@ TEST_F(IResearchViewTest, test_remove_within_trx) {
   auto json = velocypack::Parser::fromJson(
       R"({ "name": "testView", "type":"arangosearch", "cleanupIntervalStep":0, "commitIntervalMsec": 0, "consolidationIntervalMsec" : 0 })");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_NE(nullptr, logicalCollection);
   auto logicalView = vocbase.createView(json->slice(), true);
@@ -3881,7 +3882,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // in recovery (skip operations before or at recovery tick)
   {
     auto before = StorageEngineMock::recoveryStateResult;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_NE(nullptr, logicalCollection);
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -3963,7 +3964,7 @@ TEST_F(IResearchViewTest, test_remove) {
     auto before = StorageEngineMock::recoveryStateResult;
     StorageEngineMock::recoveryStateResult =
         arangodb::RecoveryState::IN_PROGRESS;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4046,7 +4047,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4103,7 +4104,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4162,7 +4163,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery : single operation transaction
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4213,7 +4214,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery batch (FindOrCreate)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4270,7 +4271,7 @@ TEST_F(IResearchViewTest, test_remove) {
   // not in recovery batch (SyncAndReplace)
   {
     StorageEngineMock::recoveryStateResult = arangodb::RecoveryState::DONE;
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto viewImpl = vocbase.createView(viewJson->slice(), false);
@@ -4328,7 +4329,7 @@ TEST_F(IResearchViewTest, test_remove) {
 TEST_F(IResearchViewTest, test_open) {
   // default data path
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     std::string dataPath =
         ((((std::filesystem::path() /= testFilesystemPath) /=
            std::string("databases")) /=
@@ -4364,7 +4365,7 @@ TEST_F(IResearchViewTest, test_query) {
 
   // no filter/order provided, means "RETURN *"
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     auto* view =
@@ -4388,7 +4389,7 @@ TEST_F(IResearchViewTest, test_query) {
         "{ \"name\": \"testCollection\" }");
     auto linkJson = arangodb::velocypack::Parser::fromJson(
         "{ \"view\": \"testView\", \"includeAllFields\": true }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -4445,7 +4446,7 @@ TEST_F(IResearchViewTest, test_query) {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
 
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     std::vector<std::string> collections{logicalCollection->name()};
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -4538,7 +4539,7 @@ TEST_F(IResearchViewTest, test_query) {
         "{ \"links\": { \"testCollection\": { \"includeAllFields\": true } } "
         "}");
     ASSERT_TRUE(server.server().hasFeature<arangodb::FlushFeature>());
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
@@ -4609,10 +4610,8 @@ TEST_F(IResearchViewTest, test_register_link) {
 
   // new link in recovery
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson0->slice(), false);
@@ -4690,10 +4689,8 @@ TEST_F(IResearchViewTest, test_register_link) {
 
   // new link
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson0->slice(), false);
@@ -4788,10 +4785,8 @@ TEST_F(IResearchViewTest, test_register_link) {
 
   // known link
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson1->slice(), false);
@@ -4930,10 +4925,8 @@ TEST_F(IResearchViewTest, test_unregister_link) {
 
   // link removed before view (in recovery)
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5053,10 +5046,8 @@ TEST_F(IResearchViewTest, test_unregister_link) {
 
   // link removed before view
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5168,10 +5159,8 @@ TEST_F(IResearchViewTest, test_unregister_link) {
 
   // view removed before link
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
@@ -5207,10 +5196,8 @@ TEST_F(IResearchViewTest, test_unregister_link) {
 
   // view deallocated before link removed
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
 
     {
@@ -5282,10 +5269,8 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
 
   // test empty before open (TRI_vocbase_t::createView(...) will call open())
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    _engine.views.clear();
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, viewJson->slice(), true)
@@ -5307,12 +5292,10 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // test add via link before open (TRI_vocbase_t::createView(...) will call
   // open())
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
+    _engine.views.clear();
     auto updateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     arangodb::LogicalView::ptr logicalView;
@@ -5321,7 +5304,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
              .instantiate(logicalView, vocbase, viewJson->slice(), false)
              .ok()));
     ASSERT_TRUE((false == !logicalView));
-    engine.createView(vocbase, logicalView->id(),
+    _engine.createView(vocbase, logicalView->id(),
                       *logicalView);  // ensure link can find view
     StorageEngineMock(server.server())
         .registerView(vocbase, logicalView);  // ensure link can find view
@@ -5353,14 +5336,12 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // test drop via link before open (TRI_vocbase_t::createView(...) will call
   // open())
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
+    _engine.views.clear();
     auto updateJson0 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
     auto updateJson1 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     arangodb::LogicalView::ptr logicalView;
@@ -5369,7 +5350,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
              .instantiate(logicalView, vocbase, viewJson->slice(), false)
              .ok()));
     ASSERT_TRUE((false == !logicalView));
-    engine.createView(vocbase, logicalView->id(),
+    _engine.createView(vocbase, logicalView->id(),
                       *logicalView);  // ensure link can find view
     StorageEngineMock(server.server())
         .registerView(vocbase, logicalView);  // ensure link can find view
@@ -5416,9 +5397,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // store
   // initial populate persisted view
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
+    _engine.views.clear();
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto linkJson =
@@ -5427,7 +5406,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 102 "
         "}");
     ASSERT_TRUE(server.server().hasFeature<arangodb::FlushFeature>());
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((false == !logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -5459,13 +5438,11 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   }
   // test persisted CIDs on open
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
+    _engine.views.clear();
     auto createJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 102 "
         "}");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     auto* viewImpl =
@@ -5484,12 +5461,10 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // test add via link after open (TRI_vocbase_t::createView(...) will call
   // open())
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
+    _engine.views.clear();
     auto updateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5518,14 +5493,12 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // test drop via link after open (TRI_vocbase_t::createView(...) will call
   // open())
   {
-    auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::DatabaseFeature>().engine());
-    engine.views.clear();
+    _engine.views.clear();
     auto updateJson0 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
     auto updateJson1 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -5590,7 +5563,7 @@ TEST_F(IResearchViewTest, test_overwrite_immutable_properties) {
       "]"
       "}");
 
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalView =
       vocbase.createView(viewJson->slice(), false);  // create view
   ASSERT_TRUE(nullptr != logicalView);
@@ -5701,7 +5674,7 @@ TEST_F(IResearchViewTest, test_transaction_registration) {
       "{ \"name\": \"testCollection1\" }");
   auto viewJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\" }");
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection0 = vocbase.createCollection(collectionJson0->slice());
   ASSERT_TRUE((nullptr != logicalCollection0));
   auto logicalCollection1 = vocbase.createCollection(collectionJson1->slice());
@@ -6063,7 +6036,7 @@ TEST_F(IResearchViewTest, test_transaction_snapshot) {
   auto viewJson = arangodb::velocypack::Parser::fromJson(
       "{ \"name\": \"testView\", \"type\": \"arangosearch\", "
       "\"commitIntervalMsec\": 0 }");
-  Vocbase vocbase(testDBInfo(server.server()), server.engine());
+  Vocbase vocbase(testDBInfo(server.server()), _engine);
   auto logicalCollection = vocbase.createCollection(collectionJson->slice());
   ASSERT_TRUE((false == !logicalCollection));
   auto logicalView = vocbase.createView(viewJson->slice(), false);
@@ -6288,7 +6261,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // modify meta params
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
 
@@ -6443,7 +6416,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
   // test rollback on meta modification failure (as an example invalid value for
   // 'cleanupIntervalStep')
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -6525,7 +6498,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // modify meta params with links to missing collections
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -6614,7 +6587,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -6707,7 +6680,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -6890,7 +6863,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // overwrite links
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson0 = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection0\" }");
     auto collectionJson1 = arangodb::velocypack::Parser::fromJson(
@@ -7106,7 +7079,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
 
   // update existing link (full update)
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -7250,7 +7223,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
         "{ \"cleanupIntervalStep\": 62, \"links\": { \"testCollection\": {} } "
         "}");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7365,7 +7338,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7413,7 +7386,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7511,7 +7484,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {}, \"testCollection1\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -7630,7 +7603,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -7749,7 +7722,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -7847,7 +7820,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {}, \"testCollection1\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -7967,7 +7940,7 @@ TEST_F(IResearchViewTest, test_update_overwrite) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection0\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -8094,7 +8067,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // modify meta params
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
     ASSERT_TRUE(view->category() ==
@@ -8174,7 +8147,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
   // test rollback on meta modification failure (as an example invalid value for
   // 'cleanupIntervalStep')
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -8253,7 +8226,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // modify meta params with links to missing collections
   {
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalView = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !logicalView));
     ASSERT_TRUE((logicalView->category() ==
@@ -8339,7 +8312,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -8429,7 +8402,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
   {
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(createJson->slice(), false);
@@ -8636,7 +8609,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add a new link (in recovery)
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -8714,7 +8687,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add a new link
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -8820,7 +8793,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add a new link to a collection with documents
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -8944,7 +8917,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // add new link to non-existant collection
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
     ASSERT_TRUE(view->category() ==
@@ -9026,7 +8999,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove link (in recovery)
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9115,7 +9088,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove link
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9274,7 +9247,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove link from non-existant collection
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto view = vocbase.createView(createJson->slice(), false);
     ASSERT_TRUE((false == !view));
 
@@ -9354,7 +9327,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove non-existant link
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9436,7 +9409,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // remove + add link to same collection (reindex)
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -9578,7 +9551,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
 
   // update existing link (partial update)
   {
-    Vocbase vocbase(testDBInfo(server.server()), server.engine());
+    Vocbase vocbase(testDBInfo(server.server()), _engine);
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -10037,7 +10010,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"cleanupIntervalStep\": 62 }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -10152,7 +10125,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -10200,7 +10173,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
     ASSERT_TRUE((nullptr != logicalCollection));
     auto logicalView = vocbase.createView(viewCreateJson->slice(), false);
@@ -10298,7 +10271,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection1\": {} } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -10418,7 +10391,7 @@ TEST_F(IResearchViewTest, test_update_partial) {
     auto viewUpdateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection1\": null } }");
 
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     auto logicalCollection0 =
         vocbase.createCollection(collection0Json->slice());
     ASSERT_TRUE((nullptr != logicalCollection0));
@@ -10791,7 +10764,7 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
         "    [\"obj.c\", \"\", \"obj.d\"], [\"obj.e\", \"obj.f.f1\", "
         "\"obj.g\"] ] "
         "} ");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, json->slice(), true)
@@ -10856,7 +10829,7 @@ TEST_F(IResearchViewTest, create_view_with_stored_value) {
         "    [\"obj.d\"], [\"obj.c.c1\", \"obj.c\", \"obj.c\", \"obj.d\", "
         "\"obj.c.c2\"], [\"obj.b\", \"obj.b\"] ] "
         "} ");
-    TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+    TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
     arangodb::LogicalView::ptr view;
     EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                      .create(view, vocbase, json->slice(), true)
@@ -10921,7 +10894,7 @@ TEST_F(IResearchViewTest, create_view_with_stored_value_with_compression) {
       "    {\"fields\":[\"obj.a\"], \"compression\":\"none\"} , "
       "{\"fields\":[\"obj.b.b1\"], \"compression\":\"lz4\"} ] "
       "} ");
-  TRI_vocbase_t vocbase(testDBInfo(server.server()), server.engine());
+  TRI_vocbase_t vocbase(testDBInfo(server.server()), _engine);
   arangodb::LogicalView::ptr view;
   EXPECT_TRUE((arangodb::iresearch::IResearchView::factory()
                    .create(view, vocbase, json->slice(), true)

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -5305,7 +5305,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
              .ok()));
     ASSERT_TRUE((false == !logicalView));
     _engine.createView(vocbase, logicalView->id(),
-                      *logicalView);  // ensure link can find view
+                       *logicalView);  // ensure link can find view
     StorageEngineMock(server.server())
         .registerView(vocbase, logicalView);  // ensure link can find view
     auto* viewImpl =
@@ -5351,7 +5351,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
              .ok()));
     ASSERT_TRUE((false == !logicalView));
     _engine.createView(vocbase, logicalView->id(),
-                      *logicalView);  // ensure link can find view
+                       *logicalView);  // ensure link can find view
     StorageEngineMock(server.server())
         .registerView(vocbase, logicalView);  // ensure link can find view
     auto* viewImpl =

--- a/tests/IResearch/IResearchViewTest.cpp
+++ b/tests/IResearch/IResearchViewTest.cpp
@@ -62,7 +62,6 @@
 #include "RestServer/DatabasePathFeature.h"
 #include "RestServer/FlushFeature.h"
 #include "RestServer/ViewTypesFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
@@ -4611,7 +4610,7 @@ TEST_F(IResearchViewTest, test_register_link) {
   // new link in recovery
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -4692,7 +4691,7 @@ TEST_F(IResearchViewTest, test_register_link) {
   // new link
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -4790,7 +4789,7 @@ TEST_F(IResearchViewTest, test_register_link) {
   // known link
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -4932,7 +4931,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
   // link removed before view (in recovery)
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -5055,7 +5054,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
   // link removed before view
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -5170,7 +5169,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
   // view removed before link
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -5209,7 +5208,7 @@ TEST_F(IResearchViewTest, test_unregister_link) {
   // view deallocated before link removed
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     auto logicalCollection = vocbase.createCollection(collectionJson->slice());
@@ -5284,7 +5283,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // test empty before open (TRI_vocbase_t::createView(...) will call open())
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     Vocbase vocbase(testDBInfo(server.server()), server.engine());
     arangodb::LogicalView::ptr view;
@@ -5309,7 +5308,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // open())
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     auto updateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
@@ -5355,7 +5354,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // open())
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     auto updateJson0 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
@@ -5418,7 +5417,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // initial populate persisted view
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     auto collectionJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testCollection\" }");
@@ -5461,7 +5460,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // test persisted CIDs on open
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     auto createJson = arangodb::velocypack::Parser::fromJson(
         "{ \"name\": \"testView\", \"type\": \"arangosearch\", \"id\": 102 "
@@ -5486,7 +5485,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // open())
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     auto updateJson = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");
@@ -5520,7 +5519,7 @@ TEST_F(IResearchViewTest, test_tracked_cids) {
   // open())
   {
     auto& engine = *static_cast<StorageEngineMock*>(
-        &server.getFeature<arangodb::EngineSelectorFeature>().engine());
+        &server.getFeature<arangodb::DatabaseFeature>().engine());
     engine.views.clear();
     auto updateJson0 = arangodb::velocypack::Parser::fromJson(
         "{ \"links\": { \"testCollection\": { } } }");

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -45,7 +45,6 @@
 #include "RestServer/UpgradeFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 #include "MaintenanceFeatureMock.h"
 
@@ -205,7 +204,7 @@ struct MaintenanceFeatureTestThreaded : ::testing::Test {
     as.addFeature<metrics::MetricsFeature>(
         LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
         LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-        LazyApplicationFeatureReference<EngineSelectorFeature>(nullptr),
+        LazyApplicationFeatureReference<DatabaseFeature>(nullptr),
         LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(
             nullptr),
         LazyApplicationFeatureReference<ClusterFeature>(nullptr));

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -61,7 +61,6 @@
 #include "RocksDBEngine/RocksDBRecoveryManager.h"
 #include "Scheduler/SchedulerFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Iterator.h>
@@ -539,10 +538,10 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
     auto& roOptions = as.addFeature<RocksDBOptionFeature>(&agencyFeature);
     as.addFeature<application_features::GreetingsFeaturePhase>(
         std::false_type{});
-    auto& selector = as.addFeature<EngineSelectorFeature>();
+    auto& dbFeature = as.addFeature<DatabaseFeature>();
     auto& metrics = as.addFeature<metrics::MetricsFeature>(
         LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
-        LazyApplicationFeatureReference<StatisticsFeature>(nullptr), selector,
+        LazyApplicationFeatureReference<StatisticsFeature>(nullptr), dbFeature,
         LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(
             nullptr),
         LazyApplicationFeatureReference<ClusterFeature>(nullptr));
@@ -554,10 +553,9 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
     auto& schedulerFeature = as.addFeature<SchedulerFeature>(metrics);
 
     auto& rocksDbRecoveryManager = as.addFeature<RocksDBRecoveryManager>();
-    auto& databaseFeature = as.addFeature<DatabaseFeature>();
-    auto& vectorIndex = as.addFeature<VectorIndexFeature>(databaseFeature);
+    auto& vectorIndex = as.addFeature<VectorIndexFeature>(dbFeature);
     auto& rocksDbIndexCacheRefillFeature =
-        as.addFeature<RocksDBIndexCacheRefillFeature>(databaseFeature, nullptr,
+        as.addFeature<RocksDBIndexCacheRefillFeature>(dbFeature, nullptr,
                                                       metrics);
     auto& cacheOptions = as.addFeature<CacheOptionsFeature>();
     auto& sharedPrngFeature = as.addFeature<SharedPRNGFeature>();
@@ -571,13 +569,13 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
     engine = std::make_unique<RocksDBEngine>(
         as, roOptions, metrics, dbpath, vectorIndex, flush, dumpLimits,
         schedulerFeature, replicatedLogFeature, rocksDbRecoveryManager,
-        databaseFeature, rocksDbIndexCacheRefillFeature, cacheManagerFeature,
+        dbFeature, rocksDbIndexCacheRefillFeature, cacheManagerFeature,
         agencyFeature);
-    selector.setEngineTesting(engine.get());
+    dbFeature.setEngineTesting(engine.get());
   }
 
   ~MaintenanceTestActionPhaseOne() {
-    as.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(nullptr);
+    as.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
   }
 
   auto dbName() const -> std::string {

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -61,6 +61,7 @@
 #include "RocksDBEngine/RocksDBRecoveryManager.h"
 #include "Scheduler/SchedulerFeature.h"
 #include "Statistics/StatisticsFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
 
 #include <velocypack/Iterator.h>
@@ -538,6 +539,7 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
     auto& roOptions = as.addFeature<RocksDBOptionFeature>(&agencyFeature);
     as.addFeature<application_features::GreetingsFeaturePhase>(
         std::false_type{});
+    auto& selector = as.addFeature<EngineSelectorFeature>();
     auto& dbFeature = as.addFeature<DatabaseFeature>();
     auto& metrics = as.addFeature<metrics::MetricsFeature>(
         LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
@@ -571,10 +573,12 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
         schedulerFeature, replicatedLogFeature, rocksDbRecoveryManager,
         dbFeature, rocksDbIndexCacheRefillFeature, cacheManagerFeature,
         agencyFeature);
+    selector.setEngineTesting(engine.get());
     dbFeature.setEngineTesting(engine.get());
   }
 
   ~MaintenanceTestActionPhaseOne() {
+    as.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(nullptr);
     as.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
   }
 

--- a/tests/Metrics/MetricsFeatureTest.cpp
+++ b/tests/Metrics/MetricsFeatureTest.cpp
@@ -40,7 +40,7 @@ ArangodServer server = ArangodServer(opts, nullptr);
 metrics::MetricsFeature feature = metrics::MetricsFeature(
     server, LazyApplicationFeatureReference<QueryRegistryFeature>(server),
     LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-    LazyApplicationFeatureReference<EngineSelectorFeature>(nullptr),
+    LazyApplicationFeatureReference<DatabaseFeature>(nullptr),
     LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
     LazyApplicationFeatureReference<ClusterFeature>(nullptr));
 

--- a/tests/Mocks/PhysicalCollectionMock.cpp
+++ b/tests/Mocks/PhysicalCollectionMock.cpp
@@ -35,7 +35,6 @@
 #include "IResearch/IResearchCommon.h"
 #include "IResearch/IResearchFeature.h"
 #include "Logger/LogMacros.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/OperationOrigin.h"
 #include "Transaction/StandaloneContext.h"
@@ -1248,10 +1247,7 @@ void PhysicalCollectionMock::prepareIndexes(
     arangodb::velocypack::Slice indexesSlice) {
   before();
 
-  auto& engine = _logicalCollection.vocbase()
-                     .server()
-                     .getFeature<arangodb::EngineSelectorFeature>()
-                     .engine();
+  auto& engine = _logicalCollection.vocbase().engine();
   auto& idxFactory = engine.indexFactory();
 
   for (VPackSlice v : VPackArrayIterator(indexesSlice)) {

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -310,6 +310,7 @@ void MockServer::startFeatures() {
   auto orderedFeatures = _server.getOrderedFeatures();
 
   _server.getFeature<EngineSelectorFeature>().setEngineTesting(_engine.get());
+  _server.getFeature<DatabaseFeature>().setEngineTesting(_engine.get());
 
   if (_server.hasFeature<SchedulerFeature>()) {
     auto& sched = _server.getFeature<SchedulerFeature>();

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -309,8 +309,12 @@ void MockServer::startFeatures() {
   _server.setupDependencies(false);
   auto orderedFeatures = _server.getOrderedFeatures();
 
-  _server.getFeature<EngineSelectorFeature>().setEngineTesting(_engine.get());
-  _server.getFeature<DatabaseFeature>().setEngineTesting(_engine.get());
+  if (_server.hasFeature<EngineSelectorFeature>()) {
+    _server.getFeature<EngineSelectorFeature>().setEngineTesting(_engine.get());
+  }
+  if (_server.hasFeature<DatabaseFeature>()) {
+    _server.getFeature<DatabaseFeature>().setEngineTesting(_engine.get());
+  }
 
   if (_server.hasFeature<SchedulerFeature>()) {
     auto& sched = _server.getFeature<SchedulerFeature>();

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -111,7 +111,6 @@
 #include "Sharding/ShardingFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "Statistics/StatisticsWorker.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngineFeature.h"
 #include "TemplateSpecializer.h"
 #include "Transaction/ManagerFeature.h"
@@ -160,7 +159,7 @@ static void SetupGreetingsPhase(MockServer& server) {
   server.addFeature<metrics::MetricsFeature>(
       false, LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
       LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-      LazyApplicationFeatureReference<EngineSelectorFeature>(nullptr),
+      LazyApplicationFeatureReference<DatabaseFeature>(nullptr),
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
       LazyApplicationFeatureReference<ClusterFeature>(nullptr));
   server.addFeature<SharedPRNGFeature>(false);
@@ -309,7 +308,6 @@ void MockServer::startFeatures() {
   _server.setupDependencies(false);
   auto orderedFeatures = _server.getOrderedFeatures();
 
-  _server.getFeature<EngineSelectorFeature>().setEngineTesting(_engine.get());
   _server.getFeature<DatabaseFeature>().setEngineTesting(_engine.get());
 
   if (_server.hasFeature<SchedulerFeature>()) {
@@ -443,7 +441,7 @@ TRI_vocbase_t& MockServer::getSystemDatabase() const {
 MockMetricsServer::MockMetricsServer(bool start) : MockServer() {
   // setup required application features
   SetupGreetingsPhase(*this);
-  addFeature<EngineSelectorFeature>(false);
+  addFeature<DatabaseFeature>(false);
 
   if (start) {
     MockMetricsServer::startFeatures();

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -111,6 +111,7 @@
 #include "Sharding/ShardingFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "Statistics/StatisticsWorker.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/StorageEngineFeature.h"
 #include "TemplateSpecializer.h"
 #include "Transaction/ManagerFeature.h"
@@ -308,6 +309,7 @@ void MockServer::startFeatures() {
   _server.setupDependencies(false);
   auto orderedFeatures = _server.getOrderedFeatures();
 
+  _server.getFeature<EngineSelectorFeature>().setEngineTesting(_engine.get());
   _server.getFeature<DatabaseFeature>().setEngineTesting(_engine.get());
 
   if (_server.hasFeature<SchedulerFeature>()) {
@@ -442,6 +444,7 @@ MockMetricsServer::MockMetricsServer(bool start) : MockServer() {
   // setup required application features
   SetupGreetingsPhase(*this);
   addFeature<DatabaseFeature>(false);
+  addFeature<EngineSelectorFeature>(false);
 
   if (start) {
     MockMetricsServer::startFeatures();

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -447,7 +447,6 @@ TRI_vocbase_t& MockServer::getSystemDatabase() const {
 MockMetricsServer::MockMetricsServer(bool start) : MockServer() {
   // setup required application features
   SetupGreetingsPhase(*this);
-  addFeature<DatabaseFeature>(false);
   addFeature<EngineSelectorFeature>(false);
 
   if (start) {

--- a/tests/Mocks/StorageEngineMock.cpp
+++ b/tests/Mocks/StorageEngineMock.cpp
@@ -48,7 +48,6 @@
 #include "Indexes/SortedIndexAttributeMatcher.h"
 #include "Replication2/ReplicatedLog/LogCommon.h"
 #include "RestServer/FlushFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Helpers.h"
 #include "Transaction/Hints.h"
 #include "Transaction/Manager.h"
@@ -77,9 +76,7 @@ struct IndexFactoryMock : arangodb::IndexFactory {
       : IndexFactory(server) {
     if (injectClusterIndexes) {
       arangodb::ClusterIndexFactory::linkIndexFactories(
-          server, *this,
-          server.getFeature<arangodb::EngineSelectorFeature>()
-              .engine<arangodb::ClusterEngine>());
+          server, *this, server.getFeature<arangodb::ClusterEngine>());
     }
   }
 

--- a/tests/Replication2/Mocks/MockVocbase.h
+++ b/tests/Replication2/Mocks/MockVocbase.h
@@ -27,6 +27,7 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "RestServer/DatabaseFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "Utils/VersionTracker.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/vocbase.h"
@@ -58,6 +59,9 @@ struct MockVocbase : TRI_vocbase_t {
                       createDatabaseInfo(server, name, id), storageEngine,
                       versionTracker, true),
         storageEngine(server) {
+    server.addFeature<arangodb::EngineSelectorFeature>();
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+        &storageEngine);
     server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         &storageEngine);
   }

--- a/tests/Replication2/Mocks/MockVocbase.h
+++ b/tests/Replication2/Mocks/MockVocbase.h
@@ -26,12 +26,12 @@
 #include <gmock/gmock.h>
 
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "RestServer/DatabaseFeature.h"
 #include "Utils/VersionTracker.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/vocbase.h"
 #include "VocBase/VocbaseInfo.h"
 #include "Mocks/StorageEngineMock.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 namespace arangodb::replication2::tests {
 
@@ -58,8 +58,7 @@ struct MockVocbase : TRI_vocbase_t {
                       createDatabaseInfo(server, name, id), storageEngine,
                       versionTracker, true),
         storageEngine(server) {
-    server.addFeature<arangodb::EngineSelectorFeature>();
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         &storageEngine);
   }
 

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/DocumentStateMachineTest.h
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/DocumentStateMachineTest.h
@@ -86,8 +86,8 @@ struct DocumentStateMachineTest : testing::Test {
   MockTransactionManager transactionManagerMock;
   arangodb::tests::mocks::MockServer mockServer =
       arangodb::tests::mocks::MockServer();
-  MockVocbase vocbaseMock = MockVocbase(
-      mockServer.server(), MockDocumentStateHandlersFactory::kDbName, 2);
+  MockVocbase vocbaseMock =
+      makeVocbase(mockServer, MockDocumentStateHandlersFactory::kDbName, 2);
   std::shared_ptr<IScheduler> schedulerMock =
       std::make_shared<test::SyncScheduler>();
 
@@ -134,6 +134,13 @@ struct DocumentStateMachineTest : testing::Test {
     return std::make_shared<DocumentFollowerStateWrapper>(
         factory.constructCore(vocbaseMock, globalId, coreParams),
         handlersFactoryMock, schedulerMock);
+  }
+
+  static replication2::tests::MockVocbase makeVocbase(
+      arangodb::tests::mocks::MockServer& s, std::string const& name,
+      std::uint64_t id) {
+    s.server().addFeature<arangodb::DatabaseFeature>();
+    return replication2::tests::MockVocbase(s.server(), name, id);
   }
 
   void SetUp() override {

--- a/tests/Replication2/ReplicatedState/StateMachines/DocumentState/ShardHandlerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateMachines/DocumentState/ShardHandlerTest.cpp
@@ -36,6 +36,7 @@
 #include "Replication2/Mocks/DocumentStateMocks.h"
 #include "Replication2/Mocks/MockVocbase.h"
 #include "Replication2/StateMachines/Document/DocumentStateShardHandler.h"
+#include "RestServer/DatabaseFeature.h"
 #include "velocypack/Value.h"
 #include "gmock/gmock.h"
 
@@ -52,6 +53,7 @@ struct ShardHandlerTest : testing::Test {
   std::shared_ptr<MockVocbase> vocbaseMock = nullptr;
 
   void SetUp() override {
+    mockServer.server().addFeature<arangodb::DatabaseFeature>();
     vocbaseMock = std::make_shared<MockVocbase>(mockServer.server(),
                                                 "shardHandlerTestDb", 1);
   }

--- a/tests/Replication2/ReplicatedState/StateManagerTest.cpp
+++ b/tests/Replication2/ReplicatedState/StateManagerTest.cpp
@@ -89,8 +89,15 @@ struct StateManagerTest : testing::Test {
   arangodb::tests::mocks::MockServer mockServer =
       arangodb::tests::mocks::MockServer();
   replication2::tests::MockVocbase vocbaseMock =
-      replication2::tests::MockVocbase(mockServer.server(),
-                                       "documentStateMachineTestDb", 2);
+      makeVocbase(mockServer, "documentStateMachineTestDb", 2);
+
+  static replication2::tests::MockVocbase makeVocbase(
+      arangodb::tests::mocks::MockServer& s, std::string const& name,
+      std::uint64_t id) {
+    s.server().addFeature<arangodb::DatabaseFeature>();
+    return replication2::tests::MockVocbase(s.server(), name, id);
+  }
+
   std::shared_ptr<storage::rocksdb::test::DelayedExecutor> executor =
       std::make_shared<storage::rocksdb::test::DelayedExecutor>();
   // Note that this purposefully does not initialize the PersistedStateInfo that

--- a/tests/RestServer/FlushFeatureTest.cpp
+++ b/tests/RestServer/FlushFeatureTest.cpp
@@ -76,8 +76,8 @@ class FlushFeatureTest
             arangodb::QueryRegistryFeature>(server),
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
-        arangodb::LazyApplicationFeatureReference<
-            arangodb::DatabaseFeature>(server),
+        arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+            server),
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -113,8 +113,7 @@ class FlushFeatureTest
   }
 
   ~FlushFeatureTest() {
-    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
-        nullptr);
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features
     for (auto& f : features) {

--- a/tests/RestServer/FlushFeatureTest.cpp
+++ b/tests/RestServer/FlushFeatureTest.cpp
@@ -43,6 +43,7 @@
 #include "RocksDBEngine/RocksDBFormat.h"
 #include "RocksDBEngine/RocksDBRecoveryHelper.h"
 #include "RocksDBEngine/RocksDBTypes.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
@@ -89,6 +90,9 @@ class FlushFeatureTest
                           false);  // required for V8DealerFeature::prepare()
     auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
     features.emplace_back(dbFeature, false);
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    features.emplace_back(selector, false);
+    selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
     features.emplace_back(
         server.addFeature<arangodb::QueryRegistryFeature>(
@@ -113,6 +117,8 @@ class FlushFeatureTest
   }
 
   ~FlushFeatureTest() {
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+        nullptr);
     server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features

--- a/tests/RestServer/FlushFeatureTest.cpp
+++ b/tests/RestServer/FlushFeatureTest.cpp
@@ -34,21 +34,19 @@
 #include "Cluster/ClusterFeature.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "Logger/Logger.h"
-#include "RestServer/DatabaseFeature.h"
 #include "RestServer/FlushFeature.h"
 #include "Metrics/MetricsFeature.h"
 #include "RestServer/arangod.h"
+#include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
 #include "RocksDBEngine/RocksDBFormat.h"
 #include "RocksDBEngine/RocksDBRecoveryHelper.h"
 #include "RocksDBEngine/RocksDBTypes.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #ifdef USE_V8
 #include "V8Server/V8DealerFeature.h"
 #endif
@@ -79,7 +77,7 @@ class FlushFeatureTest
         arangodb::LazyApplicationFeatureReference<arangodb::StatisticsFeature>(
             nullptr),
         arangodb::LazyApplicationFeatureReference<
-            arangodb::EngineSelectorFeature>(server),
+            arangodb::DatabaseFeature>(server),
         arangodb::LazyApplicationFeatureReference<
             arangodb::metrics::ClusterMetricsFeature>(nullptr),
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -89,12 +87,9 @@ class FlushFeatureTest
                           false);  // required for ClusterFeature::prepare()
     features.emplace_back(server.addFeature<arangodb::ClusterFeature>(metrics),
                           false);  // required for V8DealerFeature::prepare()
-    features.emplace_back(
-        server.addFeature<arangodb::DatabaseFeature>(),
-        false);  // required for MMFilesWalRecoverState constructor
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    features.emplace_back(selector, false);
-    selector.setEngineTesting(&engine);
+    auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
+    features.emplace_back(dbFeature, false);
+    dbFeature.setEngineTesting(&engine);
     features.emplace_back(
         server.addFeature<arangodb::QueryRegistryFeature>(
             server.getFeature<arangodb::metrics::MetricsFeature>()),
@@ -118,7 +113,7 @@ class FlushFeatureTest
   }
 
   ~FlushFeatureTest() {
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         nullptr);
 
     // destroy application features

--- a/tests/RocksDBEngine/TransactionManagerTest.cpp
+++ b/tests/RocksDBEngine/TransactionManagerTest.cpp
@@ -36,7 +36,6 @@
 #include "RestServer/arangod.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 using namespace arangodb;
 
@@ -52,7 +51,7 @@ TEST(RocksDBTransactionManager, test_non_overlapping) {
   auto& metrics = server.addFeature<metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
       LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-      LazyApplicationFeatureReference<EngineSelectorFeature>(nullptr),
+      LazyApplicationFeatureReference<DatabaseFeature>(nullptr),
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
       LazyApplicationFeatureReference<ClusterFeature>(nullptr));
   transaction::ManagerFeature feature(server, metrics);
@@ -79,7 +78,7 @@ TEST(RocksDBTransactionManager, test_overlapping) {
   auto& metrics = server.addFeature<metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
       LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-      LazyApplicationFeatureReference<EngineSelectorFeature>(nullptr),
+      LazyApplicationFeatureReference<DatabaseFeature>(nullptr),
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(nullptr),
       LazyApplicationFeatureReference<ClusterFeature>(nullptr));
   transaction::ManagerFeature feature(server, metrics);

--- a/tests/Scheduler/ThreadPoolPerfTest.cpp
+++ b/tests/Scheduler/ThreadPoolPerfTest.cpp
@@ -47,7 +47,7 @@ struct SupervisedSchedulerPool {
             mockApplicationServer.server(),
             LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
             LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
-            LazyApplicationFeatureReference<EngineSelectorFeature>(nullptr),
+            LazyApplicationFeatureReference<DatabaseFeature>(nullptr),
             LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(
                 nullptr),
             LazyApplicationFeatureReference<ClusterFeature>(nullptr))),

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -45,6 +45,7 @@
 #include "RestServer/QueryRegistryFeature.h"
 #include "Sharding/ShardDistributionReporter.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
 #include "Cluster/ClusterFeature.h"
@@ -203,6 +204,9 @@ class ShardDistributionReporterTest
     auto& dbFeature = server.addFeature<DatabaseFeature>();
     features.emplace_back(
         dbFeature, false);  // required for TRI_vocbase_t::dropCollection(...)
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    features.emplace_back(selector, false);
+    selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
     features.emplace_back(
         server.addFeature<arangodb::metrics::MetricsFeature>(

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -45,7 +45,6 @@
 #include "RestServer/QueryRegistryFeature.h"
 #include "Sharding/ShardDistributionReporter.h"
 #include "SimpleHttpClient/SimpleHttpResult.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
 #include "Cluster/ClusterFeature.h"
@@ -53,7 +52,6 @@
 #include "Statistics/StatisticsFeature.h"
 #include "RestServer/arangod.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 using namespace arangodb;
 using namespace arangodb::cluster;
@@ -202,19 +200,18 @@ class ShardDistributionReporterTest
     aliases[dbserver2] = dbserver2short;
     aliases[dbserver3] = dbserver3short;
 
+    auto& dbFeature = server.addFeature<DatabaseFeature>();
     features.emplace_back(
-        server.addFeature<arangodb::DatabaseFeature>(),
-        false);  // required for TRI_vocbase_t::dropCollection(...)
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    features.emplace_back(selector, false);
-    selector.setEngineTesting(&engine);
+        dbFeature, false);  // required for TRI_vocbase_t::dropCollection(...)
+    dbFeature.setEngineTesting(&engine);
     features.emplace_back(
         server.addFeature<arangodb::metrics::MetricsFeature>(
             arangodb::LazyApplicationFeatureReference<
                 arangodb::QueryRegistryFeature>(server),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
-            selector,
+            arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
+                dbFeature),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -210,8 +210,8 @@ class ShardDistributionReporterTest
                 arangodb::QueryRegistryFeature>(server),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
-            arangodb::LazyApplicationFeatureReference<arangodb::DatabaseFeature>(
-                dbFeature),
+            arangodb::LazyApplicationFeatureReference<
+                arangodb::DatabaseFeature>(dbFeature),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -214,8 +214,7 @@ class ShardDistributionReporterTest
                 arangodb::QueryRegistryFeature>(server),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
-            arangodb::LazyApplicationFeatureReference<
-                arangodb::DatabaseFeature>(dbFeature),
+            dbFeature,
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/StorageEngine/PhysicalCollectionTest.cpp
+++ b/tests/StorageEngine/PhysicalCollectionTest.cpp
@@ -40,6 +40,7 @@
 #include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "Transaction/BatchOptions.h"
 #include "Transaction/Helpers.h"
@@ -77,6 +78,9 @@ class PhysicalCollectionTest
             arangodb::AuthenticationFeature>());  // required for VocbaseContext
     auto& dbFeature = server.addFeature<DatabaseFeature>();
     features.emplace_back(dbFeature);
+    auto& selector = server.addFeature<EngineSelectorFeature>();
+    features.emplace_back(selector);
+    selector.setEngineTesting(&engine);
     dbFeature.setEngineTesting(&engine);
     features.emplace_back(server.addFeature<metrics::MetricsFeature>(
         LazyApplicationFeatureReference<QueryRegistryFeature>(server),
@@ -94,6 +98,7 @@ class PhysicalCollectionTest
   }
 
   ~PhysicalCollectionTest() {
+    server.getFeature<EngineSelectorFeature>().setEngineTesting(nullptr);
     server.getFeature<DatabaseFeature>().setEngineTesting(nullptr);
 
     for (auto& f : features) {

--- a/tests/StorageEngine/PhysicalCollectionTest.cpp
+++ b/tests/StorageEngine/PhysicalCollectionTest.cpp
@@ -40,7 +40,6 @@
 #include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
 #include "Transaction/BatchOptions.h"
 #include "Transaction/Helpers.h"
@@ -51,7 +50,6 @@
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 using namespace arangodb;
 
@@ -77,13 +75,12 @@ class PhysicalCollectionTest
     features.emplace_back(
         server.addFeature<
             arangodb::AuthenticationFeature>());  // required for VocbaseContext
-    features.emplace_back(server.addFeature<DatabaseFeature>());
-    auto& selector = server.addFeature<EngineSelectorFeature>();
-    features.emplace_back(selector);
-    selector.setEngineTesting(&engine);
+    auto& dbFeature = server.addFeature<DatabaseFeature>();
+    features.emplace_back(dbFeature);
+    dbFeature.setEngineTesting(&engine);
     features.emplace_back(server.addFeature<metrics::MetricsFeature>(
         LazyApplicationFeatureReference<QueryRegistryFeature>(server),
-        LazyApplicationFeatureReference<StatisticsFeature>(nullptr), selector,
+        LazyApplicationFeatureReference<StatisticsFeature>(nullptr), dbFeature,
         LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(
             nullptr),
         LazyApplicationFeatureReference<ClusterFeature>(nullptr)));
@@ -97,7 +94,7 @@ class PhysicalCollectionTest
   }
 
   ~PhysicalCollectionTest() {
-    server.getFeature<EngineSelectorFeature>().setEngineTesting(nullptr);
+    server.getFeature<DatabaseFeature>().setEngineTesting(nullptr);
 
     for (auto& f : features) {
       f.get().unprepare();

--- a/tests/VocBase/LogicalDataSourceTest.cpp
+++ b/tests/VocBase/LogicalDataSourceTest.cpp
@@ -116,8 +116,7 @@ class LogicalDataSourceTest : public ::testing::Test {
   }
 
   ~LogicalDataSourceTest() {
-    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
-        nullptr);
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features
     for (auto& f : features) {

--- a/tests/VocBase/LogicalDataSourceTest.cpp
+++ b/tests/VocBase/LogicalDataSourceTest.cpp
@@ -28,12 +28,11 @@
 #include "../Mocks/StorageEngineMock.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "RestServer/DatabaseFeature.h"
 #include "Metrics/MetricsFeature.h"
 #include "RestServer/arangod.h"
+#include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Sharding/ShardingFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
 #include "velocypack/Parser.h"
@@ -82,11 +81,9 @@ class LogicalDataSourceTest : public ::testing::Test {
 
   LogicalDataSourceTest() : server(nullptr, nullptr), engine(server) {
     // setup required application features
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    features.emplace_back(selector, false);
-    selector.setEngineTesting(&engine);
-    features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(),
-                          false);
+    auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
+    features.emplace_back(dbFeature, false);
+    dbFeature.setEngineTesting(&engine);
     features.emplace_back(
         server.addFeature<arangodb::metrics::MetricsFeature>(
             arangodb::LazyApplicationFeatureReference<
@@ -94,7 +91,7 @@ class LogicalDataSourceTest : public ::testing::Test {
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<
-                arangodb::EngineSelectorFeature>(nullptr),
+                arangodb::DatabaseFeature>(dbFeature),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -119,7 +116,7 @@ class LogicalDataSourceTest : public ::testing::Test {
   }
 
   ~LogicalDataSourceTest() {
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         nullptr);
 
     // destroy application features

--- a/tests/VocBase/LogicalDataSourceTest.cpp
+++ b/tests/VocBase/LogicalDataSourceTest.cpp
@@ -95,7 +95,7 @@ class LogicalDataSourceTest : public ::testing::Test {
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<
-                arangodb::DatabaseFeature>(dbFeature),
+                arangodb::DatabaseFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(

--- a/tests/VocBase/LogicalDataSourceTest.cpp
+++ b/tests/VocBase/LogicalDataSourceTest.cpp
@@ -33,6 +33,7 @@
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Sharding/ShardingFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/LogicalView.h"
 #include "velocypack/Parser.h"
@@ -81,6 +82,9 @@ class LogicalDataSourceTest : public ::testing::Test {
 
   LogicalDataSourceTest() : server(nullptr, nullptr), engine(server) {
     // setup required application features
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    features.emplace_back(selector, false);
+    selector.setEngineTesting(&engine);
     auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
     features.emplace_back(dbFeature, false);
     dbFeature.setEngineTesting(&engine);
@@ -116,6 +120,8 @@ class LogicalDataSourceTest : public ::testing::Test {
   }
 
   ~LogicalDataSourceTest() {
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+        nullptr);
     server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -44,6 +44,7 @@
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
+#include "StorageEngine/EngineSelectorFeature.h"
 #include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
@@ -120,6 +121,9 @@ class LogicalViewTest
   ViewFactory viewFactory;
 
   LogicalViewTest() : server(nullptr, nullptr), engine(server) {
+    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
+    features.emplace_back(selector, false);
+    selector.setEngineTesting(&engine);
     features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(),
                           false);  // required for ExecContext
     auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
@@ -160,8 +164,9 @@ class LogicalViewTest
   }
 
   ~LogicalViewTest() {
-    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
+    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
         nullptr);
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(nullptr);
 
     // destroy application features
     for (auto& f : features) {

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -34,11 +34,9 @@
 #include "Aql/QueryRegistry.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "Logger/Logger.h"
-#include "RestServer/DatabaseFeature.h"
 #include "Metrics/MetricsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/ViewTypesFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Utils/ExecContext.h"
 #include "VocBase/LogicalView.h"
 #include "VocBase/VocbaseInfo.h"
@@ -47,8 +45,8 @@
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "RestServer/arangod.h"
+#include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 
 namespace {
 struct TestView : public arangodb::LogicalView {
@@ -122,13 +120,11 @@ class LogicalViewTest
   ViewFactory viewFactory;
 
   LogicalViewTest() : server(nullptr, nullptr), engine(server) {
-    auto& selector = server.addFeature<arangodb::EngineSelectorFeature>();
-    features.emplace_back(selector, false);
-    selector.setEngineTesting(&engine);
     features.emplace_back(server.addFeature<arangodb::AuthenticationFeature>(),
                           false);  // required for ExecContext
-    features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(),
-                          false);
+    auto& dbFeature = server.addFeature<arangodb::DatabaseFeature>();
+    features.emplace_back(dbFeature, false);
+    dbFeature.setEngineTesting(&engine);
     features.emplace_back(
         server.addFeature<arangodb::metrics::MetricsFeature>(
             arangodb::LazyApplicationFeatureReference<
@@ -136,7 +132,7 @@ class LogicalViewTest
             arangodb::LazyApplicationFeatureReference<
                 arangodb::StatisticsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<
-                arangodb::EngineSelectorFeature>(nullptr),
+                arangodb::DatabaseFeature>(dbFeature),
             arangodb::LazyApplicationFeatureReference<
                 arangodb::metrics::ClusterMetricsFeature>(nullptr),
             arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
@@ -164,7 +160,7 @@ class LogicalViewTest
   }
 
   ~LogicalViewTest() {
-    server.getFeature<arangodb::EngineSelectorFeature>().setEngineTesting(
+    server.getFeature<arangodb::DatabaseFeature>().setEngineTesting(
         nullptr);
 
     // destroy application features

--- a/tests/sepp/Server.cpp
+++ b/tests/sepp/Server.cpp
@@ -154,7 +154,7 @@ void Server::Impl::setupServer(std::string const& name, int& result) {
   auto& metrics = _server.addFeature<metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(_server),
       LazyApplicationFeatureReference<StatisticsFeature>(_server),
-      LazyApplicationFeatureReference<EngineSelectorFeature>(_server),
+      LazyApplicationFeatureReference<DatabaseFeature>(_server),
       LazyApplicationFeatureReference<metrics::ClusterMetricsFeature>(_server),
       LazyApplicationFeatureReference<ClusterFeature>(_server));
   _server.addFeature<metrics::ClusterMetricsFeature>();
@@ -185,7 +185,6 @@ void Server::Impl::setupServer(std::string const& name, int& result) {
   auto& databasePath = _server.addFeature<DatabasePathFeature>();
   auto& dumpLimits = _server.addFeature<DumpLimitsFeature>();
   _server.addFeature<HttpEndpointProvider, EndpointFeature>();
-  _server.addFeature<EngineSelectorFeature>();
   _server.addFeature<EnvironmentFeature>();
   _server.addFeature<FileSystemFeature>();
   auto& flush = _server.addFeature<FlushFeature>(metrics);

--- a/tests/sepp/Server.cpp
+++ b/tests/sepp/Server.cpp
@@ -185,6 +185,7 @@ void Server::Impl::setupServer(std::string const& name, int& result) {
   auto& databasePath = _server.addFeature<DatabasePathFeature>();
   auto& dumpLimits = _server.addFeature<DumpLimitsFeature>();
   _server.addFeature<HttpEndpointProvider, EndpointFeature>();
+  _server.addFeature<EngineSelectorFeature>();
   _server.addFeature<EnvironmentFeature>();
   _server.addFeature<FileSystemFeature>();
   auto& flush = _server.addFeature<FlushFeature>(metrics);

--- a/tests/sepp/Workloads/EdgeCache.cpp
+++ b/tests/sepp/Workloads/EdgeCache.cpp
@@ -37,7 +37,6 @@
 #include "Cache/Manager.h"
 #include "Cache/CacheManagerFeature.h"
 #include "RocksDBEngine/RocksDBEngine.h"
-#include "StorageEngine/EngineSelectorFeature.h"
 #include "Transaction/Manager.h"
 #include "Transaction/ManagerFeature.h"
 #include "Transaction/Methods.h"
@@ -167,10 +166,7 @@ auto EdgeCache::Thread::report() const -> ThreadReport {
     data.add("freeMemoryTasks", VPackValue(stats.freeMemoryTasks));
     data.add("lifeTimeHitrate", VPackValue(rates.first));
 
-    auto& engine = _server.vocbase()
-                       ->server()
-                       .getFeature<EngineSelectorFeature>()
-                       .engine<RocksDBEngine>();
+    auto& engine = _server.vocbase()->engine<RocksDBEngine>();
     auto [entriesSizeTotal, entriesSizeEffective, inserts, compressedInserts,
           emptyInserts] = engine.getCacheMetrics();
     data.add("inserts", VPackValue(inserts));


### PR DESCRIPTION
### Scope & Purpose

This PR removes EngineSelectorFeature from the following files. Try to directly inject StorageEngine or RocksDBEngine (if applicable) to the callee functions.
- RocksDBEngine/RocksDBRestReplicationHandler.cpp
- RestHandler/RestDumpHandler.cpp
- RestHandler/RestReplicationHandler.cpp
- IResearch/IResearchAnalyzerFeature.cpp 
- RestServer/FlushFeature.cpp
- RestServer/UpgradeFeature.cpp
- RestServer/CheckVersionFeature.cpp
- RestServer/TemporaryStorageFeature.cpp 
- RestServer/DatabaseFeature.cpp
- Network/NetworkFeature.cpp 

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
