### PR TITLE
[COR-678] Cleanup remaining --server.storage-engine

### DIFF
--- a/etc/arangodb3/arangod.conf.in
+++ b/etc/arangodb3/arangod.conf.in
@@ -24,7 +24,6 @@ directory = @LOCALSTATEDIR@/lib/arangodb3
 #   endpoint = tcp://[fe80::21a:5df1:aede:98cf]:8529
 #
 endpoint = tcp://127.0.0.1:8529
-storage-engine = auto
 
 # reuse a port on restart or wait until it is freed by the operating system
 # reuse-address = false

--- a/tests/toast/lib/toast/deployment/command_builder.ex
+++ b/tests/toast/lib/toast/deployment/command_builder.ex
@@ -54,9 +54,7 @@ defmodule Toast.Deployment.CommandBuilder do
   defp config_file(:coordinator), do: "etc/testing/arangod-coordinator.conf"
   defp config_file(:dbserver), do: "etc/testing/arangod-dbserver.conf"
 
-  defp role_args(:single) do
-    [{"--server.storage-engine", "rocksdb"}]
-  end
+  defp role_args(:single) do: []
 
   defp role_args(:agent) do
     [

--- a/tests/toast/lib/toast/deployment/command_builder.ex
+++ b/tests/toast/lib/toast/deployment/command_builder.ex
@@ -54,7 +54,7 @@ defmodule Toast.Deployment.CommandBuilder do
   defp config_file(:coordinator), do: "etc/testing/arangod-coordinator.conf"
   defp config_file(:dbserver), do: "etc/testing/arangod-dbserver.conf"
 
-  defp role_args(:single) do: []
+  defp role_args(:single), do: []
 
   defp role_args(:agent) do
     [

--- a/tests/toast/test/deployment/command_builder_test.exs
+++ b/tests/toast/test/deployment/command_builder_test.exs
@@ -62,13 +62,6 @@ defmodule Toast.Deployment.CommandBuilderTest do
   end
 
   describe "build_args/3 role args" do
-    test "single includes storage engine args" do
-      result =
-        CommandBuilder.build_args(%{role: :single, port: 8529, args: %{}}, @paths, @repo_root)
-
-      assert has_flag_value?(result, "--server.storage-engine", "rocksdb")
-    end
-
     test "agent includes agency args" do
       result =
         CommandBuilder.build_args(%{role: :agent, port: 8529, args: %{}}, @paths, @repo_root)
@@ -136,9 +129,7 @@ defmodule Toast.Deployment.CommandBuilderTest do
                "--log.ids",
                "true",
                "--log.process",
-               "true",
-               "--server.storage-engine",
-               "rocksdb"
+               "true"
              ]
     end
 


### PR DESCRIPTION
### Scope & Purpose

Removed leftovers of `--server.storage-engine`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
