### PR TITLE
[BTS-2386] Remove support for restoring fulltext indexes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -252,8 +252,9 @@
   - `arangodb_v8_context_max`: maximum number of concurrent V8 contexts.
   - `arangodb_v8_context_min`: minimum number of concurrent V8 contexts.
 
-* arangorestore now automatically converts deprecated `fulltext` indexes to
-  `inverted` indexes when restoring dumps from older versions.
+* arangorestore now skips deprecated `fulltext` indexes when restoring dumps
+  from older versions. Fulltext indexes are no longer supported; use
+  ArangoSearch (inverted indexes) instead.
 
 * Remove leftovers of arangoimp.
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -135,8 +135,7 @@ void rewriteIndexType(VPackSlice idxDef, VPackBuilder& builder,
 /// Returns the (possibly rewritten) slice. If a transformation occurred, the
 /// returned slice points into @p rebuilder.
 VPackSlice transformDeprecatedIndexType(VPackSlice idxDef,
-                                        VPackBuilder& rebuilder,
-                                        std::string_view collectionName) {
+                                        VPackBuilder& rebuilder) {
   VPackSlice type = idxDef.get(StaticStrings::IndexType);
   if (!type.isString()) {
     return idxDef;
@@ -149,16 +148,6 @@ VPackSlice transformDeprecatedIndexType(VPackSlice idxDef,
 
   if (type.isEqualString("hash") || type.isEqualString("skiplist")) {
     rewriteIndexType(idxDef, rebuilder, "persistent");
-    return rebuilder.slice();
-  }
-
-  if (type.isEqualString("fulltext")) {
-    LOG_TOPIC("43c19", INFO, Logger::REPLICATION)
-        << "Transforming deprecated fulltext index into inverted index "
-           "for collection '"
-        << collectionName << "'";
-    rewriteIndexType(idxDef, rebuilder, "inverted",
-                     {"minLength", "sparse", "unique", "deduplicate"});
     return rebuilder.slice();
   }
 
@@ -1913,7 +1902,16 @@ Result RestReplicationHandler::processRestoreIndexes(
         continue;
       }
 
-      idxDef = transformDeprecatedIndexType(idxDef, rebuilder, name);
+      if (type.isEqualString("fulltext")) {
+        LOG_TOPIC("43c19", WARN, Logger::RESTORE) << std::format(
+            "Skipping deprecated fulltext index for collection '{}'. Fulltext "
+            "indexes are no longer supported since ArangoDB 4.0; use "
+            "ArangoSearch (inverted index) instead.",
+            name);
+        continue;
+      }
+
+      idxDef = transformDeprecatedIndexType(idxDef, rebuilder);
 
       if (type.isEqualString(StaticStrings::IndexNameVector) &&
           !server().getFeature<VectorIndexFeature>().isVectorIndexEnabled()) {
@@ -2035,7 +2033,16 @@ Result RestReplicationHandler::processRestoreIndexesCoordinator(
       continue;
     }
 
-    idxDef = transformDeprecatedIndexType(idxDef, rebuilder, name);
+    if (type.isEqualString("fulltext")) {
+      LOG_TOPIC("43c1a", WARN, Logger::RESTORE) << std::format(
+          "Skipping deprecated fulltext index for collection '{}'. Fulltext "
+          "indexes are no longer supported since ArangoDB 4.0; use "
+          "ArangoSearch (inverted index) instead.",
+          name);
+      continue;
+    }
+
+    idxDef = transformDeprecatedIndexType(idxDef, rebuilder);
 
     if (type.isEqualString(StaticStrings::IndexNameVector) &&
         !server().getFeature<VectorIndexFeature>().isVectorIndexEnabled()) {

--- a/tests/js/client/shell/large/shell-restore-integration.js
+++ b/tests/js/client/shell/large/shell-restore-integration.js
@@ -1336,7 +1336,7 @@ function restoreIntegrationSuite() {
     },
 
     // Test for restoring deprecated fulltext index type
-    // Fulltext indexes are deprecated and should be converted to inverted
+    // Fulltext indexes are no longer supported and should be skipped on restore
     testRestoreDeprecatedFulltextIndex: function () {
       let path = fs.getTempFile();
       fs.makeDirectory(path);
@@ -1367,14 +1367,12 @@ function restoreIntegrationSuite() {
 
       let c = db._collection(cn);
       let indexes = c.indexes();
-      // Fulltext index should be converted to inverted
-      assertEqual(2, indexes.length);
+      // Fulltext index should be skipped, leaving only the primary index
+      assertEqual(1, indexes.length);
       assertEqual("primary", indexes[0].type);
       assertEqual(["_key"], indexes[0].fields);
-      // Fulltext index converted to inverted
-      assertEqual("inverted", indexes[1].type);
-      assertEqual("textField", indexes[1].fields[0].name);
 
+      // data is still restored even though the fulltext index is dropped
       assertEqual(100, c.count());
       fs.removeDirectoryRecursive(path, true);
     },


### PR DESCRIPTION
### Scope & Purpose

*(Please describe the changes in this PR for reviewers, motivation, rationale - **mandatory**)*

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2386
- [ ] Design document: 
