### PR TITLE
[COR-529] Handle OOM during vector index training

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,11 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* COR-529: Track vector index training memory against the global resource
+  monitor and fail with `TRI_ERROR_RESOURCE_LIMIT` instead of OOM-killing
+  the process. New optional index parameter `numberOfDocsPerCentroid`
+  (default 256) caps the training reservoir size.
+
 * Update node modules:
  - lodash to 4.18.0
  - minimatch to 3.1.4

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,7 @@
 * COR-529: Track vector index training memory against the global resource
   monitor and fail with `TRI_ERROR_RESOURCE_LIMIT` instead of OOM-killing
   the process. New optional index parameter `numberOfDocsPerCentroid`
-  (default 256) caps the training reservoir size.
+  (default 100) caps the training reservoir size.
 
 * Update node modules:
  - lodash to 4.18.0

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -147,17 +147,13 @@ VPackBuilder enrichVectorIndexes(VPackSlice indexes,
       result.add(StaticStrings::IndexTrainingState, VPackValue(aggregateState));
 
       if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
-        std::string_view shardError;
         for (auto const& [_, shardState] : states) {
           if (!shardState.error.empty()) {
-            shardError = shardState.error;
+            result.add(StaticStrings::ErrorMessage,
+                       VPackValue(shardState.error));
             break;
           }
         }
-        result.add(StaticStrings::ErrorMessage,
-                   VPackValue(shardError.empty()
-                                  ? "not enough training data for vector index"
-                                  : shardError));
       }
 
       if (withShardDetails) {
@@ -325,10 +321,7 @@ async<void> RestIndexHandler::getIndexes() {
                 VectorIndexShardState state;
                 state.trainingState = std::string(trainingStateToString(ts));
                 if (ts == VectorIndexTrainingState::kUnusable) {
-                  auto err = vecIdx->trainingError();
-                  state.error =
-                      err.empty() ? "not enough training data for vector index"
-                                  : std::move(err);
+                  state.error = vecIdx->trainingError();
                 }
                 state.resolvedNLists = vecIdx->resolvedNLists().value_or(0);
                 states.emplace(std::string(coll->name()), std::move(state));
@@ -546,18 +539,13 @@ async<void> RestIndexHandler::getIndexes() {
                     VPackValue(aggregateState));
 
             if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
-              std::string_view shardError;
               for (auto const& [_, shardState] : states) {
                 if (!shardState.error.empty()) {
-                  shardError = shardState.error;
+                  tmp.add(StaticStrings::ErrorMessage,
+                          VPackValue(shardState.error));
                   break;
                 }
               }
-              tmp.add(
-                  StaticStrings::ErrorMessage,
-                  VPackValue(shardError.empty()
-                                 ? "not enough training data for vector index"
-                                 : shardError));
             }
 
             tmp.add(VPackValue("shards"));

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -147,18 +147,12 @@ VPackBuilder enrichVectorIndexes(VPackSlice indexes,
       result.add(StaticStrings::IndexTrainingState, VPackValue(aggregateState));
 
       if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
-        std::string_view shardError;
         for (auto const& [_, shardState] : states) {
           if (!shardState.error.empty()) {
-            shardError = shardState.error;
+            result.add(StaticStrings::ErrorMessage,
+                       VPackValue(shardState.error));
             break;
           }
-        }
-        if (shardError.empty()) {
-          result.add(StaticStrings::ErrorMessage,
-                     VPackValue("not enough training data for vector index"));
-        } else {
-          result.add(StaticStrings::ErrorMessage, VPackValue(shardError));
         }
       }
 
@@ -327,7 +321,7 @@ async<void> RestIndexHandler::getIndexes() {
                 VectorIndexShardState state;
                 state.trainingState = std::string(trainingStateToString(ts));
                 if (ts == VectorIndexTrainingState::kUnusable) {
-                  state.error = "not enough training data for vector index";
+                  state.error = vecIdx->trainingError();
                 }
                 state.resolvedNLists = vecIdx->resolvedNLists().value_or(0);
                 states.emplace(std::string(coll->name()), std::move(state));
@@ -545,19 +539,12 @@ async<void> RestIndexHandler::getIndexes() {
                     VPackValue(aggregateState));
 
             if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
-              std::string_view shardError;
               for (auto const& [_, shardState] : states) {
                 if (!shardState.error.empty()) {
-                  shardError = shardState.error;
+                  tmp.add(StaticStrings::ErrorMessage,
+                          VPackValue(shardState.error));
                   break;
                 }
-              }
-              if (shardError.empty()) {
-                tmp.add(StaticStrings::ErrorMessage,
-                        VPackValue("not enough training data for "
-                                   "vector index"));
-              } else {
-                tmp.add(StaticStrings::ErrorMessage, VPackValue(shardError));
               }
             }
 

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -147,13 +147,20 @@ VPackBuilder enrichVectorIndexes(VPackSlice indexes,
       result.add(StaticStrings::IndexTrainingState, VPackValue(aggregateState));
 
       if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
+        // Agency `Current` is updated asynchronously by the DBServer's
+        // build manager, so for a fresh index the shard `error` can still
+        // be empty while the state is already published as `unusable`.
+        // Fall back to the same placeholder used by the in-memory single-
+        // server path so the response shape is consistent.
+        std::string_view shardError =
+            StaticStrings::VectorIndexDefaultTrainingError;
         for (auto const& [_, shardState] : states) {
           if (!shardState.error.empty()) {
-            result.add(StaticStrings::ErrorMessage,
-                       VPackValue(shardState.error));
+            shardError = shardState.error;
             break;
           }
         }
+        result.add(StaticStrings::ErrorMessage, VPackValue(shardError));
       }
 
       if (withShardDetails) {
@@ -539,13 +546,18 @@ async<void> RestIndexHandler::getIndexes() {
                     VPackValue(aggregateState));
 
             if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
+              // See the enrichVectorIndexes branch above: agency `Current`
+              // lags ensureIndex, so fall back to the placeholder when no
+              // shard has a real error yet.
+              std::string_view shardError =
+                  "not enough training data for vector index";
               for (auto const& [_, shardState] : states) {
                 if (!shardState.error.empty()) {
-                  tmp.add(StaticStrings::ErrorMessage,
-                          VPackValue(shardState.error));
+                  shardError = shardState.error;
                   break;
                 }
               }
+              tmp.add(StaticStrings::ErrorMessage, VPackValue(shardError));
             }
 
             tmp.add(VPackValue("shards"));

--- a/arangod/RestHandler/RestIndexHandler.cpp
+++ b/arangod/RestHandler/RestIndexHandler.cpp
@@ -147,13 +147,17 @@ VPackBuilder enrichVectorIndexes(VPackSlice indexes,
       result.add(StaticStrings::IndexTrainingState, VPackValue(aggregateState));
 
       if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
+        std::string_view shardError;
         for (auto const& [_, shardState] : states) {
           if (!shardState.error.empty()) {
-            result.add(StaticStrings::ErrorMessage,
-                       VPackValue(shardState.error));
+            shardError = shardState.error;
             break;
           }
         }
+        result.add(StaticStrings::ErrorMessage,
+                   VPackValue(shardError.empty()
+                                  ? "not enough training data for vector index"
+                                  : shardError));
       }
 
       if (withShardDetails) {
@@ -321,7 +325,10 @@ async<void> RestIndexHandler::getIndexes() {
                 VectorIndexShardState state;
                 state.trainingState = std::string(trainingStateToString(ts));
                 if (ts == VectorIndexTrainingState::kUnusable) {
-                  state.error = vecIdx->trainingError();
+                  auto err = vecIdx->trainingError();
+                  state.error =
+                      err.empty() ? "not enough training data for vector index"
+                                  : std::move(err);
                 }
                 state.resolvedNLists = vecIdx->resolvedNLists().value_or(0);
                 states.emplace(std::string(coll->name()), std::move(state));
@@ -539,13 +546,18 @@ async<void> RestIndexHandler::getIndexes() {
                     VPackValue(aggregateState));
 
             if (aggregateState == StaticStrings::IndexTrainingStateUnusable) {
+              std::string_view shardError;
               for (auto const& [_, shardState] : states) {
                 if (!shardState.error.empty()) {
-                  tmp.add(StaticStrings::ErrorMessage,
-                          VPackValue(shardState.error));
+                  shardError = shardState.error;
                   break;
                 }
               }
+              tmp.add(
+                  StaticStrings::ErrorMessage,
+                  VPackValue(shardError.empty()
+                                 ? "not enough training data for vector index"
+                                 : shardError));
             }
 
             tmp.add(VPackValue("shards"));

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -190,11 +190,7 @@ void RocksDBVectorIndex::toVelocyPack(
   builder.add(StaticStrings::IndexTrainingState,
               VPackValue(trainingStateToString(trainingState)));
   if (trainingState == VectorIndexTrainingState::kUnusable) {
-    auto error = trainingError();
-    builder.add(
-        StaticStrings::ErrorMessage,
-        VPackValue(error.empty() ? "not enough training data for vector index"
-                                 : error));
+    builder.add(StaticStrings::ErrorMessage, VPackValue(trainingError()));
   }
 
   if (auto const nLists = resolvedNLists(); nLists.has_value()) {
@@ -356,7 +352,7 @@ void RocksDBVectorIndex::truncateCommit(TruncateGuard&& guard,
                                         TRI_voc_tick_t tick,
                                         transaction::Methods* trx) {
   resetTrainingState();
-  setTrainingError({});
+  setTrainingError("not enough training data for vector index");
   _faissIndex.reset();
   _trainedData = {};
   RocksDBIndex::truncateCommit(std::move(guard), tick, trx);

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -190,8 +190,11 @@ void RocksDBVectorIndex::toVelocyPack(
   builder.add(StaticStrings::IndexTrainingState,
               VPackValue(trainingStateToString(trainingState)));
   if (trainingState == VectorIndexTrainingState::kUnusable) {
-    builder.add(StaticStrings::ErrorMessage,
-                VPackValue("not enough training data for vector index"));
+    auto error = trainingError();
+    builder.add(
+        StaticStrings::ErrorMessage,
+        VPackValue(error.empty() ? "not enough training data for vector index"
+                                 : error));
   }
 
   if (auto const nLists = resolvedNLists(); nLists.has_value()) {
@@ -313,6 +316,16 @@ bool RocksDBVectorIndex::setTrainingState(
 void RocksDBVectorIndex::resetTrainingState() noexcept {
   _trainingState.exchange(VectorIndexTrainingState::kUnusable,
                           std::memory_order_acq_rel);
+}
+
+void RocksDBVectorIndex::setTrainingError(std::string error) noexcept {
+  std::lock_guard lock(_trainingErrorMutex);
+  _trainingError = std::move(error);
+}
+
+std::string RocksDBVectorIndex::trainingError() const {
+  std::lock_guard lock(_trainingErrorMutex);
+  return _trainingError;
 }
 
 Result RocksDBVectorIndex::prepareIndex(std::unique_ptr<rocksdb::Iterator> it,

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -356,6 +356,7 @@ void RocksDBVectorIndex::truncateCommit(TruncateGuard&& guard,
                                         TRI_voc_tick_t tick,
                                         transaction::Methods* trx) {
   resetTrainingState();
+  setTrainingError({});
   _faissIndex.reset();
   _trainedData = {};
   RocksDBIndex::truncateCommit(std::move(guard), tick, trx);

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -352,7 +352,7 @@ void RocksDBVectorIndex::truncateCommit(TruncateGuard&& guard,
                                         TRI_voc_tick_t tick,
                                         transaction::Methods* trx) {
   resetTrainingState();
-  setTrainingError(std::string{kDefaultTrainingError});
+  setTrainingError(std::string{StaticStrings::VectorIndexDefaultTrainingError});
   _faissIndex.reset();
   _trainedData = {};
   RocksDBIndex::truncateCommit(std::move(guard), tick, trx);

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.cpp
@@ -352,7 +352,7 @@ void RocksDBVectorIndex::truncateCommit(TruncateGuard&& guard,
                                         TRI_voc_tick_t tick,
                                         transaction::Methods* trx) {
   resetTrainingState();
-  setTrainingError("not enough training data for vector index");
+  setTrainingError(std::string{kDefaultTrainingError});
   _faissIndex.reset();
   _trainedData = {};
   RocksDBIndex::truncateCommit(std::move(guard), tick, trx);

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <type_traits>
 
+#include "Basics/StaticStrings.h"
 #include "RocksDBIndex.h"
 #include "VectorIndex/VectorIndexDefinition.h"
 #include "RocksDBEngine/RocksDBIndex.h"
@@ -173,13 +174,10 @@ class RocksDBVectorIndex final : public RocksDBIndex {
   std::atomic<VectorIndexTrainingState> _trainingState{
       VectorIndexTrainingState::kUnusable};
 
+  mutable std::mutex _trainingErrorMutex;
   // Placeholder used while the build manager hasn't yet diagnosed why the
   // index is unusable (e.g. between ensureIndex and the first scan).
-  static constexpr std::string_view kDefaultTrainingError =
-      "not enough training data for vector index";
-
-  mutable std::mutex _trainingErrorMutex;
-  std::string _trainingError{kDefaultTrainingError};
+  std::string _trainingError{StaticStrings::VectorIndexDefaultTrainingError};
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -24,6 +24,8 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <type_traits>
 
 #include "RocksDBIndex.h"
@@ -141,9 +143,11 @@ class RocksDBVectorIndex final : public RocksDBIndex {
     return _trainingState.load(std::memory_order_acquire);
   }
 
-  /// @brief Clear trained data on build failure so that
-  /// stale training state is not accidentally persisted.
   void resetTrainingState() noexcept;
+
+  void setTrainingError(std::string error) noexcept;
+
+  std::string trainingError() const;
 
  protected:
   ResultT<std::vector<float>> preModificationCheck(std::string_view operation,
@@ -168,6 +172,9 @@ class RocksDBVectorIndex final : public RocksDBIndex {
   std::size_t _trainingThreshold{0};
   std::atomic<VectorIndexTrainingState> _trainingState{
       VectorIndexTrainingState::kUnusable};
+
+  mutable std::mutex _trainingErrorMutex;
+  std::string _trainingError;
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -174,7 +174,9 @@ class RocksDBVectorIndex final : public RocksDBIndex {
       VectorIndexTrainingState::kUnusable};
 
   mutable std::mutex _trainingErrorMutex;
-  std::string _trainingError;
+  // default vector index state is unusable with "not enough training data"
+  // error, until proven otherwise
+  std::string _trainingError{"not enough training data for vector index"};
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBVectorIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndex.h
@@ -173,10 +173,13 @@ class RocksDBVectorIndex final : public RocksDBIndex {
   std::atomic<VectorIndexTrainingState> _trainingState{
       VectorIndexTrainingState::kUnusable};
 
+  // Placeholder used while the build manager hasn't yet diagnosed why the
+  // index is unusable (e.g. between ensureIndex and the first scan).
+  static constexpr std::string_view kDefaultTrainingError =
+      "not enough training data for vector index";
+
   mutable std::mutex _trainingErrorMutex;
-  // default vector index state is unusable with "not enough training data"
-  // error, until proven otherwise
-  std::string _trainingError{"not enough training data for vector index"};
+  std::string _trainingError{kDefaultTrainingError};
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -37,6 +37,7 @@
 #include <cstdint>
 #include <format>
 #include <functional>
+#include <limits>
 #include <string>
 #include <thread>
 
@@ -260,6 +261,13 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
 
   auto const seed = RandomDevice::seed64();
 
+  // Guard against uint64_t overflow when computing the reservoir size.
+  // Wrap here would under-account memScope and let training allocate unbounded.
+  TRI_ASSERT(def.dimension > 0);
+  TRI_ASSERT(def.dimension <=
+             std::numeric_limits<std::uint64_t>::max() / sizeof(float));
+  TRI_ASSERT(reservoirCapacity <= std::numeric_limits<std::uint64_t>::max() /
+                                      (def.dimension * sizeof(float)));
   std::uint64_t const expectedReservoirBytes =
       static_cast<std::uint64_t>(reservoirCapacity) * def.dimension *
       sizeof(float);

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -174,8 +174,11 @@ BoundedDocumentIterator::BoundedDocumentIterator(RocksDBKeyBounds bounds,
 }
 
 VectorIndexTrainer::VectorIndexTrainer(RocksDBVectorIndex const& index,
+                                       ResourceMonitor& resourceMonitor,
                                        rocksdb::DB* db, RocksDBKeyBounds bounds)
-    : _index(index), _docIt(std::move(bounds), db) {}
+    : _index(index),
+      _resourceMonitor(resourceMonitor),
+      _docIt(std::move(bounds), db) {}
 
 std::shared_ptr<faiss::IndexIVF> VectorIndexTrainer::createFaissIndex(
     std::size_t resolvedNLists) const {
@@ -247,7 +250,7 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
     return std::move(resolved).result();
   }
   std::size_t const reservoirCapacity = std::invoke([&] {
-    auto const capacity = resolved.get() * kMaxTrainingSizePerNLists;
+    auto const capacity = resolved.get() * def.numberOfDocsPerCentroid;
     if (_index.sparse()) {
       return capacity;
     }
@@ -257,12 +260,18 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
 
   auto const seed = RandomDevice::seed64();
 
+  std::uint64_t const expectedReservoirBytes =
+      static_cast<std::uint64_t>(reservoirCapacity) * def.dimension *
+      sizeof(float);
+  ResourceUsageScope memScope(_resourceMonitor, expectedReservoirBytes);
+
   LOG_TOPIC("b161b", INFO, Logger::ENGINES) << std::format(
       "[shard={}, index={}] Collecting training data dimension {} for {} "
-      "index with numDocsHint: {}, reservoir capacity: {}, sampler seed: {}.",
+      "index with numDocsHint: {}, reservoir capacity: {} (~{} MiB), sampler "
+      "seed: {}.",
       _index.collection().name(), _index.id().id(), def.dimension,
       _index.sparse() ? "sparse" : "non-sparse", numDocsHint, reservoirCapacity,
-      seed);
+      expectedReservoirBytes / (1024 * 1024), seed);
 
   VectorIndexTrainingSampler sampler{def.dimension, reservoirCapacity, seed};
   std::vector<float> inputBuffer;
@@ -318,7 +327,13 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
     if (resolved.fail()) {
       return std::move(resolved).result();
     }
-    sampler.resize(resolved.get() * kMaxTrainingSizePerNLists);
+    auto const newCapacity = resolved.get() * def.numberOfDocsPerCentroid;
+    if (newCapacity < reservoirCapacity) {
+      auto const newBytes = static_cast<std::uint64_t>(newCapacity) *
+                            def.dimension * sizeof(float);
+      memScope.decrease(expectedReservoirBytes - newBytes);
+    }
+    sampler.resize(newCapacity);
   }
 
   auto trainingData = std::move(sampler).release();
@@ -335,7 +350,8 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
                   "training process."};
   }
 
-  return ResultT<TrainingDataset>({std::move(trainingData), validSeen});
+  return ResultT<TrainingDataset>(
+      {std::move(trainingData), validSeen, std::move(memScope)});
 }
 
 ResultT<std::size_t> VectorIndexTrainer::resolveNLists(
@@ -695,8 +711,10 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
   return firstError;
 }
 
-VectorIndexBuilder::VectorIndexBuilder(RocksDBVectorIndex& index)
+VectorIndexBuilder::VectorIndexBuilder(RocksDBVectorIndex& index,
+                                       ResourceMonitor& resourceMonitor)
     : _index(index),
+      _resourceMonitor(resourceMonitor),
       _engine(index.collection().vocbase().engine<RocksDBEngine>()),
       _rootDB(_engine.db()->GetRootDB()),
       _rcoll(static_cast<RocksDBCollection*>(index.collection().getPhysical())),
@@ -747,7 +765,7 @@ Result VectorIndexBuilder::build(
 
   // TRAINING PHASE
   auto const numDocsHint = _rcoll->meta().numberDocuments();
-  VectorIndexTrainer trainer(_index, _rootDB, _bounds);
+  VectorIndexTrainer trainer(_index, _resourceMonitor, _rootDB, _bounds);
 
   auto const trainStart = std::chrono::steady_clock::now();
   if (shouldAbort()) {

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -318,22 +318,13 @@ VectorIndexTrainer::collectTrainingDataset(rocksdb::Iterator& it,
 
   std::size_t const validSeen = sampler.itemsSeen();
 
-  // Sparse+scaling: we need to resize after full iteration since we cannot
-  // calculate the true k from numDocsHint (which over-counts by the number of
-  // docs without the vector field). A uniform subsample of a uniform sample
-  // stays uniform, so this preserves the Algorithm L guarantee.
   if (sparseScaling && validSeen > 0) {
-    auto resolved = resolveNLists(validSeen);
-    if (resolved.fail()) {
-      return std::move(resolved).result();
+    if (auto res = shrinkReservoirForSparseScaling(validSeen, reservoirCapacity,
+                                                   expectedReservoirBytes,
+                                                   memScope, sampler);
+        res.fail()) {
+      return res;
     }
-    auto const newCapacity = resolved.get() * def.numberOfDocsPerCentroid;
-    if (newCapacity < reservoirCapacity) {
-      auto const newBytes = static_cast<std::uint64_t>(newCapacity) *
-                            def.dimension * sizeof(float);
-      memScope.decrease(expectedReservoirBytes - newBytes);
-    }
-    sampler.resize(newCapacity);
   }
 
   auto trainingData = std::move(sampler).release();
@@ -363,6 +354,28 @@ ResultT<std::size_t> VectorIndexTrainer::resolveNLists(
                   "numDocsHint is 0"};
   }
   return resolveNListsParameter(nLists, numDocsHint);
+}
+
+// We resize after the full iteration because numDocsHint over-counts by the
+// number of docs without the vector field. A uniform subsample of a uniform
+// sample stays uniform, so this preserves the Algorithm L guarantee.
+Result VectorIndexTrainer::shrinkReservoirForSparseScaling(
+    std::size_t validSeen, std::size_t reservoirCapacity,
+    std::uint64_t expectedReservoirBytes, ResourceUsageScope& memScope,
+    VectorIndexTrainingSampler& sampler) const {
+  auto resolved = resolveNLists(validSeen);
+  if (resolved.fail()) {
+    return std::move(resolved).result();
+  }
+  auto const& def = _index.getDefinition();
+  auto const newCapacity = resolved.get() * def.numberOfDocsPerCentroid;
+  if (newCapacity < reservoirCapacity) {
+    auto const newBytes =
+        static_cast<std::uint64_t>(newCapacity) * def.dimension * sizeof(float);
+    memScope.decrease(expectedReservoirBytes - newBytes);
+  }
+  sampler.resize(newCapacity);
+  return {};
 }
 
 ResultT<std::shared_ptr<faiss::IndexIVF>> VectorIndexTrainer::train(

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -369,11 +369,6 @@ Result VectorIndexTrainer::shrinkReservoirForSparseScaling(
   }
   auto const& def = _index.getDefinition();
   auto const newCapacity = resolved.get() * def.numberOfDocsPerCentroid;
-  if (newCapacity < reservoirCapacity) {
-    auto const newBytes =
-        static_cast<std::uint64_t>(newCapacity) * def.dimension * sizeof(float);
-    memScope.decrease(expectedReservoirBytes - newBytes);
-  }
   sampler.resize(newCapacity);
   return {};
 }

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
@@ -52,13 +52,10 @@ class Index;
 class RocksDBIndex;
 class RocksDBVectorIndex;
 class RocksDBEngine;
+struct ResourceMonitor;
 }  // namespace arangodb
 
 namespace arangodb::vector {
-
-// Taken from:
-// ClusteringParameters.max_points_per_centroid
-static constexpr std::size_t kMaxTrainingSizePerNLists{256};
 
 TrainedData serializeIndex(faiss::IndexIVF const& index);
 
@@ -87,7 +84,8 @@ class VectorIndexTrainer {
   };
 
  public:
-  VectorIndexTrainer(RocksDBVectorIndex const& index, rocksdb::DB* db,
+  VectorIndexTrainer(RocksDBVectorIndex const& index,
+                     ResourceMonitor& resourceMonitor, rocksdb::DB* db,
                      RocksDBKeyBounds bounds);
 
   static std::shared_ptr<faiss::IndexIVF> restoreFromTrainedData(
@@ -115,6 +113,7 @@ class VectorIndexTrainer {
   ResultT<std::size_t> resolveNLists(std::uint64_t numDocsHint) const;
 
   RocksDBVectorIndex const& _index;
+  ResourceMonitor& _resourceMonitor;
   BoundedDocumentIterator _docIt;
 };
 
@@ -124,7 +123,8 @@ Result ingestVectors(RocksDBVectorIndex& index, rocksdb::DB* rootDB,
 
 class VectorIndexBuilder {
  public:
-  explicit VectorIndexBuilder(RocksDBVectorIndex& index);
+  VectorIndexBuilder(RocksDBVectorIndex& index,
+                     ResourceMonitor& resourceMonitor);
 
   Result build(std::shared_ptr<RocksDBIndex> indexPtr,
                metrics::Histogram<metrics::LogScale<double>>& trainingDuration,
@@ -135,6 +135,7 @@ class VectorIndexBuilder {
   Result persistTrainedData(TrainedData const& trainedData);
 
   RocksDBVectorIndex& _index;
+  ResourceMonitor& _resourceMonitor;
   RocksDBEngine& _engine;
   rocksdb::DB* _rootDB;
   RocksDBCollection* _rcoll;

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
@@ -81,9 +81,7 @@ class VectorIndexTrainer {
     // field. Used to resolve nLists for sparse indexes where numDocsHint
     // (total doc count) overestimates the actual vector-bearing doc count.
     std::size_t totalValidVectorCount;
-    // Holds the reservoir bytes against the resource monitor for the full
-    // lifetime of `data` (i.e. through the FAISS train() step). Released
-    // when this dataset is destroyed.
+    // Holds the reservoir bytes against the monitor for `data`'s lifetime.
     ResourceUsageScope memScope;
   };
 

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "Basics/AttributeNameParser.h"
+#include "Basics/ResourceUsage.h"
 #include "Basics/Result.h"
 #include "Basics/ResultT.h"
 #include "VectorIndex/VectorIndexDefinition.h"
@@ -52,7 +53,6 @@ class Index;
 class RocksDBIndex;
 class RocksDBVectorIndex;
 class RocksDBEngine;
-struct ResourceMonitor;
 }  // namespace arangodb
 
 namespace arangodb::vector {
@@ -81,6 +81,10 @@ class VectorIndexTrainer {
     // field. Used to resolve nLists for sparse indexes where numDocsHint
     // (total doc count) overestimates the actual vector-bearing doc count.
     std::size_t totalValidVectorCount;
+    // Holds the reservoir bytes against the resource monitor for the full
+    // lifetime of `data` (i.e. through the FAISS train() step). Released
+    // when this dataset is destroyed.
+    ResourceUsageScope memScope;
   };
 
  public:

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.h
@@ -35,7 +35,6 @@
 #include <cstdint>
 #include <memory>
 #include <stop_token>
-#include <string_view>
 #include <vector>
 
 #include <faiss/IndexIVF.h>
@@ -56,6 +55,8 @@ class RocksDBEngine;
 }  // namespace arangodb
 
 namespace arangodb::vector {
+
+class VectorIndexTrainingSampler;
 
 TrainedData serializeIndex(faiss::IndexIVF const& index);
 
@@ -113,6 +114,14 @@ class VectorIndexTrainer {
   /// Resolve the nLists value from the definition, using numDocsHint for
   /// scaling mode.
   ResultT<std::size_t> resolveNLists(std::uint64_t numDocsHint) const;
+
+  /// Sparse+scaling post-iteration step: recompute reservoir capacity from
+  /// the actual valid-vector count, shrink the sampler, and release the
+  /// freed bytes from the resource monitor.
+  Result shrinkReservoirForSparseScaling(
+      std::size_t validSeen, std::size_t reservoirCapacity,
+      std::uint64_t expectedReservoirBytes, ResourceUsageScope& memScope,
+      VectorIndexTrainingSampler& sampler) const;
 
   RocksDBVectorIndex const& _index;
   ResourceMonitor& _resourceMonitor;

--- a/arangod/VectorIndex/VectorIndexBuildManager.cpp
+++ b/arangod/VectorIndex/VectorIndexBuildManager.cpp
@@ -254,13 +254,15 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
         auto const numDocs = rcoll->meta().numberDocuments();
         if (numDocs < vecIdx.trainingThreshold()) {
           skippedWaiters.insert(vecIdx.id().id());
-          reportIndexError(
-              vocbase, *coll, vecIdx,
-              Result{TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
-                     std::format("not enough training data for vector "
-                                 "index, need at least {} documents "
-                                 "but only {} present",
-                                 vecIdx.trainingThreshold(), numDocs)});
+          auto belowThresholdMsg = std::format(
+              "not enough training data for vector "
+              "index, need at least {} documents "
+              "but only {} present",
+              vecIdx.trainingThreshold(), numDocs);
+          vecIdx.setTrainingError(belowThresholdMsg);
+          reportIndexError(vocbase, *coll, vecIdx,
+                           Result{TRI_ERROR_QUERY_VECTOR_INDEX_NOT_READY,
+                                  std::move(belowThresholdMsg)});
           continue;
         }
 

--- a/arangod/VectorIndex/VectorIndexBuildManager.cpp
+++ b/arangod/VectorIndex/VectorIndexBuildManager.cpp
@@ -55,9 +55,6 @@ DECLARE_GAUGE(arangodb_vector_index_unusable, uint64_t,
               "Number of unusable vector indexes on this DBServer");
 DECLARE_GAUGE(arangodb_vector_index_training_ongoing, uint64_t,
               "Number of vector index trainings currently ongoing");
-DECLARE_GAUGE(arangodb_vector_index_training_memory_peak_bytes, uint64_t,
-              "Peak memory in bytes used by the most recent vector index "
-              "training reservoir on this server");
 
 struct VectorTrainingDurationScale {
   static arangodb::metrics::LogScale<double> scale() {
@@ -93,8 +90,6 @@ VectorIndexBuildManager::VectorIndexBuildManager(
       _untrainedCount(metrics.add(arangodb_vector_index_unusable{})),
       _trainingOngoingCount(
           metrics.add(arangodb_vector_index_training_ongoing{})),
-      _trainingMemoryPeakBytes(
-          metrics.add(arangodb_vector_index_training_memory_peak_bytes{})),
       _trainingDuration(metrics.add(arangodb_vector_index_training_duration{})),
       _ingestionDuration(
           metrics.add(arangodb_vector_index_ingestion_duration{})) {}
@@ -298,8 +293,6 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
             return Result{TRI_ERROR_INTERNAL, e.what()};
           }
         });
-        _trainingMemoryPeakBytes.store(_resourceMonitor.peak(),
-                                       std::memory_order_relaxed);
         _trainingOngoingCount.fetch_sub(1);
 
         if (res.fail()) {

--- a/arangod/VectorIndex/VectorIndexBuildManager.cpp
+++ b/arangod/VectorIndex/VectorIndexBuildManager.cpp
@@ -23,6 +23,7 @@
 
 #include "VectorIndex/VectorIndexBuildManager.h"
 
+#include "Basics/Exceptions.h"
 #include "Basics/GlobalResourceMonitor.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
@@ -281,15 +282,29 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
 
         _trainingOngoingCount.fetch_add(1);
         _resourceMonitor.clear();
+        vecIdx.setTrainingError({});
         auto indexPtr = std::static_pointer_cast<RocksDBIndex>(idx);
         VectorIndexBuilder builder(vecIdx, _resourceMonitor);
-        auto const res = builder.build(std::move(indexPtr), _trainingDuration,
-                                       _ingestionDuration, stopToken);
+
+        // ResourceUsageScope throws on overflow; catch so cleanup below
+        // runs uniformly for both Result-failed and thrown failures.
+        auto const res = std::invoke([&]() -> Result {
+          try {
+            return builder.build(std::move(indexPtr), _trainingDuration,
+                                 _ingestionDuration, stopToken);
+          } catch (basics::Exception const& e) {
+            return Result{e.code(), e.message()};
+          } catch (std::exception const& e) {
+            return Result{TRI_ERROR_INTERNAL, e.what()};
+          }
+        });
         _trainingMemoryPeakBytes.store(_resourceMonitor.peak(),
                                        std::memory_order_relaxed);
         _trainingOngoingCount.fetch_sub(1);
 
         if (res.fail()) {
+          vecIdx.resetTrainingState();
+          vecIdx.setTrainingError(std::string{res.errorMessage()});
           fulfillWaiters(vecIdx.id(), res);
           if (res.is(TRI_ERROR_RESOURCE_LIMIT)) {
             LOG_TOPIC("e165b", ERR, Logger::ENGINES)

--- a/arangod/VectorIndex/VectorIndexBuildManager.cpp
+++ b/arangod/VectorIndex/VectorIndexBuildManager.cpp
@@ -278,7 +278,7 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
             << " documents). Starting deferred training.";
 
         _trainingOngoingCount.fetch_add(1);
-        _resourceMonitor.clear();
+        TRI_ASSERT(_resourceMonitor.current() == 0);
         auto indexPtr = std::static_pointer_cast<RocksDBIndex>(idx);
         VectorIndexBuilder builder(vecIdx, _resourceMonitor);
 

--- a/arangod/VectorIndex/VectorIndexBuildManager.cpp
+++ b/arangod/VectorIndex/VectorIndexBuildManager.cpp
@@ -279,7 +279,6 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
 
         _trainingOngoingCount.fetch_add(1);
         _resourceMonitor.clear();
-        vecIdx.setTrainingError({});
         auto indexPtr = std::static_pointer_cast<RocksDBIndex>(idx);
         VectorIndexBuilder builder(vecIdx, _resourceMonitor);
 
@@ -298,8 +297,10 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
         _trainingOngoingCount.fetch_sub(1);
 
         if (res.fail()) {
-          vecIdx.resetTrainingState();
+          // Set the error before flipping state to kUnusable so a concurrent
+          // REST reader never observes kUnusable with an empty error.
           vecIdx.setTrainingError(std::string{res.errorMessage()});
+          vecIdx.resetTrainingState();
           fulfillWaiters(vecIdx.id(), res);
           if (res.is(TRI_ERROR_RESOURCE_LIMIT)) {
             LOG_TOPIC("e165b", ERR, Logger::ENGINES)

--- a/arangod/VectorIndex/VectorIndexBuildManager.cpp
+++ b/arangod/VectorIndex/VectorIndexBuildManager.cpp
@@ -23,8 +23,10 @@
 
 #include "VectorIndex/VectorIndexBuildManager.h"
 
+#include "Basics/GlobalResourceMonitor.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/voc-errors.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "Cluster/ServerState.h"
 #include "Indexes/Index.h"
@@ -52,6 +54,9 @@ DECLARE_GAUGE(arangodb_vector_index_unusable, uint64_t,
               "Number of unusable vector indexes on this DBServer");
 DECLARE_GAUGE(arangodb_vector_index_training_ongoing, uint64_t,
               "Number of vector index trainings currently ongoing");
+DECLARE_GAUGE(arangodb_vector_index_training_memory_peak_bytes, uint64_t,
+              "Peak memory in bytes used by the most recent vector index "
+              "training reservoir on this server");
 
 struct VectorTrainingDurationScale {
   static arangodb::metrics::LogScale<double> scale() {
@@ -83,9 +88,12 @@ VectorIndexBuildManager::VectorIndexBuildManager(
     : _dbFeature(dbFeature),
       _maintenance(maintenance),
       _scheduler(scheduler),
+      _resourceMonitor(GlobalResourceMonitor::instance()),
       _untrainedCount(metrics.add(arangodb_vector_index_unusable{})),
       _trainingOngoingCount(
           metrics.add(arangodb_vector_index_training_ongoing{})),
+      _trainingMemoryPeakBytes(
+          metrics.add(arangodb_vector_index_training_memory_peak_bytes{})),
       _trainingDuration(metrics.add(arangodb_vector_index_training_duration{})),
       _ingestionDuration(
           metrics.add(arangodb_vector_index_ingestion_duration{})) {}
@@ -272,17 +280,30 @@ void VectorIndexBuildManager::scanAndBuild(std::stop_token const& stopToken,
             << " documents). Starting deferred training.";
 
         _trainingOngoingCount.fetch_add(1);
+        _resourceMonitor.clear();
         auto indexPtr = std::static_pointer_cast<RocksDBIndex>(idx);
-        VectorIndexBuilder builder(vecIdx);
+        VectorIndexBuilder builder(vecIdx, _resourceMonitor);
         auto const res = builder.build(std::move(indexPtr), _trainingDuration,
                                        _ingestionDuration, stopToken);
+        _trainingMemoryPeakBytes.store(_resourceMonitor.peak(),
+                                       std::memory_order_relaxed);
         _trainingOngoingCount.fetch_sub(1);
 
         if (res.fail()) {
           fulfillWaiters(vecIdx.id(), res);
-          LOG_TOPIC("e164b", ERR, Logger::ENGINES)
-              << "[index=" << vecIdx.id().id()
-              << "] Vector build failed: " << res.errorMessage();
+          if (res.is(TRI_ERROR_RESOURCE_LIMIT)) {
+            LOG_TOPIC("e165b", ERR, Logger::ENGINES)
+                << "[index=" << vecIdx.id().id()
+                << "] Vector build aborted: training reservoir exceeded the "
+                   "configured memory limit. Lower numberOfDocsPerCentroid in "
+                   "the index definition or raise the global memory limit. "
+                   "Details: "
+                << res.errorMessage();
+          } else {
+            LOG_TOPIC("e164b", ERR, Logger::ENGINES)
+                << "[index=" << vecIdx.id().id()
+                << "] Vector build failed: " << res.errorMessage();
+          }
           failedBuilds[vecIdx.objectId()] = {std::chrono::steady_clock::now(),
                                              numDocs};
 

--- a/arangod/VectorIndex/VectorIndexBuildManager.h
+++ b/arangod/VectorIndex/VectorIndexBuildManager.h
@@ -31,6 +31,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "Basics/ResourceUsage.h"
 #include "Basics/Result.h"
 #include "Futures/Future.h"
 #include "Futures/Promise.h"
@@ -106,8 +107,16 @@ class VectorIndexBuildManager {
   Scheduler& _scheduler;
   std::jthread _thread;
 
+  // Tracks memory used by the training-data reservoir of each build.
+  // Backed by GlobalResourceMonitor::instance(), so allocations roll up
+  // into ArangoDB's global memory counter and a build that would exceed
+  // the global limit fails fast with TRI_ERROR_RESOURCE_LIMIT instead of
+  // OOM-killing the process. Cleared between builds.
+  ResourceMonitor _resourceMonitor;
+
   metrics::Gauge<uint64_t>& _untrainedCount;
   metrics::Gauge<uint64_t>& _trainingOngoingCount;
+  metrics::Gauge<uint64_t>& _trainingMemoryPeakBytes;
   metrics::Histogram<metrics::LogScale<double>>& _trainingDuration;
   metrics::Histogram<metrics::LogScale<double>>& _ingestionDuration;
 

--- a/arangod/VectorIndex/VectorIndexBuildManager.h
+++ b/arangod/VectorIndex/VectorIndexBuildManager.h
@@ -107,11 +107,6 @@ class VectorIndexBuildManager {
   Scheduler& _scheduler;
   std::jthread _thread;
 
-  // Tracks memory used by the training-data reservoir of each build.
-  // Backed by GlobalResourceMonitor::instance(), so allocations roll up
-  // into ArangoDB's global memory counter and a build that would exceed
-  // the global limit fails fast with TRI_ERROR_RESOURCE_LIMIT instead of
-  // OOM-killing the process. Cleared between builds.
   ResourceMonitor _resourceMonitor;
 
   metrics::Gauge<uint64_t>& _untrainedCount;

--- a/arangod/VectorIndex/VectorIndexBuildManager.h
+++ b/arangod/VectorIndex/VectorIndexBuildManager.h
@@ -111,7 +111,6 @@ class VectorIndexBuildManager {
 
   metrics::Gauge<uint64_t>& _untrainedCount;
   metrics::Gauge<uint64_t>& _trainingOngoingCount;
-  metrics::Gauge<uint64_t>& _trainingMemoryPeakBytes;
   metrics::Histogram<metrics::LogScale<double>>& _trainingDuration;
   metrics::Histogram<metrics::LogScale<double>>& _ingestionDuration;
 

--- a/arangod/VectorIndex/VectorIndexDefinition.h
+++ b/arangod/VectorIndex/VectorIndexDefinition.h
@@ -41,7 +41,7 @@ namespace arangodb::vector {
 static constexpr std::uint64_t kdefaultTrainingIterations{25};
 static constexpr std::uint64_t kdefaultNProbe{1};
 // Mirrors faiss::ClusteringParameters::max_points_per_centroid.
-static constexpr std::uint64_t kdefaultNumberOfDocsPerCentroid{256};
+static constexpr std::uint64_t kdefaultNumberOfDocsPerCentroid{100};
 
 struct SearchParameters {
   std::optional<std::int64_t> nProbe;

--- a/arangod/VectorIndex/VectorIndexDefinition.h
+++ b/arangod/VectorIndex/VectorIndexDefinition.h
@@ -40,6 +40,9 @@ namespace arangodb::vector {
 // Number of training iterations, in faiss it is 25 by default
 static constexpr std::uint64_t kdefaultTrainingIterations{25};
 static constexpr std::uint64_t kdefaultNProbe{1};
+// Per-centroid sample count for the training reservoir. Mirrors
+// faiss::ClusteringParameters::max_points_per_centroid.
+static constexpr std::uint64_t kdefaultNumberOfDocsPerCentroid{256};
 
 struct SearchParameters {
   std::optional<std::int64_t> nProbe;
@@ -225,6 +228,13 @@ struct UserVectorIndexDefinition {
 
   std::int64_t defaultNProbe;
 
+  // Caps the per-centroid sample count of the training reservoir. The
+  // reservoir's worst-case size in bytes is
+  //   nLists * numberOfDocsPerCentroid * dimension * sizeof(float).
+  // Lower this to reduce memory pressure during training at the cost of
+  // training-set quality.
+  std::uint64_t numberOfDocsPerCentroid;
+
   // FAISS factory string.
   std::optional<std::string> factory;
 
@@ -263,6 +273,14 @@ struct UserVectorIndexDefinition {
             .invariant([](auto value) -> inspection::Status {
               if (value < 1) {
                 return {"defaultNProbe must be 1 or greater!"};
+              }
+              return inspection::Status::Success{};
+            }),
+        f.field("numberOfDocsPerCentroid", x.numberOfDocsPerCentroid)
+            .fallback(kdefaultNumberOfDocsPerCentroid)
+            .invariant([](auto value) -> inspection::Status {
+              if (value < 1) {
+                return {"numberOfDocsPerCentroid must be 1 or greater!"};
               }
               return inspection::Status::Success{};
             }));

--- a/arangod/VectorIndex/VectorIndexDefinition.h
+++ b/arangod/VectorIndex/VectorIndexDefinition.h
@@ -40,8 +40,7 @@ namespace arangodb::vector {
 // Number of training iterations, in faiss it is 25 by default
 static constexpr std::uint64_t kdefaultTrainingIterations{25};
 static constexpr std::uint64_t kdefaultNProbe{1};
-// Per-centroid sample count for the training reservoir. Mirrors
-// faiss::ClusteringParameters::max_points_per_centroid.
+// Mirrors faiss::ClusteringParameters::max_points_per_centroid.
 static constexpr std::uint64_t kdefaultNumberOfDocsPerCentroid{256};
 
 struct SearchParameters {
@@ -228,10 +227,8 @@ struct UserVectorIndexDefinition {
 
   std::int64_t defaultNProbe;
 
-  // Caps the per-centroid sample count of the training reservoir. The
-  // reservoir's worst-case size in bytes is
-  //   nLists * numberOfDocsPerCentroid * dimension * sizeof(float).
-  // Lower this to reduce memory pressure during training at the cost of
+  // Reservoir size = nLists * numberOfDocsPerCentroid * dimension *
+  // sizeof(float). Lower this to reduce training memory at the cost of
   // training-set quality.
   std::uint64_t numberOfDocsPerCentroid;
 

--- a/arangod/VectorIndex/VectorIndexDefinition.h
+++ b/arangod/VectorIndex/VectorIndexDefinition.h
@@ -40,7 +40,8 @@ namespace arangodb::vector {
 // Number of training iterations, in faiss it is 25 by default
 static constexpr std::uint64_t kdefaultTrainingIterations{25};
 static constexpr std::uint64_t kdefaultNProbe{1};
-// Mirrors faiss::ClusteringParameters::max_points_per_centroid.
+// Matches autofaiss's points_per_cluster default; lower than FAISS's
+// own max_points_per_centroid (256) to keep training memory in check.
 static constexpr std::uint64_t kdefaultNumberOfDocsPerCentroid{100};
 
 struct SearchParameters {

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -160,6 +160,8 @@ class StaticStrings {
   static std::string_view constexpr IndexTrainingStateIngesting{"ingesting"};
   static std::string_view constexpr IndexTrainingStateReady{"ready"};
   static std::string_view constexpr IndexResolvedNLists{"resolvedNLists"};
+  static std::string_view constexpr VectorIndexDefaultTrainingError{
+      "not enough training data for vector index"};
 
   // static index names
   static std::string const IndexNameEdge;

--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -270,6 +270,81 @@ function VectorIndexTestCreationWithVectors() {
             }
         },
 
+        testCreateVectorIndexNumberOfDocsPerCentroidDefaults: function() {
+            let gen = randomNumberGeneratorFloat(seed);
+
+            let docs = [];
+            for (let i = 0; i < 100; ++i) {
+                const vector = Array.from({ length: dimension }, () => gen());
+                docs.push({ vector });
+            }
+            collection.insert(docs);
+
+            collection.ensureIndex({
+                name: "vector_l2",
+                type: "vector",
+                fields: ["vector"],
+                inBackground: false,
+                params: {
+                    metric: "l2",
+                    dimension: dimension,
+                    nLists: 1,
+                    trainingIterations: 10,
+                },
+            });
+            const idx = collection.getIndexes().find(i => i.name === "vector_l2");
+            assertEqual(256, idx.params.numberOfDocsPerCentroid,
+                "default numberOfDocsPerCentroid should be 256");
+        },
+
+        testCreateVectorIndexWithCustomNumberOfDocsPerCentroid: function() {
+            let gen = randomNumberGeneratorFloat(seed);
+
+            let docs = [];
+            for (let i = 0; i < 100; ++i) {
+                const vector = Array.from({ length: dimension }, () => gen());
+                docs.push({ vector });
+            }
+            collection.insert(docs);
+
+            collection.ensureIndex({
+                name: "vector_l2",
+                type: "vector",
+                fields: ["vector"],
+                inBackground: false,
+                params: {
+                    metric: "l2",
+                    dimension: dimension,
+                    nLists: 1,
+                    trainingIterations: 10,
+                    numberOfDocsPerCentroid: 32,
+                },
+            });
+            const idx = collection.getIndexes().find(i => i.name === "vector_l2");
+            assertEqual(32, idx.params.numberOfDocsPerCentroid);
+        },
+
+        testCreateVectorIndexWithZeroNumberOfDocsPerCentroid: function() {
+            try {
+                collection.ensureIndex({
+                    name: "vector_l2",
+                    type: "vector",
+                    fields: ["vector"],
+                    inBackground: false,
+                    params: {
+                        metric: "l2",
+                        dimension: dimension,
+                        nLists: 1,
+                        trainingIterations: 10,
+                        numberOfDocsPerCentroid: 0,
+                    },
+                });
+                fail();
+            } catch (e) {
+                assertEqual(errors.ERROR_BAD_PARAMETER.code, e.errorNum);
+            }
+        },
+
         testCreateVectorIndexWithVectorsContainingIntegersAndDoubles: function() {
             let gen = randomNumberGeneratorFloat(seed);
 

--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -293,8 +293,8 @@ function VectorIndexTestCreationWithVectors() {
                 },
             });
             const idx = collection.getIndexes().find(i => i.name === "vector_l2");
-            assertEqual(256, idx.params.numberOfDocsPerCentroid,
-                "default numberOfDocsPerCentroid should be 256");
+            assertEqual(100, idx.params.numberOfDocsPerCentroid,
+                "default numberOfDocsPerCentroid should be 100");
         },
 
         testCreateVectorIndexWithCustomNumberOfDocsPerCentroid: function() {

--- a/tests/js/client/server_parameters/test-vector-index-memory-limit-noncluster.js
+++ b/tests/js/client/server_parameters/test-vector-index-memory-limit-noncluster.js
@@ -1,0 +1,117 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, assertEqual, assertTrue, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// / @author Jure Bajic
+// //////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'vector-index': true,
+    'query.global-memory-limit': '8388608',
+    'query.memory-limit': '8388608',
+  };
+}
+
+const jsunity = require('jsunity');
+const internal = require('internal');
+const db = internal.db;
+const errors = internal.errors;
+const {
+  randomNumberGeneratorFloat,
+  generateSeed,
+} = require('@arangodb/testutils/seededRandom');
+const {
+  generateDocs,
+} = require('@arangodb/testutils/vector-index-common');
+
+const dbName = 'vectorMemoryLimitDb';
+const collName = 'vectorMemoryLimitColl';
+
+// Reservoir = min(nLists * numberOfDocsPerCentroid, numDocs) * dimension * 4.
+// 16 * 100 * 2048 * 4 = 13 107 200 bytes (~12.5 MiB), comfortably above the
+// 8 MiB global limit set in getOptions. numDocs is sized so the reservoir is
+// not bounded below the limit by the document count.
+const dimension = 2048;
+const nLists = 16;
+const docsPerCentroid = 100;
+const numDocs = nLists * docsPerCentroid + 200;
+
+function vectorIndexMemoryLimitSuite() {
+  let collection;
+  const seed = generateSeed();
+
+  return {
+    setUpAll: function () {
+      db._useDatabase('_system');
+      try { db._dropDatabase(dbName); } catch (e) {}
+      db._createDatabase(dbName);
+      db._useDatabase(dbName);
+      collection = db._create(collName, {numberOfShards: 1});
+      const gen = randomNumberGeneratorFloat(seed);
+      const docs = generateDocs(gen, numDocs, dimension);
+      // Insert in batches so a single bulk insert does not itself trip the
+      // global limit during the test's own setup.
+      const batchSize = 100;
+      for (let i = 0; i < docs.length; i += batchSize) {
+        collection.insert(docs.slice(i, i + batchSize));
+      }
+    },
+
+    tearDownAll: function () {
+      db._useDatabase('_system');
+      try { db._dropDatabase(dbName); } catch (e) {}
+    },
+
+    testTrainingReservoirHitsGlobalMemoryLimit: function () {
+      // inBackground:false makes ensureIndex block until the build manager
+      // finishes training; on failure the call throws synchronously with the
+      // real error, so we don't have to poll for state transitions.
+      try {
+        collection.ensureIndex({
+          name: 'vec_l2',
+          type: 'vector',
+          fields: ['vector'],
+          inBackground: false,
+          params: {
+            metric: 'l2',
+            dimension,
+            nLists,
+            numberOfDocsPerCentroid: docsPerCentroid,
+            trainingIterations: 10,
+          },
+        });
+        fail();
+      } catch (err) {
+        assertEqual(errors.ERROR_RESOURCE_LIMIT.code, err.errorNum,
+          'Expected ERROR_RESOURCE_LIMIT, got: ' +
+          err.errorNum + ' / ' + err.errorMessage);
+        assertTrue(/memory|resource/i.test(err.errorMessage),
+          'Expected error to mention memory/resource limit, got: ' +
+          err.errorMessage);
+      }
+    },
+  };
+}
+
+jsunity.run(vectorIndexMemoryLimitSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Introduces `resourceManger` into VectorIndexManager to avoid OOM during vector index creation. The issue is we can allocate a lot of data when doing the training process; Before we allocated `256 * nLists * dimension * 4` bytes. And now we have two changes;
1. We use a resource manager to check whether we can allocate that much memory
2. We introduce an additional parameter `numberOfDocsPerCentroid` which controls how many data points per centroid to train now (default is 100, since autofaiss uses the same). The previous value was 256. 


## Type of PR

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-529
- [ ] Design document: 
