### PR TITLE
[cor-688] Fixed inconsistent handling of null in array and object spread operations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
+* COR-688: BugFix - Fixed inconsistent handling of null in array and object spread operations. 
+  null spread operands now produce query warnings, matching the behavior of other unsupported operand types.
 
 * COR-553: Added AQL array `ALL`/`ANY`/`NONE`/`AT LEAST` support for the `LIKE`
   operator, e.g. `["foo", "bar"] ANY LIKE "b%"` and

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -706,8 +706,6 @@ AqlValue Expression::executeSimpleExpressionArray(ExpressionContext& ctx,
             builder->add(e);
           }
         }
-      } else if (result.isNull(true)) {
-        result.toVelocyPack(&trx.vpackOptions(), *builder.get(), false);
       } else {
         ctx.registerWarning(
             TRI_ERROR_QUERY_ARRAY_EXPECTED,
@@ -829,8 +827,6 @@ AqlValue Expression::executeSimpleExpressionObject(ExpressionContext& ctx,
 
           addOrUpdateEntry(it.key().copyString(), copiedValue, true);
         }
-      } else if (spliceValue.isNull(true)) {
-        // no-op
       } else {
         ctx.registerWarning(
             TRI_ERROR_QUERY_OBJECT_EXPECTED,

--- a/tests/js/client/aql/aql-array-splicing.js
+++ b/tests/js/client/aql/aql-array-splicing.js
@@ -57,8 +57,21 @@ function splicingSuite () {
     },
     testArraySplicingNull : function() {
       let query = `LET a = null RETURN [...a]`;
-      let res = db._query(query).toArray();
-      assertEqual([[null]], res);
+      let data = db._query(query).data;
+      assertEqual([[]], data.result);
+      assertEqual(1, data.extra.warnings.length);
+      assertEqual(errors.ERROR_QUERY_ARRAY_EXPECTED.code,
+        data.extra.warnings[0].code);
+      assertTrue(data.extra.warnings[0].message.includes('array splice'));
+    },
+    testArraySplicingInlineNull : function() {
+      let query = `RETURN [1, ...null, 3]`;
+      let data = db._query(query).data;
+      assertEqual([[1, 3]], data.result);
+      assertEqual(1, data.extra.warnings.length);
+      assertEqual(errors.ERROR_QUERY_ARRAY_EXPECTED.code,
+        data.extra.warnings[0].code);
+      assertTrue(data.extra.warnings[0].message.includes('array splice'));
     },
     testArraySplicingObject : function() {
       let query = `LET a = {} RETURN [...a]`;

--- a/tests/js/client/aql/aql-object-splicing.js
+++ b/tests/js/client/aql/aql-object-splicing.js
@@ -70,10 +70,23 @@ function objectSplicingSuite () {
       assertEqual(errors.ERROR_QUERY_OBJECT_EXPECTED.code,
         data.extra.warnings[0].code);
     },
-    testObjectSplicingNullNoOp: function () {
+    testObjectSplicingNull: function () {
       let query = `LET x = null RETURN { ...x }`;
-      let res = db._query(query).toArray();
-      assertEqual([{}], res);
+      let data = db._query(query).data;
+      assertEqual([{}], data.result);
+      assertEqual(1, data.extra.warnings.length);
+      assertEqual(errors.ERROR_QUERY_OBJECT_EXPECTED.code,
+        data.extra.warnings[0].code);
+      assertTrue(data.extra.warnings[0].message.includes('object splice'));
+    },
+    testObjectSplicingInlineNull: function () {
+      let query = `RETURN { a: 1, ...null, c: 3 }`;
+      let data = db._query(query).data;
+      assertEqual([{ a: 1, c: 3 }], data.result);
+      assertEqual(1, data.extra.warnings.length);
+      assertEqual(errors.ERROR_QUERY_OBJECT_EXPECTED.code,
+        data.extra.warnings[0].code);
+      assertTrue(data.extra.warnings[0].message.includes('object splice'));
     },
     testObjectSplicingEmptyObject: function () {
       let query = `LET o = {} RETURN { ...o, x: 1 }`;


### PR DESCRIPTION
In this PR we have addressed inconsistent handling of null in array and object spread operations.

- When spreading an object into an object literal, non-object values are not merged into the object and raises a query warning.
After Fix:
127.0.0.1:8529@_system> db._query(`RETURN { a: 1, ...null, c: 3 }`)
[object ArangoQueryCursor, count: 1, results cached: false, hasMore: false, warning(s): "1564 in object splice: object expected"]

[ 
  { 
    "a" : 1, 
    "c" : 3 
  } 
]

- When spreading an array into an array literal, non-array values are skipped and raised a query warning.
After fix:
127.0.0.1:8529@_system> db._query(`RETURN [1, ...null, 3]`)
[object ArangoQueryCursor, count: 1, results cached: false, hasMore: false, warning(s): "1563 in array splice: array expected"]

[ 
  [ 
    1, 
    3 
  ] 
]