### PR TITLE
Activities cleanup

### DIFF
--- a/arangod/RestHandler/RestDumpHandler.cpp
+++ b/arangod/RestHandler/RestDumpHandler.cpp
@@ -200,12 +200,12 @@ void RestDumpHandler::handleCommandDumpNext() {
   auto context = _dumpManager->find(id, database, user);
   // immediately prolong lifetime of context, so it doesn't get invalidated
   // while we are using it.
-
-  auto fetch = activities::makeWithParent<activities::GenericActivity>(
-      context->activity(), "RocksDBDumpNext",
-      std::unordered_map<std::string, std::string>{{"id", id}});
-
   context->extendLifetime();
+
+  auto guard = activities::Registry::ScopedCurrentlyExecutingActivity(
+      context->activity());
+  auto fetch = activities::make<activities::GenericActivity>(
+      "RocksDBDumpNext", activities::GenericActivityData{{"id", id}});
 
   auto batch = context->next(*batchId, lastBatch);
   auto counts = context->getBlockCounts();

--- a/arangod/StorageEngine/TransactionActivity.h
+++ b/arangod/StorageEngine/TransactionActivity.h
@@ -85,7 +85,6 @@ struct TransactionActivity
       : activities::GuardedActivity<TransactionActivity,
                                     TransactionActivityData>(
             id, parent, "TransactionActivity", {}) {}
-  using Data = TransactionActivityData;
 
   auto setTransactionId(TransactionId tid) {
     _data.getLockedGuard()->tid = tid;

--- a/lib/Activities/include/Activities/Registry.h
+++ b/lib/Activities/include/Activities/Registry.h
@@ -110,21 +110,16 @@ struct [[nodiscard]] Registry::ScopedCurrentlyExecutingActivity {
 };
 
 template<typename Func>
-auto withSetCurrentlyExecutingActivity(ActivityHandle activity, Func&& func) {
+auto withCurrentlyExecutingActivity(Func&& func) {
   return [
-    func = std::forward<Func>(func), activity
+    func = std::forward<Func>(func),
+    activity = Registry::currentlyExecutingActivity()
   ]<typename... Args,
     typename = std::enable_if_t<std::is_invocable_v<Func, Args...>>>(
       Args && ... args) mutable {
     Registry::ScopedCurrentlyExecutingActivity guard(activity);
     return std::forward<Func>(func)(std::forward<Args>(args)...);
   };
-}
-
-template<typename Func>
-auto withCurrentlyExecutingActivity(Func&& func) {
-  return withSetCurrentlyExecutingActivity(
-      Registry::currentlyExecutingActivity(), std::forward<Func>(func));
 }
 
 }  // namespace arangodb::activities

--- a/lib/Activities/include/Activities/RegistryGlobalVariable.h
+++ b/lib/Activities/include/Activities/RegistryGlobalVariable.h
@@ -40,11 +40,4 @@ template<typename T, typename... Args>
 auto make(Args&&... args) -> T::HandleType {
   return registry.makeActivity<T>(std::forward<Args>(args)...);
 }
-
-template<typename T, typename... Args>
-auto makeWithParent(ActivityHandle parent, Args&&... args) -> T::HandleType {
-  return registry.makeActivityWithParent<T>(std::move(parent),
-                                            std::forward<Args>(args)...);
-}
-
 }  // namespace arangodb::activities

--- a/tests/Activities/ActivitiesSchedulerTest.cpp
+++ b/tests/Activities/ActivitiesSchedulerTest.cpp
@@ -131,17 +131,18 @@ TEST_F(ActivitiesSchedulerTest, with_set_current_activity_works) {
 
   auto new_activity = arangodb::activities::make<activities::GenericActivity>(
       "TestActivity", this->activityData);
-  auto id_to_expect = new_activity;
-  // No guard is intentional
-
-  scheduler.queue(
-      arangodb::RequestLane::CLIENT_FAST,
-      arangodb::activities::withSetCurrentlyExecutingActivity(
-          id_to_expect, [&id_to_expect]() {
-            EXPECT_EQ(
-                arangodb::activities::Registry::currentlyExecutingActivity(),
-                id_to_expect);
-          }));
+  {
+    auto new_guard =
+        arangodb::activities::Registry::ScopedCurrentlyExecutingActivity(
+            new_activity);
+    scheduler.queue(
+        arangodb::RequestLane::CLIENT_FAST,
+        arangodb::activities::withCurrentlyExecutingActivity([&new_activity]() {
+          EXPECT_EQ(
+              arangodb::activities::Registry::currentlyExecutingActivity(),
+              new_activity);
+        }));
+  }
 
   // TODO: Is there a way to know whether the queued thing ran?
   scheduler.shutdown();

--- a/tests/Activities/ActivityRegistryTest.cpp
+++ b/tests/Activities/ActivityRegistryTest.cpp
@@ -168,41 +168,22 @@ TEST_F(ActivityRegistryTest, nested_scopes_set_reset_activity) {
   EXPECT_EQ(Registry::currentlyExecutingActivity(), nullptr);
 }
 
-TEST_F(ActivityRegistryTest, with_set_current_activity) {
-  auto a = activities::make<GenericActivity>("GenericActivity",
-                                             GenericActivityData{});
-  EXPECT_EQ(Registry::currentlyExecutingActivity(), ActivityRoot);
-
-  auto scoped = withSetCurrentlyExecutingActivity(
-      a, [a]() { EXPECT_EQ(Registry::currentlyExecutingActivity(), a); });
-
-  EXPECT_EQ(Registry::currentlyExecutingActivity(), ActivityRoot);
-
-  auto b = activities::make<GenericActivity>("GenericActivity",
-                                             GenericActivityData{});
-  auto scopeGuard = Registry::ScopedCurrentlyExecutingActivity(b);
-
-  EXPECT_EQ(Registry::currentlyExecutingActivity(), b);
-
-  scoped();
-
-  EXPECT_EQ(Registry::currentlyExecutingActivity(), b);
-}
-
 TEST_F(ActivityRegistryTest, with_current_activity) {
-  auto outer = activities::make<GenericActivity>("GenericActivity",
-                                                 GenericActivityData{});
-  auto inner = activities::make<GenericActivity>("GenericActivity",
-                                                 GenericActivityData{});
-
+  auto outer =
+      activities::make<GenericActivity>("outer", GenericActivityData{});
   auto outerGuard = Registry::ScopedCurrentlyExecutingActivity(outer);
+
   auto testee = withCurrentlyExecutingActivity(
-      [current = Registry::currentlyExecutingActivity()]() {
+      [current = Registry::currentlyExecutingActivity(), outer]() {
         EXPECT_EQ(Registry::currentlyExecutingActivity(), current);
+        EXPECT_EQ(current, outer);
       });
 
   {
+    auto inner =
+        activities::make<GenericActivity>("inner", GenericActivityData{});
     auto innerGuard = Registry::ScopedCurrentlyExecutingActivity(inner);
+
     testee();
   }
 }

--- a/tests/Activities/CMakeLists.txt
+++ b/tests/Activities/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(arango_tests_activities OBJECT
   ActivitiesAsyncTest.cpp
   ActivitiesSchedulerTest.cpp
   ActivityRegistryTest.cpp
-  GenericActivityTest.cpp)
+  GenericActivityTest.cpp
+  CustomGuardedActivityTest.cpp)
 target_link_libraries(arango_tests_activities PRIVATE
   arango_activities_global
   arango_tests_basics 

--- a/tests/Activities/CustomGuardedActivityTest.cpp
+++ b/tests/Activities/CustomGuardedActivityTest.cpp
@@ -1,0 +1,86 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+#include "Activities/RegistryGlobalVariable.h"
+#include "Async/async.h"
+#include "Containers/Concurrent/thread.h"
+#include "Activities/GenericActivity.h"
+#include "Inspection/JsonPrintInspector.h"
+#include <gtest/gtest.h>
+
+#include <coroutine>
+#include <thread>
+
+using namespace arangodb;
+using namespace arangodb::activities;
+
+namespace {
+struct CustomData {
+  int a;
+  std::string b;
+};
+template<typename Inspector>
+auto inspect(Inspector& f, CustomData& x) {
+  return f.object(x).fields(f.field("a", x.a), f.field("b", x.b));
+}
+struct CustomActivity : GuardedActivity<CustomActivity, CustomData> {
+  CustomActivity(ActivityId id, ActivityHandle parent, ActivityType type,
+                 CustomData data)
+      : GuardedActivity<CustomActivity, CustomData>(
+            std::move(id), std::move(parent), std::move(type),
+            std::move(data)) {}
+};
+
+}  // namespace
+
+struct CustomGuardedActivityTest : ::testing::Test {
+  CustomGuardedActivityTest() {
+    Registry::setCurrentlyExecutingActivity(activities::Root);
+  }
+  void TearDown() override { registry.garbageCollect(); }
+};
+
+TEST_F(CustomGuardedActivityTest, metadata_is_set) {
+  auto a = CustomActivity(1, nullptr, "TestActivity",       //
+                          CustomData{.a = 4, .b = "one"});  //
+
+  auto t = a.copyData();
+  ASSERT_EQ(t.a, 4);
+  ASSERT_EQ(t.b, "one");
+}
+
+TEST_F(CustomGuardedActivityTest, metadata_can_be_changed) {
+  auto a = CustomActivity(1, nullptr, "TestActivity",       //
+                          CustomData{.a = 4, .b = "one"});  //
+  a.updateData([](auto&& m) { m.a = 7; });
+
+  auto t = a.copyData();
+  ASSERT_EQ(t.a, 7);
+  ASSERT_EQ(t.b, "one");
+}
+
+TEST_F(CustomGuardedActivityTest, metadata_mutator_returns_value) {
+  auto a = CustomActivity(1, nullptr, "TestActivity",       //
+                          CustomData{.a = 4, .b = "one"});  //
+  auto w = a.getData([](auto&& m) { return m.a; });
+
+  ASSERT_EQ(w, 4);
+}

--- a/tests/js/client/shell/api/activities.js
+++ b/tests/js/client/shell/api/activities.js
@@ -118,11 +118,20 @@ function activityRegistrySuite() {
           internal.wait(1);
           maxWait--;
         }
-        assertArrayLengthLargerThan(activities.filter(dumpContextFetchFilter()), 0);
+        const dumpContextFetchActivities = activities.filter(dumpContextFetchFilter());
+        assertArrayLengthLargerThan(dumpContextFetchActivities, 0);
         assertArrayLengthLargerThan(activities, 3);
         assertArrayLengthLargerThan(activities.filter(activityRestHandlerFilter()), 0);
         assertArrayLengthLargerThan(activities.filter(dumpRestHandlerFilter()), 0);
-        assertArrayLengthLargerThan(activities.filter(dumpContextFilter()), 0);
+        const dumpContextActivities = activities.filter(dumpContextFilter());
+        assertArrayLengthLargerThan(dumpContextActivities, 0);
+
+        // check that one of the dump context activities is the parent activity
+        // of one of the dump fetch activities
+        const dumpContextActivityIds = dumpContextActivities.map((a) => a.id);
+        const dumpContextFetchActivityParents = dumpContextFetchActivities.map((a) => a.parent);
+        assertArrayLengthLargerThan(dumpContextActivityIds
+          .filter((id) => dumpContextFetchActivityParents.includes(id)), 0);
 
         // stop first dump-fetch Rest call with a second call
         const cursorId2 = fetchDumpAsynchronously(dumpId, server);


### PR DESCRIPTION
Does some cleanup in the activities:
- Gets rid of unnecessary alias in `TransactionActivity.h`
- Gets rid of unnecessary functions (`RestDumpHandler.cpp`,`Registry.h`, `RegistryGlobalVariable.h`, `ActivityRegistryTest`)
  -> withSetCurrentlyExecutingActivity is the same as executing withCurrentlyExecutingActivity in a ScopedCurrentlyExecutingActivity
  -> makeWithParent is the same as executing make in a ScopedCurrentlyExecutingActivity
- Adds gtests for a custom typed activity (CustomGuardedActivityTest.cpp and corresponding CMakeLists.txt)
- Tests parent-child relationship in a test in `activities.js`
