### PR TITLE
Replace `TRI_vocbase_t` with `Database` (leftover)

### DIFF
--- a/tests/RocksDBEngine/Mocks.h
+++ b/tests/RocksDBEngine/Mocks.h
@@ -63,8 +63,8 @@ struct MockDumpLimitsProvider : IDumpLimitsProvider {
 struct MockDatabaseProvider : IDatabaseProvider {
   MOCK_METHOD(VocbasePtr, useDatabase, (std::string_view), (const, override));
   MOCK_METHOD(VocbasePtr, useDatabase, (TRI_voc_tick_t), (const, override));
-  MOCK_METHOD(void, enumerateDatabases,
-              (std::function<void(Database&)> const&), (override));
+  MOCK_METHOD(void, enumerateDatabases, (std::function<void(Database&)> const&),
+              (override));
   MOCK_METHOD(void, inventory,
               (velocypack::Builder&, TRI_voc_tick_t,
                std::function<bool(LogicalCollection const*)> const&),

--- a/tests/RocksDBEngine/Mocks.h
+++ b/tests/RocksDBEngine/Mocks.h
@@ -64,7 +64,7 @@ struct MockDatabaseProvider : IDatabaseProvider {
   MOCK_METHOD(VocbasePtr, useDatabase, (std::string_view), (const, override));
   MOCK_METHOD(VocbasePtr, useDatabase, (TRI_voc_tick_t), (const, override));
   MOCK_METHOD(void, enumerateDatabases,
-              (std::function<void(TRI_vocbase_t&)> const&), (override));
+              (std::function<void(Database&)> const&), (override));
   MOCK_METHOD(void, inventory,
               (velocypack::Builder&, TRI_voc_tick_t,
                std::function<bool(LogicalCollection const*)> const&),


### PR DESCRIPTION
### Scope & Purpose

Replace leftover `TRI_vocbase_t` with `Database`

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
