### PR TITLE
COR-707 - CONTAINS(): Raise a warning for non-string inputs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
 
+* COR-707 - CONTAINS(): Raise a warning for non-string inputs.
+  Improved validation for the AQL CONTAINS() function. When either argument is not a string, 
+  CONTAINS() now emits a warning and returns null, aligning its behavior with the documented specification. This helps users identify unsupported input types and detect potential query issues more easily.
+
 * Upgraded included rclone to v1.74.3 with go1.25.11 and non-vulnerable
   dependencies.
 

--- a/arangod/Aql/Function/StringFunctions.cpp
+++ b/arangod/Aql/Function/StringFunctions.cpp
@@ -1127,6 +1127,7 @@ AqlValue functions::RTrim(ExpressionContext* expressionContext, AstNode const&,
 /// @brief function CONTAINS
 AqlValue functions::Contains(ExpressionContext* ctx, AstNode const&,
                              VPackFunctionParametersView parameters) {
+  static char const* AFN = "CONTAINS";
   auto* trx = &ctx->trx();
   auto const& vopts = trx->vpackOptions();
   AqlValue const& value =
@@ -1135,6 +1136,13 @@ AqlValue functions::Contains(ExpressionContext* ctx, AstNode const&,
       aql::functions::extractFunctionParameterValue(parameters, 1);
   AqlValue const& returnIndex =
       aql::functions::extractFunctionParameterValue(parameters, 2);
+
+  // CONTAINS is intended for string inputs. If either the value or the search
+  // argument is not a string, emit a warning and return null.
+  if (!value.isString() || !search.isString()) {
+    registerInvalidArgumentWarning(ctx, AFN);
+    return AqlValue(AqlValueHintNull());
+  }
 
   bool const willReturnIndex = returnIndex.toBoolean();
 

--- a/tests/js/client/aql/aql-functions-string.js
+++ b/tests/js/client/aql/aql-functions-string.js
@@ -1136,16 +1136,65 @@ function ahuacatlStringFunctionsTestSuite () {
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, 'RETURN CONTAINS("test", "test", "test", "test")'); 
       assertQueryError(errors.ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH.code, 'RETURN CONTAINS()'); 
       assertEqual([ -1 ], getQueryResults('RETURN CONTAINS("test", "test2", "test3")')); 
-      assertEqual([ false ], getQueryResults('RETURN CONTAINS(null, null)')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS(4, 4)')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS({ }, { })')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS({ a: 1, b: 2 }, { a: 1, b: 2 })')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS([ ], [ ])')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS([ 1, 2, 3 ], [ 1, 2, 3 ])')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS([ 1, 2 ], [ 1, 2 ])')); 
-      assertEqual([ true ], getQueryResults('RETURN CONTAINS([ 1, 2, 3 ], 2)')); 
-      assertEqual([ false ], getQueryResults('RETURN CONTAINS(null, "yes")')); 
-      assertEqual([ false ], getQueryResults('RETURN CONTAINS(3, null)')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS(null, null)')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS(4, 4)')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS({ }, { })')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS({ a: 1, b: 2 }, { a: 1, b: 2 })')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS([ ], [ ])')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS([ 1, 2, 3 ], [ 1, 2, 3 ])')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS([ 1, 2 ], [ 1, 2 ])')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS([ 1, 2, 3 ], 2)')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS(null, "yes")')); 
+      assertEqual([ null ], getQueryResults('RETURN CONTAINS(3, null)')); 
+    },
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test that CONTAINS emits a warning for non-string inputs and
+// /        returns null
+// //////////////////////////////////////////////////////////////////////////////
+
+    testContainsNonStringWarning: function () {
+      const warningCode = errors.ERROR_QUERY_FUNCTION_ARGUMENT_TYPE_MISMATCH.code;
+
+      const nonStringCases = [
+        'RETURN CONTAINS({ a: 1, b: 2 }, { a: 1, b: 2 })',
+        'RETURN CONTAINS({ }, { })',
+        'RETURN CONTAINS([ 1, 2, 3 ], [ 1, 2, 3 ])',
+        'RETURN CONTAINS([ 1, 2, 3 ], 2)',
+        'RETURN CONTAINS(4, 4)',
+        'RETURN CONTAINS(null, null)',
+        'RETURN CONTAINS("test2", 2)',
+        'RETURN CONTAINS(1234, "23")',
+        'RETURN CONTAINS(null, "yes")',
+        'RETURN CONTAINS(3, null)',
+      ];
+
+      nonStringCases.forEach(function (query) {
+        const data = db._query(query).data;
+        assertEqual([ null ], data.result, query);
+        assertEqual(1, data.extra.warnings.length, query);
+        assertEqual(warningCode, data.extra.warnings[0].code, query);
+      });
+    },
+
+// //////////////////////////////////////////////////////////////////////////////
+// / @brief test that CONTAINS does not emit a warning for string inputs
+// //////////////////////////////////////////////////////////////////////////////
+
+    testContainsStringNoWarning: function () {
+      const stringCases = [
+        'RETURN CONTAINS("test2", "test")',
+        'RETURN CONTAINS("xxasdxx", "asd")',
+        'RETURN CONTAINS("test", "test2")',
+        'RETURN CONTAINS("test123", "")',
+        'RETURN CONTAINS("", "test123")',
+        'RETURN CONTAINS("test2", "test", true)',
+      ];
+
+      stringCases.forEach(function (query) {
+        const data = db._query(query).data;
+        assertEqual(0, data.extra.warnings.length, query);
+      });
     },
 
 // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When either input to CONTAINS() is not a string: Raising a warning indicating that CONTAINS() is intended for string inputs.
and returns null.

- Align the implementation with the documented behavior of CONTAINS().
- Make users aware when the function is used with unsupported input types.
- This helps users identify unsupported input types and detect potential query issues more easily.

**After Fix:**
127.0.0.1:8529@_system> db._query(`RETURN CONTAINS({ a: 1, b: 2 }, { a: 1, b: 2 })`);
[object ArangoQueryCursor, count: 1, results cached: false, hasMore: false, warning(s): "1542 invalid argument type in call to function 'CONTAINS()'"]

[ 
  null 
]