### PR TITLE
[COR-522] : feature/COR-522-Use-Distribute-on-repeated-smart-edge-join.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
+* COR-522: Use Distribute on repeated smart edge join.
 
 * COR-299: Upgrade ScatterNode to DistributeNode if shardkey is known
 

--- a/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
+++ b/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
@@ -39,6 +39,8 @@
 #include "Containers/SmallVector.h"
 
 #include "Logger/LogMacros.h"
+#include "Basics/StaticStrings.h"
+#include "Transaction/Helpers.h"
 
 #define LOG_RULE LOG_DEVEL_IF(false) << "UpgradeScatterToDistribute: "
 
@@ -87,6 +89,13 @@ arangodb::aql::Variable const* getOutVariable(
     }
   }
   return nullptr;
+}
+arangodb::aql::AstNode* createParseKeyCall(arangodb::aql::Ast* ast,
+                                           arangodb::aql::AstNode const* input) {
+  using namespace arangodb::aql;
+  AstNode* args = ast->createNodeArray();
+  args->addMember(ast->clone(input));
+  return ast->createNodeFunctionCall("PARSE_KEY", args, true);
 }
 
 bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
@@ -167,11 +176,24 @@ bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
       LOG_RULE << "var is neither on the left nor on the right side, skip";
       continue;
     }
-    std::string const attrField = shardKeyNode->getString();
-    bool const isShardKey = std::find(shardKeys.begin(), shardKeys.end(),
-                                      attrField) != shardKeys.end();
+
+    std::string attrField = shardKeyNode->getString();
+    if (attrField == arangodb::StaticStrings::IdString) {
+        attrField = arangodb::StaticStrings::KeyString;
+        Ast* ast = node->plan()->getAst();
+        expression = createParseKeyCall(ast, expression);
+    }
+
+    bool isShardKey = std::find(shardKeys.begin(), shardKeys.end(),
+                                attrField) != shardKeys.end();
+
     if (isShardKey > 0 && expression != nullptr) {
-      distDep.shardKeyAccessMap[shardKeyNode->getStringView()] = expression;
+      if (shardKeyNode->getString() == arangodb::StaticStrings::IdString) {
+        distDep.shardKeyAccessMap[arangodb::StaticStrings::KeyString] = expression;
+      }
+      else{
+        distDep.shardKeyAccessMap[shardKeyNode->getStringView()] = expression;
+      }
     }
   }
   // Found shard-keys in all or-branches

--- a/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
+++ b/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
@@ -90,8 +90,8 @@ arangodb::aql::Variable const* getOutVariable(
   }
   return nullptr;
 }
-arangodb::aql::AstNode* createParseKeyCall(arangodb::aql::Ast* ast,
-                                           arangodb::aql::AstNode const* input) {
+arangodb::aql::AstNode* createParseKeyCall(
+    arangodb::aql::Ast* ast, arangodb::aql::AstNode const* input) {
   using namespace arangodb::aql;
   AstNode* args = ast->createNodeArray();
   args->addMember(ast->clone(input));
@@ -179,9 +179,9 @@ bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
 
     std::string attrField = shardKeyNode->getString();
     if (attrField == arangodb::StaticStrings::IdString) {
-        attrField = arangodb::StaticStrings::KeyString;
-        Ast* ast = node->plan()->getAst();
-        expression = createParseKeyCall(ast, expression);
+      attrField = arangodb::StaticStrings::KeyString;
+      Ast* ast = node->plan()->getAst();
+      expression = createParseKeyCall(ast, expression);
     }
 
     bool isShardKey = std::find(shardKeys.begin(), shardKeys.end(),
@@ -189,9 +189,9 @@ bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
 
     if (isShardKey > 0 && expression != nullptr) {
       if (shardKeyNode->getString() == arangodb::StaticStrings::IdString) {
-        distDep.shardKeyAccessMap[arangodb::StaticStrings::KeyString] = expression;
-      }
-      else{
+        distDep.shardKeyAccessMap[arangodb::StaticStrings::KeyString] =
+            expression;
+      } else {
         distDep.shardKeyAccessMap[shardKeyNode->getStringView()] = expression;
       }
     }

--- a/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
+++ b/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
@@ -40,6 +40,7 @@ function optimizerUpgradeScatterToDistributeSuite() {
       db._drop("UnitTestsCollection_col_dsl");
       db._drop("UnitTestsCollection_col");
       db._drop("UnitTestsCollection_col_id");
+      db._drop("UnitTestsCollection_col_id_key");
 
       col = db._create("UnitTestsCollection_col", { numberOfShards: 10});
       col_dsl = db._create("UnitTestsCollection_col_dsl", { numberOfShards: 10, distributeShardsLike: "UnitTestsCollection_col" });
@@ -96,6 +97,8 @@ function optimizerUpgradeScatterToDistributeSuite() {
       db._drop("UnitTestsCollection_col_msk");
       db._drop("UnitTestsCollection_col_dsl");
       db._drop("UnitTestsCollection_col");
+      db._drop("UnitTestsCollection_col_id");
+      db._drop("UnitTestsCollection_col_id_key");
     },
 
     test_DefaultShardKey_Upgrade: function() {
@@ -214,7 +217,7 @@ function optimizerUpgradeScatterToDistributeSuite() {
       db._explain(query);
       print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
-      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+      assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
       let result = db._query(query).toArray();
       assertNotEqual(result.length, col_id.count());
     },
@@ -230,8 +233,160 @@ function optimizerUpgradeScatterToDistributeSuite() {
       print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
-      let result = db._query(query).toArray();
-      assertEqual(result.length, col_id_key.count());
+    },
+
+    test_DefaultShardKey_Upgrade_id_5: function() {
+      let query =
+          `FOR doc1 IN ${col_id_key.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._id == doc1._id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_6: function() {
+      let query =
+          `FOR doc1 IN ${col_id_key.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._id == doc1._key
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_7: function() {
+      let query =
+          `FOR doc1 IN ${col_id_key.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2.x == doc1.y
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_8: function() {
+      let query =
+          `FOR doc1 IN ${col_id_key.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2.x == doc1._id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_9: function() {
+      let query =
+          `FOR doc1 IN ${col_id_key.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2.x == doc1._id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_10: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_msk_dsl.name()}
+             FILTER doc2._key == doc1._key
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk_dsl.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_11: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_msk_dsl.name()}
+             FILTER doc2._key == doc1._id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk_dsl.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_12: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._key == doc1._key
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_13: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_msk.name()}
+             FILTER doc2._id == doc1._key
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_14: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_msk.name()}
+             FILTER doc2._id == doc1._id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_15: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._id == doc1._key
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+    },
+
+    test_DefaultShardKey_Upgrade_id_16: function() {
+      let query =
+          `FOR doc1 IN ${col_msk.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._key == doc1.shardKey
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     }
   };
 }

--- a/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
+++ b/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
@@ -31,6 +31,7 @@ function optimizerUpgradeScatterToDistributeSuite() {
   let col_dsl; // distribute shards like the main collection
   let col_msk; // sharded, but unrelated collection with multiple shard keys
   let col_msk_dsl; // distribute shards like the collection with multiple shard keys
+  let col_id;
 
   return {
     setUpAll: function () {
@@ -38,6 +39,7 @@ function optimizerUpgradeScatterToDistributeSuite() {
       db._drop("UnitTestsCollection_col_msk");
       db._drop("UnitTestsCollection_col_dsl");
       db._drop("UnitTestsCollection_col");
+      db._drop("UnitTestsCollection_col_id");
 
       col = db._create("UnitTestsCollection_col", { numberOfShards: 10});
       col_dsl = db._create("UnitTestsCollection_col_dsl", { numberOfShards: 10, distributeShardsLike: "UnitTestsCollection_col" });
@@ -45,8 +47,13 @@ function optimizerUpgradeScatterToDistributeSuite() {
       col_msk = db._create("UnitTestsCollection_col_msk", { numberOfShards: 3, shardKeys: ["shardKey", "shardKey2"] });
       col_msk_dsl = db._create("UnitTestsCollection_col_msk_dsl", { numberOfShards: 3, shardKeys: ["shardKey", "shardKey2"], distributeShardsLike: "UnitTestsCollection_col_msk" });
 
+      col_id = db._create("UnitTestsCollection_col_id", { numberOfShards: 10});
+      col_id_key = db._create("UnitTestsCollection_col_id_key", { numberOfShards: 3, shardKeys: ["_key"]});
+
       let docs = [];
       let docs_no_key = [];
+      let docs_id = [];
+      let docs_id_key = [];
       for (let i = 0; i < 1000; ++i) {
         docs.push({
           _key: "key-" + i,
@@ -65,11 +72,23 @@ function optimizerUpgradeScatterToDistributeSuite() {
           foreign_shardKey2: "shardKey2-" + i,
           value: i
         });
+        docs_id.push({
+          _key: "key-" + i,
+          foreign_id: col_id.name()+ "/key-" + i,
+          value: i
+        });
+        docs_id_key.push({
+          _key: "key-" + i,
+          foreign_id: col_id_key.name()+ "/key-" + i,
+          value: i
+        });  
       }
       col.insert(docs);
       col_dsl.insert(docs);
       col_msk.insert(docs_no_key);
       col_msk_dsl.insert(docs_no_key);
+      col_id.insert(docs_id);
+      col_id_key.insert(docs_id_key);
     },
 
     tearDownAll: function () {
@@ -85,6 +104,8 @@ function optimizerUpgradeScatterToDistributeSuite() {
             FOR doc2 IN ${col.name()}
              FILTER doc2._key == doc1.foreign_key
              RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
       let result = db._query(query).toArray();
@@ -155,6 +176,63 @@ function optimizerUpgradeScatterToDistributeSuite() {
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
+
+    test_DefaultShardKey_Upgrade_id_1: function() {
+      let query =
+          `FOR doc1 IN ${col_id.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._id == doc1.foreign_id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+      let result = db._query(query).toArray();
+      assertEqual(result.length, col_id.count());
+    },
+
+   test_DefaultShardKey_Upgrade_id_2: function() {
+      let query =
+          `FOR doc1 IN ${col_id.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._key == doc1._id
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+      let result = db._query(query).toArray();
+      assertNotEqual(result.length, col_id.count());
+    },
+
+    test_DefaultShardKey_Upgrade_id_3: function() {
+      let query =
+          `FOR doc1 IN ${col_id.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2.x == doc1.y
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+      let result = db._query(query).toArray();
+      assertNotEqual(result.length, col_id.count());
+    },
+
+    test_DefaultShardKey_Upgrade_id_4: function() {
+      let query =
+          `FOR doc1 IN ${col_id_key.name()}
+            FOR doc2 IN ${col_id.name()}
+             FILTER doc2._key == doc1._key
+             RETURN [doc1, doc2]`;
+      db._explain(query);
+      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
+      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
+      let plan = db._createStatement({query: query}).explain().plan;
+      assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
+      let result = db._query(query).toArray();
+      assertEqual(result.length, col_id_key.count());
+    }
   };
 }
 

--- a/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
+++ b/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
@@ -109,7 +109,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1.foreign_key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
       let result = db._query(query).toArray();
@@ -188,7 +187,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._id == doc1.foreign_id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
       let result = db._query(query).toArray();
@@ -202,7 +200,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1._id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -214,7 +211,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2.x == doc1.y
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -226,8 +222,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1._key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -239,8 +233,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._id == doc1._id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -252,8 +244,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._id == doc1._key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -265,8 +255,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2.x == doc1.y
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -278,8 +266,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2.x == doc1._id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -291,8 +277,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2.x == doc1._id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_id_key.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -304,8 +288,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1._key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk_dsl.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -317,8 +299,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1._id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk_dsl.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -330,8 +310,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1._key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -343,7 +321,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._id == doc1._key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -355,7 +332,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._id == doc1._id
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -367,8 +343,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._id == doc1._key
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     },
@@ -380,8 +354,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
              FILTER doc2._key == doc1.shardKey
              RETURN [doc1, doc2]`;
       db._explain(query);
-      print(JSON.stringify("shardKeys: " + db._collection(col_msk.name()).properties().shardKeys, null, 2));
-      print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
     }

--- a/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
+++ b/tests/js/client/aql/aql-optimizer-upgrade-scatter-to-distribute-cluster.js
@@ -32,6 +32,7 @@ function optimizerUpgradeScatterToDistributeSuite() {
   let col_msk; // sharded, but unrelated collection with multiple shard keys
   let col_msk_dsl; // distribute shards like the collection with multiple shard keys
   let col_id;
+  let col_id_key;
 
   return {
     setUpAll: function () {
@@ -204,8 +205,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
       print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertTrue(plan.rules.includes("upgrade-scatter-to-distribute"));
-      let result = db._query(query).toArray();
-      assertNotEqual(result.length, col_id.count());
     },
 
     test_DefaultShardKey_Upgrade_id_3: function() {
@@ -218,8 +217,6 @@ function optimizerUpgradeScatterToDistributeSuite() {
       print(JSON.stringify("shardKeys: " + db._collection(col_id.name()).properties().shardKeys, null, 2));
       let plan = db._createStatement({query: query}).explain().plan;
       assertFalse(plan.rules.includes("upgrade-scatter-to-distribute"));
-      let result = db._query(query).toArray();
-      assertNotEqual(result.length, col_id.count());
     },
 
     test_DefaultShardKey_Upgrade_id_4: function() {


### PR DESCRIPTION
This PR foucses on : [https://arangodb.atlassian.net/browse/COR-522]
Use Distribute on repeated smart edge join.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ X] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ X] Enterprise PR: https://github.com/arangodb/enterprise/tree/feature/COR-522-Use-Distribute-on-repeated-smart-edge-join (enterprise branch created.)
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 

Additional Information:
1. if _key is shardKey & FILTER found 
  1.1 _key compared both sides (lhr & rhs)-> DistributeNode
  1.2 _key atleast one side (lhs or rhs)  -> DistributeNode
  1.3 _id compared both sides (lhr & rhs) -> DistributeNode
  1.4 _id atleast one side (lhs or rhs)   -> DistributeNode
  1.5 NoShardKey both sides               -> ScatterNode 

2. if _key is not shardkey & FILTER found -
  2.1 _key compared both sides             -> ScatterNode
  2.2 _key(lhs) compare _id(rhs)           -> scatterNode
  2.3 _key compared to ShardKey (lhs or rhs) -> DistributeNode (ShardKey redirects to specific shard)
  2.4 _id (lhs) compared to _key(rhs) -> ScatterNode
  2.5 _id compared both sides -> ScatterNode
  2.6 _id compared to ShardKey (lhs or rhs) -> DistributeNode (ShardKey redirects to specific shard)
  2.7 ShardKey compared bothsides -> DistributeNode (ShardKey redirects to specific shard)
