### PR TITLE
[COR-693] TSAN ClusterFeature data race issue

### DIFF
--- a/arangod/Cluster/ClusterFeature.cpp
+++ b/arangod/Cluster/ClusterFeature.cpp
@@ -595,7 +595,7 @@ void ClusterFeature::shutdown() try {
 
   // must make sure that the HeartbeatThread is fully stopped before
   // we destroy the AgencyCallbackRegistry.
-  _heartbeatThread.reset();
+  _heartbeatThread.store(nullptr, std::memory_order_release);
 
   if (_asyncAgencyCommPool) {
     _asyncAgencyCommPool->drainConnections();
@@ -616,12 +616,12 @@ void ClusterFeature::startHeartbeatThread(
     AgencyCallbackRegistry* agencyCallbackRegistry, uint64_t interval_ms,
     uint64_t maxFailsBeforeWarning, double noHeartbeatDelayBeforeShutdown,
     std::string const& endpoints) {
-  _heartbeatThread = std::make_shared<HeartbeatThread>(
+  auto heartbeatThread = std::make_shared<HeartbeatThread>(
       server(), agencyCallbackRegistry,
       std::chrono::microseconds(interval_ms * 1000), maxFailsBeforeWarning,
       noHeartbeatDelayBeforeShutdown);
 
-  if (!_heartbeatThread->init() || !_heartbeatThread->start()) {
+  if (!heartbeatThread->init() || !heartbeatThread->start()) {
     // failure only occures in cluster mode.
     LOG_TOPIC("7e050", FATAL, arangodb::Logger::CLUSTER)
         << "heartbeat could not connect to agency endpoints (" << endpoints
@@ -629,10 +629,12 @@ void ClusterFeature::startHeartbeatThread(
     FATAL_ERROR_EXIT();
   }
 
-  while (!_heartbeatThread->isReady()) {
+  while (!heartbeatThread->isReady()) {
     // wait until heartbeat is ready
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
+
+  _heartbeatThread.store(std::move(heartbeatThread), std::memory_order_release);
 }
 
 void ClusterFeature::pruneAsyncAgencyConnectionPool() {
@@ -640,11 +642,12 @@ void ClusterFeature::pruneAsyncAgencyConnectionPool() {
 }
 
 void ClusterFeature::shutdownHeartbeatThread() {
-  if (_heartbeatThread != nullptr) {
-    _heartbeatThread->beginShutdown();
+  auto heartbeatThread = _heartbeatThread.load(std::memory_order_acquire);
+  if (heartbeatThread != nullptr) {
+    heartbeatThread->beginShutdown();
     auto start = std::chrono::steady_clock::now();
     size_t counter = 0;
-    while (_heartbeatThread->isRunning()) {
+    while (heartbeatThread->isRunning()) {
       if (std::chrono::steady_clock::now() - start > std::chrono::seconds(65)) {
         LOG_TOPIC("d8a5b", FATAL, Logger::CLUSTER)
             << "exiting prematurely as we failed terminating the heartbeat "
@@ -699,13 +702,14 @@ void ClusterFeature::shutdownAgencyCache() {
 }
 
 void ClusterFeature::notify() {
-  if (_heartbeatThread != nullptr) {
-    _heartbeatThread->notify();
+  if (auto heartbeatThread = _heartbeatThread.load(std::memory_order_acquire);
+      heartbeatThread != nullptr) {
+    heartbeatThread->notify();
   }
 }
 
 std::shared_ptr<HeartbeatThread> ClusterFeature::heartbeatThread() {
-  return _heartbeatThread;
+  return _heartbeatThread.load(std::memory_order_acquire);
 }
 
 ClusterInfo& ClusterFeature::clusterInfo() {

--- a/arangod/Cluster/ClusterFeature.h
+++ b/arangod/Cluster/ClusterFeature.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <unordered_set>
 
@@ -239,7 +240,7 @@ class ClusterFeature : public application_features::ApplicationFeature {
 
   ErrorCode _syncerShutdownCode = TRI_ERROR_SHUTTING_DOWN;
   std::unique_ptr<ClusterInfo> _clusterInfo;
-  std::shared_ptr<HeartbeatThread> _heartbeatThread;
+  std::atomic<std::shared_ptr<HeartbeatThread>> _heartbeatThread;
   std::unique_ptr<AgencyCache> _agencyCache;
   uint64_t _heartbeatInterval = 0;
   std::unique_ptr<AgencyCallbackRegistry> _agencyCallbackRegistry;


### PR DESCRIPTION
### Scope & Purpose

Where a data race happens:
- ClusterFeature.cpp: line 598: `_heartbeatThread.reset();` -> Tries to write to `shared_ptr` itself
- ClusterFeature.cpp: line 708: `return _heartbeatThread;` -> Tries to read `shared_ptr` itself.

Please be noted that the data race is happening in the `shared_ptr` itself, not the pointee that the `shared_ptr` points to.

Introduced `atomic` to the `shared_ptr`. 

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
