### PR TITLE
[COR-213] Move "harden" conditional from AuthMode into ExecContext

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -73,10 +73,9 @@ auto AuthMode::Superuser::request() const noexcept
 }
 
 AuthMode::Classic::Classic(auth::UserManager& userManager, std::string username,
-                           bool apiHardened, GeneralRequest& req)
+                           GeneralRequest& req)
     : _userManager(userManager),
       _username(std::move(username)),
-      _apiHardened(apiHardened),
       _request(req) {}
 
 auto AuthMode::Classic::username() const noexcept -> std::string_view {
@@ -278,12 +277,6 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
           },
           [&](p::Admin const& /*admin*/) -> Result {
             // Classic admin action requires RW access to the _system database.
-            return isAdmin();
-          },
-          [&](p::HardenedAdmin const& /*admin*/) -> Result {
-            if (!_apiHardened) {
-              return {};
-            }
             return isAdmin();
           },
           [&](p::SeeDatabase const& database) -> Result {

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -101,11 +101,10 @@ struct AuthMode {
   struct Classic : IAuth {
     auth::UserManager& _userManager;
     std::string const _username;
-    bool const _apiHardened{};
     GeneralRequest& _request;
 
     Classic(auth::UserManager& userManager, std::string username,
-            bool apiHardened, GeneralRequest& req);
+            GeneralRequest& req);
 
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
 

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -278,7 +278,7 @@ struct WriteUser {
 // pass a `perms::Xxx{...}` and it is wrapped automatically.
 using Permission = std::variant<
     // admin actions
-    perms::Admin, perms::HardenedAdmin,
+    perms::Admin,
     // database permissions
     perms::SeeDatabase, perms::CreateDatabase, perms::DropDatabase,
     perms::UseDatabase,

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -39,7 +39,7 @@ thread_local std::shared_ptr<ExecContext const> ExecContext::CURRENT = nullptr;
 
 std::shared_ptr<ExecContext const> const ExecContext::Superuser =
     std::make_shared<ExecContext const>(ConstructorToken{},
-                                        AuthMode{AuthMode::Superuser{}},
+                                        AuthMode{AuthMode::Superuser{}}, true,
                                         VocbasePtr{nullptr});
 
 /// Should always contain a reference to current user context
@@ -64,8 +64,10 @@ std::shared_ptr<ExecContext const> ExecContext::superuserAsShared() {
 }
 
 ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
-                         VocbasePtr vocbase)
-    : _authMode(std::move(authMode)), _vocbase(std::move(vocbase)) {}
+                         bool isRestApiHardened, VocbasePtr vocbase)
+    : _authMode(std::move(authMode)),
+      _isRestApiHardened(isRestApiHardened),
+      _vocbase(std::move(vocbase)) {}
 
 /*static*/ std::shared_ptr<ExecContext> ExecContext::create(
     AuthenticationFeature& authenticationFeature, RbacFeature& rbacFeature,
@@ -105,11 +107,11 @@ ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
     }
 
     ADB_PROD_ASSERT(userManager != nullptr);
-    return AuthMode::Classic(*userManager, req.user(),
-                             securityFeature.isRestApiHardened(), req);
+    return AuthMode::Classic(*userManager, req.user(), req);
   }()};
 
   return std::make_shared<ExecContext>(ConstructorToken{}, std::move(authMode),
+                                       securityFeature.isRestApiHardened(),
                                        std::move(vocbase));
 }
 
@@ -171,7 +173,14 @@ Result ExecContext::canUseAdminAction(rbac::Category::Any const& action) const {
 Result ExecContext::canUseHardenedAction(
     rbac::Category::Any const& action) const {
   using namespace auth::perms;
-  return can(HardenedAdmin{.action{action}});
+  ADB_PROD_ASSERT(!_authMode.isRbac() || _isRestApiHardened)
+      << "RBAC is enabled, but REST API is not hardened: "
+         "RBAC implies --server.harden=true ("
+         "ServerSecurityFeatureOptions::hardenedRestApi = true).";
+  if (!_isRestApiHardened) {
+    return {};
+  }
+  return can(Admin{.action{action}});
 }
 
 Result ExecContext::canSeeDatabase(std::string_view db) const {
@@ -388,12 +397,12 @@ auto ExecContextSuperuserScope::getSuperuserContextFrom(
     ExecContext const* const old) -> std::shared_ptr<ExecContext const> {
   // save the original request for audit logging, if there is one
   if (old != nullptr && old->request().has_value()) {
-    struct EC : ExecContext {};
     // NOTE we could store the vocbase as well, but I'm unsure if that's helpful
     //      (note that an exec context contains a request iff it
     //      contains a vocbase)
     return std::make_shared<ExecContext>(
-        EC::ConstructorToken{}, AuthMode{AuthMode::Superuser{*old->request()}},
+        ExecContext::ConstructorToken{},
+        AuthMode{AuthMode::Superuser{*old->request()}}, old->_isRestApiHardened,
         nullptr);
   } else {
     return ExecContext::Superuser;

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -244,7 +244,7 @@ struct [[deprecated(
 
  private:
   static auto getSuperuserContextFrom(ExecContext const* old)
-      ->std::shared_ptr<ExecContext const>;
+      -> std::shared_ptr<ExecContext const>;
 
   std::shared_ptr<ExecContext const> _old;
 };

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -61,7 +61,8 @@ class ExecContext {
   class ConstructorToken {};
 
  public:
-  ExecContext(ConstructorToken, AuthMode authMode, VocbasePtr vocbase);
+  ExecContext(ConstructorToken, AuthMode authMode, bool isRestApiHardened,
+              VocbasePtr vocbase);
   ExecContext(ExecContext const&) = delete;
   ExecContext(ExecContext&&) = delete;
 
@@ -208,11 +209,12 @@ class ExecContext {
   [[nodiscard]] std::string authMethod() const;
 #endif
 
- protected:
+ private:
   AuthMode _authMode;
+  bool const _isRestApiHardened;
   VocbasePtr _vocbase;
 
- private:
+  // TODO (Tobias) this feels out of place. Look into it.
   /// should be used to indicate a canceled request / thread
   std::atomic<bool> _canceled{false};
 
@@ -242,7 +244,7 @@ struct [[deprecated(
 
  private:
   static auto getSuperuserContextFrom(ExecContext const* old)
-      -> std::shared_ptr<ExecContext const>;
+      ->std::shared_ptr<ExecContext const>;
 
   std::shared_ptr<ExecContext const> _old;
 };


### PR DESCRIPTION
### Scope & Purpose

This keeps the permission API clean from a distinction that is tied to whether a particular piece of code (e.g. certain RestHandler endpoints) is guarded by a certain permission. Having it there still keeps the branch in only one place, and still spares RestHandlers from explicitly branching on the command-line option.