### PR TITLE
[COR-747] Replace ArangodServer dependencies with ApplicationServer

### DIFF
--- a/arangod/Agency/v8-agency.cpp
+++ b/arangod/Agency/v8-agency.cpp
@@ -43,7 +43,7 @@ static void JS_StateAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {
@@ -72,7 +72,7 @@ static void JS_EnabledAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {
@@ -90,7 +90,7 @@ static void JS_LeadingAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {
@@ -124,7 +124,7 @@ static void JS_ReadAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {
@@ -161,7 +161,7 @@ static void JS_WriteAgent(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {

--- a/arangod/Cluster/v8-cluster.cpp
+++ b/arangod/Cluster/v8-cluster.cpp
@@ -137,7 +137,7 @@ static void JS_DoesDatabaseExistClusterInfo(
     TRI_V8_THROW_EXCEPTION_USAGE("doesDatabaseExist(<database-id>)");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   bool const result =
       ci.doesDatabaseExist(TRI_ObjectToString(isolate, args[0]));
@@ -163,7 +163,7 @@ static void JS_Databases(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("databases()");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   std::vector<DatabaseID> res = ci.databases();
   v8::Handle<v8::Array> a = v8::Array::New(isolate, (int)res.size());
@@ -188,7 +188,7 @@ static void JS_FlushClusterInfo(
 
   onlyInCluster();
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {
@@ -226,7 +226,7 @@ static void JS_GetCollectionInfoClusterInfo(
 
   auto databaseID = TRI_ObjectToString(isolate, args[0]);
   auto collectionID = TRI_ObjectToString(isolate, args[1]);
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   std::shared_ptr<LogicalCollection> col =
       ci.getCollectionNT(databaseID, collectionID);
@@ -316,7 +316,7 @@ static void JS_GetCollectionInfoCurrentClusterInfo(
 
   auto databaseID = TRI_ObjectToString(isolate, args[0]);
   auto collectionID = TRI_ObjectToString(isolate, args[1]);
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   std::shared_ptr<LogicalCollection> col =
       ci.getCollectionNT(databaseID, collectionID);
@@ -427,7 +427,7 @@ static void JS_GetResponsibleServerClusterInfo(
     TRI_V8_THROW_EXCEPTION_USAGE("getResponsibleServer(<shard-id>)");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   auto maybeShardID =
       ShardID::shardIdFromString(TRI_ObjectToString(isolate, args[0]));
@@ -488,7 +488,7 @@ static void JS_GetResponsibleServersClusterInfo(
     TRI_V8_THROW_EXCEPTION_USAGE("getResponsibleServers(<shard-ids>)");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   auto result = ci.getResponsibleServers(shardIds);
 
@@ -540,7 +540,7 @@ static void JS_GetResponsibleShardClusterInfo(
 
   CollectionID collectionId = TRI_ObjectToString(isolate, args[0]);
   auto& vocbase = GetContextVocBase(isolate);
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   auto collInfo = ci.getCollectionNT(vocbase.name(), collectionId);
   if (collInfo == nullptr) {
@@ -588,7 +588,7 @@ static void JS_GetServerEndpointClusterInfo(
     TRI_V8_THROW_EXCEPTION_USAGE("getServerEndpoint(<server-id>)");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   std::string const result =
       ci.getServerEndpoint(TRI_ObjectToString(isolate, args[0]));
@@ -612,7 +612,7 @@ static void JS_GetServerNameClusterInfo(
     TRI_V8_THROW_EXCEPTION_USAGE("getServerName(<endpoint>)");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   std::string const result =
       ci.getServerName(TRI_ObjectToString(isolate, args[0]));
@@ -636,7 +636,7 @@ static void JS_GetDBServers(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("getDBServers()");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   auto DBServers = ci.getCurrentDBServers();
   auto serverAliases = ci.getServerAliases();
@@ -689,7 +689,7 @@ static void JS_GetCoordinators(
     TRI_V8_THROW_EXCEPTION_USAGE("getCoordinators()");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   std::vector<std::string> coordinators = ci.getCurrentCoordinators();
 
@@ -715,7 +715,7 @@ static void JS_UniqidClusterInfo(
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
   if (!v8security.isInternalContext(isolate) &&
       !v8security.isAdminScriptContext(isolate)) {
@@ -834,7 +834,7 @@ static void JS_setFoxxmasterQueueupdate(
   ServerState::instance()->setFoxxmasterQueueupdate(value);
 
   if (AsyncAgencyCommManager::isEnabled()) {
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
     AgencyComm comm(v8g->server());
     std::string key = "Current/FoxxmasterQueueupdate";
     VPackSlice val = value ? VPackSlice::trueSlice() : VPackSlice::falseSlice();
@@ -872,7 +872,7 @@ static void JS_systemCollectionsCreated(
   }
 
   if (AsyncAgencyCommManager::isEnabled()) {
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
     AgencyComm comm(v8g->server());
     std::string key = "SystemCollectionsCreated";
     VPackSlice val = setTo ? VPackSlice::trueSlice() : VPackSlice::falseSlice();
@@ -1075,7 +1075,7 @@ static void JS_GetAnalyzersRevision(
 
   auto const databaseID = TRI_ObjectToString(isolate, args[0]);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
   auto const analyzerRevision = ci.getAnalyzersRevision(databaseID);
 
@@ -1109,7 +1109,7 @@ static void JS_WaitForPlanVersion(
         "<planVersion> is invalid, has to be a number larger 0");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& ci = v8g->server().getFeature<ClusterFeature>().clusterInfo();
 
   VPackBuilder result;

--- a/arangod/ClusterEngine/ClusterV8Functions.cpp
+++ b/arangod/ClusterEngine/ClusterV8Functions.cpp
@@ -80,7 +80,7 @@ static void JS_FlushWal(v8::FunctionCallbackInfo<v8::Value> const& args) {
     }
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& feature = v8g->server().getFeature<ClusterFeature>();
   Result res =
       flushWalOnAllDBServers(feature, waitForSync, flushColumnFamilies);
@@ -177,7 +177,7 @@ static void JS_WaitForEstimatorSync(
     v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   v8g->server().getFeature<DatabaseFeature>().engine().waitForEstimatorSync();
 
@@ -189,7 +189,7 @@ void ClusterV8Functions::registerResources() {
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   // patch ArangoCollection object
   v8::Handle<v8::ObjectTemplate> rt =

--- a/arangod/RocksDBEngine/RocksDBV8Functions.cpp
+++ b/arangod/RocksDBEngine/RocksDBV8Functions.cpp
@@ -85,7 +85,7 @@ static void JS_FlushWal(v8::FunctionCallbackInfo<v8::Value> const& args) {
     }
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   v8g->server().getFeature<DatabaseFeature>().engine().flushWal(
       waitForSync, flushColumnFamilies);
   TRI_V8_RETURN_TRUE();
@@ -204,7 +204,7 @@ static void JS_WaitForEstimatorSync(
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   v8g->server().getFeature<DatabaseFeature>().engine().waitForEstimatorSync();
 
@@ -218,7 +218,7 @@ static void JS_WalRecoveryStartSequence(
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto* engine = dynamic_cast<RocksDBEngine*>(
       &v8g->server().getFeature<DatabaseFeature>().engine());
   if (engine == nullptr) {

--- a/arangod/V8Server/v8-actions.cpp
+++ b/arangod/V8Server/v8-actions.cpp
@@ -1058,7 +1058,7 @@ static TRI_action_result_t ExecuteActionVocbase(
 static void JS_DefineAction(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   if (args.Length() != 3) {
     TRI_V8_THROW_EXCEPTION_USAGE(
@@ -1129,7 +1129,7 @@ static void JS_ReloadRouting(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   if (!v8g->server().getFeature<V8DealerFeature>().addGlobalExecutorMethod(
           GlobalExecutorMethods::MethodType::kReloadRouting)) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
@@ -1454,7 +1454,7 @@ static ErrorCode clusterSendToAllServers(
     v8::Isolate* isolate, std::string const& dbname,
     std::string const& path,  // Note: Has to be properly encoded!
     arangodb::rest::RequestType const& method, std::string const& body) {
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   network::ConnectionPool* pool =
       v8g->server().getFeature<NetworkFeature>().pool();
   if (!pool || !pool->config().clusterInfo) {
@@ -1701,7 +1701,7 @@ static void JS_FoxxQueueVersion(
   }
 
   if (ServerState::instance()->isCoordinator()) {
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
 
     auto& feature = v8g->server().getFeature<FoxxFeature>();
 
@@ -1734,7 +1734,7 @@ static void JS_FoxxQueueVersionBump(
 
   if (ServerState::instance()->isCoordinator()) {
     // only necessary in coordinator
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
 
     auto& feature = v8g->server().getFeature<FoxxFeature>();
     feature.bumpQueueVersionIfRequired();
@@ -1749,7 +1749,7 @@ static void JS_ClusterApiJwtPolicy(
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   ClusterFeature const& cf = v8g->server().getFeature<ClusterFeature>();
   std::string const& policy = cf.apiJwtPolicy();
@@ -1763,7 +1763,7 @@ static void JS_IsFoxxApiDisabled(
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   ServerSecurityFeature& security =
       v8g->server().getFeature<ServerSecurityFeature>();
   TRI_V8_RETURN_BOOL(security.isFoxxApiDisabled());
@@ -1776,7 +1776,7 @@ static void JS_IsFoxxStoreDisabled(
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   ServerSecurityFeature& security =
       v8g->server().getFeature<ServerSecurityFeature>();
   TRI_V8_RETURN_BOOL(security.isFoxxStoreDisabled());
@@ -1789,7 +1789,7 @@ static void JS_FoxxAllowInstallFromRemote(
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   ServerSecurityFeature& security =
       v8g->server().getFeature<ServerSecurityFeature>();
   TRI_V8_RETURN_BOOL(security.foxxAllowInstallFromRemote());
@@ -1860,7 +1860,7 @@ static void JS_CreateHotbackup(
 
   VPackBuilder result;
 #if USE_ENTERPRISE
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   HotBackup h(v8g->server());
   auto r = h.execute("create", obj.slice(), result);
   if (r.fail()) {
@@ -1924,7 +1924,7 @@ void TRI_InitV8ServerUtils(v8::Isolate* isolate) {
       JS_FoxxQueueVersionBump);
 
   // poll interval for Foxx queues
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   FoxxFeature& foxxFeature = v8g->server().getFeature<FoxxFeature>();
 
   isolate->GetCurrentContext()

--- a/arangod/V8Server/v8-analyzers.cpp
+++ b/arangod/V8Server/v8-analyzers.cpp
@@ -291,7 +291,7 @@ void JS_Create(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   PREVENT_EMBEDDED_TRANSACTION();
 
-  TRI_GET_SERVER_GLOBALS(arangodb::ArangodServer);
+  TRI_GET_GLOBALS();
   auto& analyzers =
       v8g->server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>();
 
@@ -434,7 +434,7 @@ void JS_Get(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   PREVENT_EMBEDDED_TRANSACTION();
 
-  TRI_GET_SERVER_GLOBALS(arangodb::ArangodServer);
+  TRI_GET_GLOBALS();
   auto& analyzers =
       v8g->server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>();
 
@@ -507,7 +507,7 @@ void JS_List(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION(TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
   }
 
-  TRI_GET_SERVER_GLOBALS(arangodb::ArangodServer);
+  TRI_GET_GLOBALS();
   auto& analyzers =
       v8g->server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>();
   auto sysVocbase =
@@ -595,7 +595,7 @@ void JS_Remove(v8::FunctionCallbackInfo<v8::Value> const& args) {
 
   PREVENT_EMBEDDED_TRANSACTION();
 
-  TRI_GET_SERVER_GLOBALS(arangodb::ArangodServer);
+  TRI_GET_GLOBALS();
   auto& analyzers =
       v8g->server().getFeature<arangodb::iresearch::IResearchAnalyzerFeature>();
 

--- a/arangod/V8Server/v8-dispatcher.cpp
+++ b/arangod/V8Server/v8-dispatcher.cpp
@@ -90,7 +90,7 @@ static void JS_RegisterTask(v8::FunctionCallbackInfo<v8::Value> const& args) {
   v8::Local<v8::Context> context = isolate->GetCurrentContext();
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   V8DealerFeature& v8Dealer = v8g->server().getFeature<V8DealerFeature>();
   V8SecurityFeature& v8security = v8g->server().getFeature<V8SecurityFeature>();
 

--- a/arangod/V8Server/v8-replication.cpp
+++ b/arangod/V8Server/v8-replication.cpp
@@ -70,7 +70,7 @@ static void JS_StateLoggerReplication(
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   v8::Handle<v8::Object> result = v8::Object::New(isolate);
   TRI_vocbase_t& vocbase = GetContextVocBase(isolate);
@@ -98,7 +98,7 @@ static void JS_TickRangesLoggerReplication(
   v8::Handle<v8::Array> result;
 
   VPackBuilder builder;
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   Result res = engine.createTickRanges(builder);
   if (res.fail()) {
@@ -122,7 +122,7 @@ static void JS_FirstTickLoggerReplication(
   v8::HandleScope scope(isolate);
 
   TRI_voc_tick_t tick = UINT64_MAX;
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   Result res = engine.firstTick(tick);
   if (res.fail()) {
@@ -164,7 +164,7 @@ static void JS_LastLoggerReplication(
   auto transactionContext =
       transaction::V8Context::create(vocbase, origin, true);
   VPackBuilder builder(transactionContext->getVPackOptions());
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   Result res = engine.lastLogger(vocbase, tickStart, tickEnd, builder);
   v8::Handle<v8::Value> result;
@@ -218,7 +218,7 @@ static void SynchronizeReplication(
             .FromMaybe(v8::Local<v8::Value>()));
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   ReplicationApplierConfiguration configuration =
       ReplicationApplierConfiguration::fromVelocyPack(
           v8g->server(), builder.slice(), databaseName);
@@ -354,7 +354,7 @@ static ReplicationApplier* getContinuousApplier(v8::Isolate* isolate,
     applier = vocbase.replicationApplier();
   } else {
     // applier type global
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
     auto& replicationFeature = v8g->server().getFeature<ReplicationFeature>();
     applier = replicationFeature.globalReplicationApplier();
   }
@@ -547,7 +547,7 @@ static void StateApplierReplicationAll(
     TRI_V8_THROW_EXCEPTION_USAGE("stateAll()");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   DatabaseFeature& databaseFeature =
       v8g->server().getFeature<DatabaseFeature>();
 

--- a/arangod/V8Server/v8-statistics.cpp
+++ b/arangod/V8Server/v8-statistics.cpp
@@ -113,7 +113,7 @@ static void JS_ServerStatistics(
   v8::HandleScope scope(isolate);
   auto context = TRI_IGETC;
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   v8::Handle<v8::Object> result = v8::Object::New(isolate);
 
@@ -270,7 +270,7 @@ static void JS_EnabledStatistics(
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   bool enabled = v8g->server().getFeature<StatisticsFeature>().isEnabled();
   v8::Handle<v8::Value> result = v8::Boolean::New(isolate, enabled);
   TRI_V8_RETURN(result);
@@ -282,7 +282,7 @@ static void JS_EnabledStatisticsAllDatabases(
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   bool enabled = v8g->server().getFeature<StatisticsFeature>().isEnabled();
   bool allDatabases =
       v8g->server().getFeature<StatisticsFeature>().allDatabases();
@@ -300,7 +300,7 @@ static void JS_EnabledMetrics(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate)
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   bool enabled =
       v8g->server().getFeature<metrics::MetricsFeature>().exportAPI();
   v8::Handle<v8::Value> result = v8::Boolean::New(isolate, enabled);

--- a/arangod/V8Server/v8-ttl.cpp
+++ b/arangod/V8Server/v8-ttl.cpp
@@ -50,7 +50,7 @@ static void JS_TtlProperties(v8::FunctionCallbackInfo<v8::Value> const& args) {
   VPackBuilder builder;
   Result result;
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   if (args.Length() == 0) {
     // get properties
     result = methods::Ttl::getProperties(v8g->server().getFeature<TtlFeature>(),
@@ -80,7 +80,7 @@ static void JS_TtlStatistics(v8::FunctionCallbackInfo<v8::Value> const& args) {
   v8::HandleScope scope(isolate);
 
   VPackBuilder builder;
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   Result result = methods::Ttl::getStatistics(
       v8g->server().getFeature<TtlFeature>(), builder);
 

--- a/arangod/V8Server/v8-users.cpp
+++ b/arangod/V8Server/v8-users.cpp
@@ -55,7 +55,7 @@ namespace {
 arangodb::Result existsCollection(v8::Isolate* isolate,
                                   std::string const& database,
                                   std::string const& collection) {
-  TRI_GET_SERVER_GLOBALS(arangodb::ArangodServer);
+  TRI_GET_GLOBALS();
   if (!v8g->server().hasFeature<arangodb::DatabaseFeature>()) {
     return arangodb::Result(TRI_ERROR_INTERNAL,
                             "failure to find feature 'Database'");
@@ -562,7 +562,7 @@ static void JS_GetPermission(v8::FunctionCallbackInfo<v8::Value> const& args) {
     // return the current database permissions
     v8::Handle<v8::Object> result = v8::Object::New(isolate);
 
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
     v8g->server().getFeature<DatabaseFeature>().enumerateDatabases(
         [&](TRI_vocbase_t& vocbase) -> void {
           auto lvl = um->databaseAuthLevel(username, vocbase.name(), false);

--- a/arangod/V8Server/v8-views.cpp
+++ b/arangod/V8Server/v8-views.cpp
@@ -225,7 +225,7 @@ static void JS_CreateViewVocbase(
 
   try {
     // First refresh our analyzers cache to see all latest changes in analyzers
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
     auto res =
         v8g->server()
             .getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()
@@ -651,7 +651,7 @@ static void JS_PropertiesViewVocbase(
     }
 
     auto& vocbase = GetContextVocBase(isolate);
-    TRI_GET_SERVER_GLOBALS(ArangodServer);
+    TRI_GET_GLOBALS();
     auto res =
         v8g->server()
             .getFeature<arangodb::iresearch::IResearchAnalyzerFeature>()

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -247,7 +247,7 @@ static void JS_Compact(v8::FunctionCallbackInfo<v8::Value> const& args) {
     }
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   Result res = engine.compactAll(changeLevel, compactBottomMostLevel);
 
@@ -1542,7 +1542,7 @@ static void JS_Engine(v8::FunctionCallbackInfo<v8::Value> const& args) {
   v8::HandleScope scope(isolate);
 
   // return engine data
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   VPackBuilder builder;
   engine.getCapabilities(builder);
@@ -1561,7 +1561,7 @@ static void JS_EngineStats(v8::FunctionCallbackInfo<v8::Value> const& args) {
   v8::HandleScope scope(isolate);
 
   // return engine data
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   VPackBuilder builder;
   engine.getStatistics(builder);
@@ -1585,7 +1585,7 @@ static void JS_VersionServer(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_RETURN(TRI_V8_ASCII_STRING(isolate, ARANGODB_VERSION));
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   VPackBuilder builder;
   arangodb::RestVersionHandler::getVersion(v8g->server(), true, true, builder,
                                            api_version::defaultApiVersion);
@@ -1597,7 +1597,7 @@ static void JS_VersionServer(v8::FunctionCallbackInfo<v8::Value> const& args) {
 static void JS_PathDatabase(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
 
   TRI_V8_RETURN_STD_STRING(engine.databasePath());
@@ -1660,7 +1660,7 @@ static void JS_UseDatabase(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("db._useDatabase(<name>)");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   if (!v8g->_securityContext.canUseDatabase()) {
     TRI_V8_THROW_EXCEPTION(TRI_ERROR_FORBIDDEN);
@@ -1716,7 +1716,7 @@ static void JS_Databases(v8::FunctionCallbackInfo<v8::Value> const& args) {
     user = TRI_ObjectToString(isolate, args[0]);
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   std::vector<std::string> names =
       methods::Databases::list(v8g->server(), user);
   v8::Handle<v8::Array> result = v8::Array::New(isolate, (int)names.size());
@@ -1858,7 +1858,7 @@ static void JS_Endpoints(v8::FunctionCallbackInfo<v8::Value> const& args) {
     TRI_V8_THROW_EXCEPTION_USAGE("db._endpoints()");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   TRI_ASSERT(v8g->server().hasFeature<HttpEndpointProvider>());
   auto& endpoints = v8g->server().getFeature<HttpEndpointProvider>();
   auto& vocbase = GetContextVocBase(isolate);
@@ -1887,7 +1887,7 @@ static void JS_TrustedProxies(v8::FunctionCallbackInfo<v8::Value> const& args) {
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   auto context = TRI_IGETC;
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& gs = v8g->server().getFeature<GeneralServerFeature>();
   if (gs.proxyCheck()) {
     v8::Handle<v8::Array> result = v8::Array::New(isolate);
@@ -1914,7 +1914,7 @@ static void JS_AuthenticationEnabled(
   TRI_V8_TRY_CATCH_BEGIN(isolate);
   v8::HandleScope scope(isolate);
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& authentication = v8g->server().getFeature<AuthenticationFeature>();
 
   v8::Handle<v8::Boolean> result =
@@ -2014,7 +2014,7 @@ static void JS_CurrentWalFiles(
   v8::HandleScope scope(isolate);
   auto context = TRI_IGETC;
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   StorageEngine& engine = v8g->server().getFeature<DatabaseFeature>().engine();
   std::vector<std::string> names = engine.currentWalFiles();
   std::sort(names.begin(), names.end());
@@ -2112,7 +2112,7 @@ static void JS_EncryptionKeyReload(
     TRI_V8_THROW_EXCEPTION_USAGE("encryptionKeyReload()");
   }
 
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto* engine = dynamic_cast<RocksDBEngine*>(
       &v8g->server().getFeature<DatabaseFeature>().engine());
   if (engine == nullptr) {
@@ -2141,7 +2141,7 @@ void TRI_InitV8VocBridge(v8::Isolate* isolate, v8::Handle<v8::Context> context,
   v8::HandleScope scope(isolate);
 
   // check the isolate
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   TRI_ASSERT(v8g->_transactionContext == nullptr);
   // register the database

--- a/arangod/V8Server/v8-vocindex.cpp
+++ b/arangod/V8Server/v8-vocindex.cpp
@@ -250,7 +250,7 @@ static void CreateVocBase(v8::FunctionCallbackInfo<v8::Value> const& args,
   }
 
   // waitForSync can be 3. or 4. parameter
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
   auto& cluster = v8g->server().getFeature<ClusterFeature>();
   bool createWaitsForSyncReplication = cluster.createWaitsForSyncReplication();
   bool enforceReplicationFactor = true;

--- a/arangod/VocBase/Methods/Transactions.cpp
+++ b/arangod/VocBase/Methods/Transactions.cpp
@@ -30,7 +30,6 @@
 #include "Basics/ReadLocker.h"
 #include "Basics/ScopeGuard.h"
 #include "Cluster/ServerState.h"
-#include "RestServer/arangod.h"
 #include "Transaction/Methods.h"
 #include "Transaction/Options.h"
 #include "Transaction/V8Context.h"
@@ -50,7 +49,7 @@
 namespace arangodb {
 
 bool allowTransactions(v8::Isolate* isolate) {
-  TRI_GET_SERVER_GLOBALS(ArangodServer);
+  TRI_GET_GLOBALS();
 
   V8DealerFeature& v8Dealer = v8g->server().getFeature<V8DealerFeature>();
   if (v8Dealer.allowJavaScriptTransactions()) {

--- a/client-tools/Shell/V8ClientConnection.cpp
+++ b/client-tools/Shell/V8ClientConnection.cpp
@@ -970,7 +970,7 @@ static void ClientConnection_ConstructorCallback(
   v8::Local<v8::External> wrap = v8::Local<v8::External>::Cast(args.Data());
   ClientFeature* client = static_cast<ClientFeature*>(wrap->Value());
 
-  TRI_GET_SERVER_GLOBALS(application_features::ApplicationServer);
+  TRI_GET_GLOBALS();
 
   auto v8connection =
       std::make_unique<V8ClientConnection>(v8g->server(), *client);

--- a/client-tools/Shell/V8ShellFeature.cpp
+++ b/client-tools/Shell/V8ShellFeature.cpp
@@ -1002,7 +1002,7 @@ static void JS_Exit(v8::FunctionCallbackInfo<v8::Value> const& args) {
     code = TRI_ObjectToInt64(isolate, args[0]);
   }
 
-  TRI_GET_SERVER_GLOBALS(application_features::ApplicationServer);
+  TRI_GET_GLOBALS();
   ShellFeature& shell = v8g->server().getFeature<ShellFeature>();
 
   shell.setExitCode(static_cast<int>(code));

--- a/lib/V8/v8-globals.cpp
+++ b/lib/V8/v8-globals.cpp
@@ -313,6 +313,18 @@ std::string TRI_ObjectToString(v8::Local<v8::Context> context,
   return std::string(*x, x.length());
 }
 
+TRI_v8_global_t* CreateV8Globals(
+    arangodb::application_features::ApplicationServer& server,
+    v8::Isolate* isolate, size_t id) {
+  TRI_GET_GLOBALS();
+
+  TRI_ASSERT(v8g == nullptr);
+  v8g = new TRI_v8_global_t(server, isolate, id);
+  isolate->SetData(arangodb::V8PlatformFeature::V8_DATA_SLOT, v8g);
+
+  return v8g;
+}
+
 /// @brief returns a global context
 TRI_v8_global_t* TRI_GetV8Globals(v8::Isolate* isolate) {
   TRI_GET_GLOBALS();

--- a/lib/V8/v8-globals.h
+++ b/lib/V8/v8-globals.h
@@ -37,7 +37,7 @@
 #include "ApplicationFeatures/HttpEndpointProvider.h"
 #include "Basics/StringBuffer.h"
 #include "Basics/operating-system.h"
-#include "RestServer/arangod.h"
+#include "ApplicationFeatures/ApplicationServer.h"
 #include "V8/JavaScriptSecurityContext.h"
 #include "V8/V8PlatformFeature.h"
 
@@ -421,10 +421,6 @@ std::string TRI_ObjectToString(v8::Local<v8::Context> context,
   TRI_v8_global_t* v8g = static_cast<TRI_v8_global_t*>( \
       isolate->GetData(arangodb::V8PlatformFeature::V8_DATA_SLOT))
 
-#define TRI_GET_SERVER_GLOBALS(server)                    \
-  V8Global<server>* v8g = static_cast<V8Global<server>*>( \
-      isolate->GetData(arangodb::V8PlatformFeature::V8_DATA_SLOT))
-
 /// @brief fetch a string-member from the global into the local scope of the
 /// function
 ///     will give you a variable of the same name.
@@ -486,6 +482,10 @@ struct TRI_v8_global_t {
 
   /// @brief decrease the number of active externals
   void decreaseActiveExternals() { --_activeExternals; }
+
+  arangodb::application_features::ApplicationServer& server() noexcept {
+    return _server;
+  }
 
   /// @brief agency template
   v8::Persistent<v8::ObjectTemplate> AgencyTempl;
@@ -850,35 +850,12 @@ struct TRI_v8_global_t {
   std::unordered_map<void*, SharedPtrPersistent> JSSharedPtrs;
 };
 
-// Intentionally final since we don't have virtual destructor
-template<typename Server>
-struct V8Global final : TRI_v8_global_t {
-  V8Global(Server& server, v8::Isolate* isolate, size_t id)
-      : TRI_v8_global_t{server, isolate, id} {}
-
-  Server& server() noexcept {
-#ifdef ARANGODB_ENABLE_MAINTAINER_MODE
-    auto* p = dynamic_cast<Server*>(&_server);
-    TRI_ASSERT(p);
-    return *p;
-#else
-    return static_cast<Server&>(_server);
-#endif
-  }
-};
+using V8Global = TRI_v8_global_t;
 
 // Creates a global context
-template<typename Server>
-V8Global<Server>* CreateV8Globals(Server& server, v8::Isolate* isolate,
-                                  size_t id) {
-  TRI_GET_GLOBALS();
-
-  TRI_ASSERT(v8g == nullptr);
-  v8g = new V8Global<Server>(server, isolate, id);
-  isolate->SetData(arangodb::V8PlatformFeature::V8_DATA_SLOT, v8g);
-
-  return static_cast<V8Global<Server>*>(v8g);
-}
+V8Global* CreateV8Globals(
+    arangodb::application_features::ApplicationServer& server,
+    v8::Isolate* isolate, size_t id);
 
 /// @brief gets the global context
 TRI_v8_global_t* TRI_GetV8Globals(v8::Isolate*);

--- a/tests/Aql/ExecutionNode/IndexNodeTest.cpp
+++ b/tests/Aql/ExecutionNode/IndexNodeTest.cpp
@@ -65,7 +65,8 @@ class IndexNodeTest
 
 };  // IndexNodeTest
 
-arangodb::CreateDatabaseInfo createInfo(arangodb::ArangodServer& server) {
+arangodb::CreateDatabaseInfo createInfo(
+    arangodb::application_features::ApplicationServer& server) {
   arangodb::CreateDatabaseInfo info(server, arangodb::ExecContext::current());
   auto rv = info.load("testVocbase", 2);
   if (rv.fail()) {

--- a/tests/Auth/UserManagerTest.cpp
+++ b/tests/Auth/UserManagerTest.cpp
@@ -25,18 +25,13 @@
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 
-#include "fakeit.hpp"
-
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Aql/QueryRegistry.h"
-#include "Auth/Handler.h"
 #include "Auth/User.h"
 #include "Auth/UserManagerImpl.h"
 #include "Cluster/ServerState.h"
-#include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 
-using namespace fakeit;
 using namespace arangodb;
 using namespace arangodb::aql;
 
@@ -50,7 +45,7 @@ class TestQueryRegistry : public QueryRegistry {
 
 class UserManagerTest : public ::testing::Test {
  protected:
-  ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   TestQueryRegistry queryRegistry;
   ServerState* state;
   auth::UserManagerImpl um;

--- a/tests/Graph/GraphTestTools.h
+++ b/tests/Graph/GraphTestTools.h
@@ -64,7 +64,7 @@ namespace graph {
 struct GraphTestSetup
     : public arangodb::tests::LogSuppressor<arangodb::Logger::FIXME,
                                             arangodb::LogLevel::ERR> {
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::unique_ptr<TRI_vocbase_t> system;
   std::vector<
@@ -88,8 +88,8 @@ struct MockGraphDatabase {
   TRI_vocbase_t vocbase;
   VersionTracker versionTracker;
 
-  MockGraphDatabase(ArangodServer& server, StorageEngine& engine,
-                    std::string name)
+  MockGraphDatabase(application_features::ApplicationServer& server,
+                    StorageEngine& engine, std::string name)
       : vocbase(createInfo(server, name, 1), engine, versionTracker, true) {}
 
   ~MockGraphDatabase() {}

--- a/tests/IResearch/ExpressionFilterTest.cpp
+++ b/tests/IResearch/ExpressionFilterTest.cpp
@@ -24,13 +24,11 @@
 
 #include "gtest/gtest.h"
 
-#include "iresearch/tests/tests_config.hpp"
 #include "analysis/token_attributes.hpp"
 #include "index/directory_reader.hpp"
 #include "search/all_filter.hpp"
 #include "search/cost.hpp"
 #include "search/score.hpp"
-#include "search/scorers.hpp"
 #include "store/memory_directory.hpp"
 #include "store/store_utils.hpp"
 #include "utils/type_limits.hpp"
@@ -59,7 +57,6 @@
 #include "IResearch/IResearchFilterFactory.h"
 #include "IResearch/IResearchView.h"
 #include "IResearch/VelocyPackHelper.h"
-#include "Logger/LogTopic.h"
 #include "Logger/Logger.h"
 #include "RestServer/AqlFeature.h"
 #include "Cluster/MaintenanceFeature.h"
@@ -67,7 +64,6 @@
 #include "RestServer/DatabasePathFeature.h"
 #include "VectorIndex/VectorIndexFeature.h"
 #include "Metrics/MetricsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/SystemDatabaseFeature.h"
 #include "RestServer/ViewTypesFeature.h"
@@ -80,7 +76,6 @@
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "Statistics/StatisticsWorker.h"
 
 extern const char* ARGV0;  // defined in main.cpp
 
@@ -229,7 +224,7 @@ struct IResearchExpressionFilterTest
       public arangodb::tests::LogSuppressor<arangodb::iresearch::TOPIC,
                                             arangodb::LogLevel::FATAL>,
       public arangodb::tests::IResearchLogSuppressor {
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::unique_ptr<TRI_vocbase_t> system;
   std::vector<

--- a/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
+++ b/tests/IResearch/IResearchAnalyzerFeatureTest.cpp
@@ -27,7 +27,6 @@
 #include "analysis/analyzers.hpp"
 #include "analysis/token_attributes.hpp"
 #include "index/norm.hpp"
-#include <filesystem>
 
 #include "IResearch/IResearchTestCommon.h"
 #include "IResearch/RestHandlerMock.h"
@@ -37,15 +36,12 @@
 #include "Mocks/StorageEngineMock.h"
 
 #include "Agency/AsyncAgencyComm.h"
-#include "Agency/Store.h"
 #include "ApplicationFeatures/CommunicationFeaturePhase.h"
 #include "Aql/AqlFunctionFeature.h"
 #include "Aql/AstNode.h"
 #include "Aql/Function.h"
 #include "Aql/OptimizerRulesFeature.h"
-#include "Aql/QueryRegistry.h"
 #include "Auth/UserManagerMock.h"
-#include "Basics/files.h"
 #include "Cluster/AgencyCache.h"
 #include "Cluster/ClusterFeature.h"
 #include "Cluster/ClusterInfo.h"
@@ -62,7 +58,6 @@
 #include "RestServer/AqlFeature.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/DatabasePathFeature.h"
-#include "RestServer/FlushFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Metrics/MetricsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
@@ -1536,7 +1531,8 @@ TEST_F(IResearchAnalyzerFeatureCoordinatorTest, test_ensure_index_add_factory) {
   // add index factory
   {
     struct IndexTypeFactory : public arangodb::IndexTypeFactory {
-      IndexTypeFactory(arangodb::ArangodServer& server)
+      IndexTypeFactory(
+          arangodb::application_features::ApplicationServer& server)
           : arangodb::IndexTypeFactory(server) {}
 
       virtual bool equal(arangodb::velocypack::Slice lhs,
@@ -2673,7 +2669,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
     // required features cannot use the existing server since its features
     // already have some state
 
-    arangodb::ArangodServer newServer(nullptr, nullptr);
+    arangodb::application_features::ApplicationServer newServer(nullptr,
+                                                                nullptr);
     auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
         arangodb::LazyApplicationFeatureReference<
             arangodb::QueryRegistryFeature>(nullptr),
@@ -2774,7 +2771,8 @@ TEST_F(IResearchAnalyzerFeatureTest, test_remove) {
       arangodb::ServerState::instance()->setRole(beforeRole);
     };
 
-    arangodb::ArangodServer newServer(nullptr, nullptr);
+    arangodb::application_features::ApplicationServer newServer(nullptr,
+                                                                nullptr);
     auto& auth = newServer.addFeature<arangodb::AuthenticationFeature>();
     auto& metrics = newServer.addFeature<arangodb::metrics::MetricsFeature>(
         arangodb::LazyApplicationFeatureReference<
@@ -3302,7 +3300,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_tokens) {
   // create a new instance of an ApplicationServer and fill it with the required
   // features cannot use the existing server since its features already have
   // some state
-  arangodb::ArangodServer newServer(nullptr, nullptr);
+  arangodb::application_features::ApplicationServer newServer(nullptr, nullptr);
   StorageEngineMock engine(newServer);
   auto& dbfeature = newServer.addFeature<arangodb::DatabaseFeature>();
   dbfeature.setEngineTesting(&engine);
@@ -4386,7 +4384,7 @@ TEST_F(IResearchAnalyzerFeatureTest, test_visit) {
     }
   };
 
-  arangodb::ArangodServer newServer(nullptr, nullptr);
+  arangodb::application_features::ApplicationServer newServer(nullptr, nullptr);
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
   StorageEngineMock engine(newServer);
   dbFeature.setEngineTesting(&engine);
@@ -4734,7 +4732,7 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_toVelocyPack) {
   // create a new instance of an ApplicationServer and fill it with the required
   // features cannot use the existing server since its features already have
   // some state
-  arangodb::ArangodServer newServer(nullptr, nullptr);
+  arangodb::application_features::ApplicationServer newServer(nullptr, nullptr);
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
   StorageEngineMock engine(newServer);
   dbFeature.setEngineTesting(&engine);
@@ -4887,7 +4885,7 @@ TEST_F(IResearchAnalyzerFeatureTest, custom_analyzers_vpack_create) {
   // create a new instance of an ApplicationServer and fill it with the required
   // features cannot use the existing server since its features already have
   // some state
-  arangodb::ArangodServer newServer(nullptr, nullptr);
+  arangodb::application_features::ApplicationServer newServer(nullptr, nullptr);
   auto& dbFeature = newServer.addFeature<arangodb::DatabaseFeature>();
   StorageEngineMock engine(newServer);
   dbFeature.setEngineTesting(&engine);

--- a/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
+++ b/tests/IResearch/IResearchInvertedIndexMetaTest.cpp
@@ -30,9 +30,7 @@
 #include "IResearch/IResearchInvertedIndexMeta.h"
 #include "Mocks/LogLevels.h"
 #include "Mocks/Servers.h"
-#include "Mocks/StorageEngineMock.h"
 #include "VocBase/Methods/Collections.h"
-#include "RestServer/AqlFeature.h"
 #include "RestServer/DatabaseFeature.h"
 
 using namespace arangodb;
@@ -41,7 +39,7 @@ using namespace arangodb::basics;
 using namespace std::literals;
 
 namespace {
-void serializationChecker(ArangodServer& server,
+void serializationChecker(application_features::ApplicationServer& server,
                           arangodb::StorageEngine& engine,
                           std::string_view jsonAsString) {
   auto json = VPackParser::fromJson({jsonAsString.data(), jsonAsString.size()});

--- a/tests/IResearch/IResearchOrderTest.cpp
+++ b/tests/IResearch/IResearchOrderTest.cpp
@@ -46,7 +46,6 @@
 #include "IResearch/IResearchFeature.h"
 #include "IResearch/IResearchFilterContext.h"
 #include "IResearch/IResearchOrderFactory.h"
-#include "RestServer/arangod.h"
 #include "Cluster/MaintenanceFeature.h"
 #include "RestServer/AqlFeature.h"
 #include "RestServer/DatabaseFeature.h"
@@ -56,7 +55,6 @@
 #include "RestServer/QueryRegistryFeature.h"
 #include "RestServer/ViewTypesFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "Statistics/StatisticsWorker.h"
 #include "Transaction/Methods.h"
 #include "Transaction/StandaloneContext.h"
 
@@ -275,7 +273,7 @@ class IResearchOrderTest
                                             arangodb::LogLevel::FATAL>,
       public arangodb::tests::IResearchLogSuppressor {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::vector<
       std::pair<arangodb::application_features::ApplicationFeature&, bool>>

--- a/tests/IResearch/IResearchViewMetaTest.cpp
+++ b/tests/IResearch/IResearchViewMetaTest.cpp
@@ -35,12 +35,11 @@
 #include "velocypack/Iterator.h"
 #include "velocypack/Parser.h"
 #include "Basics/VelocyPackHelper.h"
-#include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 
 class IResearchViewMetaTest : public ::testing::Test {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
 
   IResearchViewMetaTest() : server(nullptr, nullptr), engine(server) {

--- a/tests/Maintenance/MaintenanceFeatureTest.cpp
+++ b/tests/Maintenance/MaintenanceFeatureTest.cpp
@@ -41,7 +41,6 @@
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Metrics/MetricsFeature.h"
 #include "Mocks/Servers.h"
-#include "Network/NetworkFeature.h"
 #include "RestServer/UpgradeFeature.h"
 #include "Statistics/StatisticsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
@@ -195,7 +194,7 @@ struct MaintenanceFeatureTestThreaded : ::testing::Test {
   std::shared_ptr<arangodb::options::ProgramOptions> po =
       std::make_shared<arangodb::options::ProgramOptions>(
           "test", std::string(), std::string(), "path");
-  arangodb::ArangodServer as{po, nullptr};
+  arangodb::application_features::ApplicationServer as{po, nullptr};
 
   void SetUp() override {
     using namespace arangodb;
@@ -216,7 +215,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_0_times_ok) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
                                  //
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -255,7 +255,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_0_times_fail) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
                                  //
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -297,7 +298,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_1_time_ok) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
                                  //
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -338,7 +340,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_1_time_fail) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
                                  //
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -382,7 +385,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_2_times_ok) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
                                  //
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -425,7 +429,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_100_times_ok) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -468,7 +473,8 @@ TEST_F(MaintenanceFeatureTestThreaded, iterate_action_100_times_fail) {
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
   tf.setSecondsActionsBlock(0);  // disable retry wait for now
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -510,7 +516,8 @@ TEST_F(MaintenanceFeatureTestThreaded, populate_action_queue_and_validate) {
   TestMaintenanceFeature& tf =
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -590,7 +597,8 @@ TEST_F(MaintenanceFeatureTestThreaded, action_that_generates_a_preaction) {
   TestMaintenanceFeature& tf =
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -648,7 +656,8 @@ TEST_F(MaintenanceFeatureTestThreaded, action_that_generates_a_postaction) {
   TestMaintenanceFeature& tf =
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -706,7 +715,8 @@ TEST_F(MaintenanceFeatureTestThreaded,
   TestMaintenanceFeature& tf =
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -748,7 +758,8 @@ TEST_F(MaintenanceFeatureTestThreaded, action_delete) {
   TestMaintenanceFeature& tf =
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();
@@ -803,7 +814,8 @@ TEST_F(MaintenanceFeatureTestThreaded,
   TestMaintenanceFeature& tf =
       as.addFeature<arangodb::MaintenanceFeature, TestMaintenanceFeature>();
 
-  std::thread th(&arangodb::ArangodServer::run, &as, 0, nullptr);
+  std::thread th(&arangodb::application_features::ApplicationServer::run, &as,
+                 0, nullptr);
 
   auto threadGuard = arangodb::scopeGuard([&]() noexcept {
     as.beginShutdown();

--- a/tests/Maintenance/MaintenanceRestHandlerTest.cpp
+++ b/tests/Maintenance/MaintenanceRestHandlerTest.cpp
@@ -30,7 +30,6 @@
 #include "Endpoint/ConnectionInfo.h"
 #include "Rest/HttpRequest.h"
 #include "Rest/HttpResponse.h"
-#include "RestServer/arangod.h"
 
 #include <velocypack/Buffer.h>
 #include <velocypack/Builder.h>
@@ -75,7 +74,8 @@ TEST(MaintenanceRestHandler, parse_rest_put) {
   auto* dummyResponse = new arangodb::HttpResponse(
       arangodb::rest::ResponseCode::OK, 1, nullptr,
       arangodb::rest::ResponseCompressionType::kNoCompression);
-  arangodb::ArangodServer dummyServer{nullptr, nullptr};
+  arangodb::application_features::ApplicationServer dummyServer{nullptr,
+                                                                nullptr};
   TestHandler dummyHandler(dummyServer, dummyRequest, dummyResponse);
 
   ASSERT_TRUE(dummyHandler.test_parsePutBody(body.slice()));

--- a/tests/Maintenance/MaintenanceTest.cpp
+++ b/tests/Maintenance/MaintenanceTest.cpp
@@ -68,7 +68,6 @@
 #include <velocypack/Iterator.h>
 
 #include <iostream>
-#include <iterator>
 #include <memory>
 #include <random>
 
@@ -141,7 +140,7 @@ class SharedMaintenanceTest : public ::testing::Test {
   NodePtr originalPlan;
   NodePtr supervision;
   NodePtr current;
-  ArangodServer server;
+  application_features::ApplicationServer server;
   StorageEngineMock engine;
 
   // map <shortId, UUID>
@@ -519,7 +518,7 @@ class MaintenanceTestActionPhaseOne : public SharedMaintenanceTest {
   int _dummy;
   std::shared_ptr<options::ProgramOptions> po;
   basics::SharedPRNG sharedPRNG;
-  ArangodServer as;
+  application_features::ApplicationServer as;
   containers::FlatHashSet<DatabaseID> makeDirty;
   MaintenanceFeature::errors_t errors;
 

--- a/tests/Metrics/MetricsFeatureTest.cpp
+++ b/tests/Metrics/MetricsFeatureTest.cpp
@@ -28,7 +28,6 @@
 #include "Metrics/Metric.h"
 #include "Metrics/MetricsFeature.h"
 #include "MetricsFeatureTest.h"
-#include "RestServer/arangod.h"
 #include "RestServer/QueryRegistryFeature.h"
 
 using namespace arangodb;
@@ -36,7 +35,7 @@ using namespace arangodb;
 std::shared_ptr<arangodb::options::ProgramOptions> opts =
     std::make_shared<arangodb::options::ProgramOptions>(
         "metrics_feature_test", std::string(), std::string(), "path");
-ArangodServer server = ArangodServer(opts, nullptr);
+application_features::ApplicationServer server(opts, nullptr);
 metrics::MetricsFeature feature = metrics::MetricsFeature(
     server, LazyApplicationFeatureReference<QueryRegistryFeature>(server),
     LazyApplicationFeatureReference<StatisticsFeature>(nullptr),

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -278,7 +278,9 @@ MockServer::~MockServer() {
   ServerState::instance()->setRebootId(_oldRebootId);
 }
 
-ArangodServer& MockServer::server() { return _server; }
+application_features::ApplicationServer& MockServer::server() {
+  return _server;
+}
 
 void MockServer::init() {
   _oldApplicationServerState = _server.state();

--- a/tests/Mocks/Servers.h
+++ b/tests/Mocks/Servers.h
@@ -26,7 +26,6 @@
 #include "Mocks/LogLevels.h"
 
 #include "Agency/AgencyCommon.h"
-#include "RestServer/arangod.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Cluster/ClusterTypes.h"
 #include "Cluster/ServerState.h"
@@ -73,7 +72,7 @@ class MockServer {
              bool injectClusterIndexes = false);
   virtual ~MockServer();
 
-  ArangodServer& server();
+  application_features::ApplicationServer& server();
   void init();
 
   Database& getSystemDatabase() const;
@@ -128,7 +127,7 @@ class MockServer {
   arangodb::application_features::ApplicationServer::State
       _oldApplicationServerState = arangodb::application_features::
           ApplicationServer::State::UNINITIALIZED;
-  arangodb::ArangodServer _server;
+  arangodb::application_features::ApplicationServer _server;
   std::unique_ptr<StorageEngineMock> _engine;
   std::unordered_map<arangodb::application_features::ApplicationFeature*, bool>
       _features;

--- a/tests/Replication2/main-replication2.cpp
+++ b/tests/Replication2/main-replication2.cpp
@@ -21,20 +21,16 @@
 /// @author Andreas Streichardt
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <chrono>
 #include <thread>
 
 #include "gtest/gtest.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "ApplicationFeatures/ShellColorsFeature.h"
 #include "Basics/ArangoGlobalContext.h"
 #include "Logger/Logger.h"
 #include "Random/RandomGenerator.h"
-#include "VocBase/Identifiers/ServerId.h"
 #include "Rest/Version.h"
 #include "Basics/VelocyPackHelper.h"
-#include "RestServer/arangod.h"
 
 char const* ARGV0 = "";
 
@@ -73,7 +69,7 @@ int main(int argc, char* argv[]) {
 
   ARGV0 = subargv[0];
 
-  arangodb::ArangodServer server(nullptr, nullptr);
+  arangodb::application_features::ApplicationServer server(nullptr, nullptr);
 
   arangodb::Logger::setShowLineNumber(logLineNumbers);
   arangodb::Logger::initialize(server, false);

--- a/tests/RestServer/FlushFeatureTest.cpp
+++ b/tests/RestServer/FlushFeatureTest.cpp
@@ -23,26 +23,18 @@
 
 #include "gtest/gtest.h"
 
-#include "velocypack/Parser.h"
-
 #include "IResearch/common.h"
 #include "Mocks/LogLevels.h"
 #include "Mocks/StorageEngineMock.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Basics/encoding.h"
 #include "Cluster/ClusterFeature.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "Logger/Logger.h"
 #include "RestServer/FlushFeature.h"
 #include "Metrics/MetricsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
-#include "RocksDBEngine/RocksDBEngine.h"
-#include "RocksDBEngine/RocksDBFormat.h"
-#include "RocksDBEngine/RocksDBRecoveryHelper.h"
-#include "RocksDBEngine/RocksDBTypes.h"
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
@@ -64,7 +56,7 @@ class FlushFeatureTest
       public arangodb::tests::LogSuppressor<arangodb::Logger::ENGINES,
                                             arangodb::LogLevel::FATAL> {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::vector<
       std::pair<arangodb::application_features::ApplicationFeature&, bool>>

--- a/tests/RocksDBEngine/TransactionManagerTest.cpp
+++ b/tests/RocksDBEngine/TransactionManagerTest.cpp
@@ -22,9 +22,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "gtest/gtest.h"
+
 #include <chrono>
-#include <condition_variable>
-#include <mutex>
 #include <thread>
 
 #include "ApplicationFeatures/ApplicationServer.h"
@@ -33,7 +32,6 @@
 #include "Transaction/ManagerFeature.h"
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Statistics/StatisticsFeature.h"
 
@@ -47,7 +45,7 @@ using namespace arangodb;
 
 /// @brief simple non-overlapping
 TEST(RocksDBTransactionManager, test_non_overlapping) {
-  ArangodServer server{nullptr, nullptr};
+  application_features::ApplicationServer server{nullptr, nullptr};
   auto& metrics = server.addFeature<metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
       LazyApplicationFeatureReference<StatisticsFeature>(nullptr),
@@ -74,7 +72,7 @@ TEST(RocksDBTransactionManager, test_non_overlapping) {
 /// @brief simple non-overlapping
 TEST(RocksDBTransactionManager, test_overlapping) {
   auto trxId = static_cast<TransactionId>(1);
-  ArangodServer server{nullptr, nullptr};
+  application_features::ApplicationServer server{nullptr, nullptr};
   auto& metrics = server.addFeature<metrics::MetricsFeature>(
       LazyApplicationFeatureReference<QueryRegistryFeature>(nullptr),
       LazyApplicationFeatureReference<StatisticsFeature>(nullptr),

--- a/tests/Sharding/ShardDistributionReporterTest.cpp
+++ b/tests/Sharding/ShardDistributionReporterTest.cpp
@@ -22,9 +22,6 @@
 /// @author Copyright 2017, ArangoDB GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-#include <queue>
-#include <thread>
-
 #include "gtest/gtest.h"
 
 #include "fakeit.hpp"
@@ -39,23 +36,18 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Cluster/ClusterInfo.h"
 #include "Cluster/CollectionInfoCurrent.h"
-#include "Futures/Utilities.h"
 #include "RestServer/DatabaseFeature.h"
 #include "Metrics/MetricsFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Sharding/ShardDistributionReporter.h"
-#include "SimpleHttpClient/SimpleHttpResult.h"
 #include "VocBase/LogicalCollection.h"
-#include "VocBase/ticks.h"
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/QueryRegistryFeature.h"
 
 using namespace arangodb;
 using namespace arangodb::cluster;
-using namespace arangodb::httpclient;
 
 static const VPackBuilder testDatabaseBuilder = dbArgsBuilder("testVocbase");
 static const VPackSlice testDatabaseArgs = testDatabaseBuilder.slice();
@@ -131,7 +123,7 @@ class ShardDistributionReporterTest
       public arangodb::tests::LogSuppressor<arangodb::Logger::CLUSTER,
                                             arangodb::LogLevel::FATAL> {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::vector<
       std::pair<arangodb::application_features::ApplicationFeature&, bool>>

--- a/tests/SimpleHttpClient/ConnectionCacheTest.cpp
+++ b/tests/SimpleHttpClient/ConnectionCacheTest.cpp
@@ -27,7 +27,6 @@
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "ApplicationFeatures/CommunicationFeaturePhase.h"
 #include "Endpoint/Endpoint.h"
-#include "RestServer/arangod.h"
 #include "SimpleHttpClient/ConnectionCache.h"
 #include "SimpleHttpClient/GeneralClientConnection.h"
 
@@ -35,7 +34,7 @@ using namespace arangodb;
 using namespace arangodb::httpclient;
 
 TEST(ConnectionCacheTest, testEmpty) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -47,7 +46,7 @@ TEST(ConnectionCacheTest, testEmpty) {
 }
 
 TEST(ConnectionCacheTest, testAcquireInvalidEndpoint) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -71,7 +70,7 @@ TEST(ConnectionCacheTest, testAcquireInvalidEndpoint) {
 }
 
 TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnection) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -98,7 +97,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnection) {
 }
 
 TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnectionForce) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -128,7 +127,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseClosedConnectionForce) {
 }
 
 TEST(ConnectionCacheTest, testAcquireAndReleaseRepeat) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -188,7 +187,7 @@ TEST(ConnectionCacheTest, testAcquireAndReleaseRepeat) {
 }
 
 TEST(ConnectionCacheTest, testSameEndpointMultipleLeases) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -237,7 +236,7 @@ TEST(ConnectionCacheTest, testSameEndpointMultipleLeases) {
 }
 
 TEST(ConnectionCacheTest, testDifferentEndpoints) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -276,7 +275,7 @@ TEST(ConnectionCacheTest, testDifferentEndpoints) {
 }
 
 TEST(ConnectionCacheTest, testSameEndpointDifferentProtocols) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -315,7 +314,7 @@ TEST(ConnectionCacheTest, testSameEndpointDifferentProtocols) {
 }
 
 TEST(ConnectionCacheTest, testDropSuperfluous) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(
@@ -356,7 +355,7 @@ TEST(ConnectionCacheTest, testDropSuperfluous) {
 }
 
 TEST(ConnectionCacheTest, testSameEndpointMultipleLeasesOverExpiry) {
-  ArangodServer server(nullptr, nullptr);
+  application_features::ApplicationServer server(nullptr, nullptr);
   server.addFeature<application_features::CommunicationFeaturePhase>();
 
   ConnectionCache cache(

--- a/tests/StorageEngine/PhysicalCollectionTest.cpp
+++ b/tests/StorageEngine/PhysicalCollectionTest.cpp
@@ -27,17 +27,15 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Parser.h>
 
-#include "IResearch/RestHandlerMock.h"
 #include "IResearch/common.h"
 #include "Mocks/LogLevels.h"
 #include "Mocks/StorageEngineMock.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Aql/QueryRegistry.h"
 #include "Basics/Result.h"
 #include "GeneralServer/AuthenticationFeature.h"
+#include "Logger/Logger.h"
 #include "Metrics/MetricsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "StorageEngine/PhysicalCollection.h"
@@ -64,7 +62,7 @@ class PhysicalCollectionTest
       arangodb::tests::LogSuppressor<arangodb::Logger::AUTHENTICATION,
                                      arangodb::LogLevel::WARN> {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::vector<std::reference_wrapper<
       arangodb::application_features::ApplicationFeature>>

--- a/tests/V8Server/V8AnalyzersTest.cpp
+++ b/tests/V8Server/V8AnalyzersTest.cpp
@@ -260,8 +260,7 @@ TEST_F(V8AnalyzerTest, test_instance_accessors) {
   // required for TRI_AddMethodVocbase(...)
   v8::Context::Scope contextScope(context);
   // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-  std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
-      CreateV8Globals(server.server(), isolate, 0));
+  std::unique_ptr<V8Global> v8g(CreateV8Globals(server.server(), isolate, 0));
   // otherwise v8:-utils::CreateErrorObject(...) will fail
   v8g->ArangoErrorTempl.Reset(isolate, v8::ObjectTemplate::New(isolate));
   v8g->_vocbase = &vocbase;
@@ -573,8 +572,7 @@ TEST_F(V8AnalyzerTest, test_manager_create) {
 
   // required for TRI_AddMethodVocbase(...)
   v8::Context::Scope contextScope(context);
-  std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
-      CreateV8Globals(server.server(), isolate, 0));
+  std::unique_ptr<V8Global> v8g(CreateV8Globals(server.server(), isolate, 0));
 
   // otherwise v8:-utils::CreateErrorObject(...) will fail
   v8g->ArangoErrorTempl.Reset(isolate, v8::ObjectTemplate::New(isolate));
@@ -1061,8 +1059,7 @@ TEST_F(V8AnalyzerTest, test_manager_get) {
   v8::Context::Scope contextScope(context);
 
   // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-  std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
-      CreateV8Globals(server.server(), isolate, 0));
+  std::unique_ptr<V8Global> v8g(CreateV8Globals(server.server(), isolate, 0));
   v8g->ArangoErrorTempl.Reset(
       isolate,
       v8::ObjectTemplate::New(
@@ -1495,8 +1492,7 @@ TEST_F(V8AnalyzerTest, test_manager_list) {
   // required for TRI_AddMethodVocbase(...)
   v8::Context::Scope contextScope(context);
   // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-  std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
-      CreateV8Globals(server.server(), isolate, 0));
+  std::unique_ptr<V8Global> v8g(CreateV8Globals(server.server(), isolate, 0));
   // otherwise v8:-utils::CreateErrorObject(...) will fail
   v8g->ArangoErrorTempl.Reset(isolate, v8::ObjectTemplate::New(isolate));
   arangodb::iresearch::TRI_InitV8Analyzers(*v8g, isolate);
@@ -1895,8 +1891,7 @@ TEST_F(V8AnalyzerTest, test_manager_remove) {
   // required for TRI_AddMethodVocbase(...)
   v8::Context::Scope contextScope(context);
   // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-  std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
-      CreateV8Globals(server.server(), isolate, 0));
+  std::unique_ptr<V8Global> v8g(CreateV8Globals(server.server(), isolate, 0));
   // otherwise v8:-utils::CreateErrorObject(...) will fail
   v8g->ArangoErrorTempl.Reset(isolate, v8::ObjectTemplate::New(isolate));
   arangodb::iresearch::TRI_InitV8Analyzers(*v8g, isolate);

--- a/tests/V8Server/V8UsersTest.cpp
+++ b/tests/V8Server/V8UsersTest.cpp
@@ -230,7 +230,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
   // required for TRI_AddMethodVocbase(...)
   v8::Context::Scope contextScope(context);
   // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-  std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+  std::unique_ptr<V8Global> v8g(
       CreateV8Globals(server.server(), isolate.get(), 0));
   // otherwise v8:-utils::CreateErrorObject(...) will fail
   v8g->ArangoErrorTempl.Reset(isolate.get(),

--- a/tests/V8Server/V8ViewsTest.cpp
+++ b/tests/V8Server/V8ViewsTest.cpp
@@ -231,7 +231,7 @@ TEST_F(V8ViewsTest, test_auth) {
         context);  // required for TRI_AddMethodVocbase(...)
 
     // create and set inside 'isolate' for use 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
 
     // otherwise v8:-utils::CreateErrorObject(...) will fail
@@ -374,7 +374,7 @@ TEST_F(V8ViewsTest, test_auth) {
     // required for TRI_AddMethodVocbase(...)
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),
@@ -507,7 +507,7 @@ TEST_F(V8ViewsTest, test_auth) {
     // required for TRI_AddMethodVocbase(...)
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),
@@ -639,7 +639,7 @@ TEST_F(V8ViewsTest, test_auth) {
     // required for TRI_AddMethodVocbase(...)
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),
@@ -829,7 +829,7 @@ TEST_F(V8ViewsTest, test_auth) {
     // required for TRI_AddMethodVocbase(...)
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),
@@ -1030,7 +1030,7 @@ TEST_F(V8ViewsTest, test_auth) {
     // required for TRI_AddMethodVocbase(...)
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),
@@ -1186,7 +1186,7 @@ TEST_F(V8ViewsTest, test_auth) {
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use
     // with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),
@@ -1351,7 +1351,7 @@ TEST_F(V8ViewsTest, test_auth) {
     // required for TRI_AddMethodVocbase(...)
     v8::Context::Scope contextScope(context);
     // create and set inside 'isolate' for use with 'TRI_GET_GLOBALS()'
-    std::unique_ptr<V8Global<arangodb::ArangodServer>> v8g(
+    std::unique_ptr<V8Global> v8g(
         CreateV8Globals(server.server(), isolate.get(), 0));
     // otherwise v8:-utils::CreateErrorObject(...) will fail
     v8g->ArangoErrorTempl.Reset(isolate.get(),

--- a/tests/VocBase/LogicalDataSourceTest.cpp
+++ b/tests/VocBase/LogicalDataSourceTest.cpp
@@ -29,7 +29,6 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Metrics/MetricsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 #include "Sharding/ShardingFeature.h"
@@ -73,7 +72,7 @@ class LogicalViewImpl : public arangodb::LogicalView {
 
 class LogicalDataSourceTest : public ::testing::Test {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::vector<
       std::pair<arangodb::application_features::ApplicationFeature&, bool>>

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -31,7 +31,6 @@
 #include "Mocks/StorageEngineMock.h"
 
 #include "ApplicationFeatures/ApplicationServer.h"
-#include "Aql/QueryRegistry.h"
 #include "GeneralServer/AuthenticationFeature.h"
 #include "Logger/Logger.h"
 #include "Metrics/MetricsFeature.h"
@@ -44,7 +43,6 @@
 #include "Cluster/ClusterFeature.h"
 #include "Metrics/ClusterMetricsFeature.h"
 #include "Statistics/StatisticsFeature.h"
-#include "RestServer/arangod.h"
 #include "RestServer/DatabaseFeature.h"
 #include "RestServer/QueryRegistryFeature.h"
 
@@ -112,7 +110,7 @@ class LogicalViewTest
       public arangodb::tests::LogSuppressor<arangodb::Logger::AUTHENTICATION,
                                             arangodb::LogLevel::ERR> {
  protected:
-  arangodb::ArangodServer server;
+  arangodb::application_features::ApplicationServer server;
   StorageEngineMock engine;
   std::vector<
       std::pair<arangodb::application_features::ApplicationFeature&, bool>>

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -39,7 +39,6 @@
 #include "Logger/Logger.h"
 #include "Random/RandomGenerator.h"
 #include "Rest/Version.h"
-#include "RestServer/arangod.h"
 #include "RestServer/ServerIdFeature.h"
 #include "VocBase/Identifiers/ServerId.h"
 
@@ -119,7 +118,7 @@ int main(int argc, char* argv[]) {
 
   ARGV0 = subargv[0];
 
-  arangodb::ArangodServer server(nullptr, nullptr);
+  arangodb::application_features::ApplicationServer server(nullptr, nullptr);
   arangodb::ServerState state(server);
   state.setRole(arangodb::ServerState::ROLE_SINGLE);
   arangodb::ShellColorsFeature sc(server);


### PR DESCRIPTION
### Scope & Purpose

Enterprise companion: https://github.com/arangodb/enterprise/pull/1668

Only the arangod main function needs to know about ArangodServer. Everywhere else we can just use the ApplicationServer.

- [x] :hammer: Refactoring/simplification
