### PR TITLE
Free exhausted cursors in graph traversal queues

### DIFF
--- a/arangod/Graph/Queues/CursorFifoQueue.h
+++ b/arangod/Graph/Queues/CursorFifoQueue.h
@@ -159,6 +159,7 @@ class CursorFifoQueue {
       if (not cursor.hasMore()) {
         _resourceMonitor.decreaseMemoryUsage(sizeof(CursorRef));
         _continuationQueue.pop_front();
+        cursor.markForDeletion();
         continue;
       }
       for (auto&& step : cursor.next()) {

--- a/arangod/Graph/Queues/CursorWeightedQueue.h
+++ b/arangod/Graph/Queues/CursorWeightedQueue.h
@@ -75,6 +75,7 @@ class CursorWeightedQueue {
         append(step);
       }
     }
+    cursor.markForDeletion();
   }
 
   void setStartContent(std::vector<Step> startSteps) {

--- a/tests/Graph/CursorWeightedQueueTest.cpp
+++ b/tests/Graph/CursorWeightedQueueTest.cpp
@@ -80,8 +80,19 @@ template<typename Step>
 struct MockNeighbourCursor {
   auto next() -> std::vector<Step> { return {}; };
   auto hasMore() -> bool { return false; };
-  auto markForDeletion() -> void{};
+  auto markForDeletion() -> void { _deletable = true; };
+
+  bool _deletable = false;
 };
+
+TEST_F(CursorWeightedQueueTest, it_should_mark_appended_cursor_for_deletion) {
+  auto queue =
+      CursorWeightedQueue<Step, MockNeighbourCursor<Step>>(_resourceMonitor);
+  auto cursor = MockNeighbourCursor<Step>{};
+  queue.append(cursor);
+  EXPECT_TRUE(cursor._deletable);
+}
+
 TEST_F(CursorWeightedQueueTest, it_should_be_empty_if_new_queue_initialized) {
   auto queue =
       CursorWeightedQueue<Step, MockNeighbourCursor<Step>>(_resourceMonitor);


### PR DESCRIPTION
### Scope & Purpose

This fixes a cursor retention issue in graph traversal queues.

#### What happens internally

1. A weighted traversal expands a vertex by asking "a provider" for that vertex’s neighbours. Those neighbours are put into a queue.

2. The relevant path starts in `OneSidedEnumerator.cpp:170`. If we can go deeper, we create a cursor for this vertex’s neighbours and hand it to the queue.
```cpp
if (step.getDepth() < _options.getMaxDepth() && !res.isPruned()) {
 if (_queue.usesCursor()) {
   auto& cursor = _provider.createNeighbourCursor(step, posPrevious);
   _queue.append(cursor);
```
3. Weighted traversals use `CursorWeightedQueue`, for which `usesCursor()` is true.
4. The provider creates a cursor and stores it into a list (see `SingleServerProvider.cpp:178`). First it deletes old cursors, but only if `_deletable == true`. Then it creates a new cursor inside `_neighbourCursors`. Cluster path has a similar shape.
```cpp
auto SingleServerProvider<Step>::createNeighbourCursor(...)
   -> SingleServerNeighbourCursor<Step>& {
 _neighbourCursors.remove_if(
     [](SingleServerNeighbourCursor<Step> const& cursor) {
       return cursor._deletable;
     });
 return _neighbourCursors.emplace_back(...);
}
```
5. The cursor object can be marked as removable (`markForDeletion`). `CursorWeightedQueue` drains the cursor but does not mark it (see `CursorWeightedQueue.h:71`). So, the provider keeps dead cursors until the end of the query.
```cpp
void append(Cursor& cursor) {
 // exhaust the full cursor
 while (cursor.hasMore()) {
   for (auto const& step : cursor.next()) {
     append(step);
   }
 }
}
```

#### Example query
```
FOR v, e, p IN 1..100 OUTBOUND @start @@edges
  OPTIONS {{ order: "weighted", weightAttribute: "weight", defaultWeight: 1 }}
  COLLECT WITH COUNT INTO count
  RETURN count
```
This consumes more memory on a graph where each visited vertex has many outgoing edges or where depth reaches many vertices.

#### The fix
Mark the cursor for removal when `hasMore()` becomes false.

Also touched `CursorFifoQueue` because it appears to have the same missing `markForDeletion()` pattern.


- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [x] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [x] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
