### PR TITLE
Grouped Sort State Machine Error

### DIFF
--- a/arangod/Aql/Executor/GroupedSortExecutor.cpp
+++ b/arangod/Aql/Executor/GroupedSortExecutor.cpp
@@ -35,7 +35,7 @@ std::tuple<ExecutorState, NoStats, AqlCall> GroupedSortExecutor::produceRows(
   while (!output.isFull()) {
     // return if group is finished or input is finished
     _storageBackend.consumeInputRange(inputRange);
-    if (!_storageBackend.hasPendingGroupOrOutput()) {
+    if (!_storageBackend.hasMoreReadyOutputRows()) {
       return {inputRange.upstreamState(), NoStats{}, std::move(upstreamCall)};
     }
     while (!output.isFull() && _storageBackend.hasMoreReadyOutputRows()) {
@@ -63,7 +63,7 @@ GroupedSortExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
   while (call.needSkipMore()) {
     // return if group is finished or input is finished
     _storageBackend.consumeInputRange(inputRange);
-    if (!_storageBackend.hasPendingGroupOrOutput()) {
+    if (!_storageBackend.hasMoreReadyOutputRows()) {
       return {inputRange.upstreamState(), NoStats{}, call.getSkipCount(),
               std::move(upstreamCall)};
     }

--- a/arangod/Aql/Executor/GroupedSortExecutor.cpp
+++ b/arangod/Aql/Executor/GroupedSortExecutor.cpp
@@ -28,22 +28,22 @@ std::tuple<ExecutorState, NoStats, AqlCall> GroupedSortExecutor::produceRows(
   AqlCall upstreamCall{};
 
   // fill with rest from before
-  while (!output.isFull() && _storageBackend.hasMore()) {
+  while (!output.isFull() && _storageBackend.hasMoreReadyOutputRows()) {
     _storageBackend.produceOutputRow(output);
   }
 
   while (!output.isFull()) {
     // return if group is finished or input is finished
     _storageBackend.consumeInputRange(inputRange);
-    if (!_storageBackend.hasMore()) {
+    if (!_storageBackend.hasPendingGroupOrOutput()) {
       return {inputRange.upstreamState(), NoStats{}, std::move(upstreamCall)};
     }
-    while (!output.isFull() && _storageBackend.hasMore()) {
+    while (!output.isFull() && _storageBackend.hasMoreReadyOutputRows()) {
       _storageBackend.produceOutputRow(output);
     }
   }
 
-  if (_storageBackend.hasMore()) {
+  if (_storageBackend.hasPendingGroupOrOutput()) {
     return {ExecutorState::HASMORE, NoStats{}, std::move(upstreamCall)};
   }
   return {inputRange.upstreamState(), NoStats{}, std::move(upstreamCall)};
@@ -55,7 +55,7 @@ GroupedSortExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
   AqlCall upstreamCall{};
 
   // fill with rest from before
-  while (call.needSkipMore() && _storageBackend.hasMore()) {
+  while (call.needSkipMore() && _storageBackend.hasMoreReadyOutputRows()) {
     _storageBackend.skipOutputRow();
     call.didSkip(1);
   }
@@ -63,17 +63,17 @@ GroupedSortExecutor::skipRowsRange(AqlItemBlockInputRange& inputRange,
   while (call.needSkipMore()) {
     // return if group is finished or input is finished
     _storageBackend.consumeInputRange(inputRange);
-    if (!_storageBackend.hasMore()) {
+    if (!_storageBackend.hasPendingGroupOrOutput()) {
       return {inputRange.upstreamState(), NoStats{}, call.getSkipCount(),
               std::move(upstreamCall)};
     }
-    while (call.needSkipMore() && _storageBackend.hasMore()) {
+    while (call.needSkipMore() && _storageBackend.hasMoreReadyOutputRows()) {
       _storageBackend.skipOutputRow();
       call.didSkip(1);
     }
   }
 
-  if (_storageBackend.hasMore()) {
+  if (_storageBackend.hasPendingGroupOrOutput()) {
     return {ExecutorState::HASMORE, NoStats{}, call.getSkipCount(),
             std::move(upstreamCall)};
   }

--- a/arangod/Aql/Executor/GroupedSortExecutorBackend.cpp
+++ b/arangod/Aql/Executor/GroupedSortExecutorBackend.cpp
@@ -90,7 +90,7 @@ void StorageBackend::consumeInputRange(AqlItemBlockInputRange& inputRange) {
   InputAqlItemRow input{CreateInvalidInputRowHint{}};
 
   // make sure that previous group was already fully consumed
-  TRI_ASSERT(!hasMore());
+  TRI_ASSERT(!hasMoreReadyOutputRows());
 
   while (inputRange.hasDataRow()) {
     auto rowId =
@@ -128,7 +128,7 @@ void StorageBackend::consumeInputRange(AqlItemBlockInputRange& inputRange) {
   guard.steal();
 }
 void StorageBackend::produceOutputRow(OutputAqlItemRow& output) {
-  TRI_ASSERT(hasMore());
+  TRI_ASSERT(hasMoreReadyOutputRows());
   InputAqlItemRow inRow(_inputBlocks[_finishedGroup[_returnNext].first],
                         _finishedGroup[_returnNext].second);
   output.copyRow(inRow);
@@ -136,11 +136,14 @@ void StorageBackend::produceOutputRow(OutputAqlItemRow& output) {
   ++_returnNext;
 }
 void StorageBackend::skipOutputRow() noexcept {
-  TRI_ASSERT(hasMore());
+  TRI_ASSERT(hasMoreReadyOutputRows());
   ++_returnNext;
 }
-bool StorageBackend::hasMore() const {
+bool StorageBackend::hasMoreReadyOutputRows() const {
   return _returnNext < _finishedGroup.size();
+}
+bool StorageBackend::hasPendingGroupOrOutput() const {
+  return hasMoreReadyOutputRows() or not _currentGroup.empty();
 }
 
 void StorageBackend::startNewGroup(std::vector<RowIndex>&& newGroup) {

--- a/arangod/Aql/Executor/GroupedSortExecutorBackend.h
+++ b/arangod/Aql/Executor/GroupedSortExecutorBackend.h
@@ -39,7 +39,8 @@ struct StorageBackend {
   void consumeInputRange(AqlItemBlockInputRange& inputRange);
   void produceOutputRow(OutputAqlItemRow& output);
   void skipOutputRow() noexcept;
-  bool hasMore() const;
+  bool hasMoreReadyOutputRows() const;
+  bool hasPendingGroupOrOutput() const;
   using RowIndex = std::pair<uint32_t, uint32_t>;
 
  private:

--- a/tests/Aql/Executor/GroupedSortExecutorTest.cpp
+++ b/tests/Aql/Executor/GroupedSortExecutorTest.cpp
@@ -449,3 +449,37 @@ TEST_P(GroupedSortExecutorTest, skip_too_much) {
       .expectedState(ExecutionState::DONE)
       .run();
 }
+
+TEST_P(GroupedSortExecutorTest, offset_and_limit_return_next_group) {
+  auto groupedRegisterId = 0;
+  auto sortRegisterId = 1;
+  makeExecutorTestHelper<2, 2>()
+      .addConsumer<GroupedSortExecutor>(
+          registerInfos(RegIdSet{sortRegisterId, groupedRegisterId}),
+          groupedSortExecutorInfos({groupedRegisterId}, {sortRegisterId}),
+          ExecutionNode::SORT)
+      .setInputSplitType(GetParam())
+      .setInputValue({{0, 5}, {1, 7}})
+      .expectOutput({groupedRegisterId, sortRegisterId}, {{1, 7}})
+      .setCall(AqlCall{1, false, 1, AqlCall::LimitType::HARD})
+      .expectSkipped(1)
+      .expectedState(ExecutionState::DONE)
+      .run();
+}
+
+TEST_P(GroupedSortExecutorTest, reports_hasmore_when_group_still_pending) {
+  auto groupedRegisterId = 0;
+  auto sortRegisterId = 1;
+  makeExecutorTestHelper<2, 2>()
+      .addConsumer<GroupedSortExecutor>(
+          registerInfos(RegIdSet{sortRegisterId, groupedRegisterId}),
+          groupedSortExecutorInfos({groupedRegisterId}, {sortRegisterId}),
+          ExecutionNode::SORT)
+      .setInputSplitType(GetParam())
+      .setInputValue({{2, 3}, {2, 1}, {199, 8}})
+      .expectOutput({groupedRegisterId, sortRegisterId}, {{2, 1}, {2, 3}})
+      .setCall(AqlCall{0, false, 2, AqlCall::LimitType::SOFT})
+      .expectSkipped(0)
+      .expectedState(ExecutionState::HASMORE)
+      .run();
+}

--- a/tests/js/client/aql/aql-optimizer-indexes-group-sort.js
+++ b/tests/js/client/aql/aql-optimizer-indexes-group-sort.js
@@ -115,6 +115,85 @@ function optimizerIndexesGroupSortTestSuite() {
     },
 
     ///////////////////////////////////////////////////////////////////////////////
+    /// @brief regression test for https://github.com/arangodb/arangodb/issues/22909
+    ////////////////////////////////////////////////////////////////////////////////
+
+    test_group_sort_with_offset_limit_returns_pending_group: function () {
+      const collection = create_collection();
+      collection.insert([
+        { _key: "000000", a: 0, b: 0, payload: { i: 0, text: "" } },
+        { _key: "000001", a: 1, b: 0, payload: { i: 1, text: "x" } },
+      ]);
+      collection.ensureIndex({ type: "persistent", name: "idx_a", fields: ["a"] });
+      waitForEstimatorSync();
+
+      const query = "FOR d IN @@collection FILTER d.a >= 0 SORT d.a, d._key LIMIT 1, 1 RETURN [d._key, d.a, d.b, d.payload]";
+      const plan = query_plan(query, collection.name());
+      assertTrue(query_plan_uses_index_for_sorting(plan), plan.rules);
+      assertTrue(sort_node_does_a_group_sort(plan), plan.nodes);
+      assertEqual([["000001", 1, 0, { i: 1, text: "x" }]], execute(query, collection.name()), query);
+    },
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief test index usage with limit and offset
+    ////////////////////////////////////////////////////////////////////////////////
+
+    test_indexed_group_sort_with_limit_gives_same_results_as_unindexed_sort: function () {
+      let randomNumber = randomNumberGeneratorInt(seed);
+      const row_count = 2000;
+      const collection = create_collection();
+      collection.insert(Array.from({ length: row_count }, (_, index) => index).map(i => {
+        return { a: i % 9, x: row_count - i - 1, b: randomNumber() };
+      }));
+      collection.ensureIndex({ type: "persistent", fields: ["a", "b"] });
+      waitForEstimatorSync();
+      const c_expected = copy_collection(collection.name());
+
+      for (let offset of [0, 1, 5, 222]) {
+        for (let limit of [0, 1, 8, 9, 100, 1000, 1999, 2000, 2001]) {
+          const query = "FOR doc IN @@collection SORT doc.a, doc.x LIMIT " + offset + ", " + limit + " RETURN [doc.a, doc.x, doc.b]";
+          const plan = query_plan(query, collection.name());
+          assertTrue(query_plan_uses_index_for_sorting(plan), query + ': ' + plan.rules);
+          assertTrue(sort_node_does_a_group_sort(plan), query + ': ' + plan.nodes);
+          assertEqual(
+            db._query(query, { "@collection": c_expected.name() }).toArray(),
+            db._query(query, { "@collection": collection.name() }).toArray(),
+            query);
+        }
+      }
+    },
+
+    ///////////////////////////////////////////////////////////////////////////////
+    /// @brief test index usage with limit and fullCount
+    ////////////////////////////////////////////////////////////////////////////////
+
+    test_indexed_group_sort_with_fullcount_gives_same_results_as_unindexed_sort: function () {
+      let randomNumber = randomNumberGeneratorInt(seed);
+      const row_count = 2000;
+      const collection = create_collection();
+      collection.insert(Array.from({ length: row_count }, (_, index) => index).map(i => {
+        return { a: i % 9, x: row_count - i - 1, b: randomNumber() };
+      }));
+      collection.ensureIndex({ type: "persistent", fields: ["a", "b"] });
+      waitForEstimatorSync();
+      const c_expected = copy_collection(collection.name());
+
+      for (let offset of [0, 5, 100]) {
+        for (let limit of [1, 9, 100, 2000]) {
+          const query = "FOR doc IN @@collection SORT doc.a, doc.x LIMIT " + offset + ", " + limit + " RETURN [doc.a, doc.x, doc.b]";
+          const plan = query_plan(query, collection.name());
+          assertTrue(query_plan_uses_index_for_sorting(plan), query + ': ' + plan.rules);
+          assertTrue(sort_node_does_a_group_sort(plan), query + ': ' + plan.nodes);
+          const actual = db._query(query, { "@collection": collection.name() }, { fullCount: true });
+          const expected = db._query(query, { "@collection": c_expected.name() }, { fullCount: true });
+          assertEqual(expected.toArray(), actual.toArray(), query);
+          assertEqual(row_count, actual.getExtra().stats.fullCount, query);
+          assertEqual(expected.getExtra().stats.fullCount, actual.getExtra().stats.fullCount, query);
+        }
+      }
+    },
+
+    ///////////////////////////////////////////////////////////////////////////////
     /// @brief test index usage
     ////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/js/client/aql/aql-optimizer-indexes-group-sort.js
+++ b/tests/js/client/aql/aql-optimizer-indexes-group-sort.js
@@ -140,7 +140,7 @@ function optimizerIndexesGroupSortTestSuite() {
 
     test_indexed_group_sort_with_limit_gives_same_results_as_unindexed_sort: function () {
       let randomNumber = randomNumberGeneratorInt(seed);
-      const row_count = 2000;
+      const row_count = 80;
       const collection = create_collection();
       collection.insert(Array.from({ length: row_count }, (_, index) => index).map(i => {
         return { a: i % 9, x: row_count - i - 1, b: randomNumber() };
@@ -149,12 +149,12 @@ function optimizerIndexesGroupSortTestSuite() {
       waitForEstimatorSync();
       const c_expected = copy_collection(collection.name());
 
-      for (let offset of [0, 1, 5, 222]) {
-        for (let limit of [0, 1, 8, 9, 100, 1000, 1999, 2000, 2001]) {
+      for (let offset of [1, 5, 75]) {
+        for (let limit of [1, 8, 9, 19, 25, 78, 79, 81]) {
           const query = "FOR doc IN @@collection SORT doc.a, doc.x LIMIT " + offset + ", " + limit + " RETURN [doc.a, doc.x, doc.b]";
           const plan = query_plan(query, collection.name());
-          assertTrue(query_plan_uses_index_for_sorting(plan), query + ': ' + plan.rules);
-          assertTrue(sort_node_does_a_group_sort(plan), query + ': ' + plan.nodes);
+          assertTrue(query_plan_uses_index_for_sorting(plan), plan.rules);
+          assertTrue(sort_node_does_a_group_sort(plan), plan.nodes);
           assertEqual(
             db._query(query, { "@collection": c_expected.name() }).toArray(),
             db._query(query, { "@collection": collection.name() }).toArray(),
@@ -169,7 +169,7 @@ function optimizerIndexesGroupSortTestSuite() {
 
     test_indexed_group_sort_with_fullcount_gives_same_results_as_unindexed_sort: function () {
       let randomNumber = randomNumberGeneratorInt(seed);
-      const row_count = 2000;
+      const row_count = 80;
       const collection = create_collection();
       collection.insert(Array.from({ length: row_count }, (_, index) => index).map(i => {
         return { a: i % 9, x: row_count - i - 1, b: randomNumber() };
@@ -178,8 +178,8 @@ function optimizerIndexesGroupSortTestSuite() {
       waitForEstimatorSync();
       const c_expected = copy_collection(collection.name());
 
-      for (let offset of [0, 5, 100]) {
-        for (let limit of [1, 9, 100, 2000]) {
+      for (let offset of [1, 5, 75]) {
+        for (let limit of [1, 8, 9, 19, 25, 78, 79, 81]) {
           const query = "FOR doc IN @@collection SORT doc.a, doc.x LIMIT " + offset + ", " + limit + " RETURN [doc.a, doc.x, doc.b]";
           const plan = query_plan(query, collection.name());
           assertTrue(query_plan_uses_index_for_sorting(plan), query + ': ' + plan.rules);


### PR DESCRIPTION
### Scope & Purpose
Grouped sort did not continue work, when skipping ends right now a group, while another group has already been started during reading of the current input block.

- GitHub Issue: https://github.com/arangodb/arangodb/issues/22909