### PR TITLE
Apply optimize count when EN::Distribute

### DIFF
--- a/arangod/Aql/Optimizer/Rule/OptimizeCount.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizeCount.cpp
@@ -256,8 +256,6 @@ void optimizeCountRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
           break;
         }
 
-        case EN::DISTRIBUTE:
-
         case EN::INSERT:
         case EN::UPDATE:
         case EN::REPLACE:


### PR DESCRIPTION
### Scope & Purpose

For some reason the `EN::DISTRIBUTE` was excluded from applying the count optimisation. Try removing this exception