### PR TITLE
[COR-473] Enable linear scanning for unusable shards

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,9 @@
   and fail with an internal error with the message "Did not find a DBServer to
   contact for RemoteNode" in production.
 
+* COR-473: Enabled linear scanning of shards that are untrained and in
+  unusable state for having insufficient documents
+
 * Upgraded included rclone to v1.73.5 with go1.25.11 and non-vulnerable
   dependencies.
 

--- a/arangod/Aql/Executor/EnumerateNearVectorExecutor.cpp
+++ b/arangod/Aql/Executor/EnumerateNearVectorExecutor.cpp
@@ -152,8 +152,6 @@ void EnumerateNearVectorsExecutor::searchResults() {
   _documents = std::move(result.capturedDocuments);
   _currentProcessedResultCount = 0;
 
-  TRI_ASSERT(hasResults());
-
   auto validCount = std::count_if(_labels.begin(), _labels.end(),
                                   [](auto const& l) { return l != -1; });
   LOG_TOPIC("f1a2b", DEBUG, Logger::ENGINES) << std::format(

--- a/arangod/Aql/Optimizer/Rule/UseVectorIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/UseVectorIndex.cpp
@@ -345,7 +345,7 @@ void useVectorIndexRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
         continue;
       }
 
-      if (!index->isVectorIndexReady()) {
+      if (!index->isVectorIndexReady() && !index->isLinearScanEnabled()) {
         THROW_ARANGO_EXCEPTION_MESSAGE(
             TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
             std::format(

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -509,6 +509,14 @@ Index::StreamSupportResult ClusterIndex::supportsStreamInterface(
   return Index::StreamSupportResult::makeUnsupported();
 }
 
+bool ClusterIndex::isLinearScanEnabled() const noexcept {
+  //  Linear scanning is enabled only for vector indexes.
+  if (ADB_LIKELY(_indexType == TRI_IDX_TYPE_VECTOR_INDEX))
+    return true;
+
+  return false;
+}
+
 bool ClusterIndex::isVectorIndexReady() const noexcept {
   if (_indexType != TRI_IDX_TYPE_VECTOR_INDEX) {
     return false;

--- a/arangod/ClusterEngine/ClusterIndex.cpp
+++ b/arangod/ClusterEngine/ClusterIndex.cpp
@@ -511,8 +511,7 @@ Index::StreamSupportResult ClusterIndex::supportsStreamInterface(
 
 bool ClusterIndex::isLinearScanEnabled() const noexcept {
   //  Linear scanning is enabled only for vector indexes.
-  if (ADB_LIKELY(_indexType == TRI_IDX_TYPE_VECTOR_INDEX))
-    return true;
+  if (ADB_LIKELY(_indexType == TRI_IDX_TYPE_VECTOR_INDEX)) return true;
 
   return false;
 }

--- a/arangod/ClusterEngine/ClusterIndex.h
+++ b/arangod/ClusterEngine/ClusterIndex.h
@@ -123,6 +123,8 @@ class ClusterIndex : public Index {
 
   bool isVectorIndexReady() const noexcept override;
 
+  bool isLinearScanEnabled() const noexcept override;
+
  protected:
   ClusterEngineType _engineType;
   Index::IndexType _indexType;

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -1022,6 +1022,8 @@ bool Index::canWarmup() const noexcept { return false; }
 
 bool Index::isVectorIndexReady() const noexcept { return false; }
 
+bool Index::isLinearScanEnabled() const noexcept { return false; }
+
 vector::UserVectorIndexDefinition const& Index::getVectorIndexDefinition() {
   TRI_ASSERT(false);
   THROW_ARANGO_EXCEPTION_MESSAGE(

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -458,6 +458,8 @@ class Index {
   // way to
   virtual bool isVectorIndexReady() const noexcept;
 
+  virtual bool isLinearScanEnabled() const noexcept;
+
   virtual StoredValues const& storedValues() const;
 
   virtual bool canWarmup() const noexcept;

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -388,11 +388,15 @@ RocksDBVectorIndex::bruteForceSearch(
   };
 
   //  Iterate over all documents in the shard and build the heap.
+  //  TODO: Redesign and refactor the min/max implementations
+  //  https://arangodb.atlassian.net/browse/COR-615
   iter->allDocuments([&](LocalDocumentId docId, aql::DocumentData&&,
                          velocypack::Slice docSlice) -> bool {
     currentDocVector.clear();
     auto ret = getNormalizedVectorFromDocument(docSlice, currentDocVector);
-    if (!ret) return true;
+    if (!ret) {
+      return true;
+    }
 
     if (hasFilter && !filterDocuments(config, ctx, docSlice)) {
       return true;

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -32,6 +32,9 @@
 #include <cstring>
 
 #include "Aql/AstNode.h"
+#include "Aql/AqlFunctionsInternalCache.h"
+#include "Aql/AqlValue.h"
+#include "Aql/DocumentExpressionContext.h"
 #include "Basics/StaticStrings.h"
 #include "Aql/Function.h"
 #include "Assertions/Assert.h"
@@ -276,8 +279,7 @@ void RocksDBVectorIndex::toVelocyPack(
 }
 
 bool RocksDBVectorIndex::getNormalizedVectorFromDocument(
-  const velocypack::Slice& docSlice,
-  vector::Vector& vec) {
+    const velocypack::Slice& docSlice, vector::Vector& vec) {
   if (readDocumentVectorData(docSlice, vec).fail()) {
     return false;
   }
@@ -288,9 +290,12 @@ bool RocksDBVectorIndex::getNormalizedVectorFromDocument(
   return true;
 }
 
-float RocksDBVectorIndex::computeDistance(const vector::Vector& vec1, const vector::Vector& vec2, bool isDescending) {
-  TRI_ASSERT(vec1.size() == vec2.size()) << "Vector dimensions don't match, " <<
-    "[" << vec1 << "] != [" << vec2 << "]";
+float RocksDBVectorIndex::computeDistance(const vector::Vector& vec1,
+                                          const vector::Vector& vec2,
+                                          bool isDescending) {
+  TRI_ASSERT(vec1.size() == vec2.size())
+      << "Vector dimensions don't match, "
+      << "[" << vec1 << "] != [" << vec2 << "]";
 
   auto dim = vec1.size();
 
@@ -303,15 +308,62 @@ float RocksDBVectorIndex::computeDistance(const vector::Vector& vec1, const vect
   return distance;
 }
 
+bool RocksDBVectorIndex::filterDocuments(
+    vector::VectorSearchConfig const& config,
+    vector::VectorSearchContext const& ctx, velocypack::Slice docSlice) {
+  TRI_ASSERT(ctx.queryContext != nullptr);
+  TRI_ASSERT(config.filterExpression != nullptr);
+  TRI_ASSERT(config.documentVariable != nullptr);
+  TRI_ASSERT(ctx.inputRow != nullptr);
+
+  auto* trx = ctx.trx;
+  aql::AqlFunctionsInternalCache functionsCache;
+
+  aql::GenericDocumentExpressionContext exprCtx(
+      *trx, *ctx.queryContext, functionsCache, config.filterVarsToRegs,
+      *ctx.inputRow, config.documentVariable);
+  exprCtx.setCurrentDocument(docSlice);
+  bool mustDestroy = false;
+  aql::AqlValue result =
+      config.filterExpression->execute(&exprCtx, mustDestroy);
+  aql::AqlValueGuard guard(result, mustDestroy);
+  return result.toBoolean();
+}
+
+void RocksDBVectorIndex::captureDocument(
+    vector::VectorSearchConfig const& config,
+    vector::VectorSearchContext const& ctx,
+    containers::NodeHashMap<LocalDocumentId, velocypack::SharedSlice>*
+        captureSink,
+    LocalDocumentId docId, velocypack::Slice docSlice) {
+  if (captureSink == nullptr) {
+    return;
+  }
+
+  auto* trx = ctx.trx;
+  auto const& projectionMode = config.strategy.projection;
+
+  if (projectionMode == vector::ProjectionMode::kDocument) {
+    captureSink->insert_or_assign(docId, vector::toOwnedSharedSlice(docSlice));
+  } else if (projectionMode == vector::ProjectionMode::kCovered &&
+             hasStoredValues()) {
+    auto extracted =
+        transaction::extractAttributeValues(*trx, _storedValues, docSlice, true)
+            ->get();
+    captureSink->insert_or_assign(docId, extracted->sharedSlice());
+  }
+}
+
 std::pair<vector::Labels, vector::Distances>
-RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
-                                     std::size_t topK,
-                                     transaction::Methods* trx,
-                                     vector::ProjectionMode projectionMode,
-                                     containers::NodeHashMap<LocalDocumentId,
-                                                             velocypack::SharedSlice>*
-                                         captureSink) {
+RocksDBVectorIndex::bruteForceSearch(
+    vector::Vector& searchVector, vector::VectorSearchConfig const& config,
+    vector::VectorSearchContext const& ctx,
+    containers::NodeHashMap<LocalDocumentId, velocypack::SharedSlice>*
+        captureSink) {
   auto const dim = _definition.dimension;
+  auto const topK = config.topK;
+  auto* trx = ctx.trx;
+  // auto const& projectionMode = config.strategy.projection;
 
   bool const isDescending =
       _definition.metric == vector::SimilarityMetric::kCosine ||
@@ -326,22 +378,8 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
   vector::Vector currentDocVector;
   currentDocVector.reserve(dim);
 
-  auto captureDocument = [&](LocalDocumentId docId,
-                             velocypack::Slice docSlice) {
-    if (captureSink == nullptr) {
-      return;
-    }
-    if (projectionMode == vector::ProjectionMode::kDocument) {
-      captureSink->insert_or_assign(docId, vector::toOwnedSharedSlice(docSlice));
-    } else if (projectionMode == vector::ProjectionMode::kCovered &&
-               hasStoredValues()) {
-      auto extracted =
-          transaction::extractAttributeValues(*trx, _storedValues, docSlice,
-                                              true)
-              ->get();
-      captureSink->insert_or_assign(docId, extracted->sharedSlice());
-    }
-  };
+  bool const hasFilter = config.strategy.filter != FilterMode::kNone;
+  aql::AqlFunctionsInternalCache functionsCache;
 
   auto eraseCaptured = [&](vector::VectorIndexLabelId id) {
     if (captureSink != nullptr && id >= 0) {
@@ -352,40 +390,39 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
   //  Iterate over all documents in the shard and build the heap.
   iter->allDocuments([&](LocalDocumentId docId, aql::DocumentData&&,
                          velocypack::Slice docSlice) -> bool {
-
     currentDocVector.clear();
     auto ret = getNormalizedVectorFromDocument(docSlice, currentDocVector);
-    if (!ret)
+    if (!ret) return true;
+
+    if (hasFilter && !filterDocuments(config, ctx, docSlice)) {
       return true;
+    }
 
     auto dist = computeDistance(currentDocVector, searchVector, isDescending);
     auto id = static_cast<vector::VectorIndexLabelId>(docId.id());
 
-    if (n < topK)
-    {
+    if (n < topK) {
       if (isDescending) {
         faiss::minheap_push(n + 1, distances.data(), labels.data(), dist, id);
       } else {
         faiss::maxheap_push(n + 1, distances.data(), labels.data(), dist, id);
       }
-      captureDocument(docId, docSlice);
+      captureDocument(config, ctx, captureSink, docId, docSlice);
       ++n;
-    }
-    else
-    {
+    } else {
       if (isDescending) {
         if (dist > distances[0]) {
           eraseCaptured(labels[0]);
-          faiss::minheap_replace_top(topK, distances.data(), labels.data(), dist,
-                                    id);
-          captureDocument(docId, docSlice);
+          faiss::minheap_replace_top(topK, distances.data(), labels.data(),
+                                     dist, id);
+          captureDocument(config, ctx, captureSink, docId, docSlice);
         }
       } else {
         if (dist < distances[0]) {
           eraseCaptured(labels[0]);
-          faiss::maxheap_replace_top(topK, distances.data(), labels.data(), dist,
-                                    id);
-          captureDocument(docId, docSlice);
+          faiss::maxheap_replace_top(topK, distances.data(), labels.data(),
+                                     dist, id);
+          captureDocument(config, ctx, captureSink, docId, docSlice);
         }
       }
     }
@@ -434,18 +471,17 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   bool const captureNeeded =
       config.strategy.projection == ProjectionMode::kCovered ||
       (config.strategy.projection == ProjectionMode::kDocument &&
-        config.strategy.filter == FilterMode::kDocument);
+       config.strategy.filter == FilterMode::kDocument);
   auto* captureSink = captureNeeded ? &result.capturedDocuments : nullptr;
 
   if (auto const state = _trainingState.load();
       state != VectorIndexTrainingState::kReady) {
-
     if (isLinearScanEnabled()) {
       // Not enough training data: fall back to linear scan on this shard so
       // cluster vector search stays usable.
 
-      auto [labels, distances] = bruteForceSearch(
-          inputs, config.topK, ctx.trx, config.strategy.projection, captureSink);
+      auto [labels, distances] =
+          bruteForceSearch(inputs, config, ctx, captureSink);
       result.labels = std::move(labels);
       result.distances = std::move(distances);
       return result;
@@ -483,9 +519,7 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   return result;
 }
 
-bool RocksDBVectorIndex::isLinearScanEnabled() const noexcept {
-  return true;
-}
+bool RocksDBVectorIndex::isLinearScanEnabled() const noexcept { return true; }
 
 bool RocksDBVectorIndex::isVectorIndexReady() const noexcept {
   return _trainingState.load(std::memory_order_acquire) ==

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -291,7 +291,6 @@ bool RocksDBVectorIndex::getNormalizedVectorFromDocument(
 float RocksDBVectorIndex::computeDistance(const vector::Vector& vec1, const vector::Vector& vec2, bool isDescending) {
   TRI_ASSERT(vec1.size() == vec2.size()) << "Vector dimensions don't match, " <<
     "[" << vec1 << "] != [" << vec2 << "]";
-    // vec1.size() << " != " << vec2.size();
 
   auto dim = vec1.size();
 
@@ -324,8 +323,8 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
 
   auto iter = _collection.getPhysical()->getAllIterator(trx, ReadOwnWrites::no);
 
-  vector::Vector vec;
-  vec.reserve(dim);
+  vector::Vector currentDocVector;
+  currentDocVector.reserve(dim);
 
   auto captureDocument = [&](LocalDocumentId docId,
                              velocypack::Slice docSlice) {
@@ -354,12 +353,12 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
   iter->allDocuments([&](LocalDocumentId docId, aql::DocumentData&&,
                          velocypack::Slice docSlice) -> bool {
 
-    vec.clear();
-    auto ret = getNormalizedVectorFromDocument(docSlice, vec);
+    currentDocVector.clear();
+    auto ret = getNormalizedVectorFromDocument(docSlice, currentDocVector);
     if (!ret)
       return true;
 
-    auto dist = computeDistance(vec, searchVector, isDescending);
+    auto dist = computeDistance(currentDocVector, searchVector, isDescending);
     auto id = static_cast<vector::VectorIndexLabelId>(docId.id());
 
     if (n < topK)
@@ -394,6 +393,10 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
     return true;
   });
 
+  // Truncate labels and distances to min(topK, total_no_of_documents)
+  labels.resize(n);
+  distances.resize(n);
+
   // Reorder heap so results are sorted
   if (isDescending) {
     faiss::minheap_reorder(topK, distances.data(), labels.data());
@@ -416,8 +419,6 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   TRI_ASSERT(ctx.inputs != nullptr);
   TRI_ASSERT(ctx.trx != nullptr);
   // The on_heap_changed are not thread safe unless this is true
-  // ADB_PROD_ASSERT(_faissIndex->parallel_mode == 0)
-  //     << "FAISS parallel_mode must be 0; got " << _faissIndex->parallel_mode;
 
   auto& inputs = *ctx.inputs;
   TRI_ASSERT(inputs.size() == _definition.dimension)

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -252,23 +252,11 @@ void RocksDBVectorIndex::toVelocyPack(
     builder.close();
   }
 
-  auto const isEmptyShard = [&]() noexcept -> bool {
-    // On DBServers (and single server) this is a RocksDB collection.
-    // For empty shards, vector search should be allowed and return no results.
-    auto* physical = collection().getPhysical();
-    auto* meta = dynamic_cast<RocksDBMetaCollection*>(physical);
-    return meta != nullptr && meta->meta().numberDocuments() == 0;
-  };
-
   auto const trainingState = _trainingState.load();
-  auto const reportedState =
-      (trainingState == VectorIndexTrainingState::kUnusable && isEmptyShard())
-          ? VectorIndexTrainingState::kReady
-          : trainingState;
 
   builder.add(StaticStrings::IndexTrainingState,
-              VPackValue(trainingStateToString(reportedState)));
-  if (reportedState == VectorIndexTrainingState::kUnusable) {
+              VPackValue(trainingStateToString(trainingState)));
+  if (trainingState == VectorIndexTrainingState::kUnusable) {
     builder.add(StaticStrings::ErrorMessage,
                 VPackValue("not enough training data for vector index"));
   }

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -55,6 +55,8 @@
 #include "VocBase/Identifiers/LocalDocumentId.h"
 #include "VocBase/LogicalCollection.h"
 #include <rocksdb/db.h>
+#include "RocksDBEngine/RocksDBMetaCollection.h"
+#include "VectorIndex/VectorIndexDefinition.h"
 
 #include "faiss/MetricType.h"
 #include "faiss/utils/distances.h"
@@ -247,16 +249,133 @@ void RocksDBVectorIndex::toVelocyPack(
     builder.close();
   }
 
+  auto const isEmptyShard = [&]() noexcept -> bool {
+    // On DBServers (and single server) this is a RocksDB collection.
+    // For empty shards, vector search should be allowed and return no results.
+    auto* physical = collection().getPhysical();
+    auto* meta = dynamic_cast<RocksDBMetaCollection*>(physical);
+    return meta != nullptr && meta->meta().numberDocuments() == 0;
+  };
+
   auto const trainingState = _trainingState.load();
+  auto const reportedState =
+      (trainingState == VectorIndexTrainingState::kUnusable && isEmptyShard())
+          ? VectorIndexTrainingState::kReady
+          : trainingState;
+
   builder.add(StaticStrings::IndexTrainingState,
-              VPackValue(trainingStateToString(trainingState)));
-  if (trainingState == VectorIndexTrainingState::kUnusable) {
-    builder.add(StaticStrings::ErrorMessage, VPackValue(trainingError()));
+              VPackValue(trainingStateToString(reportedState)));
+  if (reportedState == VectorIndexTrainingState::kUnusable) {
+    builder.add(StaticStrings::ErrorMessage,
+                VPackValue("not enough training data for vector index"));
   }
 
   if (auto const nLists = resolvedNLists(); nLists.has_value()) {
     builder.add(StaticStrings::IndexResolvedNLists, VPackValue(*nLists));
   }
+}
+
+bool RocksDBVectorIndex::getNormalizedVectorFromDocument(
+  const velocypack::Slice& docSlice,
+  vector::Vector& vec) {
+  if (readDocumentVectorData(docSlice, vec).fail()) {
+    return false;
+  }
+  auto dim = vec.size();
+  if (_definition.metric == vector::SimilarityMetric::kCosine) {
+    faiss::fvec_renorm_L2(dim, 1, vec.data());
+  }
+  return true;
+}
+
+float RocksDBVectorIndex::computeDistance(const vector::Vector& vec1, const vector::Vector& vec2, bool isDescending) {
+  TRI_ASSERT(vec1.size() == vec2.size()) << "Vector dimensions don't match, " <<
+    "[" << vec1 << "] != [" << vec2 << "]";
+    // vec1.size() << " != " << vec2.size();
+
+  auto dim = vec1.size();
+
+  float distance;
+  if (isDescending)
+    distance = faiss::fvec_inner_product(vec1.data(), vec2.data(), dim);
+  else
+    distance = faiss::fvec_L2sqr(vec1.data(), vec2.data(), dim);
+
+  return distance;
+}
+
+std::pair<vector::Labels, vector::Distances>
+RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
+                                     std::size_t topK,
+                                     transaction::Methods* trx) {
+  auto const dim = _definition.dimension;
+
+  bool const isDescending =
+      _definition.metric == vector::SimilarityMetric::kCosine ||
+      _definition.metric == vector::SimilarityMetric::kInnerProduct;
+
+  vector::Labels labels(topK, -1);
+  vector::Distances distances(topK);
+  std::size_t n = 0;
+
+  auto iter = _collection.getPhysical()->getAllIterator(trx, ReadOwnWrites::no);
+
+  vector::Vector vec;
+  vec.reserve(dim);
+
+  //  Iterate over all documents in the shard and build the heap.
+  iter->allDocuments([&](LocalDocumentId docId, aql::DocumentData&&,
+                         velocypack::Slice docSlice) -> bool {
+
+    vec.clear();
+    auto ret = getNormalizedVectorFromDocument(docSlice, vec);
+    if (!ret)
+      return true;
+
+    auto dist = computeDistance(vec, searchVector, isDescending);
+    auto id = static_cast<vector::VectorIndexLabelId>(docId.id());
+
+    if (n < topK)
+    {
+      if (isDescending) {
+        faiss::minheap_push(n + 1, distances.data(), labels.data(), dist, id);
+      } else {
+        faiss::maxheap_push(n + 1, distances.data(), labels.data(), dist, id);
+      }
+    }
+    else
+    {
+      if (isDescending) {
+        if (dist > distances[0]) {
+          faiss::minheap_replace_top(topK, distances.data(), labels.data(), dist,
+                                    id);
+        }
+      } else {
+        if (dist < distances[0]) {
+          faiss::maxheap_replace_top(topK, distances.data(), labels.data(), dist,
+                                    id);
+        }
+      }
+    }
+    ++n;
+
+    return true;
+  });
+
+  // Reorder heap so results are sorted
+  if (isDescending) {
+    faiss::minheap_reorder(topK, distances.data(), labels.data());
+  } else {
+    faiss::maxheap_reorder(topK, distances.data(), labels.data());
+  }
+
+  // L2: fvec_L2sqr returns squared distances, take sqrt
+  if (_definition.metric == vector::SimilarityMetric::kL2) {
+    std::ranges::transform(distances, distances.begin(),
+                           [](float d) { return std::sqrt(d); });
+  }
+
+  return {std::move(labels), std::move(distances)};
 }
 
 vector::SearchResult RocksDBVectorIndex::readBatch(
@@ -265,8 +384,8 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   TRI_ASSERT(ctx.inputs != nullptr);
   TRI_ASSERT(ctx.trx != nullptr);
   // The on_heap_changed are not thread safe unless this is true
-  ADB_PROD_ASSERT(_faissIndex->parallel_mode == 0)
-      << "FAISS parallel_mode must be 0; got " << _faissIndex->parallel_mode;
+  // ADB_PROD_ASSERT(_faissIndex->parallel_mode == 0)
+  //     << "FAISS parallel_mode must be 0; got " << _faissIndex->parallel_mode;
 
   auto& inputs = *ctx.inputs;
   TRI_ASSERT(inputs.size() == _definition.dimension)
@@ -278,8 +397,19 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
     faiss::fvec_renorm_L2(_definition.dimension, 1, inputs.data());
   }
 
+  vector::SearchResult result;
   if (auto const state = _trainingState.load();
       state != VectorIndexTrainingState::kReady) {
+
+    if (isLinearScanEnabled()) {
+      // Not enough training data: fall back to linear scan on this shard so
+      // cluster vector search stays usable.
+      auto [labels, distances] = bruteForceSearch(inputs, config.topK, ctx.trx);
+      result.labels = std::move(labels);
+      result.distances = std::move(distances);
+      return result;
+    }
+
     // This should never happen — the optimizer should not use
     // EnumerateNearVectorNode when the vector index is not ready.
     THROW_ARANGO_EXCEPTION_MESSAGE(
@@ -290,7 +420,6 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   TRI_ASSERT(_faissIndex != nullptr);
 
   // Trained: normal FAISS IVF search
-  vector::SearchResult result;
   result.distances.resize(config.topK);
   result.labels.resize(config.topK);
 
@@ -316,6 +445,10 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   }
 
   return result;
+}
+
+bool RocksDBVectorIndex::isLinearScanEnabled() const noexcept {
+  return true;
 }
 
 bool RocksDBVectorIndex::isVectorIndexReady() const noexcept {

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -307,7 +307,11 @@ float RocksDBVectorIndex::computeDistance(const vector::Vector& vec1, const vect
 std::pair<vector::Labels, vector::Distances>
 RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
                                      std::size_t topK,
-                                     transaction::Methods* trx) {
+                                     transaction::Methods* trx,
+                                     vector::ProjectionMode projectionMode,
+                                     containers::NodeHashMap<LocalDocumentId,
+                                                             velocypack::SharedSlice>*
+                                         captureSink) {
   auto const dim = _definition.dimension;
 
   bool const isDescending =
@@ -322,6 +326,29 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
 
   vector::Vector vec;
   vec.reserve(dim);
+
+  auto captureDocument = [&](LocalDocumentId docId,
+                             velocypack::Slice docSlice) {
+    if (captureSink == nullptr) {
+      return;
+    }
+    if (projectionMode == vector::ProjectionMode::kDocument) {
+      captureSink->insert_or_assign(docId, vector::toOwnedSharedSlice(docSlice));
+    } else if (projectionMode == vector::ProjectionMode::kCovered &&
+               hasStoredValues()) {
+      auto extracted =
+          transaction::extractAttributeValues(*trx, _storedValues, docSlice,
+                                              true)
+              ->get();
+      captureSink->insert_or_assign(docId, extracted->sharedSlice());
+    }
+  };
+
+  auto eraseCaptured = [&](vector::VectorIndexLabelId id) {
+    if (captureSink != nullptr && id >= 0) {
+      captureSink->erase(LocalDocumentId{static_cast<std::uint64_t>(id)});
+    }
+  };
 
   //  Iterate over all documents in the shard and build the heap.
   iter->allDocuments([&](LocalDocumentId docId, aql::DocumentData&&,
@@ -342,22 +369,27 @@ RocksDBVectorIndex::bruteForceSearch(vector::Vector& searchVector,
       } else {
         faiss::maxheap_push(n + 1, distances.data(), labels.data(), dist, id);
       }
+      captureDocument(docId, docSlice);
+      ++n;
     }
     else
     {
       if (isDescending) {
         if (dist > distances[0]) {
+          eraseCaptured(labels[0]);
           faiss::minheap_replace_top(topK, distances.data(), labels.data(), dist,
                                     id);
+          captureDocument(docId, docSlice);
         }
       } else {
         if (dist < distances[0]) {
+          eraseCaptured(labels[0]);
           faiss::maxheap_replace_top(topK, distances.data(), labels.data(), dist,
                                     id);
+          captureDocument(docId, docSlice);
         }
       }
     }
-    ++n;
 
     return true;
   });
@@ -398,13 +430,21 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   }
 
   vector::SearchResult result;
+  bool const captureNeeded =
+      config.strategy.projection == ProjectionMode::kCovered ||
+      (config.strategy.projection == ProjectionMode::kDocument &&
+        config.strategy.filter == FilterMode::kDocument);
+  auto* captureSink = captureNeeded ? &result.capturedDocuments : nullptr;
+
   if (auto const state = _trainingState.load();
       state != VectorIndexTrainingState::kReady) {
 
     if (isLinearScanEnabled()) {
       // Not enough training data: fall back to linear scan on this shard so
       // cluster vector search stays usable.
-      auto [labels, distances] = bruteForceSearch(inputs, config.topK, ctx.trx);
+
+      auto [labels, distances] = bruteForceSearch(
+          inputs, config.topK, ctx.trx, config.strategy.projection, captureSink);
       result.labels = std::move(labels);
       result.distances = std::move(distances);
       return result;
@@ -423,11 +463,6 @@ vector::SearchResult RocksDBVectorIndex::readBatch(
   result.distances.resize(config.topK);
   result.labels.resize(config.topK);
 
-  bool const captureNeeded =
-      config.strategy.projection == ProjectionMode::kCovered ||
-      (config.strategy.projection == ProjectionMode::kDocument &&
-       config.strategy.filter == FilterMode::kDocument);
-  auto* captureSink = captureNeeded ? &result.capturedDocuments : nullptr;
   auto faissSearchContext = makeFaissIteratorContext(config, ctx, captureSink);
 
   faiss::SearchParametersIVF searchParametersIvf;

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -158,12 +158,27 @@ class RocksDBVectorIndex final : public RocksDBIndex {
                 OperationOptions const& /*options*/) override;
 
  private:
-  float computeDistance(const vector::Vector& vec1, const vector::Vector& vec2, bool isDescending);
-  bool getNormalizedVectorFromDocument(const velocypack::Slice& docSlice, vector::Vector& vec);
+  //  Helper functions for bruteForceSearch
+  void captureDocument(
+      vector::VectorSearchConfig const& config,
+      vector::VectorSearchContext const& ctx,
+      containers::NodeHashMap<LocalDocumentId, velocypack::SharedSlice>*
+          captureSink,
+      LocalDocumentId docId, velocypack::Slice docSlice);
+
+  bool filterDocuments(vector::VectorSearchConfig const& config,
+                       vector::VectorSearchContext const& ctx,
+                       velocypack::Slice docSlice);
+
+  float computeDistance(const vector::Vector& vec1, const vector::Vector& vec2,
+                        bool isDescending);
+
+  bool getNormalizedVectorFromDocument(const velocypack::Slice& docSlice,
+                                       vector::Vector& vec);
 
   std::pair<vector::Labels, vector::Distances> bruteForceSearch(
-      vector::Vector& searchVector, std::size_t topK, transaction::Methods* trx,
-      vector::ProjectionMode projectionMode,
+      vector::Vector& searchVector, vector::VectorSearchConfig const& config,
+      vector::VectorSearchContext const& ctx,
       containers::NodeHashMap<LocalDocumentId, velocypack::SharedSlice>*
           captureSink);
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -88,6 +88,8 @@ class RocksDBVectorIndex final : public RocksDBIndex {
 
   bool isVectorIndexReady() const noexcept override;
 
+  bool isLinearScanEnabled() const noexcept override;
+
   Result readDocumentVectorData(velocypack::Slice doc,
                                 std::vector<float>& vector) const;
 
@@ -156,6 +158,13 @@ class RocksDBVectorIndex final : public RocksDBIndex {
                 OperationOptions const& /*options*/) override;
 
  private:
+  float computeDistance(const vector::Vector& vec1, const vector::Vector& vec2, bool isDescending);
+  bool getNormalizedVectorFromDocument(const velocypack::Slice& docSlice, vector::Vector& vec);
+
+  std::pair<vector::Labels, vector::Distances>
+  bruteForceSearch(vector::Vector& searchVector, std::size_t topK,
+                   transaction::Methods* trx);
+
   vector::VectorIndexMetadata loadVectorIndexMetadata(
       velocypack::Slice info) const;
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -161,9 +161,11 @@ class RocksDBVectorIndex final : public RocksDBIndex {
   float computeDistance(const vector::Vector& vec1, const vector::Vector& vec2, bool isDescending);
   bool getNormalizedVectorFromDocument(const velocypack::Slice& docSlice, vector::Vector& vec);
 
-  std::pair<vector::Labels, vector::Distances>
-  bruteForceSearch(vector::Vector& searchVector, std::size_t topK,
-                   transaction::Methods* trx);
+  std::pair<vector::Labels, vector::Distances> bruteForceSearch(
+      vector::Vector& searchVector, std::size_t topK, transaction::Methods* trx,
+      vector::ProjectionMode projectionMode,
+      containers::NodeHashMap<LocalDocumentId, velocypack::SharedSlice>*
+          captureSink);
 
   vector::VectorIndexMetadata loadVectorIndexMetadata(
       velocypack::Slice info) const;

--- a/arangod/RocksDBEngine/RocksDBVectorIndexList.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexList.cpp
@@ -39,7 +39,6 @@
 
 namespace arangodb::vector {
 
-namespace {
 // Copy a non-owning slice's bytes into a fresh owning SharedSlice.
 velocypack::SharedSlice toOwnedSharedSlice(velocypack::Slice slice) {
   velocypack::Buffer<uint8_t> buf;
@@ -60,7 +59,6 @@ faiss::InvertedListsIterator* makeWithStoredValuesByVersion(
   }
   ADB_UNREACHABLE;
 }
-}  // namespace
 
 /// RocksDBInvertedListsIteratorBase
 RocksDBInvertedListsIteratorBase::RocksDBInvertedListsIteratorBase(

--- a/arangod/RocksDBEngine/RocksDBVectorIndexList.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexList.h
@@ -57,7 +57,9 @@ inline faiss::MetricType metricToFaissMetric(
     case SimilarityMetric::kInnerProduct:
       return faiss::METRIC_INNER_PRODUCT;
   }
+
 }
+  velocypack::SharedSlice toOwnedSharedSlice(velocypack::Slice slice);
 
 // =====================================================================
 // Iterator selection table

--- a/arangod/RocksDBEngine/RocksDBVectorIndexList.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexList.h
@@ -57,9 +57,8 @@ inline faiss::MetricType metricToFaissMetric(
     case SimilarityMetric::kInnerProduct:
       return faiss::METRIC_INNER_PRODUCT;
   }
-
 }
-  velocypack::SharedSlice toOwnedSharedSlice(velocypack::Slice slice);
+velocypack::SharedSlice toOwnedSharedSlice(velocypack::Slice slice);
 
 // =====================================================================
 // Iterator selection table

--- a/arangod/VectorIndex/VectorReadBatch.h
+++ b/arangod/VectorIndex/VectorReadBatch.h
@@ -52,7 +52,11 @@ namespace vector {
 
 // FAISS uses int64_t labels; the static_assert in RocksDBVectorIndex.cpp
 // guards this assumption against future faiss changes.
+using Vector = std::vector<float>;
 using VectorIndexLabelId = std::int64_t;
+using Labels = std::vector<VectorIndexLabelId>;
+using Distance = float;
+using Distances = std::vector<Distance>;
 
 // Static per-search configuration. Built once by EnumerateNearVectorNode in
 // createBlock and reused for every readBatch call within an executor.

--- a/js/common/modules/@arangodb/testutils/vector-index-common.js
+++ b/js/common/modules/@arangodb/testutils/vector-index-common.js
@@ -406,6 +406,42 @@ function generateDocs(gen, count, dimension) {
     return docs;
 }
 
+/**
+ * Pre-computes a pool of keys grouped by shard using SHARD_ID() in a single
+ * AQL query, similar to the approach in shell-cluster-dbserver-shard-metrics.
+ *
+ * @param {function} collection - collection object
+ * @param {number} keysNeeded - No. of keys needed
+ * @returns {JSON} {shardNames: [...], keysPerShard: {shardName: [key, ...], ...}}.
+ */
+function buildKeyPool(collection, keysNeeded) {
+    const shardNames = Object.keys(collection.shards(true));
+    const keysPerShard = {};
+    for (const s of shardNames) {
+        keysPerShard[s] = [];
+    }
+
+    const batchSize = 1000;
+    let keyIndex = 0;
+    while (Object.values(keysPerShard).some(keys => keys.length < keysNeeded)) {
+        const results = db._query(`
+            FOR i IN @from..@to
+              LET key = CONCAT('k', i)
+              RETURN {key, shard: SHARD_ID(@coll, {_key: key})}
+        `, {from: keyIndex, to: keyIndex + batchSize - 1, coll: collection.name()}).toArray();
+
+        for (const {key, shard} of results) {
+            if (keysPerShard[shard] && keysPerShard[shard].length < keysNeeded) {
+                keysPerShard[shard].push(key);
+            }
+        }
+        keyIndex += batchSize;
+    }
+
+    return {shardNames, keysPerShard};
+}
+
+exports.buildKeyPool = buildKeyPool;
 exports.generateDocs = generateDocs;
 exports.createVectorGenerator = createVectorGenerator;
 exports.DistanceFunctions = DistanceFunctions;

--- a/js/common/modules/@arangodb/testutils/vector-index-common.js
+++ b/js/common/modules/@arangodb/testutils/vector-index-common.js
@@ -29,6 +29,9 @@ const {
     randomInteger,
 } = require("@arangodb/testutils/seededRandom");
 
+const internal = require("internal");
+const db = internal.db;
+
 const VectorIndexTrainingState = Object.freeze({
     kUnusable: "unusable",
     kTraining: "training",
@@ -238,41 +241,44 @@ const sleepIntervalSec = 0.1;
 // Checks whether a single vector index has the expected training state.
 // Single server: the index has a top-level `trainingState` field.
 // Cluster: the index has a `shards` object where each shard has a `trainingState` field.
-function indexMatchesState(idx, state) {
+function indexMatchesState(idx, states) {
     if (idx.trainingState !== undefined) {
         // Single server: top-level trainingState.
-        return idx.trainingState === state;
+        return states.includes(idx.trainingState);
     }
     if (idx.shards !== undefined) {
         // Cluster: every shard must match.
         const shardEntries = Object.values(idx.shards);
         return shardEntries.length > 0 &&
-            shardEntries.every(s => s.trainingState === state);
+            shardEntries.every(s => states.includes(s.trainingState));
     }
     return false;
 }
 
 // Checks whether the given vector indexes match the expected state.
 // If indexName is provided, only that index is checked; otherwise all vector indexes.
-function vectorIndexesMatchState(indexes, state, indexName) {
+function vectorIndexesMatchState(indexes, allowedVectorIndexStates, indexName) {
+    if (!Array.isArray(allowedVectorIndexStates)) {
+        allowedVectorIndexStates = [allowedVectorIndexStates];
+    }
     const vectorIndexes = indexes.filter(idx => idx.type === 'vector');
     if (indexName !== undefined) {
         const idx = vectorIndexes.find(ix => ix.name === indexName);
-        return idx !== undefined && indexMatchesState(idx, state);
+        return idx !== undefined && indexMatchesState(idx, allowedVectorIndexStates);
     }
     return vectorIndexes.length > 0 &&
-        vectorIndexes.every(idx => indexMatchesState(idx, state));
+        vectorIndexes.every(idx => indexMatchesState(idx, allowedVectorIndexStates));
 }
 
 // Waits until vector index(es) on the collection reach the given state.
 // Uses collection.indexes(true, true) to include per-shard details in cluster mode.
 // If indexName is provided, only that single index is checked.
-function waitForState(collection, state, timeoutSec, indexName) {
+function waitForState(collection, allowedVectorIndexStates, timeoutSec, indexName) {
     const internal = require("internal");
     const iterations = Math.floor(timeoutSec / sleepIntervalSec);
     for (let i = 0; i < iterations; i++) {
         const indexes = collection.indexes(false, true);
-        if (vectorIndexesMatchState(indexes, state, indexName)) {
+        if (vectorIndexesMatchState(indexes, allowedVectorIndexStates, indexName)) {
             return true;
         }
         internal.sleep(sleepIntervalSec);
@@ -283,8 +289,7 @@ function waitForState(collection, state, timeoutSec, indexName) {
 /**
  * Inserts docs in batches, calling ensureIndex() at a random batch slot
  * determined by the seed. This tests that index creation works regardless of
- * whether it happens before, during, or after data insertion. After all docs
- * are inserted, waits for the vector index to reach the ready state.
+ * whether it happens before, during, or after data insertion.
  *
  * @param {object} opts
  * @param {ArangoCollection} opts.collection
@@ -294,13 +299,10 @@ function waitForState(collection, state, timeoutSec, indexName) {
  * @param {string} opts.indexName - name of the vector index to assert ready
  * @param {number} [opts.batchSize=100]
  * @param {function} [opts.onBatchInserted] - called with insert result per batch
- * @param {number} [opts.readyTimeoutSec=60] - timeout for waiting until the
- *   vector index reaches the ready state
  */
-function insertDocsAndAssertIndex({collection, docs, seed, indexDef,
+function insertDocsAndCreateIndex({collection, docs, seed, indexDef,
                                     indexName, batchSize = 100,
-                                    onBatchInserted,
-                                    readyTimeoutSec = 60}) {
+                                    onBatchInserted}) {
     const numBatches = Math.ceil(docs.length / batchSize);
     const ensureIndexSlot = Math.abs(seed) % (numBatches + 1);
     const fullIndexDef = {name: indexName, ...indexDef};
@@ -328,17 +330,92 @@ function insertDocsAndAssertIndex({collection, docs, seed, indexDef,
         }
     }
     if (ensureIndexSlot === numBatches) {
-        collection.ensureIndex(fullIndexDef);
+        try {
+            collection.ensureIndex(fullIndexDef);
+        } catch (e) {
+            //  We're swallowing exceptions here to allow
+            //  for the case where there aren't enough documents
+            //  in the shard which will result into executing a
+            //  linear scan instead.
+        }
     }
-    // const ready = waitForVectorIndexState(
-    //     collection, indexName, VectorIndexTrainingState.kReady,
-    //     readyTimeoutSec);
-    // if (!ready) {
-    //     throw new Error(
-    //         `Vector index '${indexName}' on collection ` +
-    //         `'${collection.name()}' did not reach ready state ` +
-    //         `within ${readyTimeoutSec}s`);
-    // }
+}
+
+/**
+ * Inserts docs in batches, calling ensureIndex() at a random batch slot
+ * determined by the seed. This tests that index creation works regardless of
+ * whether it happens before, during, or after data insertion. After all docs
+ * are inserted, waits for the vector index to reach the ready state.
+ *
+ * @param {object} opts
+ * @param {ArangoCollection} opts.collection
+ * @param {Array} opts.docs - documents to insert
+ * @param {number} opts.seed - random seed (used to pick ensureIndex slot)
+ * @param {object} opts.indexDef - index definition passed to ensureIndex()
+ * @param {string} opts.indexName - name of the vector index to assert ready
+ * @param {number} [opts.batchSize=100]
+ * @param {function} [opts.onBatchInserted] - called with insert result per batch
+ * @param {number} [opts.readyTimeoutSec=60] - timeout for waiting until the
+ *   vector index reaches the ready state
+ */
+function insertDocsAndAssertIndex({collection, docs, seed, indexDef,
+                                    indexName, batchSize = 100,
+                                    onBatchInserted,
+                                    readyTimeoutSec = 60}) {
+
+    insertDocsAndCreateIndex({collection, docs, seed, indexDef,
+                                        indexName, batchSize,
+                                        onBatchInserted});
+
+    const ready = waitForVectorIndexState(
+        collection, indexName, VectorIndexTrainingState.kReady,
+        readyTimeoutSec);
+    if (!ready) {
+        throw new Error(
+            `Vector index '${indexName}' on collection ` +
+            `'${collection.name()}' did not reach ready state ` +
+            `within ${readyTimeoutSec}s`);
+    }
+}
+
+/**
+ * Inserts docs in batches, calling ensureIndex() at a random batch slot
+ * determined by the seed. This tests that index creation works regardless of
+ * whether it happens before, during, or after data insertion. After all docs
+ * are inserted, waits for the vector index to reach one of the supplied states.
+ *
+ * @param {object} opts
+ * @param {ArangoCollection} opts.collection
+ * @param {Array} opts.docs - documents to insert
+ * @param {number} opts.seed - random seed (used to pick ensureIndex slot)
+ * @param {object} opts.indexDef - index definition passed to ensureIndex()
+ * @param {string} opts.indexName - name of the vector index to assert ready
+ * @param {number} [opts.batchSize=100]
+ * @param {function} [opts.onBatchInserted] - called with insert result per batch
+ * @param {Array} opts.allowedVectorIndexStates - One or more of the vector index states
+                                           ready, training, ingesting, unusable
+ * @param {number} [opts.readyTimeoutSec=60] - timeout for waiting until the
+ *   vector index reaches the ready state
+ */
+function insertDocsAndAssertIndexStates({collection, docs, seed, indexDef,
+                                    indexName, batchSize = 100,
+                                    onBatchInserted,
+                                    allowedVectorIndexStates,
+                                    readyTimeoutSec = 60}) {
+
+    insertDocsAndCreateIndex({collection, docs, seed, indexDef,
+                                        indexName, batchSize,
+                                        onBatchInserted});
+
+    const ready = waitForVectorIndexState(
+        collection, indexName, allowedVectorIndexStates,
+        readyTimeoutSec);
+    if (!ready) {
+        throw new Error(
+            `Vector index '${indexName}' on collection ` +
+            `'${collection.name()}' did not reach ready state ` +
+            `within ${readyTimeoutSec}s`);
+    }
 }
 
 /**
@@ -347,12 +424,13 @@ function insertDocsAndAssertIndex({collection, docs, seed, indexDef,
  *
  * @param {ArangoCollection} collection
  * @param {string} indexName - name of the vector index to wait for
- * @param {string} expectedState - ready, training, ingesting, ready
+ * @param {Array} allowedVectorIndexStates - One or more of the vector index states
+ *                                     ready, training, ingesting, unusable
  * @param {number} [timeoutSec=60]
  * @returns {boolean}
  */
-function waitForVectorIndexState(collection, indexName, expectedState, timeoutSec = 60) {
-    return waitForState(collection, expectedState, timeoutSec, indexName);
+function waitForVectorIndexState(collection, indexName, allowedVectorIndexStates, timeoutSec = 60) {
+    return waitForState(collection, allowedVectorIndexStates, timeoutSec, indexName);
 }
 
 /**
@@ -449,4 +527,5 @@ exports.VectorIndexTrainingState = VectorIndexTrainingState;
 exports.waitForVectorIndexState = waitForVectorIndexState;
 exports.waitForAllVectorIndexesState = waitForAllVectorIndexesState;
 exports.insertDocsAndAssertIndex = insertDocsAndAssertIndex;
+exports.insertDocsAndAssertIndexStates = insertDocsAndAssertIndexStates;
 exports.assertEnsureIndexResultUnusable = assertEnsureIndexResultUnusable;

--- a/js/common/modules/@arangodb/testutils/vector-index-common.js
+++ b/js/common/modules/@arangodb/testutils/vector-index-common.js
@@ -330,15 +330,15 @@ function insertDocsAndAssertIndex({collection, docs, seed, indexDef,
     if (ensureIndexSlot === numBatches) {
         collection.ensureIndex(fullIndexDef);
     }
-    const ready = waitForVectorIndexState(
-        collection, indexName, VectorIndexTrainingState.kReady,
-        readyTimeoutSec);
-    if (!ready) {
-        throw new Error(
-            `Vector index '${indexName}' on collection ` +
-            `'${collection.name()}' did not reach ready state ` +
-            `within ${readyTimeoutSec}s`);
-    }
+    // const ready = waitForVectorIndexState(
+    //     collection, indexName, VectorIndexTrainingState.kReady,
+    //     readyTimeoutSec);
+    // if (!ready) {
+    //     throw new Error(
+    //         `Vector index '${indexName}' on collection ` +
+    //         `'${collection.name()}' did not reach ready state ` +
+    //         `within ${readyTimeoutSec}s`);
+    // }
 }
 
 /**

--- a/tests/js/client/aql/vector/aql-vector-optimizations.js
+++ b/tests/js/client/aql/vector/aql-vector-optimizations.js
@@ -74,9 +74,9 @@ function VectorIndexIteratorScenariosTestSuite() {
     let randomPoint;
     const dimension = 16;
     const numberOfDocsFactor = isCluster ? numberOfShards : 1;
-    const numberOfDocs = 1000 * numberOfDocsFactor;
+    const numberOfDocs = 100 * numberOfDocsFactor;
     const seed = generateSeed();
-    const nProbeAndNlists = 8;
+    const nProbeAndNlists = 101;
 
     const indexNode = function(plan) {
         const ns = plan.nodes.filter(n => n.type === "EnumerateNearVectorNode");

--- a/tests/js/client/aql/vector/aql-vector-optimizations.js
+++ b/tests/js/client/aql/vector/aql-vector-optimizations.js
@@ -32,7 +32,8 @@ const {
     generateSeed,
 } = require("@arangodb/testutils/seededRandom");
 const {
-    insertDocsAndAssertIndex,
+    insertDocsAndAssertIndexStates,
+    VectorIndexTrainingState,
 } = require("@arangodb/testutils/vector-index-common");
 const isCluster = require("internal").isCluster();
 
@@ -158,7 +159,7 @@ function VectorIndexIteratorScenariosTestSuite() {
                 });
             }
 
-            insertDocsAndAssertIndex({
+            insertDocsAndAssertIndexStates({
                 collection, docs, seed,
                 indexName: "vector_l2_scenarios",
                 indexDef: {
@@ -174,6 +175,7 @@ function VectorIndexIteratorScenariosTestSuite() {
                     },
                     storedValues: ["val", "category"],
                 },
+                allowedVectorIndexStates: [VectorIndexTrainingState.kReady, VectorIndexTrainingState.kUnusable]
             });
         },
 

--- a/tests/js/client/aql/vector/aql-vector-optimizations.js
+++ b/tests/js/client/aql/vector/aql-vector-optimizations.js
@@ -37,9 +37,20 @@ const {
 } = require("@arangodb/testutils/vector-index-common");
 const isCluster = require("internal").isCluster();
 
-const dbName = "vectorIteratorScenariosDb";
-const collName = "vectorColl";
 const numberOfShards = 3;
+
+const ITERATOR_SCENARIO_CONFIGS = [
+    {
+        name: "trainedIndex",
+        numberOfDocs: 1000,
+        nProbeAndNlists: 8,
+    },
+    {
+        name: "linearScan",
+        numberOfDocs: 100,
+        nProbeAndNlists: 101,
+    },
+];
 
 const verifyResultsMatchFilter = function(results, filterFn, message) {
     for (let i = 0; i < results.length; ++i) {
@@ -70,14 +81,18 @@ const verifyTopK = function(results, k) {
 //
 // The collection has storedValues = ["val", "category"]. `extra` is NOT in
 // storedValues, so it forces scF=F or scP=F when used.
-function VectorIndexIteratorScenariosTestSuite() {
+function VectorIndexIteratorScenariosTestSuite(config) {
     let collection;
     let randomPoint;
     const dimension = 16;
     const numberOfDocsFactor = isCluster ? numberOfShards : 1;
-    const numberOfDocs = 100 * numberOfDocsFactor;
+    const numberOfDocs = config.numberOfDocs * numberOfDocsFactor;
+    const nProbeAndNlists = config.nProbeAndNlists;
+    const dbName = "vectorIteratorScenariosDb_" + config.name;
+    const collName = "vectorColl_" + config.name;
+    const indexName = "vector_l2_scenarios_" + config.name;
+
     const seed = generateSeed();
-    const nProbeAndNlists = 101;
 
     const indexNode = function(plan) {
         const ns = plan.nodes.filter(n => n.type === "EnumerateNearVectorNode");
@@ -161,7 +176,7 @@ function VectorIndexIteratorScenariosTestSuite() {
 
             insertDocsAndAssertIndexStates({
                 collection, docs, seed,
-                indexName: "vector_l2_scenarios",
+                indexName: indexName,
                 indexDef: {
                     type: "vector",
                     fields: ["vector"],
@@ -373,6 +388,16 @@ function VectorIndexIteratorScenariosTestSuite() {
     };
 }
 
-jsunity.run(VectorIndexIteratorScenariosTestSuite);
+function makeVectorIndexIteratorScenariosTestSuite(config) {
+    return function () {
+        return VectorIndexIteratorScenariosTestSuite(config);
+    };
+}
 
-return jsunity.done();
+let result = 0;
+for (const config of ITERATOR_SCENARIO_CONFIGS) {
+    jsunity.run(makeVectorIndexIteratorScenariosTestSuite(config));
+    result = jsunity.done();
+}
+
+return result;

--- a/tests/js/client/aql/vector/aql-vector-per-shard-state-cluster.js
+++ b/tests/js/client/aql/vector/aql-vector-per-shard-state-cluster.js
@@ -35,6 +35,7 @@ const {
 const {
     VectorIndexTrainingState,
     waitForVectorIndexState,
+    buildKeyPool
 } = require("@arangodb/testutils/vector-index-common");
 const dbName = "vectorPerShardStateDB";
 const dimension = 100;
@@ -50,36 +51,6 @@ const docsBelowThreshold = nLists - 1;
 
 function generateVector(gen) {
     return Array.from({length: dimension}, () => gen());
-}
-
-/// Pre-computes a pool of keys grouped by shard using SHARD_ID() in a single
-/// AQL query, similar to the approach in shell-cluster-dbserver-shard-metrics.
-/// Returns {shardNames: [...], keysPerShard: {shardName: [key, ...], ...}}.
-function buildKeyPool(collection, keysNeeded) {
-    const shardNames = Object.keys(collection.shards(true));
-    const keysPerShard = {};
-    for (const s of shardNames) {
-        keysPerShard[s] = [];
-    }
-
-    const batchSize = 1000;
-    let keyIndex = 0;
-    while (Object.values(keysPerShard).some(keys => keys.length < keysNeeded)) {
-        const results = db._query(`
-            FOR i IN @from..@to
-              LET key = CONCAT('k', i)
-              RETURN {key, shard: SHARD_ID(@coll, {_key: key})}
-        `, {from: keyIndex, to: keyIndex + batchSize - 1, coll: collection.name()}).toArray();
-
-        for (const {key, shard} of results) {
-            if (keysPerShard[shard] && keysPerShard[shard].length < keysNeeded) {
-                keysPerShard[shard].push(key);
-            }
-        }
-        keyIndex += batchSize;
-    }
-
-    return {shardNames, keysPerShard};
 }
 
 /// Inserts `count` docs with valid vectors using pre-computed keys for a

--- a/tests/js/client/aql/vector/aql-vector-training-states.js
+++ b/tests/js/client/aql/vector/aql-vector-training-states.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertTrue, assertFalse, fail */
+/*global assertEqual, assertTrue, assertFalse */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -28,7 +28,6 @@ const internal = require("internal");
 const jsunity = require("jsunity");
 const arangodb = require("@arangodb");
 const aql = arangodb.aql;
-const errors = internal.errors;
 const db = internal.db;
 const {
   randomNumberGeneratorFloat,
@@ -153,12 +152,10 @@ function VectorTrainingStateTestSuite(sparse) {
 
       const gen = randomNumberGeneratorFloat(seed);
       const qp = Array.from({length: dimension}, () => gen());
-      try {
-        db._query(buildSearchQuery(collection, qp));
-        fail();
-      } catch (e) {
-        assertEqual(errors.ERROR_QUERY_VECTOR_INDEX_NOT_READY.code, e.errorNum);
-      }
+      // An unusable index is still searchable via a linear scan; with no
+      // documents present the scan simply returns no results.
+      const results = db._query(buildSearchQuery(collection, qp)).toArray();
+      assertEqual(0, results.length);
     },
 
     testBelowThresholdIndexRemainsUnusable: function () {
@@ -177,12 +174,10 @@ function VectorTrainingStateTestSuite(sparse) {
       assertIndexUnusable(collection, "vec_l2");
 
       const qp = Array.from({length: dimension}, () => gen());
-      try {
-        db._query(buildSearchQuery(collection, qp));
-        fail();
-      } catch (e) {
-        assertEqual(errors.ERROR_QUERY_VECTOR_INDEX_NOT_READY.code, e.errorNum);
-      }
+      // Unusable index falls back to a linear scan over the documents present;
+      // with belowThresholdCount (>= LIMIT) docs the scan fills the top-k.
+      const results = db._query(buildSearchQuery(collection, qp)).toArray();
+      assertEqual(5, results.length);
     },
 
     testAboveThresholdIndexBecomesReady: function () {
@@ -290,12 +285,10 @@ function SparseVectorIndexTestSuite() {
       assertIndexUnusable(collection, "vec_l2");
 
       const qp = vectorDocs[0].vector;
-      try {
-        db._query(buildSearchQuery(collection, qp));
-        fail();
-      } catch (e) {
-        assertEqual(errors.ERROR_QUERY_VECTOR_INDEX_NOT_READY.code, e.errorNum);
-      }
+      // Unusable sparse index falls back to a linear scan; only the
+      // vector-bearing docs (belowThresholdCount >= LIMIT) are candidates.
+      const results = db._query(buildSearchQuery(collection, qp)).toArray();
+      assertEqual(5, results.length);
     },
   };
 }

--- a/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan-cluster.js
+++ b/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan-cluster.js
@@ -1,0 +1,288 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertTrue, assertFalse, assertNotEqual */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Koushal Kawade
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const db = internal.db;
+const isCluster = internal.isCluster();
+
+const {
+    VectorIndexTrainingState,
+    waitForVectorIndexState,
+    buildKeyPool
+} = require("@arangodb/testutils/vector-index-common");
+
+const dbName = "vectorUnusableShardLinearScanDB";
+
+//  Shared 2D dataset (10 points) for single-server linear-vs-IVF test and for
+//  cluster mixed-shard vs all-ready comparison.
+const VECTORS_2D_DATASET = [
+    [1.1, 0.1],
+    [1.0, 0.0],
+    [0.9, -0.1],
+    [0.5, 0.5],
+    [0.0, 1.0],
+    [-0.2, 0.8],
+    [2.0, -0.5],
+    [0.3, -0.9],
+    [-1.0, 0.0],
+    [0.7, 0.7],
+];
+const SEARCH_VECTOR_2D = [1.2, 0.2];
+
+function insertDocsForShard(collection, keys, count, vectors) {
+    assertTrue(keys.length >= count,
+        "Not enough keys for shard, need " + count + " have " + keys.length);
+    const batchSize = 500;
+    for (let i = 0; i < count; i += batchSize) {
+        const size = Math.min(batchSize, count - i);
+        const docs = [];
+        for (let j = 0; j < size; ++j) {
+            docs.push({_key: keys[i + j], vector: vectors[i + j]});
+        }
+        collection.insert(docs);
+    }
+}
+
+function getPerShardStates(collection, indexName) {
+    const idx = collection.indexes(true, true).find(i => i.name === indexName);
+    if (!idx || !idx.shards) {
+        return null;
+    }
+    return idx.shards;
+}
+
+function waitForPerShardStates(collection, indexName, expectations, timeoutSec) {
+    const sleepInterval = 0.5;
+    const iterations = Math.floor(timeoutSec / sleepInterval);
+
+    for (let iter = 0; iter < iterations; ++iter) {
+        const shardStates = getPerShardStates(collection, indexName);
+        assertNotEqual(shardStates, null);
+        let allMatch = true;
+        for (const [shard, expected] of Object.entries(expectations)) {
+            const actual = shardStates[shard];
+            if (actual.trainingState !== expected.trainingState) {
+                allMatch = false;
+                break;
+            }
+            if (expected.hasError && actual.error.length === 0) {
+                allMatch = false;
+                break;
+            }
+        }
+        if (allMatch) {
+            return true;
+        }
+        internal.sleep(sleepInterval);
+    }
+    return false;
+}
+
+function vectorTopKeys(collectionName, indexHint, bind) {
+    const sortExpr = "APPROX_NEAR_L2(d.vector, @qp, {nProbe: @nProbe}) ASC";
+    const q = "FOR d IN " + collectionName +
+        " OPTIONS { indexHint: \"" + indexHint + "\" } " +
+        "SORT " + sortExpr +
+        " LIMIT @lim RETURN d._key";
+    return db._query(q, bind).toArray();
+}
+
+//  Vectors placed very far from `queryPoint` so they never enter a modest top-k.
+function farVectorFrom(queryPoint) {
+    const v = [];
+    for (let i = 0; i < queryPoint.length; ++i) {
+        v.push(queryPoint[i] + 1.0e6);
+    }
+    return v;
+}
+
+function VectorIndexUnusableShardLinearScanSuite() {
+    return {
+        setUp: function () {
+            db._useDatabase("_system");
+            db._createDatabase(dbName);
+            db._useDatabase(dbName);
+        },
+
+        tearDown: function () {
+            db._useDatabase("_system");
+            db._dropDatabase(dbName);
+        },
+
+        //  Same 10-point 2D dataset as testLinearVsTrainedSameResultsAllApproxNearFunctions.
+        //  nLists=3: two shards get 4 vectors each (trained); one shard gets 2 (< nLists,
+        //  unusable, linear scan). cAllReady adds far-away fillers only on the starved
+        //  shard so every shard has enough vectors to train; top-k stays identical with
+        //  nProbe=nLists=3.
+        testClusterMixedShardIvfPlusLinearMatchesAllReadyIvf: function () {
+            if (!isCluster) {
+                return;
+            }
+
+            const clusterNlists = 3;
+            const clusterDim = 2;
+            const docsBelow = clusterNlists - 1;
+            const nFull = 4;
+            const keysNeeded = nFull;
+
+            //  This collection will have 1 shard in unusable state
+            const collOneShardUnusable = "vecOneShardUnusable";
+
+            //  This collection will have all shards trained and in ready state
+            const collAllReady = "vecAllShardsReady";
+
+            const indexHint = "vec_l2";
+            const nProbeExhaustive = clusterNlists;
+
+            const idxDef = {
+                name: indexHint,
+                type: "vector",
+                fields: ["vector"],
+                inBackground: true,
+                params: {
+                    metric: "l2",
+                    dimension: clusterDim,
+                    nLists: clusterNlists,
+                    defaultNProbe: 1,
+                    trainingIterations: 25,
+                },
+            };
+
+            const cOneShardUnusable = db._create(collOneShardUnusable, {numberOfShards: 3});
+            const cAllReady = db._create(collAllReady, {numberOfShards: 3});
+
+            const shardNamesForOneUnusable = Object.keys(cOneShardUnusable.shards(true)).sort();
+            assertEqual(3, shardNamesForOneUnusable.length);
+
+            const poolOne = buildKeyPool(cOneShardUnusable, keysNeeded);
+            const poolAll = buildKeyPool(cAllReady, keysNeeded);
+
+            //  Shard names for vecOneShardUnusable collection
+            const starvedNameMixed = shardNamesForOneUnusable[0];
+            const full1Mixed = shardNamesForOneUnusable[1];
+            const full2Mixed = shardNamesForOneUnusable[2];
+
+            function getShardOfKey(coll, key) {
+                return db._query(
+                    `RETURN SHARD_ID(@c, {_key: @k})`,
+                    {c: coll.name(), k: key}).toArray()[0];
+            }
+
+            //  Shard names for vecAllShardsReady collection
+            const starvedNameAll = getShardOfKey(cAllReady, poolOne.keysPerShard[starvedNameMixed][0]);
+            const full1All = getShardOfKey(cAllReady, poolOne.keysPerShard[full1Mixed][0]);
+            const full2All = getShardOfKey(cAllReady, poolOne.keysPerShard[full2Mixed][0]);
+
+            const vs = VECTORS_2D_DATASET;
+            const vectorsStarved = vs.slice(0, docsBelow);
+            const vectorsFull1 = vs.slice(docsBelow, docsBelow + nFull);
+            const vectorsFull2 = vs.slice(docsBelow + nFull, docsBelow + 2 * nFull);
+            assertEqual(10, vectorsStarved.length + vectorsFull1.length + vectorsFull2.length);
+
+            insertDocsForShard(
+                cOneShardUnusable, poolOne.keysPerShard[starvedNameMixed], docsBelow,
+                vectorsStarved);
+            insertDocsForShard(
+                cOneShardUnusable, poolOne.keysPerShard[full1Mixed], nFull,
+                vectorsFull1);
+            insertDocsForShard(
+                cOneShardUnusable, poolOne.keysPerShard[full2Mixed], nFull,
+                vectorsFull2);
+
+            const keysStarvedAll = poolAll.keysPerShard[starvedNameAll];
+            insertDocsForShard(
+                cAllReady, keysStarvedAll, docsBelow,
+                vectorsStarved);
+
+            //  In vecAllShardsReady collection the shards are filled with
+            //  2, 4 and 4 vectors, same as the other collection. This will
+            //  prevent the shard from getting trained and enter into ready state.
+            //  That is why we fill the unusable shard with 2 extra vectors that
+            //  are far away from the search vector ensuring that they never
+            //  show up in the search results.
+            const filler = [];
+            for (let i = docsBelow; i < keysNeeded; ++i) {
+                filler.push(farVectorFrom(SEARCH_VECTOR_2D));
+            }
+            insertDocsForShard(
+                cAllReady, keysStarvedAll.slice(docsBelow),
+                keysNeeded - docsBelow,
+                filler);
+            insertDocsForShard(
+                cAllReady, poolAll.keysPerShard[full1All], nFull,
+                vectorsFull1);
+            insertDocsForShard(
+                cAllReady, poolAll.keysPerShard[full2All], nFull,
+                vectorsFull2);
+
+            cOneShardUnusable.ensureIndex(idxDef);
+            cAllReady.ensureIndex(idxDef);
+
+            const expectationsMixed = {};
+            expectationsMixed[full1Mixed] = {trainingState: VectorIndexTrainingState.kReady, hasError: false};
+            expectationsMixed[full2Mixed] = {trainingState: VectorIndexTrainingState.kReady, hasError: false};
+            expectationsMixed[starvedNameMixed] = {
+                trainingState: VectorIndexTrainingState.kUnusable,
+                hasError: false,
+            };
+            assertTrue(
+                waitForPerShardStates(cOneShardUnusable, indexHint, expectationsMixed, 120),
+                "mixed: two shards ready, starved shard unusable");
+
+            const mixedStates = getPerShardStates(cOneShardUnusable, indexHint);
+            assertEqual(VectorIndexTrainingState.kUnusable,
+                mixedStates[starvedNameMixed].trainingState);
+            assertTrue(mixedStates[starvedNameMixed].error.length > 0);
+
+            assertTrue(
+                waitForVectorIndexState(cAllReady, indexHint, VectorIndexTrainingState.kReady, 120),
+                "all-shard baseline index should become ready");
+
+            const docTotalMixed = docsBelow + 2 * nFull;
+            const lim = 5;
+            assertTrue(lim <= docTotalMixed, "limit should not exceed mixed collection size");
+            const bind = {
+                qp: SEARCH_VECTOR_2D,
+                lim,
+                nProbe: nProbeExhaustive,
+            };
+
+            const keysMixed = vectorTopKeys(collOneShardUnusable, indexHint, bind);
+            const keysAll = vectorTopKeys(collAllReady, indexHint, bind);
+
+            assertEqual(lim, keysMixed.length);
+            assertEqual(lim, keysAll.length);
+            assertEqual(keysMixed, keysAll,
+                "mixed (IVF + linear on starved shard) vs all-ready IVF, nProbe=nLists");
+        },
+
+    };
+}
+
+jsunity.run(VectorIndexUnusableShardLinearScanSuite);
+
+return jsunity.done();

--- a/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
+++ b/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
@@ -249,6 +249,76 @@ function VectorIndexUnusableShardLinearScanSuite() {
             db._drop(collNameCompare);
         },
 
+        //  Pushed-down filters must be applied during linear scan fallback.
+        testLinearScanAppliesPushedFilter: function () {
+            if (isCluster)
+                return;
+
+            const collName = "vecLinearScanFilter";
+            const nListsSmall = 10;
+            const nListsLarge = 20;
+            const c = db._create(collName, {numberOfShards: 1});
+
+            const docs = [
+                {_key: "near_ok", vector: [1.0, 0.0], extra: 10},
+                {_key: "near_bad", vector: [0.95, 0.05], extra: 200},
+                {_key: "far_ok", vector: [0.0, 1.0], extra: 50},
+                {_key: "far_bad", vector: [-1.0, 0.0], extra: 150},
+            ];
+            c.insert(docs);
+
+            const indexParams = {
+                type: "vector",
+                fields: ["vector"],
+                inBackground: true,
+                params: {
+                    metric: "l2",
+                    dimension: 2,
+                    defaultNProbe: 1,
+                    trainingIterations: 25,
+                },
+            };
+
+            c.ensureIndex(Object.assign({name: "vec_ready", params: Object.assign({}, indexParams.params, {nLists: nListsSmall})}, indexParams));
+            c.ensureIndex(Object.assign({name: "vec_linear", params: Object.assign({}, indexParams.params, {nLists: nListsLarge})}, indexParams));
+
+            assertTrue(
+                waitForVectorIndexState(c, "vec_ready", VectorIndexTrainingState.kReady, 120));
+            assertTrue(
+                waitForVectorIndexState(c, "vec_linear", VectorIndexTrainingState.kUnusable, 120));
+
+            const bind = {qp: [1.2, 0.2], lim: 10};
+            const query = function (hint) {
+                return "FOR d IN " + collName +
+                    " OPTIONS { indexHint: \"" + hint + "\" } " +
+                    "FILTER d.extra < 100 " +
+                    "LET dist = APPROX_NEAR_L2(@qp, d.vector) " +
+                    "SORT dist LIMIT @lim RETURN d";
+            };
+
+            const readyResults = db._query(query("vec_ready"), bind).toArray();
+            const linearResults = db._query(query("vec_linear"), bind).toArray();
+
+            assertEqual(2, readyResults.length,
+                "trained index should return only docs matching the filter");
+            assertEqual(2, linearResults.length,
+                "linear scan should return only docs matching the filter");
+
+            for (const row of readyResults) {
+                assertTrue(row.extra < 100, "trained result must match filter");
+            }
+            for (const row of linearResults) {
+                assertTrue(row.extra < 100, "linear scan result must match filter");
+            }
+
+            const readyKeys = readyResults.map(r => r._key).sort();
+            const linearKeys = linearResults.map(r => r._key).sort();
+            assertEqual(readyKeys, linearKeys,
+                "linear scan and trained IVF should agree on filtered top-k");
+
+            db._drop(collName);
+        },
+
     };
 }
 

--- a/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
+++ b/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
@@ -1,0 +1,251 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global fail, assertEqual, assertTrue, assertFalse, assertNotEqual */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Koushal Kawade
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const db = internal.db;
+const isCluster = internal.isCluster();
+
+const {
+    VectorIndexTrainingState,
+    waitForVectorIndexState,
+    buildKeyPool
+} = require("@arangodb/testutils/vector-index-common");
+
+const dbName = "vectorUnusableShardLinearScanDB";
+
+//  Shared 2D dataset (10 points) for single-server linear-vs-IVF test and for
+//  cluster mixed-shard vs all-ready comparison.
+const VECTORS_2D_DATASET = [
+    [1.1, 0.1],
+    [1.0, 0.0],
+    [0.9, -0.1],
+    [0.5, 0.5],
+    [0.0, 1.0],
+    [-0.2, 0.8],
+    [2.0, -0.5],
+    [0.3, -0.9],
+    [-1.0, 0.0],
+    [0.7, 0.7],
+];
+const SEARCH_VECTOR_2D = [1.2, 0.2];
+
+function insertDocsForShard(collection, keys, count, vectors) {
+    assertTrue(keys.length >= count,
+        "Not enough keys for shard, need " + count + " have " + keys.length);
+    const batchSize = 500;
+    for (let i = 0; i < count; i += batchSize) {
+        const size = Math.min(batchSize, count - i);
+        const docs = [];
+        for (let j = 0; j < size; ++j) {
+            docs.push({_key: keys[i + j], vector: vectors[i + j]});
+        }
+        collection.insert(docs);
+    }
+}
+
+function getPerShardStates(collection, indexName) {
+    const idx = collection.indexes(true, true).find(i => i.name === indexName);
+    if (!idx || !idx.shards) {
+        return null;
+    }
+    return idx.shards;
+}
+
+function waitForPerShardStates(collection, indexName, expectations, timeoutSec) {
+    const sleepInterval = 0.5;
+    const iterations = Math.floor(timeoutSec / sleepInterval);
+
+    for (let iter = 0; iter < iterations; ++iter) {
+        const shardStates = getPerShardStates(collection, indexName);
+        assertNotEqual(shardStates, null);
+        let allMatch = true;
+        for (const [shard, expected] of Object.entries(expectations)) {
+            const actual = shardStates[shard];
+            if (actual.trainingState !== expected.trainingState) {
+                allMatch = false;
+                break;
+            }
+            if (expected.hasError && actual.error.length === 0) {
+                allMatch = false;
+                break;
+            }
+        }
+        if (allMatch) {
+            return true;
+        }
+        internal.sleep(sleepInterval);
+    }
+    return false;
+}
+
+function vectorTopKeys(collectionName, indexHint, bind) {
+    const sortExpr = "APPROX_NEAR_L2(d.vector, @qp, {nProbe: @nProbe}) ASC";
+    const q = "FOR d IN " + collectionName +
+        " OPTIONS { indexHint: \"" + indexHint + "\" } " +
+        "SORT " + sortExpr +
+        " LIMIT @lim RETURN d._key";
+    return db._query(q, bind).toArray();
+}
+
+//  Vectors placed very far from `queryPoint` so they never enter a modest top-k.
+function farVectorFrom(queryPoint) {
+    const v = [];
+    for (let i = 0; i < queryPoint.length; ++i) {
+        v.push(queryPoint[i] + 1.0e6);
+    }
+    return v;
+}
+
+function VectorIndexUnusableShardLinearScanSuite() {
+    return {
+        setUp: function () {
+            db._useDatabase("_system");
+            db._createDatabase(dbName);
+            db._useDatabase(dbName);
+        },
+
+        tearDown: function () {
+            db._useDatabase("_system");
+            db._dropDatabase(dbName);
+        },
+
+        //  Ten 2D vectors on a single-shard collection:
+        //  When nLists=10 the shards train,
+        //  when nLists=20 they stay unusable (linear scan).
+        //  With a high value of nProbe on the trained IVF index,
+        //  APPROX_NEAR_* results must match between the two indexes.
+        testLinearVsTrainedSameResultsAllApproxNearFunctions: function () {
+            if (isCluster)
+                return;
+
+            const collNameCompare = "vecLinearVsTrained";
+            const nListsSmall = 10;
+            const nListsLarge = 20;
+            const c = db._create(collNameCompare, {numberOfShards: 1});
+
+            let k = 0;
+            for (const vec of VECTORS_2D_DATASET) {
+                c.insert({_key: "d" + (k++), vector: vec});
+            }
+
+            const vectorSearchCases = [
+                {
+                    metric: "l2",
+                    label: "L2",
+                    sortExpr: "APPROX_NEAR_L2(d.vector, @qp, {nProbe: @nProbe}) ASC",
+                },
+                {
+                    metric: "cosine",
+                    label: "COSINE",
+                    sortExpr: "APPROX_NEAR_COSINE(d.vector, @qp, {nProbe: @nProbe}) DESC",
+                },
+                {
+                    metric: "innerProduct",
+                    label: "INNER_PRODUCT",
+                    sortExpr: "APPROX_NEAR_INNER_PRODUCT(d.vector, @qp, {nProbe: @nProbe}) DESC",
+                },
+            ];
+
+            for (const row of vectorSearchCases) {
+                //  index with small nLists value
+                //  training will succeed for this index
+                c.ensureIndex({
+                    name: "vec_" + row.label + "_n" + nListsSmall,
+                    type: "vector",
+                    fields: ["vector"],
+                    inBackground: true,
+                    params: {
+                        metric: row.metric,
+                        dimension: 2,
+                        nLists: nListsSmall,
+                        defaultNProbe: 1,
+                        trainingIterations: 25,
+                    },
+                });
+
+                //  index with a large nLists value
+                //  training will fail and the index will be marked as unusable
+                c.ensureIndex({
+                    name: "vec_" + row.label + "_n" + nListsLarge,
+                    type: "vector",
+                    fields: ["vector"],
+                    inBackground: true,
+                    params: {
+                        metric: row.metric,
+                        dimension: 2,
+                        nLists: nListsLarge,
+                        defaultNProbe: 1,
+                        trainingIterations: 25,
+                    },
+                });
+            }
+
+            const lim = 5;
+            const nProbeExhaustive = nListsSmall;
+            const bindBase = {qp: SEARCH_VECTOR_2D, lim: lim, nProbe: nProbeExhaustive};
+
+            for (const row of vectorSearchCases) {
+                const hintSmall = "vec_" + row.label + "_n" + nListsSmall;
+                const hintLarge = "vec_" + row.label + "_n" + nListsLarge;
+
+                assertTrue(
+                    waitForVectorIndexState(
+                        c, hintSmall, VectorIndexTrainingState.kReady, 120),
+                    "nLists=" + nListsSmall + " index " + hintSmall + " should become ready");
+
+                assertTrue(
+                    waitForVectorIndexState(
+                        c, hintLarge, VectorIndexTrainingState.kUnusable, 120),
+                    "nLists=" + nListsLarge + " index " + hintLarge +
+                    " should become unusable (not enough training vectors)");
+
+                const q = "FOR d IN " + collNameCompare +
+                    " OPTIONS { indexHint: \"" + hintSmall + "\" } " +
+                    "SORT " + row.sortExpr +
+                    " LIMIT @lim RETURN d._key";
+                const keysSmall = db._query(q, bindBase).toArray();
+
+                const qLarge = "FOR d IN " + collNameCompare +
+                    " OPTIONS { indexHint: \"" + hintLarge + "\" } " +
+                    "SORT " + row.sortExpr +
+                    " LIMIT @lim RETURN d._key";
+                const keysLarge = db._query(qLarge, bindBase).toArray();
+
+                assertEqual(
+                    keysSmall, keysLarge,
+                    row.label + ": trained IVF (exhaustive nProbe) vs linear scan top-k _key order");
+            }
+
+            db._drop(collNameCompare);
+        },
+
+    };
+}
+
+jsunity.run(VectorIndexUnusableShardLinearScanSuite);
+
+return jsunity.done();

--- a/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
+++ b/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
@@ -204,40 +204,46 @@ function VectorIndexUnusableShardLinearScanSuite() {
                 });
             }
 
-            const lim = 5;
-            const nProbeExhaustive = nListsSmall;
-            const bindBase = {qp: SEARCH_VECTOR_2D, lim: lim, nProbe: nProbeExhaustive};
+            //  Test for topK in the range of [0..no_of_docs + 5] to verify
+            //  that we get the correct sort ordering every time.
+            //  Also check that bruteForceSearch() correctly handles the case
+            //  where we have fewer vectors than topK.
+            for (let lim = 0; lim < SEARCH_VECTOR_2D.length + 5; ++lim) {
 
-            for (const row of vectorSearchCases) {
-                const hintSmall = "vec_" + row.label + "_n" + nListsSmall;
-                const hintLarge = "vec_" + row.label + "_n" + nListsLarge;
+                const nProbeExhaustive = nListsSmall;
+                const bindBase = {qp: SEARCH_VECTOR_2D, lim: lim, nProbe: nProbeExhaustive};
 
-                assertTrue(
-                    waitForVectorIndexState(
-                        c, hintSmall, VectorIndexTrainingState.kReady, 120),
-                    "nLists=" + nListsSmall + " index " + hintSmall + " should become ready");
+                for (const row of vectorSearchCases) {
+                    const hintSmall = "vec_" + row.label + "_n" + nListsSmall;
+                    const hintLarge = "vec_" + row.label + "_n" + nListsLarge;
 
-                assertTrue(
-                    waitForVectorIndexState(
-                        c, hintLarge, VectorIndexTrainingState.kUnusable, 120),
-                    "nLists=" + nListsLarge + " index " + hintLarge +
-                    " should become unusable (not enough training vectors)");
+                    assertTrue(
+                        waitForVectorIndexState(
+                            c, hintSmall, VectorIndexTrainingState.kReady, 120),
+                        "nLists=" + nListsSmall + " index " + hintSmall + " should become ready");
 
-                const q = "FOR d IN " + collNameCompare +
-                    " OPTIONS { indexHint: \"" + hintSmall + "\" } " +
-                    "SORT " + row.sortExpr +
-                    " LIMIT @lim RETURN d._key";
-                const keysSmall = db._query(q, bindBase).toArray();
+                    assertTrue(
+                        waitForVectorIndexState(
+                            c, hintLarge, VectorIndexTrainingState.kUnusable, 120),
+                        "nLists=" + nListsLarge + " index " + hintLarge +
+                        " should become unusable (not enough training vectors)");
 
-                const qLarge = "FOR d IN " + collNameCompare +
-                    " OPTIONS { indexHint: \"" + hintLarge + "\" } " +
-                    "SORT " + row.sortExpr +
-                    " LIMIT @lim RETURN d._key";
-                const keysLarge = db._query(qLarge, bindBase).toArray();
+                    const q = "FOR d IN " + collNameCompare +
+                        " OPTIONS { indexHint: \"" + hintSmall + "\" } " +
+                        "SORT " + row.sortExpr +
+                        " LIMIT @lim RETURN d._key";
+                    const keysSmall = db._query(q, bindBase).toArray();
 
-                assertEqual(
-                    keysSmall, keysLarge,
-                    row.label + ": trained IVF (exhaustive nProbe) vs linear scan top-k _key order");
+                    const qLarge = "FOR d IN " + collNameCompare +
+                        " OPTIONS { indexHint: \"" + hintLarge + "\" } " +
+                        "SORT " + row.sortExpr +
+                        " LIMIT @lim RETURN d._key";
+                    const keysLarge = db._query(qLarge, bindBase).toArray();
+
+                    assertEqual(
+                        keysSmall, keysLarge,
+                        row.label + ": " + lim + ": trained IVF (exhaustive nProbe) vs linear scan top-k _key order");
+                }
             }
 
             db._drop(collNameCompare);

--- a/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
+++ b/tests/js/client/aql/vector/aql-vector-unusable-shard-linear-scan.js
@@ -255,7 +255,7 @@ function VectorIndexUnusableShardLinearScanSuite() {
                 return;
 
             const collName = "vecLinearScanFilter";
-            const nListsSmall = 10;
+            const nListsSmall = 1;
             const nListsLarge = 20;
             const c = db._create(collName, {numberOfShards: 1});
 
@@ -279,8 +279,12 @@ function VectorIndexUnusableShardLinearScanSuite() {
                 },
             };
 
-            c.ensureIndex(Object.assign({name: "vec_ready", params: Object.assign({}, indexParams.params, {nLists: nListsSmall})}, indexParams));
-            c.ensureIndex(Object.assign({name: "vec_linear", params: Object.assign({}, indexParams.params, {nLists: nListsLarge})}, indexParams));
+            const makeIndexDef = (name, nLists) => Object.assign({}, indexParams, {
+                name,
+                params: Object.assign({}, indexParams.params, {nLists}),
+            });
+            c.ensureIndex(makeIndexDef("vec_ready", nListsSmall));
+            c.ensureIndex(makeIndexDef("vec_linear", nListsLarge));
 
             assertTrue(
                 waitForVectorIndexState(c, "vec_ready", VectorIndexTrainingState.kReady, 120));


### PR DESCRIPTION
### Scope & Purpose

This PR enables linear scanning of shards that remain untrained and in unusable state due to unavailability of enough documents to conduct shard training.

- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-473
- [ ] Design document: 
