### PR TITLE
[BTS-2118] [ES-2909] Fix Traversal Variables Used Computation

### DIFF
--- a/arangod/Aql/EdgeConditionBuilder.cpp
+++ b/arangod/Aql/EdgeConditionBuilder.cpp
@@ -148,4 +148,10 @@ void EdgeConditionBuilder::replaceAttributeAccess(
   replace(_modCondition);
 }
 
+void EdgeConditionBuilder::getVariablesUsedHere(VarSet& result) const {
+  Ast::getReferencedVariables(_fromCondition, result);
+  Ast::getReferencedVariables(_toCondition, result);
+  Ast::getReferencedVariables(_modCondition, result);
+}
+
 }  // namespace arangodb::aql

--- a/arangod/Aql/EdgeConditionBuilder.h
+++ b/arangod/Aql/EdgeConditionBuilder.h
@@ -87,6 +87,9 @@ class EdgeConditionBuilder {
                               std::span<std::string_view> attribute,
                               Variable const* replaceVariable);
 
+  /// @brief getVariablesUsedHere
+  void getVariablesUsedHere(VarSet& result) const;
+
   // Add a condition on the edges that is not related to
   // the direction e.g. `label == foo`
   void addConditionPart(AstNode const*);

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -503,15 +503,19 @@ void TraversalNode::replaceAttributeAccess(
 
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
+  auto validateVariable = [this](const aql::Variable* var) {
+    return ((!vertexOutVariable() || var != vertexOutVariable()) &&
+            (!edgeOutVariable() || var != edgeOutVariable()) &&
+            (!pathOutVariable() || var != pathOutVariable()) &&
+            (getTemporaryVariable() && var != getTemporaryVariable()) &&
+            !_optimizedOutVariables.contains(var->id));
+  };
+
   auto fetchVarsFromNode = [&](const AstNode* node) {
     auto varSet = VarSet{};
     Ast::getReferencedVariables(node, varSet);
     for (auto const& condVar : varSet) {
-      if ((!vertexOutVariable() || condVar != vertexOutVariable()) &&
-          (!edgeOutVariable() || condVar != edgeOutVariable()) &&
-          (!pathOutVariable() || condVar != pathOutVariable()) &&
-          (getTemporaryVariable() && condVar != getTemporaryVariable()) &&
-          !_optimizedOutVariables.contains(condVar->id)) {
+      if (validateVariable(condVar)) {
         result.emplace(condVar);
       }
     }
@@ -521,13 +525,26 @@ void TraversalNode::getVariablesUsedHere(VarSet& result) const {
     fetchVarsFromNode(_condition->root());
   }
 
-  //  Condition nodes
+  //  Global condition nodes
   std::for_each(_globalEdgeConditions.begin(), _globalEdgeConditions.end(),
                 fetchVarsFromNode);
   std::for_each(_globalVertexConditions.begin(), _globalVertexConditions.end(),
                 fetchVarsFromNode);
   std::for_each(_postFilterConditions.begin(), _postFilterConditions.end(),
                 fetchVarsFromNode);
+
+  //  Depth dependent conditions
+  std::for_each(_edgeConditions.begin(), _edgeConditions.end(),
+                [&](const auto& ec) {
+                  VarSet tVarSet;
+                  ec.second->getVariablesUsedHere(tVarSet);
+                  for (const auto& v : tVarSet) {
+                    if (validateVariable(v)) result.emplace(v);
+                  }
+                });
+
+  std::for_each(_vertexConditions.begin(), _vertexConditions.end(),
+                [&](const auto& vc) { fetchVarsFromNode(vc.second); });
 
   if (_fromCondition) {
     fetchVarsFromNode(_fromCondition);

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -53,6 +53,7 @@
 #include "VocBase/ticks.h"
 
 #include <absl/strings/str_cat.h>
+#include <velocypack/Builder.h>
 #include <velocypack/Iterator.h>
 
 #include <memory>
@@ -443,10 +444,17 @@ void TraversalNode::replaceAttributeAccess(
     _pruneVariables = std::move(variables);
   }
 
+  LOG_DEVEL << this->id() << "condition replace " << searchVariable->name
+            << " by " << replaceVariable->name;
   if (_condition && self != this) {
+    LOG_DEVEL << this->id() << " is happening";
     _condition->replaceAttributeAccess(searchVariable, attribute,
                                        replaceVariable);
+    VPackBuilder b;
+    _condition->toVelocyPack(b, true);
+    LOG_DEVEL << this->id() << " condition " << b.toJson();
   }
+  LOG_DEVEL << this->id() << "done";
 
   if (_postFilterExpression != nullptr) {
     _postFilterExpression->replaceAttributeAccess(searchVariable, attribute,
@@ -502,12 +510,17 @@ void TraversalNode::replaceAttributeAccess(
 
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
-  for (auto const& condVar : _conditionVariables) {
-    if (condVar != pathOutVariable() && condVar != getTemporaryVariable()) {
-      result.emplace(condVar);
+  LOG_DEVEL << this->id() << "variables used here called";
+  if (_condition != nullptr && _condition->root() != nullptr) {
+    auto re = VarSet{};
+    Ast::getReferencedVariables(_condition->root(), re);
+    for (auto const& condVar : re) {
+      if (condVar != vertexOutVariable() && condVar != edgeOutVariable() &&
+          condVar != pathOutVariable() && condVar != getTemporaryVariable()) {
+        result.emplace(condVar);
+      }
     }
   }
-
   for (auto const& pruneVar : _pruneVariables) {
     if (pruneVar != vertexOutVariable() && pruneVar != edgeOutVariable() &&
         pruneVar != pathOutVariable()) {
@@ -524,6 +537,10 @@ void TraversalNode::getVariablesUsedHere(VarSet& result) const {
 
   if (usesInVariable()) {
     result.emplace(_inVariable);
+  }
+
+  for (auto&& v : result) {
+    LOG_DEVEL << this->id() << " uses " << v->name;
   }
 }
 
@@ -1094,6 +1111,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     if (it != _tmpObjVariable) {
       auto idIt = varInfo.find(it->id);
       TRI_ASSERT(idIt != varInfo.end());
+      LOG_DEVEL << this->id() << " adding condition var " << it->name;
       filterConditionVariables.emplace_back(
           std::make_pair(it, idIt->second.registerId));
       inputRegisters.emplace(idIt->second.registerId);
@@ -1340,6 +1358,10 @@ void TraversalNode::setCondition(
   VarSet varsUsedByCondition;
 
   Ast::getReferencedVariables(condition->root(), varsUsedByCondition);
+
+  VPackBuilder b;
+  condition->toVelocyPack(b, true);
+  LOG_DEVEL << this->id() << " the condition: " << b.toJson();
 
   for (auto const& oneVar : varsUsedByCondition) {
     if ((_vertexOutVariable == nullptr ||

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -447,8 +447,6 @@ void TraversalNode::replaceAttributeAccess(
   if (_condition && self != this) {
     _condition->replaceAttributeAccess(searchVariable, attribute,
                                        replaceVariable);
-    VPackBuilder b;
-    _condition->toVelocyPack(b, true);
   }
 
   if (_postFilterExpression != nullptr) {
@@ -505,51 +503,44 @@ void TraversalNode::replaceAttributeAccess(
 
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
-  //  Gather all nodes together and get
-  //  their respective used variables
-  std::vector<const AstNode*> conditionNodes;
-  if (_condition && _condition->root()) {
-    conditionNodes.push_back(_condition->root());
-  }
-
-  //  Condition nodes
-  auto appendConditions = [&conditionNodes](const auto& conditionNode) {
-    conditionNodes.push_back(conditionNode);
-  };
-  std::for_each(_globalEdgeConditions.begin(), _globalEdgeConditions.end(),
-                appendConditions);
-  std::for_each(_globalVertexConditions.begin(), _globalVertexConditions.end(),
-                appendConditions);
-  std::for_each(_postFilterConditions.begin(), _postFilterConditions.end(),
-                appendConditions);
-
-  if (_fromCondition) {
-    conditionNodes.push_back(_fromCondition);
-  }
-
-  if (_toCondition) {
-    conditionNodes.push_back(_toCondition);
-  }
-
-  //  Expressions
-  if (_pruneExpression && _pruneExpression->node()) {
-    conditionNodes.push_back(_pruneExpression->node());
-  }
-
-  if (_postFilterExpression && _postFilterExpression->node()) {
-    conditionNodes.push_back(_postFilterExpression->node());
-  }
-
-  //  Process all condition nodes
-  for (const auto& conditionNode : conditionNodes) {
+  auto fetchVarsFromNode = [&](const AstNode* node) {
     auto varSet = VarSet{};
-    Ast::getReferencedVariables(conditionNode, varSet);
+    Ast::getReferencedVariables(node, varSet);
     for (auto const& condVar : varSet) {
       if (condVar != vertexOutVariable() && condVar != edgeOutVariable() &&
           condVar != pathOutVariable() && condVar != getTemporaryVariable()) {
         result.emplace(condVar);
       }
     }
+  };
+
+  if (_condition && _condition->root()) {
+    fetchVarsFromNode(_condition->root());
+  }
+
+  //  Condition nodes
+  std::for_each(_globalEdgeConditions.begin(), _globalEdgeConditions.end(),
+                fetchVarsFromNode);
+  std::for_each(_globalVertexConditions.begin(), _globalVertexConditions.end(),
+                fetchVarsFromNode);
+  std::for_each(_postFilterConditions.begin(), _postFilterConditions.end(),
+                fetchVarsFromNode);
+
+  if (_fromCondition) {
+    fetchVarsFromNode(_fromCondition);
+  }
+
+  if (_toCondition) {
+    fetchVarsFromNode(_toCondition);
+  }
+
+  //  Expressions
+  if (_pruneExpression && _pruneExpression->node()) {
+    fetchVarsFromNode(_pruneExpression->node());
+  }
+
+  if (_postFilterExpression && _postFilterExpression->node()) {
+    fetchVarsFromNode(_postFilterExpression->node());
   }
 
   if (usesInVariable()) {
@@ -1373,9 +1364,6 @@ void TraversalNode::setCondition(
   VarSet varsUsedByCondition;
 
   Ast::getReferencedVariables(condition->root(), varsUsedByCondition);
-
-  VPackBuilder b;
-  condition->toVelocyPack(b, true);
 
   for (auto const& oneVar : varsUsedByCondition) {
     if ((_vertexOutVariable == nullptr ||

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -444,17 +444,13 @@ void TraversalNode::replaceAttributeAccess(
     _pruneVariables = std::move(variables);
   }
 
-  LOG_DEVEL << this->id() << "condition replace " << searchVariable->name
-            << " by " << replaceVariable->name;
+  << " by " << replaceVariable->name;
   if (_condition && self != this) {
-    LOG_DEVEL << this->id() << " is happening";
     _condition->replaceAttributeAccess(searchVariable, attribute,
                                        replaceVariable);
     VPackBuilder b;
     _condition->toVelocyPack(b, true);
-    LOG_DEVEL << this->id() << " condition " << b.toJson();
   }
-  LOG_DEVEL << this->id() << "done";
 
   if (_postFilterExpression != nullptr) {
     _postFilterExpression->replaceAttributeAccess(searchVariable, attribute,
@@ -510,7 +506,6 @@ void TraversalNode::replaceAttributeAccess(
 
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
-  LOG_DEVEL << this->id() << "variables used here called";
   if (_condition != nullptr && _condition->root() != nullptr) {
     auto re = VarSet{};
     Ast::getReferencedVariables(_condition->root(), re);
@@ -537,10 +532,6 @@ void TraversalNode::getVariablesUsedHere(VarSet& result) const {
 
   if (usesInVariable()) {
     result.emplace(_inVariable);
-  }
-
-  for (auto&& v : result) {
-    LOG_DEVEL << this->id() << " uses " << v->name;
   }
 }
 
@@ -1111,7 +1102,6 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     if (it != _tmpObjVariable) {
       auto idIt = varInfo.find(it->id);
       TRI_ASSERT(idIt != varInfo.end());
-      LOG_DEVEL << this->id() << " adding condition var " << it->name;
       filterConditionVariables.emplace_back(
           std::make_pair(it, idIt->second.registerId));
       inputRegisters.emplace(idIt->second.registerId);
@@ -1361,7 +1351,6 @@ void TraversalNode::setCondition(
 
   VPackBuilder b;
   condition->toVelocyPack(b, true);
-  LOG_DEVEL << this->id() << " the condition: " << b.toJson();
 
   for (auto const& oneVar : varsUsedByCondition) {
     if ((_vertexOutVariable == nullptr ||

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -507,8 +507,11 @@ void TraversalNode::getVariablesUsedHere(VarSet& result) const {
     auto varSet = VarSet{};
     Ast::getReferencedVariables(node, varSet);
     for (auto const& condVar : varSet) {
-      if (condVar != vertexOutVariable() && condVar != edgeOutVariable() &&
-          condVar != pathOutVariable() && condVar != getTemporaryVariable()) {
+      if ((!vertexOutVariable() || condVar != vertexOutVariable()) &&
+          (!edgeOutVariable() || condVar != edgeOutVariable()) &&
+          (!pathOutVariable() || condVar != pathOutVariable()) &&
+          (getTemporaryVariable() && condVar != getTemporaryVariable()) &&
+          !_optimizedOutVariables.contains(condVar->id)) {
         result.emplace(condVar);
       }
     }

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -444,7 +444,6 @@ void TraversalNode::replaceAttributeAccess(
     _pruneVariables = std::move(variables);
   }
 
-  << " by " << replaceVariable->name;
   if (_condition && self != this) {
     _condition->replaceAttributeAccess(searchVariable, attribute,
                                        replaceVariable);
@@ -506,27 +505,50 @@ void TraversalNode::replaceAttributeAccess(
 
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
-  if (_condition != nullptr && _condition->root() != nullptr) {
-    auto re = VarSet{};
-    Ast::getReferencedVariables(_condition->root(), re);
-    for (auto const& condVar : re) {
+  //  Gather all nodes together and get
+  //  their respective used variables
+  std::vector<const AstNode*> conditionNodes;
+  if (_condition && _condition->root()) {
+    conditionNodes.push_back(_condition->root());
+  }
+
+  //  Condition nodes
+  auto appendConditions = [&conditionNodes](const auto& conditionNode) {
+    conditionNodes.push_back(conditionNode);
+  };
+  std::for_each(_globalEdgeConditions.begin(), _globalEdgeConditions.end(),
+                appendConditions);
+  std::for_each(_globalVertexConditions.begin(), _globalVertexConditions.end(),
+                appendConditions);
+  std::for_each(_postFilterConditions.begin(), _postFilterConditions.end(),
+                appendConditions);
+
+  if (_fromCondition) {
+    conditionNodes.push_back(_fromCondition);
+  }
+
+  if (_toCondition) {
+    conditionNodes.push_back(_toCondition);
+  }
+
+  //  Expressions
+  if (_pruneExpression && _pruneExpression->node()) {
+    conditionNodes.push_back(_pruneExpression->node());
+  }
+
+  if (_postFilterExpression && _postFilterExpression->node()) {
+    conditionNodes.push_back(_postFilterExpression->node());
+  }
+
+  //  Process all condition nodes
+  for (const auto& conditionNode : conditionNodes) {
+    auto varSet = VarSet{};
+    Ast::getReferencedVariables(conditionNode, varSet);
+    for (auto const& condVar : varSet) {
       if (condVar != vertexOutVariable() && condVar != edgeOutVariable() &&
           condVar != pathOutVariable() && condVar != getTemporaryVariable()) {
         result.emplace(condVar);
       }
-    }
-  }
-  for (auto const& pruneVar : _pruneVariables) {
-    if (pruneVar != vertexOutVariable() && pruneVar != edgeOutVariable() &&
-        pruneVar != pathOutVariable()) {
-      result.emplace(pruneVar);
-    }
-  }
-
-  for (auto const& postVar : _postFilterVariables) {
-    if (postVar != vertexOutVariable() && postVar != edgeOutVariable() &&
-        postVar != pathOutVariable()) {
-      result.emplace(postVar);
     }
   }
 
@@ -1098,14 +1120,17 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
   std::vector<std::pair<Variable const*, RegisterId>> filterConditionVariables;
   filterConditionVariables.reserve(_conditionVariables.size());
 
-  for (auto const& it : _conditionVariables) {
-    if (it != _tmpObjVariable) {
-      auto idIt = varInfo.find(it->id);
-      TRI_ASSERT(idIt != varInfo.end());
-      filterConditionVariables.emplace_back(
-          std::make_pair(it, idIt->second.registerId));
-      inputRegisters.emplace(idIt->second.registerId);
-    }
+  VarSet usedVars;
+  getVariablesUsedHere(usedVars);
+
+  for (const auto* variable : usedVars) {
+    if (variable == _tmpObjVariable) continue;
+
+    auto itVarInfo = varInfo.find(variable->id);
+    TRI_ASSERT(itVarInfo != varInfo.end());
+    filterConditionVariables.emplace_back(
+        std::make_pair(variable, itVarInfo->second.registerId));
+    inputRegisters.emplace(itVarInfo->second.registerId);
   }
 
   auto registerInfos = createRegisterInfos(std::move(inputRegisters),

--- a/tests/js/client/aql/aql-traversal-vars-used-regression.js
+++ b/tests/js/client/aql/aql-traversal-vars-used-regression.js
@@ -65,8 +65,10 @@ function traversalVarsUsedRegressionSuite() {
                 RETURN v
         `;
 
-      let ex = explainer.explain(query);
-      require("internal").log(JSON.stringify(ex));
+      // This test is red up to the fix because arangod errors
+      // with a missing variable error for the doc variable
+      // in the TraversalNode
+      let ex = db._createStatement(query).explain().plan;
     },
 
   };

--- a/tests/js/client/aql/aql-traversal-vars-used-regression.js
+++ b/tests/js/client/aql/aql-traversal-vars-used-regression.js
@@ -1,0 +1,77 @@
+/*jshint globalstrict:false, strict:false, maxlen: 500 */
+/*global assertEqual, assertTrue, fail */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const internal = require("internal");
+const errors = internal.errors;
+const explainer = require("@arangodb/aql/explainer");
+const db = require("@arangodb").db;
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief test suite
+////////////////////////////////////////////////////////////////////////////////
+
+function traversalVarsUsedRegressionSuite() {
+  const testDatabaseName = "UnitTestDatabase";
+  const testDocumentCollectionName = "UnitTestDocuments";
+  const testEdgeCollectionName = "UnitTestEdgeCollection";
+  
+  return {
+    setUp: function() {
+      let coll = db._createDocumentCollection(testDocumentCollectionName);
+      db._createEdgeCollection(testEdgeCollectionName);
+
+      var projects = [];
+
+      // need enough documents for a materialize node to be part of the plan!
+      for(var i = 0; i<101; i++) {
+	projects.push({name: `${i}`});
+      }
+      coll.insert(projects);
+      coll.ensureIndex({type: "persistent", fields: [ "name" ]});
+    },
+    tearDown: function() {
+      db._drop(testEdgeCollectionName);
+      db._drop(testDocumentCollectionName);
+    },
+    testTraversalVarsUsedRegression: function () {
+      let query = 
+        `FOR doc IN ${testDocumentCollectionName}
+              SORT doc.name
+                FOR v, e, p IN 1..1 OUTBOUND {} ${testEdgeCollectionName}
+	        FILTER v.tag == doc.tag
+                RETURN v
+        `;
+
+      let ex = explainer.explain(query);
+      require("internal").log(JSON.stringify(ex));
+    },
+
+  };
+}
+
+jsunity.run(traversalVarsUsedRegressionSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

The TraversalNode keeps a cache of used variables in expressions; this cache was not updated when variable replacement was performed, for instance by the optimizer code dealing with materialize nodes. this lead to unknown variable errors for certain queries.