### PR TITLE
[COR-518] Fix tsan on database check

### DIFF
--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -160,7 +160,7 @@ void ArangodServer::addFeatures(
   addFeature<ReplicationMetricsFeature>(metrics);
   addFeature<ReplicationTimeoutFeature>();
   auto& scheduler = addFeature<SchedulerFeature>(metrics);
-  auto& vectorIndex = addFeature<VectorIndexFeature>();
+  auto& vectorIndex = addFeature<VectorIndexFeature>(database);
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   addFeature<ProcessEnvironmentFeature>(std::string{binaryName});
 #endif

--- a/arangod/VectorIndex/VectorIndexFeature.cpp
+++ b/arangod/VectorIndex/VectorIndexFeature.cpp
@@ -36,8 +36,9 @@
 namespace arangodb {
 
 VectorIndexFeature::VectorIndexFeature(
-    application_features::ApplicationServer& server)
-    : ApplicationFeature{server, *this} {
+    application_features::ApplicationServer& server,
+    DatabaseFeature& databaseFeature)
+    : ApplicationFeature{server, *this}, _databaseFeature{databaseFeature} {
   setOptional(false);
   startsAfter<application_features::BasicFeaturePhaseServer>();
 }
@@ -49,8 +50,19 @@ void VectorIndexFeature::collectOptions(
 }
 
 bool VectorIndexFeature::shouldRunBuildManager() const {
-  return isVectorIndexEnabled() && (ServerState::instance()->isDBServer() ||
-                                    ServerState::instance()->isSingleServer());
+  if (!isVectorIndexEnabled()) {
+    return false;
+  }
+  if (!ServerState::instance()->isDBServer() &&
+      !ServerState::instance()->isSingleServer()) {
+    return false;
+  }
+  // Skip during transient startup modes that exit via _exit() without
+  // running destructors, which would leak the build manager's jthread.
+  if (_databaseFeature.checkVersion() || _databaseFeature.upgrade()) {
+    return false;
+  }
+  return true;
 }
 
 void VectorIndexFeature::start() {
@@ -58,7 +70,7 @@ void VectorIndexFeature::start() {
     return;
   }
   TRI_ASSERT(SchedulerFeature::SCHEDULER != nullptr);
-  _buildManager.emplace(server().getFeature<DatabaseFeature>(),
+  _buildManager.emplace(_databaseFeature,
                         server().getFeature<MaintenanceFeature>(),
                         server().getFeature<metrics::MetricsFeature>(),
                         *SchedulerFeature::SCHEDULER);

--- a/arangod/VectorIndex/VectorIndexFeature.h
+++ b/arangod/VectorIndex/VectorIndexFeature.h
@@ -34,10 +34,13 @@
 
 namespace arangodb {
 
+class DatabaseFeature;
+
 class VectorIndexFeature final
     : public application_features::ApplicationFeature {
  public:
-  explicit VectorIndexFeature(application_features::ApplicationServer& server);
+  VectorIndexFeature(application_features::ApplicationServer& server,
+                     DatabaseFeature& databaseFeature);
 
   static constexpr std::string_view name() noexcept { return "VectorIndex"; }
 
@@ -60,6 +63,7 @@ class VectorIndexFeature final
  private:
   bool shouldRunBuildManager() const;
 
+  DatabaseFeature& _databaseFeature;
   VectorIndexFeatureOptions _options;
   std::optional<vector::VectorIndexBuildManager> _buildManager;
 };

--- a/tests/Graph/GraphTestTools.cpp
+++ b/tests/Graph/GraphTestTools.cpp
@@ -70,7 +70,8 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
                         false);
   features.emplace_back(
       server.addFeature<arangodb::transaction::ManagerFeature>(metrics), false);
-  features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(), false);
+  auto& databaseFeature = server.addFeature<arangodb::DatabaseFeature>();
+  features.emplace_back(databaseFeature, false);
   features.emplace_back(server.addFeature<arangodb::EngineSelectorFeature>(),
                         false);
   server.getFeature<EngineSelectorFeature>().setEngineTesting(&engine);
@@ -91,8 +92,8 @@ GraphTestSetup::GraphTestSetup() : server(nullptr, nullptr), engine(server) {
                         true);  // required for IResearchAnalyzerFeature
   features.emplace_back(
       server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
-  features.emplace_back(server.addFeature<arangodb::VectorIndexFeature>(),
-                        true);
+  features.emplace_back(
+      server.addFeature<arangodb::VectorIndexFeature>(databaseFeature), true);
 
   for (auto& f : features) {
     f.first.prepare();

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -270,8 +270,9 @@ struct IResearchExpressionFilterTest
         arangodb::LazyApplicationFeatureReference<arangodb::ClusterFeature>(
             nullptr));
     features.emplace_back(metrics, false);
-    features.emplace_back(server.addFeature<arangodb::VectorIndexFeature>(),
-                          false);
+    features.emplace_back(
+        server.addFeature<arangodb::VectorIndexFeature>(databaseFeature),
+        false);
     features.emplace_back(
         server.addFeature<arangodb::QueryRegistryFeature>(metrics),
         false);  // must be first

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -311,10 +311,12 @@ class IResearchOrderTest
         server.addFeature<arangodb::aql::AqlFunctionFeature>(), true);
     features.emplace_back(
         server.addFeature<arangodb::MaintenanceFeature>(nullptr), false);
-    features.emplace_back(server.addFeature<arangodb::DatabaseFeature>(),
+    auto& databaseFeature = server.addFeature<arangodb::DatabaseFeature>();
+    features.emplace_back(databaseFeature,
                           false);  // required for calculationVocbase
-    features.emplace_back(server.addFeature<arangodb::VectorIndexFeature>(),
-                          false);
+    features.emplace_back(
+        server.addFeature<arangodb::VectorIndexFeature>(databaseFeature),
+        false);
     {
       auto& feature =
           features

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -555,7 +555,7 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
 
     auto& rocksDbRecoveryManager = as.addFeature<RocksDBRecoveryManager>();
     auto& databaseFeature = as.addFeature<DatabaseFeature>();
-    auto& vectorIndex = as.addFeature<VectorIndexFeature>();
+    auto& vectorIndex = as.addFeature<VectorIndexFeature>(databaseFeature);
     auto& rocksDbIndexCacheRefillFeature =
         as.addFeature<RocksDBIndexCacheRefillFeature>(databaseFeature, nullptr,
                                                       metrics);

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -182,7 +182,7 @@ static void SetupDatabaseFeaturePhase(MockServer& server) {
       false);  // true ??
   server.addFeature<AuthenticationFeature>(true);
   server.addFeature<transaction::ManagerFeature>(false, metrics);
-  server.addFeature<DatabaseFeature>(false);
+  auto& databaseFeature = server.addFeature<DatabaseFeature>(false);
   server.addFeature<EngineSelectorFeature>(false);
   server.addFeature<StorageEngineFeature>(false);
   server.addFeature<SystemDatabaseFeature>(true);
@@ -191,7 +191,7 @@ static void SetupDatabaseFeaturePhase(MockServer& server) {
   server.addFeature<ViewTypesFeature>(false);  // true ??
   server.addFeature<MaintenanceFeature>(false,
                                         nullptr);  // do not start the thread
-  server.addFeature<VectorIndexFeature>(true);
+  server.addFeature<VectorIndexFeature>(true, databaseFeature);
 
 #if USE_ENTERPRISE
   // required for AuthenticationFeature with USE_ENTERPRISE

--- a/tests/sepp/Server.cpp
+++ b/tests/sepp/Server.cpp
@@ -217,7 +217,7 @@ void Server::Impl::setupServer(std::string const& name, int& result) {
   _server.addFeature<ReplicationMetricsFeature>(metrics);
   _server.addFeature<ReplicationTimeoutFeature>();
   auto& scheduler = _server.addFeature<SchedulerFeature>(metrics);
-  auto& vectorIndex = _server.addFeature<VectorIndexFeature>();
+  auto& vectorIndex = _server.addFeature<VectorIndexFeature>(database);
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   _server.addFeature<ProcessEnvironmentFeature>(name);
 #endif


### PR DESCRIPTION
### Scope & Purpose

Fixes a tsan issue when we start building the thread when starting ararngodb to do database check
```
    [FAILED]  version

  ****> "test" failed:
irregular termination of  'Tue May 05 2026 03:16:54 GMT+0000 (GMT) executeAndWait: cmd =/root/project/build/bin/arangod args =["-c","none","/tmp/ArangoDB/0/arangosh_G1P1Q3/version","--database.auto-upgrade","false","--database.upgrade-check","false","--database.check-version","true"]' : false exit code: 66  -  Sanitizer indicated issues  - 

* Test "crash_0"
    [FAILED]  crash_report

  ****> "version_ALL" failed:
irregular termination of  'Tue May 05 2026 03:16:54 GMT+0000 (GMT) executeAndWait: cmd =/root/project/build/bin/arangod args =["-c","none","/tmp/ArangoDB/0/arangosh_G1P1Q3/version","--database.auto-upgrade","false","--database.upgrade-check","false","--database.check-version","true"]' : false exit code: 66  -  Sanitizer indicated issues  - 


  ****> "all" failed:
SUT crashed: 
Report of 'arangod' in /tmp/ArangoDB/0/arangosh_G1P1Q3/version/tsan.log.arangod.3016 contains: 
==================
WARNING: ThreadSanitizer: thread leak (pid=3016)
  Thread T51 'VecIdxBuild' (tid=3068, finished) created by main thread at:
    #0 pthread_create <null> (arangod+0x17dd045) (BuildId: 649b46474d26d613d42530da920099d26c6acabb)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State>>, void (*)()) <null> (libstdc++.so.6+0xeceb0) (BuildId: 753c6c8608b61d4e67be8f0c890e03e0aa046b8b)
    #2 arangodb::VectorIndexFeature::start() /root/project/arangod/VectorIndex/VectorIndexFeature.cpp:68 (arangod+0x1f736dc) (BuildId: 649b46474d26d613d42530da920099d26c6acabb)
    #3 arangodb::application_features::ApplicationServer::start() /root/project/lib/ApplicationFeatures/ApplicationServer.cpp:660 (arangod+0x4719827) (BuildId: 649b46474d26d613d42530da920099d26c6acabb)
    #4 arangodb::application_features::ApplicationServer::run(int, char**) /root/project/lib/ApplicationFeatures/ApplicationServer.cpp:226 (arangod+0x4713b51) (BuildId: 649b46474d26d613d42530da920099d26c6acabb)
    #5 runServer /root/project/arangod/RestServer/arangod.cpp:229 (arangod+0x1864271) (BuildId: 649b46474d26d613d42530da920099d26c6acabb)
    #6 main /root/project/arangod/RestServer/arangod.cpp:290 (arangod+0x1864271)

==================
ThreadSanitizer: reported 1 warnings


 * Overall state: Fail
Marking crashy!
   Suites failed: 2 Tests Failed: 1
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-518
- [ ] Design document: 
