### PR TITLE
[COR-299] Fix after re-activation of aql tests

### DIFF
--- a/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
+++ b/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
@@ -44,15 +44,14 @@
 
 #define LOG_RULE LOG_DEVEL_IF(false) << "UpgradeScatterToDistribute: "
 
+namespace arangodb::aql {
+
+namespace {
 struct DistributeNodeDependency {
-  std::unordered_map<std::string_view, arangodb::aql::AstNode const*>
-      shardKeyAccessMap;
+  std::unordered_map<std::string_view, AstNode const*> shardKeyAccessMap;
 };
 
-arangodb::aql::Collection const* getCollection(
-    arangodb::aql::ExecutionNode const* node) {
-  using namespace arangodb::aql;
-
+Collection const* getCollection(ExecutionNode const* node) {
   switch (node->getType()) {
     case ExecutionNode::NodeType::ENUMERATE_COLLECTION:
       return ExecutionNode::castTo<EnumerateCollectionNode const*>(node)
@@ -65,9 +64,7 @@ arangodb::aql::Collection const* getCollection(
   return nullptr;
 }
 
-arangodb::aql::Variable const* getVariableFromAttributeAccess(
-    arangodb::aql::AstNode const* node) {
-  using namespace arangodb::aql;
+Variable const* getVariableFromAttributeAccess(AstNode const* node) {
   if (node->numMembers() > 0) {
     node = node->getMember(0);
   }
@@ -77,9 +74,7 @@ arangodb::aql::Variable const* getVariableFromAttributeAccess(
   return static_cast<Variable const*>(node->getData());
 }
 
-arangodb::aql::Variable const* getOutVariable(
-    arangodb::aql::ExecutionNode const* node) {
-  using namespace arangodb::aql;
+Variable const* getOutVariable(ExecutionNode const* node) {
   const auto nodeType = node->getType();
   if (nodeType == ExecutionNode::NodeType::INDEX ||
       nodeType == ExecutionNode::NodeType::ENUMERATE_COLLECTION) {
@@ -91,10 +86,8 @@ arangodb::aql::Variable const* getOutVariable(
   return nullptr;
 }
 
-bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
-                                arangodb::aql::ExecutionNode const* node,
+bool checkIfAllShardKeysAreUsed(AstNode const* root, ExecutionNode const* node,
                                 DistributeNodeDependency& distDep) {
-  using namespace arangodb::aql;
   if (root == nullptr) {
     return false;
   }
@@ -127,7 +120,7 @@ bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
   if (andNode == nullptr) {
     return false;
   }
-  TRI_ASSERT(andNode->type == arangodb::aql::NODE_TYPE_OPERATOR_NARY_AND);
+  TRI_ASSERT(andNode->type == NODE_TYPE_OPERATOR_NARY_AND);
   size_t const numConds = andNode->numMembers();
   LOG_RULE << "found " << numConds << " conditions. iterating";
   for (size_t j = 0; j < numConds; ++j) {
@@ -180,13 +173,10 @@ bool checkIfAllShardKeysAreUsed(arangodb::aql::AstNode const* root,
   return distDep.shardKeyAccessMap.size() == shardKeys.size();
 }
 
-void replaceScatterWithDistribute(arangodb::aql::ExecutionPlan& plan,
-                                  arangodb::aql::ExecutionNode* scatter,
-                                  arangodb::aql::Collection const* coll,
-                                  arangodb::aql::ExecutionNodeId targetNodeId,
+void replaceScatterWithDistribute(ExecutionPlan& plan, ExecutionNode* scatter,
+                                  Collection const* coll,
+                                  ExecutionNodeId targetNodeId,
                                   DistributeNodeDependency const& distDep) {
-  using namespace arangodb::aql;
-
   Ast* ast = plan.getAst();
   Variable* shardInputVar = ast->variables()->createTemporaryVariable();
   AstNode* obj = ast->createNodeObject();
@@ -210,13 +200,11 @@ void replaceScatterWithDistribute(arangodb::aql::ExecutionPlan& plan,
   plan.insertBefore(distribution, calc);
 }
 
-std::unique_ptr<arangodb::aql::Condition> getCondition(
-    arangodb::aql::ExecutionPlan* plan, arangodb::aql::ExecutionNode* current) {
-  auto condition = std::make_unique<arangodb::aql::Condition>(plan->getAst());
-  if (current->getType() == arangodb::aql::ExecutionNode::INDEX) {
-    auto const indexNode =
-        arangodb::aql::ExecutionNode::castTo<arangodb::aql::IndexNode const*>(
-            current);
+std::unique_ptr<Condition> getCondition(ExecutionPlan* plan,
+                                        ExecutionNode* current) {
+  auto condition = std::make_unique<Condition>(plan->getAst());
+  if (current->getType() == ExecutionNode::INDEX) {
+    auto const indexNode = ExecutionNode::castTo<IndexNode const*>(current);
 
     auto indexes = indexNode->getIndexes();
     for (auto&& i : indexes) {
@@ -236,10 +224,9 @@ std::unique_ptr<arangodb::aql::Condition> getCondition(
       condition->andCombine(filter->node());
     }
     return condition;
-  } else if (current->getType() ==
-             arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION) {
-    auto const enumNode = arangodb::aql::ExecutionNode::castTo<
-        arangodb::aql::EnumerateCollectionNode const*>(current);
+  } else if (current->getType() == ExecutionNode::ENUMERATE_COLLECTION) {
+    auto const enumNode =
+        ExecutionNode::castTo<EnumerateCollectionNode const*>(current);
     auto const filter = enumNode->filter();
     if (filter != nullptr && filter->node() != nullptr) {
       condition->andCombine(filter->node());
@@ -249,7 +236,8 @@ std::unique_ptr<arangodb::aql::Condition> getCondition(
   return nullptr;
 }
 
-namespace arangodb::aql {
+}  // namespace
+
 void upgradeScatterToDistributeRule(Optimizer* opt,
                                     std::unique_ptr<ExecutionPlan> plan,
                                     OptimizerRule const& rule) {

--- a/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
+++ b/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
@@ -30,10 +30,12 @@
 #include "Aql/ExecutionNode/CalculationNode.h"
 #include "Aql/ExecutionNode/DistributeNode.h"
 #include "Aql/ExecutionNode/EnumerateCollectionNode.h"
+#include "Aql/ExecutionNode/ExecutionNode.h"
 #include "Aql/ExecutionNode/IndexNode.h"
 #include "Aql/Expression.h"
 #include "Aql/Optimizer.h"
 #include "Aql/OptimizerRule.h"
+#include "Indexes/Index.h"
 
 #include "Cluster/ServerState.h"
 #include "Containers/SmallVector.h"
@@ -215,6 +217,16 @@ std::unique_ptr<arangodb::aql::Condition> getCondition(
     auto const indexNode =
         arangodb::aql::ExecutionNode::castTo<arangodb::aql::IndexNode const*>(
             current);
+
+    auto indexes = indexNode->getIndexes();
+    for (auto&& i : indexes) {
+      if (i->type() ==
+          arangodb::Index::IndexType::TRI_IDX_TYPE_INVERTED_INDEX) {
+        LOG_RULE << "Inverted Indexes are unsupported for this rule";
+        return nullptr;
+      }
+    }
+
     auto const cond = indexNode->condition();
     if (cond != nullptr && cond->root() != nullptr) {
       condition->andCombine(cond->root());
@@ -259,20 +271,22 @@ void upgradeScatterToDistributeRule(Optimizer* opt,
   for (auto const node : nodes) {
     ExecutionNode* current = node->getFirstParent();
     while (current != nullptr) {
-      auto condition = getCondition(plan.get(), current);
+      if (current->getType() == ExecutionNode::INDEX ||
+          current->getType() == ExecutionNode::ENUMERATE_COLLECTION) {
+        auto condition = getCondition(plan.get(), current);
 
-      if (condition != nullptr) {
-        condition->normalize(plan.get());
+        if (condition != nullptr) {
+          condition->normalize(plan.get());
 
-        DistributeNodeDependency distDep;
-        if (checkIfAllShardKeysAreUsed(condition->root(), current, distDep)) {
-          auto const scatterNode = ExecutionNode::castTo<ScatterNode*>(node);
-          Collection const* coll{getCollection(current)};
-          replaceScatterWithDistribute(*plan, scatterNode, coll, current->id(),
-                                       distDep);
-          wasModified = true;
+          DistributeNodeDependency distDep;
+          if (checkIfAllShardKeysAreUsed(condition->root(), current, distDep)) {
+            auto const scatterNode = ExecutionNode::castTo<ScatterNode*>(node);
+            Collection const* coll{getCollection(current)};
+            replaceScatterWithDistribute(*plan, scatterNode, coll,
+                                         current->id(), distDep);
+            wasModified = true;
+          }
         }
-
         // Only the first Index / Enumeration Parent-Node is relevant for us, we
         // can skip the rest
         break;

--- a/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
+++ b/arangod/Aql/Optimizer/Rule/UpgradeScatterToDistribute.cpp
@@ -261,7 +261,7 @@ void upgradeScatterToDistributeRule(Optimizer* opt,
     while (current != nullptr) {
       auto condition = getCondition(plan.get(), current);
 
-      if (condition != nullptr && (condition->root() != nullptr)) {
+      if (condition != nullptr) {
         condition->normalize(plan.get());
 
         DistributeNodeDependency distDep;
@@ -275,7 +275,6 @@ void upgradeScatterToDistributeRule(Optimizer* opt,
 
         // Only the first Index / Enumeration Parent-Node is relevant for us, we
         // can skip the rest
-
         break;
       }
       current = current->getFirstParent();

--- a/tests/js/client/aql/large/aql-shardids-cluster.js
+++ b/tests/js/client/aql/large/aql-shardids-cluster.js
@@ -29,9 +29,9 @@ const jsunity = require("jsunity");
 const internal = require("internal");
 const db = require('internal').db;
 
-const disableSingleDocOp = {
+const disableSingleDocOpUpgradeScatter = {
   optimizer: {
-    rules: [ "-optimize-cluster-single-document-operations"]
+    rules: [ "-optimize-cluster-single-document-operations", "-upgrade-scatter-to-distribute"]
   }
 };
 const disableSingleShard = {
@@ -139,7 +139,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
   };
 
   const validatePlan = (query, nodeType, c) => {
-    const plan = db._createStatement({query: query, bindVars: {}, options: disableSingleDocOp}).explain().plan;
+    const plan = db._createStatement({query: query, bindVars: {}, options: disableSingleDocOpUpgradeScatter}).explain().plan;
     assertFalse(hasDistributeNode(plan.nodes));
     const allRestricted = allNodesOfTypeAreRestrictedToShard(plan.nodes,
                                                              nodeType, c);
@@ -222,7 +222,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             FILTER doc._key == "${doc._key}"
             RETURN doc`;
         validatePlan(queryKey, "IndexNode", collection);
-        let res = db._query(queryKey, {}, disableSingleDocOp).toArray();
+        let res = db._query(queryKey, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(1, res.length);
         assertEqual(doc._key, res[0]._key);
         assertEqual(doc._rev, res[0]._rev);
@@ -239,7 +239,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             FILTER doc.${shardKey} == ${i}
             RETURN doc`;
         validatePlan(query, "IndexNode", collectionByKey);
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(4, res.length);
         for (let doc of res) {
           assertEqual(i, doc.value);
@@ -261,7 +261,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [doc, joined]
         `;
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         // we find 4 in first Loop, and 4 joins each
         assertEqual(16, res.length);
         for (let [doc, joined] of res) {
@@ -304,7 +304,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             FILTER doc.${shardKey} == ${doc[shardKey]}
             RETURN doc`;
         validatePlan(queryKey, "IndexNode", collectionByKey);
-        let res = db._query(queryKey, {}, disableSingleDocOp).toArray();
+        let res = db._query(queryKey, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(1, res.length);
         assertEqual(doc._key, res[0]._key);
         assertEqual(doc._rev, res[0]._rev);
@@ -328,7 +328,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               FILTER joined.${shardKey} == ${doc[shardKey]}
             RETURN [doc, joined]`;
         validatePlan(queryKey, "IndexNode", collectionByKey);
-        let res = db._query(queryKey, {}, disableSingleDocOp).toArray();
+        let res = db._query(queryKey, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(1, res.length);
         assertEqual(doc._key, res[0][0]._key);
         assertEqual(doc._rev, res[0][0]._rev);
@@ -346,7 +346,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             FILTER doc.${shardKey} == ${i}
             RETURN doc`;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(4, res.length);
         for (let doc of res) {
           assertEqual(i, doc.value);
@@ -367,7 +367,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [doc, joined]
         `;
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         // we find 4 in first Loop, and 4 joins each
         assertEqual(16, res.length);
         for (let [doc, joined] of res) {
@@ -407,7 +407,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(4, res.length);
         for (let doc of res) {
           assertTrue(i === doc.value);
@@ -427,7 +427,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(4, res.length);
         for (let doc of res) {
           assertTrue(i === doc.value);
@@ -449,7 +449,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(4, res.length);
         for (let doc of res) {
           assertTrue(i === doc.value);
@@ -470,7 +470,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(4, res.length);
         for (let doc of res) {
           assertTrue(i === doc.value);
@@ -492,7 +492,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         // No restriction yet
         //validatePlan(query, "IndexNode", collectionByKey);
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(8, res.length);
         for (let doc of res) {
           assertTrue(i === doc.value || i + 1 === doc.value);
@@ -512,7 +512,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         // Multi-shard not implemented yet
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let res = db._query(query, {}, disableSingleDocOp).toArray();
+        let res = db._query(query, {}, disableSingleDocOpUpgradeScatter).toArray();
         assertEqual(8, res.length);
         for (let doc of res) {
           assertTrue(i === doc.value || i + 1 === doc.value);
@@ -533,7 +533,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -557,7 +557,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -581,7 +581,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         // Multi-shard not implemented yet
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -606,7 +606,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         // Multi-shard not implemented yet
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -630,7 +630,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -658,7 +658,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -682,7 +682,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN doc1
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let doc of results) {
@@ -703,7 +703,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN doc1
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let doc of results) {
@@ -725,7 +725,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -777,7 +777,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -802,7 +802,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -826,7 +826,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 4);
         let results = raw.toArray();
@@ -851,7 +851,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 4);
         let results = raw.toArray();
@@ -876,7 +876,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -900,7 +900,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -924,7 +924,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -952,7 +952,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -976,7 +976,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [doc1, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -997,7 +997,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [doc1, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -1019,7 +1019,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1071,7 +1071,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1096,7 +1096,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1121,7 +1121,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -1145,7 +1145,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -1169,7 +1169,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -1197,7 +1197,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -1221,7 +1221,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [doc1, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -1242,7 +1242,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [doc1, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -1316,7 +1316,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1341,7 +1341,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
               RETURN [NEW, doc2]
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1415,7 +1415,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1439,7 +1439,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1463,7 +1463,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1489,7 +1489,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1513,7 +1513,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1537,7 +1537,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1559,7 +1559,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1581,7 +1581,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -1602,7 +1602,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN NEW
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 100);
         let results = raw.toArray();
@@ -1626,7 +1626,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN NEW
         `;
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 100);
         let results = raw.toArray();
@@ -1653,7 +1653,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -1680,7 +1680,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "IndexNode", collectionByKey1);
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -1706,7 +1706,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -1734,7 +1734,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         // validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -1760,7 +1760,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -1791,7 +1791,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "IndexNode", collectionByKey1);
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -1817,7 +1817,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let doc of results) {
@@ -1841,7 +1841,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let doc of results) {
@@ -1865,7 +1865,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1922,7 +1922,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1950,7 +1950,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -1977,7 +1977,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -2004,7 +2004,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "IndexNode", collectionByKey1);
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -2030,7 +2030,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -2061,7 +2061,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "IndexNode", collectionByKey1);
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -2087,7 +2087,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -2111,7 +2111,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -2135,7 +2135,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -2192,7 +2192,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -2220,7 +2220,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey1);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -2247,7 +2247,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -2274,7 +2274,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "IndexNode", collectionByKey1);
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(16, results.length);
         for (let [doc1, doc2] of results) {
@@ -2300,7 +2300,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "EnumerateCollectionNode", collectionByKey1);
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -2331,7 +2331,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         validatePlan(query, "IndexNode", collectionByKey1);
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 16);
         let results = raw.toArray();
@@ -2357,7 +2357,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -2381,7 +2381,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let results = raw.toArray();
         assertEqual(400, results.length);
         for (let [doc1, doc2] of results) {
@@ -2462,7 +2462,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -2490,7 +2490,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 400);
         let results = raw.toArray();
@@ -2569,7 +2569,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2595,7 +2595,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2620,7 +2620,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2648,7 +2648,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2673,7 +2673,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2699,7 +2699,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2722,7 +2722,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2746,7 +2746,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
             RETURN [NEW, doc2]
       `;
 
-      let raw = db._query(query, {}, disableSingleDocOp);
+      let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
       let stats = raw.getExtra().stats;
       assertEqual(stats.writesExecuted, 10000);
       let results = raw.toArray();
@@ -2772,7 +2772,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "EnumerateCollectionNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 100);
         let results = raw.toArray();
@@ -2801,7 +2801,7 @@ function ahuacatlShardIdsOptimizationTestSuite() {
         `;
         validatePlan(query, "IndexNode", collectionByKey2);
 
-        let raw = db._query(query, {}, disableSingleDocOp);
+        let raw = db._query(query, {}, disableSingleDocOpUpgradeScatter);
         let stats = raw.getExtra().stats;
         assertEqual(stats.writesExecuted, 100);
         let results = raw.toArray();


### PR DESCRIPTION
### Scope & Purpose

After some tests are enabled for 4.0 after the merge of devel it turned out that the original optimizer rule introduced in #22665 was buggy. This makes at least the tests pass again.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
