### PR TITLE
clip the uninteresting parts from the rta-makedata error output

### DIFF
--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -251,7 +251,7 @@ function makeDataWrapper (options) {
       res[whichRTA] = rc;
       if (!rc.status) {
         this.continueTesting = false;
-        res[whichRTA].message += file + ':\n' + ct.run.readRtaErrorLog(logFile),
+        res[whichRTA].message += file + ':\n' + ct.run.readRtaErrorLog(logFile);
         res.status = false;
         res.failed += 1;
       } else {

--- a/js/client/modules/@arangodb/testsuites/rta_makedata.js
+++ b/js/client/modules/@arangodb/testsuites/rta_makedata.js
@@ -251,8 +251,7 @@ function makeDataWrapper (options) {
       res[whichRTA] = rc;
       if (!rc.status) {
         this.continueTesting = false;
-        let rx = new RegExp(/\\n/g);
-        res[whichRTA].message += file + ':\n' + fs.read(logFile).replace(rx, '\n');
+        res[whichRTA].message += file + ':\n' + ct.run.readRtaErrorLog(logFile),
         res.status = false;
         res.failed += 1;
       } else {

--- a/js/client/modules/@arangodb/testutils/client-tools.js
+++ b/js/client/modules/@arangodb/testutils/client-tools.js
@@ -697,6 +697,45 @@ function cleanupBGShells (clients, cn) {
   });
 }
 
+function readRtaErrorLog(logFile) {
+  let rx = new RegExp(/\\n/g);
+  const unInteristingRtaLogTopics = [
+    "9c2f7",
+    "5095d",
+    "2abe3",
+    "930d9",
+  ];
+  const buf = fs.readBuffer(fs.join(logFile));
+  let lineStart = 0;
+  let maxBuffer = buf.length;
+  let fnLines = "";
+  for (let j = 0; j < maxBuffer; j++) {
+    if (buf[j] === 10) { // \n
+      let line = buf.utf8Slice(lineStart, j);
+      lineStart = j + 1;
+
+      let foundUninteresting = false;
+      unInteristingRtaLogTopics.forEach(logToken => {
+        if (line.search(logToken) !== -1) {
+          foundUninteresting = true;
+        }
+      });
+      if (!foundUninteresting) {
+        // clip unnessecary noise from the start:
+        if (line.search("8a210") > 0) {
+          line = line.substring(line.search(': ') + 2);
+        } else if (line.search("409ee") > 0 ||
+                   line.search("cb0bd") > 0 ||
+                   line.search("cb0bf") > 0) {
+          line = line.substring(line.search('}') + 1);
+        }
+        fnLines += line.replace(rx, '\n') + '\n';
+      }
+    }
+  }
+  return fnLines;
+}
+
 function rtaMakedata(options, instanceManager, writeReadClean, msg, logFile, moreargv=[], addArgs=undefined) {
   let args = Object.assign(makeArgsArangosh(options), {
     'server.endpoint': instanceManager.findEndpoint(),
@@ -891,7 +930,8 @@ exports.run = {
   arangoBenchmark: runArangoBenchmark,
   arangoBackup: runArangoBackup,
   rtaWaitShardsInSync: rtaWaitShardsInSync,
-  rtaMakedata: rtaMakedata
+  rtaMakedata: rtaMakedata,
+  readRtaErrorLog: readRtaErrorLog
 };
 
 exports.registerOptions = function(optionsDefaults, optionsDocumentation) {

--- a/js/client/modules/@arangodb/testutils/persistence-common.js
+++ b/js/client/modules/@arangodb/testutils/persistence-common.js
@@ -662,9 +662,8 @@ class persistenceToolkit extends trs.runLocalInArangoshRunner {
     let logFile = fs.join(fs.getTempPath(), `rta_out_makedata.log`);
     let rc = ct.run.rtaMakedata(this.instanceManager.options, this.instanceManager, 0, "creating test data", logFile, this.rtaArgs);
     if (!rc.status) {
-      let rx = new RegExp(/\\n/g);
       this.results.RtaMakedata = {
-        message:  'Makedata:\n' + fs.read(logFile).replace(rx, '\n'),
+        message:  'Makedata:\n' + ct.run.readRtaErrorLog(logFile),
         status: false,
         duration: rc.duration
       };
@@ -752,9 +751,8 @@ class persistenceToolkit extends trs.runLocalInArangoshRunner {
     let logFile = fs.join(fs.getTempPath(), `rta_out_checkdata.log`);
     let rc = ct.run.rtaMakedata(this.secondRunOptions, this.instanceManager, 1, "checking test data", logFile, this.rtaArgs);
     if (!rc.status) {
-      let rx = new RegExp(/\\n/g);
       this.results.RtaCheckdata = {
-        message: 'Checkdata:\n' + fs.read(logFile).replace(rx, '\n'),
+        message: 'Checkdata:\n' + ct.run.readRtaErrorLog(logFile),
         status: false,
         failed: 1,
         duration: rc.duration,


### PR DESCRIPTION
### Scope & Purpose

the default arangosh error output is a bit noisy. when invoking rta-makedata we can clip that noise for compacter errormessages.

- [x] :hankey: Bugfix
