### PR TITLE
[COR-586] Add port exhaustion check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,7 +122,7 @@ js/node/node_modules/**/.nyc_output
 npm-debug.log
 
 /log-*
-data-*
+./data-*
 databases
 !js/apps/system/_admin/aardvark/APP/react/src/views/databases
 cluster-init

--- a/tests/toast/README.md
+++ b/tests/toast/README.md
@@ -630,8 +630,32 @@ directory specified by `--result-dir`):
 | 0 | All tests passed |
 | 1 | Test failures |
 | 2 | Sanitizer errors detected |
-| 3 | Infrastructure failure (deployment failed to start, etc.) |
+| 3 | Infrastructure failure (deployment failed to start, port exhaustion, etc.) |
 | 4 | Server crash |
+
+### Port Exhaustion Detection
+
+Between tests, Toast monitors the system's TCP socket count to detect port
+exhaustion before it causes cascading test failures. Two thresholds are
+checked:
+
+- **System threshold** (15,000): total TCP sockets on the system. Catches
+  catastrophic exhaustion regardless of source.
+- **Deployment threshold** (500 per server): sockets added since the
+  deployment started, scaled by server count. Catches connection leaks
+  within the deployment earlier than the system threshold would.
+
+When either threshold is reached, the suite aborts with an infrastructure
+issue. The post-execution summary shows a per-server breakdown (inbound vs
+outbound sockets by TCP state), and `mix toast.analyze detail infrastructure`
+includes a trajectory showing which tests contributed the most sockets.
+
+The check uses `ss` (preferred) or `netstat` (fallback) for the routine count.
+The detailed per-server breakdown (requiring more expensive PID resolution) is
+only gathered once when a threshold is actually breached.
+
+If neither `ss` nor `netstat` is available, the check is disabled with a
+warning.
 
 ### CI Mode
 
@@ -672,9 +696,10 @@ mix toast.analyze detail 3
 # Show detail for a range of issues
 mix toast.analyze detail 2-4
 
-# Show only crash or sanitizer issues
+# Show only specific issue types
 mix toast.analyze detail crashes
 mix toast.analyze detail sanitizer
+mix toast.analyze detail infrastructure
 
 # Overview of diagnostics file contents
 mix toast.analyze info

--- a/tests/toast/docs/architecture.md
+++ b/tests/toast/docs/architecture.md
@@ -144,6 +144,7 @@ Design decisions:
 | `Toast.Deployment.DefaultEventListener` | No-op implementation of EventListener. |
 | `Toast.Deployment.CrashBarrier` | Between-tests barrier that checks `/proc/<pid>/status` to detect in-flight crashes before the next test starts. |
 | `Toast.Deployment.HealthBarrier` | Between-tests barrier that waits for each server's HealthMonitor to report healthy before the next test starts. Catches "alive but unresponsive" cases (deadlocks, resource exhaustion). |
+| `Toast.Deployment.Netstat` | Between-tests port exhaustion check. Counts system TCP sockets via `ss`/`netstat` (~2ms fast path); gathers per-server PID-based breakdown (~40ms) only on threshold breach. Two thresholds: system-wide (15k) and per-deployment (500/server above baseline). |
 | `Toast.Deployment.Supervisor` | DynamicSupervisor for Controller processes. |
 
 ### Process Management (`Toast.Process.*`)
@@ -172,7 +173,7 @@ Design decisions:
 | `ToastTest.Runner.TestExecution` | Core test execution loop (setup_all, per-test spawn, result handling). |
 | `ToastTest.Runner.TestProcess` | Spawn and manage individual test processes with timeout handling. |
 | `ToastTest.Runner.TestFilter` | Filter test modules by line number, test name, and ExUnit tags. |
-| `ToastTest.Runner.BetweenTests` | Between-test checks with three phases: (1) `CrashBarrier.await_settled/2` checks `/proc/<pid>/status` for in-flight crashes, (2) `HealthBarrier.await_healthy/2` waits for health monitors to report healthy, (3) suite's custom `between_tests/2` callback (or default `BetweenTests.check/2`). Also enforces suite deadline. |
+| `ToastTest.Runner.BetweenTests` | Between-test checks with four phases: (1) `CrashBarrier.await_settled/2` checks for in-flight crashes, (2) `HealthBarrier.await_healthy/2` waits for health monitors, (3) `Netstat.check/3` checks port exhaustion, (4) suite's custom `between_tests/2` callback (or default `BetweenTests.check/2`). |
 | `ToastTest.Runner.PostExecution` | Post-suite diagnostics collection (agency dump, artifact collection, attribution). |
 | `ToastTest.Runner.ResultBuilder` | Build SuiteResult from test data, diagnostics, and enrichment. |
 | `ToastTest.Runner.FailureFormatter` | Format test failures for display. |

--- a/tests/toast/docs/data-structures-and-dependencies.md
+++ b/tests/toast/docs/data-structures-and-dependencies.md
@@ -1,0 +1,515 @@
+# Data Structures and Dependencies
+
+Key data structures and module dependency map for the TOAST test framework.
+See [architecture.md](./architecture.md) for the system overview.
+
+
+## Key Data Structures
+
+### Toast.Deployment.t()
+
+The public handle returned by `Toast.Deployment.start/3`. Passed to test
+context and all deployment operations. Contains enough to address the
+Controller GenServer but not the full internal state.
+
+```elixir
+%Toast.Deployment{
+  id: "single-00",                    # unique deployment identifier
+  controller: #PID<0.123.0>,          # Controller GenServer pid
+  api_version: 1,                     # API version prefix (nil, integer, or string)
+  servers: %{                         # Map of server_id => ServerInfo
+    "single-00" => %ServerInfo{
+      id: "single-00",
+      role: :single,
+      port: 8529,
+      endpoint: "http://127.0.0.1:8529",
+      arango_id: nil
+    }
+  },
+  jwt_provider: nil                   # Toast.JWT.Provider (nil when auth disabled)
+}
+```
+
+Why this exists as a separate struct from Controller.State: the Controller.State
+is internal to the GenServer and contains mutable runtime state (server pids,
+health monitors, crash tracking). The Deployment struct is a stable reference
+that test code can hold without coupling to GenServer internals.
+
+The `servers` map contains `ServerInfo` structs -- lightweight, immutable
+snapshots taken at deploy time. These are distinct from `ServerInstance` which
+carries mutable runtime state.
+
+
+### Toast.Deployment.Controller.State
+
+Internal state of the Controller GenServer. Not exposed outside the GenServer
+process. See [architecture.md](./architecture.md#controllerstate) for the full
+breakdown.
+
+```elixir
+%Controller.State{
+  config: %Toast.Deployment.Config{},  # Deployment configuration
+  id: "single-00",                     # Deployment ID
+  status: :ready,                      # :stopped | :starting | :ready | :degraded | :stopping | :failed
+  servers: %{                          # Map of server_id => ServerInstance
+    "single-00" => %ServerInstance{...}
+  },
+  expected_crashes: %{},               # Map of server_id => CrashExpectation
+  error: nil,                          # Error details if status is :failed
+  agency_dump: nil,                    # Captured agency state (cluster only)
+  event_listener: ToastTest.DeploymentListener,  # EventListener behaviour impl
+  jwt_provider: nil                    # Toast.JWT.Provider (nil when auth disabled)
+}
+```
+
+
+### Toast.Deployment.ServerInstance.t()
+
+Runtime state of a single server process within a deployment:
+
+```elixir
+%Toast.Deployment.ServerInstance{
+  id: "single-00",               # server identifier
+  role: :single,                 # :single | :agent | :dbserver | :coordinator
+  port: 8529,                    # TCP port for HTTP API
+  endpoint: "http://127.0.0.1:8529",
+  pid: 12345,                    # OS process ID (from erlexec)
+  log_file: "/tmp/toast/.../arangod.log",
+  server_dir: "/tmp/toast/.../",
+  server_pid: #PID<0.456.0>,    # ServerProcess GenServer pid
+  health_monitor: #PID<0.789.0>,# HealthMonitor GenServer pid
+  operational_state: :running,   # :running | :paused | :stopped | :killed | :crashed
+  intentional: false,            # true when state change was requested by test code
+  expecting_exit: false,         # true during stop/kill (before process exit arrives)
+  arango_id: nil,                # ArangoDB-assigned internal ID (cluster only)
+  launch_spec: %{...}           # executable, args, env, dirs -- reused for relaunch
+}
+```
+
+The `intentional` flag is the key mechanism for distinguishing test-driven
+server manipulation from actual failures. When a test calls `stop_server`,
+`intentional` is set to `true` before the stop. When the process exit
+notification arrives, the Controller checks this flag to decide whether to
+trigger the crash protocol.
+
+`operational_state` and `intentional` together determine the Controller's
+response:
+
+```
+operational_state  intentional  Meaning
+-----------------  -----------  -------
+:running           false        Normal operation
+:paused            true         Test paused the server (SIGSTOP)
+:stopped           true         Test stopped the server (SIGTERM)
+:killed            true         Test killed the server (SIGKILL)
+:crashed           true         Expected crash (test called expect_crash)
+:crashed           false        Unexpected crash --> :failed status
+```
+
+
+### Toast.Deployment.Config.t()
+
+Deployment infrastructure configuration. Immutable after `Config.new/1`. All
+timeouts are pre-multiplied by `timeout_factor` (via `Toast.Env`).
+
+```elixir
+%Toast.Deployment.Config{
+  # Paths
+  build_dir: "/path/to/build",       # where arangod binary lives
+
+  # Server args
+  server_args: %{},                   # map of option => value for all/single servers
+  show_server_logs: false,            # print arangod stderr
+
+  # Sanitizer
+  sanitizer_override: :alubsan,       # forced sanitizer type, or nil
+  active_sanitizers: #MapSet<["ASAN_OPTIONS", ...]>,  # active env var names
+
+  # Cluster
+  cluster: nil,                       # nil for single server, ClusterOpts for cluster
+
+  # Timeouts (milliseconds, pre-multiplied by timeout_factor)
+  startup_timeout: 60_000,
+  shutdown_timeout: 60_000,
+  timeout_factor: 1,                  # multiplier (3 for sanitizer, 10 for rr)
+
+  # Protocol
+  api_version: nil,                   # API version prefix for URLs
+  protocol: :http1,                   # :http1 | :http2
+  ssl: false,                         # enable SSL/TLS
+
+  # Authentication
+  authentication: false,              # enable JWT authentication
+  jwt_algorithm: :hmac,               # :hmac | :ecdsa
+
+  # Recording
+  rr: nil,                            # MapSet of roles to record with rr
+  rr_path: nil,                       # path to rr executable
+
+  # Resources
+  memory_budget: nil                  # memory budget in bytes (auto-detected)
+}
+```
+
+
+### ToastTest.Config.t()
+
+Test execution configuration. Separate from Deployment.Config because it
+covers test runner concerns, not deployment infrastructure.
+
+```elixir
+%ToastTest.Config{
+  base_dir: "/tmp/toast/...",         # per-run server data
+  result_dir: "toast-results",        # where results are written
+  deployment_mode: :single_server,    # :single_server | :cluster | :manual
+  timeout_factor: 1,                  # multiplier
+  global_timeout: 3_600_000,          # entire test run
+  test_timeout: 300_000,              # single test
+  keep_data: false,                   # preserve server data after run
+  ci: false,                          # enable CI packaging
+  debugger: :auto,                    # :gdb | :lldb | :auto | :none
+  attach_debugger: false,             # pause for debugger attachment
+  coredump_timeout: 180_000,          # coredump analysis budget
+  coredump_dir: nil,                  # explicit coredump search directory
+  dump_agency_on_error: true          # capture agency state on failure
+}
+```
+
+
+### Toast.Client.t()
+
+REST client wrapping `Req`. Supports database scoping, API versioning, and
+multiple authentication modes:
+
+```elixir
+%Toast.Client{
+  base_url: "http://127.0.0.1:8529",
+  database: "mydb",                  # nil for system-level requests
+  api_version: 1,                    # integer, string, or nil
+  auth: {:basic, "root", ""},        # {:basic, u, p} | {:jwt, token} | {:jwt_provider, provider} | nil
+  req: %Req.Request{...}             # underlying HTTP client
+}
+```
+
+URL construction: `{base_url}/{version_prefix}/{db_prefix}{path}`
+- version_prefix: `/_arango/v1` (integer) or `/_arango/edge` (string)
+- db_prefix: `/_db/mydb`
+- Both are omitted when nil
+
+
+### Toast.Diagnostics.Coredump.Report.t()
+
+Structured result from debugger analysis of a core dump:
+
+```elixir
+%Toast.Diagnostics.Coredump.Report{
+  core_path: "/tmp/toast/.../core.12345",
+  binary_path: "/path/to/build/bin/arangod",
+  debugger: :lldb,                   # which debugger produced this
+  signal: "SIGSEGV",                 # signal name from debugger output
+  faulting_address: "0x0",           # address that caused the fault
+  crash_thread: 3,                   # thread index that crashed
+  threads: [                         # all threads with backtraces
+    %{
+      index: 0,
+      name: "arangod",
+      frames: [
+        %{index: 0, function: "main", file: "main.cpp", line: 42},
+        ...
+      ]
+    },
+    ...
+  ]
+}
+```
+
+
+### ToastTest.SuiteRun
+
+Per-suite execution context, passed through the Runner:
+
+```elixir
+%ToastTest.SuiteRun{
+  suite_module: MySuite.Suite,
+  deployment: %Toast.Deployment{...},  # nil until deploy succeeds
+  suite_deadline: 1709123456789,       # monotonic_time(:millisecond)
+  timeout_factor: 3.0
+}
+```
+
+
+### ETS Tables
+
+Toast uses ETS for cross-process shared state:
+
+| Table | Type | Access | Purpose |
+|-------|------|--------|---------|
+| `:toast_suite_abort` | `:set` | `:public` | Abort signaling. Single `{:aborted, reason}` entry. |
+| `:toast_deployment_registry` | `:set` | `:public` | Maps suite module to active deployment and extra context. |
+| `ToastTest.EventStore` | `:ordered_set` | `:public` | Chronological lifecycle events keyed by `{timestamp, sequence}`. |
+
+
+## Module Dependency Map
+
+Dependencies flow top-to-bottom. Each arrow means "calls/uses".
+
+```
+Mix.Tasks.Toast
+Mix.Tasks.Toast.Gen.Suite
+  |   uses: Mix.Tasks.Toast.Helpers (pure arg parsing)
+  |         Toast.Env (configuration resolution)
+  |
+  v
+ToastTest.Runner
+  |   uses: ToastTest.ExUnitCompat (ExUnit internal shim)
+  |         ToastTest.TestLifecycle (shared test lifecycle primitives)
+  |         ToastTest.Runner.TestExecution (core test execution loop)
+  |         ToastTest.Runner.TestProcess (test process spawn/management)
+  |         ToastTest.Runner.TestFilter (test filtering)
+  |         ToastTest.Runner.BetweenTests (health checks between tests)
+  |         ToastTest.Runner.PostExecution (post-suite diagnostics)
+  |         ToastTest.Runner.ResultBuilder (SuiteResult assembly)
+  |         ToastTest.Runner.FailureFormatter (failure display)
+  |         ToastTest.Runner.Timeout (deadline management)
+  |         ToastTest.SuiteRun (data struct)
+  |         ToastTest.Abort (ETS-backed abort state)
+  |         ToastTest.DeploymentRegistry (ETS)
+  |         ToastTest.DeploymentListener (EventListener impl)
+  |         ToastTest.CrashMonitor (abort on crash)
+  |         ToastTest.ResultCollector (ExUnit formatter)
+  |         ToastTest.ArtifactCollector (filesystem artifact discovery)
+  |         ToastTest.Attribution (issue production)
+  |         ToastTest.SuiteResult (build + write results)
+  |         ToastTest.Formatting.PostExecSummary (CLI output)
+  |         ToastTest.Formatting.RunSummary (overall run summary)
+  |         ToastTest.Formatting.RrSummary (rr recording summary)
+  |         ToastTest.WithDeployment (scoped per-test deployments)
+  |         ToastTest.DeployConfig (deployment config builder)
+  |         Toast.Deployment.CrashBarrier (between-tests crash detection)
+  |         Toast.Deployment.HealthBarrier (between-tests health check)
+  |         Toast.Deployment.Netstat (between-tests port exhaustion check)
+  |
+  v
+Toast.Deployment (public API facade)
+  |   uses: Toast.Deployment.Config (configuration)
+  |         Toast.Client (REST client)
+  |         Toast.Deployment.Controller
+  |         Toast.Deployment.ServerInstance
+  |         Toast.Deployment.Factory
+  |         Toast.JWT.KeyGen (JWT material generation)
+  |         Toast.JWT.Provider (JWT signer handle)
+  |
+  v
+Toast.Deployment.Controller (GenServer)
+  |   uses: Toast.Deployment.Controller.State (nested defstruct)
+  |         Toast.Deployment.DeployPipeline (multi-phase deploy)
+  |         Toast.Deployment.ShutdownPipeline (ordered shutdown/rollback/abort)
+  |         Toast.Deployment.ServerLifecycle (pure functions)
+  |         Toast.Deployment.ServerInstance (data struct)
+  |         Toast.Deployment.CrashExpectation (data struct)
+  |         Toast.Deployment.Events (event emission)
+  |         Toast.Deployment.EventListener (behaviour)
+  |         Toast.Process.CrashInfo (data struct)
+  |         Toast.Diagnostics.AgencyDump (cluster agency dump)
+
+Toast.Deployment.DeployPipeline
+  |   uses: Toast.Deployment.Events (event emission)
+  |         Toast.Deployment.Health (HTTP health checks)
+  |         Toast.Deployment.ServerLifecycle (server ops)
+  |         Toast.Process.ServerProcess (launch OS processes)
+  |         Toast.Process.Supervisor (start children)
+
+Toast.Deployment.ShutdownPipeline
+  |   uses: Toast.Deployment.ServerLifecycle (stop servers)
+  |         Toast.Process.ServerProcess (stop, signal)
+  |         Toast.Process.Supervisor (stop health monitors)
+
+Toast.Deployment.Factory
+  |   uses: Toast.Deployment.CommandBuilder (arangod CLI args)
+  |         Toast.Deployment.ClusterOpts (cluster topology)
+  |         Toast.Utils.Filesystem (dir creation, binary discovery)
+  |         Toast.Diagnostics.Sanitizer (build env vars)
+  |         Toast.Deployment.Config
+
+Toast.Process.ServerProcess (GenServer, wraps erlexec)
+  |   no Toast dependencies -- communicates via messages
+
+Toast.Process.CrashInfo (data struct, no dependencies)
+
+Toast.Process.HealthMonitor (GenServer, HTTP polling)
+  |   uses: Req (HTTP client, direct -- not via Toast.Client)
+
+Toast.JWT.KeyGen (JWT key generation)
+  |   uses: :crypto, :public_key (Erlang stdlib)
+
+Toast.JWT.Provider (data struct, holds signer)
+  |   uses: Toast.JWT (which uses Joken for signing)
+
+Toast.Utils (utility functions, no Toast dependencies)
+
+Toast.Diagnostics.Coredump
+  |   uses: Toast.Diagnostics.Coredump.Debugger (behaviour)
+  |         Toast.Diagnostics.Coredump.GDB (behaviour impl)
+  |         Toast.Diagnostics.Coredump.LLDB (behaviour impl)
+  |         Toast.Diagnostics.Coredump.Report (data struct)
+
+ToastTest.Abort (ETS-backed abort state, no Toast deps)
+
+ToastTest.TestLifecycle (shared test lifecycle primitives, no Toast deps)
+
+ToastTest.Formatting.CLI (GenServer, no Toast deps)
+ToastTest.ResultCollector (ExUnit formatter, stores test data)
+
+ToastTest.EventStore (ETS-backed event store)
+  |   uses: ToastTest.EventStore.Projections (derived views)
+
+ToastTest.DeploymentListener (EventListener implementation)
+  |   uses: ToastTest.EventStore (event recording)
+  |         ToastTest.CrashMonitor (crash notification)
+
+ToastTest.ArtifactCollector (pure filesystem discovery)
+  |   uses: Toast.Diagnostics.Coredump (discover core dumps)
+  |         Toast.Deployment.ServerInstance (struct access)
+
+ToastTest.Attribution (orchestrates issue production)
+  |   uses: ToastTest.Attribution.TimeWindows (time window calculations)
+  |         ToastTest.Attribution.ServerLogs (server log data)
+  |         ToastTest.Enrichment.Coredump (coredump analysis)
+  |         ToastTest.Enrichment.Logs (log parsing)
+  |         ToastTest.Enrichment.Sanitizer (sanitizer file reading)
+  |         ToastTest.CrashEvent (struct access)
+
+ToastTest.Attribution.TimeWindows (pure, no dependencies)
+
+ToastTest.Enrichment.Logs (pure file I/O, no Toast deps)
+ToastTest.Enrichment.Sanitizer (pure file I/O, no Toast deps)
+ToastTest.Enrichment.Coredump
+  |   uses: Toast.Diagnostics.Coredump (debugger analysis)
+
+ToastTest.SuiteResult (central data struct)
+  |   uses: ToastTest.SuiteResult.JSON (JSON serialization)
+  |         ToastTest.SuiteResult.JUnitXML (JUnit XML serialization)
+  |         ToastTest.ResultCollector (test_data type)
+
+ToastTest.Formatting.PostExecSummary (CLI output formatting)
+  |   uses: ToastTest.SuiteResult (struct access)
+  |         ToastTest.Formatting (shared utilities)
+
+ToastTest.Formatting.RunSummary (overall run summary)
+  |   uses: ToastTest.SuiteResult (struct access)
+
+ToastTest.DiagnosticsSummary (aggregate diagnostics)
+  |   uses: ToastTest.SuiteResult (struct access)
+
+ToastTest.ResultPackaging (CI artifact packaging)
+  |   uses: Toast.Utils.Compression (compression tools)
+
+ToastTest.Case (ExUnit.CaseTemplate)
+  |   uses: Toast.Client (create client for test context)
+  |         ToastTest.DeploymentRegistry
+  |         ToastTest.Expect (imported into test modules)
+
+ToastTest.Suite (macro module)
+  |   uses: ToastTest.Case (via __using__ expansion)
+
+ToastTest.JavascriptSuite (macro module)
+  |   uses: ToastTest.Suite (via __using__ expansion)
+
+ToastTest.JS.TestRunner
+  |   uses: ToastTest.JS.ResultMapper (map results to ExUnit structs)
+  |         ToastTest.JS.Executor (behaviour)
+  |         ToastTest.ExUnitCompat (ExUnit event emission)
+  |         ToastTest.EventStore (lifecycle events)
+
+ToastTest.JS.ArangoshExecutor (Executor implementation)
+  |   uses: Jason (JSON parsing)
+
+ToastTest.JS.ModuleBuilder (pure, no runtime dependencies)
+
+ToastTest.JS.ResultMapper (pure, no dependencies)
+
+ToastTest.Interactive
+  |   uses: ToastTest.ExUnitCompat (ExUnit internal shim)
+  |         ToastTest.TestLifecycle (shared test lifecycle primitives)
+  |         ToastTest.DeploymentRegistry
+
+ToastTest.WithDeployment (scoped deployment helper)
+  |   uses: ToastTest.DeployConfig (config builder)
+  |         Toast.Deployment (start/stop)
+  |         ToastTest.DeploymentEventListener (event listener)
+
+ToastTest.DeployConfig (pure config builder, minimal deps)
+  |   uses: Toast.Deployment.Config
+
+ToastTest.DeploymentEventListener (EventListener for manual deployments)
+  |   uses: ToastTest.EventStore (event recording)
+
+Toast.Deployment.CrashBarrier (between-tests crash check)
+  |   uses: Toast.Process.ProcStatus (/proc/<pid>/status reader)
+  |         Toast.Utils.Polling (poll-until utility)
+
+Toast.Deployment.HealthBarrier (between-tests health check)
+  |   uses: Toast.Process.HealthMonitor (health probe state)
+  |         Toast.Deployment.ServerLifecycle (probe health monitor)
+  |         Toast.Utils.Polling (poll-until utility)
+
+Toast.Deployment.Netstat (between-tests port exhaustion check)
+  |   uses: ss or netstat (external, detected at startup)
+
+Toast.Process.ProcStatus (reads /proc/<pid>/status, no Toast deps)
+
+Toast.Utils.Polling (generic polling utility, no Toast deps)
+
+Mix.Tasks.Toast.Analyze
+  |   uses: Mix.Tasks.Toast.Analyze.Data (data loading)
+  |         Mix.Tasks.Toast.Analyze.Issues (issue listing)
+  |         Mix.Tasks.Toast.Analyze.Detail (detailed diagnostics)
+  |         Mix.Tasks.Toast.Analyze.Info (file overview)
+  |         Mix.Tasks.Toast.Analyze.Perf (performance analysis)
+  |         Mix.Tasks.Toast.Analyze.Weights (weight suggestions)
+  |         ToastTest.LogAnalysis (log data transformation)
+```
+
+### Dependency Principles
+
+- **Toast.Deployment** is the only module that touches the Controller
+  GenServer. All other code goes through the `Toast.Deployment` public API.
+
+- **DeployPipeline and ShutdownPipeline** handle the complex multi-phase
+  startup and shutdown sequences as pure pipeline functions that operate on
+  Controller.State. The Controller delegates to them and focuses on message
+  routing and state management.
+
+- **Attribution replaces the old Matcher/CrashMatcher/SanitizerMatcher
+  hierarchy.** `Attribution` orchestrates issue production using
+  `TimeWindows` (pure leaf) and the `Enrichment.*` modules (pure file I/O).
+  This is a clean DAG with no circular dependencies.
+
+- **Enrichment modules** (`Enrichment.Logs`, `Enrichment.Sanitizer`,
+  `Enrichment.Coredump`) are pure file I/O with minimal Toast dependencies.
+
+- **ToastTest.Runner** is the most connected module because it orchestrates
+  the full test lifecycle. Its complexity is managed by delegation to
+  focused submodules: `TestExecution`, `TestProcess`, `BetweenTests`,
+  `PostExecution`, `ResultBuilder`, `TestFilter`, and `Timeout`.
+
+- **Process modules** (ServerProcess, HealthMonitor) have zero Toast
+  dependencies. They communicate purely via messages (`:server_crashed`,
+  `:server_unhealthy`). This makes them independently testable and reusable.
+
+- **Event system** provides loose coupling between deployment lifecycle and
+  test execution. The `EventListener` behaviour allows different consumers
+  (test runner vs interactive mode) without the deployment layer knowing
+  about test execution concerns.
+
+- **Configuration is split into three layers**: `Toast.Env` resolves from
+  all sources, `Toast.Deployment.Config` holds deployment concerns,
+  `ToastTest.Config` holds test execution concerns. This reflects the
+  architectural boundary between infrastructure and test runner.
+
+- **External dependencies** are wrapped at boundaries:
+  - `erlexec` is wrapped by `ServerProcess`
+  - `Req` is wrapped by `Toast.Client` (except HealthMonitor which uses it
+    directly for simplicity -- it only needs a single GET)
+  - ExUnit internals are wrapped by `ExUnitCompat`
+  - `Joken` is wrapped by `Toast.JWT.*`

--- a/tests/toast/docs/test-execution-and-diagnostics.md
+++ b/tests/toast/docs/test-execution-and-diagnostics.md
@@ -175,6 +175,12 @@ check_between_tests(config, prev_test)
   |     --> waits for each server's health monitor to report healthy
   |     --> catches deadlocks, resource exhaustion
   |
+  +-- Netstat.check(deployment, tool, baseline)
+  |     --> counts system TCP sockets via ss/netstat (~2ms)
+  |     --> aborts if system threshold (15k) or deployment
+  |         threshold (500/server above baseline) is exceeded
+  |     --> on breach: gathers per-server PID breakdown (~40ms, once)
+  |
   +-- suite_module has between_tests/2?
   |     --> call suite_module.between_tests(deployment, prev_test)
   |         return :ok or {:error, reason}
@@ -186,9 +192,9 @@ check_between_tests(config, prev_test)
         --> :failed => {:error, "Server crashed..."}
 ```
 
-If the health check returns `{:error, reason}`, the Runner calls `abort!` and
-skips all remaining tests. This prevents cascading failures from a crashed or
-degraded deployment.
+If any check returns `{:error, reason}`, the Runner calls `abort!` and
+skips all remaining tests. This prevents cascading failures from a crashed,
+degraded, or port-exhausted deployment.
 
 The `:degraded` check is important: if a test stops a server for chaos testing
 but doesn't restart it, the deployment stays degraded. The Runner catches this
@@ -475,7 +481,8 @@ Test execution
   |      Collects structured test results
   |
   +--> EventStore
-  |      Records deployment lifecycle events (server start/stop/crash)
+  |      Records deployment lifecycle events (server start/stop/crash),
+  |      netstat snapshots, and infrastructure issues
   |
   +--> After suite completes (Runner.PostExecution):
          agency dump (cluster, pre-shutdown)
@@ -519,7 +526,7 @@ artifacts unconditionally.
 | 0 | All tests passed | -- |
 | 1 | Test failures | Lowest |
 | 2 | Sanitizer errors detected | Medium |
-| 3 | Infrastructure failure (deploy failed, etc.) | High |
+| 3 | Infrastructure failure (deploy failed, port exhaustion, etc.) | High |
 | 4 | Server crash | Highest |
 
 The ordering prioritizes crashes (4) over infrastructure (3) over sanitizer (2)

--- a/tests/toast/lib/mix/tasks/toast.ex
+++ b/tests/toast/lib/mix/tasks/toast.ex
@@ -203,7 +203,9 @@ defmodule Mix.Tasks.Toast do
     run_results = %{
       test_failures: result.stats.failures,
       server_crashed: DiagnosticsSummary.has_server_crash?(result.suites),
-      infrastructure_failure: DiagnosticsSummary.has_timeout?(result.suites),
+      infrastructure_failure:
+        DiagnosticsSummary.has_timeout?(result.suites) or
+          DiagnosticsSummary.has_infrastructure?(result.suites),
       sanitizer_errors: DiagnosticsSummary.has_sanitizer_errors?(result.suites)
     }
 

--- a/tests/toast/lib/mix/tasks/toast/analyze/data.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/data.ex
@@ -28,7 +28,8 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
     "crash" => :crash,
     "test_failure" => :test_failure,
     "sanitizer_report" => :sanitizer_report,
-    "timeout" => :timeout
+    "timeout" => :timeout,
+    "infrastructure" => :infrastructure
   }
 
   def load_results(result_dir) do
@@ -61,6 +62,7 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
         |> Map.put(:servers, all_servers)
         |> Map.put(:deployments, deployments)
         |> Map.put(:events, events)
+        |> Map.put(:modules, result.modules)
       end)
       |> Enum.map(&Issues.attach_test_location(&1, result.modules))
       |> then(&Issues.resolve_coredumps(&1, coredump_index))
@@ -90,6 +92,10 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
       %{test_location: loc} when is_binary(loc) -> "#{base} (#{loc})"
       _ -> base
     end
+  end
+
+  def format_type(%{type: :infrastructure, detail: %{subtype: subtype}}) do
+    "infrastructure (#{subtype})"
   end
 
   def format_type(issue) do
@@ -150,18 +156,10 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
   end
 
   defp attach_time_bounds(
-         %{type: :sanitizer_report, detail: %{timestamp: ts}} = issue,
+         %{type: type, detail: %{timestamp: ts}} = issue,
          _modules
        )
-       when is_integer(ts) do
-    Map.put(issue, :time_bounds, {ts, ts})
-  end
-
-  defp attach_time_bounds(
-         %{type: :timeout, detail: %{timestamp: ts}} = issue,
-         _modules
-       )
-       when is_integer(ts) do
+       when type in [:sanitizer_report, :timeout, :infrastructure] and is_integer(ts) do
     Map.put(issue, :time_bounds, {ts, ts})
   end
 

--- a/tests/toast/lib/mix/tasks/toast/analyze/detail.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/detail.ex
@@ -252,8 +252,9 @@ defmodule Mix.Tasks.Toast.Analyze.Detail do
 
     server_total =
       Enum.reduce(sorted, 0, fn {server_id, server}, acc ->
-        Mix.shell().info("    #{colorize(server_id, :cyan, color)}  #{server.sockets.total}")
+        Mix.shell().info("    #{colorize(server_id, :cyan, color)} (port #{server.port})")
 
+        Mix.shell().info("      total  #{server.sockets.total}")
         print_direction("← in ", server.sockets.in, color)
         print_direction("→ out", server.sockets.out, color)
 

--- a/tests/toast/lib/mix/tasks/toast/analyze/detail.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/detail.ex
@@ -233,9 +233,17 @@ defmodule Mix.Tasks.Toast.Analyze.Detail do
       Mix.shell().info("  Time:   #{Data.fmt_dt(detail.timestamp)}")
     end
 
+    kind = if detail[:kind] == :deployment, do: "deployment", else: "system"
+
     Mix.shell().info(
-      "  Total:  #{colorize("#{detail.total} system sockets", :red, color)} (threshold: #{detail.threshold})"
+      "  Total:  #{colorize("#{detail.total} #{kind} sockets", :red, color)} (threshold: #{detail.threshold})"
     )
+
+    if detail[:kind] == :deployment do
+      Mix.shell().info(
+        "  Delta:  #{detail.deployment_delta} sockets since deployment (baseline: #{detail.baseline})"
+      )
+    end
 
     Mix.shell().info("")
     Mix.shell().info(colorize("  Per-server breakdown (by process ownership):", :bright, color))

--- a/tests/toast/lib/mix/tasks/toast/analyze/detail.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/detail.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Toast.Analyze.Detail do
   alias ToastTest.Formatting.Logs, as: LogFormatting
   alias ToastTest.LogAnalysis
 
-  @issue_spec_keywords ~w(all crashes test_failures sanitizer timeouts)
+  @issue_spec_keywords ~w(all crashes test_failures sanitizer timeouts infrastructure)
 
   def issue_spec?(arg) do
     arg in @issue_spec_keywords or Regex.match?(~r/^\d+(-\d+)?$/, arg)
@@ -94,6 +94,7 @@ defmodule Mix.Tasks.Toast.Analyze.Detail do
   defp parse_keyword("test_failures"), do: {:type, :test_failure}
   defp parse_keyword("sanitizer"), do: {:type, :sanitizer_report}
   defp parse_keyword("timeouts"), do: {:type, :timeout}
+  defp parse_keyword("infrastructure"), do: {:type, :infrastructure}
 
   defp select_issues(indexed, :all), do: indexed
 
@@ -166,6 +167,7 @@ defmodule Mix.Tasks.Toast.Analyze.Detail do
   defp type_color(:crash), do: :red
   defp type_color(:sanitizer_report), do: :yellow
   defp type_color(:timeout), do: :red
+  defp type_color(:infrastructure), do: :red
 
   # --- Test failure detail ---
 
@@ -219,6 +221,165 @@ defmodule Mix.Tasks.Toast.Analyze.Detail do
       Mix.shell().info("")
       Enum.each(detail.servers, &print_timeout_server(&1, color))
     end
+  end
+
+  # --- Infrastructure detail ---
+
+  defp print_issue_body(%{type: :infrastructure, detail: detail} = issue, color, _bt_opts) do
+    subtype = detail.subtype |> Atom.to_string() |> String.replace("_", " ")
+    Mix.shell().info("  #{colorize(String.upcase(subtype), :red, color)}")
+
+    if detail[:timestamp] do
+      Mix.shell().info("  Time:   #{Data.fmt_dt(detail.timestamp)}")
+    end
+
+    Mix.shell().info(
+      "  Total:  #{colorize("#{detail.total} system sockets", :red, color)} (threshold: #{detail.threshold})"
+    )
+
+    Mix.shell().info("")
+    Mix.shell().info(colorize("  Per-server breakdown (by process ownership):", :bright, color))
+
+    sorted = Enum.sort_by(detail.by_server, fn {_, v} -> -v.sockets.total end)
+
+    server_total =
+      Enum.reduce(sorted, 0, fn {server_id, server}, acc ->
+        Mix.shell().info("    #{colorize(server_id, :cyan, color)}  #{server.sockets.total}")
+
+        print_direction("← in ", server.sockets.in, color)
+        print_direction("→ out", server.sockets.out, color)
+
+        acc + server.sockets.total
+      end)
+
+    rest = detail.total - server_total
+
+    if rest > 0 do
+      Mix.shell().info("    #{colorize("(other)", :faint, color)}  #{rest}")
+    end
+
+    print_netstat_trajectory(issue, color)
+  end
+
+  defp print_direction(_label, stats, _color) when stats == %{}, do: :ok
+
+  defp print_direction(label, stats, color) do
+    formatted =
+      stats
+      |> Enum.sort_by(fn {_, n} -> -n end)
+      |> Enum.map_join(", ", fn {state, n} -> "#{n} #{state}" end)
+
+    Mix.shell().info("      #{colorize(label, :faint, color)}  #{formatted}")
+  end
+
+  @trajectory_limit 10
+
+  defp print_netstat_trajectory(%{detail: %{timestamp: issue_ts}} = issue, color)
+       when is_integer(issue_ts) do
+    events = issue[:events] || []
+
+    snapshots =
+      events
+      |> Enum.filter(&(&1.event == :netstat_snapshot))
+      |> Enum.sort_by(& &1.timestamp)
+
+    if snapshots != [] do
+      entries = annotate_snapshots(snapshots, issue_ts, issue[:modules] || %{})
+
+      print_top_contributors(entries, color)
+      print_recent_trajectory(entries, length(snapshots), color)
+    end
+  end
+
+  defp print_netstat_trajectory(_detail, _color), do: :ok
+
+  @baseline_labels %{
+    pre_deployment: "(pre-deployment)",
+    deployment_ready: "(deployment ready)"
+  }
+
+  defp annotate_snapshots(snapshots, issue_ts, modules) do
+    timeline = build_test_timeline(modules)
+
+    {entries, _} =
+      Enum.reduce(snapshots, {[], {0, timeline}}, fn snap, {acc, {prev, remaining}} ->
+        delta = snap.total - prev
+        marker = if snap.timestamp == issue_ts, do: :threshold, else: nil
+
+        {label, remaining} =
+          case Map.get(@baseline_labels, snap[:label]) do
+            nil -> advance_timeline(snap.timestamp, remaining)
+            baseline_label -> {baseline_label, remaining}
+          end
+
+        entry = %{
+          total: snap.total,
+          delta: delta,
+          test: label,
+          marker: marker,
+          baseline: snap[:label] != nil
+        }
+
+        {[entry | acc], {snap.total, remaining}}
+      end)
+
+    Enum.reverse(entries)
+  end
+
+  defp print_top_contributors(entries, color) do
+    top =
+      entries
+      |> Enum.filter(&(&1.delta > 0 and not &1.baseline))
+      |> Enum.sort_by(& &1.delta, :desc)
+      |> Enum.take(@trajectory_limit)
+
+    if top != [] do
+      Mix.shell().info("")
+      Mix.shell().info(colorize("  Top contributors (by socket increase):", :bright, color))
+      Enum.each(top, &print_trajectory_entry(&1, color))
+    end
+  end
+
+  defp print_recent_trajectory(entries, total_count, color) do
+    {baselines, test_entries} = Enum.split_while(entries, & &1.baseline)
+    recent = Enum.take(test_entries, -@trajectory_limit)
+    skipped = total_count - length(baselines) - length(recent)
+
+    Mix.shell().info("")
+    Mix.shell().info(colorize("  Recent socket count trajectory:", :bright, color))
+
+    Enum.each(baselines, &print_trajectory_entry(&1, color))
+
+    if skipped > 0 do
+      Mix.shell().info(colorize("    ... #{skipped} earlier entries omitted", :faint, color))
+    end
+
+    Enum.each(recent, &print_trajectory_entry(&1, color))
+  end
+
+  defp print_trajectory_entry(entry, color) do
+    delta_str = if entry.delta >= 0, do: "+#{entry.delta}", else: "#{entry.delta}"
+    marker = if entry.marker == :threshold, do: " ← THRESHOLD", else: ""
+
+    Mix.shell().info(
+      "    #{colorize(String.pad_leading("#{entry.total}", 6), :bright, color)}  #{colorize(String.pad_leading(delta_str, 7), :faint, color)}  #{entry.test || "?"}#{colorize(marker, :red, color)}"
+    )
+  end
+
+  defp build_test_timeline(modules) do
+    for {mod, %{tests: tests}} <- modules,
+        %{finished_at: %DateTime{} = finished_at} = test <- tests do
+      {DateTime.to_unix(finished_at, :microsecond), "#{inspect(mod)}.#{test.name}"}
+    end
+    |> Enum.sort_by(&elem(&1, 0))
+  end
+
+  defp advance_timeline(snapshot_ts, timeline) do
+    {passed, remaining} =
+      Enum.split_while(timeline, fn {finished_us, _} -> finished_us <= snapshot_ts end)
+
+    test_name = if passed == [], do: nil, else: passed |> List.last() |> elem(1)
+    {test_name, remaining}
   end
 
   defp print_timeout_server(server, color) do

--- a/tests/toast/lib/toast/deployment/netstat.ex
+++ b/tests/toast/lib/toast/deployment/netstat.ex
@@ -26,7 +26,8 @@ defmodule Toast.Deployment.Netstat do
 
   require Logger
 
-  @threshold 15_000
+  @system_threshold 15_000
+  @per_server_budget 500
 
   @type direction_stats :: %{String.t() => non_neg_integer()}
 
@@ -44,13 +45,19 @@ defmodule Toast.Deployment.Netstat do
   @type exhaustion_detail :: %{
           total: non_neg_integer(),
           threshold: non_neg_integer(),
+          kind: :system | :deployment,
+          baseline: non_neg_integer(),
+          deployment_delta: non_neg_integer(),
           by_server: snapshot()
         }
 
   @type tool :: :ss | :netstat
 
-  @spec threshold() :: non_neg_integer()
-  def threshold, do: @threshold
+  @spec system_threshold() :: non_neg_integer()
+  def system_threshold, do: @system_threshold
+
+  @spec per_server_budget() :: non_neg_integer()
+  def per_server_budget, do: @per_server_budget
 
   @doc """
   Detect which socket tool is available. Returns `:ss`, `:netstat`, or `nil`.
@@ -65,21 +72,50 @@ defmodule Toast.Deployment.Netstat do
   end
 
   @doc """
-  Check system socket count against the port exhaustion threshold.
+  Check system socket count against port exhaustion thresholds.
 
-  Returns `{:ok, total}` when below threshold, or
-  `{:port_exhaustion, detail}` with a per-server breakdown when at or above.
-  The per-server breakdown requires an additional call with PID resolution
-  (~40ms) that is only made when the threshold is reached.
+  Checks two thresholds:
+  - System threshold (#{@system_threshold}): total sockets on the system
+  - Deployment threshold (#{@per_server_budget} per server): sockets added
+    since baseline, scaled by server count to catch leaks early
+
+  Returns `{:ok, total}` when below both thresholds, or
+  `{:port_exhaustion, detail}` with a per-server breakdown when either is
+  reached. The per-server breakdown requires an additional call with PID
+  resolution (~40ms) that is only made when a threshold is reached.
   """
-  @spec check(Deployment.t(), tool()) ::
+  @spec check(Deployment.t(), tool(), non_neg_integer()) ::
           {:ok, non_neg_integer()} | {:port_exhaustion, exhaustion_detail()}
-  def check(%Deployment{} = deployment, tool) do
+  def check(%Deployment{} = deployment, tool, baseline) do
     total = count_sockets(tool)
+    deployment_delta = total - baseline
+    server_count = map_size(deployment.servers)
+    deployment_threshold = server_count * @per_server_budget
 
-    if total >= @threshold do
+    {exceeded, threshold} =
+      cond do
+        total >= @system_threshold ->
+          {:system, @system_threshold}
+
+        deployment_threshold > 0 and deployment_delta >= deployment_threshold ->
+          {:deployment, deployment_threshold}
+
+        true ->
+          {nil, nil}
+      end
+
+    if exceeded do
       by_server = detailed_snapshot(deployment, tool)
-      {:port_exhaustion, %{total: total, threshold: @threshold, by_server: by_server}}
+
+      {:port_exhaustion,
+       %{
+         total: total,
+         threshold: threshold,
+         kind: exceeded,
+         baseline: baseline,
+         deployment_delta: deployment_delta,
+         by_server: by_server
+       }}
     else
       {:ok, total}
     end

--- a/tests/toast/lib/toast/deployment/netstat.ex
+++ b/tests/toast/lib/toast/deployment/netstat.ex
@@ -1,0 +1,257 @@
+################################################################################
+## DISCLAIMER
+##
+## Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+## Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+##
+## Licensed under the Business Source License 1.1 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## Copyright holder is ArangoDB GmbH, Cologne, Germany
+################################################################################
+
+defmodule Toast.Deployment.Netstat do
+  @moduledoc false
+
+  alias Toast.Deployment
+
+  require Logger
+
+  @threshold 15_000
+
+  @type direction_stats :: %{String.t() => non_neg_integer()}
+
+  @type server_snapshot :: %{
+          pid: non_neg_integer(),
+          sockets: %{
+            total: non_neg_integer(),
+            in: direction_stats(),
+            out: direction_stats()
+          }
+        }
+
+  @type snapshot :: %{String.t() => server_snapshot()}
+
+  @type exhaustion_detail :: %{
+          total: non_neg_integer(),
+          threshold: non_neg_integer(),
+          by_server: snapshot()
+        }
+
+  @type tool :: :ss | :netstat
+
+  @spec threshold() :: non_neg_integer()
+  def threshold, do: @threshold
+
+  @doc """
+  Detect which socket tool is available. Returns `:ss`, `:netstat`, or `nil`.
+  """
+  @spec detect_tool() :: tool() | nil
+  def detect_tool do
+    cond do
+      System.find_executable("ss") -> :ss
+      System.find_executable("netstat") -> :netstat
+      true -> nil
+    end
+  end
+
+  @doc """
+  Check system socket count against the port exhaustion threshold.
+
+  Returns `{:ok, total}` when below threshold, or
+  `{:port_exhaustion, detail}` with a per-server breakdown when at or above.
+  The per-server breakdown requires an additional call with PID resolution
+  (~40ms) that is only made when the threshold is reached.
+  """
+  @spec check(Deployment.t(), tool()) ::
+          {:ok, non_neg_integer()} | {:port_exhaustion, exhaustion_detail()}
+  def check(%Deployment{} = deployment, tool) do
+    total = count_sockets(tool)
+
+    if total >= @threshold do
+      by_server = detailed_snapshot(deployment, tool)
+      {:port_exhaustion, %{total: total, threshold: @threshold, by_server: by_server}}
+    else
+      {:ok, total}
+    end
+  end
+
+  @doc """
+  Count all non-LISTEN TCP sockets on the system (~2ms with ss, ~12ms with netstat).
+  """
+  @spec count_sockets(tool()) :: non_neg_integer()
+  def count_sockets(tool) do
+    case run_count(tool) do
+      {:ok, output} ->
+        count_lines(output)
+
+      {:error, reason} ->
+        Logger.warning("Netstat: failed to count sockets: #{inspect(reason)}")
+        0
+    end
+  end
+
+  @netstat_header_lines 2
+
+  defp run_count(:ss), do: run_cmd("ss", ["-tnH"])
+
+  defp run_count(:netstat) do
+    case run_cmd("netstat", ["-tn"]) do
+      {:ok, output} -> {:ok, drop_lines(output, @netstat_header_lines)}
+      error -> error
+    end
+  end
+
+  # --- Slow path: PID-based snapshot (~40ms ss, ~55ms netstat) ---
+
+  defp detailed_snapshot(%Deployment{} = deployment, tool) do
+    servers =
+      deployment
+      |> Deployment.server_instances()
+      |> Enum.filter(&(&1.operational_state == :running and &1.pid != nil))
+      |> Enum.map(&%{id: &1.id, pid: &1.pid, port: &1.port})
+
+    case run_detail(tool) do
+      {:ok, output} ->
+        build_snapshot_by_pid(output, servers, tool)
+
+      {:error, reason} ->
+        Logger.warning("Netstat: failed to gather detailed snapshot: #{inspect(reason)}")
+        empty = %{total: 0, in: %{}, out: %{}}
+        Map.new(servers, &{&1.id, %{pid: &1.pid, sockets: empty}})
+    end
+  end
+
+  defp run_detail(:ss), do: run_cmd("ss", ["-tnpH"])
+
+  defp run_detail(:netstat) do
+    case run_cmd("netstat", ["-tnp"]) do
+      {:ok, output} -> {:ok, drop_lines(output, @netstat_header_lines)}
+      error -> error
+    end
+  end
+
+  # --- Internals ---
+
+  defp run_cmd(cmd, args) do
+    case System.cmd(cmd, args, stderr_to_stdout: true) do
+      {output, 0} -> {:ok, output}
+      {output, code} -> {:error, "#{cmd} exited with #{code}: #{output}"}
+    end
+  end
+
+  defp drop_lines(output, 0), do: output
+
+  defp drop_lines(output, n) do
+    case :binary.match(output, "\n") do
+      {pos, 1} -> drop_lines(:binary.part(output, pos + 1, byte_size(output) - pos - 1), n - 1)
+      :nomatch -> ""
+    end
+  end
+
+  @doc false
+  @spec count_lines(String.t()) :: non_neg_integer()
+  def count_lines(""), do: 0
+
+  def count_lines(output) do
+    count = length(:binary.matches(output, "\n"))
+    if String.ends_with?(output, "\n"), do: count, else: count + 1
+  end
+
+  @pid_pattern_ss ~r/pid=(\d+)/
+  @pid_pattern_netstat ~r/^\s*(\d+)\//
+
+  @doc false
+  @spec build_snapshot_by_pid(
+          String.t(),
+          [%{id: String.t(), pid: non_neg_integer(), port: non_neg_integer()}],
+          tool()
+        ) :: snapshot()
+  def build_snapshot_by_pid(output, servers, tool \\ :ss) do
+    pid_to_server = Map.new(servers, &{&1.pid, &1})
+
+    grouped =
+      output
+      |> String.split("\n", trim: true)
+      |> Enum.flat_map(&parse_detail_line(&1, tool))
+      |> Enum.filter(&Map.has_key?(pid_to_server, &1.pid))
+      |> Enum.group_by(&Map.fetch!(pid_to_server, &1.pid).id)
+
+    Map.new(servers, fn server ->
+      sockets = Map.get(grouped, server.id, [])
+
+      {inbound, outbound} =
+        Enum.split_with(sockets, &(&1.local_port == server.port))
+
+      {server.id,
+       %{
+         pid: server.pid,
+         sockets: %{
+           total: length(sockets),
+           in: Enum.frequencies_by(inbound, & &1.state),
+           out: Enum.frequencies_by(outbound, & &1.state)
+         }
+       }}
+    end)
+  end
+
+  defp parse_detail_line(line, tool) do
+    fields = String.split(line, ~r/\s+/, trim: true)
+
+    with {:ok, state, local, pid_text} <- extract_fields(fields, tool),
+         {:ok, pid} <- extract_pid(pid_text, pid_pattern(tool)),
+         {:ok, local_port} <- extract_port(local) do
+      [%{state: state, pid: pid, local_port: local_port}]
+    else
+      _ -> []
+    end
+  end
+
+  # ss: STATE Recv-Q Send-Q Local:Port Remote:Port users:((...pid=PID...))
+  defp extract_fields([state, _, _, local, _ | rest], :ss),
+    do: {:ok, state, local, Enum.join(rest, " ")}
+
+  # netstat: Proto Recv-Q Send-Q Local:Port Remote:Port State PID/Program
+  defp extract_fields([_, _, _, local, _, state, pid_prog | _], :netstat),
+    do: {:ok, state, local, pid_prog}
+
+  defp extract_fields(_, _), do: :error
+
+  defp pid_pattern(:ss), do: @pid_pattern_ss
+  defp pid_pattern(:netstat), do: @pid_pattern_netstat
+
+  defp extract_port(addr) do
+    case addr |> String.split(":") |> List.last() do
+      nil ->
+        :error
+
+      port_str ->
+        case Integer.parse(port_str) do
+          {port, ""} -> {:ok, port}
+          _ -> :error
+        end
+    end
+  end
+
+  defp extract_pid(text, pattern) do
+    case Regex.run(pattern, text) do
+      [_, pid_str] ->
+        case Integer.parse(pid_str) do
+          {pid, ""} -> {:ok, pid}
+          _ -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+end

--- a/tests/toast/lib/toast/deployment/netstat.ex
+++ b/tests/toast/lib/toast/deployment/netstat.ex
@@ -33,6 +33,7 @@ defmodule Toast.Deployment.Netstat do
 
   @type server_snapshot :: %{
           pid: non_neg_integer(),
+          port: non_neg_integer(),
           sockets: %{
             total: non_neg_integer(),
             in: direction_stats(),
@@ -163,7 +164,7 @@ defmodule Toast.Deployment.Netstat do
       {:error, reason} ->
         Logger.warning("Netstat: failed to gather detailed snapshot: #{inspect(reason)}")
         empty = %{total: 0, in: %{}, out: %{}}
-        Map.new(servers, &{&1.id, %{pid: &1.pid, sockets: empty}})
+        Map.new(servers, &{&1.id, %{pid: &1.pid, port: &1.port, sockets: empty}})
     end
   end
 
@@ -231,6 +232,7 @@ defmodule Toast.Deployment.Netstat do
       {server.id,
        %{
          pid: server.pid,
+         port: server.port,
          sockets: %{
            total: length(sockets),
            in: Enum.frequencies_by(inbound, & &1.state),

--- a/tests/toast/lib/toast_test/diagnostics_summary.ex
+++ b/tests/toast/lib/toast_test/diagnostics_summary.ex
@@ -34,6 +34,10 @@ defmodule ToastTest.DiagnosticsSummary do
   @spec has_sanitizer_errors?([map()]) :: boolean()
   def has_sanitizer_errors?(suites), do: has_issue_type?(suites, :sanitizer_report)
 
+  @doc "Check whether any suite has infrastructure issues (e.g., port exhaustion)."
+  @spec has_infrastructure?([map()]) :: boolean()
+  def has_infrastructure?(suites), do: has_issue_type?(suites, :infrastructure)
+
   defp has_issue_type?(suites, type) do
     Enum.any?(suites, fn
       %{suite_result: %ToastTest.SuiteResult{issues: issues}} ->

--- a/tests/toast/lib/toast_test/event_store.ex
+++ b/tests/toast/lib/toast_test/event_store.ex
@@ -85,6 +85,18 @@ defmodule ToastTest.EventStore do
     snapshot().timeout_kills
   end
 
+  @doc "Return netstat snapshot events in chronological order."
+  @spec netstat_snapshots() :: [map()]
+  def netstat_snapshots do
+    snapshot().netstat_snapshots
+  end
+
+  @doc "Return infrastructure issue events in chronological order."
+  @spec infrastructure_issues() :: [map()]
+  def infrastructure_issues do
+    snapshot().infrastructure_issues
+  end
+
   @doc "Reconstruct deployment metadata from events."
   @spec deployments() :: %{String.t() => map()}
   def deployments do

--- a/tests/toast/lib/toast_test/event_store/projections.ex
+++ b/tests/toast/lib/toast_test/event_store/projections.ex
@@ -44,6 +44,8 @@ defmodule ToastTest.EventStore.Projections do
         pid_sets: %{},
         unexpected_crashes: [],
         timeout_kills: [],
+        netstat_snapshots: [],
+        infrastructure_issues: [],
         deployments: %{},
         servers: %{}
       },
@@ -167,6 +169,14 @@ defmodule ToastTest.EventStore.Projections do
     update_server_in(acc, did, sid, fn server -> %{server | arango_id: arango_id} end)
   end
 
+  defp process_event(%{event: :netstat_snapshot} = e, acc) do
+    %{acc | netstat_snapshots: [e | acc.netstat_snapshots]}
+  end
+
+  defp process_event(%{event: :infrastructure_issue} = e, acc) do
+    %{acc | infrastructure_issues: [e | acc.infrastructure_issues]}
+  end
+
   defp process_event(_, acc), do: acc
 
   defp collect_pid(acc, sid, pid) do
@@ -238,6 +248,8 @@ defmodule ToastTest.EventStore.Projections do
       pids_by_server: Map.new(acc.pids_by_server, fn {k, v} -> {k, Enum.reverse(v)} end),
       unexpected_crashes: Enum.reverse(acc.unexpected_crashes),
       timeout_kills: Enum.reverse(acc.timeout_kills),
+      netstat_snapshots: Enum.reverse(acc.netstat_snapshots),
+      infrastructure_issues: Enum.reverse(acc.infrastructure_issues),
       deployments: acc.deployments,
       servers: finalize_servers(acc.servers)
     }

--- a/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
+++ b/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
@@ -153,13 +153,22 @@ defmodule ToastTest.Formatting.PostExecSummary do
   end
 
   defp print_issue(:infrastructure, issue, counter, colors) do
-    %{detail: %{subtype: subtype, total: total, threshold: threshold, by_server: by_server}} =
+    %{
+      detail:
+        %{subtype: subtype, total: total, threshold: threshold, by_server: by_server} = detail
+    } =
       issue
 
     label = subtype |> Atom.to_string() |> String.replace("_", " ")
+    kind = if detail[:kind] == :deployment, do: "deployment", else: "system"
+
+    delta_info =
+      if detail[:kind] == :deployment,
+        do: " (#{detail.deployment_delta} since deployment)",
+        else: ""
 
     IO.puts(
-      "\n  #{colorize("[#{label}] #{total} system sockets (threshold: #{threshold})", :red, colors)}"
+      "\n  #{colorize("[#{label}] #{total} #{kind} sockets#{delta_info} (threshold: #{threshold})", :red, colors)}"
     )
 
     server_total =

--- a/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
+++ b/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
@@ -164,12 +164,10 @@ defmodule ToastTest.Formatting.PostExecSummary do
 
     delta_info =
       if detail[:kind] == :deployment,
-        do: " (#{detail.deployment_delta} since deployment)",
-        else: ""
+        do: "(#{detail.deployment_delta} since deployment; threshold: #{threshold}))",
+        else: "(threshold: #{threshold})"
 
-    IO.puts(
-      "\n  #{colorize("[#{label}] #{total} #{kind} sockets#{delta_info} (threshold: #{threshold})", :red, colors)}"
-    )
+    IO.puts("\n  #{colorize("[#{label}] #{total} #{kind} sockets #{delta_info}", :red, colors)}")
 
     server_total =
       by_server

--- a/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
+++ b/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
@@ -27,7 +27,7 @@ defmodule ToastTest.Formatting.PostExecSummary do
   alias ToastTest.Formatting.{Color, Issues, Utils}
   alias ToastTest.SuiteResult
 
-  @issue_types_by_severity [:test_failure, :sanitizer_report, :crash, :timeout]
+  @issue_types_by_severity [:test_failure, :sanitizer_report, :crash, :timeout, :infrastructure]
 
   @spec print(SuiteResult.t()) :: :ok
   def print(%SuiteResult{issues: issues, warnings: warnings} = result) do
@@ -105,6 +105,9 @@ defmodule ToastTest.Formatting.PostExecSummary do
   defp section_header(:sanitizer_report, count),
     do: {"SANITIZER REPORTS (#{count})", Color.sanitizer()}
 
+  defp section_header(:infrastructure, count),
+    do: {"INFRASTRUCTURE ISSUES (#{count})", Color.crash()}
+
   defp print_issue(:test_failure, issue, counter, _colors) do
     %{detail: %{test: %ExUnit.Test{state: {:failed, failures}} = test}} = issue
 
@@ -144,6 +147,33 @@ defmodule ToastTest.Formatting.PostExecSummary do
       server_count = length(servers)
       IO.puts("    Aborted #{server_count} #{Toast.Utils.pluralize(server_count, "server")}:")
       Enum.each(servers, &print_server_detail(&1, colors))
+    end
+
+    counter + 1
+  end
+
+  defp print_issue(:infrastructure, issue, counter, colors) do
+    %{detail: %{subtype: subtype, total: total, threshold: threshold, by_server: by_server}} =
+      issue
+
+    label = subtype |> Atom.to_string() |> String.replace("_", " ")
+
+    IO.puts(
+      "\n  #{colorize("[#{label}] #{total} system sockets (threshold: #{threshold})", :red, colors)}"
+    )
+
+    server_total =
+      by_server
+      |> Enum.sort_by(fn {_, v} -> -v.sockets.total end)
+      |> Enum.reduce(0, fn {server_id, server}, acc ->
+        IO.puts("    #{colorize(server_id, :cyan, colors)}  #{server.sockets.total}")
+        acc + server.sockets.total
+      end)
+
+    rest = total - server_total
+
+    if rest > 0 do
+      IO.puts("    #{colorize("(other)", :faint, colors)}  #{rest}")
     end
 
     counter + 1

--- a/tests/toast/lib/toast_test/formatting/utils.ex
+++ b/tests/toast/lib/toast_test/formatting/utils.ex
@@ -27,7 +27,7 @@ defmodule ToastTest.Formatting.Utils do
       IO.ANSI.color_background(color),
       IO.ANSI.bright(),
       "\n  ",
-      label,
+      String.replace(label, "\n", "\e[K\n"),
       :reset,
       "\n"
     ])

--- a/tests/toast/lib/toast_test/runner.ex
+++ b/tests/toast/lib/toast_test/runner.ex
@@ -403,6 +403,14 @@ defmodule ToastTest.Runner do
         Logger.info("Running suite #{inspect(entry.module)} (mode=#{mode})")
         Logger.debug("Deployment config: #{inspect(deploy_config)}")
 
+        netstat_tool = Toast.Deployment.Netstat.detect_tool()
+
+        if netstat_tool == nil do
+          Logger.warning("Neither ss nor netstat found — port exhaustion check disabled")
+        end
+
+        record_netstat_baseline(netstat_tool, :pre_deployment)
+
         id = Toast.Deployment.generate_id(mode)
         deployment_dir = Path.join([test_config.base_dir, entry.name, id])
 
@@ -411,7 +419,8 @@ defmodule ToastTest.Runner do
                event_listener: ToastTest.ManagedDeploymentListener
              ) do
           {:ok, deployment} ->
-            run_suite_with_deployment(deployment, suite_run, entry, ex_unit_opts)
+            record_netstat_baseline(netstat_tool, :deployment_ready)
+            run_suite_with_deployment(deployment, suite_run, entry, ex_unit_opts, netstat_tool)
 
           {:error, reason} ->
             handle_deployment_failure(suite_run, entry, reason, ex_unit_opts)
@@ -419,7 +428,13 @@ defmodule ToastTest.Runner do
     end
   end
 
-  defp run_suite_with_deployment(deployment, suite_run, %SuiteEntry{} = entry, ex_unit_opts) do
+  defp run_suite_with_deployment(
+         deployment,
+         suite_run,
+         %SuiteEntry{} = entry,
+         ex_unit_opts,
+         netstat_tool
+       ) do
     suite_module = suite_run.suite_module
     test_config = suite_run.test_config
     ToastTest.DeploymentRegistry.put(suite_module, deployment)
@@ -440,7 +455,14 @@ defmodule ToastTest.Runner do
           ToastTest.DeploymentRegistry.put_extra_context(suite_module, extra_context)
 
           result =
-            run_suite_tests(deployment, suite_run, entry.test_modules, ex_unit_opts, entry.opts)
+            run_suite_tests(
+              deployment,
+              suite_run,
+              entry.test_modules,
+              ex_unit_opts,
+              entry.opts,
+              netstat_tool
+            )
 
           run_suite_teardown(suite_module, deployment)
           result
@@ -465,7 +487,7 @@ defmodule ToastTest.Runner do
     Logger.info("Running suite #{inspect(suite_run.suite_module)} (mode=manual)")
 
     {stats, test_data} =
-      run_suite_tests(nil, suite_run, entry.test_modules, ex_unit_opts, entry.opts)
+      run_suite_tests(nil, suite_run, entry.test_modules, ex_unit_opts, entry.opts, nil)
 
     finalize_suite(nil, stats, test_data, suite_run.test_config)
   end
@@ -498,13 +520,19 @@ defmodule ToastTest.Runner do
     %{stats: stats, suite_result: suite_result}
   end
 
-  defp build_between_tests_fn(%ToastTest.SuiteRun{between_tests: false}, _deployment, _pipeline),
-    do: fn _prev -> :ok end
+  defp build_between_tests_fn(
+         %ToastTest.SuiteRun{between_tests: false},
+         _deployment,
+         _pipeline,
+         _netstat_tool
+       ),
+       do: fn _prev -> :ok end
 
   defp build_between_tests_fn(
          %ToastTest.SuiteRun{} = suite_run,
          deployment,
-         %Pipeline{} = pipeline
+         %Pipeline{} = pipeline,
+         netstat_tool
        ) do
     check_fn =
       if function_exported?(suite_run.suite_module, :between_tests, 2) do
@@ -527,7 +555,8 @@ defmodule ToastTest.Runner do
                :ok <-
                  Toast.Deployment.HealthBarrier.await_healthy(deployment,
                    timeout: barrier_timeout
-                 ) do
+                 ),
+               :ok <- if(netstat_tool, do: check_netstat(deployment, netstat_tool), else: :ok) do
             check_fn.(prev_test)
           end
 
@@ -536,6 +565,32 @@ defmodule ToastTest.Runner do
         ToastTest.ResultCollector.notify_between_tests_finished(collector, prev_test)
 
         result
+    end
+  end
+
+  defp record_netstat_baseline(nil, _label), do: :ok
+
+  defp record_netstat_baseline(tool, label) do
+    total = Toast.Deployment.Netstat.count_sockets(tool)
+    ToastTest.EventStore.notify(%{event: :netstat_snapshot, total: total, label: label})
+  end
+
+  defp check_netstat(deployment, tool) do
+    case Toast.Deployment.Netstat.check(deployment, tool) do
+      {:ok, total} ->
+        ToastTest.EventStore.notify(%{event: :netstat_snapshot, total: total})
+        :ok
+
+      {:port_exhaustion, detail} ->
+        ToastTest.EventStore.notify(%{event: :netstat_snapshot, total: detail.total})
+
+        ToastTest.EventStore.notify(%{
+          event: :infrastructure_issue,
+          subtype: :port_exhaustion,
+          detail: detail
+        })
+
+        {:error, "Port exhaustion: #{detail.total} sockets (threshold: #{detail.threshold})"}
     end
   end
 
@@ -569,12 +624,19 @@ defmodule ToastTest.Runner do
 
   ## Suite test orchestration
 
-  defp run_suite_tests(deployment, suite_run, test_modules, ex_unit_opts, suite_opts) do
+  defp run_suite_tests(
+         deployment,
+         suite_run,
+         test_modules,
+         ex_unit_opts,
+         suite_opts,
+         netstat_tool
+       ) do
     opts = normalize_opts(Keyword.merge(ExUnit.configuration(), ex_unit_opts))
     suite_name = derive_suite_name(suite_run.suite_module, suite_run.deployment_mode)
     pipeline = start_event_pipeline(opts, suite_name)
 
-    between_tests_fn = build_between_tests_fn(suite_run, deployment, pipeline)
+    between_tests_fn = build_between_tests_fn(suite_run, deployment, pipeline, netstat_tool)
 
     config =
       build_run_context(

--- a/tests/toast/lib/toast_test/runner.ex
+++ b/tests/toast/lib/toast_test/runner.ex
@@ -419,8 +419,15 @@ defmodule ToastTest.Runner do
                event_listener: ToastTest.ManagedDeploymentListener
              ) do
           {:ok, deployment} ->
-            record_netstat_baseline(netstat_tool, :deployment_ready)
-            run_suite_with_deployment(deployment, suite_run, entry, ex_unit_opts, netstat_tool)
+            baseline = record_netstat_baseline(netstat_tool, :deployment_ready)
+
+            run_suite_with_deployment(
+              deployment,
+              suite_run,
+              entry,
+              ex_unit_opts,
+              {netstat_tool, baseline}
+            )
 
           {:error, reason} ->
             handle_deployment_failure(suite_run, entry, reason, ex_unit_opts)
@@ -433,7 +440,7 @@ defmodule ToastTest.Runner do
          suite_run,
          %SuiteEntry{} = entry,
          ex_unit_opts,
-         netstat_tool
+         netstat_config
        ) do
     suite_module = suite_run.suite_module
     test_config = suite_run.test_config
@@ -461,7 +468,7 @@ defmodule ToastTest.Runner do
               entry.test_modules,
               ex_unit_opts,
               entry.opts,
-              netstat_tool
+              netstat_config
             )
 
           run_suite_teardown(suite_module, deployment)
@@ -524,7 +531,7 @@ defmodule ToastTest.Runner do
          %ToastTest.SuiteRun{between_tests: false},
          _deployment,
          _pipeline,
-         _netstat_tool
+         _netstat_config
        ),
        do: fn _prev -> :ok end
 
@@ -532,7 +539,7 @@ defmodule ToastTest.Runner do
          %ToastTest.SuiteRun{} = suite_run,
          deployment,
          %Pipeline{} = pipeline,
-         netstat_tool
+         netstat_config
        ) do
     check_fn =
       if function_exported?(suite_run.suite_module, :between_tests, 2) do
@@ -556,7 +563,7 @@ defmodule ToastTest.Runner do
                  Toast.Deployment.HealthBarrier.await_healthy(deployment,
                    timeout: barrier_timeout
                  ),
-               :ok <- if(netstat_tool, do: check_netstat(deployment, netstat_tool), else: :ok) do
+               :ok <- check_netstat(deployment, netstat_config) do
             check_fn.(prev_test)
           end
 
@@ -568,15 +575,18 @@ defmodule ToastTest.Runner do
     end
   end
 
-  defp record_netstat_baseline(nil, _label), do: :ok
+  defp record_netstat_baseline(nil, _label), do: 0
 
   defp record_netstat_baseline(tool, label) do
     total = Toast.Deployment.Netstat.count_sockets(tool)
     ToastTest.EventStore.notify(%{event: :netstat_snapshot, total: total, label: label})
+    total
   end
 
-  defp check_netstat(deployment, tool) do
-    case Toast.Deployment.Netstat.check(deployment, tool) do
+  defp check_netstat(_deployment, nil), do: :ok
+
+  defp check_netstat(deployment, {tool, baseline}) do
+    case Toast.Deployment.Netstat.check(deployment, tool, baseline) do
       {:ok, total} ->
         ToastTest.EventStore.notify(%{event: :netstat_snapshot, total: total})
         :ok
@@ -590,7 +600,15 @@ defmodule ToastTest.Runner do
           detail: detail
         })
 
-        {:error, "Port exhaustion: #{detail.total} sockets (threshold: #{detail.threshold})"}
+        kind_label = if detail.kind == :deployment, do: "Deployment", else: "System"
+
+        delta_info =
+          if detail.kind == :deployment,
+            do: " (#{detail.deployment_delta} since deployment)",
+            else: ""
+
+        {:error,
+         "#{kind_label} port exhaustion: #{detail.total} system sockets#{delta_info} (threshold: #{detail.threshold})"}
     end
   end
 
@@ -630,13 +648,13 @@ defmodule ToastTest.Runner do
          test_modules,
          ex_unit_opts,
          suite_opts,
-         netstat_tool
+         netstat_config
        ) do
     opts = normalize_opts(Keyword.merge(ExUnit.configuration(), ex_unit_opts))
     suite_name = derive_suite_name(suite_run.suite_module, suite_run.deployment_mode)
     pipeline = start_event_pipeline(opts, suite_name)
 
-    between_tests_fn = build_between_tests_fn(suite_run, deployment, pipeline, netstat_tool)
+    between_tests_fn = build_between_tests_fn(suite_run, deployment, pipeline, netstat_config)
 
     config =
       build_run_context(

--- a/tests/toast/lib/toast_test/runner.ex
+++ b/tests/toast/lib/toast_test/runner.ex
@@ -409,7 +409,7 @@ defmodule ToastTest.Runner do
           Logger.warning("Neither ss nor netstat found — port exhaustion check disabled")
         end
 
-        record_netstat_baseline(netstat_tool, :pre_deployment)
+        baseline = record_netstat_baseline(netstat_tool, :pre_deployment)
 
         id = Toast.Deployment.generate_id(mode)
         deployment_dir = Path.join([test_config.base_dir, entry.name, id])
@@ -419,7 +419,7 @@ defmodule ToastTest.Runner do
                event_listener: ToastTest.ManagedDeploymentListener
              ) do
           {:ok, deployment} ->
-            baseline = record_netstat_baseline(netstat_tool, :deployment_ready)
+            record_netstat_baseline(netstat_tool, :deployment_ready)
 
             run_suite_with_deployment(
               deployment,
@@ -604,11 +604,10 @@ defmodule ToastTest.Runner do
 
         delta_info =
           if detail.kind == :deployment,
-            do: " (#{detail.deployment_delta} since deployment)",
-            else: ""
+            do: "(#{detail.deployment_delta} since deployment; threshold: #{detail.threshold}))",
+            else: "(threshold: #{detail.threshold})"
 
-        {:error,
-         "#{kind_label} port exhaustion: #{detail.total} system sockets#{delta_info} (threshold: #{detail.threshold})"}
+        {:error, "#{kind_label} port exhaustion: #{detail.total} system sockets #{delta_info}"}
     end
   end
 

--- a/tests/toast/lib/toast_test/runner/post_execution.ex
+++ b/tests/toast/lib/toast_test/runner/post_execution.ex
@@ -115,6 +115,9 @@ defmodule ToastTest.Runner.PostExecution do
     all_log_files = ResultBuilder.collect_log_files(snapshot.servers)
     server_logs = ToastTest.Attribution.ServerLogs.collect(issues, all_log_files, windows)
 
+    infra_issues = build_infrastructure_issues(snapshot.infrastructure_issues, windows)
+    issues = infra_issues ++ issues
+
     Logger.debug("Building results (#{length(issues)} issues found)")
     active_sanitizers = test_config.active_sanitizers
 
@@ -138,6 +141,22 @@ defmodule ToastTest.Runner.PostExecution do
 
     SuiteResult.write_all(suite_result, test_config.result_dir)
     suite_result
+  end
+
+  defp build_infrastructure_issues([], _windows), do: []
+
+  defp build_infrastructure_issues(infra_events, windows) do
+    Enum.map(infra_events, fn event ->
+      {scope, confidence, phase} =
+        ToastTest.Attribution.TimeWindows.attribute(event.timestamp, windows)
+
+      detail =
+        event.detail
+        |> Map.merge(%{subtype: event.subtype, timestamp: event.timestamp})
+        |> Toast.Utils.maybe_put(:phase, phase)
+
+      %{type: :infrastructure, scope: scope, confidence: confidence, detail: detail}
+    end)
   end
 
   defp build_coredump_analyzer_opts(test_config) do

--- a/tests/toast/lib/toast_test/suite_result.ex
+++ b/tests/toast/lib/toast_test/suite_result.ex
@@ -111,7 +111,7 @@ defmodule ToastTest.SuiteResult do
   @type scope :: :suite | {:module, module()} | {:test, module(), atom()}
 
   @type issue :: %{
-          type: :test_failure | :crash | :sanitizer_report | :timeout,
+          type: :test_failure | :crash | :sanitizer_report | :timeout | :infrastructure,
           scope: scope(),
           confidence: :high | :low | nil,
           detail: map()

--- a/tests/toast/lib/toast_test/suite_result/junit_xml.ex
+++ b/tests/toast/lib/toast_test/suite_result/junit_xml.ex
@@ -196,6 +196,10 @@ defmodule ToastTest.SuiteResult.JUnitXML do
 
   defp issue_type_label(%{type: :sanitizer_report}), do: "sanitizer report"
   defp issue_type_label(%{type: :timeout}), do: "timeout"
+
+  defp issue_type_label(%{type: :infrastructure, detail: %{subtype: subtype}}),
+    do: "infrastructure: #{subtype}"
+
   defp issue_type_label(%{type: type}), do: Atom.to_string(type)
 
   # Counts tests with infrastructure issues that wouldn't otherwise show as errors.

--- a/tests/toast/test/toast/deployment/netstat_test.exs
+++ b/tests/toast/test/toast/deployment/netstat_test.exs
@@ -1,0 +1,127 @@
+################################################################################
+## DISCLAIMER
+##
+## Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+## Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+##
+## Licensed under the Business Source License 1.1 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## Copyright holder is ArangoDB GmbH, Cologne, Germany
+################################################################################
+
+defmodule Toast.Deployment.NetstatTest do
+  use ExUnit.Case, async: true
+
+  alias Toast.Deployment.Netstat
+
+  @ss_output """
+  ESTAB      0       0      127.0.0.1:8530         127.0.0.1:45678  users:(("arangod",pid=1234,fd=10))
+  ESTAB      0       0      127.0.0.1:45678        127.0.0.1:8530   users:(("arangod",pid=1234,fd=11))
+  ESTAB      0       0      127.0.0.1:8531         127.0.0.1:50000  users:(("arangod",pid=5678,fd=20))
+  CLOSE-WAIT 0       0      127.0.0.1:8531         127.0.0.1:50001  users:(("arangod",pid=5678,fd=21))
+  ESTAB      0       0      127.0.0.1:9999         127.0.0.1:12345  users:(("other",pid=9999,fd=5))
+  """
+
+  @netstat_output """
+  tcp        0      0 127.0.0.1:8530          127.0.0.1:45678         ESTABLISHED 1234/arangod
+  tcp        0      0 127.0.0.1:45678         127.0.0.1:8530          ESTABLISHED 1234/arangod
+  tcp        0      0 127.0.0.1:8531          127.0.0.1:50000         ESTABLISHED 5678/arangod
+  tcp        0      0 127.0.0.1:8531          127.0.0.1:50001         CLOSE_WAIT  5678/arangod
+  tcp        0      0 127.0.0.1:9999          127.0.0.1:12345         ESTABLISHED 9999/other
+  """
+
+  @servers [
+    %{id: "single-0", pid: 1234, port: 8530},
+    %{id: "dbserver-0", pid: 5678, port: 8531}
+  ]
+
+  describe "count_lines/1" do
+    test "counts non-empty lines" do
+      assert Netstat.count_lines("line1\nline2\nline3\n") == 3
+    end
+
+    test "returns 0 for empty output" do
+      assert Netstat.count_lines("") == 0
+    end
+
+    test "handles output without trailing newline" do
+      assert Netstat.count_lines("line1\nline2") == 2
+    end
+  end
+
+  describe "build_snapshot_by_pid/3 with ss" do
+    test "groups sockets by server PID with in/out classification" do
+      snapshot = Netstat.build_snapshot_by_pid(@ss_output, @servers, :ss)
+
+      assert %{"single-0" => single, "dbserver-0" => dbserver} = snapshot
+
+      assert single.pid == 1234
+      assert single.sockets.total == 2
+      assert single.sockets.in == %{"ESTAB" => 1}
+      assert single.sockets.out == %{"ESTAB" => 1}
+
+      assert dbserver.pid == 5678
+      assert dbserver.sockets.total == 2
+      assert dbserver.sockets.in == %{"ESTAB" => 1, "CLOSE-WAIT" => 1}
+      assert dbserver.sockets.out == %{}
+    end
+
+    test "includes servers with zero sockets" do
+      snapshot = Netstat.build_snapshot_by_pid("", @servers, :ss)
+
+      assert %{"single-0" => single, "dbserver-0" => dbserver} = snapshot
+      assert single.sockets.total == 0
+      assert dbserver.sockets.total == 0
+    end
+
+    test "ignores sockets belonging to unknown PIDs" do
+      output = """
+      ESTAB      0       0      127.0.0.1:9999         127.0.0.1:12345  users:(("other",pid=9999,fd=5))
+      """
+
+      snapshot = Netstat.build_snapshot_by_pid(output, @servers, :ss)
+
+      assert snapshot["single-0"].sockets.total == 0
+      assert snapshot["dbserver-0"].sockets.total == 0
+    end
+  end
+
+  describe "build_snapshot_by_pid/3 with netstat" do
+    test "groups sockets by server PID with in/out classification" do
+      snapshot = Netstat.build_snapshot_by_pid(@netstat_output, @servers, :netstat)
+
+      assert %{"single-0" => single, "dbserver-0" => dbserver} = snapshot
+
+      assert single.pid == 1234
+      assert single.sockets.total == 2
+      assert single.sockets.in == %{"ESTABLISHED" => 1}
+      assert single.sockets.out == %{"ESTABLISHED" => 1}
+
+      assert dbserver.pid == 5678
+      assert dbserver.sockets.total == 2
+      assert dbserver.sockets.in == %{"ESTABLISHED" => 1, "CLOSE_WAIT" => 1}
+      assert dbserver.sockets.out == %{}
+    end
+
+    test "ignores sockets belonging to unknown PIDs" do
+      output = """
+      tcp        0      0 127.0.0.1:9999          127.0.0.1:12345         ESTABLISHED 9999/other
+      """
+
+      snapshot = Netstat.build_snapshot_by_pid(output, @servers, :netstat)
+
+      assert snapshot["single-0"].sockets.total == 0
+      assert snapshot["dbserver-0"].sockets.total == 0
+    end
+  end
+end

--- a/tests/toast/test/toast/deployment/netstat_test.exs
+++ b/tests/toast/test/toast/deployment/netstat_test.exs
@@ -94,6 +94,19 @@ defmodule Toast.Deployment.NetstatTest do
       assert snapshot["single-0"].sockets.total == 0
       assert snapshot["dbserver-0"].sockets.total == 0
     end
+
+    test "silently drops malformed lines" do
+      output = """
+      ESTAB      0       0      127.0.0.1:8530         127.0.0.1:45678  users:(("arangod",pid=1234,fd=10))
+      truncated line
+      ESTAB      0       0
+      """
+
+      snapshot = Netstat.build_snapshot_by_pid(output, @servers, :ss)
+
+      assert snapshot["single-0"].sockets.total == 1
+      assert snapshot["dbserver-0"].sockets.total == 0
+    end
   end
 
   describe "build_snapshot_by_pid/3 with netstat" do
@@ -111,17 +124,6 @@ defmodule Toast.Deployment.NetstatTest do
       assert dbserver.sockets.total == 2
       assert dbserver.sockets.in == %{"ESTABLISHED" => 1, "CLOSE_WAIT" => 1}
       assert dbserver.sockets.out == %{}
-    end
-
-    test "ignores sockets belonging to unknown PIDs" do
-      output = """
-      tcp        0      0 127.0.0.1:9999          127.0.0.1:12345         ESTABLISHED 9999/other
-      """
-
-      snapshot = Netstat.build_snapshot_by_pid(output, @servers, :netstat)
-
-      assert snapshot["single-0"].sockets.total == 0
-      assert snapshot["dbserver-0"].sockets.total == 0
     end
   end
 end

--- a/tests/toast/test/toast_test/event_store_test.exs
+++ b/tests/toast/test/toast_test/event_store_test.exs
@@ -457,6 +457,8 @@ defmodule ToastTest.EventStoreTest do
                [
                  :deployments,
                  :events,
+                 :infrastructure_issues,
+                 :netstat_snapshots,
                  :pids_by_server,
                  :servers,
                  :timeout_kills,
@@ -469,6 +471,66 @@ defmodule ToastTest.EventStoreTest do
       assert snapshot.timeout_kills == EventStore.timeout_kills()
       assert snapshot.deployments == EventStore.deployments()
       assert snapshot.servers == EventStore.servers()
+    end
+  end
+
+  describe "netstat_snapshots/0" do
+    test "returns empty list when no snapshots recorded" do
+      assert EventStore.netstat_snapshots() == []
+    end
+
+    test "collects netstat_snapshot events in chronological order" do
+      t1 = to_us(~U[2026-03-09 10:00:00Z])
+      t2 = to_us(~U[2026-03-09 10:01:00Z])
+
+      EventStore.notify(%{
+        event: :netstat_snapshot,
+        total: 100,
+        timestamp: t1
+      })
+
+      EventStore.notify(%{
+        event: :netstat_snapshot,
+        total: 500,
+        timestamp: t2
+      })
+
+      snapshots = EventStore.netstat_snapshots()
+      assert length(snapshots) == 2
+      assert [first, second] = snapshots
+      assert first.total == 100
+      assert first.timestamp == t1
+      assert second.total == 500
+      assert second.timestamp == t2
+    end
+  end
+
+  describe "infrastructure_issues/0" do
+    test "returns empty list when no issues recorded" do
+      assert EventStore.infrastructure_issues() == []
+    end
+
+    test "collects infrastructure_issue events" do
+      t1 = to_us(~U[2026-03-09 10:00:00Z])
+
+      EventStore.notify(%{
+        event: :infrastructure_issue,
+        subtype: :port_exhaustion,
+        detail: %{
+          total: 15_000,
+          threshold: 15_000,
+          by_server: %{
+            "dbserver-0" => %{pid: 1234, total: 10_000, by_state: %{"ESTAB" => 10_000}},
+            "coordinator-0" => %{pid: 5678, total: 5_000, by_state: %{"ESTAB" => 5_000}}
+          }
+        },
+        timestamp: t1
+      })
+
+      issues = EventStore.infrastructure_issues()
+      assert [issue] = issues
+      assert issue.subtype == :port_exhaustion
+      assert issue.detail.total == 15_000
     end
   end
 

--- a/tests/toast/test/toast_test/event_store_test.exs
+++ b/tests/toast/test/toast_test/event_store_test.exs
@@ -32,18 +32,6 @@ defmodule ToastTest.EventStoreTest do
     :ok
   end
 
-  describe "start_link/1" do
-    test "starts the GenServer" do
-      pid = Process.whereis(EventStore)
-      assert pid != nil
-      assert Process.alive?(pid)
-    end
-
-    test "ETS table exists" do
-      assert :ets.info(ToastTest.EventStore) != :undefined
-    end
-  end
-
   describe "events/0" do
     test "returns empty list when no events recorded" do
       assert EventStore.events() == []
@@ -70,6 +58,17 @@ defmodule ToastTest.EventStoreTest do
 
       [recorded] = EventStore.events()
       assert recorded.timestamp == now
+    end
+
+    test "auto-generates timestamp when not provided" do
+      before = :os.system_time(:microsecond)
+      EventStore.notify(%{event: :server_started, server_id: "s1", pid: 100})
+      after_ts = :os.system_time(:microsecond)
+
+      [recorded] = EventStore.events()
+      assert is_integer(recorded.timestamp)
+      assert recorded.timestamp >= before
+      assert recorded.timestamp <= after_ts
     end
   end
 


### PR DESCRIPTION
### Scope & Purpose

Between tests, Toast monitors the system's TCP socket count to detect port exhaustion before it causes cascading test failures. Two thresholds are checked:

- **System threshold** (15,000): total TCP sockets on the system. Catches catastrophic exhaustion regardless of source.
- **Deployment threshold** (500 per server): sockets added since the deployment started, scaled by server count. Catches connection leaks within the deployment earlier than the system threshold would.

When either threshold is reached, the suite aborts with an infrastructure issue. The post-execution summary shows a per-server breakdown (inbound vs outbound sockets by TCP state), and `mix toast.analyze detail infrastructure` includes a trajectory showing which tests contributed the most sockets.

The check uses `ss` (preferred) or `netstat` (fallback) for the routine count. The detailed per-server breakdown (requiring more expensive PID resolution) is only gathered once when a threshold is actually breached.

If neither `ss` nor `netstat` is available, the check is disabled with a warning.

This PR also adds a documentation file that was previously ignored due to a too eager ignore rule.

- [x] :pizza: New feature
