### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,96 @@
+# Dependabot configuration for arangodb/arangodb.
+# Target: .github/dependabot.yml on the `devel` branch.
+# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+
+updates:
+  # ----- Production deploy image (ships to customers) -----
+  - package-ecosystem: "docker"
+    directory: "/scripts/docker/deploy"
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+      - "security"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      deploy-image-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ----- Server-side JS extensions -----
+  - package-ecosystem: "npm"
+    directory: "/js/node"
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    versioning-strategy: "increase"
+    groups:
+      js-node-production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      js-node-development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # ----- Aardvark admin web UI -----
+  - package-ecosystem: "npm"
+    directory: "/js/apps/system/_admin/aardvark/APP/react"
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+      - "aardvark"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
+    versioning-strategy: "increase"
+    groups:
+      aardvark-production-minor-patch:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      aardvark-development-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so Dependabot tracks version updates for the production deploy image and both npm package trees.

## Scope

- **Docker**: `scripts/docker/deploy` (production deploy image only)
- **npm**: `js/node` (server-side JS extensions)
- **npm**: `js/apps/system/_admin/aardvark/APP/react` (Aardvark admin UI)

Build-toolchain Dockerfiles under `scripts/docker/build/*` are intentionally not tracked — they're pinned for compiler reproducibility and automated bumps would break CI. CircleCI is the build system, so no `github-actions` ecosystem either.

## Behavior

- Weekly schedule, Monday 06:00 Europe/Berlin
- Minor + patch updates grouped per ecosystem (one PR / week / ecosystem)
- Major updates land as individual PRs so reviewers can read release notes
- Open-PR caps prevent floods (5 docker, 10 npm)
- Conventional Commits prefixes (`build`, `deps`, `deps-dev`)

## Test plan

- [ ] Merge
- [ ] Confirm Dependabot picks up the config on the next scheduled run (or trigger manually from Insights → Dependency graph → Dependabot)
- [ ] Watch the first weekly batch land and tune `open-pull-requests-limit` / grouping if PR volume is off

Driven by the security / compliance program (supply-chain dependency tracking for ISO 27001, BSI C5, SOC 2).