### PR TITLE
[COR-574] Add an activity of RocksDB compaction

### DIFF
--- a/arangod/RocksDBEngine/Listeners/CMakeLists.txt
+++ b/arangod/RocksDBEngine/Listeners/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(arango_rocksdb PRIVATE
+  RocksDBActivitiesListener.cpp
   RocksDBBackgroundErrorListener.cpp
   RocksDBMetricsListener.cpp
   RocksDBThrottle.cpp

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
@@ -1,0 +1,35 @@
+#include "RocksDBActivitiesListener.h"
+
+#include "Activities/RegistryGlobalVariable.h"
+
+#include <rocksdb/listener.h>
+#include <string>
+
+namespace arangodb {
+
+void RocksDBActivitiesListener::OnCompactionBegin(rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
+    auto handle = activities::make<activities::GenericActivity>(
+        "RocksDBCompaction",
+        activities::GenericActivityData{
+            {"job_id", std::to_string(info.job_id)},
+            {"column_family", info.cf_name},
+            {"base_input_level", std::to_string(info.base_input_level)},
+            {"output_level", std::to_string(info.output_level)},
+            {"input_files", std::to_string(info.input_files.size())},
+            {"reason", std::string(
+                rocksdb::GetCompactionReasonString(info.compaction_reason)
+            )},
+            {"phase", "running"}
+        }
+    );
+
+    std::lock_guard guard(_mutex);
+    _activities.emplace(info.job_id, std::move(handle));
+}
+
+void RocksDBActivitiesListener::OnCompactionCompleted(rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
+    std::lock_guard guard(_mutex);
+    _activities.erase(info.job_id);
+}
+
+}  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
@@ -47,12 +47,12 @@ void RocksDBActivitiesListener::OnCompactionBegin(
     _activities.emplace(info.job_id, std::move(handle));
   } catch (std::exception const& e) {
     LOG_TOPIC("5a91c", WARN, Logger::ENGINES)
-        << "failed to create RocksDBCompaction activity for job "
-        << info.job_id << ": " << e.what();
+        << "failed to create RocksDBCompaction activity for job " << info.job_id
+        << ": " << e.what();
   } catch (...) {
     LOG_TOPIC("5a91d", WARN, Logger::ENGINES)
-        << "failed to create RocksDBCompaction activity for job "
-        << info.job_id << ": unknown exception";
+        << "failed to create RocksDBCompaction activity for job " << info.job_id
+        << ": unknown exception";
   }
 }
 

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
@@ -23,28 +23,37 @@
 #include "RocksDBActivitiesListener.h"
 
 #include "Activities/RegistryGlobalVariable.h"
+#include "Logger/LogMacros.h"
 
-#include <rocksdb/listener.h>
 #include <string>
 
 namespace arangodb {
 
 void RocksDBActivitiesListener::OnCompactionBegin(
     rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
-  auto handle = activities::make<activities::GenericActivity>(
-      "RocksDBCompaction",
-      activities::GenericActivityData{
-          {"job_id", std::to_string(info.job_id)},
-          {"column_family", info.cf_name},
-          {"base_input_level", std::to_string(info.base_input_level)},
-          {"output_level", std::to_string(info.output_level)},
-          {"input_files", std::to_string(info.input_files.size())},
-          {"reason", std::string(rocksdb::GetCompactionReasonString(
-                         info.compaction_reason))},
-          {"phase", "running"}});
+  try {
+    auto handle = activities::make<activities::GenericActivity>(
+        "RocksDBCompaction",
+        activities::GenericActivityData{
+            {"job_id", std::to_string(info.job_id)},
+            {"column_family", info.cf_name},
+            {"base_input_level", std::to_string(info.base_input_level)},
+            {"output_level", std::to_string(info.output_level)},
+            {"input_files", std::to_string(info.input_files.size())},
+            {"reason", std::string(rocksdb::GetCompactionReasonString(
+                           info.compaction_reason))}});
 
-  std::lock_guard guard(_mutex);
-  _activities.emplace(info.job_id, std::move(handle));
+    std::lock_guard guard(_mutex);
+    _activities.emplace(info.job_id, std::move(handle));
+  } catch (std::exception const& e) {
+    LOG_TOPIC("5a91c", WARN, Logger::ENGINES)
+        << "failed to create RocksDBCompaction activity for job "
+        << info.job_id << ": " << e.what();
+  } catch (...) {
+    LOG_TOPIC("5a91d", WARN, Logger::ENGINES)
+        << "failed to create RocksDBCompaction activity for job "
+        << info.job_id << ": unknown exception";
+  }
 }
 
 void RocksDBActivitiesListener::OnCompactionCompleted(

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.cpp
@@ -1,3 +1,25 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
 #include "RocksDBActivitiesListener.h"
 
 #include "Activities/RegistryGlobalVariable.h"
@@ -7,29 +29,28 @@
 
 namespace arangodb {
 
-void RocksDBActivitiesListener::OnCompactionBegin(rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
-    auto handle = activities::make<activities::GenericActivity>(
-        "RocksDBCompaction",
-        activities::GenericActivityData{
-            {"job_id", std::to_string(info.job_id)},
-            {"column_family", info.cf_name},
-            {"base_input_level", std::to_string(info.base_input_level)},
-            {"output_level", std::to_string(info.output_level)},
-            {"input_files", std::to_string(info.input_files.size())},
-            {"reason", std::string(
-                rocksdb::GetCompactionReasonString(info.compaction_reason)
-            )},
-            {"phase", "running"}
-        }
-    );
+void RocksDBActivitiesListener::OnCompactionBegin(
+    rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
+  auto handle = activities::make<activities::GenericActivity>(
+      "RocksDBCompaction",
+      activities::GenericActivityData{
+          {"job_id", std::to_string(info.job_id)},
+          {"column_family", info.cf_name},
+          {"base_input_level", std::to_string(info.base_input_level)},
+          {"output_level", std::to_string(info.output_level)},
+          {"input_files", std::to_string(info.input_files.size())},
+          {"reason", std::string(rocksdb::GetCompactionReasonString(
+                         info.compaction_reason))},
+          {"phase", "running"}});
 
-    std::lock_guard guard(_mutex);
-    _activities.emplace(info.job_id, std::move(handle));
+  std::lock_guard guard(_mutex);
+  _activities.emplace(info.job_id, std::move(handle));
 }
 
-void RocksDBActivitiesListener::OnCompactionCompleted(rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
-    std::lock_guard guard(_mutex);
-    _activities.erase(info.job_id);
+void RocksDBActivitiesListener::OnCompactionCompleted(
+    rocksdb::DB*, rocksdb::CompactionJobInfo const& info) {
+  std::lock_guard guard(_mutex);
+  _activities.erase(info.job_id);
 }
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
@@ -1,11 +1,33 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
 #include "Activities/GenericActivity.h"
 
 #include <rocksdb/listener.h>
 
 #include <mutex>
 #include <unordered_map>
-
-#pragma once
 
 namespace rocksdb {
 struct CompactionJobInfo;
@@ -15,14 +37,16 @@ class DB;
 namespace arangodb {
 
 class RocksDBActivitiesListener : public rocksdb::EventListener {
-    public:
-     RocksDBActivitiesListener() = default;
+ public:
+  RocksDBActivitiesListener() = default;
 
-     void OnCompactionBegin(rocksdb::DB*, rocksdb::CompactionJobInfo const&) override;
-     void OnCompactionCompleted(rocksdb::DB*, rocksdb::CompactionJobInfo const&) override;
-    
-    private: 
-     std::mutex _mutex;
-     std::unordered_map<int, activities::GenericActivity::HandleType> _activities;
+  void OnCompactionBegin(rocksdb::DB*,
+                         rocksdb::CompactionJobInfo const&) override;
+  void OnCompactionCompleted(rocksdb::DB*,
+                             rocksdb::CompactionJobInfo const&) override;
+
+ private:
+  std::mutex _mutex;
+  std::unordered_map<int, activities::GenericActivity::HandleType> _activities;
 };
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
@@ -1,0 +1,28 @@
+#include "Activities/GenericActivity.h"
+
+#include <rocksdb/listener.h>
+
+#include <mutex>
+#include <unordered_map>
+
+#pragma once
+
+namespace rocksdb {
+struct CompactionJobInfo;
+class DB;
+}  // namespace rocksdb
+
+namespace arangodb {
+
+class RocksDBActivitiesListener : public rocksdb::EventListener {
+    public:
+     RocksDBActivitiesListener() = default;
+
+     void OnCompactionBegin(rocksdb::DB*, rocksdb::CompactionJobInfo const&) override;
+     void OnCompactionCompleted(rocksdb::DB*, rocksdb::CompactionJobInfo const&) override;
+    
+    private: 
+     std::mutex _mutex;
+     std::unordered_map<int, activities::GenericActivity::HandleType> _activities;
+};
+}  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
@@ -29,14 +29,9 @@
 #include <mutex>
 #include <unordered_map>
 
-namespace rocksdb {
-struct CompactionJobInfo;
-class DB;
-}  // namespace rocksdb
-
 namespace arangodb {
 
-class RocksDBActivitiesListener : public rocksdb::EventListener {
+class RocksDBActivitiesListener final : public rocksdb::EventListener {
  public:
   RocksDBActivitiesListener() = default;
 
@@ -49,4 +44,5 @@ class RocksDBActivitiesListener : public rocksdb::EventListener {
   std::mutex _mutex;
   std::unordered_map<int, activities::GenericActivity::HandleType> _activities;
 };
+
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
+++ b/arangod/RocksDBEngine/Listeners/RocksDBActivitiesListener.h
@@ -33,7 +33,7 @@ namespace arangodb {
 
 class RocksDBActivitiesListener final : public rocksdb::EventListener {
  public:
-  RocksDBActivitiesListener() = default;
+  ~RocksDBActivitiesListener() override = default;
 
   void OnCompactionBegin(rocksdb::DB*,
                          rocksdb::CompactionJobInfo const&) override;

--- a/arangod/RocksDBEngine/RocksDBEngine.cpp
+++ b/arangod/RocksDBEngine/RocksDBEngine.cpp
@@ -74,6 +74,7 @@
 #include "Replication2/Storage/RocksDB/ReplicatedStateInfo.h"
 #include "Replication2/Storage/WAL/LogPersistor.h"
 #include "Replication2/Storage/WAL/WalManager.h"
+#include "RocksDBEngine/Listeners/RocksDBActivitiesListener.h"
 #include "RocksDBEngine/Listeners/RocksDBBackgroundErrorListener.h"
 #include "RocksDBEngine/Listeners/RocksDBMetricsListener.h"
 #include "RocksDBEngine/Listeners/RocksDBThrottle.h"
@@ -1159,6 +1160,7 @@ void RocksDBEngine::start() {
   _dbOptions.listeners.push_back(_errorListener);
   _dbOptions.listeners.push_back(
       std::make_shared<RocksDBMetricsListener>(_metrics));
+  _dbOptions.listeners.push_back(std::make_shared<RocksDBActivitiesListener>());
 
   rocksdb::BlockBasedTableOptions tableOptions =
       _optionsProvider.getTableOptions();

--- a/tests/Activities/CMakeLists.txt
+++ b/tests/Activities/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(arango_tests_activities PRIVATE
   arango_activities_global
   arango_tests_basics 
   arango_async
+  arango_rocksdb
   gtest
 )
 

--- a/tests/Activities/CMakeLists.txt
+++ b/tests/Activities/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(arango_tests_activities OBJECT
   ActivityRegistryTest.cpp
   GenericActivityTest.cpp
   CustomGuardedActivityTest.cpp
-  InternalRequestActivityTest.cpp)
+  InternalRequestActivityTest.cpp
+  RocksDBActivitiesListenerTest.cpp)
 target_link_libraries(arango_tests_activities PRIVATE
   arango_activities_global
   arango_tests_basics 

--- a/tests/Activities/RocksDBActivitiesListenerTest.cpp
+++ b/tests/Activities/RocksDBActivitiesListenerTest.cpp
@@ -1,6 +1,29 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
 #include <gtest/gtest.h>
 #include <rocksdb/listener.h>
 #include <velocypack/Iterator.h>
+#include <boost/token_functions.hpp>
 
 #include "Activities/Registry.h"
 #include "Activities/RegistryGlobalVariable.h"
@@ -21,40 +44,99 @@ rocksdb::CompactionJobInfo makeInfo(int job_id, std::string cf = "default",
 }
 
 std::vector<velocypack::Slice> compactionActivities() {
-    auto snap = activities::registry.snapshot();
-    EXPECT_TRUE(snap.ok());
-    std::vector<velocypack::Slice> out;
-    for (auto entry : velocypack::ArrayIterator(snap.get().slice())) {
-        auto type = entry.get("type");
-        if (type.isString() && type.stringView() == "RocksDBCompaction") {
-            out.push_back(entry);
-        }
+  auto snap = activities::registry.snapshot();
+  EXPECT_TRUE(snap.ok());
+  std::vector<velocypack::Slice> out;
+  for (auto entry : velocypack::ArrayIterator(snap.get().slice())) {
+    auto type = entry.get("type");
+    if (type.isString() && type.stringView() == "RocksDBCompaction") {
+      out.push_back(entry);
     }
-    return out;
+  }
+  return out;
 }
 }  // namespace
 
 struct RocksDBActivitiesListenerTest : public ::testing::Test {
-    static void SetUpTestSuite() { activities::registry.garbageCollectAll(); }
-    void TearDown() override {
-        activities::registry.garbageCollectAll();
-        EXPECT_EQ(activities::registry.size(), 0);
-    }
-    RocksDBActivitiesListener listener;
+  static void SetUpTestSuite() { activities::registry.garbageCollectAll(); }
+  void TearDown() override {
+    activities::registry.garbageCollectAll();
+    EXPECT_EQ(activities::registry.size(), 0);
+  }
+  RocksDBActivitiesListener listener;
 };
 
-TEST_F(RocksDBActivitiesListenerTest, activity_is_present_while_compaction_is_running) {
-    auto info = makeInfo(/*job_id*/ 3, /*cf*/ "documents", /*baseLevel*/ 2, /*outLevel*/ 3);
-    listener.OnCompactionBegin(nullptr, info);
+TEST_F(RocksDBActivitiesListenerTest,
+       activity_is_present_while_compaction_is_running) {
+  auto info = makeInfo(/*job_id*/ 3, /*cf*/ "documents", /*baseLevel*/ 2,
+                       /*outLevel*/ 3);
+  listener.OnCompactionBegin(nullptr, info);
 
+  auto acts = compactionActivities();
+  ASSERT_EQ(acts.size(), 1u);
+  auto data = acts[0].get("data");
+  EXPECT_EQ(data.get("job_id").copyString(), "3");
+  EXPECT_EQ(data.get("column_family").copyString(), "documents");
+  EXPECT_EQ(data.get("base_input_level").copyString(), "2");
+  EXPECT_EQ(data.get("output_level").copyString(), "3");
+  listener.OnCompactionCompleted(nullptr, info);
+}
+
+TEST_F(RocksDBActivitiesListenerTest, activity_data_contains_all_expected_fields) {
+    auto info = makeInfo(7, "documents", 2, 3);
+    info.input_files = {"sst1.sst", "sst2.sst", "sst3.sst"};
+    info.compaction_reason = rocksdb::CompactionReason::kManualCompaction;
+    listener.OnCompactionBegin(nullptr, info);
+    
     auto acts = compactionActivities();
     ASSERT_EQ(acts.size(), 1u);
+    EXPECT_EQ(acts[0].get("type").copyString(), "RocksDBCompaction");
+    EXPECT_TRUE(acts[0].get("parent").isNone());
+    
     auto data = acts[0].get("data");
-    EXPECT_EQ(data.get("job_id").copyString(), "3");
+    EXPECT_EQ(data.get("job_id").copyString(), "7");
     EXPECT_EQ(data.get("column_family").copyString(), "documents");
     EXPECT_EQ(data.get("base_input_level").copyString(), "2");
     EXPECT_EQ(data.get("output_level").copyString(), "3");
+    EXPECT_EQ(data.get("input_files").copyString(), "3");
+    EXPECT_EQ(data.get("reason").copyString(), "ManualCompaction");
+    EXPECT_EQ(data.get("phase").copyString(), "running");
+
     listener.OnCompactionCompleted(nullptr, info);
 }
+
+TEST_F(RocksDBActivitiesListenerTest, multiple_compactions_complete_out_of_order) {
+    listener.OnCompactionBegin(nullptr, makeInfo(1, "A"));
+    listener.OnCompactionBegin(nullptr, makeInfo(2, "B"));
+    EXPECT_EQ(compactionActivities().size(), 2u);
+
+    listener.OnCompactionCompleted(nullptr, makeInfo(2, "B"));
+    auto acts = compactionActivities();
+    ASSERT_EQ(acts.size(), 1u);
+    EXPECT_EQ(acts[0].get("data").get("job_id").copyString(), "1");
+
+    listener.OnCompactionCompleted(nullptr, makeInfo(1, "A"));
+    EXPECT_TRUE(compactionActivities().empty());
+}
+
+TEST_F(RocksDBActivitiesListenerTest, completion_without_begin_is_noop) {
+    listener.OnCompactionCompleted(nullptr, makeInfo(0));
+    EXPECT_TRUE(compactionActivities().empty());
+}
+
+TEST_F(RocksDBActivitiesListenerTest, duplecate_begin_for_same_job_id_keeps_first_activity) {
+    auto first = makeInfo(5, "first");
+    auto second = makeInfo(5, "second");
+    listener.OnCompactionBegin(nullptr, first);
+    listener.OnCompactionBegin(nullptr, second);
+
+    auto acts = compactionActivities();
+    ASSERT_EQ(acts.size(), 1u);
+    EXPECT_EQ(acts[0].get("data").get("column_family").copyString(), "first");
+
+    listener.OnCompactionCompleted(nullptr, first);
+}
+
+
 
 }  // namespace arangodb

--- a/tests/Activities/RocksDBActivitiesListenerTest.cpp
+++ b/tests/Activities/RocksDBActivitiesListenerTest.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include <rocksdb/listener.h>
+#include <velocypack/Iterator.h>
+
+#include "Activities/Registry.h"
+#include "Activities/RegistryGlobalVariable.h"
+#include "RocksDBEngine/Listeners/RocksDBActivitiesListener.h"
+
+namespace arangodb {
+
+namespace {
+rocksdb::CompactionJobInfo makeInfo(int job_id, std::string cf = "default",
+                                    int baseLevel = 0, int outLevel = 1) {
+  rocksdb::CompactionJobInfo info{};
+  info.cf_name = std::move(cf);
+  info.job_id = job_id;
+  info.base_input_level = baseLevel;
+  info.output_level = outLevel;
+  info.compaction_reason = rocksdb::CompactionReason::kLevelL0FilesNum;
+  return info;
+}
+
+std::vector<velocypack::Slice> compactionActivities() {
+    auto snap = activities::registry.snapshot();
+    EXPECT_TRUE(snap.ok());
+    std::vector<velocypack::Slice> out;
+    for (auto entry : velocypack::ArrayIterator(snap.get().slice())) {
+        auto type = entry.get("type");
+        if (type.isString() && type.stringView() == "RocksDBCompaction") {
+            out.push_back(entry);
+        }
+    }
+    return out;
+}
+}  // namespace
+
+struct RocksDBActivitiesListenerTest : public ::testing::Test {
+    static void SetUpTestSuite() { activities::registry.garbageCollectAll(); }
+    void TearDown() override {
+        activities::registry.garbageCollectAll();
+        EXPECT_EQ(activities::registry.size(), 0);
+    }
+    RocksDBActivitiesListener listener;
+};
+
+TEST_F(RocksDBActivitiesListenerTest, activity_is_present_while_compaction_is_running) {
+    auto info = makeInfo(/*job_id*/ 3, /*cf*/ "documents", /*baseLevel*/ 2, /*outLevel*/ 3);
+    listener.OnCompactionBegin(nullptr, info);
+
+    auto acts = compactionActivities();
+    ASSERT_EQ(acts.size(), 1u);
+    auto data = acts[0].get("data");
+    EXPECT_EQ(data.get("job_id").copyString(), "3");
+    EXPECT_EQ(data.get("column_family").copyString(), "documents");
+    EXPECT_EQ(data.get("base_input_level").copyString(), "2");
+    EXPECT_EQ(data.get("output_level").copyString(), "3");
+    listener.OnCompactionCompleted(nullptr, info);
+}
+
+}  // namespace arangodb

--- a/tests/Activities/RocksDBActivitiesListenerTest.cpp
+++ b/tests/Activities/RocksDBActivitiesListenerTest.cpp
@@ -23,7 +23,6 @@
 #include <gtest/gtest.h>
 #include <rocksdb/listener.h>
 #include <velocypack/Iterator.h>
-#include <boost/token_functions.hpp>
 
 #include "Activities/Registry.h"
 #include "Activities/RegistryGlobalVariable.h"
@@ -82,61 +81,62 @@ TEST_F(RocksDBActivitiesListenerTest,
   listener.OnCompactionCompleted(nullptr, info);
 }
 
-TEST_F(RocksDBActivitiesListenerTest, activity_data_contains_all_expected_fields) {
-    auto info = makeInfo(7, "documents", 2, 3);
-    info.input_files = {"sst1.sst", "sst2.sst", "sst3.sst"};
-    info.compaction_reason = rocksdb::CompactionReason::kManualCompaction;
-    listener.OnCompactionBegin(nullptr, info);
-    
-    auto acts = compactionActivities();
-    ASSERT_EQ(acts.size(), 1u);
-    EXPECT_EQ(acts[0].get("type").copyString(), "RocksDBCompaction");
-    EXPECT_TRUE(acts[0].get("parent").isNone());
-    
-    auto data = acts[0].get("data");
-    EXPECT_EQ(data.get("job_id").copyString(), "7");
-    EXPECT_EQ(data.get("column_family").copyString(), "documents");
-    EXPECT_EQ(data.get("base_input_level").copyString(), "2");
-    EXPECT_EQ(data.get("output_level").copyString(), "3");
-    EXPECT_EQ(data.get("input_files").copyString(), "3");
-    EXPECT_EQ(data.get("reason").copyString(), "ManualCompaction");
-    EXPECT_EQ(data.get("phase").copyString(), "running");
+TEST_F(RocksDBActivitiesListenerTest,
+       activity_data_contains_all_expected_fields) {
+  auto info = makeInfo(7, "documents", 2, 3);
+  info.input_files = {"sst1.sst", "sst2.sst", "sst3.sst"};
+  info.compaction_reason = rocksdb::CompactionReason::kManualCompaction;
+  listener.OnCompactionBegin(nullptr, info);
 
-    listener.OnCompactionCompleted(nullptr, info);
+  auto acts = compactionActivities();
+  ASSERT_EQ(acts.size(), 1u);
+  EXPECT_EQ(acts[0].get("type").copyString(), "RocksDBCompaction");
+  EXPECT_TRUE(acts[0].get("parent").isNone());
+
+  auto data = acts[0].get("data");
+  EXPECT_EQ(data.get("job_id").copyString(), "7");
+  EXPECT_EQ(data.get("column_family").copyString(), "documents");
+  EXPECT_EQ(data.get("base_input_level").copyString(), "2");
+  EXPECT_EQ(data.get("output_level").copyString(), "3");
+  EXPECT_EQ(data.get("input_files").copyString(), "3");
+  EXPECT_EQ(data.get("reason").copyString(), "ManualCompaction");
+  EXPECT_EQ(data.get("phase").copyString(), "running");
+
+  listener.OnCompactionCompleted(nullptr, info);
 }
 
-TEST_F(RocksDBActivitiesListenerTest, multiple_compactions_complete_out_of_order) {
-    listener.OnCompactionBegin(nullptr, makeInfo(1, "A"));
-    listener.OnCompactionBegin(nullptr, makeInfo(2, "B"));
-    EXPECT_EQ(compactionActivities().size(), 2u);
+TEST_F(RocksDBActivitiesListenerTest,
+       multiple_compactions_complete_out_of_order) {
+  listener.OnCompactionBegin(nullptr, makeInfo(1, "A"));
+  listener.OnCompactionBegin(nullptr, makeInfo(2, "B"));
+  EXPECT_EQ(compactionActivities().size(), 2u);
 
-    listener.OnCompactionCompleted(nullptr, makeInfo(2, "B"));
-    auto acts = compactionActivities();
-    ASSERT_EQ(acts.size(), 1u);
-    EXPECT_EQ(acts[0].get("data").get("job_id").copyString(), "1");
+  listener.OnCompactionCompleted(nullptr, makeInfo(2, "B"));
+  auto acts = compactionActivities();
+  ASSERT_EQ(acts.size(), 1u);
+  EXPECT_EQ(acts[0].get("data").get("job_id").copyString(), "1");
 
-    listener.OnCompactionCompleted(nullptr, makeInfo(1, "A"));
-    EXPECT_TRUE(compactionActivities().empty());
+  listener.OnCompactionCompleted(nullptr, makeInfo(1, "A"));
+  EXPECT_TRUE(compactionActivities().empty());
 }
 
 TEST_F(RocksDBActivitiesListenerTest, completion_without_begin_is_noop) {
-    listener.OnCompactionCompleted(nullptr, makeInfo(0));
-    EXPECT_TRUE(compactionActivities().empty());
+  listener.OnCompactionCompleted(nullptr, makeInfo(0));
+  EXPECT_TRUE(compactionActivities().empty());
 }
 
-TEST_F(RocksDBActivitiesListenerTest, duplecate_begin_for_same_job_id_keeps_first_activity) {
-    auto first = makeInfo(5, "first");
-    auto second = makeInfo(5, "second");
-    listener.OnCompactionBegin(nullptr, first);
-    listener.OnCompactionBegin(nullptr, second);
+TEST_F(RocksDBActivitiesListenerTest,
+       duplecate_begin_for_same_job_id_keeps_first_activity) {
+  auto first = makeInfo(5, "first");
+  auto second = makeInfo(5, "second");
+  listener.OnCompactionBegin(nullptr, first);
+  listener.OnCompactionBegin(nullptr, second);
 
-    auto acts = compactionActivities();
-    ASSERT_EQ(acts.size(), 1u);
-    EXPECT_EQ(acts[0].get("data").get("column_family").copyString(), "first");
+  auto acts = compactionActivities();
+  ASSERT_EQ(acts.size(), 1u);
+  EXPECT_EQ(acts[0].get("data").get("column_family").copyString(), "first");
 
-    listener.OnCompactionCompleted(nullptr, first);
+  listener.OnCompactionCompleted(nullptr, first);
 }
-
-
 
 }  // namespace arangodb

--- a/tests/Activities/RocksDBActivitiesListenerTest.cpp
+++ b/tests/Activities/RocksDBActivitiesListenerTest.cpp
@@ -100,7 +100,6 @@ TEST_F(RocksDBActivitiesListenerTest,
   EXPECT_EQ(data.get("output_level").copyString(), "3");
   EXPECT_EQ(data.get("input_files").copyString(), "3");
   EXPECT_EQ(data.get("reason").copyString(), "ManualCompaction");
-  EXPECT_EQ(data.get("phase").copyString(), "running");
 
   listener.OnCompactionCompleted(nullptr, info);
 }


### PR DESCRIPTION
### Scope & Purpose

- Extended `EventListener` to `RocksDBActivitiesListener` so it will be notified whenever RocksDB performs a compaction.
- Overrode no-op functions: `OnCompactionBegin()` and `OnCompactionCompleted()`.
- Wrote C++ unit tests; these tests don't cover the integrity with RocksDB invoking a compaction.

- [ ] :hankey: Bugfix
- [x] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
