### PR TITLE
[COR-75] Remove RocksDBKeyLeaser

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
+* COR-75: Removed RocksDBKeyLeaser, making RocksDBKey own its leased string buffer directly.
+
 * Fix shipped cmake file to make the build work on cmake >= 4.
 
 * Upgraded FAISS to v1.14.2.

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -1525,12 +1525,12 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
 
   TRI_ASSERT(res.ok());
 
-  RocksDBKeyLeaser key(trx);
-  key->constructDocument(objectId(), documentId);
-  TRI_ASSERT(key->containsLocalDocumentId(documentId));
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructDocument(objectId(), documentId);
+  TRI_ASSERT(key.containsLocalDocumentId(documentId));
 
   // banish new document to avoid caching without committing first
-  invalidateCacheEntry(key.ref());
+  invalidateCacheEntry(key);
 
   // disable indexing in this transaction if we are allowed to
   IndexingDisabler disabler(mthds, state->isSingleOperation());
@@ -1557,7 +1557,7 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
     rocksdb::Status s =
         mthds->GetForUpdate(RocksDBColumnFamilyManager::get(
                                 RocksDBColumnFamilyManager::Family::Documents),
-                            key->string(), &ps);
+                            key.string(), &ps);
     if (s.ok()) {
       // the LocalDocumentId should not have existed before...
       res.reset(TRI_ERROR_ARANGO_CONFLICT,
@@ -1575,10 +1575,10 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
 #endif
   size_t const byteSize = static_cast<size_t>(doc.byteSize());
 
-  rocksdb::Status s = mthds->PutUntracked(
-      RocksDBColumnFamilyManager::get(
-          RocksDBColumnFamilyManager::Family::Documents),
-      key.ref(), rocksdb::Slice(doc.startAs<char>(), byteSize));
+  rocksdb::Status s =
+      mthds->PutUntracked(RocksDBColumnFamilyManager::get(
+                              RocksDBColumnFamilyManager::Family::Documents),
+                          key, rocksdb::Slice(doc.startAs<char>(), byteSize));
 
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::document));
@@ -1670,11 +1670,11 @@ Result RocksDBCollection::removeDocument(transaction::Methods* trx,
   TRI_ASSERT(objectId() != 0);
   Result res;
 
-  RocksDBKeyLeaser key(trx);
-  key->constructDocument(objectId(), documentId);
-  TRI_ASSERT(key->containsLocalDocumentId(documentId));
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructDocument(objectId(), documentId);
+  TRI_ASSERT(key.containsLocalDocumentId(documentId));
 
-  invalidateCacheEntry(key.ref());
+  invalidateCacheEntry(key);
 
   RocksDBMethods* mthds =
       RocksDBTransactionState::toMethods(trx, _logicalCollection.id());
@@ -1701,7 +1701,7 @@ Result RocksDBCollection::removeDocument(transaction::Methods* trx,
   rocksdb::Status s =
       mthds->SingleDelete(RocksDBColumnFamilyManager::get(
                               RocksDBColumnFamilyManager::Family::Documents),
-                          key.ref());
+                          key);
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::document));
     res.withError([&doc](result::Error& err) {
@@ -1719,7 +1719,7 @@ Result RocksDBCollection::removeDocument(transaction::Methods* trx,
   trx->state()->trackShardUsage(
       *trx->resolver(), _logicalCollection.vocbase().name(),
       _logicalCollection.name(), trx->username(), AccessMode::Type::WRITE,
-      "document remove", key->size());
+      "document remove", key.size());
 
   auto const& indexes = indexesSnapshot.getIndexes();
 
@@ -1843,10 +1843,10 @@ Result RocksDBCollection::modifyDocument(
   // disable indexing in this transaction if we are allowed to
   IndexingDisabler disabler(mthds, trx->isSingleOperationTransaction());
 
-  RocksDBKeyLeaser key(trx);
-  key->constructDocument(objectId(), oldDocumentId);
-  TRI_ASSERT(key->containsLocalDocumentId(oldDocumentId));
-  invalidateCacheEntry(key.ref());
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructDocument(objectId(), oldDocumentId);
+  TRI_ASSERT(key.containsLocalDocumentId(oldDocumentId));
+  invalidateCacheEntry(key);
 
   TRI_IF_FAILURE("RocksDBCollection::modifyFail1") {
     if (_logicalCollection.replicationVersion() == replication::Version::ONE ||
@@ -1867,7 +1867,7 @@ Result RocksDBCollection::modifyDocument(
   rocksdb::Status s =
       mthds->SingleDelete(RocksDBColumnFamilyManager::get(
                               RocksDBColumnFamilyManager::Family::Documents),
-                          key.ref());
+                          key);
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::document));
     res.withError([&newDoc](result::Error& err) {
@@ -1898,8 +1898,8 @@ Result RocksDBCollection::modifyDocument(
     return res.reset(TRI_ERROR_DEBUG);
   }
 
-  key->constructDocument(objectId(), newDocumentId);
-  TRI_ASSERT(key->containsLocalDocumentId(newDocumentId));
+  key.constructDocument(objectId(), newDocumentId);
+  TRI_ASSERT(key.containsLocalDocumentId(newDocumentId));
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   if (options.isRestore && ServerState::instance()->isDBServer()) {
@@ -1907,7 +1907,7 @@ Result RocksDBCollection::modifyDocument(
     rocksdb::Status s =
         mthds->GetForUpdate(RocksDBColumnFamilyManager::get(
                                 RocksDBColumnFamilyManager::Family::Documents),
-                            key->string(), &ps);
+                            key.string(), &ps);
     if (s.ok()) {
       // the LocalDocumentId should not have existed before...
       res.reset(TRI_ERROR_ARANGO_CONFLICT,
@@ -1933,14 +1933,14 @@ Result RocksDBCollection::modifyDocument(
 
   s = mthds->PutUntracked(RocksDBColumnFamilyManager::get(
                               RocksDBColumnFamilyManager::Family::Documents),
-                          key.ref(),
+                          key,
                           rocksdb::Slice(newDoc.startAs<char>(), byteSize));
   if (!s.ok()) {
     return res.reset(rocksutils::convertStatus(s, rocksutils::document));
   }
 
   // banish new document to avoid caching without committing first
-  invalidateCacheEntry(key.ref());
+  invalidateCacheEntry(key);
 
   trx->state()->trackShardUsage(
       *trx->resolver(), _logicalCollection.vocbase().name(),
@@ -2013,14 +2013,14 @@ Result RocksDBCollection::lookupDocumentVPack(
   TRI_ASSERT(trx->state()->isRunning());
   TRI_ASSERT(objectId() != 0);
 
-  RocksDBKeyLeaser key(trx);
-  key->constructDocument(objectId(), token);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructDocument(objectId(), token);
 
   std::shared_ptr<cache::Cache> cache;
   if (options.readCache && (cache = useCache())) {
     // check cache first for fast path
-    auto f = cache->find(key->string().data(),
-                         static_cast<uint32_t>(key->string().size()));
+    auto f = cache->find(key.string().data(),
+                         static_cast<uint32_t>(key.string().size()));
     if (f.found()) {
       cb(token, nullptr,
          VPackSlice(reinterpret_cast<uint8_t const*>(f.value()->value())));
@@ -2045,8 +2045,8 @@ Result RocksDBCollection::lookupDocumentVPack(
           ? mthd->SingleGet(
                 static_cast<RocksDBEngine::RocksDBSnapshot const*>(snapshot)
                     ->getSnapshot(),
-                *family, key->string(), ps)
-          : mthd->Get(family, key->string(), &ps,
+                *family, key.string(), ps)
+          : mthd->Get(family, key.string(), &ps,
                       static_cast<ReadOwnWrites>(options.readOwnWrites));
 
   if (!s.ok()) {
@@ -2065,8 +2065,8 @@ Result RocksDBCollection::lookupDocumentVPack(
       ps.size() <= _maxCacheValueSize) {
     // write entry back to cache
     cache::Cache::SimpleInserter<DocumentCacheType>{
-        static_cast<DocumentCacheType&>(*cache), key->string().data(),
-        static_cast<uint32_t>(key->string().size()), ps.data(),
+        static_cast<DocumentCacheType&>(*cache), key.string().data(),
+        static_cast<uint32_t>(key.string().size()), ps.data(),
         static_cast<uint64_t>(ps.size())};
   }
   cache.reset();

--- a/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBEdgeIndex.cpp
@@ -821,9 +821,9 @@ Result RocksDBEdgeIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
   TRI_ASSERT(fromTo.isString());
   std::string_view fromToRef = fromTo.stringView();
 
-  RocksDBKeyLeaser key(&trx);
-  key->constructEdgeIndexValue(objectId(), fromToRef, documentId);
-  TRI_ASSERT(key->containsLocalDocumentId(documentId));
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructEdgeIndexValue(objectId(), fromToRef, documentId);
+  TRI_ASSERT(key.containsLocalDocumentId(documentId));
 
   VPackSlice toFrom = _isFromIndex
                           ? transaction::helpers::extractToFromDocument(doc)
@@ -832,7 +832,7 @@ Result RocksDBEdgeIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
   RocksDBValue value = RocksDBValue::EdgeIndexValue(toFrom.stringView());
 
   Result res;
-  rocksdb::Status s = mthd->PutUntracked(_cf, key.ref(), value.string());
+  rocksdb::Status s = mthd->PutUntracked(_cf, key, value.string());
 
   if (s.ok()) {
     std::hash<std::string_view> hasher;
@@ -859,8 +859,8 @@ Result RocksDBEdgeIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
   std::string_view fromToRef = fromTo.stringView();
   TRI_ASSERT(fromTo.isString());
 
-  RocksDBKeyLeaser key(&trx);
-  key->constructEdgeIndexValue(objectId(), fromToRef, documentId);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructEdgeIndexValue(objectId(), fromToRef, documentId);
 
   VPackSlice toFrom = _isFromIndex
                           ? transaction::helpers::extractToFromDocument(doc)
@@ -869,7 +869,7 @@ Result RocksDBEdgeIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
   RocksDBValue value = RocksDBValue::EdgeIndexValue(toFrom.stringView());
 
   Result res;
-  rocksdb::Status s = mthd->Delete(_cf, key.ref());
+  rocksdb::Status s = mthd->Delete(_cf, key);
 
   if (s.ok()) {
     std::hash<std::string_view> hasher;

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -26,6 +26,7 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/Ast.h"
 #include "Aql/AstNode.h"
+#include "Basics/ThreadLocalLeaser.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/Utf8Helper.h"
 #include "Basics/VelocyPackHelper.h"

--- a/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBFulltextIndex.cpp
@@ -243,12 +243,12 @@ Result RocksDBFulltextIndex::insert(transaction::Methods& trx,
 
   // size_t const count = words.size();
   for (std::string const& word : words) {
-    RocksDBKeyLeaser key(&trx);
-    key->constructFulltextIndexValue(objectId(), std::string_view(word),
-                                     documentId);
-    TRI_ASSERT(key->containsLocalDocumentId(documentId));
+    RocksDBKey key(ThreadLocalStringLeaser::lease());
+    key.constructFulltextIndexValue(objectId(), std::string_view(word),
+                                    documentId);
+    TRI_ASSERT(key.containsLocalDocumentId(documentId));
 
-    rocksdb::Status s = mthd->PutUntracked(_cf, key.ref(), value.string());
+    rocksdb::Status s = mthd->PutUntracked(_cf, key, value.string());
 
     if (!s.ok()) {
       res.reset(rocksutils::convertStatus(s, rocksutils::index));
@@ -275,12 +275,12 @@ Result RocksDBFulltextIndex::remove(transaction::Methods& trx,
   // now we are going to construct the value to insert into rocksdb
   // unique indexes have a different key structure
   for (std::string const& word : words) {
-    RocksDBKeyLeaser key(&trx);
+    RocksDBKey key(ThreadLocalStringLeaser::lease());
 
-    key->constructFulltextIndexValue(objectId(), std::string_view(word),
-                                     documentId);
+    key.constructFulltextIndexValue(objectId(), std::string_view(word),
+                                    documentId);
 
-    rocksdb::Status s = mthd->Delete(_cf, key.ref());
+    rocksdb::Status s = mthd->Delete(_cf, key);
 
     if (!s.ok()) {
       res.reset(rocksutils::convertStatus(s, rocksutils::index));

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -405,12 +405,12 @@ class RDBNearIterator final : public IndexIterator {
   void estimateDensity() {
     S2CellId cell = S2CellId(_near.origin());
 
-    RocksDBKeyLeaser key(_trx);
-    key->constructGeoIndexValue(_index->objectId(), cell.id(),
-                                LocalDocumentId(1));
-    _iter->Seek(key->string());
+    RocksDBKey key(ThreadLocalStringLeaser::lease());
+    key.constructGeoIndexValue(_index->objectId(), cell.id(),
+                               LocalDocumentId(1));
+    _iter->Seek(key.string());
     if (!_iter->Valid()) {
-      _iter->SeekForPrev(key->string());
+      _iter->SeekForPrev(key.string());
     }
     if (_iter->Valid()) {
       _near.estimateDensity(RocksDBValue::centroid(_iter->value()));
@@ -833,18 +833,18 @@ Result RocksDBGeoIndex::insert(transaction::Methods& trx, RocksDBMethods* mthd,
   TRI_ASSERT(S2::IsUnitLength(centroid));
 
   RocksDBValue val = RocksDBValue::S2Value(centroid);
-  RocksDBKeyLeaser key(&trx);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
 
   TRI_ASSERT(!_unique);
 
   for (S2CellId cell : cells) {
-    key->constructGeoIndexValue(objectId(), cell.id(), documentId);
-    TRI_ASSERT(key->containsLocalDocumentId(documentId));
+    key.constructGeoIndexValue(objectId(), cell.id(), documentId);
+    TRI_ASSERT(key.containsLocalDocumentId(documentId));
 
     rocksdb::Status s =
         mthd->PutUntracked(RocksDBColumnFamilyManager::get(
                                RocksDBColumnFamilyManager::Family::GeoIndex),
-                           key.ref(), val.string());
+                           key, val.string());
 
     if (!s.ok()) {
       res.reset(rocksutils::convertStatus(s, rocksutils::index));
@@ -877,16 +877,16 @@ Result RocksDBGeoIndex::remove(transaction::Methods& trx, RocksDBMethods* mthd,
 
   TRI_ASSERT(!cells.empty());
 
-  RocksDBKeyLeaser key(&trx);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
 
   // FIXME: can we rely on the region coverer to return
   // the same cells everytime for the same parameters ?
   for (S2CellId cell : cells) {
-    key->constructGeoIndexValue(objectId(), cell.id(), documentId);
+    key.constructGeoIndexValue(objectId(), cell.id(), documentId);
     rocksdb::Status s =
         mthd->Delete(RocksDBColumnFamilyManager::get(
                          RocksDBColumnFamilyManager::Family::GeoIndex),
-                     key.ref());
+                     key);
     if (!s.ok()) {
       res.reset(rocksutils::convertStatus(s, rocksutils::index));
       addErrorMsg(res);

--- a/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBGeoIndex.cpp
@@ -28,6 +28,7 @@
 #include "Aql/AstNode.h"
 #include "Aql/Function.h"
 #include "Aql/SortCondition.h"
+#include "Basics/ThreadLocalLeaser.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "GeoIndex/Covering.h"

--- a/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
+++ b/arangod/RocksDBEngine/RocksDBIncrementalSync.cpp
@@ -153,9 +153,9 @@ Result removeKeysOutsideRange(
   TRI_ASSERT(index->type() == Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX);
   auto primaryIndex = static_cast<RocksDBPrimaryIndex*>(index.get());
 
-  RocksDBKeyLeaser key(&trx);
-  key->constructPrimaryIndexValue(primaryIndex->objectId(), highRef);
-  iterator.seek(key->string());
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructPrimaryIndexValue(primaryIndex->objectId(), highRef);
+  iterator.seek(key.string());
 
   iterator.next(
       [&](rocksdb::Slice const& rocksKey, rocksdb::Slice const& rocksValue) {

--- a/arangod/RocksDBEngine/RocksDBIterators.cpp
+++ b/arangod/RocksDBEngine/RocksDBIterators.cpp
@@ -334,10 +334,10 @@ class RocksDBAnyIndexIterator final : public IndexIterator {
     // the number of scan steps to some reasonable amount.
     uint64_t steps = RandomGenerator::interval(_total - 1) % 500;
 
-    RocksDBKeyLeaser key(_trx);
-    key->constructDocument(
+    RocksDBKey key(ThreadLocalStringLeaser::lease());
+    key.constructDocument(
         _objectId, LocalDocumentId(RandomGenerator::interval(UINT64_MAX)));
-    _iterator->Seek(key->string());
+    _iterator->Seek(key.string());
 
     if (checkIter()) {
       while (steps-- > 0) {

--- a/arangod/RocksDBEngine/RocksDBIterators.cpp
+++ b/arangod/RocksDBEngine/RocksDBIterators.cpp
@@ -24,6 +24,7 @@
 #include "RocksDBIterators.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Basics/Exceptions.h"
+#include "Basics/ThreadLocalLeaser.h"
 #include "Random/RandomGenerator.h"
 #include "RocksDBEngine/RocksDBColumnFamilyManager.h"
 #include "RocksDBEngine/RocksDBCommon.h"

--- a/arangod/RocksDBEngine/RocksDBKey.cpp
+++ b/arangod/RocksDBEngine/RocksDBKey.cpp
@@ -57,10 +57,11 @@ constexpr std::uint64_t vectorIndexMetadataSlot(
 
 const char RocksDBKey::_stringSeparator = '\0';
 
-RocksDBKey::RocksDBKey(std::string* leased)
+RocksDBKey::RocksDBKey(ThreadLocalStringLeaser::Lease lease)
     : _type(RocksDBEntryType::Document),  // placeholder
       _local(),
-      _buffer(leased != nullptr ? leased : &_local) {}
+      _lease(std::move(lease)),
+      _buffer(_lease->get()) {}
 
 RocksDBKey::RocksDBKey(rocksdb::Slice slice)
     : _type(static_cast<RocksDBEntryType>(slice.data()[0])),
@@ -70,6 +71,7 @@ RocksDBKey::RocksDBKey(rocksdb::Slice slice)
 RocksDBKey::RocksDBKey(RocksDBKey&& other) noexcept
     : _type(other._type), _local(), _buffer(&_local) {
   _local.assign(std::move(*(other._buffer)));
+  other._lease.reset();
   other._buffer = &(other._local);
 }
 

--- a/arangod/RocksDBEngine/RocksDBKey.h
+++ b/arangod/RocksDBEngine/RocksDBKey.h
@@ -31,9 +31,12 @@
 #include "VocBase/voc-types.h"
 #include "Zkd/ZkdHelper.h"
 
+#include "Basics/ThreadLocalLeaser.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <iosfwd>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -59,9 +62,8 @@ class RocksDBKey {
         _local(),
         _buffer(&_local) {}
 
-  /// @brief construct a leased RocksDBKey
-  /// @param leased will use _local std::string if nullptr
-  explicit RocksDBKey(std::string* leased);
+  /// @brief construct a RocksDBKey using a leased string buffer
+  explicit RocksDBKey(ThreadLocalStringLeaser::Lease lease);
 
   explicit RocksDBKey(rocksdb::Slice slice);
 
@@ -350,9 +352,6 @@ class RocksDBKey {
     return _type == other._type && *_buffer == *(other._buffer);
   }
 
-  /// @brief does this use the inline buffer or a leased one
-  inline bool usesInlineBuffer() const { return &_local == _buffer; }
-
   /// @brief  internal buffer string, unmanaged use carefully
   inline std::string* buffer() const { return _buffer; }
 
@@ -405,7 +404,8 @@ class RocksDBKey {
   static const char _stringSeparator;
 
   RocksDBEntryType _type;
-  std::string _local;  // local inline buffer
+  std::string _local;
+  std::optional<ThreadLocalStringLeaser::Lease> _lease;
   std::string* _buffer;
 };
 

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -657,16 +657,16 @@ LocalDocumentId RocksDBPrimaryIndex::lookupKey(transaction::Methods* trx,
                                                std::string_view keyRef,
                                                ReadOwnWrites readOwnWrites,
                                                bool& foundInCache) const {
-  RocksDBKeyLeaser key(trx);
-  key->constructPrimaryIndexValue(objectId(), keyRef);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructPrimaryIndexValue(objectId(), keyRef);
 
   foundInCache = false;
   bool lockTimeout = false;
   auto cache = useCache();
   if (cache != nullptr) {
     // check cache first for fast path
-    auto f = cache->find(key->string().data(),
-                         static_cast<uint32_t>(key->string().size()));
+    auto f = cache->find(key.string().data(),
+                         static_cast<uint32_t>(key.string().size()));
     if (f.found()) {
       foundInCache = true;
       rocksdb::Slice s(reinterpret_cast<char const*>(f.value()->value()),
@@ -682,7 +682,7 @@ LocalDocumentId RocksDBPrimaryIndex::lookupKey(transaction::Methods* trx,
   RocksDBMethods* mthds =
       RocksDBTransactionState::toMethods(trx, _collection.id());
   rocksdb::PinnableSlice val;
-  rocksdb::Status s = mthds->Get(_cf, key->string(), &val, readOwnWrites);
+  rocksdb::Status s = mthds->Get(_cf, key.string(), &val, readOwnWrites);
   if (!s.ok()) {
     return LocalDocumentId();
   }
@@ -690,8 +690,8 @@ LocalDocumentId RocksDBPrimaryIndex::lookupKey(transaction::Methods* trx,
   if (cache != nullptr && !lockTimeout && val.size() <= _maxCacheValueSize) {
     // write entry back to cache
     cache::Cache::SimpleInserter<PrimaryIndexCacheType>{
-        static_cast<PrimaryIndexCacheType&>(*cache), key->string().data(),
-        static_cast<uint32_t>(key->string().size()), val.data(),
+        static_cast<PrimaryIndexCacheType&>(*cache), key.string().data(),
+        static_cast<uint32_t>(key.string().size()), val.data(),
         static_cast<uint64_t>(val.size())};
   }
 
@@ -715,8 +715,8 @@ Result RocksDBPrimaryIndex::lookupRevision(transaction::Methods* trx,
   documentId = LocalDocumentId::none();
   revisionId = RevisionId::none();
 
-  RocksDBKeyLeaser key(trx);
-  key->constructPrimaryIndexValue(objectId(), keyRef);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructPrimaryIndexValue(objectId(), keyRef);
 
   // acquire rocksdb transaction
   RocksDBMethods* mthds =
@@ -725,9 +725,9 @@ Result RocksDBPrimaryIndex::lookupRevision(transaction::Methods* trx,
   rocksdb::Status s;
   if (lockForUpdate) {
     TRI_ASSERT(readOwnWrites == ReadOwnWrites::yes);
-    s = mthds->GetForUpdate(_cf, key->string(), &val);
+    s = mthds->GetForUpdate(_cf, key.string(), &val);
   } else {
-    s = mthds->Get(_cf, key->string(), &val, readOwnWrites);
+    s = mthds->Get(_cf, key.string(), &val, readOwnWrites);
   }
   if (!s.ok()) {
     return rocksutils::convertStatus(s, rocksutils::StatusHint::document);
@@ -770,20 +770,20 @@ Result RocksDBPrimaryIndex::insert(transaction::Methods& trx,
   transaction::helpers::extractKeyAndRevFromDocument(slice, keySlice, revision);
   TRI_ASSERT(keySlice.isString());
 
-  RocksDBKeyLeaser key(&trx);
-  key->constructPrimaryIndexValue(objectId(), keySlice.stringView());
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructPrimaryIndexValue(objectId(), keySlice.stringView());
 
   // we do not need to perform any additional checks here since the document key
   // is already locked at the beginning of the insert operation
 
   // invalidate new index cache entry to avoid caching without committing first
-  invalidateCacheEntry(key->string().data(),
-                       static_cast<uint32_t>(key->string().size()));
+  invalidateCacheEntry(key.string().data(),
+                       static_cast<uint32_t>(key.string().size()));
 
   TRI_ASSERT(revision.isSet());
   auto value = RocksDBValue::PrimaryIndexValue(documentId, revision);
   rocksdb::Status s =
-      mthd->Put(_cf, key.ref(), value.string(), /*assume_tracked*/ true);
+      mthd->Put(_cf, key, value.string(), /*assume_tracked*/ true);
   if (!s.ok()) {
     Result res = rocksutils::convertStatus(s, rocksutils::index);
     addErrorMsg(res, keySlice.stringView());
@@ -817,20 +817,20 @@ Result RocksDBPrimaryIndex::update(
     return res;
   }
 
-  RocksDBKeyLeaser key(&trx);
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
 
-  key->constructPrimaryIndexValue(objectId(), keySlice.stringView());
+  key.constructPrimaryIndexValue(objectId(), keySlice.stringView());
 
   RevisionId revision = transaction::helpers::extractRevFromDocument(newDoc);
   auto value = RocksDBValue::PrimaryIndexValue(newDocumentId, revision);
 
   // invalidate new index cache entry to avoid caching without committing first
-  invalidateCacheEntry(key->string().data(),
-                       static_cast<uint32_t>(key->string().size()));
+  invalidateCacheEntry(key.string().data(),
+                       static_cast<uint32_t>(key.string().size()));
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   {
-    rocksdb::Status s = mthd->GetForUpdate(_cf, key->string(), nullptr);
+    rocksdb::Status s = mthd->GetForUpdate(_cf, key.string(), nullptr);
     if (s.IsNotFound()) {
       // the key must have existed before in the primary index
       res.reset(TRI_ERROR_ARANGO_CONFLICT,
@@ -850,7 +850,7 @@ Result RocksDBPrimaryIndex::update(
 #endif
 
   rocksdb::Status s =
-      mthd->Put(_cf, key.ref(), value.string(), /*assume_tracked*/ false);
+      mthd->Put(_cf, key, value.string(), /*assume_tracked*/ false);
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::index));
     addErrorMsg(res, keySlice.stringView());
@@ -868,15 +868,15 @@ Result RocksDBPrimaryIndex::remove(transaction::Methods& trx,
   // TODO: deal with matching revisions?
   VPackSlice keySlice = transaction::helpers::extractKeyFromDocument(slice);
   TRI_ASSERT(keySlice.isString());
-  RocksDBKeyLeaser key(&trx);
-  key->constructPrimaryIndexValue(objectId(), keySlice.stringView());
+  RocksDBKey key(ThreadLocalStringLeaser::lease());
+  key.constructPrimaryIndexValue(objectId(), keySlice.stringView());
 
-  invalidateCacheEntry(key->string().data(),
-                       static_cast<uint32_t>(key->string().size()));
+  invalidateCacheEntry(key.string().data(),
+                       static_cast<uint32_t>(key.string().size()));
 
   // acquire rocksdb transaction
   auto* mthds = RocksDBTransactionState::toMethods(&trx, _collection.id());
-  rocksdb::Status s = mthds->Delete(_cf, key.ref());
+  rocksdb::Status s = mthds->Delete(_cf, key);
   if (!s.ok()) {
     res.reset(rocksutils::convertStatus(s, rocksutils::index));
     addErrorMsg(res, keySlice.stringView());

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.h
@@ -33,7 +33,6 @@
 #include <velocypack/Slice.h>
 
 namespace arangodb {
-class RocksDBKeyLeaser;
 
 namespace transaction {
 class Methods;

--- a/arangod/RocksDBEngine/RocksDBTransactionState.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.cpp
@@ -27,7 +27,6 @@
 #include "Aql/QueryCache.h"
 #include "Basics/Exceptions.h"
 #include "Basics/Result.h"
-#include "Basics/ThreadLocalLeaser.h"
 #include "Basics/system-compiler.h"
 #include "Basics/system-functions.h"
 #include "Cache/CacheManagerFeature.h"
@@ -47,7 +46,6 @@
 #include "Statistics/ServerStatistics.h"
 #include "StorageEngine/EngineSelectorFeature.h"
 #include "StorageEngine/TransactionCollection.h"
-#include "Transaction/Context.h"
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 #include "Transaction/History.h"
 #endif
@@ -379,20 +377,3 @@ RocksDBTransactionStateGuard::~RocksDBTransactionStateGuard() {
   _state->unuse();
 }
 #endif
-
-/// @brief constructor, leases a builder
-RocksDBKeyLeaser::RocksDBKeyLeaser(transaction::Methods* trx)
-    : _ctx(trx->transactionContextPtr()),
-      _key(ThreadLocalStringLeaser::lease().release().release()) {
-  TRI_ASSERT(_ctx != nullptr);
-  TRI_ASSERT(_key.buffer() != nullptr);
-}
-
-/// @brief destructor
-RocksDBKeyLeaser::~RocksDBKeyLeaser() {
-  if (!_key.usesInlineBuffer()) {
-    // TODO: this is very ugly.
-    ThreadLocalStringLeaser::acquire(
-        std::unique_ptr<std::string>(_key.buffer()));
-  }
-}

--- a/arangod/RocksDBEngine/RocksDBTransactionState.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionState.h
@@ -175,21 +175,4 @@ struct RocksDBTransactionStateGuard {
 #endif
 };
 
-class RocksDBKeyLeaser {
- public:
-  explicit RocksDBKeyLeaser(transaction::Methods*);
-  ~RocksDBKeyLeaser();
-  inline RocksDBKey* builder() { return &_key; }
-  inline RocksDBKey* operator->() { return &_key; }
-  inline RocksDBKey const* operator->() const { return &_key; }
-  inline RocksDBKey* get() { return &_key; }
-  inline RocksDBKey const* get() const { return &_key; }
-  inline RocksDBKey& ref() { return _key; }
-  inline RocksDBKey const& ref() const { return _key; }
-
- private:
-  transaction::Context* _ctx;
-  RocksDBKey _key;
-};
-
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -320,13 +320,13 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
         _cache(std::static_pointer_cast<VPackIndexCacheType>(std::move(cache))),
         _maxCacheValueSize(_cache == nullptr ? 0 : _cache->maxCacheValueSize()),
         _indexIteratorOptions(opts),
-        _key(trx),
+        _key(ThreadLocalStringLeaser::lease()),
         _done(false) {
     TRI_ASSERT(index->unique());
     TRI_ASSERT(index->columnFamily() ==
                RocksDBColumnFamilyManager::get(
                    RocksDBColumnFamilyManager::Family::VPackIndex));
-    _key->constructUniqueVPackIndexValue(index->objectId(), indexValues);
+    _key.constructUniqueVPackIndexValue(index->objectId(), indexValues);
 
     // if the cache is enabled, it must use the VPackKeyHasher!
     TRI_ASSERT(_cache == nullptr || _cache->hasherName() == "VPackKeyHasher");
@@ -375,7 +375,7 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
   bool rearmImpl(velocypack::Slice slice,
                  IndexIteratorOptions const& /*opts*/) override {
     TRI_ASSERT(slice.length() > 0);
-    _key->constructUniqueVPackIndexValue(_index->objectId(), slice);
+    _key.constructUniqueVPackIndexValue(_index->objectId(), slice);
     return true;
   }
 
@@ -411,11 +411,11 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
         [&cb, this](rocksdb::PinnableSlice& ps) {
           if (_index->hasStoredValues()) {
             auto data = SliceCoveringDataWithStoredValues(
-                RocksDBKey::indexedVPack(_key.ref()),
+                RocksDBKey::indexedVPack(_key),
                 RocksDBValue::uniqueIndexStoredValues(ps));
             cb(LocalDocumentId(RocksDBValue::documentId(ps)), data);
           } else {
-            auto data = SliceCoveringData(RocksDBKey::indexedVPack(_key.ref()));
+            auto data = SliceCoveringData(RocksDBKey::indexedVPack(_key));
             cb(LocalDocumentId(RocksDBValue::documentId(ps)), data);
           }
         },
@@ -467,7 +467,7 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
     rocksdb::PinnableSlice ps;
     RocksDBMethods* mthds =
         RocksDBTransactionState::toMethods(_trx, _collection->id());
-    rocksdb::Status s = mthds->Get(_index->columnFamily(), _key->string(), &ps,
+    rocksdb::Status s = mthds->Get(_index->columnFamily(), _key.string(), &ps,
                                    canReadOwnWrites());
 
     if (s.ok()) {
@@ -480,7 +480,7 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
         // LocalDocumentId
         builder->add(VPackValue(RocksDBValue::documentId(ps).id()));
         // index values
-        builder->add(RocksDBKey::indexedVPack(_key->string()));
+        builder->add(RocksDBKey::indexedVPack(_key.string()));
         if (_index->hasStoredValues()) {
           // "storedValues"
           builder->add(RocksDBValue::uniqueIndexStoredValues(ps));
@@ -522,7 +522,7 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
 
   rocksdb::Slice lookupValueForCache() const noexcept {
     // use bounds start value
-    return ::lookupValueFromSlice(_key->string());
+    return ::lookupValueFromSlice(_key.string());
   }
 
   ResourceMonitor& _resourceMonitor;
@@ -531,7 +531,7 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
   std::shared_ptr<VPackIndexCacheType> _cache;
   size_t const _maxCacheValueSize;
   IndexIteratorOptions const _indexIteratorOptions;
-  RocksDBKeyLeaser _key;
+  RocksDBKey _key;
   bool _done;
 };
 

--- a/lib/Basics/ThreadLocalLeaser.h
+++ b/lib/Basics/ThreadLocalLeaser.h
@@ -48,9 +48,6 @@ struct ThreadLocalLeaser {
     auto operator*() noexcept -> T& { return *get(); }
     auto operator*() const noexcept -> T const& { return *get(); }
 
-    auto release() -> std::unique_ptr<T> {
-      return std::exchange(_object, nullptr);
-    }
     auto acquire(std::unique_ptr<T>&& m) -> void { _object = std::move(m); }
 
    private:

--- a/lib/Basics/ThreadLocalLeaser.h
+++ b/lib/Basics/ThreadLocalLeaser.h
@@ -48,6 +48,11 @@ struct ThreadLocalLeaser {
     auto operator*() noexcept -> T& { return *get(); }
     auto operator*() const noexcept -> T const& { return *get(); }
 
+    auto release() -> std::unique_ptr<T> {
+      return std::exchange(_object, nullptr);
+    }
+    auto acquire(std::unique_ptr<T>&& m) -> void { _object = std::move(m); }
+
    private:
     Lease(std::unique_ptr<T>&& leasee) : _object(std::move(leasee)) {
       TRI_ASSERT(_object != nullptr);

--- a/lib/Basics/ThreadLocalLeaser.h
+++ b/lib/Basics/ThreadLocalLeaser.h
@@ -48,6 +48,9 @@ struct ThreadLocalLeaser {
     auto operator*() noexcept -> T& { return *get(); }
     auto operator*() const noexcept -> T const& { return *get(); }
 
+    auto release() -> std::unique_ptr<T> {
+      return std::exchange(_object, nullptr);
+    }
     auto acquire(std::unique_ptr<T>&& m) -> void { _object = std::move(m); }
 
    private:

--- a/lib/Basics/ThreadLocalLeaser.h
+++ b/lib/Basics/ThreadLocalLeaser.h
@@ -48,13 +48,6 @@ struct ThreadLocalLeaser {
     auto operator*() noexcept -> T& { return *get(); }
     auto operator*() const noexcept -> T const& { return *get(); }
 
-    // TODO: this is used precisely in one (dubious) place
-    // Maybe we can remove that;
-    auto release() -> std::unique_ptr<T> {
-      return std::exchange(_object, nullptr);
-    }
-    auto acquire(std::unique_ptr<T>&& m) -> void { _object = std::move(m); }
-
    private:
     Lease(std::unique_ptr<T>&& leasee) : _object(std::move(leasee)) {
       TRI_ASSERT(_object != nullptr);
@@ -66,11 +59,6 @@ struct ThreadLocalLeaser {
   static auto stashSize() noexcept -> size_t { return current._stash.size(); }
   static constexpr auto maxStashedPerThread = size_t{128};
   static auto lease() -> Lease { return current.doLease(); }
-  // TODO: This is a hack to enable RocksDBKeyLeaser to return a
-  // string to the stash.
-  static auto acquire(std::unique_ptr<T>&& item) {
-    current._stash.emplace_back(std::move(item));
-  }
   static auto clear() -> void { current._stash.clear(); }
   friend struct Lease;
 


### PR DESCRIPTION
### Scope & Purpose

This PR implements https://arangodb.atlassian.net/browse/COR-75, the removal of RocksDBKeyLeaser, which is an external RAII wrapper around RocksDBKey. Now RocksDBKey owns its leased string buffer directly.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-75
- [ ] Design document: 
