### PR TITLE
[QA-784]  getEndpoint/request/download refactor

### DIFF
--- a/js/client/modules/@arangodb/testutils/clusterstats.js
+++ b/js/client/modules/@arangodb/testutils/clusterstats.js
@@ -1,5 +1,5 @@
 /* jshint strict: false, sub: true */
-/* global print, arango */
+/* global print */
 'use strict';
 
 // //////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/authentication/admin-cluster-apis.js
+++ b/tests/js/client/authentication/admin-cluster-apis.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global fail, assertTrue, assertEqual */
+/*global fail */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -26,17 +26,14 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse} = jsunity.jsUnity.assertions;
 const arango = require("@arangodb").arango;
 const db = require("internal").db;
 const users = require("@arangodb/users");
-const request = require('@arangodb/request');
+let IM = global.instanceManager;
 
 function AuthSuite() {
   'use strict';
-  let baseUrl = function () {
-    return arango.getEndpoint().replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
-  };
-
   const user1 = 'hackers@arango.ai';
   const user2 = 'noone@arango.ai';
   let servers = [];
@@ -68,13 +65,12 @@ function AuthSuite() {
   return {
 
     setUpAll: function () {
+      IM.rememberConnection();
       servers = Object.keys(arango.GET('/_admin/cluster/health').Health).filter(function(s) {
         return s.match(/^PRMR/);
       });
 
       assertTrue(servers.length > 0, servers);
-
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
 
       try {
         users.remove(user1);
@@ -97,7 +93,7 @@ function AuthSuite() {
     },
 
     tearDownAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.reconnectMe();
       try {
         users.remove(user1);
       } catch (err) {
@@ -114,62 +110,62 @@ function AuthSuite() {
     },
     
     testClusterHealthRoot: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', 'root', '');
       checkClusterHealth();
     },
     
     testClusterHealthOtherDBRW: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, "foobar");
       checkClusterHealth();
     },
     
     testClusterHealthOtherDBRO: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, "foobar");
       checkClusterHealth();
     },
     
     testClusterNodeVersionRoot: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', 'root', '');
       checkClusterNodeVersion();
     },
     
     testClusterNodeVersionDBRW: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, "foobar");
       checkClusterNodeVersion();
     },
     
     testClusterNodeVersionDBRO: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, "foobar");
       checkClusterNodeVersion();
     },
     
     testClusterNodeEngineRoot: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', 'root', '');
       checkClusterNodeEngine();
     },
     
     testClusterNodeEngineOtherDBRW: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, "foobar");
       checkClusterNodeEngine();
     },
     
     testClusterNodeEngineOtherDBRO: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, "foobar");
       checkClusterNodeEngine();
     },
     
     testClusterNodeStatsRoot: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', 'root', '');
       checkClusterNodeStats();
     },
     
     testClusterNodeStatsOtherDBRW: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, "foobar");
       checkClusterNodeStats();
     },
     
     testClusterNodeStatsOtherDBRO: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, "foobar");
       checkClusterNodeStats();
     },
     

--- a/tests/js/client/authentication/auth-analyzer.js
+++ b/tests/js/client/authentication/auth-analyzer.js
@@ -1,21 +1,16 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertTrue, assertFalse, assertEqual, assertMatch, fail, arango */
+/* global getOptions, fail */
 
 
 const jsunity = require('jsunity');
-const internal = require('internal');
-const error = internal.errors;
-const print = internal.print;
-const arango = internal.arango;
-
+const {assertEqual, assertTrue, assertFalse} = jsunity.jsUnity.assertions;
+const arango = require("@arangodb").arango;
 const db = require("@arangodb").db;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
-const endpoint = arango.getEndpoint();
-const base64Encode = require('internal').base64Encode;
+let IM = global.instanceManager;
 
 function testSuite() {
-  const jwtSecret = 'haxxmann';
   const user = 'bob';
 
   const system = "_system";
@@ -37,6 +32,7 @@ function testSuite() {
 
   return {
     setUp: function() {
+      IM.rememberConnection();
 
       db._createDatabase(rodb);
       db._createDatabase(rwdb);
@@ -67,6 +63,8 @@ function testSuite() {
       db._dropDatabase(rodb);
 
       arango.DELETE("/_api/analyzer/" + name + "?force=true");
+
+      IM.reconnectMe();
     },
 
     testAnalyzerGet : function() {

--- a/tests/js/client/authentication/auth-cluster.js
+++ b/tests/js/client/authentication/auth-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global fail, assertTrue */
+/*global fail */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -25,11 +25,12 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
+const {assertEqual, assertNotEqual, assertTrue, assertFalse, assertNotUndefined} = jsunity.jsUnity.assertions;
 const arango = require("@arangodb").arango;
 const db = require("internal").db;
 const request = require('@arangodb/request');
 const crypto = require('@arangodb/crypto');
-const expect = require('chai').expect;
+let IM = global.instanceManager;
 
 ////////////////////////////////////////////////////////////////////////////////
 /// @brief test suite
@@ -53,15 +54,14 @@ function AuthSuite() {
     }, 'HS256');
 
     var res = request.get({
-      url: baseUrl(arango.getEndpoint()) + "/_admin/cluster/health",
+      url: IM.url + "/_admin/cluster/health",
       auth: {
         bearer: jwt,
       }
     });
-    expect(res).to.be.an.instanceof(request.Response);
-    expect(res).to.have.property('statusCode', 200);
-    expect(res).to.have.property('json');
-    expect(res.json).to.have.property('Health');
+    assertEqual(res.statusCode, 200);
+    assertNotUndefined(res.json);
+    assertNotUndefined(res.json.Health);
 
     return Object.keys(res.json.Health).filter(serverId => {
       return serverId.substr(0, 4) === role;
@@ -75,7 +75,8 @@ function AuthSuite() {
     ////////////////////////////////////////////////////////////////////////////////
 
     setUp: function () {
-      arango.reconnect(arango.getEndpoint(), db._name(), "root", "");
+      IM.rememberConnection();
+      arango.reconnect(IM.endpoint, db._name(), "root", "");
 /*
       try {
         users.remove(user);
@@ -89,6 +90,7 @@ function AuthSuite() {
     ////////////////////////////////////////////////////////////////////////////////
 
     tearDown: function () {
+      IM.reconnectMe();
       /*try {
         users.remove(user);
       }
@@ -103,48 +105,42 @@ function AuthSuite() {
       }, 'HS256');
 
       let coordinators = getServersWithRole("CRDN");
-      expect(coordinators).to.be.a('array');
-      expect(coordinators.length).to.be.gt(0);
+      assertTrue(coordinators.length > 0);
       coordinators.forEach(cc => {
-        expect(cc).to.have.property('Endpoint');
+        assertNotUndefined(cc.Endpoint);
         var res = request.get({
           url: baseUrl(cc.Endpoint) + "/_api/version",
           auth: {
             bearer: jwt,
           }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', 200);
+        assertEqual(res.statusCode, 200);
       });
 
       let dbservers = getServersWithRole("PRMR");
-      expect(dbservers).to.be.a('array');
-      expect(dbservers.length).to.be.gt(0);
+      assertTrue(dbservers.length > 0);
       dbservers.forEach(cc => {
-        expect(cc).to.have.property('Endpoint');
+        assertNotUndefined(cc.Endpoint);
         var res = request.get({
           url: baseUrl(cc.Endpoint) + "/_api/version",
           auth: {
             bearer: jwt,
           }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', 401);
+        assertEqual(res.statusCode, 401);
       });
 
       let agencies = getServersWithRole("AGNT");
-      expect(agencies).to.be.a('array');
-      expect(agencies.length).to.be.gt(0);
+      assertTrue(agencies.length > 0);
       agencies.forEach(cc => {
-        expect(cc).to.have.property('Endpoint');
+        assertNotUndefined(cc.Endpoint);
         var res = request.get({
           url: baseUrl(cc.Endpoint) + "/_api/version",
           auth: {
             bearer: jwt,
           }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', 401);
+        assertEqual(res.statusCode, 401);
       });
     },
 
@@ -155,48 +151,42 @@ function AuthSuite() {
       }, 'HS256');
 
       let coordinators = getServersWithRole("CRDN");
-      expect(coordinators).to.be.a('array');
-      expect(coordinators.length).to.be.gt(0);
+      assertTrue(coordinators.length > 0);
       coordinators.forEach(cc => {
-        expect(cc).to.have.property('Endpoint');
+        assertNotUndefined(cc.Endpoint);
         var res = request.get({
           url: baseUrl(cc.Endpoint) + "/_api/version",
           auth: {
             bearer: jwt,
           }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', 200);
+        assertEqual(res.statusCode, 200);
       });
 
       let dbservers = getServersWithRole("PRMR");
-      expect(dbservers).to.be.a('array');
-      expect(dbservers.length).to.be.gt(0);
+      assertTrue(dbservers.length > 0);
       dbservers.forEach(cc => {
-        expect(cc).to.have.property('Endpoint');
+        assertNotUndefined(cc.Endpoint);
         var res = request.get({
           url: baseUrl(cc.Endpoint) + "/_api/version",
           auth: {
             bearer: jwt,
           }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', 200);
+        assertEqual(res. statusCode, 200);
       });
 
       let agencies = getServersWithRole("AGNT");
-      expect(agencies).to.be.a('array');
-      expect(agencies.length).to.be.gt(0);
+      assertTrue(agencies.length > 0);
       agencies.forEach(cc => {
-        expect(cc).to.have.property('Endpoint');
+        assertNotUndefined(cc.Endpoint);
         var res = request.get({
           url: baseUrl(cc.Endpoint) + "/_api/version",
           auth: {
             bearer: jwt,
           }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', 200);
+        assertEqual(res.statusCode, 200);
       });
     }
 
@@ -229,11 +219,10 @@ function JwtAllowedPathsClusterSuite() {
     }, 'HS256');
 
     var res = request.get({
-      url: baseUrl(arango.getEndpoint()) + "/_admin/cluster/health",
+      url: IM.url + "/_admin/cluster/health",
       auth: { bearer: jwt }
     });
-    expect(res).to.be.an.instanceof(request.Response);
-    expect(res).to.have.property('statusCode', 200);
+    assertEqual(res.statusCode, 200);
 
     return Object.keys(res.json.Health).filter(serverId => {
       return serverId.substr(0, 4) === role;
@@ -262,16 +251,14 @@ function JwtAllowedPathsClusterSuite() {
     ];
     roles.forEach(({ code, name }) => {
       let servers = getServersWithRole(code);
-      expect(servers).to.be.an('array');
-      expect(servers.length).to.be.gt(0);
+      assertTrue(servers.length > 0);
       servers.forEach(server => {
-        expect(server).to.have.property('Endpoint');
+        assertNotUndefined(server.Endpoint);
         var res = request.get({
           url: baseUrl(server.Endpoint) + path,
           auth: { bearer: jwt }
         });
-        expect(res).to.be.an.instanceof(request.Response);
-        expect(res).to.have.property('statusCode', expectedStatus,
+        assertEqual(res.statusCode, expectedStatus,
           `expected ${expectedStatus} on ${name} ${server.Endpoint} for path ${path}, but got ${JSON.stringify(res.statusCode)}`);
       });
     });

--- a/tests/js/client/authentication/auth.js
+++ b/tests/js/client/authentication/auth.js
@@ -51,8 +51,11 @@ function AuthSuite() {
   return {
 
     // set up
+    setUpAll: function() {
+      IM.rememberConnection();
+    },
     setUp: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.reconnectMe();
 
       try {
         users.remove(user);
@@ -61,6 +64,9 @@ function AuthSuite() {
     },
 
     // tear down
+    tearDownAll: function() {
+      IM.reconnectMe();
+    },
     tearDown: function () {
       // our test temporarily disables access to the user collection,
       // so our request to clear the failure points must be authenticated

--- a/tests/js/client/authentication/dump-api-cluster.js
+++ b/tests/js/client/authentication/dump-api-cluster.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertTrue, assertEqual, assertNotUndefined */
+/*global */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -25,10 +25,12 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotUndefined} = jsunity.jsUnity.assertions;
 const arango = require("@arangodb").arango;
 const db = require("internal").db;
 const users = require("@arangodb/users");
 const dump = require('@arangodb/arango-dump');
+let IM = global.instanceManager;
 
 function AuthSuite() {
   'use strict';
@@ -40,7 +42,7 @@ function AuthSuite() {
       
   return {
     setUpAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.rememberConnection();
 
       try {
         users.remove(user1);
@@ -72,7 +74,7 @@ function AuthSuite() {
     },
 
     tearDownAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.reconnectMe();
       try {
         users.remove(user1);
       } catch (err) {
@@ -89,41 +91,41 @@ function AuthSuite() {
     },
 
     testCreateContextNoPermission: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', "root", "");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', "root", "");
 
       const shards = db[cn].shards(true);
       const shard = Object.keys(shards)[0];
       const server = shards[shard][0];
 
       // user2 should not be able to create a dump context
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, 'foobar');
       let result = dump.start({shards: [shard]}, server);
       assertEqual(result.code, 403);
 
       // user1 can create a dump
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, 'foobar');
       result = dump.start({shards: [shard]}, server);
       assertEqual(result.code, 201);
       let token = result.headers["x-arango-dump-id"];
       assertNotUndefined(token);
 
       // user2 should not be able to read from the collection using the handle
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, 'foobar');
       result = dump.next(token, 1, undefined, server);
       assertEqual(result.code, 403);
 
       // user1 can read the dump
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, 'foobar');
       result = dump.next(token, 1, undefined, server);
       assertEqual(result.code, 204); // collection is empty
 
       // user2 should not be able to delete the dump context
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, 'foobar');
       result = dump.delete(token, server);
       assertEqual(result.code, 403);
 
       // user1 can delete the dump
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, 'foobar');
       result = dump.delete(token, server);
       assertEqual(result.code, 200);
     },

--- a/tests/js/client/authentication/foxx-arango-auth-spec-sjs.js
+++ b/tests/js/client/authentication/foxx-arango-auth-spec-sjs.js
@@ -8,7 +8,7 @@ const internal = require('internal');
 const db = internal.db;
 const basePath = fs.makeAbsolute(fs.join(internal.pathForTesting('common'), 'test-data', 'apps', 'arango-auth'));
 let connectionHandle = arango.getConnectionHandle();
-const url = arango.getEndpoint().replace(/\+vpp/, '').replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
+const url = global.instanceManager.url;
 
 describe('Foxx arangoUser', function () {
   let mount;

--- a/tests/js/client/authentication/restore.js
+++ b/tests/js/client/authentication/restore.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertTrue, assertEqual */
+/*global */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -26,9 +26,11 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual} = jsunity.jsUnity.assertions;
 const arango = require("@arangodb").arango;
 const db = require("internal").db;
 const users = require("@arangodb/users");
+let IM = global.instanceManager;
 
 function AuthSuite() {
   'use strict';
@@ -40,7 +42,7 @@ function AuthSuite() {
       
   return {
     setUpAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.rememberConnection();
 
       try {
         users.remove(user1);
@@ -67,7 +69,7 @@ function AuthSuite() {
     },
 
     tearDownAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.reconnectMe();
       try {
         users.remove(user1);
       } catch (err) {
@@ -84,15 +86,15 @@ function AuthSuite() {
     },
     
     tearDown: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', "root", "");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', "root", "");
       db._drop(cn);
 
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.reconnectMe();
       db._drop(cn);
     },
     
     testRestoreSystemDBRoot: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+      IM.reconnectMe();
     
       let result = arango.PUT('/_api/replication/restore-collection', {
         parameters: { name: cn, type: 2 }, indexes: [] 
@@ -101,7 +103,7 @@ function AuthSuite() {
     },
     
     testRestoreSystemDBRootOverwrite: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+      IM.reconnectMe();
     
       let result = arango.PUT('/_api/replication/restore-collection', {
         parameters: { name: cn, type: 2 }, indexes: [] 
@@ -126,7 +128,7 @@ function AuthSuite() {
     },
     
     testRestoreOtherDBRoot: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', 'root', '');
     
       let result = arango.PUT('/_api/replication/restore-collection', {
         parameters: { name: cn, type: 2 }, indexes: [] 
@@ -135,7 +137,7 @@ function AuthSuite() {
     },
     
     testRestoreOtherDBRW: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, 'foobar');
     
       let result = arango.PUT('/_api/replication/restore-collection', {
         parameters: { name: cn, type: 2 }, indexes: [] 
@@ -144,7 +146,7 @@ function AuthSuite() {
     },
     
     testRestoreOtherDBRWOverwrite: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, 'foobar');
     
       let result = arango.PUT('/_api/replication/restore-collection', {
         parameters: { name: cn, type: 2 }, indexes: [] 
@@ -169,7 +171,7 @@ function AuthSuite() {
     },
     
     testRestoreOtherDBRO: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, 'foobar');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, 'foobar');
     
       let result = arango.PUT('/_api/replication/restore-collection', {
         parameters: { name: cn, type: 2 }, indexes: [] 

--- a/tests/js/client/authentication/statistics-cluster-sjs.js
+++ b/tests/js/client/authentication/statistics-cluster-sjs.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertTrue, assertEqual */
+/*global */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -26,19 +26,17 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual} = jsunity.jsUnity.assertions;
 const arango = require("@arangodb").arango;
 const db = require("internal").db;
 const users = require("@arangodb/users");
+let IM = global.instanceManager;
 
 function AuthSuite() {
   'use strict';
-  let baseUrl = function () {
-    return arango.getEndpoint().replace(/^tcp:/, 'http:').replace(/^ssl:/, 'https:');
-  };
-
   const user1 = 'hackers@arango.ai';
   const user2 = 'noone@arango.ai';
-      
+
   let checkStatistics = function() {
     let result = arango.GET('/_admin/aardvark/statistics/coordshort');
     assertTrue(result.enabled);
@@ -47,7 +45,7 @@ function AuthSuite() {
   return {
 
     setUpAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.rememberConnection();
 
       try {
         users.remove(user1);
@@ -74,7 +72,7 @@ function AuthSuite() {
     },
 
     tearDownAll: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', "root", "");
+      IM.reconnectMe();
       try {
         users.remove(user1);
       } catch (err) {
@@ -89,27 +87,27 @@ function AuthSuite() {
       } catch (err) {
       }
     },
-    
+
     testStatisticsSystemDBRoot: function () {
-      arango.reconnect(arango.getEndpoint(), '_system', 'root', '');
+      IM.reconnectMe();
       checkStatistics();
     },
-    
+
     testStatisticsOtherDBRoot: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', 'root', '');
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', 'root', '');
       checkStatistics();
     },
-    
+
     testStatisticsOtherDBRW: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user1, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user1, "foobar");
       checkStatistics();
     },
-    
+
     testStatisticsOtherDBRO: function () {
-      arango.reconnect(arango.getEndpoint(), 'UnitTestsDatabase', user2, "foobar");
+      arango.reconnect(IM.endpoint, 'UnitTestsDatabase', user2, "foobar");
       checkStatistics();
     },
-    
+
   };
 }
 

--- a/tests/js/client/authentication/user-access-right-foxx-queue-general-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-foxx-queue-general-spec-sjs.js
@@ -27,13 +27,13 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual} = jsunity.jsUnity.assertions;
 const helper = require('@arangodb/testutils/user-helper');
 const foxxManager = require('@arangodb/foxx/manager');
 const fs = require('fs');
 const internal = require('internal');
 const basePath = fs.makeAbsolute(fs.join(internal.pathForTesting('common'), 'test-data', 'apps'));
-const request = require('@arangodb/request');
 
 const arangodb = require('@arangodb');
 const arango = require('@arangodb').arango;
@@ -71,66 +71,60 @@ describe('Foxx service', () => {
       RETURN queue
     `).toArray();
     const res = arango.POST_RAW(mount, '');
-    expect(res.code).to.equal(204);
+    assertEqual(res.code, 204);
     const queuesAfter = db._query(aql`
       FOR queue IN _queues
       FILTER queue._key != 'default'
       RETURN queue
     `).toArray();
-    expect(queuesAfter.length - queuesBefore.length).to.equal(1, 'Could not register Foxx queue');
+    assertEqual(queuesAfter.length - queuesBefore.length, 1, 'Could not register Foxx queue');
   });
 
   it('should not register a queue two times', () => {
     const queuesBefore = db._queues.all().toArray();
     let res = arango.POST_RAW(mount, '');
-    expect(res.code).to.equal(204);
+    assertEqual(res.code, 204);
     waitForJob();
     res = arango.POST_RAW(mount, '');
-    expect(res.code).to.equal(204);
+    assertEqual(res.code, 204);
     const queuesAfter = db._queues.all().toArray();
-    expect(queuesAfter.length - queuesBefore.length).to.equal(1);
+    assertEqual(queuesAfter.length - queuesBefore.length, 1);
   });
 
   it('should support jobs running in the queue', () => {
     let res = arango.POST(mount, '');
-    expect(res.code).to.equal(204);
-    expect(waitForJob()).to.equal(true, 'job from Foxx queue did not run!');
+    assertEqual(res.code, 204);
+    assertTrue(waitForJob(), 'job from Foxx queue did not run!');
     const jobResult = db._query(aql`
       FOR i IN foxx_queue_test
         FILTER i.job == true
         RETURN 1
     `).toArray();
-    expect(jobResult.length).to.equal(1);
+    assertEqual(jobResult.length, 1);
   });
 
   it('should support jobs running in the queue', () => {
-    let res = request.post(`${arango.getEndpoint().replace('tcp://', 'http://')}/${mount}`, {
-      body: JSON.stringify({repeatTimes: 2})
-    });
-    expect(res.statusCode).to.equal(204);
-    expect(waitForJob(2)).to.equal(true, 'job from foxx queue did not run!');
+    let res = arango.POST_RAW(mount, {repeatTimes: 2});
+    assertEqual(res.code, 204);
+    assertTrue(waitForJob(2), 'job from foxx queue did not run!');
     const jobResult = db._query(aql`
       FOR i IN foxx_queue_test
         FILTER i.job == true
         RETURN 1
     `).toArray();
-    expect(jobResult.length).to.equal(2);
+    assertEqual(jobResult.length, 2);
   });
 
   it('should ignore the arango user', () => {
-    let res = internal.download(`${arango.getEndpoint().replace('tcp://', 'http://')}/${mount}`, '', {
-      method: 'post',
-      username: 'root',
-      password: ''
-    });
-    expect(res.code).to.equal(204);
-    expect(waitForJob()).to.equal(true, 'job from foxx queue did not run!');
+    let res = arango.POST_RAW(mount, '');
+    assertEqual(res.code, 204);
+    assertTrue(waitForJob(), 'job from foxx queue did not run!');
     const jobResult = db._query(aql`
       FOR i IN foxx_queue_test
         FILTER i.job == true
         RETURN 1
     `).toArray();
-    expect(jobResult.length).to.equal(1);
+    assertEqual(jobResult.length, 1);
   });
 
   const waitForJob = (runs = 1) => {

--- a/tests/js/client/authentication/user-access-right-task-collection-level-create-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-collection-level-create-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const dbName = helper.dbName;
 const colName = helper.colName;
 const rightLevels = helper.rightLevels;
@@ -48,6 +47,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const setKeySpace = (keySpaceId, name) => {
@@ -74,20 +74,11 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -97,10 +88,10 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
@@ -142,11 +133,11 @@ describe('User Rights Management', () => {
                 db._useDatabase(dbName);
                 rootTruncateCollection();
                 dropKeySpace(keySpaceId);
-                expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+                assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
               });
 
               it('by key', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 setKeySpace(keySpaceId, name);
                 const taskId = 'task_collection_level_create_by_key' + name;
                 const task = {
@@ -173,12 +164,12 @@ describe('User Rights Management', () => {
                     let col = db._collection(colName);
                     try {
                       col.document('123');
-                      expect(false).to.equal(true, 'Precondition failed, document already inserted.');
+                      assertFalse(true, 'Precondition failed, document already inserted.');
                     } catch (e) {}
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} the create did not pass through...`);
-                    expect(col.document('123').foo).to.equal('bar', `${name} the create did not pass through...`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} the create did not pass through...`);
+                    assertEqual(col.document('123').foo, 'bar', `${name} the create did not pass through...`);
                   } else {
                     let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                       (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
@@ -186,31 +177,31 @@ describe('User Rights Management', () => {
                       let col = db._collection(colName);
                       try {
                         col.document('123');
-                        expect(false).to.equal(true, 'Precondition failed, document already inserted.');
+                        assertFalse(true, 'Precondition failed, document already inserted.');
                       } catch (e) {}
                     }
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to create the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to create the document with insufficient rights`);
                     if (hasReadAccess) {
                       let col = db._collection(colName);
                       try {
-                        expect(col.document('123').foo).to.not.equal('bar', `${name} managed to create the document with insufficient rights`);
+                        assertNotEqual(col.document('123').foo, 'bar', `${name} managed to create the document with insufficient rights`);
                       } catch (e) {}
                     }
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });
 
               it('by aql', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 const taskId = 'task_collection_level_create_by_aql' + name;
                 let q = `INSERT {_key: '456', foo: 'bar'} IN ${colName} RETURN NEW`;
                 setKeySpace(keySpaceId, name);
@@ -235,28 +226,28 @@ describe('User Rights Management', () => {
                     let col = db._collection(colName);
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} the create did not pass through...`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} the create did not pass through...`);
                     let doc = col.document('456');
-                    expect(doc.foo).to.equal('bar', `${name}  the create did not pass through...`);
+                    assertEqual(doc.foo, 'bar', `${name}  the create did not pass through...`);
                   } else {
                     let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                       (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to create the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to create the document with insufficient rights`);
                     if (hasReadAccess) {
                       let col = db._collection(colName);
                       try {
-                        expect(col.document('456').foo).to.not.equal('bar', `${name} managed to create the document with insufficient rights`);
+                        assertNotEqual(col.document('456').foo, 'bar', `${name} managed to create the document with insufficient rights`);
                       } catch (e) {}
                     }
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-collection-level-drop-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-collection-level-drop-spec-sjs.js
@@ -28,12 +28,12 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
 const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const dbName = helper.dbName;
 const colName = helper.colName;
 const rightLevels = helper.rightLevels;
@@ -48,6 +48,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +63,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -70,7 +71,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -78,16 +79,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -97,15 +89,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -119,7 +111,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -152,7 +144,7 @@ describe('User Rights Management', () => {
               });
 
               it('by key', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist.');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist.');
                 setKey(keySpaceId, name);
                 const taskId = 'task_collection_level_drop_by_key' + name;
                 const task = {
@@ -174,43 +166,43 @@ describe('User Rights Management', () => {
                   if ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                     colLevel['rw'].has(name)) {
                     let col = db._collection(colName);
-                    expect(col.document('123')._key).to.equal('123', 'Precondition failed, document does not exist.');
+                    assertEqual(col.document('123')._key, '123', 'Precondition failed, document does not exist.');
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not drop the document with sufficient rights`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not drop the document with sufficient rights`);
                     try {
                       col.document('123');
-                      expect(true).to.equal(false, `${name} could not drop the document with sufficient rights`);
+                      assertTrue(false, `${name} could not drop the document with sufficient rights`);
                     } catch (e) {}
                   } else {
                     let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                       (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
                     if (hasReadAccess) {
                       let col = db._collection(colName);
-                      expect(col.document('123')._key).to.equal('123', 'Precondition failed, document does not exist.');
+                      assertEqual(col.document('123')._key, '123', 'Precondition failed, document does not exist.');
                     }
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to remove the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to remove the document with insufficient rights`);
                     if (hasReadAccess) {
                       let col = db._collection(colName);
                       try {
-                        expect(col.document('123')._key).to.equal('123', `${name} managed to remove the document with insufficient rights`);
+                        assertEqual(col.document('123')._key, '123', `${name} managed to remove the document with insufficient rights`);
                       } catch (e) {}
                     }
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });
 
               it('by aql', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 let q = `REMOVE '456' IN ${colName} RETURN OLD`;
                 setKey(keySpaceId, name);
                 const taskId = 'task_collection_level_drop_by_key' + name;
@@ -235,30 +227,30 @@ describe('User Rights Management', () => {
                     let col = db._collection(colName);
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not drop the document with sufficient rights`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not drop the document with sufficient rights`);
                     try {
                       col.document('456');
-                      expect(true).to.equal(false, 'Document still in collection after remove');
+                      assertTrue(false, 'Document still in collection after remove');
                     } catch (e) {}
                   } else {
                     let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                       (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to remove the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to remove the document with insufficient rights`);
                     if (hasReadAccess) {
                       let col = db._collection(colName);
                       try {
-                        expect(col.document('456')._key).to.equal('456', `${name} managed to remove the document with insufficient rights`);
+                        assertEqual(col.document('456')._key, '456', `${name} managed to remove the document with insufficient rights`);
                       } catch (e) {}
                     }
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-collection-level-read-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-collection-level-read-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const dbName = helper.dbName;
 const colName = helper.colName;
 const rightLevels = helper.rightLevels;
@@ -48,6 +47,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -70,7 +70,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -78,16 +78,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -97,15 +88,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -119,7 +110,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -151,7 +142,7 @@ describe('User Rights Management', () => {
               });
 
               it('by key', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 setKey(keySpaceId, name);
                 const taskId = 'task_collection_level_read_by_key' + name;
                 const task = {
@@ -174,24 +165,24 @@ describe('User Rights Management', () => {
                     (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not read the document with sufficient rights`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not read the document with sufficient rights`);
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to read the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to read the document with insufficient rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });
 
               it('by aql', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 let q = `FOR x IN ${colName} RETURN x`;
                 setKey(keySpaceId, name);
                 const taskId = 'task_collection_level_read_by_aql' + name;
@@ -215,18 +206,18 @@ describe('User Rights Management', () => {
                     (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not read the document with sufficient rights`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not read the document with sufficient rights`);
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to read the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to read the document with insufficient rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-collection-level-truncate-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-collection-level-truncate-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const dbName = helper.dbName;
 const colName = helper.colName;
 const rightLevels = helper.rightLevels;
@@ -48,6 +47,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -70,7 +70,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -78,16 +78,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -97,15 +88,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -119,7 +110,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -166,8 +157,8 @@ describe('User Rights Management', () => {
               });
 
               it('via js', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
-                expect(rootCount()).to.equal(6, 'Precondition failed, too few documents.');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
+                assertEqual(rootCount(), 6, 'Precondition failed, too few documents.');
                 setKey(keySpaceId, name);
                 const taskId = 'task_collection_level_truncate' + name;
                 const task = {
@@ -190,20 +181,20 @@ describe('User Rights Management', () => {
                     colLevel['rw'].has(name)) {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} could not truncate the collection with sufficient rights`);
-                    expect(rootCount()).to.equal(0, `${name} could not truncate the collection with sufficient rights`);
+                    assertTrue(getKey(keySpaceId, `${name}_status`), `${name} could not truncate the collection with sufficient rights`);
+                    assertEqual(rootCount(), 0, `${name} could not truncate the collection with sufficient rights`);
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} managed to truncate the collection with insufficient rights`);
-                    expect(rootCount()).to.equal(6, `${name} managed to truncate the collection with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_status`), `${name} managed to truncate the collection with insufficient rights`);
+                    assertEqual(rootCount(), 6, `${name} managed to truncate the collection with insufficient rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-collection-level-update-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-collection-level-update-spec-sjs.js
@@ -28,13 +28,12 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const errors = require('@arangodb').errors;
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const dbName = helper.dbName;
 const colName = helper.colName;
 const rightLevels = helper.rightLevels;
@@ -48,6 +47,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const setKeySpace = (keySpaceId, name) => {
@@ -74,20 +74,11 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -97,15 +88,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -119,7 +110,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -151,7 +142,7 @@ describe('User Rights Management', () => {
               });
 
               it('by key', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 setKeySpace(keySpaceId, name + '_update');
                 const taskIdUpdate = 'task_collection_level_update_by_key' + name;
                 const taskUpdate = {
@@ -190,52 +181,52 @@ describe('User Rights Management', () => {
                   if ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                     colLevel['rw'].has(name)) {
                     let col = db._collection(colName);
-                    expect(col.document('123').foo).to.not.equal('bar', 'Precondition failed, document already has the attribute set.');
+                    assertNotEqual(col.document('123').foo, 'bar', 'Precondition failed, document already has the attribute set.');
                     tasks.register(taskUpdate);
                     wait(keySpaceId, `${name}_update`);
-                    expect(getKey(keySpaceId, `${name}_update_status`)).to.equal(true, `${name} the update did not pass through...`);
-                    expect(col.document('123').foo).to.equal('bar', `${name} the update did not pass through...`);
+                    assertTrue(getKey(keySpaceId, `${name}_update_status`), `${name} the update did not pass through...`);
+                    assertEqual(col.document('123').foo, 'bar', `${name} the update did not pass through...`);
 
                     tasks.register(taskReplace);
                     wait(keySpaceId, `${name}_replace`);
-                    expect(getKey(keySpaceId, `${name}_replace_status`)).to.equal(true, `${name} the update did not pass through...`);
-                    expect(col.document('123').foo).to.equal('baz', `${name} the replace did not pass through...`);
+                    assertTrue(getKey(keySpaceId, `${name}_replace_status`), `${name} the update did not pass through...`);
+                    assertEqual(col.document('123').foo, 'baz', `${name} the replace did not pass through...`);
                   } else {
                     let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                       (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
                     if (hasReadAccess) {
                       let col = db._collection(colName);
-                      expect(col.document('123').foo).to.not.equal('bar', 'Precondition failed, document already has the attribute set.');
+                      assertNotEqual(col.document('123').foo, 'bar', 'Precondition failed, document already has the attribute set.');
                     }
                     tasks.register(taskUpdate);
                     wait(keySpaceId, `${name}_update`);
-                    expect(getKey(keySpaceId, `${name}_update_status`)).to.not.equal(true, `${name} managed to update the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_update_status`), `${name} managed to update the document with insufficient rights`);
                     if (hasReadAccess) {
                       let col = db._collection(colName);
-                      expect(col.document('123').foo).to.not.equal('bar', `${name} managed to update the document with insufficient rights`);
+                      assertNotEqual(col.document('123').foo, 'bar', `${name} managed to update the document with insufficient rights`);
                     }
 
                     tasks.register(taskReplace);
                     wait(keySpaceId, `${name}_replace`);
-                    expect(getKey(keySpaceId, `${name}_replace_status`)).to.not.equal(true, `${name} managed to replace the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_replace_status`), `${name} managed to replace the document with insufficient rights`);
                     if (hasReadAccess) {
                       let col = db._collection(colName);
-                      expect(col.document('123').foo).to.not.equal('baz', `${name} managed to replace the document with insufficient rights`);
+                      assertNotEqual(col.document('123').foo, 'baz', `${name} managed to replace the document with insufficient rights`);
                     }
                   }
                 } else {
                   try {
                     tasks.register(taskUpdate);
                     tasks.register(taskReplace);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });
 
               it('by aql', () => {
-                expect(rootTestCollection()).to.equal(true, 'Precondition failed, the collection does not exist');
+                assertTrue(rootTestCollection(), 'Precondition failed, the collection does not exist');
                 let q = `FOR x IN ${colName} UPDATE x WITH {foo: 'bar'} IN ${colName} RETURN NEW`;
                 let q2 = `FOR x IN ${colName} REPLACE x WITH {foo: 'baz'} IN ${colName} RETURN NEW`;
                 const taskIdUpdate = 'task_collection_level_update_by_aql' + name;
@@ -278,41 +269,41 @@ describe('User Rights Management', () => {
                     let col = db._collection(colName);
                     tasks.register(taskUpdate);
                     wait(keySpaceId, `${name}_update`);
-                    expect(getKey(keySpaceId, `${name}_update_status`)).to.equal(true, `${name} the update did not pass through...`);
-                    expect(col.document('123').foo).to.equal('bar');
+                    assertTrue(getKey(keySpaceId, `${name}_update_status`), `${name} the update did not pass through...`);
+                    assertEqual(col.document('123').foo, 'bar');
 
                     tasks.register(taskReplace);
                     wait(keySpaceId, `${name}_replace`);
-                    expect(getKey(keySpaceId, `${name}_replace_status`)).to.equal(true, `${name} the update did not pass through...`);
-                    expect(col.document('123').foo).to.equal('baz');
+                    assertTrue(getKey(keySpaceId, `${name}_replace_status`), `${name} the update did not pass through...`);
+                    assertEqual(col.document('123').foo, 'baz');
                   } else {
                     let hasReadAccess = ((dbLevel['rw'].has(name) || dbLevel['ro'].has(name)) &&
                       (colLevel['rw'].has(name) || colLevel['ro'].has(name)));
                     tasks.register(taskUpdate);
                     wait(keySpaceId, `${name}_update`);
-                    expect(getKey(keySpaceId, `${name}_update_status`)).to.not.equal(true, `${name} managed to update the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_update_status`), `${name} managed to update the document with insufficient rights`);
 
                     if (hasReadAccess) {
                       let col = db._collection(colName);
-                      expect(col.document('123').foo).to.not.equal('bar', `${name} managed to update the document with insufficient rights`);
+                      assertNotEqual(col.document('123').foo, 'bar', `${name} managed to update the document with insufficient rights`);
                     }
 
                     tasks.register(taskReplace);
                     wait(keySpaceId, `${name}_replace`);
-                    expect(getKey(keySpaceId, `${name}_replace_status`)).to.not.equal(true, `${name} managed to replace the document with insufficient rights`);
+                    assertFalse(getKey(keySpaceId, `${name}_replace_status`), `${name} managed to replace the document with insufficient rights`);
 
                     if (hasReadAccess) {
                       let col = db._collection(colName);
-                      expect(col.document('123').foo).to.not.equal('baz', `${name} managed to replace the document with insufficient rights`);
+                      assertNotEqual(col.document('123').foo, 'baz', `${name} managed to replace the document with insufficient rights`);
                     }
                   }
                 } else {
                   try {
                     tasks.register(taskUpdate);
                     tasks.register(taskReplace);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-collection-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-collection-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
@@ -49,6 +48,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -63,7 +63,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -71,7 +71,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -79,16 +79,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -98,15 +89,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -119,7 +110,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -153,7 +144,7 @@ describe('User Rights Management', () => {
             });
 
             it('create a task which creates a collection', () => {
-              expect(rootTestCollection()).to.equal(false, 'Precondition failed, the collection still exists');
+              assertFalse(rootTestCollection(), 'Precondition failed, the collection still exists');
               setKey(keySpaceId, name);
               const taskId = 'task_collection_' + name;
               const task = {
@@ -172,16 +163,16 @@ describe('User Rights Management', () => {
                 tasks.register(task);
                 wait(keySpaceId, name);
                 if (dbLevel['rw'].has(name)) {
-                  expect(rootTestCollection()).to.equal(true, 'Collection creation reported success, but collection was not found afterwards.');
+                  assertTrue(rootTestCollection(), 'Collection creation reported success, but collection was not found afterwards.');
                 } else {
-                  expect(rootTestCollection()).to.equal(false, `${name} was able to create a collection with insufficent rights`);
+                  assertFalse(rootTestCollection(), `${name} was able to create a collection with insufficent rights`);
                 }
               } else {
                 try {
                   tasks.register(task);
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 } catch (e) {
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                 }
               }
             });

--- a/tests/js/client/authentication/user-access-right-task-create-a-user-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-create-a-user-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const namePrefix = helper.namePrefix;
 const rightLevels = helper.rightLevels;
 const errors = require('@arangodb').errors;
@@ -48,6 +47,7 @@ const testUser = `${namePrefix}TestUser`;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -70,7 +70,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -78,16 +78,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + '/_admin/execute?returnAsJSON=true',
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.removeAllUsers();
@@ -95,7 +86,7 @@ helper.generateAllUsers();
 
 describe('User Rights Management', () => {
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -110,7 +101,7 @@ describe('User Rights Management', () => {
           before(() => {
             // What are defaults if unchanged?
             helper.switchUser(name);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -168,16 +159,16 @@ describe('User Rights Management', () => {
                 tasks.register(task);
                 wait(keySpaceId, name);
                 if (systemLevel['rw'].has(name)) {
-                  expect(rootTestUser()).to.equal(true, 'User creation reported success, but User was not found afterwards.');
+                  assertTrue(rootTestUser(), 'User creation reported success, but User was not found afterwards.');
                 } else {
-                  expect(rootTestUser()).to.equal(false, `${name} was able to create a user with insufficent rights`);
+                  assertFalse(rootTestUser(), `${name} was able to create a user with insufficent rights`);
                 }
               } else {
                 try {
                   tasks.register(task);
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 } catch (e) {
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                 }
               }
             });

--- a/tests/js/client/authentication/user-access-right-task-create-db-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-create-db-spec-sjs.js
@@ -28,11 +28,10 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const namePrefix = helper.namePrefix;
 const rightLevels = helper.rightLevels;
 const testDBName = `${namePrefix}DBNew`;
@@ -47,6 +46,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -61,7 +61,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -69,7 +69,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -77,16 +77,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + '/_admin/execute?returnAsJSON=true',
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.removeAllUsers();
@@ -94,7 +85,7 @@ helper.generateAllUsers();
 
 describe('User Rights Management', () => {
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -108,7 +99,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -169,16 +160,16 @@ describe('User Rights Management', () => {
                 tasks.register(task);
                 wait(keySpaceId, name);
                 if (systemLevel['rw'].has(name)) {
-                  expect(rootTestDB()).to.equal(true, 'DB creation reported success, but DB was not found afterwards.');
+                  assertTrue(rootTestDB(), 'DB creation reported success, but DB was not found afterwards.');
                 } else {
-                  expect(rootTestDB()).to.equal(false, `${name} was able to create a database with insufficent rights`);
+                  assertFalse(rootTestDB(), `${name} was able to create a database with insufficent rights`);
                 }
               } else {
                 try {
                   tasks.register(task);
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 } catch (e) {
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                 }
               }
             });

--- a/tests/js/client/authentication/user-access-right-task-create-graph-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-create-graph-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const graphModule = require('@arangodb/general-graph');
 const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
@@ -52,6 +51,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -66,7 +66,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -74,7 +74,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -82,16 +82,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -101,15 +92,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0);
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0);
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -123,7 +114,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -194,9 +185,9 @@ describe('User Rights Management', () => {
               });
 
               it('graph', () => {
-                expect(rootTestGraph()).to.equal(false, 'Precondition failed, the graph still exists');
-                expect(rootTestCollection(testEdgeColName)).to.equal(false, 'Precondition failed, the edge collection still exists');
-                expect(rootTestCollection(testVertexColName)).to.equal(false, 'Precondition failed, the vertex collection still exists');
+                assertFalse(rootTestGraph(), 'Precondition failed, the graph still exists');
+                assertFalse(rootTestCollection(testEdgeColName), 'Precondition failed, the edge collection still exists');
+                assertFalse(rootTestCollection(testVertexColName), 'Precondition failed, the vertex collection still exists');
                 setKey(keySpaceId, name);
                 const taskId = 'task_create_graph_' + name;
                 const task = {
@@ -218,20 +209,20 @@ describe('User Rights Management', () => {
                   if (dbLevel['rw'].has(name)) {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(rootTestGraph()).to.equal(true, 'Graph creation reported success, but graph was not found afterwards.');
-                    expect(rootTestCollection(testEdgeColName)).to.equal(true, 'Graph creation reported success, but edge colleciton was not found afterwards.');
-                    expect(rootTestCollection(testVertexColName)).to.equal(true, 'Graph creation reported success, but vertex colleciton was not found afterwards.');
+                    assertTrue(rootTestGraph(), 'Graph creation reported success, but graph was not found afterwards.');
+                    assertTrue(rootTestCollection(testEdgeColName), 'Graph creation reported success, but edge colleciton was not found afterwards.');
+                    assertTrue(rootTestCollection(testVertexColName), 'Graph creation reported success, but vertex colleciton was not found afterwards.');
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, name);
-                    expect(rootTestGraph()).to.equal(false, `${name} was able to create a graph with insufficent rights`);
+                    assertFalse(rootTestGraph(), `${name} was able to create a graph with insufficent rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });
@@ -241,9 +232,9 @@ describe('User Rights Management', () => {
 
                 rootCreateCollection(testEdgeColName, true);
                 rootCreateCollection(testVertexColName, false);
-                expect(rootTestGraph()).to.equal(false, 'Precondition failed, the graph still exists');
-                expect(rootTestCollection(testEdgeColName)).to.equal(true, 'Precondition failed, the edge collection still not exists');
-                expect(rootTestCollection(testVertexColName)).to.equal(true, 'Precondition failed, the vertex collection still not exists');
+                assertFalse(rootTestGraph(), 'Precondition failed, the graph still exists');
+                assertTrue(rootTestCollection(testEdgeColName), 'Precondition failed, the edge collection still not exists');
+                assertTrue(rootTestCollection(testVertexColName), 'Precondition failed, the vertex collection still not exists');
                 setKey(keySpaceId, name + '_existing_collections');
                 const taskId = 'task_create_graph_existing_collections' + name;
                 const task = {
@@ -265,20 +256,20 @@ describe('User Rights Management', () => {
                   if (dbLevel['rw'].has(name) && (colLevel['rw'].has(name) || colLevel['ro'].has(name))) {
                     tasks.register(task);
                     wait(keySpaceId, `${name}_existing_collections`);
-                    expect(rootTestGraph()).to.equal(true, 'Graph creation reported success, but graph was not found afterwards.');
-                    expect(rootTestCollection(testEdgeColName)).to.equal(true, 'Graph creation reported success, but edge colleciton was not found afterwards.');
-                    expect(rootTestCollection(testVertexColName)).to.equal(true, 'Graph creation reported success, but vertex colleciton was not found afterwards.');
+                    assertTrue(rootTestGraph(), 'Graph creation reported success, but graph was not found afterwards.');
+                    assertTrue(rootTestCollection(testEdgeColName), 'Graph creation reported success, but edge colleciton was not found afterwards.');
+                    assertTrue(rootTestCollection(testVertexColName), 'Graph creation reported success, but vertex colleciton was not found afterwards.');
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, `${name}_existing_collections`);
-                    expect(rootTestGraph()).to.equal(false, `${name} was able to create a graph with insufficent rights`);
+                    assertFalse(rootTestGraph(), `${name} was able to create a graph with insufficent rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-search-alias-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-search-alias-spec-sjs.js
@@ -27,12 +27,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const errors = require('@arangodb').errors;
 const db = require('@arangodb').db;
 const namePrefix = helper.namePrefix;
@@ -40,7 +39,6 @@ const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testViewName = `${namePrefix}ViewNew`;
 const testColName = `${namePrefix}ColNew`;
-const testColNameAnother = `${namePrefix}ColAnotherNew`;
 const indexName = `${namePrefix}Inverted`;
 const keySpaceId = 'task_create_view_keyspace';
 
@@ -51,6 +49,7 @@ const colLevel = helper.colLevel;
 
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -67,7 +66,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -75,7 +74,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -83,16 +82,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -104,15 +94,15 @@ const testViewType = "search-alias";
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0);
+    assertTrue(userSet.size > 0);
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -126,7 +116,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -227,8 +217,8 @@ describe('User Rights Management', () => {
             };
 
             const checkError = (e) => {
-              expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-              expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+              assertEqual(e.code, 403, "Expected to get forbidden REST error code, but got another one");
+              assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
             };
 
             describe('create a', () => {
@@ -244,7 +234,7 @@ describe('User Rights Management', () => {
               const key = `${name}`;
 
               it('view with empty (default) parameters', () => {
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
 
                 setKey(keySpaceId, name);
                 const taskId = 'task_create_view_default_params_' + key;
@@ -267,8 +257,8 @@ describe('User Rights Management', () => {
                 if (dbLevel['rw'].has(name)) {
                   tasks.register(task);
                   wait(keySpaceId, key);
-                  expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                  assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not create the view with sufficient rights`);
+                  assertTrue(rootTestView(testViewName), 'View creation reported success, but view was not found afterwards');
                 } else {
                   try {
                     tasks.register(task);
@@ -277,9 +267,9 @@ describe('User Rights Management', () => {
                     checkError(e);
                     return;
                   } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 }
               });
 

--- a/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-create-view-arangosearch-spec-sjs.js
@@ -27,12 +27,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const errors = require('@arangodb').errors;
 const db = require('@arangodb').db;
 const namePrefix = helper.namePrefix;
@@ -51,6 +50,7 @@ const colLevel = helper.colLevel;
 
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -67,7 +67,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -75,7 +75,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -83,16 +83,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -104,15 +95,15 @@ const testViewType = "arangosearch";
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0);
+    assertTrue(userSet.size > 0);
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -126,7 +117,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -227,8 +218,8 @@ describe('User Rights Management', () => {
             };
 
             const checkError = (e) => {
-              expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-              expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+              assertEqual(e.code, 403, "Expected to get forbidden REST error code, but got another one");
+              assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
             };
 
             describe('create a', () => {
@@ -244,7 +235,7 @@ describe('User Rights Management', () => {
               const key = `${name}`;
 
               it('view with empty (default) parameters', () => {
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
 
                 setKey(keySpaceId, name);
                 const taskId = 'task_create_view_default_params_' + key;
@@ -267,8 +258,8 @@ describe('User Rights Management', () => {
                 if (dbLevel['rw'].has(name)) {
                   tasks.register(task);
                   wait(keySpaceId, key);
-                  expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
+                  assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not create the view with sufficient rights`);
+                  assertTrue(rootTestView(testViewName), 'View creation reported success, but view was not found afterwards');
                 } else {
                   try {
                     tasks.register(task);
@@ -277,9 +268,9 @@ describe('User Rights Management', () => {
                     checkError(e);
                     return;
                   } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 }
               });
 
@@ -287,7 +278,7 @@ describe('User Rights Management', () => {
                 rootDropView(testViewName);
                 rootDropCollection(testColName);
 
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
+                assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
 
                 setKey(keySpaceId, key);
                 const taskId = 'task_create_view_non_default_params_except_links_' + key;
@@ -310,9 +301,9 @@ describe('User Rights Management', () => {
                 if (dbLevel['rw'].has(name)) {
                   tasks.register(task);
                   wait(keySpaceId, key);
-                  expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                  expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                  expect(rootGetViewProps(testViewName, true)["cleanupIntervalStep"]).to.equal(20, 'View creation reported success, but view property was not set as expected during creation');
+                  assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not create the view with sufficient rights`);
+                  assertTrue(rootTestView(testViewName), 'View creation reported success, but view was not found afterwards');
+                  assertEqual(rootGetViewProps(testViewName, true)["cleanupIntervalStep"], 20, 'View creation reported success, but view property was not set as expected during creation');
                 } else {
                   try {
                     tasks.register(task);
@@ -321,9 +312,9 @@ describe('User Rights Management', () => {
                     checkError(e);
                     return;
                   } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 }
               });
 
@@ -332,8 +323,8 @@ describe('User Rights Management', () => {
                 rootDropCollection(testColName);
 
                 rootCreateCollection(testColName);
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
+                assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
+                assertTrue(rootTestCollection(testColName), 'Precondition failed, the collection still not exists');
 
                 setKey(keySpaceId, key);
                 const taskId = 'task_create_view_with_links_to_existing_collection_' + key;
@@ -357,14 +348,14 @@ describe('User Rights Management', () => {
                   if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
                     tasks.register(task);
                     wait(keySpaceId, key);
-                    expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                    expect(rootTestViewHasLinks(testViewName, [`${testColName}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
+                    assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not create the view with sufficient rights`);
+                    assertTrue(rootTestView(testViewName), 'View creation reported success, but view was not found afterwards');
+                    assertTrue(rootTestViewHasLinks(testViewName, [`${testColName}`]), 'View links expected to be visible, but were not found afterwards');
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, key);
-                    expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could create the view with insufficient rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
                 } else {
                   try {
@@ -374,9 +365,9 @@ describe('User Rights Management', () => {
                     checkError(e);
                     return;
                   } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 }
               });
 
@@ -387,9 +378,9 @@ describe('User Rights Management', () => {
                 rootCreateCollection(testColName);
                 rootCreateCollection(testColNameAnother);
 
-                expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
-                expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+                assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
+                assertTrue(rootTestCollection(testColName), 'Precondition failed, the collection still not exists');
+                assertTrue(rootTestCollection(testColNameAnother), 'Precondition failed, the collection still not exists');
 
                 setKey(keySpaceId, key);
                 const taskId = 'task_create_view_with_links_to_existing_collections_with_same_access_level_' + key;
@@ -416,14 +407,14 @@ describe('User Rights Management', () => {
                   if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
                     tasks.register(task);
                     wait(keySpaceId, key);
-                    expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                    expect(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
+                    assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not create the view with sufficient rights`);
+                    assertTrue(rootTestView(testViewName), 'View creation reported success, but view was not found afterwards');
+                    assertTrue(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`]), 'View links expected to be visible, but were not found afterwards');
                   } else {
                     tasks.register(task);
                     wait(keySpaceId, key);
-                    expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could create the view with insufficient rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
                 } else {
                   try {
@@ -433,9 +424,9 @@ describe('User Rights Management', () => {
                     checkError(e);
                     return;
                   } finally {
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   }
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 }
               });
 
@@ -451,9 +442,9 @@ describe('User Rights Management', () => {
                   rootCreateCollection(testColNameAnother);
                   rootGrantCollection(testColNameAnother, name, "ro");
 
-                  expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                  expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
-                  expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+                  assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
+                  assertTrue(rootTestCollection(testColName), 'Precondition failed, the collection still not exists');
+                  assertTrue(rootTestCollection(testColNameAnother), 'Precondition failed, the collection still not exists');
 
                   setKey(keySpaceId, key);
                   const taskId = 'task_create_view_with_links_to_existing_collections_with_RO_access_level_to_one_of_them_' + key;
@@ -480,14 +471,14 @@ describe('User Rights Management', () => {
                     if (colLevel['rw'].has(name)) {
                       tasks.register(task);
                       wait(keySpaceId, key);
-                      expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not create the view with sufficient rights`);
-                      expect(rootTestView(testViewName)).to.equal(true, 'View creation reported success, but view was not found afterwards');
-                      expect(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`])).to.equal(true, 'View links expected to be visible, but were not found afterwards');
+                      assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not create the view with sufficient rights`);
+                      assertTrue(rootTestView(testViewName), 'View creation reported success, but view was not found afterwards');
+                      assertTrue(rootTestViewHasLinks(testViewName, [`${testColName}`, `${testColNameAnother}`]), 'View links expected to be visible, but were not found afterwards');
                     } else {
                       tasks.register(task);
                       wait(keySpaceId, key);
-                      expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                      expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                      assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could create the view with insufficient rights`);
+                      assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                     }
                   } else {
                     try {
@@ -497,9 +488,9 @@ describe('User Rights Management', () => {
                       checkError(e);
                       return;
                     } finally {
-                      expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                      assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                     }
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   }
                 });
 
@@ -514,9 +505,9 @@ describe('User Rights Management', () => {
                   rootCreateCollection(testColNameAnother);
                   rootGrantCollection(testColNameAnother, name, "none");
 
-                  expect(rootTestView(testViewName)).to.equal(false, 'Precondition failed, the view still exists');
-                  expect(rootTestCollection(testColName)).to.equal(true, 'Precondition failed, the collection still not exists');
-                  expect(rootTestCollection(testColNameAnother)).to.equal(true, 'Precondition failed, the collection still not exists');
+                  assertFalse(rootTestView(testViewName), 'Precondition failed, the view still exists');
+                  assertTrue(rootTestCollection(testColName), 'Precondition failed, the collection still not exists');
+                  assertTrue(rootTestCollection(testColNameAnother), 'Precondition failed, the collection still not exists');
 
                   setKey(keySpaceId, key);
                   const taskId = 'task_create_view_with_links_to_existing_collections_with_NONE_access_level_to_one_of_them_' + key;
@@ -542,8 +533,8 @@ describe('User Rights Management', () => {
                   if (dbLevel['rw'].has(name)) {
                     tasks.register(task);
                     wait(keySpaceId, key);
-                    expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could create the view with insufficient rights`);
-                    expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                    assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could create the view with insufficient rights`);
+                    assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                   } else {
                     try {
                       tasks.register(task);
@@ -552,9 +543,9 @@ describe('User Rights Management', () => {
                       checkError(e);
                       return;
                     } finally {
-                      expect(rootTestView(testViewName)).to.equal(false, `${name} was able to create a view with insufficent rights`);
+                      assertFalse(rootTestView(testViewName), `${name} was able to create a view with insufficent rights`);
                     }
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   }
                 });
 

--- a/tests/js/client/authentication/user-access-right-task-drop-a-user-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-drop-a-user-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const namePrefix = helper.namePrefix;
 const rightLevels = helper.rightLevels;
 const errors = require('@arangodb').errors;
@@ -48,6 +47,7 @@ const testUser = `${namePrefix}TestUser`;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -70,7 +70,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -78,16 +78,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + '/_admin/execute?returnAsJSON=true',
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.removeAllUsers();
@@ -95,7 +86,7 @@ helper.generateAllUsers();
 
 describe('User Rights Management', () => {
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -109,7 +100,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -175,18 +166,18 @@ describe('User Rights Management', () => {
                 if (systemLevel['rw'].has(name)) {
                   tasks.register(task);
                   wait(keySpaceId, name);
-                  expect(rootTestUser()).to.equal(false, 'Drop user stated success, but user still found.');
+                  assertFalse(rootTestUser(), 'Drop user stated success, but user still found.');
                 } else {
                   tasks.register(task);
                   wait(keySpaceId, name);
-                  expect(rootTestUser()).to.equal(true, 'managed to drop user with insufficient rights');
+                  assertTrue(rootTestUser(), 'managed to drop user with insufficient rights');
                 }
               } else {
                 try {
                   tasks.register(task);
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 } catch (e) {
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                 }
               }
             });

--- a/tests/js/client/authentication/user-access-right-task-drop-db-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-drop-db-spec-sjs.js
@@ -28,11 +28,10 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const namePrefix = helper.namePrefix;
 const rightLevels = helper.rightLevels;
 const testDBName = `${namePrefix}DBNew`;
@@ -47,6 +46,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -61,7 +61,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -69,7 +69,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -77,16 +77,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + '/_admin/execute?returnAsJSON=true',
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.removeAllUsers();
@@ -94,7 +85,7 @@ helper.generateAllUsers();
 
 describe('User Rights Management', () => {
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -108,7 +99,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -176,16 +167,16 @@ describe('User Rights Management', () => {
                 tasks.register(task);
                 wait(keySpaceId, name);
                 if (systemLevel['rw'].has(name)) {
-                  expect(rootTestDB()).to.equal(false, 'DB drop reported success, but DB was still found afterwards.');
+                  assertFalse(rootTestDB(), 'DB drop reported success, but DB was still found afterwards.');
                 } else {
-                  expect(rootTestDB()).to.equal(true, `${name} was able to drop a database with insufficient rights`);
+                  assertTrue(rootTestDB(), `${name} was able to drop a database with insufficient rights`);
                 }
               } else {
                 try {
                   tasks.register(task);
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 } catch (e) {
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                 }
               }
             });

--- a/tests/js/client/authentication/user-access-right-task-drop-graph-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-drop-graph-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const graphModule = require('@arangodb/general-graph');
 const namePrefix = helper.namePrefix;
 const dbName = helper.dbName;
@@ -52,6 +51,7 @@ const colLevel = helper.colLevel;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -66,7 +66,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const setKeySpace = (keySpaceId, name) => {
@@ -78,20 +78,11 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -101,15 +92,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0);
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -123,7 +114,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name, dbName);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -199,7 +190,7 @@ describe('User Rights Management', () => {
               });
 
               it('graph', () => {
-                expect(!rootTestGraph()).to.equal(false, 'Precondition failed, the graph still not exists');
+                assertTrue(rootTestGraph(), 'Precondition failed, the graph still not exists');
                 setKeySpace(keySpaceId, name);
                 const taskId = 'task_create_graph_' + name;
                 const task = {
@@ -217,18 +208,18 @@ describe('User Rights Management', () => {
                   tasks.register(task);
                   wait(keySpaceId, name);
                   if (colLevel['rw'].has(name)) {
-                    expect(!rootTestGraph()).to.equal(true, 'Graph drop reported success, but graph was found afterwards.');
-                    expect(!rootTestCollection(testEdgeColName)).to.equal(true, 'Graph drop reported success, but edge collection was found afterwards.');
-                    expect(!rootTestCollection(testVertexColName)).to.equal(true, 'Graph drop reported success, but vertex collection was found afterwards.');
+                    assertFalse(rootTestGraph(), 'Graph drop reported success, but graph was found afterwards.');
+                    assertFalse(rootTestCollection(testEdgeColName), 'Graph drop reported success, but edge collection was found afterwards.');
+                    assertFalse(rootTestCollection(testVertexColName), 'Graph drop reported success, but vertex collection was found afterwards.');
                   } else {
-                    expect(!rootTestGraph()).to.equal(false, `${name} was able to drop a graph with insufficent rights`);
+                    assertTrue(rootTestGraph(), `${name} was able to drop a graph with insufficent rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });
@@ -248,9 +239,9 @@ describe('User Rights Management', () => {
               });
 
               it('graph with specified collection access', () => {
-                expect(rootTestGraph()).to.equal(true, 'Precondition failed, the graph still not exists');
-                expect(rootTestCollection(testEdgeColName)).to.equal(true, 'Precondition failed, the edge collection still not exists');
-                expect(rootTestCollection(testVertexColName)).to.equal(true, 'Precondition failed, the vertex collection still not exists');
+                assertTrue(rootTestGraph(), 'Precondition failed, the graph still not exists');
+                assertTrue(rootTestCollection(testEdgeColName), 'Precondition failed, the edge collection still not exists');
+                assertTrue(rootTestCollection(testVertexColName), 'Precondition failed, the vertex collection still not exists');
                 setKeySpace(keySpaceId, name + '_specified_collection_access');
                 const taskId = 'task_create_graph_specified_collection_access' + name;
                 const task = {
@@ -268,18 +259,18 @@ describe('User Rights Management', () => {
                   tasks.register(task);
                   wait(keySpaceId, `${name}_specified_collection_access`);
                   if (colLevel['rw'].has(name)) {
-                    expect(!rootTestGraph()).to.equal(true, 'Graph drop reported success, but graph was found afterwards.');
-                    expect(!rootTestCollection(testEdgeColName)).to.equal(true, 'Graph drop reported success, but edge collection was found afterwards.');
-                    expect(!rootTestCollection(testVertexColName)).to.equal(true, 'Graph drop reported success, but vertex collection was found afterwards.');
+                    assertFalse(rootTestGraph(), 'Graph drop reported success, but graph was found afterwards.');
+                    assertFalse(rootTestCollection(testEdgeColName), 'Graph drop reported success, but edge collection was found afterwards.');
+                    assertFalse(rootTestCollection(testVertexColName), 'Graph drop reported success, but vertex collection was found afterwards.');
                   } else {
-                    expect(!rootTestGraph()).to.equal(false, `${name} was able to drop a graph with insufficent rights`);
+                    assertTrue(rootTestGraph(), `${name} was able to drop a graph with insufficent rights`);
                   }
                 } else {
                   try {
                     tasks.register(task);
-                    expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                    assertFalse(true, `${name} managed to register a task with insufficient rights`);
                   } catch (e) {
-                    expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                    assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                   }
                 }
               });

--- a/tests/js/client/authentication/user-access-right-task-drop-view-arangosearch-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-drop-view-arangosearch-spec-sjs.js
@@ -27,12 +27,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const errors = require('@arangodb').errors;
 const db = require('@arangodb').db;
 const namePrefix = helper.namePrefix;
@@ -51,6 +50,7 @@ const colLevel = helper.colLevel;
 
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -67,7 +67,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -75,7 +75,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -83,16 +83,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -102,15 +93,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0);
+    assertTrue(userSet.size > 0);
     for (let testViewType of ["arangosearch", "search-alias"]) {
       describe(`view type ${testViewType}`, () => {
         for (let name of userSet) {
@@ -126,7 +117,7 @@ describe('User Rights Management', () => {
             describe(`user ${name}`, () => {
               before(() => {
                 helper.switchUser(name, dbName);
-                expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+                assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
               });
 
               after(() => {
@@ -207,8 +198,8 @@ describe('User Rights Management', () => {
                 };
 
                 const checkError = (e) => {
-                  expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+                  assertEqual(e.code, 403, "Expected to get forbidden REST error code, but got another one");
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
                 };
 
                 describe('drop a', () => {
@@ -226,7 +217,7 @@ describe('User Rights Management', () => {
 
                   it('view without links', () => {
                     rootCreateView(testViewName, testViewType);
-                    expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                    assertTrue(rootTestView(testViewName), 'Precondition failed, the view doesn not exist');
                     setKey(keySpaceId, key);
                     const taskId = 'task_drop_view_without_links_' + key;
                     const task = {
@@ -247,8 +238,8 @@ describe('User Rights Management', () => {
                     if (dbLevel['rw'].has(name)) {
                       tasks.register(task);
                       wait(keySpaceId, key);
-                      expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not drop the view with sufficient rights`);
-                      expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                      assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not drop the view with sufficient rights`);
+                      assertFalse(rootTestView(testViewName), 'View deletion reported success, but view was found afterwards');
                     } else {
                       try {
                         tasks.register(task);
@@ -257,9 +248,9 @@ describe('User Rights Management', () => {
                         checkError(e);
                         return;
                       } finally {
-                        expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                        assertTrue(rootTestView(testViewName), `${name} was able to drop a view with insufficent rights`);
                       }
-                      expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                      assertFalse(true, `${name} managed to register a task with insufficient rights`);
                     }
                   });
 
@@ -269,7 +260,7 @@ describe('User Rights Management', () => {
                       rootCreateCollection("NonExistentCol");
                       rootCreateView(testViewName, testViewType, { links: { "NonExistentCol" : { includeAllFields: true } } });
                       rootDropCollection("NonExistentCol");
-                      expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                      assertTrue(rootTestView(testViewName), 'Precondition failed, the view doesn not exist');
                       setKey(keySpaceId, key);
                       const taskId = 'task_drop_view_with_link_to_nonexist_col' + key;
                       const task = {
@@ -290,7 +281,7 @@ describe('User Rights Management', () => {
                       if (dbLevel['rw'].has(name)) {
                         tasks.register(task);
                         wait(keySpaceId, key);
-                        expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                        assertFalse(rootTestView(testViewName), 'View deletion reported success, but view was found afterwards');
                       } else {
                         try {
                           tasks.register(task);
@@ -299,9 +290,9 @@ describe('User Rights Management', () => {
                           checkError(e);
                           return;
                         } finally {
-                          expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                          assertTrue(rootTestView(testViewName), `${name} was able to drop a view with insufficent rights`);
                         }
-                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                        assertFalse(true, `${name} managed to register a task with insufficient rights`);
                       }
                     });
 
@@ -311,7 +302,7 @@ describe('User Rights Management', () => {
 
                       rootCreateCollection(testCol1Name);
                       rootCreateView(testViewName, testViewType, { links: { [testCol1Name]: { includeAllFields: true } } });
-                      expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                      assertTrue(rootTestView(testViewName), 'Precondition failed, the view doesn not exist');
                       setKey(keySpaceId, key);
                       const taskId = 'task_drop_view_with_link_to_existing_col' + key;
                       const task = {
@@ -333,12 +324,12 @@ describe('User Rights Management', () => {
                         if(colLevel['rw'].has(name) || colLevel['ro'].has(name)){
                           tasks.register(task);
                           wait(keySpaceId, key);
-                          expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                          assertFalse(rootTestView(testViewName), 'View deletion reported success, but view was found afterwards');
                         } else {
                           tasks.register(task);
                           wait(keySpaceId, key);
-                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to drop the view with insufficient rights`);
-                          expect(rootTestView(testViewName)).to.equal(true, 'View deletion reported success, but view was found afterwards');
+                          assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to drop the view with insufficient rights`);
+                          assertTrue(rootTestView(testViewName), 'View deletion reported success, but view was found afterwards');
                         }
                       } else {
                         try {
@@ -348,9 +339,9 @@ describe('User Rights Management', () => {
                           checkError(e);
                           return;
                         } finally {
-                          expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                          assertTrue(rootTestView(testViewName), `${name} was able to drop a view with insufficent rights`);
                         }
-                        expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                        assertFalse(true, `${name} managed to register a task with insufficient rights`);
                       }
                     });
 
@@ -363,7 +354,7 @@ describe('User Rights Management', () => {
                         rootCreateCollection(testCol1Name);
                         rootCreateCollection(testCol2Name);
                         rootCreateView(testViewName, testViewType, { links: { [testCol1Name]: { includeAllFields: true }, [testCol2Name]: { includeAllFields: true } } });
-                        expect(rootTestView(testViewName)).to.equal(true, 'Precondition failed, the view doesn not exist');
+                        assertTrue(rootTestView(testViewName), 'Precondition failed, the view doesn not exist');
                         rootGrantCollection(testCol2Name, name, 'rw');
 
                         setKey(keySpaceId, key);
@@ -387,12 +378,12 @@ describe('User Rights Management', () => {
                           if (colLevel['ro'].has(name)) {
                             tasks.register(task);
                             wait(keySpaceId, key);
-                            expect(rootTestView(testViewName)).to.equal(false, 'View deletion reported success, but view was found afterwards');
+                            assertFalse(rootTestView(testViewName), 'View deletion reported success, but view was found afterwards');
                           } else {
                             tasks.register(task);
                             wait(keySpaceId, key);
-                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could drop the view with insufficient rights`);
-                            expect(rootTestView(testViewName)).to.equal(true, `${name} was able to drop a view with insufficent rights`);
+                            assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could drop the view with insufficient rights`);
+                            assertTrue(rootTestView(testViewName), `${name} was able to drop a view with insufficent rights`);
                           }
                         } else {
                           try {
@@ -402,9 +393,9 @@ describe('User Rights Management', () => {
                             checkError(e);
                             return;
                           } finally {
-                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could drop the view with insufficient rights`);
+                            assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could drop the view with insufficient rights`);
                           }
-                          expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                          assertFalse(true, `${name} managed to register a task with insufficient rights`);
                         }
                       });
 

--- a/tests/js/client/authentication/user-access-right-task-read-view-arangosearch-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-read-view-arangosearch-spec-sjs.js
@@ -27,12 +27,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const errors = require('@arangodb').errors;
 const db = require('@arangodb').db;
 const namePrefix = helper.namePrefix;
@@ -40,7 +39,6 @@ const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testView1Name = `${namePrefix}View1New`;
 const testView2Name = `${namePrefix}View2New`;
-const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
 const indexName = `${namePrefix}Inverted`;
@@ -54,7 +52,7 @@ const colLevel = helper.colLevel;
 
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
-const tmp = require('internal');
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -71,7 +69,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -79,12 +77,12 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const getNumericKey = (keySpaceId, key, defaultValue = 0) => {
   try {
-    return parseInt(executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body);
+    return parseInt(executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody);
   } catch(e) {
     return defaultValue;
   }
@@ -95,16 +93,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.switchUser('root', '_system');
@@ -114,15 +103,15 @@ helper.generateAllUsers();
 describe('User Rights Management', () => {
   it('should check if all users are created', () => {
     helper.switchUser('root', '_system');
-    expect(userSet.size).to.be.greaterThan(0); 
-    expect(userSet.size).to.equal(helper.userCount);
+    assertTrue(userSet.size > 0); 
+    assertEqual(userSet.size, helper.userCount);
     for (let name of userSet) {
-      expect(users.document(name), `Could not find user: ${name}`).to.not.be.undefined;
+      assertNotUndefined(users.document(name), `Could not find user: ${name}`);
     }
   });
 
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0);
+    assertTrue(userSet.size > 0);
     for (let testViewType of ["arangosearch", "search-alias"]) {
       describe(`view type ${testViewType}`, () => {
         for (let name of userSet) {
@@ -138,7 +127,7 @@ describe('User Rights Management', () => {
             describe(`user ${name}`, () => {
               before(() => {
                 helper.switchUser(name, dbName);
-                expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+                assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
               });
 
               after(() => {
@@ -264,8 +253,8 @@ describe('User Rights Management', () => {
                 };
 
                 const checkError = (e) => {
-                  expect(e.code).to.equal(403, "Expected to get forbidden REST error code, but got another one");
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
+                  assertEqual(e.code, 403, "Expected to get forbidden REST error code, but got another one");
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code, "Expected to get forbidden error number, but got another one");
                 };
 
                 describe('read a view', () => {
@@ -276,7 +265,7 @@ describe('User Rights Management', () => {
                   const key = `${testViewType}_${name}`;
 
                   it('by AQL with link to single collection', () => {
-                    expect(rootTestView(testView1Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                    assertTrue(rootTestView(testView1Name), 'Precondition failed, the view doesn\'t exist');
                     setKey(keySpaceId, key);
                     const taskId = 'task_read_view_single_collection_' + key;
                     const task = {
@@ -300,13 +289,13 @@ describe('User Rights Management', () => {
                       if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
                         tasks.register(task);
                         wait(keySpaceId, key);
-                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not read the view with sufficient rights`);
+                        assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not read the view with sufficient rights`);
                         //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
-                        //expect(getNumericKey(keySpaceId, `${name}_length`)).to.equal(testNumDocs, 'View read failed');
+                        //assertEqual(getNumericKey(keySpaceId, `${name}_length`), testNumDocs, 'View read failed');
                       } else {
                         tasks.register(task);
                         wait(keySpaceId, key);
-                        expect(getKey(keySpaceId, `${key}_status`)).to.not.equal(true, `${name} managed to read the view with insufficient rights`);
+                        assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to read the view with insufficient rights`);
                       }
                     } else {
                       try {
@@ -316,15 +305,15 @@ describe('User Rights Management', () => {
                         checkError(e);
                         return;
                       } finally {
-                        expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} could read the view with insufficient rights`);
+                        assertFalse(getKey(keySpaceId, `${key}_status`), `${name} could read the view with insufficient rights`);
                       }
-                      expect(false).to.equal(true, `${key} managed to register a task with insufficient rights`);
+                      assertFalse(true, `${key} managed to register a task with insufficient rights`);
                     }
                   });
 
                   if (testViewType === 'arangosearch') {
                     it('by AQL with links to multiple collections with same access level', () => {
-                      expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                      assertTrue(rootTestView(testView2Name), 'Precondition failed, the view doesn\'t exist');
                       setKey(keySpaceId, key);
                       const taskId = 'task_read_view_multi_collections_same_access_' + key;
                       const task = {
@@ -348,13 +337,13 @@ describe('User Rights Management', () => {
                         if (colLevel['rw'].has(name) || colLevel['ro'].has(name)) {
                           tasks.register(task);
                           wait(keySpaceId, key);
-                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(true, `${name} could not read the view with sufficient rights`);
+                          assertTrue(getKey(keySpaceId, `${key}_status`), `${name} could not read the view with sufficient rights`);
                           //FIXME: issue #429 (https://github.com/arangodb/backlog/issues/429)
-                          //expect(getNumericKey(keySpaceId, `${name}_length`)).to.equal(testNumDocs*2, 'View read failed');
+                          //assertEqual(getNumericKey(keySpaceId, `${name}_length`), testNumDocs*2, 'View read failed');
                         } else {
                           tasks.register(task);
                           wait(keySpaceId, key);
-                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
+                          assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to read the view with insufficient rights`);
                         }
                       } else {
                         try {
@@ -364,9 +353,9 @@ describe('User Rights Management', () => {
                           checkError(e);
                           return;
                         } finally {
-                          expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
+                          assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to read the view with insufficient rights`);
                         }
-                        expect(false).to.equal(true, `${key} managed to register a task with insufficient rights`);
+                        assertFalse(true, `${key} managed to register a task with insufficient rights`);
                       }
                     });
 
@@ -375,7 +364,7 @@ describe('User Rights Management', () => {
                       describe(descName, () => {
                         before(() => {
                           rootGrantCollection(testCol2Name, name, 'none');
-                          expect(rootTestView(testView2Name)).to.equal(true, 'Precondition failed, the view doesn\'t exist');
+                          assertTrue(rootTestView(testView2Name), 'Precondition failed, the view doesn\'t exist');
                         });
 
                         it('by AQL query (data)', () => {
@@ -400,7 +389,7 @@ describe('User Rights Management', () => {
                           if (dbLevel['rw'].has(name)) {
                             tasks.register(task);
                             wait(keySpaceId, key);
-                            expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to perform a query on view with insufficient rights`);
+                            assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to perform a query on view with insufficient rights`);
                           } else {
                             try {
                               tasks.register(task);
@@ -409,9 +398,9 @@ describe('User Rights Management', () => {
                               checkError(e);
                               return;
                             } finally {
-                              expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to read the view with insufficient rights`);
+                              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to read the view with insufficient rights`);
                             }
-                            expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                            assertFalse(true, `${name} managed to register a task with insufficient rights`);
                           }
                         });
                         it('by its properties', () => {
@@ -435,7 +424,7 @@ describe('User Rights Management', () => {
                           if (dbLevel['rw'].has(name)) {
                             tasks.register(task);
                             wait(keySpaceId, key);
-                            expect(getKey(keySpaceId, `${key}_status`)).to.not.equal(true, `${name} managed to get a view properties with insufficient rights`);
+                            assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to get a view properties with insufficient rights`);
                           } else {
                             try {
                               tasks.register(task);
@@ -444,9 +433,9 @@ describe('User Rights Management', () => {
                               checkError(e);
                               return;
                             } finally {
-                              expect(getKey(keySpaceId, `${key}_status`)).to.equal(false, `${name} managed to get the view properties with insufficient rights`);
+                              assertFalse(getKey(keySpaceId, `${key}_status`), `${name} managed to get the view properties with insufficient rights`);
                             }
-                            expect(false).to.equal(true, `${key} managed to register a task with insufficient rights`);
+                            assertFalse(true, `${key} managed to register a task with insufficient rights`);
                           }
                         });
                       });

--- a/tests/js/client/authentication/user-access-right-task-repeatable-update-a-user-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-repeatable-update-a-user-spec-sjs.js
@@ -28,14 +28,13 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
 const users = require('@arangodb/users');
 const internal = require('internal');
 const db = internal.db;
 const helper = require('@arangodb/testutils/user-helper');
-const download = internal.download;
 const keySpaceId = 'task_update_user_keyspace';
 const taskId = 'task_update_user_periodic';
 const arango = internal.arango;
@@ -43,7 +42,7 @@ let connectionHandle = arango.getConnectionHandle();
 const taskPeriod = 0.3;
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -55,7 +54,7 @@ const setKey = (keySpaceId, key) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  let res = executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body;
+  let res = executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody;
   let num = Number(res);
   if (isNaN(num)) {
     console.error('KEY_GET response: ' + res);
@@ -65,19 +64,7 @@ const getKey = (keySpaceId, key) => {
 };
 
 const executeJS = (code) => {
-  let username = 'root';
-  let password = '';
-
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: username,
-    password: password
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + '/_admin/execute?returnAsJSON=true',
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 const waitForTaskStart = () => {
@@ -88,7 +75,7 @@ const waitForTaskStart = () => {
       break;
     }
   }
-  expect(i).to.be.above(0, 'Task must have run at least once');
+  assertTrue(i > 0, 'Task must have run at least once');
 };
 
 const waitForTaskStop = () => {
@@ -97,14 +84,14 @@ const waitForTaskStop = () => {
   while (--i > 0) {
     internal.wait(taskPeriod);
     let current = getKey(keySpaceId, 'bob');
-    expect(current).to.not.be.equal(0, 'Received invalid key');
+    assertNotEqual(current, 0, 'Received invalid key');
     if (current === last) {
       break;
     }
     last = current;
     internal.wait(taskPeriod);
   }
-  expect(i).to.be.above(0, 'The repeatable task was able continue running with insufficient rights');
+  assertTrue(i > 0, 'The repeatable task was able continue running with insufficient rights');
 };
 
 describe('User Rights Management', () => {
@@ -115,7 +102,7 @@ describe('User Rights Management', () => {
     users.grantCollection('bob', '_system', '*', 'rw');
 
     helper.switchUser('bob');
-    expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+    assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
   });
   after(() => {
     helper.switchUser('root', '_system');

--- a/tests/js/client/authentication/user-access-right-task-update-a-user-spec-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-update-a-user-spec-sjs.js
@@ -28,12 +28,11 @@
 
 'use strict';
 
-const expect = require('chai').expect;
+const jsunity = require("jsunity");
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const namePrefix = helper.namePrefix;
 const rightLevels = helper.rightLevels;
 const errors = require('@arangodb').errors;
@@ -48,6 +47,7 @@ const testUser = `${namePrefix}TestUser`;
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
 const db = require('internal').db;
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -62,7 +62,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -70,7 +70,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -78,16 +78,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + '/_admin/execute?returnAsJSON=true',
-    code,
-    httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 helper.removeAllUsers();
@@ -95,7 +86,7 @@ helper.generateAllUsers();
 
 describe('User Rights Management', () => {
   it('should test rights for', () => {
-    expect(userSet.size).to.be.greaterThan(0); 
+    assertTrue(userSet.size > 0); 
     for (let name of userSet) {
       let canUse = false;
       try {
@@ -109,7 +100,7 @@ describe('User Rights Management', () => {
         describe(`user ${name}`, () => {
           before(() => {
             helper.switchUser(name);
-            expect(createKeySpace(keySpaceId)).to.equal(true, 'keySpace creation failed!');
+            assertTrue(createKeySpace(keySpaceId), 'keySpace creation failed!');
           });
 
           after(() => {
@@ -178,16 +169,16 @@ describe('User Rights Management', () => {
                 tasks.register(task);
                 wait(keySpaceId, name);
                 if (systemLevel['rw'].has(name)) {
-                  expect(getKey(keySpaceId, `${name}_status`)).to.equal(true, `${name} was not able to update a user with sufficient rights`);
+                  assertTrue(getKey(keySpaceId, `${name}_status`), `${name} was not able to update a user with sufficient rights`);
                 } else {
-                  expect(getKey(keySpaceId, `${name}_status`)).to.not.equal(true, `${name} was able to update a user with insufficient rights.`);
+                  assertFalse(getKey(keySpaceId, `${name}_status`), `${name} was able to update a user with insufficient rights.`);
                 }
               } else {
                 try {
                   tasks.register(task);
-                  expect(false).to.equal(true, `${name} managed to register a task with insufficient rights`);
+                  assertFalse(true, `${name} managed to register a task with insufficient rights`);
                 } catch (e) {
-                  expect(e.errorNum).to.equal(errors.ERROR_FORBIDDEN.code);
+                  assertEqual(e.errorNum, errors.ERROR_FORBIDDEN.code);
                 }
               }
             });

--- a/tests/js/client/authentication/user-access-right-task-update-view-arangosearch-sjs.js
+++ b/tests/js/client/authentication/user-access-right-task-update-view-arangosearch-sjs.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:true, strict:true, maxlen: 5000 */
-/* global assertEqual, assertTrue, assertFalse, assertFail */
+/* global */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -27,6 +27,7 @@
 
 'use strict';
 const jsunity = require('jsunity');
+const {assertEqual, assertTrue, assertFalse, assertNotEqual, assertFail} = jsunity.jsUnity.assertions;
 const testHelper = require('@arangodb/test-helper');
 const isEqual = testHelper.isEqual;
 const deriveTestSuite = testHelper.deriveTestSuite;
@@ -34,8 +35,6 @@ const deriveTestSuiteWithnamespace = testHelper.deriveTestSuiteWithnamespace;
 const users = require('@arangodb/users');
 const helper = require('@arangodb/testutils/user-helper');
 const tasks = require('@arangodb/tasks');
-const pu = require('@arangodb/testutils/process-utils');
-const download = require('internal').download;
 const errors = require('@arangodb').errors;
 const db = require('@arangodb').db;
 const namePrefix = helper.namePrefix;
@@ -43,7 +42,6 @@ const dbName = helper.dbName;
 const rightLevels = helper.rightLevels;
 const testViewName = `${namePrefix}ViewNew`;
 const testViewRename = `${namePrefix}ViewRename`;
-const testViewType = "arangosearch";
 const testCol1Name = `${namePrefix}Col1New`;
 const testCol2Name = `${namePrefix}Col2New`;
 const indexName = `${namePrefix}inverted`;
@@ -55,6 +53,7 @@ const colLevel = helper.colLevel;
 
 const arango = require('internal').arango;
 let connectionHandle = arango.getConnectionHandle();
+
 for (let l of rightLevels) {
   systemLevel[l] = new Set();
   dbLevel[l] = new Set();
@@ -71,7 +70,7 @@ const wait = (keySpaceId, key) => {
 };
 
 const createKeySpace = (keySpaceId) => {
-  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).body === 'true';
+  return executeJS(`return global.KEYSPACE_CREATE('${keySpaceId}', 128, true);`).parsedBody === true;
 };
 
 const dropKeySpace = (keySpaceId) => {
@@ -79,7 +78,7 @@ const dropKeySpace = (keySpaceId) => {
 };
 
 const getKey = (keySpaceId, key) => {
-  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).body === 'true';
+  return executeJS(`return global.KEY_GET('${keySpaceId}', '${key}');`).parsedBody === true;
 };
 
 const setKey = (keySpaceId, name) => {
@@ -87,15 +86,7 @@ const setKey = (keySpaceId, name) => {
 };
 
 const executeJS = (code) => {
-  let httpOptions = pu.makeAuthorizationHeaders({
-    username: 'root',
-    password: ''
-  }, {});
-  httpOptions.method = 'POST';
-  httpOptions.timeout = 1800;
-  httpOptions.returnBodyOnError = true;
-  return download(arango.getEndpoint().replace('tcp', 'http') + `/_db/${dbName}/_admin/execute?returnAsJSON=true`,
-    code, httpOptions);
+  return arango.POST_RAW('/_admin/execute', code);
 };
 
 

--- a/tests/js/client/dump/check-foxx.js
+++ b/tests/js/client/dump/check-foxx.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen : 4000 */
-/* global assertEqual, arango */
+/* global */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -25,50 +25,52 @@
 // / @author Copyright 2018, ArangoDB Inc., Cologne, Germany
 // //////////////////////////////////////////////////////////////////////////////
 
-const internal = require('internal');
 const jsunity = require('jsunity');
+const {assertEqual} = jsunity.jsUnity.assertions;
+const arango = require("@arangodb").arango;
+const db = require("@arangodb").db;
 let IM = global.instanceManager;
 
-const request = require('@arangodb/request');
-
-const db = require("@arangodb").db;
-
-const MOUNT = "/test";
-const serviceUrl = (url) => {
-  return url + "/_db/" + encodeURIComponent(db._name()) + MOUNT;
-};
+const path = "/_db/" + encodeURIComponent(db._name()) + "/test";
 const _ = require('lodash');
-const options = {
-  json: true
-};
-
-function getCoordinators() {
-  return IM.arangods.filter(arangod => {
-    return arangod.isFrontend(); }).map(arangod => {
-      return arangod.url;}).map(serviceUrl);
-}
 
 
 function foxxTestSuite () {
   return {
     setUp: () => {
+      IM.rememberConnection();
     },
-    tearDown: () => {},
+    tearDown: () => {
+      IM.reconnectMe();
+    },
 
     testServiceIsMounted: function () {
-      const serversToTest = getCoordinators();
-      const res = request.get(serversToTest[0], options);
-      assertEqual(200, res.statusCode);
-      assertEqual({hello: 'world'}, res.json);
+      IM.rememberConnection();
+      IM.arangods.forEach(d => {
+        if (d.isFrontend()){
+          d.toThisInstance(() => {
+            let res = arango.GET_RAW(path);
+            assertEqual(200, res.code);
+            assertEqual({hello: 'world'}, res.parsedBody);
+          });
+          return;
+        }
+      });
+      IM.reconnectMe();
     },
 
     testServiceIsPropagated: function () {
-      const serversToTest = getCoordinators();
-      serversToTest.forEach(m => {
-        const res = request.get(m, options);
-        assertEqual(200, res.statusCode);
-        assertEqual({hello: 'world'}, res.json);
+      IM.rememberConnection();
+      IM.arangods.forEach(d => {
+        if (d.isFrontend()){
+          d.toThisInstance(() => {
+            let res = arango.GET_RAW(path);
+            assertEqual(200, res.code);
+            assertEqual({hello: 'world'}, res.parsedBody);
+          });
+        }
       });
+      IM.reconnectMe();
     }
   };
 }

--- a/tests/js/client/server_parameters/www-authenticate-off.js
+++ b/tests/js/client/server_parameters/www-authenticate-off.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertEqual, assertFalse, arango */
+/* global getOptions */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -27,7 +27,6 @@
 
 let db = require('internal').db;
 const protocols = ["tcp", "h2"];
-const user = "root";
 
 if (getOptions === true) {
   return {
@@ -35,24 +34,24 @@ if (getOptions === true) {
   };
 }
 const jsunity = require('jsunity');
-const request = require('@arangodb/request').request;
-
-let connectWith = function(protocol, user, password) {
-  let endpoint = arango.getEndpoint().replace(/^[a-zA-Z0-9\+]+:/, protocol + ':');
-  arango.reconnect(endpoint, db._name(), user, password);
-};
+const {assertEqual, assertTrue, assertFalse, assertNotEqual} = jsunity.jsUnity.assertions;
+const arango = require('@arangodb').arango;
+let IM = global.instanceManager;
 
 function testSuite() {
 
   return {
+    setUp: function() {
+      IM.rememberConnection();
+    },
 
     tearDown: function() {
-      connectWith(protocols[0], user, "");
+      IM.reconnectMe();
     },
 
     testHeader: function() {
       protocols.forEach((protocol) => {
-        connectWith(protocol, user, "");
+        arango.reconnect(IM.url.replace(/^[a-zA-Z0-9\+]+:/, protocol + ':'), db._name(), "root", "");
         let result = arango.GET_RAW("/_api/version");
         assertEqual(200, result.code);
         assertFalse(result.headers.hasOwnProperty('www-authenticate'));

--- a/tests/js/client/server_parameters/www-authenticate.js
+++ b/tests/js/client/server_parameters/www-authenticate.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/* global getOptions, assertEqual, assertFalse, assertTrue, arango, print */
+/* global getOptions, print */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -31,31 +31,28 @@ if (getOptions === true) {
   };
 }
 const jsunity = require('jsunity');
+const {assertEqual, assertTrue, assertFalse, assertNotEqual} = jsunity.jsUnity.assertions;
 const crypto = require('@arangodb/crypto');
 const protocols = ["tcp", "h2"];
 const users = require("@arangodb/users");
+const arango = require('@arangodb').arango;
 const db = require('internal').db;
 let maintainerMode = require('internal').db._version(true)['details']['maintainer-mode'];
-const helper = require('@arangodb/testutils/user-helper');
 const user = "testUser";
-
-let connectWith = function(protocol, user, password) {
-  let endpoint = arango.getEndpoint().replace(/^[a-zA-Z0-9\+]+:/, protocol + ':');
-  arango.reconnect(endpoint, db._name(), user, password);
-};
+let IM = global.instanceManager;
 
 function HttpAuthenticateSuite() {
 
   return {
 
     setUp: function() {
-      connectWith("tcp", "root", "");
+      IM.rememberConnection();
       users.save(user, "");
       users.grantDatabase(user, '_system', 'rw');
     },
 
     tearDown: function() {
-      connectWith("tcp", "root", "");
+      IM.reconnectMe();
       users.remove(user);
     },
 
@@ -68,7 +65,7 @@ function HttpAuthenticateSuite() {
       }, 'HS256');
       protocols.forEach(protocol => {
         print(`connecting with ${protocol}`);
-        connectWith(protocol, user, "");
+        arango.reconnect(IM.endpoint.replace(/^[a-zA-Z0-9\+]+:/, protocol + ':'), db._name(), user, "");
         let result = arango.GET_RAW("/_api/version", {"bearer": jwtRoot});
         assertEqual(200, result.code, JSON.stringify(result));
         assertFalse(result.headers.hasOwnProperty('www-authenticate'), JSON.stringify(result));

--- a/tests/js/client/server_permissions/test-api-transaction-restricted-sjs.js
+++ b/tests/js/client/server_permissions/test-api-transaction-restricted-sjs.js
@@ -53,6 +53,7 @@ function testSuite() {
 
   return {
     setUp: function() {
+      IM.rememberConnection();
       try {
         db._dropDatabase("UnitTestsApiTest");
       } catch (err) {}
@@ -64,7 +65,7 @@ function testSuite() {
     },
 
     tearDown: function() {
-      db._useDatabase("_system");
+      IM.reconnectMe();
       db._dropDatabase("UnitTestsApiTest");
     },
 

--- a/tests/js/client/server_permissions/test-foxx-service-access-denied-sjs.js
+++ b/tests/js/client/server_permissions/test-foxx-service-access-denied-sjs.js
@@ -3,10 +3,11 @@
 'use strict';
 const fs = require('fs');
 const jsunity = require("jsunity");
-const {assertEqual, assertTrue, assertFalse, assertNotEqual} = jsunity.jsUnity.assertions;
+const { assertEqual, assertTrue, assertFalse, assertNotEqual, assertUndefined } = jsunity.jsUnity.assertions;
 const internal = require('internal');
 const pu = require('@arangodb/testutils/process-utils');
 const FoxxManager = require('@arangodb/foxx/manager');
+const arango = require('@arangodb').arango;
 let IM = global.instanceManager;
 
 if (getOptions === true) {
@@ -17,14 +18,14 @@ if (getOptions === true) {
     'server.harden': 'true',
     'server.authentication': 'true',
     'server.jwt-secret': 'abc123',
-    'javascript.harden' : 'true',
+    'javascript.harden': 'true',
     'javascript.files-allowlist': [
       '^' + fs.escapePath(testPath), // we need to call isDirectory (internal.pathForTesting) in
-                        // the server which is forbidden in not-allowed paths
+      // the server which is forbidden in not-allowed paths
     ],
     // tests/js/common/test-data/apps/server-security/index.js
     'javascript.app-path': fs.join(testPath, 'common', 'test-data', 'apps'),
-    'javascript.endpoints-allowlist' : [
+    'javascript.endpoints-allowlist': [
       'ssl://arango.ai:443'
     ],
     'javascript.environment-variables-denylist': 'PATH',
@@ -33,22 +34,21 @@ if (getOptions === true) {
 }
 
 function testSuite() {
-  const download = internal.download;
   const basePath = fs.makeAbsolute(fs.join(internal.pathForTesting('common'), 'test-data', 'apps'));
   const foxxApp = fs.join(basePath, 'server-security');
   const mount = '/testmount';
 
   return {
-    setUp: function() {
+    setUp: function () {
       try {
-        FoxxManager.uninstall(mount, {force: true});
+        FoxxManager.uninstall(mount, { force: true });
         FoxxManager.install(foxxApp, mount);
       } catch (e) { }
     },
 
-    tearDown: function() {
+    tearDown: function () {
       try {
-        FoxxManager.uninstall(mount, {force: false});
+        FoxxManager.uninstall(mount, { force: false });
       } catch (e) {
       }
     },
@@ -56,115 +56,96 @@ function testSuite() {
     // routes are defined in:
     // tests/js/common/test-data/apps/server-security/index.js
 
-    testPid : function() {
-      const url = IM.url + mount + "/pid";
-      const res = download(url);
+    testPid: function () {
+      const res = arango.GET_RAW(mount + "/pid");
       assertEqual(403, res.code);
-      assertEqual("Forbidden", res.message);
+      assertEqual("403 Forbidden", res.errorMessage);
     },
 
-     testPasswd : function() {
-       const url = IM.url + mount + "/passwd";
-       const res = download(url);
-       assertEqual(403, res.code);
-       assertEqual("Forbidden", res.message);
-     },
+    testPasswd: function () {
+      const res = arango.GET_RAW(mount + "/passwd");
+      assertEqual(403, res.code);
+      assertEqual("403 Forbidden", res.errorMessage);
+    },
 
-     testDlHeise : function() {
-       const url = IM.url + mount + "/dl-heise";
-       const res = download(url);
-       assertEqual(403, res.code);
-       assertEqual("Forbidden", res.message);
-     },
+    testDlHeise: function () {
+      const res = arango.GET_RAW(mount + "/dl-heise");
+      assertEqual(403, res.code);
+      assertEqual("403 Forbidden", res.errorMessage);
+    },
 
-     testTestPort : function() {
-       const url = IM.url + mount + "/test-port";
-       const res = download(url);
-       assertEqual(403, res.code);
-       assertEqual("Forbidden", res.message);
-     },
+    testTestPort: function () {
+      const res = arango.GET_RAW(mount + "/test-port");
+      assertEqual(403, res.code);
+      assertEqual("403 Forbidden", res.errorMessage);
+    },
 
-     testGetTmpPath : function() {
-       const url = IM.url + mount + "/get-tmp-path";
-       const res = download(url);
-       assertEqual(200, res.code);
-       let body = JSON.parse(res.body);
-     },
+    testGetTmpPath: function () {
+      const res = arango.GET_RAW(mount + "/get-tmp-path");
+      assertEqual(200, res.code);
+    },
 
-     testGetTmpFile : function() {
-       const url = IM.url + mount + "/get-tmp-file";
-       const res = download(url);
-       assertEqual(200, res.code);
-       let body = JSON.parse(res.body);
-     },
+    testGetTmpFile: function () {
+      const res = arango.GET_RAW(mount + "/get-tmp-file");
+      assertEqual(200, res.code);
+    },
 
-     testWriteTmpFile : function() {
-       const url = IM.url + mount + "/write-tmp-file";
-       const res = download(url);
-       assertEqual(200, res.code);
-     },
+    testWriteTmpFile: function () {
+      const res = arango.GET_RAW(mount + "/write-tmp-file");
+      assertEqual(200, res.code);
+    },
 
-     testProcessStatistics : function() {
-       const url = IM.url + mount + "/process-statistics";
-       const res = download(url);
-       //disabled for oasis
-       //assertEqual(403, res.code);
-     },
+    testProcessStatistics: function () {
+      //const url = IM.url + mount + "/process-statistics";
+      //disabled for oasis
+      //assertEqual(403, res.code);
+    },
 
-     testExecuteExternal : function() {
-       const url = IM.url + mount + "/execute-external";
-       const res = download(url);
-       assertEqual(403, res.code);
-     },
+    testExecuteExternal: function () {
+      const res = arango.GET_RAW(mount + "/execute-external");
+      assertEqual(403, res.code);
+    },
 
-     testPath : function() {
-       { // read
-         const url = IM.url + mount + "/environment-variables-get-path";
-         const res = download(url);
-         assertEqual(204, res.code);
-         assertEqual("", res.body);
-       }
-       { // modify
-         const url = IM.url + mount + "/environment-variables-set-path";
-         const res = download(url);
-         assertEqual(200, res.code);
-         assertEqual("true", res.body);
-       }
-       { // read
-         const url = IM.url + mount + "/environment-variables-get-path";
-         const res = download(url);
-         assertEqual(204, res.code);
-         assertEqual("", res.body);
-       }
-     },
+    testPath: function () {
+      { // read
+        const res = arango.GET_RAW(mount + "/environment-variables-get-path");
+        assertEqual(204, res.code);
+        assertUndefined(res.parsedBody);
+      }
+      { // modify
+        const res = arango.GET_RAW(mount + "/environment-variables-set-path");
+        assertEqual(200, res.code);
+        assertEqual("true", res.parsedBody);
+      }
+      { // read
+        const res = arango.GET_RAW(mount + "/environment-variables-get-path");
+        assertEqual(204, res.code);
+        assertUndefined(res.parsedBody);
+      }
+    },
 
-     testStartupOptions : function() {
-       const url = IM.url + mount + "/startup-options-log-file";
-       const res = download(url);
-       assertEqual(204, res.code);
-       assertEqual("", res.body);
-     },
+    testStartupOptions: function () {
+      const res = arango.GET_RAW(mount + "/startup-options-log-file");
+      assertEqual(204, res.code);
+      assertUndefined(res.parsedBody);
+    },
 
-     testReadServiceFile : function() {
-       const url = IM.url + mount + "/read-service-file";
-       const res = download(url);
-       assertEqual(200, res.code);
-       let body = JSON.parse(res.body);
-       assertTrue(body.startsWith("'use strict'"));
-     },
+    testReadServiceFile: function () {
+      const res = arango.GET_RAW(mount + "/read-service-file");
+      assertEqual(200, res.code);
+      assertTrue(res.parsedBody.startsWith("'use strict'"));
+    },
 
-     testWriteRemoveServiceFile : function() {
-       {
-         const url = IM.url + mount + "/write-service-file";
-         const res = download(url);
-         assertEqual(200, res.code);
-       }
-       {
-         const url = IM.url + mount + "/remove-service-file";
-         const res = download(url);
-         assertEqual(200, res.code);
-       }
-     },
+    testWriteRemoveServiceFile: function () {
+      {
+        const res = arango.GET_RAW(mount + "/write-service-file");
+        assertEqual(200, res.code);
+      }
+      {
+        const res = arango.GET_RAW(mount + "/remove-service-file");
+        assertEqual(200, res.code);
+      }
+    },
 
   };
 }

--- a/tests/js/client/shell/large/shell-one-shard.js
+++ b/tests/js/client/shell/large/shell-one-shard.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global arango, assertTrue, assertEqual, assertNotEqual, assertMatch, assertNull, fail, GLOBAL */
+/*global fail, GLOBAL */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -26,13 +26,14 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
+const {assertEqual, assertNotEqual, assertTrue, assertFalse, assertMatch} = jsunity.jsUnity.assertions;
 const arangodb = require("@arangodb");
+const arango = arangodb.arango;
 const db = arangodb.db;
 const internal = require('internal');
 const ERRORS = arangodb.errors;
 const isEnterprise = internal.isEnterprise();
 const isCluster = internal.isCluster();
-const request = require('@arangodb/request');
 const IM = GLOBAL.instanceManager;
 const AM = IM.agencyMgr;
 
@@ -66,36 +67,15 @@ function assertNoDatabasesInPlan () {
   assertEqual(["_system"], keys, result);
 }
 
-function getEndpointsByType(type) {
-  const isType = (d) => (d.instanceRole === type);
-  const toEndpoint = (d) => (d.endpoint);
-  const endpointToURL = (endpoint) => {
-    if (endpoint.substr(0, 6) === 'ssl://') {
-      return 'https://' + endpoint.substr(6);
-    }
-    let pos = endpoint.indexOf('://');
-    if (pos === -1) {
-      return 'http://' + endpoint;
-    }
-    return 'http' + endpoint.substr(pos);
-  };
-
-  return global.instanceManager.arangods.filter(isType)
-                              .map(toEndpoint)
-                              .map(endpointToURL);
-}
-
 function checkDBServerSharding(db, expected) {
   // connect to all db servers and check if they picked up the
   // "sharding" attribute correctly
   // request module can only be used inside arangosh tests
-  let endpoints = getEndpointsByType("dbserver");
-  assertTrue(endpoints.length > 0);
-  endpoints.forEach((ep) => {
-    let res = request.get({ url: ep + "/_db/" + encodeURIComponent(db) + "/_api/database/current" });
-    assertEqual(200, res.status);
-    assertEqual(expected, res.json.result.sharding);
-  });
+  IM.arangods.forEach(d => { if(d.instanceRole === "dbServer") d.toThisInstance(() => {
+    let res = arango.GET_RAW("/_api/database/current");
+    assertEqual(200, res.code);
+    assertEqual(expected, res.parsedBody.result.sharding);
+  });});
 }
 
 function OneShardPropertiesSuite () {
@@ -103,6 +83,7 @@ function OneShardPropertiesSuite () {
 
   return {
     setUp: function () {
+      IM.rememberConnection();
       try {
         db._useDatabase("_system");
         db._dropDatabase(dn);
@@ -111,8 +92,8 @@ function OneShardPropertiesSuite () {
     },
 
     tearDown: function () {
+      IM.reconnectMe();
       try {
-        db._useDatabase("_system");
         db._dropDatabase(dn);
       } catch (ex) {
       }

--- a/tests/js/client/shell/large/shell-restore-integration.js
+++ b/tests/js/client/shell/large/shell-restore-integration.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global fail, arango */
+/* global fail */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -26,14 +26,13 @@
 
 const jsunity = require('jsunity');
 const {assertTrue, assertFalse, assertEqual, assertNotEqual, assertInstanceOf} = jsunity.jsUnity.assertions;
-const internal = require('internal');
 const arangodb = require('@arangodb');
+const arango = arangodb.arango;
 const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const db = arangodb.db;
 const isCluster = require("internal").isCluster();
 const { executeExternalAndWaitWithSanitizer, dumpUtils } = require('@arangodb/test-helper');
-const { versionHas } = require("@arangodb/test-helper");
 const dbs = [{"name": "maçã", "id": "9999994", "isUnicode": true}, {
   "name": "cachorro",
   "id": "9999995",
@@ -68,6 +67,7 @@ const validatorJson = {
   }
 };
 
+let IM = global.instanceManager;
 
 function restoreIntegrationSuite() {
   'use strict';
@@ -77,9 +77,8 @@ function restoreIntegrationSuite() {
   assertTrue(fs.isFile(arangorestore), "arangorestore not found!");
 
   let addConnectionArgs = function (args) {
-    let endpoint = arango.getEndpoint().replace(/\+vpp/, '').replace(/^http:/, 'tcp:').replace(/^https:/, 'ssl:').replace(/^h2:/, 'tcp:');
     args.push('--server.endpoint');
-    args.push(endpoint);
+    args.push(IM.endpoint);
     if (args.indexOf("--all-databases") === -1 && args.indexOf("--server.database") === -1) {
       args.push('--server.database');
       args.push(arango.getDatabaseName());
@@ -101,6 +100,7 @@ function restoreIntegrationSuite() {
   return {
 
     setUp: function () {
+      IM.rememberConnection();
       db._drop(cn);
     },
 
@@ -111,6 +111,7 @@ function restoreIntegrationSuite() {
           db._dropDatabase(database);
         }
       });
+      IM.reconnectMe();
     },
 
     testRestoreAutoIncrementKeyGenerator: function () {
@@ -1315,9 +1316,8 @@ function restoreIntegrationVectorSuite() {
   assertTrue(fs.isFile(arangorestore), "arangorestore not found!");
 
   let addConnectionArgs = function (args) {
-    let endpoint = arango.getEndpoint().replace(/\+vpp/, '').replace(/^http:/, 'tcp:').replace(/^https:/, 'ssl:').replace(/^h2:/, 'tcp:');
     args.push('--server.endpoint');
-    args.push(endpoint);
+    args.push(IM.endpoint);
     if (args.indexOf("--all-databases") === -1 && args.indexOf("--server.database") === -1) {
       args.push('--server.database');
       args.push(arango.getDatabaseName());
@@ -1339,6 +1339,7 @@ function restoreIntegrationVectorSuite() {
   return {
 
     setUp: function () {
+      IM.rememberConnection();
       db._drop(cn);
     },
 
@@ -1349,6 +1350,7 @@ function restoreIntegrationVectorSuite() {
           db._dropDatabase(database);
         }
       });
+      IM.reconnectMe();
     },
 
     testRestoreVectorIndex: function () {

--- a/tests/js/client/shell/multi/shell-validation.js
+++ b/tests/js/client/shell/multi/shell-validation.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false */
-/*global assertEqual, assertTrue, assertFalse, assertNotNull, assertNotUndefined, fail */
+/*global fail */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -25,14 +25,14 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require("jsunity");
-
-const internal = require("internal");
-const { getEndpointById } = require('@arangodb/test-helper');
-const request = require('@arangodb/request');
-const db = internal.db;
-const arangodb = require("@arangodb");
+const {assertEqual, assertTrue, assertFalse, assertNotNull, assertNotUndefined} = jsunity.jsUnity.assertions;
 const _ = require("lodash");
+const internal = require("internal");
+const arangodb = require("@arangodb");
 const ERRORS = arangodb.errors;
+const arango = arangodb.arango;
+const db = arangodb.db;
+let IM = global.instanceManager;
 
 // helper
 const isCluster = internal.isCluster();
@@ -51,15 +51,20 @@ const waitInClusterUntil = func => {
 
 const waitForCollectionPredicate = (collection, predicate) => {
   const shardList = collection.shards(true);
+  var result = true;
+  IM.rememberConnection();
   for (const [shard, servers] of Object.entries(shardList)) {
-    const endpoint = getEndpointById(servers[0]);
-    const resp = request.get(`${endpoint}/_api/collection/${shard}/properties`);
-    assertEqual(resp.statusCode, 200);
-    if (!predicate(resp.json)) {
-      return false;
-    }
+    IM.getInstanceByID(servers[0]).toThisInstance(() => {
+      const resp = arango.GET_RAW(`/_api/collection/${shard}/properties`);
+      assertEqual(resp.code, 200);
+      if (!predicate(resp.parsedBody)) {
+        result = false;
+        return;
+      }
+    });
   }
-  return true;
+  IM.reconnectMe();
+  return result;
 };
 
 const skipOptions = {"skipDocumentValidation": true};
@@ -76,6 +81,7 @@ function ValidationBasicsSuite() {
   return {
 
     setUp: () => {
+      IM.rememberConnection();
       try {
         db._drop(testCollectionName);
       } catch (ex) {
@@ -120,6 +126,7 @@ function ValidationBasicsSuite() {
         db._drop(testCollectionName);
       } catch (ex) {
       }
+      IM.reconnectMe();
     },
 
     // properties ////////////////////////////////////////////////////////////////////////////////////////
@@ -842,6 +849,7 @@ function UpdateSchemaCoverageSuite() {
   return {
 
     setUp: () => {
+      IM.rememberConnection();
       try {
         db._drop(testCollectionName);
       } catch (ex) {
@@ -858,6 +866,7 @@ function UpdateSchemaCoverageSuite() {
         db._drop(testCollectionName);
       } catch (ex) {
       }
+      IM.reconnectMe();
     },
 
     testPropertiesRemoveAttributeAfterDocInsertion: () => {
@@ -914,6 +923,7 @@ function ValidationEdgeSuite() {
   return {
 
     setUp: () => {
+      IM.rememberConnection();
       try {
         db._drop(testCollectionName);
       } catch (ex) {
@@ -942,6 +952,7 @@ function ValidationEdgeSuite() {
         db._drop(testCollectionName);
       } catch (ex) {
       }
+      IM.reconnectMe();
     },
 
     // insert ////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/shell/shell-promtool-cluster.js
+++ b/tests/js/client/shell/shell-promtool-cluster.js
@@ -1,5 +1,5 @@
 /* jshint globalstrict:false, strict:false, maxlen: 200 */
-/* global print, assertNotEqual, assertFalse, assertTrue, assertEqual, fail, arango */
+/* global print, fail */
 
 // //////////////////////////////////////////////////////////////////////////////
 // / DISCLAIMER
@@ -25,13 +25,14 @@
 // //////////////////////////////////////////////////////////////////////////////
 
 const jsunity = require('jsunity');
+const {assertEqual, assertNotEqual, assertTrue, assertFalse} = jsunity.jsUnity.assertions;
 const internal = require('internal');
 const fs = require('fs');
 const pu = require('@arangodb/testutils/process-utils');
 const console = require('console');
-const request = require("@arangodb/request");
-const expect = require('chai').expect;
 const errors = require('@arangodb').errors;
+const arango = require('@arangodb').arango;
+let IM = global.instanceManager;
 
 // name of environment variable
 const PATH = 'PROMTOOL_PATH';
@@ -39,6 +40,9 @@ const PATH = 'PROMTOOL_PATH';
 // detect the path to promtool
 let promtoolPath = internal.env[PATH];
 if (!promtoolPath) {
+  promtoolPath='/usr/bin/promtool';
+}
+if (!fs.exists(promtoolPath)) {
   promtoolPath = '.';
 }
 if (fs.isDirectory(promtoolPath)) {
@@ -50,10 +54,13 @@ const serverIdPath = "/_admin/server/id";
 const healthUrl = "_admin/cluster/health";
 
 function getServerId(server) {
-  let res = request.get({
-    url: server.url + serverIdPath
+  IM.rememberConnection();
+  let res = "";
+  server.toThisInstance(() => {
+    res = arango.GET_RAW(serverIdPath).parsedBody.id;
   });
-  return res.json.id;
+  IM.reconnectMe();
+  return res;
 }
 
 function getServerShortName(server) {
@@ -68,22 +75,25 @@ function getServerShortName(server) {
 }
 
 function checkThatServerIsResponsive(server) {
+  IM.rememberConnection();
+  var result = false;
   try {
     let serverName = getServerShortName(server);
+    let res = "";
     print("Checking if server " + serverName + " is responsive.");
-    let res = request.get({
-      url: server.url + metricsUrlPath
+    server.toThisInstance(() => {
+      res = arango.GET_RAW(metricsUrlPath);
     });
-    if (res.body.includes(serverName) && res.statusCode === 200) {
+    if (res !== "" && res.code === 200 && res.parsedBody.includes(serverName)) {
       print("Server " + serverName + " is OK!");
-      return true;
+      result = true;
     } else {
       print("Server " + serverName + " doesn't respond properly to requests.");
-      return false;
     }
   } catch(error){
-    return false;
   }
+  IM.reconnectMe();
+  return result;
 }
 
 function checkThatAllDbServersAreHealthy() {
@@ -155,21 +165,27 @@ function checkMetricsBelongToServer(metrics, server) {
 
 function validateMetricsOnServer(server) {
   print("Querying server ", server.name);
-  let res = request.get({
-    url: server.url + metricsUrlPath
+  IM.rememberConnection();
+  let res = "";
+  server.toThisInstance(() => {
+    res = arango.GET_RAW(metricsUrlPath);
   });
-  expect(res).to.be.an.instanceof(request.Response);
-  expect(res).to.have.property('statusCode', 200);
+  IM.reconnectMe();
+  assertEqual(res.code, 200);
   let body = String(res.body);
   validateMetrics(body);
 }
 
 function validateMetricsViaCoordinator(coordinator, server) {
   let serverId = getServerId(server);
-  let metricsUrl = coordinator.url + metricsUrlPath + "?serverId=" + serverId;
-  let res = request.get({ url: metricsUrl });
-  expect(res).to.be.an.instanceof(request.Response);
-  expect(res).to.have.property('statusCode', 200);
+  let metricsUrl = metricsUrlPath + "?serverId=" + serverId;
+  let res = "";
+  IM.rememberConnection();
+  coordinator.toThisInstance(() => {
+    res = arango.GET_RAW(metricsUrl);
+  });
+  IM.reconnectMe();
+  assertEqual(res.code, 200);
   let body = String(res.body);
   validateMetrics(body);
   checkMetricsBelongToServer(body, server);
@@ -211,11 +227,15 @@ function promtoolClusterSuite() {
     testInvalidServerId: function () {
       //query metrics from coordinator, supplying invalid server id
       let coordinator = coordinators[0];
-      let metricsUrl = coordinator.url + metricsUrlPath + "?serverId=" + "invalid-server-id";
-      let res = request.get({ url: metricsUrl });
-      expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 404);
-      expect(res.json.errorNum).to.equal(errors.ERROR_HTTP_BAD_PARAMETER.code);
+      let metricsUrl = metricsUrlPath + "?serverId=" + "invalid-server-id";
+      let res = "";
+      IM.rememberConnection();
+      coordinator.toThisInstance(() => {
+        res = arango.GET_RAW(metricsUrl);
+      });
+      IM.reconnectMe();
+      assertEqual(res.code, 404);
+      assertEqual(res.parsedBody.errorNum, errors.ERROR_HTTP_BAD_PARAMETER.code);
     },
     testServerDoesntRespond: function () {
       //query metrics from coordinator, supplying id of a server, that is shut down

--- a/tests/js/client/shell/shell-readonly-mode-spec.js
+++ b/tests/js/client/shell/shell-readonly-mode-spec.js
@@ -28,6 +28,7 @@
 
 const expect = require('chai').expect;
 
+const arango = require("@arangodb").arango;
 const internal = require('internal');
 const db = internal.db;
 const heartbeatInterval = 1; // 1 second
@@ -40,14 +41,12 @@ const waitForHeartbeat = function () {
 };
 
 const setReadOnlyAndGetDBServer = function() {
-  let servers = Object.keys(JSON.parse(download(endpoint + '/_admin/cluster/health').body).Health).filter(function(s) {
+  let res = arango.GET('/_admin/cluster/health');
+  let servers = Object.keys(res.Health).filter(function(s) {
     return s.match(/^PRMR/);
   });
 
-
-  let resp = download(endpoint + '/_admin/server/mode', JSON.stringify({'mode': 'readonly'}), {
-    method: 'put',
-  });
+  let resp = arango.PUT('/_admin/server/mode', {mode: 'readonly'});
   expect(resp.code).to.equal(200);
   waitForHeartbeat();
 
@@ -58,12 +57,10 @@ const setReadOnlyAndGetDBServer = function() {
 describe('Readonly mode api', function() {
   afterEach(function() {
     // restore default server mode
-    let resp = download(endpoint + '/_admin/server/mode', JSON.stringify({'mode': 'default'}), {
-      method: 'put',
-    });
-      waitForHeartbeat();
+    arango.PUT('/_admin/server/mode', {mode: 'default'});
+    waitForHeartbeat();
   });
-  
+
   after(function() {
     // wait for heartbeats so the "default" server mode has a chance to be picked up by all db servers
     // before we go on with other tests
@@ -71,55 +68,44 @@ describe('Readonly mode api', function() {
   });
 
   it('outputs its current mode', function() {
-    let resp = download(endpoint + '/_admin/server/mode');
+    let resp = arango.GET('/_admin/server/mode');
     expect(resp.code).to.equal(200);
-    let body = JSON.parse(resp.body);
-    expect(body).to.have.property('mode', 'default');
+    expect(resp).to.have.property('mode', 'default');
   });
 
   it('can switch to readonly', function() {
-    let resp = download(endpoint + '/_admin/server/mode', JSON.stringify({'mode': 'readonly'}), {
-      method: 'put',
-    });
+    let resp = arango.PUT('/_admin/server/mode', {mode: 'readonly'});
     expect(resp.code).to.equal(200);
     waitForHeartbeat();
-    let body = JSON.parse(resp.body);
-    expect(body).to.have.property('mode', 'readonly');
+    expect(resp).to.have.property('mode', 'readonly');
   });
 
   it('throws an error when not passing an object', function() {
-    let set = download(endpoint + '/_admin/server/mode', JSON.stringify('testi'), {
-      method: 'put',
-    });
+    let set = arango.PUT('/_admin/server/mode', 'readonly');
     expect(set.code).to.equal(400);
     waitForHeartbeat();
 
-    let resp = download(endpoint + '/_admin/server/mode');
-    let body = JSON.parse(resp.body);
-    expect(body).to.have.property('mode', 'default');
+    let resp = arango.GET('/_admin/server/mode');
+    expect(resp).to.have.property('mode', 'default');
   });
 
   it('throws an error when passing an unknown mode', function() {
-    let set = download(endpoint + '/_admin/server/mode', JSON.stringify({'mode': 'testi'}), {
-      method: 'put',
-    });
+    let set = arango.PUT('/_admin/server/mode', {mode: 'testi'});
     expect(set.code).to.equal(400);
     waitForHeartbeat();
 
-    let resp = download(endpoint + '/_admin/server/mode');
-    let body = JSON.parse(resp.body);
-    expect(body).to.have.property('mode', 'default');
+    let resp = arango.GET('/_admin/server/mode');
+    expect(resp).to.have.property('mode', 'default');
   });
 
   it('the heartbeat should set readonly mode for all cluster nodes', function() {
-    let resp = download(endpoint + '/_admin/server/mode', JSON.stringify({'mode': 'readonly'}), {
-      method: 'put',
-    });
+    let resp = arango.PUT('/_admin/server/mode', {mode: 'readonly'});
     expect(resp.code).to.equal(200);
     waitForHeartbeat();
-    
+
     let res = instanceManager.arangods.filter(arangod => arangod.role === 'single' || arangod.role === 'coordinator' || arangod.role === 'primary')
     .every(arangod => {
+      //Left as a download() because it does not execute.
       let resp = download(arangod.url + '/_admin/server/mode');
       if (resp.code === 503) {
         // called on a follower
@@ -130,58 +116,54 @@ describe('Readonly mode api', function() {
       }
     });
   });
-  
+
   it('can still access cluster/health API when readonly', function() {
     if (!isCluster) {
       return;
     }
 
-    let resp = download(endpoint + '/_admin/cluster/health');
+    let resp = arango.GET('/_admin/cluster/health');
     expect(resp.code).to.equal(200);
-    let body = JSON.parse(resp.body);
-    expect(body).to.have.property('ClusterId');
-    expect(body).to.have.property('Health');
+    expect(resp).to.have.property('ClusterId');
+    expect(resp).to.have.property('Health');
   });
-  
+
   it('can still access cluster/nodeVersion API when readonly', function() {
     if (!isCluster) {
       return;
     }
 
     let server = setReadOnlyAndGetDBServer();
-    let resp = download(endpoint + '/_admin/cluster/nodeVersion?ServerID=' + server);
+    let resp = arango.GET_RAW('/_admin/cluster/nodeVersion?ServerID=' + server);
     expect(resp.code).to.equal(200);
   });
-  
+
   it('can still access cluster/nodeEngine API when readonly', function() {
     if (!isCluster) {
       return;
     }
-    
+
     let server = setReadOnlyAndGetDBServer();
-    let resp = download(endpoint + '/_admin/cluster/nodeEngine?ServerID=' + server);
+    let resp = arango.GET_RAW('/_admin/cluster/nodeEngine?ServerID=' + server);
     expect(resp.code).to.equal(200);
   });
-  
+
   it('can still access cluster/nodeStatistics API when readonly', function() {
     if (!isCluster) {
       return;
     }
-    
+
     let server = setReadOnlyAndGetDBServer();
-    let resp = download(endpoint + '/_admin/cluster/nodeStatistics?ServerID=' + server);
+    let resp = arango.GET_RAW('/_admin/cluster/nodeStatistics?ServerID=' + server);
     expect(resp.code).to.equal(200);
   });
-  
+
   it('cannot create a database when readonly', function() {
-    let resp = download(endpoint + '/_admin/server/mode', JSON.stringify({'mode': 'readonly'}), {
-      method: 'put',
-    });
+    let resp = arango.PUT('/_admin/server/mode', {mode: 'readonly'});
     expect(resp.code).to.equal(200);
     waitForHeartbeat();
-    
-    let body = JSON.parse(resp.body);
-    expect(body).to.have.property('mode', 'readonly');
+
+    expect(resp).to.have.property('mode', 'readonly');
     try {
       db._createDatabase('UnitTestsDatabaseReadOnly');
       fail();


### PR DESCRIPTION
### Scope & Purpose

- Use the InstanceManager to acquire the endpoint string
- migrate tests to use fuerte 
- Use connection cache 
- Use new with-way to talk to instances

- [x] :hammer: Refactoring/simplification

#### Related Information

- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1656
- [x] GitHub issue / Jira ticket: QA-784
