### PR TITLE
Cor 537 incorrect sort when using inverted index

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* COR-537, github issue #21843: Fixed incorrect sorting order bug when using
+  inverted indexes.
+
 * GitHub issue #22821: Fix overflow issues in LIFO and FIFO cursor queues.
 
 * COR-670: Fixed a crash when a vector query with covered projections ran while

--- a/arangod/Aql/Optimizer/Rule/UseIndexForSort.cpp
+++ b/arangod/Aql/Optimizer/Rule/UseIndexForSort.cpp
@@ -322,7 +322,15 @@ struct SortToIndexNode final
         _sortNode->setGroupedElements(numberOfCoveredAttributes);
         _modified = true;
       }
-    } else {
+    } else if (index->type() != Index::IndexType::TRI_IDX_TYPE_INVERTED_INDEX) {
+      //
+      //  For B-tree and skiplist based indexes that are
+      //  already sorted, we can kick the SortNode and prevent double sorting,
+      //  iff:
+      //  - there is only attribute access
+      //  - FILTER based only on equality matches (eg. doc.name == "John" and
+      //  doc.age == 20)
+      //  - the sort condition is based on an indexed attribute
       if (isOnlyAttributeAccess && indexes.size() == 1) {
         auto root = cond->root();
 

--- a/tests/js/client/aql/aql-inverted-index.js
+++ b/tests/js/client/aql/aql-inverted-index.js
@@ -35,8 +35,9 @@ const removeFilterCoveredByIndex = "remove-filter-covered-by-index";
 const moveFiltersIntoEnumerate = "move-filters-into-enumerate";
 const useIndexForSort = "use-index-for-sort";
 const lateDocumentMaterialization = "late-document-materialization";
-const sleep = require('internal').sleep;
-const errors = require('internal').errors;
+const internal = require('internal');
+const sleep = internal.sleep;
+const errors = internal.errors;
 
 function optimizerRuleInvertedIndexTestSuite() {
   const colName = 'UnitTestInvertedIndexCollection';
@@ -658,6 +659,47 @@ function optimizerRuleInvertedIndexTestSuite() {
       for(let i = 1; i < executeRes.length; ++i) {
         assertTrue(executeRes[i-1].count > executeRes[i].count);
       }
+    },
+    testEqualityOnlySortIndexedFieldWithoutPrimarySort: function () {
+      let collectionName = 'users';
+      let colUsers = db._create(collectionName);
+      colUsers.ensureIndex({
+        fields: [
+          { name: "name" },
+          { name: "age" }
+        ],
+        name: "inv",
+        type: "inverted"
+      });
+      colUsers.insert({ name: "B", age: 20 });
+      colUsers.insert({ name: "A", age: 20 });
+      colUsers.insert({ name: "C", age: 20 });
+
+      //  https://github.com/arangodb/arangodb/issues/21843
+      //  For queries that use indexes that are already sorted (B-tree, skiplist, etc.),
+      //  execute only equality matches on indexed fields, we kick the SortNode as we
+      //  can leverage the sorted order of field values from the index.
+      //  But this behavior shouldn't be applied to inverted indexes as they're not sorted
+      //  by the field values.
+      //  We should not kick the SortNode when using this structure with inverted indexes.
+      const query = aql`
+              for doc in ${colUsers}
+              OPTIONS { indexHint: 'inv', forceIndexHint: true, waitForSync: true }
+              FILTER doc.age == 20
+              SORT doc.name ASC
+              return doc.name`;
+
+      const res = db._createStatement({query: query.query, bindVars: query.bindVars}).explain();
+      const nodes = res.plan.nodes;
+      let found = nodes.some(node => node.type === 'SortNode');
+      assertTrue(found);
+
+      let executeRes = db._query(query.query, query.bindVars).toArray();
+      assertEqual(executeRes.length, 3);
+      assertEqual(executeRes[0], "A");
+      assertEqual(executeRes[1], "B");
+      assertEqual(executeRes[2], "C");
+      colUsers.drop();
     },
   };
 }


### PR DESCRIPTION
### Scope & Purpose

In handleIndexNode() we have optimizations (for sorted indexes like skiplist and B-tree indexes) that save us the cost of sorting the results, since the index stores sorted values. This optimization was being applied to inverted indexes as well, which isn't a sorted index, and it led to removing the SortNode. That is why the sorting wasn't working when the inverted index was used for sort queries.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [X] **integration tests**
  - [ ] **resilience tests**
- [X] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://github.com/arangodb/arangodb/issues/21843
- [ ] Design document: 
