### PR TITLE
[COR-542]: Add UNION_DISTINCT_STABLE AQL Function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,8 @@
 * Upgraded included rclone to v1.73.5 with go1.25.9 and non-vulnerable
   dependencies.
 
+* COR-542: Added UNION_DISTINCT_STABLE AQL Function.
+
 * COR-528: Reserve keywords "INNER_JOIN", "LEFT_JOIN", "RIGHT_JOIN", and "OUTER_JOIN"
   are introduced for JOIN operations.
   

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,8 @@
 * Upgraded included rclone to v1.73.5 with go1.25.9 and non-vulnerable
   dependencies.
 
-* COR-542: Added UNION_DISTINCT_STABLE AQL Function.
+* COR-542: New AQL function UNION_DISTINCT_STABLE – merges arrays without duplicates
+  while preserving order, helping maintain predictable array ordering in queries
 
 * COR-528: Reserve keywords "INNER_JOIN", "LEFT_JOIN", "RIGHT_JOIN", and "OUTER_JOIN"
   are introduced for JOIN operations.

--- a/arangod/Aql/AqlFunctionFeature.cpp
+++ b/arangod/Aql/AqlFunctionFeature.cpp
@@ -306,6 +306,8 @@ void AqlFunctionFeature::addListFunctions() {
   add({"RANGE", ".,.|.", flags, &functions::Range});
   add({"UNION", ".,.|+", flags, &functions::Union});
   add({"UNION_DISTINCT", ".,.|+", flags, &functions::UnionDistinct});
+  add({"UNION_DISTINCT_STABLE", ".,.|+", flags,
+       &functions::UnionDistinctStable});
   add({"MINUS", ".,.|+", flags, &functions::Minus});
   add({"OUTERSECTION", ".,.|+", flags, &functions::Outersection});
   add({"INTERSECTION", ".,.|+", flags, &functions::Intersection});

--- a/arangod/Aql/Function/ArrayFunctions.cpp
+++ b/arangod/Aql/Function/ArrayFunctions.cpp
@@ -1049,14 +1049,12 @@ AqlValue functions::UnionDistinctStable(
     VPackSlice slice = aqlValueMaterializer.slice(value);
     for (VPackSlice v : VPackArrayIterator(slice)) {
       v = v.resolveExternal();
-      if (values.find(v) == values.end()) {
+      if (values.emplace(v).second) {
         TRI_IF_FAILURE("AqlFunctions::OutOfMemory1") {
           THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
         }
 
-        if (values.emplace(v).second) {
-          builder->add(v);
-        }
+        builder->add(v);
       }
     }
   }

--- a/arangod/Aql/Function/ArrayFunctions.cpp
+++ b/arangod/Aql/Function/ArrayFunctions.cpp
@@ -1018,6 +1018,58 @@ AqlValue functions::UnionDistinct(ExpressionContext* expressionContext,
   return AqlValue(builder->slice(), builder->size());
 }
 
+/// @brief function UNION_DISTINCT_STABLE
+AqlValue functions::UnionDistinctStable(
+    ExpressionContext* expressionContext, AstNode const&,
+    VPackFunctionParametersView parameters) {
+  static char const* AFN = "UNION_DISTINCT_STABLE";
+
+  transaction::Methods* trx = &expressionContext->trx();
+  auto* vopts = &trx->vpackOptions();
+
+  size_t const n = parameters.size();
+  containers::FlatHashSet<VPackSlice, basics::VelocyPackHelper::VPackHash,
+                          basics::VelocyPackHelper::VPackEqual>
+      values(512, basics::VelocyPackHelper::VPackHash(),
+             basics::VelocyPackHelper::VPackEqual(vopts));
+
+  auto builder = ThreadLocalBuilderLeaser::lease();
+  builder->openArray();
+  AqlValueMaterializer aqlValueMaterializer = AqlValueMaterializer(vopts);
+  for (size_t i = 0; i < n; ++i) {
+    AqlValue const& value =
+        aql::functions::extractFunctionParameterValue(parameters, i);
+
+    if (!value.isArray()) {
+      // not an array
+      registerInvalidArgumentWarning(expressionContext, AFN);
+      return AqlValue(AqlValueHintNull());
+    }
+
+    VPackSlice slice = aqlValueMaterializer.slice(value);
+    for (VPackSlice v : VPackArrayIterator(slice)) {
+      v = v.resolveExternal();
+      if (values.find(v) == values.end()) {
+        TRI_IF_FAILURE("AqlFunctions::OutOfMemory1") {
+          THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+        }
+
+        if (values.emplace(v).second) {
+          builder->add(v);
+        }
+      }
+    }
+  }
+
+  TRI_IF_FAILURE("AqlFunctions::OutOfMemory2") {
+    THROW_ARANGO_EXCEPTION(TRI_ERROR_DEBUG);
+  }
+
+  builder->close();
+
+  return AqlValue(builder->slice(), builder->size());
+}
+
 /// @brief function INTERSECTION
 AqlValue functions::Intersection(ExpressionContext* expressionContext,
                                  AstNode const&,

--- a/arangod/Aql/Function/ArrayFunctions.cpp
+++ b/arangod/Aql/Function/ArrayFunctions.cpp
@@ -1035,7 +1035,8 @@ AqlValue functions::UnionDistinctStable(
 
   auto builder = ThreadLocalBuilderLeaser::lease();
   builder->openArray();
-  AqlValueMaterializer aqlValueMaterializer = AqlValueMaterializer(vopts);
+  std::vector<AqlValueMaterializer> materializers;
+  materializers.reserve(n);
   for (size_t i = 0; i < n; ++i) {
     AqlValue const& value =
         aql::functions::extractFunctionParameterValue(parameters, i);
@@ -1046,7 +1047,8 @@ AqlValue functions::UnionDistinctStable(
       return AqlValue(AqlValueHintNull());
     }
 
-    VPackSlice slice = aqlValueMaterializer.slice(value);
+    materializers.emplace_back(vopts);
+    VPackSlice slice = materializers.back().slice(value);
     for (VPackSlice v : VPackArrayIterator(slice)) {
       v = v.resolveExternal();
       if (values.emplace(v).second) {

--- a/arangod/Aql/Functions.h
+++ b/arangod/Aql/Functions.h
@@ -361,6 +361,8 @@ AqlValue Union(arangodb::aql::ExpressionContext*, AstNode const&,
                VPackFunctionParametersView);
 AqlValue UnionDistinct(arangodb::aql::ExpressionContext*, AstNode const&,
                        VPackFunctionParametersView);
+AqlValue UnionDistinctStable(arangodb::aql::ExpressionContext*, AstNode const&,
+                             VPackFunctionParametersView);
 AqlValue Intersection(arangodb::aql::ExpressionContext*, AstNode const&,
                       VPackFunctionParametersView);
 AqlValue Outersection(arangodb::aql::ExpressionContext*, AstNode const&,

--- a/js/node/node_modules/aqb/assumptions.js
+++ b/js/node/node_modules/aqb/assumptions.js
@@ -48,7 +48,7 @@ exports.builtins = {
   MEDIAN: 1, PERCENTILE: [2, 3], VARIANCE_POPULATION: 1, VARIANCE_SAMPLE: 1,
   STDDEV_POPULATION: 1, STDDEV_SAMPLE: 1, /*REVERSE: 1,*/
   FIRST: 1, LAST: 1, NTH: 2, POSITION: [2, 3], SLICE: [2, 3],
-  UNIQUE: 1, UNION: [[1, Infinity]], UNION_DISTINCT: [[1, Infinity]],
+  UNIQUE: 1, UNION: [[1, Infinity]], UNION_DISTINCT: [[1, Infinity]], UNION_DISTINCT_STABLE: [[1, Infinity]],
   MINUS: [[1, Infinity]], INTERSECTION: [[1, Infinity]],
   CALL: [[1, Infinity]], APPLY: [[1, Infinity]],
   PUSH: [2, 3], APPEND: [2, 3], POP: 1, SHIFT: 1, UNSHIFT: [2, 3],

--- a/tests/js/client/aql/aql-failures-noncluster-fp.js
+++ b/tests/js/client/aql/aql-failures-noncluster-fp.js
@@ -169,6 +169,21 @@ function ahuacatlFailureSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test UNION_DISTINCT_STABLE for memleaks
+////////////////////////////////////////////////////////////////////////////////
+
+    testAqlFunctionUnionDistinctStable : function () {
+      var where = [ "AqlFunctions::OutOfMemory1", "AqlFunctions::OutOfMemory2"];
+
+      where.forEach(function(w) {
+        IM.debugClearFailAt();
+
+        IM.debugSetFailAt(w);
+        assertFailingQuery("RETURN NOOPT(UNION_DISTINCT_STABLE([ 1, 2, 3, 4 ], [ 5, 6, 7, 8 ], [ 9, 10, 11 ]))");
+      });
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test INTERSECTION for memleaks
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/js/client/aql/aql-functions-brute.js
+++ b/tests/js/client/aql/aql-functions-brute.js
@@ -82,6 +82,7 @@ function ahuacatlFunctionsBruteTestSuite () {
     "RANGE",
     "UNION",
     "UNION_DISTINCT",
+    "UNION_DISTINCT_STABLE",
     "MINUS",
     "INTERSECTION",
     "FLATTEN",

--- a/tests/js/client/aql/aql-functions.js
+++ b/tests/js/client/aql/aql-functions.js
@@ -1593,6 +1593,100 @@ function ahuacatlFunctionsTestSuite () {
     },
 
 ////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable1 : function () {
+      var expected = [ 1, 3, 2 ];
+      var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ 1, 3, 2 ], [ 1, 2, 3 ])");
+      assertEqual(expected, actual[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable2 : function () {
+      var expected = [ 3, 2, 1 ];
+      var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ 3, 2, 1 ], [ 1, 3, 2 ])");
+      assertEqual(expected, actual[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable3 : function () {
+      var expected = [ "Fred", "John", "Amy" ];
+      var actual = getQueryResults("FOR u IN UNION_DISTINCT_STABLE([ \"Fred\", \"John\" ], [ \"John\", \"Amy\"]) RETURN u");
+      assertEqual(expected, actual);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable4 : function () {
+      var expected = [ 1, 2, 3, 4, 5, 6 ];
+      var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ 1, 2, 3 ], [ 3, 2, 1 ], [ 4 ], [ 5, 6, 1 ])");
+      assertEqual(expected, actual[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable5 : function () {
+      var expected = [ [ ] ];
+      var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ ], [ ], [ ])");
+      assertEqual(expected, actual);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable6 : function () {
+      var expected = [ false, true ];
+      var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ ], [ false ], [ ], [ true ])");
+      assertEqual(expected, actual[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable7 : function () {
+      var expected = [ 's','a','f'];
+      var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ 's', 'a' ], [ 's', 'f' ])");
+      assertEqual(expected, actual[0]);
+    },
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStableInvalid : function () {
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE()");
+      assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], null)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], 3)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], \"yes\")");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], { })");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], [ ], null)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], [ ], true)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], [ ], 3)");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], [ ], \"yes\")");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE([ ], [ ], { })");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE(null, [ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE(true, [ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE(3, [ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE(\"yes\", [ ])");
+      assertQueryWarningAndNull(errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code, "RETURN UNION_DISTINCT_STABLE({ }, [ ])");
+    },
+
+////////////////////////////////////////////////////////////////////////////////
 /// @brief test range function
 ////////////////////////////////////////////////////////////////////////////////
     

--- a/tests/js/client/aql/aql-functions.js
+++ b/tests/js/client/aql/aql-functions.js
@@ -1661,6 +1661,16 @@ function ahuacatlFunctionsTestSuite () {
       var actual = getQueryResults("RETURN UNION_DISTINCT_STABLE([ 's', 'a' ], [ 's', 'f' ])");
       assertEqual(expected, actual[0]);
     },
+   
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test union_distinct_stable function
+////////////////////////////////////////////////////////////////////////////////
+
+    testUnionDistinctStable8 : function () {
+      var expected = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ];
+      var actual = getQueryResults("LET x = 1..10 RETURN UNION_DISTINCT_STABLE(x, [2, 3, 4])");
+      assertEqual(expected, actual[0]);
+    },
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test union_distinct_stable function


### PR DESCRIPTION
https://arangodb.atlassian.net/browse/COR-542) COR-542: Add UNION_DISTINCT_STABLE AQL Function
1.
db._query("RETURN UNION_DISTINCT_STABLE([ 1, 2, 3 ], [ 3, 2, 1 ], [ 4 ], [ 5, 6, 1 ])").toArray()
[ 
  [ 
    1, 
    2, 
    3, 
    4, 
    5, 
    6 
  ] 
]

db._query("RETURN UNION_DISTINCT([ 1, 2, 3 ], [ 3, 2, 1 ], [ 4 ], [ 5, 6, 1 ])").toArray()
[ 
  [ 
    4, 
    2, 
    3, 
    6, 
    1, 
    5 
  ] 
]

2.
db._query("RETURN UNION_DISTINCT_STABLE(     [ 5,3,1, 2 ],     [ 6, 1, 2,7 ] )").toArray()
[ 
  [ 
    5, 
    3, 
    1, 
    2, 
    6, 
    7 
  ] 
]

  db._query("RETURN UNION_DISTINCT(     [ 5,3,1, 2 ],     [ 6, 1, 2,7 ] )").toArray()
[ 
  [ 
    2, 
    7, 
    3, 
    6, 
    1, 
    5 
  ] 
]


- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:https://github.com/arangodb/enterprise/tree/features/COR-542-Add-UNION-DISTINCT-STABLE-AQL-Function(Created a branch with no changes in enterprise code repo.)
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
