### PR TITLE
Add missing case in error code for HTTP_UNAUTHORIZED

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* Add missing case to return 403 for error HTTP_UNAUTHORIZED.
+
 * COR-537, github issue #21843: Fixed incorrect sorting order bug when using
   inverted indexes.
 

--- a/lib/Rest/GeneralResponse.cpp
+++ b/lib/Rest/GeneralResponse.cpp
@@ -377,6 +377,9 @@ rest::ResponseCode GeneralResponse::responseCode(ErrorCode code) {
     case static_cast<int>(TRI_ERROR_VALIDATION_BAD_PARAMETER):
       return ResponseCode::BAD;
 
+    case static_cast<int>(TRI_ERROR_HTTP_UNAUTHORIZED):
+      return ResponseCode::UNAUTHORIZED;
+
     case static_cast<int>(TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE):
     case static_cast<int>(TRI_ERROR_ARANGO_READ_ONLY):
     case static_cast<int>(TRI_ERROR_FORBIDDEN):


### PR DESCRIPTION
This adds a missing case for `rest::ResponseCode GeneralResponse::responseCode(ErrorCode code)`.
This was found during RBAC developement and has very small consequences indeed. It is only
POST /_api/log on a Replication1 database, which produces incorrectly HTTP 500 instead of
HTTP 403. This patch corrects this.

- **Add missing case for HTTP_UNAUTHORIZED.**
- **CHANGELOG**

### Scope & Purpose

- [*] :hankey: Bugfix

