### PR TITLE
[COR-621] Extract options from features that ONLY contain obsolete/empty options.

### DIFF
--- a/arangod/RestServer/FlushFeature.cpp
+++ b/arangod/RestServer/FlushFeature.cpp
@@ -58,9 +58,8 @@ FlushFeature::FlushFeature(ApplicationServer& server,
 FlushFeature::~FlushFeature() = default;
 
 void FlushFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addObsoleteOption(
-      "--server.flush-interval",
-      "The interval (in microseconds) for flushing data.", true);
+  FlushOptionsProvider provider;
+  provider.declareOptions(options, _options);
 }
 
 void FlushFeature::registerFlushSubscription(

--- a/arangod/RestServer/FlushFeature.h
+++ b/arangod/RestServer/FlushFeature.h
@@ -26,6 +26,7 @@
 
 #include "ApplicationFeatures/ApplicationFeature.h"
 #include "Metrics/Fwd.h"
+#include "RestServer/FlushOptionsProvider.h"
 #include "VocBase/voc-types.h"
 
 #include <cstdint>
@@ -83,6 +84,7 @@ class FlushFeature final : public application_features::ApplicationFeature {
   void stop() override;
 
  private:
+  FlushFeatureOptions _options;
   std::mutex _flushSubscriptionsMutex;
   std::vector<std::weak_ptr<FlushSubscription>> _flushSubscriptions;
   bool _stopped;

--- a/arangod/RestServer/FlushOptionsProvider.cpp
+++ b/arangod/RestServer/FlushOptionsProvider.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -18,26 +18,20 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "FlushOptionsProvider.h"
 
-#include "ApplicationFeatures/ApplicationFeature.h"
-#include "RestServer/NonceOptionsProvider.h"
+#include "ProgramOptions/ProgramOptions.h"
 
 namespace arangodb {
 
-class NonceFeature : public application_features::ApplicationFeature {
- public:
-  static constexpr std::string_view name() noexcept { return "Nonce"; }
-
-  explicit NonceFeature(application_features::ApplicationServer& server);
-
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-
- private:
-  NonceFeatureOptions _options;
-};
+void FlushOptionsProvider::declareOptions(
+    std::shared_ptr<options::ProgramOptions> options,
+    FlushFeatureOptions& /*opts*/) {
+  options->addObsoleteOption(
+      "--server.flush-interval",
+      "The interval (in microseconds) for flushing data.", true);
+}
 
 }  // namespace arangodb

--- a/arangod/RestServer/FlushOptionsProvider.h
+++ b/arangod/RestServer/FlushOptionsProvider.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -18,26 +18,23 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
-#include "ApplicationFeatures/ApplicationFeature.h"
-#include "RestServer/NonceOptionsProvider.h"
+#include "ApplicationFeatures/OptionsProvider.h"
+
+namespace arangodb::options {
+class ProgramOptions;
+}
 
 namespace arangodb {
 
-class NonceFeature : public application_features::ApplicationFeature {
- public:
-  static constexpr std::string_view name() noexcept { return "Nonce"; }
+struct FlushFeatureOptions {};
 
-  explicit NonceFeature(application_features::ApplicationServer& server);
-
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-
- private:
-  NonceFeatureOptions _options;
+struct FlushOptionsProvider : OptionsProvider<FlushFeatureOptions> {
+  void declareOptions(std::shared_ptr<options::ProgramOptions> opts,
+                      FlushFeatureOptions& options) override;
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/MaxMapCountFeature.cpp
+++ b/arangod/RestServer/MaxMapCountFeature.cpp
@@ -43,9 +43,8 @@ MaxMapCountFeature::MaxMapCountFeature(
 
 void MaxMapCountFeature::collectOptions(
     std::shared_ptr<options::ProgramOptions> options) {
-  options->addObsoleteOption(
-      "--server.check-max-memory-mappings",
-      "check the maximum number of memory mappings at startup", true);
+  MaxMapCountOptionsProvider provider;
+  provider.declareOptions(options, _options);
 }
 
 uint64_t MaxMapCountFeature::actualMaxMappings() {

--- a/arangod/RestServer/MaxMapCountFeature.h
+++ b/arangod/RestServer/MaxMapCountFeature.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "ApplicationFeatures/ApplicationFeature.h"
+#include "RestServer/MaxMapCountOptionsProvider.h"
 
 namespace arangodb {
 
@@ -40,6 +41,9 @@ class MaxMapCountFeature final
 
   static uint64_t actualMaxMappings();
   static uint64_t minimumExpectedMaxMappings();
+
+ private:
+  MaxMapCountFeatureOptions _options;
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/MaxMapCountOptionsProvider.cpp
+++ b/arangod/RestServer/MaxMapCountOptionsProvider.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -18,26 +18,20 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "MaxMapCountOptionsProvider.h"
 
-#include "ApplicationFeatures/ApplicationFeature.h"
-#include "RestServer/NonceOptionsProvider.h"
+#include "ProgramOptions/ProgramOptions.h"
 
 namespace arangodb {
 
-class NonceFeature : public application_features::ApplicationFeature {
- public:
-  static constexpr std::string_view name() noexcept { return "Nonce"; }
-
-  explicit NonceFeature(application_features::ApplicationServer& server);
-
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-
- private:
-  NonceFeatureOptions _options;
-};
+void MaxMapCountOptionsProvider::declareOptions(
+    std::shared_ptr<options::ProgramOptions> options,
+    MaxMapCountFeatureOptions& /*opts*/) {
+  options->addObsoleteOption(
+      "--server.check-max-memory-mappings",
+      "check the maximum number of memory mappings at startup", true);
+}
 
 }  // namespace arangodb

--- a/arangod/RestServer/MaxMapCountOptionsProvider.h
+++ b/arangod/RestServer/MaxMapCountOptionsProvider.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -18,26 +18,23 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
-#include "ApplicationFeatures/ApplicationFeature.h"
-#include "RestServer/NonceOptionsProvider.h"
+#include "ApplicationFeatures/OptionsProvider.h"
+
+namespace arangodb::options {
+class ProgramOptions;
+}
 
 namespace arangodb {
 
-class NonceFeature : public application_features::ApplicationFeature {
- public:
-  static constexpr std::string_view name() noexcept { return "Nonce"; }
+struct MaxMapCountFeatureOptions {};
 
-  explicit NonceFeature(application_features::ApplicationServer& server);
-
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-
- private:
-  NonceFeatureOptions _options;
+struct MaxMapCountOptionsProvider : OptionsProvider<MaxMapCountFeatureOptions> {
+  void declareOptions(std::shared_ptr<options::ProgramOptions> opts,
+                      MaxMapCountFeatureOptions& options) override;
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/NonceFeature.cpp
+++ b/arangod/RestServer/NonceFeature.cpp
@@ -38,9 +38,8 @@ NonceFeature::NonceFeature(application_features::ApplicationServer& server)
 }
 
 void NonceFeature::collectOptions(std::shared_ptr<ProgramOptions> options) {
-  options->addSection("nonce", "nonces", "", true, true);
-  options->addObsoleteOption("--nonce.size",
-                             "the size of the hash array for nonces", true);
+  NonceOptionsProvider provider;
+  provider.declareOptions(options, _options);
 }
 
 }  // namespace arangodb

--- a/arangod/RestServer/NonceOptionsProvider.cpp
+++ b/arangod/RestServer/NonceOptionsProvider.cpp
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -18,26 +18,20 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
-#pragma once
+#include "NonceOptionsProvider.h"
 
-#include "ApplicationFeatures/ApplicationFeature.h"
-#include "RestServer/NonceOptionsProvider.h"
+#include "ProgramOptions/ProgramOptions.h"
 
 namespace arangodb {
 
-class NonceFeature : public application_features::ApplicationFeature {
- public:
-  static constexpr std::string_view name() noexcept { return "Nonce"; }
-
-  explicit NonceFeature(application_features::ApplicationServer& server);
-
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-
- private:
-  NonceFeatureOptions _options;
-};
+void NonceOptionsProvider::declareOptions(
+    std::shared_ptr<options::ProgramOptions> options,
+    NonceFeatureOptions& /*opts*/) {
+  options->addSection("nonce", "nonces", "", true, true);
+  options->addObsoleteOption("--nonce.size",
+                             "the size of the hash array for nonces", true);
+}
 
 }  // namespace arangodb

--- a/arangod/RestServer/NonceOptionsProvider.h
+++ b/arangod/RestServer/NonceOptionsProvider.h
@@ -1,7 +1,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
 ///
-/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
 /// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
 ///
 /// Licensed under the Business Source License 1.1 (the "License");
@@ -18,26 +18,23 @@
 ///
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ///
-/// @author Jan Steemann
 ////////////////////////////////////////////////////////////////////////////////
 
 #pragma once
 
-#include "ApplicationFeatures/ApplicationFeature.h"
-#include "RestServer/NonceOptionsProvider.h"
+#include "ApplicationFeatures/OptionsProvider.h"
+
+namespace arangodb::options {
+class ProgramOptions;
+}
 
 namespace arangodb {
 
-class NonceFeature : public application_features::ApplicationFeature {
- public:
-  static constexpr std::string_view name() noexcept { return "Nonce"; }
+struct NonceFeatureOptions {};
 
-  explicit NonceFeature(application_features::ApplicationServer& server);
-
-  void collectOptions(std::shared_ptr<options::ProgramOptions>) override final;
-
- private:
-  NonceFeatureOptions _options;
+struct NonceOptionsProvider : OptionsProvider<NonceFeatureOptions> {
+  void declareOptions(std::shared_ptr<options::ProgramOptions> opts,
+                      NonceFeatureOptions& options) override;
 };
 
 }  // namespace arangodb

--- a/arangod/arangoserver.cmake
+++ b/arangod/arangoserver.cmake
@@ -150,6 +150,7 @@ add_library(arangoserver STATIC
   RestServer/FileDescriptorsFeature.cpp
   RestServer/FileDescriptorsOptionsProvider.cpp
   RestServer/FlushFeature.cpp
+  RestServer/FlushOptionsProvider.cpp
   RestServer/FortuneFeature.cpp
   RestServer/FortuneOptionsProvider.cpp
   RestServer/IOHeartbeatThread.cpp
@@ -160,7 +161,9 @@ add_library(arangoserver STATIC
   RestServer/LogBufferFeature.cpp
   RestServer/LogBufferOptionsProvider.cpp
   RestServer/MaxMapCountFeature.cpp
+  RestServer/MaxMapCountOptionsProvider.cpp
   RestServer/NonceFeature.cpp
+  RestServer/NonceOptionsProvider.cpp
   RestServer/ApiRecordingFeature.cpp
   RestServer/ApiRecordingOptionsProvider.cpp
   RestServer/PrivilegeFeature.cpp


### PR DESCRIPTION
### Scope & Purpose

Extract obsolete options to a new structure. Part of the COR-130 rework, to extract options handling from the feature.
