### PR TITLE
Fix possible segfault in async tests

### DIFF
--- a/tests/Activities/ActivitiesAsyncTest.cpp
+++ b/tests/Activities/ActivitiesAsyncTest.cpp
@@ -84,7 +84,7 @@ TYPED_TEST(ActivitiesAsyncTest, root_activity_persists) {
   ASSERT_EQ((activities::Registry::currentlyExecutingActivity()),
             activities::Root);
 
-  auto coro = [&]() -> async<void> {
+  auto fn = [&]() -> async<void> {
     EXPECT_EQ((activities::Registry::currentlyExecutingActivity()),
               activities::Root);
 
@@ -102,7 +102,8 @@ TYPED_TEST(ActivitiesAsyncTest, root_activity_persists) {
               coro_activity);
 
     co_return;
-  }();
+  };
+  auto coro = fn();
 
   auto outer_activity =
       activities::make<GenericActivity>("TestActivity", this->activityData);
@@ -134,7 +135,7 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_parenting_works) {
   ASSERT_EQ((activities::Registry::currentlyExecutingActivity()),
             outer_activity);
 
-  auto coro = [&]() -> async<void> {
+  auto fn = [&]() -> async<void> {
     EXPECT_EQ((activities::Registry::currentlyExecutingActivity()),
               outer_activity);
 
@@ -155,7 +156,8 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_parenting_works) {
               coro_activity);
 
     co_return;
-  }();
+  };
+  auto coro = fn();
 
   auto next_outer_activity =
       activities::make<GenericActivity>("TestActivity", this->activityData);
@@ -179,7 +181,7 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_parenting_works) {
 }
 
 TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_multiple_coros) {
-  auto coro = [&](auto& wait) -> async<void> {
+  auto fn = [&](auto& wait) -> async<void> {
     auto coro_activity =
         activities::make<GenericActivity>("TestActivity", this->activityData);
     auto guard =
@@ -196,8 +198,8 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_multiple_coros) {
     co_return;
   };
 
-  auto coro1 = coro(this->wait);
-  auto coro2 = coro(this->wait2);
+  auto coro1 = fn(this->wait);
+  auto coro2 = fn(this->wait2);
 
   auto outer_activity =
       activities::make<GenericActivity>("TestActivity", this->activityData);
@@ -223,7 +225,7 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_multiple_coros) {
 
 TYPED_TEST(ActivitiesAsyncTest,
            current_activity_persists_multiple_suspension_points) {
-  auto coro = [&]() -> async<void> {
+  auto fn = [&]() -> async<void> {
     auto coro_activity =
         activities::make<GenericActivity>("TestActivity", this->activityData);
     auto guard =
@@ -241,7 +243,8 @@ TYPED_TEST(ActivitiesAsyncTest,
               coro_activity);
 
     co_return;
-  }();
+  };
+  std::ignore = fn();
 
   auto outer_activity =
       activities::make<GenericActivity>("TestActivity", this->activityData);
@@ -269,7 +272,7 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_nested_coroutines) {
               coro_activity);
   };
 
-  auto coro = [&]() -> async<void> {
+  auto fn = [&]() -> async<void> {
     auto coro_activity =
         activities::make<GenericActivity>("TestActivity", this->activityData);
     auto guard =
@@ -281,7 +284,8 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_persists_nested_coroutines) {
               coro_activity);
 
     co_return;
-  }();
+  };
+  std::ignore = fn();
 
   auto outer_activity =
       activities::make<GenericActivity>("TestActivity", this->activityData);
@@ -307,7 +311,8 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_correct_exception) {
 
     co_await this->wait;
     throw std::runtime_error("TEST!");
-  }();
+  };
+  auto coro_a = a();
 
   auto b = [&]() -> async<void> {
     auto coro_activity =
@@ -316,7 +321,7 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_correct_exception) {
         activities::Registry::ScopedCurrentlyExecutingActivity(coro_activity);
 
     try {
-      co_await std::move(a);
+      co_await std::move(coro_a);
       EXPECT_EQ(activities::Registry::currentlyExecutingActivity(),
                 coro_activity);
       TRI_ASSERT(false);
@@ -327,12 +332,13 @@ TYPED_TEST(ActivitiesAsyncTest, current_activity_correct_exception) {
                 coro_activity);
       co_return;
     }
-  }();
+  };
+  auto coro_b = b();
 
   this->wait.resume();
-  EXPECT_TRUE(b.valid());
-  EXPECT_FALSE(a.valid());
-  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(coro_b.valid());
+  EXPECT_FALSE(coro_a.valid());
+  auto awaitable = std::move(coro_b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   awaitable.await_resume();

--- a/tests/Async/AsyncTest.cpp
+++ b/tests/Async/AsyncTest.cpp
@@ -97,15 +97,16 @@ TYPED_TEST_SUITE(AsyncTest, MyTypes);
 TYPED_TEST(AsyncTest, async_return) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn = [&]() -> async<ValueType> {
     co_await this->wait;
     co_return 12;
-  }();
+  };
+  auto coro = fn();
 
   this->wait.resume();
-  EXPECT_TRUE(a.valid());
-  auto awaitable = std::move(a).operator co_await();
-  EXPECT_FALSE(a.valid());
+  EXPECT_TRUE(coro.valid());
+  auto awaitable = std::move(coro).operator co_await();
+  EXPECT_FALSE(coro.valid());
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_EQ(awaitable.await_resume(), 12);
@@ -114,20 +115,21 @@ TYPED_TEST(AsyncTest, async_return) {
 TYPED_TEST(AsyncTest, async_return_move) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn = [&]() -> async<ValueType> {
     co_await this->wait;
     co_return 12;
-  }();
+  };
+  auto coro = fn();
 
-  EXPECT_TRUE(a.valid());
+  EXPECT_TRUE(coro.valid());
 
-  auto b = std::move(a);
-  EXPECT_TRUE(b.valid());
-  EXPECT_FALSE(a.valid());
+  auto moved_coro = std::move(coro);
+  EXPECT_TRUE(moved_coro.valid());
+  EXPECT_FALSE(coro.valid());
 
-  a = std::move(b);
-  EXPECT_TRUE(a.valid());
-  EXPECT_FALSE(b.valid());
+  coro = std::move(moved_coro);
+  EXPECT_TRUE(coro.valid());
+  EXPECT_FALSE(moved_coro.valid());
 
   this->wait.resume();
   this->wait.await();
@@ -136,15 +138,16 @@ TYPED_TEST(AsyncTest, async_return_move) {
 TYPED_TEST(AsyncTest, async_return_destroy) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn = [&]() -> async<ValueType> {
     co_await this->wait;
     co_return 12;
-  }();
+  };
+  auto coro = fn();
 
   this->wait.resume();
-  EXPECT_TRUE(a.valid());
-  a.reset();
-  EXPECT_FALSE(a.valid());
+  EXPECT_TRUE(coro.valid());
+  coro.reset();
+  EXPECT_FALSE(coro.valid());
 
   this->wait.await();
 }
@@ -152,17 +155,21 @@ TYPED_TEST(AsyncTest, async_return_destroy) {
 TYPED_TEST(AsyncTest, await_ready_async) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn_a = [&]() -> async<ValueType> {
     co_await this->wait;
     co_return 12;
-  }();
+  };
+  auto coro_a = fn_a();
 
-  auto b = [&]() -> async<ValueType> { co_return 2 * co_await std::move(a); }();
+  auto fn_b = [&]() -> async<ValueType> {
+    co_return 2 * co_await std::move(coro_a);
+  };
+  auto coro_b = fn_b();
 
   this->wait.resume();
-  EXPECT_TRUE(b.valid());
-  EXPECT_FALSE(a.valid());
-  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(coro_b.valid());
+  EXPECT_FALSE(coro_a.valid());
+  auto awaitable = std::move(coro_b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_EQ(awaitable.await_resume(), 24);
@@ -171,14 +178,15 @@ TYPED_TEST(AsyncTest, await_ready_async) {
 TYPED_TEST(AsyncTest, async_throw) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn = [&]() -> async<ValueType> {
     co_await this->wait;
     throw std::runtime_error("TEST!");
-  }();
+  };
+  auto coro = fn();
 
   this->wait.resume();
-  EXPECT_TRUE(a.valid());
-  auto awaitable = std::move(a).operator co_await();
+  EXPECT_TRUE(coro.valid());
+  auto awaitable = std::move(coro).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_THROW(awaitable.await_resume(), std::runtime_error);
@@ -187,23 +195,25 @@ TYPED_TEST(AsyncTest, async_throw) {
 TYPED_TEST(AsyncTest, await_throw_async) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn_a = [&]() -> async<ValueType> {
     co_await this->wait;
     throw std::runtime_error("TEST!");
-  }();
+  };
+  auto coro_a = fn_a();
 
-  auto b = [&]() -> async<ValueType> {
+  auto fn_b = [&]() -> async<ValueType> {
     try {
-      co_return 2 * co_await std::move(a);
+      co_return 2 * co_await std::move(coro_a);
     } catch (std::runtime_error const&) {
       co_return 0;
     }
-  }();
+  };
+  auto coro_b = fn_b();
 
   this->wait.resume();
-  EXPECT_TRUE(b.valid());
-  EXPECT_FALSE(a.valid());
-  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(coro_b.valid());
+  EXPECT_FALSE(coro_a.valid());
+  auto awaitable = std::move(coro_b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_EQ(awaitable.await_resume(), 0);
@@ -212,20 +222,22 @@ TYPED_TEST(AsyncTest, await_throw_async) {
 TYPED_TEST(AsyncTest, await_async_void) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<void> {
+  auto fn_a = [&]() -> async<void> {
     co_await this->wait;
     co_return;
-  }();
+  };
+  auto coro_a = fn_a();
 
-  auto b = [&]() -> async<ValueType> {
-    co_await std::move(a);
+  auto fn_b = [&]() -> async<ValueType> {
+    co_await std::move(coro_a);
     co_return 2;
-  }();
+  };
+  auto coro_b = fn_b();
 
   this->wait.resume();
-  EXPECT_TRUE(b.valid());
-  EXPECT_FALSE(a.valid());
-  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(coro_b.valid());
+  EXPECT_FALSE(coro_a.valid());
+  auto awaitable = std::move(coro_b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_EQ(awaitable.await_resume(), 2);
@@ -234,24 +246,26 @@ TYPED_TEST(AsyncTest, await_async_void) {
 TYPED_TEST(AsyncTest, await_async_void_exception) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<void> {
+  auto fn_a = [&]() -> async<void> {
     co_await this->wait;
     throw std::runtime_error("TEST!");
-  }();
+  };
+  auto coro_a = fn_a();
 
-  auto b = [&]() -> async<ValueType> {
+  auto fn_b = [&]() -> async<ValueType> {
     try {
-      co_await std::move(a);
+      co_await std::move(coro_a);
       co_return 2;
     } catch (std::runtime_error const&) {
       co_return 0;
     }
-  }();
+  };
+  auto coro_b = fn_b();
 
   this->wait.resume();
-  EXPECT_TRUE(b.valid());
-  EXPECT_FALSE(a.valid());
-  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(coro_b.valid());
+  EXPECT_FALSE(coro_a.valid());
+  auto awaitable = std::move(coro_b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_EQ(awaitable.await_resume(), 0);
@@ -260,24 +274,24 @@ TYPED_TEST(AsyncTest, await_async_void_exception) {
 TYPED_TEST(AsyncTest, multiple_suspension_points) {
   using ValueType = TypeParam::second_type;
 
-  auto a = [&]() -> async<ValueType> {
+  auto fn_a = [&]() -> async<ValueType> {
     co_await this->wait;
     co_return 12;
   };
 
-  auto lambda = [&]() -> async<ValueType> {
+  auto fn_b = [&]() -> async<ValueType> {
     for (int i = 0; i < 10; i++) {
-      co_await a();
+      co_await fn_a();
     }
 
     co_return 0;
   };
 
-  auto b = lambda();
+  auto coro_b = fn_b();
 
   this->wait.resume();
-  EXPECT_TRUE(b.valid());
-  auto awaitable = std::move(b).operator co_await();
+  EXPECT_TRUE(coro_b.valid());
+  auto awaitable = std::move(coro_b).operator co_await();
   this->wait.await();
   EXPECT_TRUE(awaitable.await_ready());
   EXPECT_EQ(awaitable.await_resume(), 0);
@@ -315,20 +329,22 @@ TYPED_TEST(AsyncTest, execution_context_is_local_to_coroutine) {
   ExecContextScope exec(std::make_shared<ExecContext_Begin>());
   EXPECT_EQ(ExecContext::current().user(), "Begin");
 
-  auto waiting_coro = [&]() -> async<void> {
+  auto waiting_fn = [&]() -> async<void> {
     EXPECT_EQ(ExecContext::current().user(), "Begin");
     ExecContextScope exec(std::make_shared<ExecContext_Waiting>());
     EXPECT_EQ(ExecContext::current().user(), "Waiting");
     co_await this->wait;
     EXPECT_EQ(ExecContext::current().user(), "Waiting");
     co_return;
-  }();
+  };
+  auto waiting_coro = waiting_fn();
   EXPECT_EQ(ExecContext::current().user(), "Begin");
 
-  auto trivial_coro = []() -> async<void> {
+  auto trivial_fn = []() -> async<void> {
     EXPECT_EQ(ExecContext::current().user(), "Begin");
     co_return;
-  }();
+  };
+  auto trivial_coro = trivial_fn();
 
   auto calling_coro = [&]() -> async<void> {
     EXPECT_EQ(ExecContext::current().user(), "Begin");
@@ -663,10 +679,11 @@ auto expect_all_promises_in_state(arangodb::async_registry::State state,
 }  // namespace
 TYPED_TEST(AsyncTest, async_promises_in_async_registry_know_their_state) {
   {
-    auto coro = [&]() -> async<int> {
+    auto fn = [&]() -> async<int> {
       co_await this->wait;
       co_return 12;
-    }();
+    };
+    auto coro = fn();
 
     if (std::is_same<decltype(this->wait), async_tests::WaitSlot>()) {
       expect_all_promises_in_state(arangodb::async_registry::State::Suspended,

--- a/tests/Async/AsyncTestLineNumbers.tpp
+++ b/tests/Async/AsyncTestLineNumbers.tpp
@@ -27,12 +27,13 @@
 TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
   {
     async_tests::NoWait wait;
-    auto coro = [&]() -> async<void> {
+    auto fn = [&]() -> async<void> {
       auto void_fn = []() {};
       co_await wait;
       void_fn();
       co_return;
-    }();
+    };
+    std::ignore = fn();
 
     uint count = 0;
     arangodb::async_registry::registry.for_node(
@@ -45,18 +46,19 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
   arangodb::async_registry::get_thread_registry().garbage_collect();
   {
     async_tests::WaitSlot wait;
-    auto coro = [&]() -> async<void> {
+    auto fn = [&]() -> async<void> {
       auto void_fn = []() {};
       co_await wait;
       void_fn();
       co_return;
-    }();
+    };
+    std::ignore = fn();
 
     uint count = 0;
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 50);
+          EXPECT_EQ(promise.source_location.line, 51);
         });
     EXPECT_EQ(count, 1);
     wait.resume();
@@ -65,25 +67,26 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 52);
+          EXPECT_EQ(promise.source_location.line, 53);
         });
     EXPECT_EQ(count, 1);
   }
   arangodb::async_registry::get_thread_registry().garbage_collect();
   {
     async_tests::ConcurrentNoWait wait;
-    auto coro = [&]() -> async<void> {
+    auto fn = [&]() -> async<void> {
       auto void_fn = []() {};
       co_await wait;
       void_fn();
       co_return;
-    }();
+    };
+    std::ignore = fn();
 
     uint count = 0;
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 77);
+          EXPECT_EQ(promise.source_location.line, 79);
         });
     EXPECT_EQ(count, 1);
     wait.await();
@@ -92,7 +95,7 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 79);
+          EXPECT_EQ(promise.source_location.line, 81);
         });
     EXPECT_EQ(count, 1);
   }


### PR DESCRIPTION
Most of the async tests can possibly segfault because the lambdas returning coroutine objects are most of the time directly executed and not saved in a variable:
```
  auto coro = [&]() -> async<void> {
    co_await ...
    ....
  }();
```
When the coroutine is suspended at the `co_await`, the lambda goes out of scope. When we then resume the coroutine and access a captured value after the resumption (after the `co_await` line), this variable can already be overwritten and then a segfault can happen.

Fix: Define a variable for the lambda, such that it lives as long as the test itself. Then define a separate variable for the lambda execution.