### PR TITLE
OASIS-27899: Fixed an edge case in range_column_iterator::seek (#22772)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+3.12.9.3 (2026-06-04)
+-------------------
+* COR-584/OASIS-27899: Fixed an edge case in range_column_iterator::seek where
+executing a seek on an uninitialized iterator would return incorrect results if
+the target is greater than the max value of that iterator.
+
+
 3.12.9.2 (2026-05-15)
 ---------------------
 

--- a/lib/iresearch/core/formats/columnstore2.cpp
+++ b/lib/iresearch/core/formats/columnstore2.cpp
@@ -213,6 +213,14 @@ class range_column_iterator : public resettable_doc_iterator,
     }
 
     if (!doc_limits::valid(value())) {
+      if (doc > max_doc_ || doc_limits::eof(doc)) {
+        max_doc_ = doc_limits::invalid();
+        min_doc_ = doc_limits::eof();
+        std::get<document>(attrs_).value = doc_limits::eof();
+        std::get<payload>(attrs_).value = {};
+        return doc_limits::eof();
+      }
+
       std::get<document>(attrs_).value = min_doc_++;
       std::get<payload>(attrs_).value = this->payload(value() - min_base_);
       return value();

--- a/lib/iresearch/tests/formats/columnstore2_test.cpp
+++ b/lib/iresearch/tests/formats/columnstore2_test.cpp
@@ -2181,6 +2181,49 @@ TEST_P(columnstore2_test_case, dense_column_range) {
       ASSERT_TRUE(irs::doc_limits::eof(it->value()));
     }
 
+    // uninitialized range_column_iterator::seek (branch 2 must not run for
+    // target > max_doc_; doc_iterator contract requires eof)
+    {
+      auto assert_uninitialized_eof_seek = [&](irs::doc_id_t target) {
+        auto it = column->iterator(hint());
+        auto* document = irs::get<irs::document>(*it);
+        ASSERT_NE(nullptr, document);
+        auto* payload = irs::get<irs::payload>(*it);
+        ASSERT_NE(nullptr, payload);
+
+        // first call to seek()
+        ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+        ASSERT_TRUE(irs::doc_limits::eof(it->seek(target)));
+        ASSERT_TRUE(irs::doc_limits::eof(it->value()));
+
+        // subsequent calls to seek()
+        ASSERT_TRUE(irs::IsNull(payload->value));
+        ASSERT_TRUE(irs::doc_limits::eof(it->seek(target)));
+        ASSERT_TRUE(irs::doc_limits::eof(it->value()));
+
+        // next() on an eof iterator
+        ASSERT_FALSE(it->next());
+        ASSERT_TRUE(irs::doc_limits::eof(it->value()));
+      };
+
+      assert_uninitialized_eof_seek(kMax + 1);
+      assert_uninitialized_eof_seek(irs::doc_limits::eof());
+
+      // below-range target on uninitialized iterator (branch 2)
+      {
+        auto it = column->iterator(hint());
+        auto* document = irs::get<irs::document>(*it);
+        ASSERT_NE(nullptr, document);
+        auto* payload = irs::get<irs::payload>(*it);
+        ASSERT_NE(nullptr, payload);
+
+        ASSERT_EQ(irs::doc_limits::invalid(), it->value());
+        ASSERT_EQ(kMin, it->seek(42));
+        ASSERT_EQ(kMin, it->value());
+        assert_payload(std::to_string(kMin), *payload);
+      }
+    }
+
     {
       auto prev_it = column->iterator(hint());
       auto it = column->iterator(hint());


### PR DESCRIPTION
* OASIS-27899: Fixed an edge case in range_column_iterator::seek

* Updated Changelog

### Scope & Purpose

This PR fixes a bug in the range_column_iterator::seek() method in ArangoSearch.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [X] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [X] Backport for 3.12.0: https://github.com/arangodb/arangodb/pull/22775
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/OASIS-27899
- [ ] Design document: 
