### PR TITLE
fix(dependabot): remove docker block; production images live in arangodb/oskar

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,10 @@
 # Dependabot configuration for arangodb/arangodb.
 # Target: .github/dependabot.yml on the `devel` branch.
-# Docs: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+# Docker tracking removed — production images are built in arangodb/oskar, not here.
 
 version: 2
 
 updates:
-  # ----- Production deploy image (ships to customers) -----
-  - package-ecosystem: "docker"
-    directory: "/scripts/docker/deploy"
-    target-branch: "devel"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Berlin"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "docker"
-      - "security"
-    commit-message:
-      prefix: "build"
-      include: "scope"
-    groups:
-      deploy-image-minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
   # ----- Server-side JS extensions -----
   - package-ecosystem: "npm"
     directory: "/js/node"


### PR DESCRIPTION
## Summary

Removes the Docker block from `.github/dependabot.yml`. The Dockerfile it pointed at (`scripts/docker/deploy/deploy-alpine.dockerfile`) is **not** the production / shipping image — the real customer-facing container images are built in [`arangodb/oskar`](https://github.com/arangodb/oskar/tree/master/containers). A separate PR adds Dependabot coverage there.

Keeping the supply-chain control here implied production Docker coverage that didn't exist, which is worse than no signal at all for compliance evidence.

## Diff

Removes:
- `docker` block for `/scripts/docker/deploy`

Keeps:
- `npm` block for `/js/node` (server-side JS extensions)
- `npm` block for `/js/apps/system/_admin/aardvark/APP/react` (Aardvark admin UI)

## Test plan

- [ ] Merge
- [ ] Confirm in Insights → Dependency graph → Dependabot that the docker entry is gone and the two npm entries remain