### PR TITLE
Small toast refactoring + fixes

### DIFF
--- a/tests/toast/lib/mix/tasks/toast.ex
+++ b/tests/toast/lib/mix/tasks/toast.ex
@@ -205,9 +205,7 @@ defmodule Mix.Tasks.Toast do
     run_results = %{
       test_failures: result.stats.failures,
       server_crashed: DiagnosticsSummary.has_server_crash?(result.suites),
-      infrastructure_failure:
-        DiagnosticsSummary.has_timeout?(result.suites) or
-          DiagnosticsSummary.has_infrastructure?(result.suites),
+      infrastructure_failure: DiagnosticsSummary.has_infrastructure?(result.suites),
       sanitizer_errors: DiagnosticsSummary.has_sanitizer_errors?(result.suites)
     }
 

--- a/tests/toast/lib/mix/tasks/toast/analyze/data.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/data.ex
@@ -28,7 +28,6 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
     "crash" => :crash,
     "test_failure" => :test_failure,
     "sanitizer_report" => :sanitizer_report,
-    "timeout" => :timeout,
     "infrastructure" => :infrastructure
   }
 
@@ -101,7 +100,7 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
   def format_server(%{type: :crash, detail: %{server: server}}), do: server
   def format_server(%{type: :sanitizer_report, detail: %{server: server}}), do: server
 
-  def format_server(%{type: :timeout, detail: %{servers: servers}}) when is_list(servers) do
+  def format_server(%{type: :infrastructure, detail: %{subtype: :timeout, servers: servers}}) do
     servers |> Enum.map_join(", ", & &1.server_id)
   end
 
@@ -150,7 +149,7 @@ defmodule Mix.Tasks.Toast.Analyze.Data do
          %{type: type, detail: %{timestamp: ts}} = issue,
          _modules
        )
-       when type in [:sanitizer_report, :timeout, :infrastructure] and is_integer(ts) do
+       when type in [:sanitizer_report, :infrastructure] and is_integer(ts) do
     Map.put(issue, :time_bounds, {ts, ts})
   end
 

--- a/tests/toast/lib/mix/tasks/toast/analyze/detail/body.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/detail/body.ex
@@ -129,6 +129,17 @@ defmodule Mix.Tasks.Toast.Analyze.Detail.Body do
     print_netstat_trajectory(issue, color)
   end
 
+  def print(%{type: :infrastructure, detail: %{subtype: subtype} = detail}, color, _bt_opts) do
+    label = subtype |> to_string() |> String.replace("_", " ") |> String.upcase()
+    Mix.shell().info("  #{colorize(label, :red, color)}")
+
+    if detail[:timestamp] do
+      Mix.shell().info("  Time:   #{Data.fmt_dt(detail.timestamp)}")
+    end
+
+    Mix.shell().info("  Detail: #{inspect(Map.drop(detail, [:subtype, :timestamp]))}")
+  end
+
   defp print_direction(_label, stats, _color) when stats == %{}, do: :ok
 
   defp print_direction(label, stats, color) do

--- a/tests/toast/lib/mix/tasks/toast/analyze/detail/body.ex
+++ b/tests/toast/lib/mix/tasks/toast/analyze/detail/body.ex
@@ -29,6 +29,8 @@ defmodule Mix.Tasks.Toast.Analyze.Detail.Body do
   alias ToastTest.Formatting.Issues
   alias Toast.Diagnostics.Coredump.ThreadFilter
 
+  def print(issue, color, bt_opts \\ %{})
+
   def print(
         %{type: :test_failure, detail: %{test: %ExUnit.Test{state: {:failed, failures}} = test}},
         _color,
@@ -57,11 +59,15 @@ defmodule Mix.Tasks.Toast.Analyze.Detail.Body do
 
   def print(%{type: :crash, detail: detail}, color, bt_opts) do
     print_crash_info(detail, color)
-    if bt_opts.coredumps, do: print_crash_backtrace(detail, color, bt_opts)
+    print_crash_backtrace(detail, color, bt_opts)
     print_crash_extra(detail, color, bt_opts)
   end
 
-  def print(%{type: :timeout, detail: detail}, color, _bt_opts) do
+  def print(
+        %{type: :infrastructure, detail: %{subtype: :timeout} = detail},
+        color,
+        _bt_opts
+      ) do
     label = Issues.timeout_source_label(detail.source)
     Mix.shell().info("  #{colorize("[#{label}] #{detail.reason}", :red, color)}")
 
@@ -75,9 +81,12 @@ defmodule Mix.Tasks.Toast.Analyze.Detail.Body do
     end
   end
 
-  def print(%{type: :infrastructure, detail: detail} = issue, color, _bt_opts) do
-    subtype = detail.subtype |> Atom.to_string() |> String.replace("_", " ")
-    Mix.shell().info("  #{colorize(String.upcase(subtype), :red, color)}")
+  def print(
+        %{type: :infrastructure, detail: %{subtype: :port_exhaustion} = detail} = issue,
+        color,
+        _bt_opts
+      ) do
+    Mix.shell().info("  #{colorize("PORT EXHAUSTION", :red, color)}")
 
     if detail[:timestamp] do
       Mix.shell().info("  Time:   #{Data.fmt_dt(detail.timestamp)}")
@@ -271,6 +280,8 @@ defmodule Mix.Tasks.Toast.Analyze.Detail.Body do
 
   defp print_crash_info(_detail, _color), do: :ok
 
+  defp print_crash_backtrace(_detail, _color, %{coredumps: false}), do: :ok
+
   defp print_crash_backtrace(
          %{coredumps: [coredump | _]} = detail,
          color,
@@ -314,11 +325,9 @@ defmodule Mix.Tasks.Toast.Analyze.Detail.Body do
     Mix.shell().info("  #{colorize("No crash details available.", :faint, color)}")
   end
 
-  defp print_crash_extra(%{coredumps: [coredump | _]}, color, bt_opts) do
-    if bt_opts.disassembly do
-      print_optional_section(Issues.format_registers(coredump), "Registers", color)
-      print_optional_section(Issues.format_disassembly(coredump), "Disassembly", color)
-    end
+  defp print_crash_extra(%{coredumps: [coredump | _]}, color, %{disassembly: true}) do
+    print_optional_section(Issues.format_registers(coredump), "Registers", color)
+    print_optional_section(Issues.format_disassembly(coredump), "Disassembly", color)
   end
 
   defp print_crash_extra(_detail, _color, _bt_opts), do: :ok

--- a/tests/toast/lib/toast/deployment.ex
+++ b/tests/toast/lib/toast/deployment.ex
@@ -211,11 +211,39 @@ defmodule Toast.Deployment do
   Start a deployment. The mode is derived from the config:
   `config.cluster == nil` → single server, otherwise → cluster.
 
+  On failure, the deployment is stopped automatically and no deployment
+  handle is returned. Use `attempt_start/3` when you need the deployment
+  handle on failure (e.g., for post-mortem diagnostics).
+
   The `opts` keyword list can include non-config keys like `:on_crash`,
   `:on_event`, and `:id` that are forwarded to the controller.
   """
   @spec start(Config.t(), Path.t(), keyword()) :: {:ok, t()} | {:error, term()}
   def start(%Config{} = config, deployment_dir, opts \\ []) do
+    case attempt_start(config, deployment_dir, opts) do
+      {:ok, deployment} ->
+        {:ok, deployment}
+
+      {:error, reason, deployment} ->
+        stop(deployment)
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Start a deployment, returning the deployment handle even on failure.
+
+  On success, returns `{:ok, deployment}`. On failure, returns
+  `{:error, reason, deployment}` where the deployment is in a failed state
+  with servers potentially still running. The caller is responsible for
+  stopping the deployment.
+
+  This is useful when you need access to the partially-started deployment
+  for diagnostics (agency dump, server logs, artifacts).
+  """
+  @spec attempt_start(Config.t(), Path.t(), keyword()) ::
+          {:ok, t()} | {:error, term(), t()} | {:error, term()}
+  def attempt_start(%Config{} = config, deployment_dir, opts \\ []) do
     mode = Config.mode(config)
     id = Keyword.get_lazy(opts, :id, fn -> generate_id(mode) end)
     Logger.info("Starting #{mode} deployment (deployment_dir=#{deployment_dir})")
@@ -233,19 +261,27 @@ defmodule Toast.Deployment do
              id: id,
              event_listener: listener,
              jwt_provider: jwt_provider
-           ),
-         :ok <- Controller.deploy(pid, specs, config.startup_timeout, stacktrace: stacktrace) do
-      info = Controller.get_info(pid)
+           ) do
+      deployment_from_controller = fn ->
+        info = Controller.get_info(pid)
 
-      {:ok,
-       %__MODULE__{
-         id: info.id,
-         controller: pid,
-         api_version: config.api_version,
-         protocol: config.protocol,
-         servers: build_server_infos(info),
-         jwt_provider: jwt_provider
-       }}
+        %__MODULE__{
+          id: info.id,
+          controller: pid,
+          api_version: config.api_version,
+          protocol: config.protocol,
+          servers: build_server_infos(info),
+          jwt_provider: jwt_provider
+        }
+      end
+
+      case Controller.deploy(pid, specs, config.startup_timeout, stacktrace: stacktrace) do
+        :ok ->
+          {:ok, deployment_from_controller.()}
+
+        {:error, reason} ->
+          {:error, reason, deployment_from_controller.()}
+      end
     end
   end
 

--- a/tests/toast/lib/toast/deployment/controller.ex
+++ b/tests/toast/lib/toast/deployment/controller.ex
@@ -243,8 +243,7 @@ defmodule Toast.Deployment.Controller do
 
       {:error, reason, failed_state} ->
         Logger.debug("Deploy failed: #{inspect(reason)}")
-        new_state = ShutdownPipeline.handle_deploy_failure(failed_state, reason)
-        {:reply, {:error, reason}, new_state}
+        {:reply, {:error, reason}, %{failed_state | status: :failed, error: reason}}
     end
   end
 

--- a/tests/toast/lib/toast/deployment/controller.ex
+++ b/tests/toast/lib/toast/deployment/controller.ex
@@ -243,6 +243,7 @@ defmodule Toast.Deployment.Controller do
 
       {:error, reason, failed_state} ->
         Logger.debug("Deploy failed: #{inspect(reason)}")
+        if reason == :timeout, do: notify_startup_timeout(failed_state)
         {:reply, {:error, reason}, %{failed_state | status: :failed, error: reason}}
     end
   end
@@ -659,6 +660,22 @@ defmodule Toast.Deployment.Controller do
       pid: crash_info.os_pid,
       crash_info: crash_info,
       expected: expected,
+      timestamp: Toast.get_timestamp()
+    })
+  end
+
+  defp notify_startup_timeout(state) do
+    servers =
+      Enum.map(state.servers, fn {id, s} ->
+        %{server_id: id, os_pid: s.pid, log_file: s.log_file}
+      end)
+
+    state.event_listener.on_event(%{
+      event: :timeout_kill,
+      deployment_id: state.id,
+      source: :startup,
+      reason: "Startup timeout — deployment did not become ready in time",
+      servers: servers,
       timestamp: Toast.get_timestamp()
     })
   end

--- a/tests/toast/lib/toast/deployment/shutdown_pipeline.ex
+++ b/tests/toast/lib/toast/deployment/shutdown_pipeline.ex
@@ -96,7 +96,7 @@ defmodule Toast.Deployment.ShutdownPipeline do
       state.event_listener.on_event(%{
         event: :timeout_kill,
         deployment_id: state.id,
-        source: :startup_timeout,
+        source: :startup,
         reason: "Startup timeout — deployment did not become ready in time",
         servers: killed_servers,
         timestamp: Toast.get_timestamp()
@@ -195,7 +195,7 @@ defmodule Toast.Deployment.ShutdownPipeline do
     listener.on_event(%{
       event: :timeout_kill,
       deployment_id: id,
-      source: :shutdown_timeout,
+      source: :shutdown,
       reason: "Shutdown timeout — server(s) did not respond to SIGTERM",
       servers: escalated,
       timestamp: Toast.get_timestamp()

--- a/tests/toast/lib/toast/deployment/shutdown_pipeline.ex
+++ b/tests/toast/lib/toast/deployment/shutdown_pipeline.ex
@@ -87,25 +87,6 @@ defmodule Toast.Deployment.ShutdownPipeline do
     {killed_servers, %{state | expected_crashes: expected_crashes}}
   end
 
-  @spec handle_deploy_failure(State.t(), term()) :: State.t()
-  def handle_deploy_failure(state, reason) do
-    Logger.error("Deploy failed for #{state.id}: #{inspect(reason)}")
-    {killed_servers, state} = abort_all(state)
-
-    if reason == :timeout do
-      state.event_listener.on_event(%{
-        event: :timeout_kill,
-        deployment_id: state.id,
-        source: :startup,
-        reason: "Startup timeout — deployment did not become ready in time",
-        servers: killed_servers,
-        timestamp: Toast.get_timestamp()
-      })
-    end
-
-    rollback(state, reason)
-  end
-
   # --- Internal ---
 
   defp shutdown_servers(state, timeout) do

--- a/tests/toast/lib/toast/diagnostics/agency_dump.ex
+++ b/tests/toast/lib/toast/diagnostics/agency_dump.ex
@@ -60,6 +60,35 @@ defmodule Toast.Diagnostics.AgencyDump do
     end
   end
 
+  @doc """
+  Fetch agency state from the deployment and write it to `result_dir`.
+
+  Silently does nothing when the deployment is not a cluster or the agents
+  are unreachable.
+  """
+  @spec try_collect(Toast.Deployment.t(), Path.t()) :: :ok
+  def try_collect(deployment, result_dir) do
+    case Toast.Deployment.dump_agency(deployment) do
+      {:ok, json} when json != nil ->
+        case write(json, result_dir, deployment.id) do
+          {:ok, path} -> Logger.info("Agency dump written to #{path}")
+          {:error, reason} -> Logger.warning("Failed to write agency dump: #{inspect(reason)}")
+        end
+
+      {:ok, nil} ->
+        Logger.warning("Agency dump returned nil (no responsive agents?)")
+
+      {:error, reason} ->
+        Logger.debug("Agency dump skipped: #{inspect(reason)}")
+    end
+
+    :ok
+  rescue
+    e ->
+      Logger.warning("Agency dump failed: #{Exception.message(e)}")
+      :ok
+  end
+
   # 1 MB — below this we keep raw JSON for easy inspection
   @compress_threshold 1_024 * 1_024
 

--- a/tests/toast/lib/toast_test/analyze/issue_streams.ex
+++ b/tests/toast/lib/toast_test/analyze/issue_streams.ex
@@ -86,7 +86,7 @@ defmodule ToastTest.Analyze.IssueStreams do
 
   @display_padding %{
     crash: {-5_000, 0},
-    timeout: {-5_000, 0},
+    infrastructure: {-5_000, 0},
     test_failure: {-100, 100},
     sanitizer_report: {-100, 100}
   }

--- a/tests/toast/lib/toast_test/attribution.ex
+++ b/tests/toast/lib/toast_test/attribution.ex
@@ -237,10 +237,11 @@ defmodule ToastTest.Attribution do
         end)
 
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: :suite,
         confidence: :high,
         detail: %{
+          subtype: :timeout,
           source: kill.source,
           reason: kill.reason,
           timestamp: kill.timestamp,

--- a/tests/toast/lib/toast_test/attribution.ex
+++ b/tests/toast/lib/toast_test/attribution.ex
@@ -49,9 +49,9 @@ defmodule ToastTest.Attribution do
   def resolve_crash_timestamps(crash_events, artifacts) do
     Enum.map(crash_events, fn event ->
       server_artifacts = Map.get(artifacts, event.server_id)
-      {crash_entries, _log_file} = extract_crash_log(server_artifacts)
+      {error_entries, _log_file} = extract_server_errors(server_artifacts)
 
-      case crash_log_timestamp(crash_entries) do
+      case extract_crash_timestamp(error_entries) do
         nil -> event
         log_ts -> put_in(event.crash_info.timestamp, log_ts)
       end
@@ -111,10 +111,10 @@ defmodule ToastTest.Attribution do
     {issues, coredump_reports} =
       Enum.reduce(crash_events, {[], []}, fn event, {issues_acc, dumps_acc} ->
         server_artifacts = Map.get(artifacts, event.server_id)
-        {crash_entries, log_file} = extract_crash_log(server_artifacts)
+        {crash_entries, log_file} = extract_server_errors(server_artifacts)
 
         effective_timestamp =
-          crash_log_timestamp(crash_entries) || event.crash_info.timestamp
+          extract_crash_timestamp(crash_entries) || event.crash_info.timestamp
 
         {scope, confidence, phase} = TimeWindows.attribute(effective_timestamp, windows)
 
@@ -204,15 +204,19 @@ defmodule ToastTest.Attribution do
 
   # --- Crash log helpers ---
 
-  defp extract_crash_log(nil), do: {[], nil}
-  defp extract_crash_log(%{server: %{log_file: nil}}), do: {[], nil}
+  defp extract_server_errors(nil), do: {[], nil}
+  defp extract_server_errors(%{server: %{log_file: nil}}), do: {[], nil}
 
-  defp extract_crash_log(%{server: %{log_file: log_file}}) do
-    {Enrichment.Logs.extract_crash_lines(log_file), log_file}
+  defp extract_server_errors(%{server: %{log_file: log_file}}) do
+    {Enrichment.Logs.extract_trailing_errors(log_file), log_file}
   end
 
-  defp crash_log_timestamp([%{time: time} | _]), do: time
-  defp crash_log_timestamp(_), do: nil
+  defp extract_crash_timestamp(entries) do
+    case Enum.find(entries, &(&1[:topic] == :crash)) do
+      %{time: time} -> time
+      nil -> nil
+    end
+  end
 
   defp format_crash_entries([]), do: nil
 

--- a/tests/toast/lib/toast_test/attribution/server_logs.ex
+++ b/tests/toast/lib/toast_test/attribution/server_logs.ex
@@ -32,7 +32,7 @@ defmodule ToastTest.Attribution.ServerLogs do
 
   @padding %{
     crash: {-20_000, 0},
-    timeout: {-10_000, 0},
+    infrastructure: {-10_000, 0},
     test_failure: {-1_000, 1_000},
     sanitizer_report: {-5_000, 1_000}
   }
@@ -138,12 +138,14 @@ defmodule ToastTest.Attribution.ServerLogs do
 
   defp issue_window(%{type: :crash}, _windows), do: []
 
-  defp issue_window(%{type: :timeout, detail: %{timestamp: ts}}, _windows)
+  defp issue_window(
+         %{type: :infrastructure, detail: %{subtype: :timeout, timestamp: ts}},
+         _windows
+       )
        when is_integer(ts) do
-    [pad(ts, ts, :timeout)]
+    [pad(ts, ts, :infrastructure)]
   end
 
-  defp issue_window(%{type: :timeout}, _windows), do: []
   defp issue_window(_issue, _windows), do: []
 
   defp pad(start_us, end_us, type), do: TimeWindows.pad(start_us, end_us, type, @padding)

--- a/tests/toast/lib/toast_test/diagnostics_summary.ex
+++ b/tests/toast/lib/toast_test/diagnostics_summary.ex
@@ -26,10 +26,6 @@ defmodule ToastTest.DiagnosticsSummary do
   @spec has_server_crash?([map()]) :: boolean()
   def has_server_crash?(suites), do: has_issue_type?(suites, :crash)
 
-  @doc "Check whether any suite has timeout issues (e.g., startup/shutdown timeout)."
-  @spec has_timeout?([map()]) :: boolean()
-  def has_timeout?(suites), do: has_issue_type?(suites, :timeout)
-
   @doc "Check whether any suite has sanitizer error issues."
   @spec has_sanitizer_errors?([map()]) :: boolean()
   def has_sanitizer_errors?(suites), do: has_issue_type?(suites, :sanitizer_report)

--- a/tests/toast/lib/toast_test/enrichment/logs.ex
+++ b/tests/toast/lib/toast_test/enrichment/logs.ex
@@ -94,34 +94,25 @@ defmodule ToastTest.Enrichment.Logs do
   # untrusted external input, so atom table exhaustion is not a concern.
   defp maybe_put_atom(entry, key, value), do: Map.put(entry, key, String.to_atom(value))
 
-  @doc """
-  Return the timestamp (Unix microseconds) of the first crash log entry,
-  or `nil` if the log file has no crash block at its end.
-  """
-  @spec extract_crash_timestamp(Path.t()) :: Toast.timestamp() | nil
-  def extract_crash_timestamp(path) do
-    case extract_crash_lines(path) do
-      [%{time: time} | _] -> time
-      [] -> nil
-    end
-  end
+  @max_trailing_errors 100
 
   @doc """
-  Return the last contiguous block of crash-topic log entries.
+  Return the trailing contiguous block of error/fatal log entries.
 
-  Reads the file backwards to efficiently find the most recent crash output.
-  Only returns entries when the crash block is at the very end of the log
-  (the crash handler writes these as the last thing before the process dies).
+  Reads the file backwards to efficiently find entries at the end. Collects
+  all consecutive error/fatal entries working backwards from EOF, stopping
+  at the first non-error/fatal entry or after #{@max_trailing_errors} entries.
+  Returns entries in chronological order.
 
-  Returns `[]` if the file does not exist or contains no crash entries at the end.
+  Returns `[]` if the file does not exist or has no error/fatal entries at the end.
   """
-  @spec extract_crash_lines(Path.t()) :: [map()]
-  def extract_crash_lines(path) do
+  @spec extract_trailing_errors(Path.t()) :: [map()]
+  def extract_trailing_errors(path) do
     case File.open(path, [:read, :binary]) do
       {:ok, device} ->
         try do
           {:ok, file_size} = :file.position(device, :eof)
-          read_crash_entries_backwards(device, file_size)
+          read_trailing_block(device, file_size)
         after
           File.close(device)
         end
@@ -131,14 +122,14 @@ defmodule ToastTest.Enrichment.Logs do
     end
   end
 
-  defp read_crash_entries_backwards(_device, 0), do: []
+  defp read_trailing_block(_device, 0), do: []
 
-  defp read_crash_entries_backwards(device, file_size) do
+  defp read_trailing_block(device, file_size) do
     scan_backwards(device, file_size, "", [])
   end
 
   defp scan_backwards(_device, 0, leftover, acc) do
-    finalize_crash_block(leftover, acc)
+    finalize_block(leftover, acc)
   end
 
   defp scan_backwards(device, pos, leftover, acc) do
@@ -164,42 +155,37 @@ defmodule ToastTest.Enrichment.Logs do
       line == "" ->
         process_lines_reverse(rest, [])
 
-      crash_entry?(line) ->
-        case parse_line(line) do
-          {:ok, entry} -> process_lines_reverse(rest, [entry])
-          :error -> {:done, []}
-        end
-
       true ->
-        {:done, []}
+        case parse_and_check_level(line) do
+          {:ok, entry} -> process_lines_reverse(rest, [entry])
+          _ -> {:done, []}
+        end
     end
+  end
+
+  defp process_lines_reverse([_line | _rest], acc) when length(acc) >= @max_trailing_errors do
+    {:done, acc}
   end
 
   defp process_lines_reverse([line | rest], acc) do
-    if crash_entry?(line) do
-      case parse_line(line) do
-        {:ok, entry} -> process_lines_reverse(rest, [entry | acc])
-        :error -> {:done, acc}
-      end
-    else
-      {:done, acc}
+    case parse_and_check_level(line) do
+      {:ok, entry} -> process_lines_reverse(rest, [entry | acc])
+      _ -> {:done, acc}
     end
   end
 
-  defp finalize_crash_block(leftover, acc) do
-    if crash_entry?(leftover) do
-      case parse_line(leftover) do
-        {:ok, entry} -> [entry | acc]
-        :error -> acc
-      end
-    else
-      acc
+  defp finalize_block(leftover, acc) do
+    case parse_and_check_level(leftover) do
+      {:ok, entry} -> [entry | acc]
+      _ -> acc
     end
   end
 
-  defp crash_entry?(line) do
-    # Quick string check before attempting JSON parse
-    String.contains?(line, "\"crash\"")
+  defp parse_and_check_level(line) do
+    case parse_line(line) do
+      {:ok, %{level: level} = entry} when level in [:error, :fatal] -> {:ok, entry}
+      _ -> :skip
+    end
   end
 
   @doc """

--- a/tests/toast/lib/toast_test/enrichment/logs.ex
+++ b/tests/toast/lib/toast_test/enrichment/logs.ex
@@ -125,14 +125,14 @@ defmodule ToastTest.Enrichment.Logs do
   defp read_trailing_block(_device, 0), do: []
 
   defp read_trailing_block(device, file_size) do
-    scan_backwards(device, file_size, "", [])
+    scan_backwards(device, file_size, "", [], 0)
   end
 
-  defp scan_backwards(_device, 0, leftover, acc) do
-    finalize_block(leftover, acc)
+  defp scan_backwards(_device, 0, leftover, acc, count) do
+    finalize_block(leftover, acc, count)
   end
 
-  defp scan_backwards(device, pos, leftover, acc) do
+  defp scan_backwards(device, pos, leftover, acc, count) do
     read_start = max(pos - @chunk_size, 0)
     bytes_to_read = pos - read_start
 
@@ -142,39 +142,42 @@ defmodule ToastTest.Enrichment.Logs do
     data = chunk <> leftover
     [new_leftover | lines] = String.split(data, "\n")
 
-    case process_lines_reverse(Enum.reverse(lines), acc) do
-      {:done, result} -> result
-      {:continue, new_acc} -> scan_backwards(device, read_start, new_leftover, new_acc)
+    case process_lines_reverse(Enum.reverse(lines), acc, count) do
+      {:done, result} ->
+        result
+
+      {:continue, new_acc, new_count} ->
+        scan_backwards(device, read_start, new_leftover, new_acc, new_count)
     end
   end
 
-  defp process_lines_reverse([], acc), do: {:continue, acc}
+  defp process_lines_reverse([], acc, count), do: {:continue, acc, count}
 
-  defp process_lines_reverse([line | rest], []) do
-    cond do
-      line == "" ->
-        process_lines_reverse(rest, [])
-
-      true ->
-        case parse_and_check_level(line) do
-          {:ok, entry} -> process_lines_reverse(rest, [entry])
-          _ -> {:done, []}
-        end
+  defp process_lines_reverse([line | rest], [], 0) do
+    if line == "" do
+      process_lines_reverse(rest, [], 0)
+    else
+      case parse_and_check_level(line) do
+        {:ok, entry} -> process_lines_reverse(rest, [entry], 1)
+        _ -> {:done, []}
+      end
     end
   end
 
-  defp process_lines_reverse([_line | _rest], acc) when length(acc) >= @max_trailing_errors do
+  defp process_lines_reverse(_lines, acc, count) when count >= @max_trailing_errors do
     {:done, acc}
   end
 
-  defp process_lines_reverse([line | rest], acc) do
+  defp process_lines_reverse([line | rest], acc, count) do
     case parse_and_check_level(line) do
-      {:ok, entry} -> process_lines_reverse(rest, [entry | acc])
+      {:ok, entry} -> process_lines_reverse(rest, [entry | acc], count + 1)
       _ -> {:done, acc}
     end
   end
 
-  defp finalize_block(leftover, acc) do
+  defp finalize_block(_leftover, acc, count) when count >= @max_trailing_errors, do: acc
+
+  defp finalize_block(leftover, acc, _count) do
     case parse_and_check_level(leftover) do
       {:ok, entry} -> [entry | acc]
       _ -> acc

--- a/tests/toast/lib/toast_test/formatting/color.ex
+++ b/tests/toast/lib/toast_test/formatting/color.ex
@@ -24,7 +24,6 @@ defmodule ToastTest.Formatting.Color do
 
   @doc "256-color codes for section header backgrounds."
   def failure, do: 1
-  def timeout, do: 1
   def crash, do: 160
   def sanitizer, do: 214
   def warning, do: 3

--- a/tests/toast/lib/toast_test/formatting/issues.ex
+++ b/tests/toast/lib/toast_test/formatting/issues.ex
@@ -147,10 +147,10 @@ defmodule ToastTest.Formatting.Issues do
 
   def attach_test_location(issue, _modules), do: issue
 
-  def timeout_source_label(:startup_timeout), do: "Startup Timeout"
-  def timeout_source_label(:shutdown_timeout), do: "Shutdown Timeout"
-  def timeout_source_label(:test_timeout), do: "Test Timeout"
-  def timeout_source_label(:global_timeout), do: "Global Timeout"
+  def timeout_source_label(:startup), do: "Startup Timeout"
+  def timeout_source_label(:shutdown), do: "Shutdown Timeout"
+  def timeout_source_label(:suite), do: "Suite Timeout"
+  def timeout_source_label(:global), do: "Global Timeout"
   def timeout_source_label(other), do: "Timeout: #{other}"
 
   def truncate(nil, _max), do: nil

--- a/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
+++ b/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
@@ -188,6 +188,12 @@ defmodule ToastTest.Formatting.PostExecSummary do
     counter + 1
   end
 
+  defp print_issue(:infrastructure, %{detail: %{subtype: subtype} = detail}, counter, colors) do
+    label = subtype |> to_string() |> String.replace("_", " ")
+    IO.puts("\n  #{colorize("[#{label}] #{inspect(detail)}", :red, colors)}")
+    counter + 1
+  end
+
   defp print_server_detail(server, colors) do
     pid_part = if server.os_pid, do: " (PID #{server.os_pid})", else: ""
     IO.puts("    #{colorize("#{server.server_id}#{pid_part}", :cyan, colors)}")

--- a/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
+++ b/tests/toast/lib/toast_test/formatting/post_exec_summary.ex
@@ -27,7 +27,7 @@ defmodule ToastTest.Formatting.PostExecSummary do
   alias ToastTest.Formatting.{Color, Issues, Utils}
   alias ToastTest.SuiteResult
 
-  @issue_types_by_severity [:test_failure, :sanitizer_report, :crash, :timeout, :infrastructure]
+  @issue_types_by_severity [:test_failure, :sanitizer_report, :crash, :infrastructure]
 
   @spec print(SuiteResult.t()) :: :ok
   def print(%SuiteResult{issues: issues, warnings: warnings} = result) do
@@ -100,7 +100,6 @@ defmodule ToastTest.Formatting.PostExecSummary do
 
   defp section_header(:test_failure, count), do: {"TEST FAILURES (#{count})", Color.failure()}
   defp section_header(:crash, count), do: {"CRASHES (#{count})", Color.crash()}
-  defp section_header(:timeout, count), do: {"TIMEOUTS (#{count})", Color.timeout()}
 
   defp section_header(:sanitizer_report, count),
     do: {"SANITIZER REPORTS (#{count})", Color.sanitizer()}
@@ -138,8 +137,12 @@ defmodule ToastTest.Formatting.PostExecSummary do
     counter + 1
   end
 
-  defp print_issue(:timeout, issue, counter, colors) do
-    %{detail: %{source: source, reason: reason, servers: servers}} = issue
+  defp print_issue(
+         :infrastructure,
+         %{detail: %{subtype: :timeout, source: source, reason: reason, servers: servers}},
+         counter,
+         colors
+       ) do
     label = Issues.timeout_source_label(source)
     IO.puts("\n  #{colorize("[#{label}] #{reason}", :red, colors)}")
 
@@ -152,25 +155,24 @@ defmodule ToastTest.Formatting.PostExecSummary do
     counter + 1
   end
 
-  defp print_issue(:infrastructure, issue, counter, colors) do
-    %{
-      detail:
-        %{subtype: subtype, total: total, threshold: threshold, by_server: by_server} = detail
-    } =
-      issue
-
-    label = subtype |> Atom.to_string() |> String.replace("_", " ")
+  defp print_issue(
+         :infrastructure,
+         %{detail: %{subtype: :port_exhaustion, total: total} = detail},
+         counter,
+         colors
+       ) do
+    label = "port exhaustion"
     kind = if detail[:kind] == :deployment, do: "deployment", else: "system"
 
     delta_info =
       if detail[:kind] == :deployment,
-        do: "(#{detail.deployment_delta} since deployment; threshold: #{threshold}))",
-        else: "(threshold: #{threshold})"
+        do: "(#{detail.deployment_delta} since deployment; threshold: #{detail.threshold}))",
+        else: "(threshold: #{detail.threshold})"
 
     IO.puts("\n  #{colorize("[#{label}] #{total} #{kind} sockets #{delta_info}", :red, colors)}")
 
     server_total =
-      by_server
+      detail.by_server
       |> Enum.sort_by(fn {_, v} -> -v.sockets.total end)
       |> Enum.reduce(0, fn {server_id, server}, acc ->
         IO.puts("    #{colorize(server_id, :cyan, colors)}  #{server.sockets.total}")

--- a/tests/toast/lib/toast_test/formatting/utils.ex
+++ b/tests/toast/lib/toast_test/formatting/utils.ex
@@ -28,6 +28,7 @@ defmodule ToastTest.Formatting.Utils do
       IO.ANSI.bright(),
       "\n  ",
       String.replace(label, "\n", "\e[K\n"),
+      "\e[K",
       :reset,
       "\n"
     ])

--- a/tests/toast/lib/toast_test/runner.ex
+++ b/tests/toast/lib/toast_test/runner.ex
@@ -525,9 +525,42 @@ defmodule ToastTest.Runner do
 
   defp finalize_suite(deployment, stats, test_data, test_config, capture_pid) do
     pcap_path = stop_traffic_capture(capture_pid)
-    suite_result = __MODULE__.PostExecution.run(deployment, test_data, test_config, pcap_path)
+
+    servers = stop_and_collect_servers(deployment, test_data, test_config)
+
+    suite_result =
+      __MODULE__.PostExecution.run(servers, test_data, test_config, pcap_path)
+
     ToastTest.StateCleanup.reset()
     %{stats: stats, suite_result: suite_result}
+  end
+
+  defp stop_and_collect_servers(nil, _test_data, _test_config), do: %{}
+
+  defp stop_and_collect_servers(deployment, test_data, test_config) do
+    maybe_dump_agency(deployment, test_data, test_config)
+
+    Logger.debug("Stopping deployment")
+
+    {servers, error} =
+      case Toast.Deployment.stop(deployment) do
+        {:ok, info} -> {info.servers, info.error}
+        {:error, _reason, info} -> {info.servers, info.error}
+      end
+
+    if error, do: Logger.warning("Deployment stop error: #{inspect(error)}")
+    servers
+  end
+
+  defp maybe_dump_agency(deployment, test_data, test_config) do
+    has_error =
+      Abort.reason() != nil or
+        ToastTest.EventStore.unexpected_crashes() != [] or
+        test_data.failures != []
+
+    if has_error and test_config.dump_agency_on_error do
+      Toast.Diagnostics.AgencyDump.try_collect(deployment, test_config.result_dir)
+    end
   end
 
   defp maybe_start_traffic_capture(%{capture_traffic: true} = test_config, suite_name) do

--- a/tests/toast/lib/toast_test/runner.ex
+++ b/tests/toast/lib/toast_test/runner.ex
@@ -414,7 +414,7 @@ defmodule ToastTest.Runner do
         id = Toast.Deployment.generate_id(mode)
         deployment_dir = Path.join([test_config.base_dir, entry.name, id])
 
-        case Toast.Deployment.start(deploy_config, deployment_dir,
+        case Toast.Deployment.attempt_start(deploy_config, deployment_dir,
                id: id,
                event_listener: ToastTest.ManagedDeploymentListener
              ) do
@@ -429,8 +429,8 @@ defmodule ToastTest.Runner do
               {netstat_tool, baseline}
             )
 
-          {:error, reason} ->
-            handle_deployment_failure(suite_run, entry, reason, ex_unit_opts)
+          {:error, reason, deployment} ->
+            handle_deployment_failure(deployment, suite_run, entry, reason, ex_unit_opts)
         end
     end
   end
@@ -501,13 +501,34 @@ defmodule ToastTest.Runner do
     finalize_suite(nil, stats, test_data, suite_run.test_config, nil)
   end
 
-  defp handle_deployment_failure(suite_run, %SuiteEntry{} = entry, reason, ex_unit_opts) do
+  defp handle_deployment_failure(
+         deployment,
+         suite_run,
+         %SuiteEntry{} = entry,
+         reason,
+         ex_unit_opts
+       ) do
     suite_module = suite_run.suite_module
     test_config = suite_run.test_config
     mode = suite_run.deployment_mode
 
     Logger.error("Deployment failed for suite #{inspect(suite_module)}: #{inspect(reason)}")
     Abort.abort!({:deploy_failed, "Deployment failed: #{inspect(reason)}"})
+
+    if reason == :timeout do
+      servers =
+        Enum.map(deployment.servers, fn {id, server} ->
+          %{server_id: id, os_pid: nil, log_file: server.log_file}
+        end)
+
+      ToastTest.EventStore.notify(%{
+        event: :timeout_kill,
+        deployment_id: deployment.id,
+        source: :startup,
+        reason: "Startup timeout — deployment did not become ready in time",
+        servers: servers
+      })
+    end
 
     {stats, test_data} =
       mark_all_with_state(
@@ -520,7 +541,7 @@ defmodule ToastTest.Runner do
         mode
       )
 
-    finalize_suite(nil, stats, test_data, test_config, nil)
+    finalize_suite(deployment, stats, test_data, test_config, nil)
   end
 
   defp finalize_suite(deployment, stats, test_data, test_config, capture_pid) do

--- a/tests/toast/lib/toast_test/runner.ex
+++ b/tests/toast/lib/toast_test/runner.ex
@@ -431,6 +431,9 @@ defmodule ToastTest.Runner do
 
           {:error, reason, deployment} ->
             handle_deployment_failure(deployment, suite_run, entry, reason, ex_unit_opts)
+
+          {:error, reason} ->
+            handle_deployment_failure(nil, suite_run, entry, reason, ex_unit_opts)
         end
     end
   end
@@ -514,21 +517,6 @@ defmodule ToastTest.Runner do
 
     Logger.error("Deployment failed for suite #{inspect(suite_module)}: #{inspect(reason)}")
     Abort.abort!({:deploy_failed, "Deployment failed: #{inspect(reason)}"})
-
-    if reason == :timeout do
-      servers =
-        Enum.map(deployment.servers, fn {id, server} ->
-          %{server_id: id, os_pid: nil, log_file: server.log_file}
-        end)
-
-      ToastTest.EventStore.notify(%{
-        event: :timeout_kill,
-        deployment_id: deployment.id,
-        source: :startup,
-        reason: "Startup timeout — deployment did not become ready in time",
-        servers: servers
-      })
-    end
 
     {stats, test_data} =
       mark_all_with_state(

--- a/tests/toast/lib/toast_test/runner/post_execution.ex
+++ b/tests/toast/lib/toast_test/runner/post_execution.ex
@@ -31,38 +31,16 @@ defmodule ToastTest.Runner.PostExecution do
   @doc """
   Builds a `SuiteResult` after test execution completes.
 
-  For manual-mode suites (no deployment), only processes events from the event
-  store (crashes, timeout kills) and runs attribution.
+  Analyses the EventStore data (crashes, timeout kills, infrastructure issues),
+  collects artifacts from `servers` (coredumps, sanitizer files), gathers server
+  logs, and writes results to disk.
 
-  For deployed suites, additionally stops the deployment, collects artifacts
-  (coredumps, server logs), and performs full post-mortem analysis.
+  The caller is responsible for stopping the deployment and passing the resulting
+  server map. An empty map is valid (manual mode, excluded suites, failed
+  deployments) — the analysis still runs using EventStore data.
   """
-  @spec run(Toast.Deployment.t() | nil, map(), ToastTest.Config.t(), Path.t() | nil) ::
-          SuiteResult.t()
-  def run(deployment, test_data, test_config, pcap_path \\ nil)
-
-  # Manual mode — no deployment was started, so only process event store data.
-  def run(nil, test_data, _test_config, _pcap_path) do
-    snapshot = EventStore.snapshot()
-
-    crash_events = Enum.map(snapshot.unexpected_crashes, &ResultBuilder.to_crash_event/1)
-    test_data = ToastTest.Attribution.Invalidation.apply(test_data, crash_events)
-
-    {issues, _coredump_reports} =
-      ToastTest.Attribution.run(test_data, %{}, crash_events,
-        timeout_kills: snapshot.timeout_kills
-      )
-
-    SuiteResult.build(test_data, issues, events: snapshot.events)
-  end
-
-  def run(deployment, test_data, %ToastTest.Config{} = test_config, pcap_path) do
-    maybe_dump_agency(deployment, test_data, test_config)
-
-    Logger.debug("Post-execution: stopping deployment")
-    {servers, error} = stop_deployment(deployment)
-    if error, do: Logger.warning("Deployment stop error: #{inspect(error)}")
-
+  @spec run(map(), map(), ToastTest.Config.t(), Path.t() | nil) :: SuiteResult.t()
+  def run(servers, test_data, %ToastTest.Config{} = test_config, pcap_path \\ nil) do
     try do
       build_suite_result(servers, test_data, test_config, pcap_path)
     rescue
@@ -75,13 +53,6 @@ defmodule ToastTest.Runner.PostExecution do
         SuiteResult.build(test_data, [],
           warnings: ["Post-execution analysis failed: #{Exception.message(e)}"]
         )
-    end
-  end
-
-  defp stop_deployment(deployment) do
-    case Toast.Deployment.stop(deployment) do
-      {:ok, info} -> {info.servers, info.error}
-      {:error, _reason, info} -> {info.servers, info.error}
     end
   end
 
@@ -172,39 +143,6 @@ defmodule ToastTest.Runner.PostExecution do
     case Toast.Diagnostics.Coredump.resolve_debugger(test_config.debugger) do
       nil -> opts
       debugger -> [{:debugger, debugger} | opts]
-    end
-  end
-
-  defp maybe_dump_agency(deployment, test_data, test_config) do
-    has_error =
-      ToastTest.Abort.reason() != nil or
-        EventStore.unexpected_crashes() != [] or
-        test_data.failures != []
-
-    if has_error and test_config.dump_agency_on_error do
-      case Toast.Deployment.dump_agency(deployment) do
-        {:ok, json} when json != nil ->
-          write_agency_dump(json, test_config.result_dir, deployment.id)
-
-        {:ok, nil} ->
-          Logger.warning("Agency dump returned nil (no responsive agents?)")
-
-        {:error, reason} ->
-          Logger.debug("Agency dump skipped: #{inspect(reason)}")
-      end
-    end
-  rescue
-    e ->
-      Logger.warning("Agency dump failed: #{Exception.message(e)}")
-  end
-
-  defp write_agency_dump(json, result_dir, deployment_id) do
-    case Toast.Diagnostics.AgencyDump.write(json, result_dir, deployment_id) do
-      {:ok, path} ->
-        Logger.info("Agency dump written to #{path}")
-
-      {:error, reason} ->
-        Logger.warning("Failed to write agency dump: #{inspect(reason)}")
     end
   end
 

--- a/tests/toast/lib/toast_test/runner/timeout.ex
+++ b/tests/toast/lib/toast_test/runner/timeout.ex
@@ -94,7 +94,7 @@ defmodule ToastTest.Runner.Timeout do
 
   def check_suite_deadline!(%{timeout_settings: %{suite_deadline: deadline}}) do
     if System.monotonic_time(:millisecond) >= deadline do
-      abort_with_timeout(:test_timeout, "Suite timeout exceeded")
+      abort_with_timeout(:suite, "Suite timeout exceeded")
     end
   end
 
@@ -102,7 +102,7 @@ defmodule ToastTest.Runner.Timeout do
 
   def check_global_deadline!(deadline) do
     if System.monotonic_time(:millisecond) >= deadline do
-      abort_with_timeout(:global_timeout, "Global execution timeout exceeded")
+      abort_with_timeout(:global, "Global execution timeout exceeded")
     end
   end
 

--- a/tests/toast/lib/toast_test/runner/timeout.ex
+++ b/tests/toast/lib/toast_test/runner/timeout.ex
@@ -131,8 +131,10 @@ defmodule ToastTest.Runner.Timeout do
   defp resolve_source(timeout), do: {timeout, :test}
 
   defp abort_with_timeout(source, reason) do
-    Logger.warning("#{reason} — aborting suite")
-    EventStore.notify(%{event: :timeout_kill, source: source, reason: reason, servers: []})
-    Abort.abort!({:timeout, reason})
+    if is_nil(Abort.reason()) do
+      Logger.warning("#{reason} — aborting suite")
+      EventStore.notify(%{event: :timeout_kill, source: source, reason: reason, servers: []})
+      Abort.abort!({:timeout, reason})
+    end
   end
 end

--- a/tests/toast/lib/toast_test/suite_result.ex
+++ b/tests/toast/lib/toast_test/suite_result.ex
@@ -113,7 +113,7 @@ defmodule ToastTest.SuiteResult do
   @type scope :: :suite | {:module, module()} | {:test, module(), atom()}
 
   @type issue :: %{
-          type: :test_failure | :crash | :sanitizer_report | :timeout | :infrastructure,
+          type: :test_failure | :crash | :sanitizer_report | :infrastructure,
           scope: scope(),
           confidence: :high | :low | nil,
           detail: map()

--- a/tests/toast/lib/toast_test/suite_result/junit_xml.ex
+++ b/tests/toast/lib/toast_test/suite_result/junit_xml.ex
@@ -195,7 +195,6 @@ defmodule ToastTest.SuiteResult.JUnitXML do
     do: "sanitizer report: #{kind}"
 
   defp issue_type_label(%{type: :sanitizer_report}), do: "sanitizer report"
-  defp issue_type_label(%{type: :timeout}), do: "timeout"
 
   defp issue_type_label(%{type: :infrastructure, detail: %{subtype: subtype}}),
     do: "infrastructure: #{subtype}"
@@ -348,7 +347,7 @@ defmodule ToastTest.SuiteResult.JUnitXML do
   defp render_issue_detail(%{type: :crash} = issue),
     do: Issues.format_crash(issue)
 
-  defp render_issue_detail(%{type: :timeout} = issue),
+  defp render_issue_detail(%{type: :infrastructure, detail: %{subtype: :timeout}} = issue),
     do: Issues.format_timeout(issue)
 
   defp render_issue_detail(_), do: nil

--- a/tests/toast/test/mix/tasks/toast/analyze/data_test.exs
+++ b/tests/toast/test/mix/tasks/toast/analyze/data_test.exs
@@ -30,7 +30,9 @@ defmodule Mix.Tasks.Toast.Analyze.DataTest do
     test "returns bare type string" do
       assert Data.format_type(%{type: :crash, detail: %{server: "dbserver1"}}) == "crash"
       assert Data.format_type(%{type: :test_failure, detail: %{}}) == "test_failure"
-      assert Data.format_type(%{type: :timeout, detail: %{}}) == "timeout"
+
+      assert Data.format_type(%{type: :infrastructure, detail: %{subtype: :timeout}}) ==
+               "infrastructure (timeout)"
     end
 
     test "infrastructure includes subtype" do
@@ -52,19 +54,21 @@ defmodule Mix.Tasks.Toast.Analyze.DataTest do
       assert Data.format_server(issue) == "coordinator1"
     end
 
-    test "timeout issue with single server returns server_id" do
+    test "infrastructure timeout issue with single server returns server_id" do
       issue = %{
-        type: :timeout,
-        detail: %{servers: [%{server_id: "dbserver1"}]}
+        type: :infrastructure,
+        detail: %{subtype: :timeout, source: :startup, servers: [%{server_id: "dbserver1"}]}
       }
 
       assert Data.format_server(issue) == "dbserver1"
     end
 
-    test "timeout issue with multiple servers joins server_ids with comma" do
+    test "infrastructure timeout issue with multiple servers joins server_ids with comma" do
       issue = %{
-        type: :timeout,
+        type: :infrastructure,
         detail: %{
+          subtype: :timeout,
+          source: :startup,
           servers: [
             %{server_id: "coordinator1"},
             %{server_id: "dbserver1"},
@@ -76,10 +80,14 @@ defmodule Mix.Tasks.Toast.Analyze.DataTest do
       assert Data.format_server(issue) == "coordinator1, dbserver1, dbserver2"
     end
 
-    test "timeout issue with empty servers list returns empty string" do
-      # The timeout clause matches on `is_list(servers)` regardless of length,
+    test "infrastructure timeout issue with empty servers list returns empty string" do
+      # The infrastructure clause matches on `is_list(servers)` regardless of length,
       # so Enum.map_join/3 of [] returns "". The em-dash fallback is not reached.
-      issue = %{type: :timeout, detail: %{servers: []}}
+      issue = %{
+        type: :infrastructure,
+        detail: %{subtype: :timeout, source: :startup, servers: []}
+      }
+
       assert Data.format_server(issue) == ""
     end
 
@@ -228,23 +236,29 @@ defmodule Mix.Tasks.Toast.Analyze.DataTest do
     end
   end
 
-  describe "attach_time_bounds via collect_issues/2 — timeout clause" do
-    test "timeout with integer timestamp sets time_bounds to point interval {ts, ts}" do
+  describe "attach_time_bounds via collect_issues/2 — infrastructure timeout clause" do
+    test "infrastructure timeout with integer timestamp sets time_bounds to point interval {ts, ts}" do
       ts = 1_700_000_000_000_000
 
       issue = %{
-        type: :timeout,
-        detail: %{timestamp: ts, source: :test_timeout, reason: "timed out", servers: []}
+        type: :infrastructure,
+        detail: %{
+          timestamp: ts,
+          subtype: :timeout,
+          source: :suite,
+          reason: "timed out",
+          servers: []
+        }
       }
 
       [result] = Data.collect_issues([minimal_result([issue])], [])
       assert result.time_bounds == {ts, ts}
     end
 
-    test "timeout without timestamp falls through to nil clause" do
+    test "infrastructure timeout without timestamp falls through to nil clause" do
       issue = %{
-        type: :timeout,
-        detail: %{source: :test_timeout, reason: "timed out", servers: []}
+        type: :infrastructure,
+        detail: %{subtype: :timeout, source: :suite, reason: "timed out", servers: []}
       }
 
       [result] = Data.collect_issues([minimal_result([issue])], [])

--- a/tests/toast/test/toast_test/attribution/server_logs_test.exs
+++ b/tests/toast/test/toast_test/attribution/server_logs_test.exs
@@ -157,10 +157,20 @@ defmodule ToastTest.Attribution.ServerLogsTest do
     end
   end
 
-  describe "compute_windows/2 — timeout" do
+  describe "compute_windows/2 — infrastructure timeout" do
     test "pads timeout timestamp by [-10s, 0s]" do
       ts = us("10:05:00")
-      issue = %{type: :timeout, detail: %{timestamp: ts}}
+
+      issue = %{
+        type: :infrastructure,
+        detail: %{
+          subtype: :timeout,
+          source: :startup,
+          reason: "timeout",
+          servers: [],
+          timestamp: ts
+        }
+      }
 
       [{start, finish}] = ServerLogs.compute_windows([issue], windows())
 
@@ -169,13 +179,16 @@ defmodule ToastTest.Attribution.ServerLogsTest do
     end
 
     test "produces no window when detail lacks timestamp" do
-      issue = %{type: :timeout, detail: %{}}
+      issue = %{type: :infrastructure, detail: %{subtype: :timeout, source: :startup}}
 
       assert ServerLogs.compute_windows([issue], windows()) == []
     end
 
     test "produces no window when timestamp is nil" do
-      issue = %{type: :timeout, detail: %{timestamp: nil}}
+      issue = %{
+        type: :infrastructure,
+        detail: %{subtype: :timeout, source: :startup, timestamp: nil}
+      }
 
       assert ServerLogs.compute_windows([issue], windows()) == []
     end
@@ -196,7 +209,16 @@ defmodule ToastTest.Attribution.ServerLogsTest do
 
       issues = [
         %{type: :crash, detail: %{crash_info: %{timestamp: crash_ts}}},
-        %{type: :timeout, detail: %{timestamp: timeout_ts}},
+        %{
+          type: :infrastructure,
+          detail: %{
+            subtype: :timeout,
+            source: :startup,
+            reason: "timeout",
+            servers: [],
+            timestamp: timeout_ts
+          }
+        },
         %{type: :crash, detail: %{}}
       ]
 
@@ -368,7 +390,19 @@ defmodule ToastTest.Attribution.ServerLogsTest do
       log_path = write_log(dir, "agent.log", lines)
       log_files = make_log_files([{"agent1", log_path}])
 
-      issues = [%{type: :timeout, detail: %{timestamp: us("10:05:00")}}]
+      issues = [
+        %{
+          type: :infrastructure,
+          detail: %{
+            subtype: :timeout,
+            source: :startup,
+            reason: "timeout",
+            servers: [],
+            timestamp: us("10:05:00")
+          }
+        }
+      ]
+
       result = ServerLogs.collect(issues, log_files, windows())
 
       assert result["agent1"] == []
@@ -414,7 +448,16 @@ defmodule ToastTest.Attribution.ServerLogsTest do
       crash_ts = us("10:05:00")
 
       issues = [
-        %{type: :timeout, detail: %{timestamp: us("10:03:00")}},
+        %{
+          type: :infrastructure,
+          detail: %{
+            subtype: :timeout,
+            source: :startup,
+            reason: "timeout",
+            servers: [],
+            timestamp: us("10:03:00")
+          }
+        },
         %{type: :crash, detail: %{crash_info: %{timestamp: crash_ts}}}
       ]
 

--- a/tests/toast/test/toast_test/attribution_test.exs
+++ b/tests/toast/test/toast_test/attribution_test.exs
@@ -579,9 +579,9 @@ defmodule ToastTest.AttributionTest do
       assert coredumps == []
     end
 
-    test "timeout kill becomes a :timeout issue with suite scope" do
+    test "timeout kill becomes an :infrastructure issue with suite scope" do
       kill = %{
-        source: :suite_timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         servers: [%{server_id: "single1", os_pid: 1001, log_file: "/tmp/single1.log"}],
         timestamp: ~U[2026-03-09 10:05:00Z]
@@ -591,10 +591,11 @@ defmodule ToastTest.AttributionTest do
         Attribution.run(build_test_data(), empty_artifacts(), [], timeout_kills: [kill])
 
       assert [issue] = issues
-      assert issue.type == :timeout
+      assert issue.type == :infrastructure
       assert issue.scope == :suite
       assert issue.confidence == :high
-      assert issue.detail.source == :suite_timeout
+      assert issue.detail.subtype == :timeout
+      assert issue.detail.source == :suite
       assert issue.detail.reason == "Suite timeout exceeded"
       assert issue.detail.timestamp == ~U[2026-03-09 10:05:00Z]
     end
@@ -611,7 +612,7 @@ defmodule ToastTest.AttributionTest do
       }
 
       kill = %{
-        source: :suite_timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         servers: [%{server_id: "single1", os_pid: 1001, log_file: "/tmp/single1.log"}],
         timestamp: ~U[2026-03-09 10:05:00Z]
@@ -628,7 +629,7 @@ defmodule ToastTest.AttributionTest do
 
     test "timeout server without artifacts gets nil coredump" do
       kill = %{
-        source: :suite_timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         servers: [%{server_id: "single1", os_pid: 1001, log_file: "/tmp/single1.log"}],
         timestamp: ~U[2026-03-09 10:05:00Z]
@@ -660,7 +661,7 @@ defmodule ToastTest.AttributionTest do
       }
 
       kill = %{
-        source: :suite_timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         servers: [
           %{server_id: "agent1", os_pid: 2001, log_file: "/tmp/agent1.log"},

--- a/tests/toast/test/toast_test/enrichment/logs_test.exs
+++ b/tests/toast/test/toast_test/enrichment/logs_test.exs
@@ -142,8 +142,8 @@ defmodule ToastTest.Enrichment.LogsTest do
     end
   end
 
-  describe "extract_crash_lines/1" do
-    test "returns last contiguous block of crash-topic entries", %{tmp_dir: dir} do
+  describe "extract_trailing_errors/1" do
+    test "returns trailing contiguous block of error/fatal entries", %{tmp_dir: dir} do
       path =
         write_log(dir, [
           log_json("2026-03-11T15:22:17Z",
@@ -166,7 +166,7 @@ defmodule ToastTest.Enrichment.LogsTest do
           )
         ])
 
-      result = Logs.extract_crash_lines(path)
+      result = Logs.extract_trailing_errors(path)
 
       assert length(result) == 2
       assert Enum.any?(result, &(&1.message == "caught signal 11"))
@@ -174,7 +174,7 @@ defmodule ToastTest.Enrichment.LogsTest do
       refute Enum.any?(result, &(&1.message =~ "starting up"))
     end
 
-    test "returns empty when non-crash entries follow the crash block", %{tmp_dir: dir} do
+    test "returns empty when non-error entries follow the error block", %{tmp_dir: dir} do
       path =
         write_log(dir, [
           log_json("2026-03-11T15:22:18Z",
@@ -189,10 +189,10 @@ defmodule ToastTest.Enrichment.LogsTest do
           )
         ])
 
-      assert Logs.extract_crash_lines(path) == []
+      assert Logs.extract_trailing_errors(path) == []
     end
 
-    test "returns only the last crash block when multiple exist", %{tmp_dir: dir} do
+    test "returns only the trailing contiguous error block", %{tmp_dir: dir} do
       path =
         write_log(dir, [
           log_json("2026-03-11T15:00:00Z",
@@ -201,7 +201,7 @@ defmodule ToastTest.Enrichment.LogsTest do
             message: "first crash signal 6"
           ),
           log_json("2026-03-11T15:00:01Z",
-            level: "INFO",
+            level: "ERROR",
             topic: "crash",
             message: "first backtrace frame 1"
           ),
@@ -221,12 +221,12 @@ defmodule ToastTest.Enrichment.LogsTest do
             message: "second crash signal 11"
           ),
           log_json("2026-03-11T15:22:18Z",
-            level: "INFO",
+            level: "ERROR",
             topic: "crash",
             message: "second backtrace frame 1"
           ),
           log_json("2026-03-11T15:22:18Z",
-            level: "INFO",
+            level: "ERROR",
             topic: "crash",
             message: "second backtrace frame 2"
           ),
@@ -237,7 +237,7 @@ defmodule ToastTest.Enrichment.LogsTest do
           )
         ])
 
-      result = Logs.extract_crash_lines(path)
+      result = Logs.extract_trailing_errors(path)
 
       messages = Enum.map(result, & &1.message)
       assert "second crash signal 11" in messages
@@ -247,35 +247,35 @@ defmodule ToastTest.Enrichment.LogsTest do
       refute Enum.any?(messages, &String.contains?(&1, "first"))
     end
 
-    test "returns empty list when no crash entries", %{tmp_dir: dir} do
+    test "returns empty list when no error/fatal entries at end", %{tmp_dir: dir} do
       path =
         write_log(dir, [
           log_json("2026-03-11T15:22:17Z",
-            level: "INFO",
-            topic: "general",
-            message: "starting up"
-          ),
-          log_json("2026-03-11T15:22:18Z",
             level: "FATAL",
             topic: "startup",
             message: "something failed"
+          ),
+          log_json("2026-03-11T15:22:18Z",
+            level: "INFO",
+            topic: "general",
+            message: "recovered successfully"
           )
         ])
 
-      assert Logs.extract_crash_lines(path) == []
+      assert Logs.extract_trailing_errors(path) == []
     end
 
     test "returns empty list for nonexistent file" do
-      assert Logs.extract_crash_lines("/nonexistent/file.log") == []
+      assert Logs.extract_trailing_errors("/nonexistent/file.log") == []
     end
 
     test "returns empty list for empty file", %{tmp_dir: dir} do
       path = Path.join(dir, "empty.log")
       File.write!(path, "")
-      assert Logs.extract_crash_lines(path) == []
+      assert Logs.extract_trailing_errors(path) == []
     end
 
-    test "handles crash block at very end of file", %{tmp_dir: dir} do
+    test "handles error block at very end of file", %{tmp_dir: dir} do
       path =
         write_log(dir, [
           log_json("2026-03-11T15:22:17Z",
@@ -295,14 +295,14 @@ defmodule ToastTest.Enrichment.LogsTest do
           )
         ])
 
-      result = Logs.extract_crash_lines(path)
+      result = Logs.extract_trailing_errors(path)
       messages = Enum.map(result, & &1.message)
       assert "caught signal 11" in messages
       assert "Hello crash handler" in messages
       refute "starting up" in messages
     end
 
-    test "handles file with only crash lines", %{tmp_dir: dir} do
+    test "handles file with only error/fatal lines", %{tmp_dir: dir} do
       path =
         write_log(dir, [
           log_json("2026-03-11T15:22:18Z",
@@ -317,52 +317,10 @@ defmodule ToastTest.Enrichment.LogsTest do
           )
         ])
 
-      result = Logs.extract_crash_lines(path)
+      result = Logs.extract_trailing_errors(path)
       assert length(result) == 2
       assert Enum.any?(result, &(&1.message == "caught signal 11"))
       assert Enum.any?(result, &(&1.message == "Hello crash handler"))
-    end
-  end
-
-  describe "extract_crash_timestamp/1" do
-    test "returns timestamp of first crash entry", %{tmp_dir: dir} do
-      path =
-        write_log(dir, [
-          log_json("2026-03-11T15:22:17Z",
-            level: "INFO",
-            topic: "general",
-            message: "normal operation"
-          ),
-          log_json("2026-03-11T15:22:18Z",
-            level: "FATAL",
-            topic: "crash",
-            message: "caught signal 11"
-          ),
-          log_json("2026-03-11T15:22:19Z",
-            level: "INFO",
-            topic: "crash",
-            message: "backtrace frame 1"
-          )
-        ])
-
-      assert Logs.extract_crash_timestamp(path) == ts_us("2026-03-11T15:22:18Z")
-    end
-
-    test "returns nil when no crash entries at end of log", %{tmp_dir: dir} do
-      path =
-        write_log(dir, [
-          log_json("2026-03-11T15:22:17Z",
-            level: "INFO",
-            topic: "general",
-            message: "normal operation"
-          )
-        ])
-
-      assert Logs.extract_crash_timestamp(path) == nil
-    end
-
-    test "returns nil for nonexistent file" do
-      assert Logs.extract_crash_timestamp("/nonexistent/file.log") == nil
     end
   end
 

--- a/tests/toast/test/toast_test/event_store_test.exs
+++ b/tests/toast/test/toast_test/event_store_test.exs
@@ -163,7 +163,7 @@ defmodule ToastTest.EventStoreTest do
     test "records and retrieves timeout kill events" do
       EventStore.notify(%{
         event: :timeout_kill,
-        source: :suite_timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         servers: [%{server_id: "s1", os_pid: 1001}],
         timestamp: ts()
@@ -171,13 +171,13 @@ defmodule ToastTest.EventStoreTest do
 
       kills = EventStore.timeout_kills()
       assert length(kills) == 1
-      assert hd(kills).source == :suite_timeout
+      assert hd(kills).source == :suite
     end
 
     test "returns multiple timeout kills in chronological order" do
       base = to_us(~U[2026-03-09 10:00:00Z])
 
-      for {source, i} <- Enum.with_index([:suite_timeout, :global_timeout]) do
+      for {source, i} <- Enum.with_index([:suite, :global]) do
         EventStore.notify(%{
           event: :timeout_kill,
           source: source,
@@ -188,7 +188,7 @@ defmodule ToastTest.EventStoreTest do
       end
 
       kills = EventStore.timeout_kills()
-      assert Enum.map(kills, & &1.source) == [:suite_timeout, :global_timeout]
+      assert Enum.map(kills, & &1.source) == [:suite, :global]
     end
 
     test "ignores non-timeout events" do
@@ -444,7 +444,7 @@ defmodule ToastTest.EventStoreTest do
 
       EventStore.notify(%{
         event: :timeout_kill,
-        source: :suite_timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         servers: [%{server_id: "s1", os_pid: 1001}],
         timestamp: t4

--- a/tests/toast/test/toast_test/issue_formatting/logs_test.exs
+++ b/tests/toast/test/toast_test/issue_formatting/logs_test.exs
@@ -173,7 +173,7 @@ defmodule ToastTest.LogAnalysisAndFormattingLogsTest do
 
     test "timeout default window" do
       ts = to_us(~U[2026-03-09 10:00:00Z])
-      issue = %{type: :timeout, time_bounds: {ts, ts}}
+      issue = %{type: :infrastructure, time_bounds: {ts, ts}}
       {start_us, end_us} = IssueStreams.display_window(issue, nil)
       assert ts - start_us == 5 * @usec_per_sec
       assert end_us - ts == 0

--- a/tests/toast/test/toast_test/issue_formatting_test.exs
+++ b/tests/toast/test/toast_test/issue_formatting_test.exs
@@ -100,7 +100,10 @@ defmodule ToastTest.Formatting.IssuesTest do
 
       issues = [
         %{type: :crash, detail: %{coredump_paths: ["/tmp/core.1"]}},
-        %{type: :timeout, detail: %{reason: "timed out"}}
+        %{
+          type: :infrastructure,
+          detail: %{subtype: :timeout, source: :suite, reason: "timed out"}
+        }
       ]
 
       [crash, timeout] = IssueFormatting.resolve_coredumps(issues, index)
@@ -264,7 +267,8 @@ defmodule ToastTest.Formatting.IssuesTest do
     test "formats timeout with server details" do
       issue = %{
         detail: %{
-          source: :test_timeout,
+          subtype: :timeout,
+          source: :suite,
           reason: "test exceeded 60s",
           servers: [
             %{server_id: "coordinator1", os_pid: 1234, log_file: "/tmp/c1.log", coredump: nil}
@@ -273,7 +277,7 @@ defmodule ToastTest.Formatting.IssuesTest do
       }
 
       result = IssueFormatting.format_timeout(issue)
-      assert result =~ "[Test Timeout] test exceeded 60s"
+      assert result =~ "[Suite Timeout] test exceeded 60s"
       assert result =~ "coordinator1 (PID 1234)"
       assert result =~ "Log: /tmp/c1.log"
     end
@@ -281,7 +285,8 @@ defmodule ToastTest.Formatting.IssuesTest do
     test "formats timeout with multiple servers" do
       issue = %{
         detail: %{
-          source: :startup_timeout,
+          subtype: :timeout,
+          source: :startup,
           reason: "cluster failed to start",
           servers: [
             %{server_id: "coordinator1", os_pid: 100, log_file: nil, coredump: nil},
@@ -299,7 +304,7 @@ defmodule ToastTest.Formatting.IssuesTest do
 
     test "formats timeout with no servers" do
       issue = %{
-        detail: %{source: :global_timeout, reason: "exceeded 10m"}
+        detail: %{subtype: :timeout, source: :global, reason: "exceeded 10m"}
       }
 
       result = IssueFormatting.format_timeout(issue)
@@ -309,7 +314,8 @@ defmodule ToastTest.Formatting.IssuesTest do
     test "server without os_pid omits PID part" do
       issue = %{
         detail: %{
-          source: :shutdown_timeout,
+          subtype: :timeout,
+          source: :shutdown,
           reason: "shutdown stuck",
           servers: [%{server_id: "coordinator1", os_pid: nil, log_file: nil, coredump: nil}]
         }
@@ -368,20 +374,20 @@ defmodule ToastTest.Formatting.IssuesTest do
   # --- timeout_source_label/1 ---
 
   describe "timeout_source_label/1" do
-    test "startup_timeout" do
-      assert IssueFormatting.timeout_source_label(:startup_timeout) == "Startup Timeout"
+    test "startup" do
+      assert IssueFormatting.timeout_source_label(:startup) == "Startup Timeout"
     end
 
-    test "shutdown_timeout" do
-      assert IssueFormatting.timeout_source_label(:shutdown_timeout) == "Shutdown Timeout"
+    test "shutdown" do
+      assert IssueFormatting.timeout_source_label(:shutdown) == "Shutdown Timeout"
     end
 
-    test "test_timeout" do
-      assert IssueFormatting.timeout_source_label(:test_timeout) == "Test Timeout"
+    test "suite" do
+      assert IssueFormatting.timeout_source_label(:suite) == "Suite Timeout"
     end
 
-    test "global_timeout" do
-      assert IssueFormatting.timeout_source_label(:global_timeout) == "Global Timeout"
+    test "global" do
+      assert IssueFormatting.timeout_source_label(:global) == "Global Timeout"
     end
 
     test "unknown source uses fallback" do

--- a/tests/toast/test/toast_test/post_exec_summary_test.exs
+++ b/tests/toast/test/toast_test/post_exec_summary_test.exs
@@ -239,11 +239,12 @@ defmodule ToastTest.Formatting.PostExecSummaryTest do
 
   test "prints startup timeout with aborted servers, log paths, and coredump paths" do
     issue = %{
-      type: :timeout,
+      type: :infrastructure,
       scope: :suite,
       confidence: :high,
       detail: %{
-        source: :startup_timeout,
+        subtype: :timeout,
+        source: :startup,
         reason: "Startup timeout — deployment did not become ready in time",
         timestamp: ~U[2026-03-09 10:05:00Z],
         servers: [
@@ -271,7 +272,7 @@ defmodule ToastTest.Formatting.PostExecSummaryTest do
 
     output = capture_io(fn -> PostExecSummary.print(suite_result([issue])) end)
 
-    assert output =~ "TIMEOUTS (1)"
+    assert output =~ "INFRASTRUCTURE ISSUES (1)"
     assert output =~ "[Startup Timeout]"
     assert output =~ "Startup timeout"
     assert output =~ "Aborted 3 servers:"
@@ -290,11 +291,12 @@ defmodule ToastTest.Formatting.PostExecSummaryTest do
 
   test "prints test timeout without server list" do
     issue = %{
-      type: :timeout,
+      type: :infrastructure,
       scope: :suite,
       confidence: :high,
       detail: %{
-        source: :test_timeout,
+        subtype: :timeout,
+        source: :suite,
         reason: "Suite timeout exceeded",
         timestamp: ~U[2026-03-09 10:05:00Z],
         servers: []
@@ -303,18 +305,19 @@ defmodule ToastTest.Formatting.PostExecSummaryTest do
 
     output = capture_io(fn -> PostExecSummary.print(suite_result([issue])) end)
 
-    assert output =~ "[Test Timeout]"
+    assert output =~ "[Suite Timeout]"
     assert output =~ "Suite timeout exceeded"
     refute output =~ "Aborted"
   end
 
   test "prints shutdown timeout with escalated server" do
     issue = %{
-      type: :timeout,
+      type: :infrastructure,
       scope: :suite,
       confidence: :high,
       detail: %{
-        source: :shutdown_timeout,
+        subtype: :timeout,
+        source: :shutdown,
         reason: "Shutdown timeout — server(s) did not respond to SIGTERM",
         timestamp: ~U[2026-03-09 10:05:00Z],
         servers: [
@@ -330,17 +333,18 @@ defmodule ToastTest.Formatting.PostExecSummaryTest do
     assert output =~ "single (PID 12345)"
   end
 
-  test "orders sections by severity with timeouts last" do
+  test "orders sections by severity with infrastructure last" do
     issues = [
       crash_issue_with_coredump(),
       test_failure_issue(),
       sanitizer_issue(),
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: :suite,
         confidence: :high,
         detail: %{
-          source: :test_timeout,
+          subtype: :timeout,
+          source: :suite,
           reason: "Suite timeout exceeded",
           timestamp: ~U[2026-03-09 10:05:00Z],
           servers: []
@@ -356,11 +360,11 @@ defmodule ToastTest.Formatting.PostExecSummaryTest do
     failure_pos = :binary.match(output, "TEST FAILURES") |> elem(0)
     sanitizer_pos = :binary.match(output, "SANITIZER REPORTS") |> elem(0)
     crash_pos = :binary.match(output, "CRASHES") |> elem(0)
-    timeout_pos = :binary.match(output, "TIMEOUTS") |> elem(0)
+    infra_pos = :binary.match(output, "INFRASTRUCTURE ISSUES") |> elem(0)
 
     assert failure_pos < sanitizer_pos
     assert sanitizer_pos < crash_pos
-    assert crash_pos < timeout_pos
+    assert crash_pos < infra_pos
   end
 
   test "formats scope attribution" do

--- a/tests/toast/test/toast_test/runner/timeout_deadline_test.exs
+++ b/tests/toast/test/toast_test/runner/timeout_deadline_test.exs
@@ -1,0 +1,162 @@
+################################################################################
+## DISCLAIMER
+##
+## Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+## Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+##
+## Licensed under the Business Source License 1.1 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##
+## Copyright holder is ArangoDB GmbH, Cologne, Germany
+################################################################################
+
+defmodule ToastTest.Runner.TimeoutDeadlineTest do
+  use ExUnit.Case, async: false
+
+  alias ToastTest.{Abort, EventStore}
+  alias ToastTest.Runner.Timeout
+  alias ToastTest.Runner.Timeout.Settings
+
+  setup do
+    Abort.clear!()
+    EventStore.clear()
+
+    on_exit(fn ->
+      Abort.clear!()
+      EventStore.clear()
+    end)
+
+    :ok
+  end
+
+  defp expired_suite_config do
+    %{
+      timeout_settings: %Settings{
+        base_timeout: 300_000,
+        timeout_factor: 1,
+        suite_deadline: System.monotonic_time(:millisecond) - 1000,
+        suite_timeout: 600_000,
+        global_deadline: nil,
+        global_timeout: nil,
+        disable_timeouts: false
+      }
+    }
+  end
+
+  defp expired_global_deadline do
+    System.monotonic_time(:millisecond) - 1000
+  end
+
+  describe "check_suite_deadline!/1" do
+    test "fires exactly one timeout_kill event on repeated calls past deadline" do
+      config = expired_suite_config()
+
+      Timeout.check_suite_deadline!(config)
+      Timeout.check_suite_deadline!(config)
+      Timeout.check_suite_deadline!(config)
+
+      kills = EventStore.timeout_kills()
+      assert length(kills) == 1
+      assert hd(kills).source == :suite
+    end
+
+    test "sets abort reason on first call" do
+      Timeout.check_suite_deadline!(expired_suite_config())
+      assert {:timeout, "Suite timeout exceeded"} = Abort.reason()
+    end
+
+    test "is a no-op when deadline is nil" do
+      config = %{
+        timeout_settings: %Settings{
+          base_timeout: 300_000,
+          timeout_factor: 1,
+          suite_deadline: nil,
+          suite_timeout: nil,
+          global_deadline: nil,
+          global_timeout: nil,
+          disable_timeouts: false
+        }
+      }
+
+      Timeout.check_suite_deadline!(config)
+      assert is_nil(Abort.reason())
+      assert EventStore.timeout_kills() == []
+    end
+
+    test "is a no-op when deadline has not been reached" do
+      config = %{
+        timeout_settings: %Settings{
+          base_timeout: 300_000,
+          timeout_factor: 1,
+          suite_deadline: System.monotonic_time(:millisecond) + 60_000,
+          suite_timeout: 600_000,
+          global_deadline: nil,
+          global_timeout: nil,
+          disable_timeouts: false
+        }
+      }
+
+      Timeout.check_suite_deadline!(config)
+      assert is_nil(Abort.reason())
+      assert EventStore.timeout_kills() == []
+    end
+
+    test "does not fire timeout_kill when already aborted for another reason" do
+      Abort.abort!({:crash, "Server crashed"})
+
+      Timeout.check_suite_deadline!(expired_suite_config())
+
+      assert {:crash, "Server crashed"} = Abort.reason()
+      assert EventStore.timeout_kills() == []
+    end
+  end
+
+  describe "check_global_deadline!/1" do
+    test "fires exactly one timeout_kill event on repeated calls past deadline" do
+      deadline = expired_global_deadline()
+
+      Timeout.check_global_deadline!(deadline)
+      Timeout.check_global_deadline!(deadline)
+      Timeout.check_global_deadline!(deadline)
+
+      kills = EventStore.timeout_kills()
+      assert length(kills) == 1
+      assert hd(kills).source == :global
+    end
+
+    test "sets abort reason on first call" do
+      Timeout.check_global_deadline!(expired_global_deadline())
+      assert {:timeout, "Global execution timeout exceeded"} = Abort.reason()
+    end
+
+    test "is a no-op when deadline is nil" do
+      Timeout.check_global_deadline!(nil)
+      assert is_nil(Abort.reason())
+      assert EventStore.timeout_kills() == []
+    end
+
+    test "is a no-op when deadline has not been reached" do
+      Timeout.check_global_deadline!(System.monotonic_time(:millisecond) + 60_000)
+      assert is_nil(Abort.reason())
+      assert EventStore.timeout_kills() == []
+    end
+
+    test "does not fire timeout_kill when already aborted for another reason" do
+      Abort.abort!({:crash, "Server crashed"})
+
+      Timeout.check_global_deadline!(expired_global_deadline())
+
+      assert {:crash, "Server crashed"} = Abort.reason()
+      assert EventStore.timeout_kills() == []
+    end
+  end
+end

--- a/tests/toast/test/toast_test/suite_discovery_test.exs
+++ b/tests/toast/test/toast_test/suite_discovery_test.exs
@@ -33,7 +33,7 @@ defmodule ToastTest.SuiteDiscoveryTest do
 
     test "plain ExUnit test module does not export __toast_suite__/0" do
       defmodule PlainTestModule do
-        use ExUnit.Case
+        use ExUnit.Case, register: false
       end
 
       refute function_exported?(PlainTestModule, :__toast_suite__, 0)
@@ -57,7 +57,7 @@ defmodule ToastTest.SuiteDiscoveryTest do
 
       # Now test modules can use it
       defmodule OrderedTestModule do
-        use ToastTest.SuiteDiscoveryTest.OrderedSuite
+        use ToastTest.SuiteDiscoveryTest.OrderedSuite, register: false
       end
 
       assert OrderedTestModule.__toast_suite__() == OrderedSuite

--- a/tests/toast/test/toast_test/suite_result/junit_xml_test.exs
+++ b/tests/toast/test/toast_test/suite_result/junit_xml_test.exs
@@ -216,11 +216,12 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
   test "suite-scoped timeout appears as synthetic testcase in _infrastructure_ testsuite" do
     issues = [
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: :suite,
         confidence: :high,
         detail: %{
-          source: "overall",
+          subtype: :timeout,
+          source: :startup,
           reason: "suite exceeded 30 minute limit",
           timestamp: ~U[2026-03-09 10:30:00Z],
           servers: [
@@ -237,7 +238,7 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
 
       xml = read_xml!(dir, "smoke.xml")
       assert xml =~ ~r/<testsuite[^>]*name="_infrastructure_"/
-      assert xml =~ ~r/<testcase[^>]*name="timeout"/
+      assert xml =~ ~r/<testcase[^>]*name="infrastructure: timeout"/
       assert xml =~ "suite exceeded 30 minute limit"
       assert xml =~ "srv-1"
       assert xml =~ "core.9999"
@@ -473,11 +474,12 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
   test "module-scoped timeout appears as synthetic testcase in module testsuite" do
     issues = [
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: {:module, FakeModule},
         confidence: :high,
         detail: %{
-          source: "module_setup",
+          subtype: :timeout,
+          source: :startup,
           reason: "setup exceeded limit",
           timestamp: ~U[2026-03-09 10:01:00Z],
           servers: [%{server_id: "srv-1", coredump: "/tmp/core.mod"}]
@@ -492,7 +494,7 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
       xml = read_xml!(dir, "smoke.xml")
 
       assert xml =~
-               ~r/<testsuite[^>]*name="FakeModule"[^>]*>.*<testcase[^>]*name="timeout"[^>]*>.*<error message="timeout">.*setup exceeded limit.*<\/error>.*<\/testcase>.*<\/testsuite>/s
+               ~r/<testsuite[^>]*name="FakeModule"[^>]*>.*<testcase[^>]*name="infrastructure: timeout"[^>]*>.*<error message="infrastructure: timeout">.*setup exceeded limit.*<\/error>.*<\/testcase>.*<\/testsuite>/s
 
       assert xml =~ "core.mod"
     end)
@@ -501,11 +503,12 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
   test "test-scoped timeout appears in testcase error element" do
     issues = [
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: {:test, FakeModule, :"test passes"},
         confidence: :high,
         detail: %{
-          source: "test_execution",
+          subtype: :timeout,
+          source: :suite,
           reason: "test exceeded 5 minute limit",
           timestamp: ~U[2026-03-09 10:05:00Z],
           servers: []
@@ -520,7 +523,7 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
       xml = read_xml!(dir, "smoke.xml")
 
       assert xml =~
-               ~r/<testcase[^>]*name="test passes"[^>]*>\s*<error message="timeout">.*test exceeded 5 minute/s
+               ~r/<testcase[^>]*name="test passes"[^>]*>\s*<error message="infrastructure: timeout">.*test exceeded 5 minute/s
     end)
   end
 
@@ -595,14 +598,15 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
     end)
   end
 
-  test "timeout with empty servers list renders source and reason only" do
+  test "timeout with empty servers list renders subtype and reason only" do
     issues = [
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: :suite,
         confidence: :high,
         detail: %{
-          source: "overall",
+          subtype: :timeout,
+          source: :global,
           reason: "timed out",
           timestamp: ~U[2026-03-09 10:30:00Z],
           servers: []
@@ -615,17 +619,17 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
       SuiteResult.write_junit_xml(result, dir)
 
       xml = read_xml!(dir, "smoke.xml")
-      assert xml =~ "[Timeout: overall] timed out"
+      assert xml =~ "[Global Timeout] timed out"
     end)
   end
 
-  test "timeout with nil detail fields renders available fields only" do
+  test "infrastructure timeout with nil subtype renders as generic infrastructure issue" do
     issues = [
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: :suite,
         confidence: :high,
-        detail: %{source: nil, reason: "unknown", servers: nil}
+        detail: %{subtype: :timeout, source: :startup, reason: "unknown", servers: nil}
       }
     ]
 
@@ -634,7 +638,7 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
       SuiteResult.write_junit_xml(result, dir)
 
       xml = read_xml!(dir, "smoke.xml")
-      assert xml =~ "[Timeout: ] unknown"
+      assert xml =~ "[Startup Timeout] unknown"
     end)
   end
 
@@ -726,10 +730,10 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
         detail: %{server: "srv-1", report: "module-level sanitizer"}
       },
       %{
-        type: :timeout,
+        type: :infrastructure,
         scope: :suite,
         confidence: :high,
-        detail: %{source: "overall", reason: "suite-level timeout", servers: []}
+        detail: %{subtype: :timeout, source: :global, reason: "suite-level timeout", servers: []}
       }
     ]
 
@@ -749,7 +753,7 @@ defmodule ToastTest.SuiteResult.JUnitXMLTest do
 
       # Suite-level: synthetic <testcase> in _infrastructure_ testsuite
       assert xml =~
-               ~r/<testsuite[^>]*name="_infrastructure_"[^>]*>.*<testcase[^>]*name="timeout"[^>]*>.*suite-level timeout.*<\/testsuite>/s
+               ~r/<testsuite[^>]*name="_infrastructure_"[^>]*>.*<testcase[^>]*name="infrastructure: timeout"[^>]*>.*suite-level timeout.*<\/testsuite>/s
     end)
   end
 

--- a/tests/toast/test/toast_test/suite_test.exs
+++ b/tests/toast/test/toast_test/suite_test.exs
@@ -79,7 +79,7 @@ defmodule ToastTest.SuiteTest do
     end
 
     defmodule TestUsingParent do
-      use ToastTest.SuiteTest.ParentSuite
+      use ToastTest.SuiteTest.ParentSuite, register: false
     end
 
     assert TestUsingParent.__toast_suite__() == ToastTest.SuiteTest.ParentSuite
@@ -91,7 +91,7 @@ defmodule ToastTest.SuiteTest do
     end
 
     defmodule TestDefaultWeight do
-      use ToastTest.SuiteTest.DefaultWeightSuite
+      use ToastTest.SuiteTest.DefaultWeightSuite, register: false
     end
 
     assert TestDefaultWeight.__toast_weight__() == 1
@@ -103,7 +103,7 @@ defmodule ToastTest.SuiteTest do
     end
 
     defmodule TestCustomWeight do
-      use ToastTest.SuiteTest.WeightedSuite, weight: 5
+      use ToastTest.SuiteTest.WeightedSuite, weight: 5, register: false
     end
 
     assert TestCustomWeight.__toast_weight__() == 5
@@ -115,7 +115,7 @@ defmodule ToastTest.SuiteTest do
     end
 
     defmodule TestWithAttr do
-      use ToastTest.SuiteTest.AttrSuite
+      use ToastTest.SuiteTest.AttrSuite, register: false
 
       def get_toast_suite, do: @toast_suite
     end


### PR DESCRIPTION
### Scope & Purpose

- make startup/shutdown timeouts "infrastructure issues"
- make sure we always run post exec analysis, even to partially started clusters
- ignore timeouts when there is already a registered abort reason

- [x] :hankey: Bugfix
- [x] :hammer: Refactoring/simplification
