### PR TITLE
COR-569: Added activity to report ArangoSearch consolidation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* COR-569: Added activity to report ArangoSearch consolidation
+
 * BTS-2421: Fixed a bug where a dump taken while a background vector index build
   was in its ingestion phase omitted the index, causing a restore to silently
   drop it. Vector indexes are now always included in dumps.

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -62,6 +62,7 @@
 #include <absl/cleanup/cleanup.h>
 #include <absl/strings/str_cat.h>
 #include <filesystem>
+#include "arangosearch_activity.h"
 
 using namespace std::literals;
 
@@ -842,8 +843,7 @@ ResultT<IResearchDataStore::CommitResult> IResearchDataStore::commit(
 /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
 ////////////////////////////////////////////////////////////////////////////////
 IResearchDataStore::UnsafeOpResult IResearchDataStore::commitUnsafe(
-    bool wait, irs::ProgressReportCallback const& progress,
-    CommitResult& code) {
+    bool wait, irs::ProgressReportCallback const progress, CommitResult& code) {
   auto begin = std::chrono::steady_clock::now();
   auto result = commitUnsafeImpl(wait, progress, code);
   uint64_t timeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -881,8 +881,7 @@ IResearchDataStore::UnsafeOpResult IResearchDataStore::commitUnsafe(
 /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
 ////////////////////////////////////////////////////////////////////////////////
 Result IResearchDataStore::commitUnsafeImpl(
-    bool wait, irs::ProgressReportCallback const& progress,
-    CommitResult& code) {
+    bool wait, irs::ProgressReportCallback const progress, CommitResult& code) {
   code = CommitResult::NO_CHANGES;
   // NOTE: assumes that '_asyncSelf' is read-locked (for use with async tasks)
   TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
@@ -1030,7 +1029,7 @@ Result IResearchDataStore::commitUnsafeImpl(
 ////////////////////////////////////////////////////////////////////////////////
 IResearchDataStore::UnsafeOpResult IResearchDataStore::consolidateUnsafe(
     IResearchDataStoreMeta::ConsolidationPolicy const& policy,
-    irs::MergeWriter::FlushProgress const& progress, bool& emptyConsolidation) {
+    irs::MergeWriter::FlushProgress const progress, bool& emptyConsolidation) {
   auto begin = std::chrono::steady_clock::now();
   auto result = consolidateUnsafeImpl(policy, progress, emptyConsolidation);
   uint64_t timeMs = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1050,7 +1049,8 @@ IResearchDataStore::UnsafeOpResult IResearchDataStore::consolidateUnsafe(
 ////////////////////////////////////////////////////////////////////////////////
 Result IResearchDataStore::consolidateUnsafeImpl(
     IResearchDataStoreMeta::ConsolidationPolicy const& policy,
-    irs::MergeWriter::FlushProgress const& progress, bool& emptyConsolidation) {
+    irs::MergeWriter::FlushProgress const flushProgress,
+    bool& emptyConsolidation) {
   emptyConsolidation = false;  // TODO Why?
 
   if (!policy.policy()) {
@@ -1066,8 +1066,44 @@ Result IResearchDataStore::consolidateUnsafeImpl(
   TRI_ASSERT(_dataStore);  // must be valid if _asyncSelf->get() is valid
 
   try {
+    std::shared_ptr<SegmentConsolidationActivity> consolidationActivity;
+    //  Reporting consolidation activity relies on the IndexWriter's progress
+    //  callbacks. In the beginConsolidation callback we will use the
+    //  consolidation candidates information received from
+    //  IndexWriter::Consolidate to initialize the SegmentConsolidationActivity.
+    //  And in the endConsolidation callback we will use the ConsolidationResult
+    //  info and end the activity.
+    decltype(irs::IndexWriter::ConsolidationProgress::beginConsolidation)
+        beginConsolidation =
+            [&](const std::vector<irs::SegmentInfo>& candidates) {
+              SegmentConsolidationActivityData activityData;
+              for (const irs::SegmentInfo& segment : candidates) {
+                SegmentConsolidationActivityEntry entry;
+                entry.name = segment.name;
+                entry.byte_size = segment.byte_size;
+                entry.docs_count = segment.docs_count;
+                entry.live_docs_count = segment.live_docs_count;
+
+                activityData.candidates.push_back(std::move(entry));
+              }
+
+              consolidationActivity =
+                  arangodb::activities::make<SegmentConsolidationActivity>(
+                      activityData);
+            };
+
+    decltype(irs::IndexWriter::ConsolidationProgress::endConsolidation)
+        endConsolidation = [&](const irs::ConsolidationResult& result) {
+          consolidationActivity.reset();
+        };
+
+    irs::IndexWriter::ConsolidationProgress progress{
+        .beginConsolidation = std::move(beginConsolidation),
+        .endConsolidation = std::move(endConsolidation),
+        .flushProgress = std::move(flushProgress)};
+
     auto const res =
-        _dataStore._writer->Consolidate(policy.policy(), nullptr, progress);
+        _dataStore._writer->Consolidate(policy.policy(), progress, nullptr);
     if (!res) {
       return {
           TRI_ERROR_INTERNAL,

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -376,7 +376,7 @@ class IResearchDataStore {
   /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
   //////////////////////////////////////////////////////////////////////////////
   UnsafeOpResult commitUnsafe(bool wait,
-                              irs::ProgressReportCallback const& progress,
+                              irs::ProgressReportCallback const progress,
                               CommitResult& code);
 
   //////////////////////////////////////////////////////////////////////////////
@@ -385,8 +385,7 @@ class IResearchDataStore {
   //////////////////////////////////////////////////////////////////////////////
   UnsafeOpResult consolidateUnsafe(
       IResearchDataStoreMeta::ConsolidationPolicy const& policy,
-      irs::MergeWriter::FlushProgress const& progress,
-      bool& emptyConsolidation);
+      irs::MergeWriter::FlushProgress const progress, bool& emptyConsolidation);
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief run filesystem cleanup on the data store
@@ -399,8 +398,7 @@ class IResearchDataStore {
   /// @param wait even if other thread is committing
   /// @note assumes that '_asyncSelf' is read-locked (for use with async tasks)
   //////////////////////////////////////////////////////////////////////////////
-  Result commitUnsafeImpl(bool wait,
-                          irs::ProgressReportCallback const& progress,
+  Result commitUnsafeImpl(bool wait, irs::ProgressReportCallback const progress,
                           CommitResult& code);
 
   //////////////////////////////////////////////////////////////////////////////
@@ -409,8 +407,7 @@ class IResearchDataStore {
   //////////////////////////////////////////////////////////////////////////////
   Result consolidateUnsafeImpl(
       IResearchDataStoreMeta::ConsolidationPolicy const& policy,
-      irs::MergeWriter::FlushProgress const& progress,
-      bool& emptyConsolidation);
+      irs::MergeWriter::FlushProgress const progress, bool& emptyConsolidation);
 
   void initAsyncSelf();
 

--- a/arangod/IResearch/arangosearch_activity.h
+++ b/arangod/IResearch/arangosearch_activity.h
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Koushal Kawade
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include "Activities/RegistryGlobalVariable.h"
+#include "Activities/GuardedActivity.h"
+
+namespace arangodb::iresearch {
+
+//  SegmentConsolidationActivityEntry
+//  Represents info about a single segment which
+//  is part of the consolidation candidate
+struct SegmentConsolidationActivityEntry {
+  std::string name;
+  uint64_t docs_count{};
+  uint64_t live_docs_count{};
+  uint64_t byte_size{};
+};
+
+template<typename Inspector>
+inline auto inspect(Inspector& f, SegmentConsolidationActivityEntry& x) {
+  return f.object(x).fields(f.field("name", x.name),
+                            f.field("byteSize", x.byte_size),
+                            f.field("docsCount", x.docs_count),
+                            f.field("liveDocsCount", x.live_docs_count));
+}
+
+//  SegmentConsolidationActivityData
+//  Represents info about all the segments comprising
+//  a consolidation operation
+struct SegmentConsolidationActivityData {
+  std::vector<SegmentConsolidationActivityEntry> candidates;
+  bool operator==(SegmentConsolidationActivityData const&) const = default;
+};
+
+template<typename Inspector>
+inline auto inspect(Inspector& f, SegmentConsolidationActivityData& x) {
+  return f.object(x).fields(f.field("segments", x.candidates));
+}
+
+//  SegmentConsolidationActivity
+struct SegmentConsolidationActivity
+    : arangodb::activities::GuardedActivity<SegmentConsolidationActivity,
+                                            SegmentConsolidationActivityData> {
+  SegmentConsolidationActivity(arangodb::activities::ActivityId id,
+                               arangodb::activities::ActivityHandle parent,
+                               SegmentConsolidationActivityData data)
+      : arangodb::activities::GuardedActivity<SegmentConsolidationActivity,
+                                              SegmentConsolidationActivityData>(
+            id, parent, "ArangoSearchConsolidation", std::move(data)) {}
+};
+
+}  // namespace arangodb::iresearch

--- a/lib/iresearch/core/index/index_writer.cpp
+++ b/lib/iresearch/core/index/index_writer.cpp
@@ -1338,8 +1338,8 @@ uint64_t IndexWriter::CurrentSegmentId() const noexcept {
 }
 
 ConsolidationResult IndexWriter::Consolidate(
-  const ConsolidationPolicy& policy, format::ptr codec,
-  const MergeWriter::FlushProgress& progress) {
+  const ConsolidationPolicy& policy,
+  const ConsolidationProgress& progress, format::ptr codec) {
   REGISTER_TIMER_DETAILED();
   if (!codec) {
     // use default codec if not specified
@@ -1396,8 +1396,21 @@ ConsolidationResult IndexWriter::Consolidate(
     // register for consolidation
     consolidating_segments_.reserve(consolidating_segments_.size() +
                                     candidates.size());
-    for (const auto* candidate : candidates) {
-      consolidating_segments_.emplace(candidate->Meta().name);
+
+    std::vector<irs::SegmentInfo> candidateSegments;
+    for (const auto& candidate : candidates) {
+      const auto& meta = candidate->Meta();
+      consolidating_segments_.emplace(meta.name);
+
+      //  Full SegmentInfo to be used with callbacks
+      irs::SegmentInfo segment(meta.name, meta.byte_size);
+      segment.docs_count = meta.docs_count;
+      segment.live_docs_count = meta.live_docs_count;
+      candidateSegments.push_back(segment);
+    }
+
+    if (progress.beginConsolidation) {
+      progress.beginConsolidation(candidateSegments);
     }
   }
 
@@ -1434,6 +1447,12 @@ ConsolidationResult IndexWriter::Consolidate(
 
   ConsolidationResult result{candidates.size(), ConsolidationError::FAIL};
 
+  Finally end_consolidation = [&]() noexcept {
+    if (progress.endConsolidation) {
+      progress.endConsolidation(result);
+    }
+  };
+
   IndexSegment consolidation_segment;
   consolidation_segment.meta.codec = codec;  // Should use new codec
   consolidation_segment.meta.version = 0;    // Reset version for new segment
@@ -1446,7 +1465,7 @@ ConsolidationResult IndexWriter::Consolidate(
   merger.Reset(candidates.begin(), candidates.end());
 
   // We do not persist segment meta since some removals may come later
-  if (!merger.Flush(consolidation_segment.meta, progress)) {
+  if (!merger.Flush(consolidation_segment.meta, progress.flushProgress)) {
     // Nothing to consolidate or consolidation failure
     return result;
   }

--- a/lib/iresearch/core/index/index_writer.hpp
+++ b/lib/iresearch/core/index/index_writer.hpp
@@ -472,6 +472,17 @@ class IndexWriter : private util::noncopyable {
   static_assert(std::is_nothrow_move_constructible_v<Transaction>);
   static_assert(std::is_nothrow_move_assignable_v<Transaction>);
 
+  struct ConsolidationProgress {
+    //  Called after candidates are assembled and consolidation is about to begin.
+    std::function<void(const std::vector<irs::SegmentInfo>& candidates)> beginConsolidation;
+
+    //  Called after segments merging operation is completed.
+    std::function<void(const ConsolidationResult&)> endConsolidation;
+
+    //  Stop token used to abort ongoing consolidation operation
+    MergeWriter::FlushProgress flushProgress;
+  };
+
   // Returns a context allowing index modification operations
   // All document insertions will be applied to the same segment on a
   // best effort basis, e.g. a flush_all() will cause a segment switch
@@ -512,8 +523,8 @@ class IndexWriter : private util::noncopyable {
   // commit, however, the resulting acceptor will only be segments not
   // yet marked for consolidation by other policies in the same commit
   ConsolidationResult Consolidate(
-    const ConsolidationPolicy& policy, format::ptr codec = nullptr,
-    const MergeWriter::FlushProgress& progress = {});
+    const ConsolidationPolicy& policy,
+    const ConsolidationProgress& progress, format::ptr codec = nullptr);
 
   // Imports index from the specified index reader into new segment
   // Reader the index reader to import.

--- a/lib/iresearch/tests/index/index_death_tests.cpp
+++ b/lib/iresearch/tests/index/index_death_tests.cpp
@@ -323,6 +323,17 @@ void open_reader(
   ASSERT_EQ(irs::doc_limits::eof(), live_docs->value());
 }
 
+auto beginCons = [](const auto& ) {
+};
+auto endCons = [](const auto& ) {
+};
+auto flushProgress = []() {
+  return true;
+};
+
+irs::IndexWriter::ConsolidationProgress callbacks = { .beginConsolidation = beginCons,
+  .endConsolidation = endCons, .flushProgress = flushProgress };
+
 }  // namespace
 
 TEST(index_death_test_formats_10, index_meta_write_fail_1st_phase) {
@@ -1435,13 +1446,13 @@ TEST(index_death_test_formats_10,
 
     // segment meta creation failure
     ASSERT_THROW(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)),
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks),
       irs::io_error);
     ASSERT_FALSE(writer->Begin());  // nothing to flush
 
     // segment meta synchronization failure
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     ASSERT_THROW(writer->Begin(), irs::io_error);
     ASSERT_FALSE(writer->Begin());  // nothing to flush
 
@@ -1567,7 +1578,7 @@ TEST(index_death_test_formats_10,
                        doc3->stored.begin(), doc3->stored.end()));
     ASSERT_TRUE(writer->Begin());  // start transaction
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      consolidate_all)));            // register pending consolidation
+      consolidate_all), callbacks));            // register pending consolidation
     ASSERT_FALSE(writer->Commit());  // commit started transaction
     tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                   irs::DirectoryReader(dir));
@@ -1580,7 +1591,7 @@ TEST(index_death_test_formats_10,
                        doc4->stored.begin(), doc4->stored.end()));
     ASSERT_TRUE(writer->Begin());  // start transaction
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      consolidate_all)));            // register pending consolidation
+      consolidate_all), callbacks));            // register pending consolidation
     ASSERT_FALSE(writer->Commit());  // commit started transaction
     tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                   irs::DirectoryReader(dir));
@@ -1757,7 +1768,7 @@ TEST(index_death_test_formats_10,
     std::thread consolidation_thread([&writer]() {
       const irs::index_utils::ConsolidateCount consolidate_all;
       ASSERT_THROW(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)),
+        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks),
         irs::io_error);  // consolidate
     });
 
@@ -1899,7 +1910,7 @@ TEST(index_death_test_formats_10,
     std::thread consolidation_thread([&writer]() {
       const irs::index_utils::ConsolidateCount consolidate_all;
       ASSERT_TRUE(writer->Consolidate(
-        irs::index_utils::MakePolicy(consolidate_all)));  // consolidate
+        irs::index_utils::MakePolicy(consolidate_all), callbacks));  // consolidate
     });
 
     dir.wait_for_blocker();
@@ -2058,7 +2069,7 @@ TEST(index_death_test_formats_10, segment_components_write_fail_consolidation) {
 
     while (!dir.no_failures()) {
       ASSERT_THROW(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)),
+        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks),
         irs::io_error);
       ASSERT_FALSE(writer->Begin());  // nothing to flush
     }
@@ -2179,7 +2190,7 @@ TEST(index_death_test_formats_10, segment_components_sync_fail_consolidation) {
 
     while (!dir.no_failures()) {
       ASSERT_TRUE(
-        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+        writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
       ASSERT_THROW(writer->Begin(), irs::io_error);  // nothing to flush
       ASSERT_FALSE(writer->Begin());
     }
@@ -3120,7 +3131,7 @@ TEST(index_death_test_formats_14, fails_in_consolidate_with_removals) {
     const irs::index_utils::ConsolidateCount consolidate_all;
 
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     ASSERT_TRUE(writer->Commit());
     tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                   irs::DirectoryReader(dir));
@@ -3244,7 +3255,7 @@ TEST(index_death_test_formats_14, fails_in_exists) {
     const irs::index_utils::ConsolidateCount consolidate_all;
 
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     ASSERT_TRUE(writer->Commit());
     tests::AssertSnapshotEquality(writer->GetSnapshot(),
                                   irs::DirectoryReader(dir));
@@ -3433,7 +3444,7 @@ TEST(index_death_test_formats_14, fails_in_length) {
 
     const auto num_failures_before = dir.num_failures();
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     ASSERT_EQ(num_failures_before, dir.num_failures());
 
     irs::directory_cleaner::clean(dir);

--- a/lib/iresearch/tests/index/index_profile_tests.cpp
+++ b/lib/iresearch/tests/index/index_profile_tests.cpp
@@ -59,6 +59,7 @@ class index_profile_test_case : public tests::index_test_base {
   std::atomic_uint64_t tick_{irs::writer_limits::kMinTick + 1};
   std::mutex commit_mutex;
   bool onTick_{false};
+  irs::IndexWriter::ConsolidationProgress callbacks;
 
   void TransactionTick(irs::IndexWriter::Transaction& trx) {
     if (onTick_) {
@@ -77,6 +78,19 @@ class index_profile_test_case : public tests::index_test_base {
   }
 
  public:
+  index_profile_test_case() {
+    auto beginCons = [](const auto& ) {
+    };
+    auto endCons = [](const auto& ) {
+    };
+    auto flushProgress = []() {
+      return true;
+    };
+
+    callbacks = { .beginConsolidation = beginCons,
+      .endConsolidation = endCons, .flushProgress = flushProgress };
+  }
+
   void SetOnTick(bool value) noexcept { onTick_ = value; }
 
   void profile_bulk_index(size_t num_insert_threads, size_t num_import_threads,
@@ -542,9 +556,9 @@ class index_profile_test_case : public tests::index_test_base {
     auto writer = open_writer(irs::OM_CREATE, options);
 
     thread_pool.run(
-      [consolidate_interval, &working, &writer, &policy]() -> void {
+      [consolidate_interval, &working, &writer, &policy, &callbacks = this->callbacks]() -> void {
         while (working.load()) {
-          writer->Consolidate(policy);
+          writer->Consolidate(policy, callbacks);
           std::this_thread::sleep_for(
             std::chrono::milliseconds(consolidate_interval));
         }
@@ -563,7 +577,7 @@ class index_profile_test_case : public tests::index_test_base {
       writer->Commit({.tick = CommitTick()});
       EXPECT_FALSE(writer->Commit());
     }
-    ASSERT_TRUE(writer->Consolidate(policy));
+    ASSERT_TRUE(writer->Consolidate(policy, callbacks));
     {
       std::unique_lock commit_lock{commit_mutex};
       writer->Commit({.tick = CommitTick()});

--- a/lib/iresearch/tests/index/index_tests.cpp
+++ b/lib/iresearch/tests/index/index_tests.cpp
@@ -6859,7 +6859,7 @@ TEST_P(index_test_case, reuse_segment_writer) {
   // merge all segments
   {
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
   }
@@ -7156,7 +7156,7 @@ TEST_P(index_test_case, concurrent_consolidation) {
           ConsolidateRange(candidates, segments, reader, i, i + 2);
         };
 
-        if (writer->Consolidate(policy)) {
+        if (writer->Consolidate(policy, callbacks)) {
           writer->Commit();
         }
 
@@ -7255,13 +7255,13 @@ TEST_P(index_test_case, concurrent_consolidation_dedicated_commit) {
   std::vector<std::thread> pool;
 
   for (size_t i = 0; i < thread_count; ++i) {
-    pool.emplace_back(std::thread([&wait_for_all, &writer, i]() mutable {
+    pool.emplace_back(std::thread([&wait_for_all, &writer, i, &callbacks = this->callbacks]() mutable {
       wait_for_all();
 
       size_t num_segments = std::numeric_limits<size_t>::max();
 
       while (num_segments > 1) {
-        auto policy = [&i, &num_segments](
+        auto policy = [&i, &num_segments, &callbacks](
                         irs::Consolidation& candidates,
                         const irs::IndexReader& reader,
                         const irs::ConsolidatingSegments& segments,
@@ -7270,7 +7270,7 @@ TEST_P(index_test_case, concurrent_consolidation_dedicated_commit) {
           ConsolidateRange(candidates, segments, reader, i, i + 2);
         };
 
-        writer->Consolidate(policy);
+        writer->Consolidate(policy, callbacks);
 
         i = (i + 1) % num_segments;
       }
@@ -7383,7 +7383,7 @@ TEST_P(index_test_case, concurrent_consolidation_two_phase_dedicated_commit) {
   std::vector<std::thread> pool;
 
   for (size_t i = 0; i < thread_count; ++i) {
-    pool.emplace_back(std::thread([&wait_for_all, &writer, i]() mutable {
+    pool.emplace_back(std::thread([&wait_for_all, &writer, i, &callbacks = this->callbacks]() mutable {
       wait_for_all();
 
       size_t num_segments = std::numeric_limits<size_t>::max();
@@ -7398,7 +7398,7 @@ TEST_P(index_test_case, concurrent_consolidation_two_phase_dedicated_commit) {
           ConsolidateRange(candidates, segments, meta, i, i + 2);
         };
 
-        writer->Consolidate(policy);
+        writer->Consolidate(policy, callbacks);
 
         i = (i + 1) % num_segments;
       }
@@ -7527,7 +7527,7 @@ TEST_P(index_test_case, concurrent_consolidation_cleanup) {
           ConsolidateRange(candidates, segments, reader, i, i + 2);
         };
 
-        if (writer->Consolidate(policy)) {
+        if (writer->Consolidate(policy, callbacks)) {
           writer->Commit();
           irs::directory_cleaner::clean(this->dir());
         }
@@ -7628,9 +7628,9 @@ TEST_P(index_test_case, consolidate_single_segment) {
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // nothing to consolidate
     ASSERT_TRUE(writer->Consolidate(
-      check_consolidating_segments));  // check segments registered for
+      check_consolidating_segments, callbacks));  // check segments registered for
                                        // consolidation
     writer->Commit();
     AssertSnapshotEquality(*writer);
@@ -7671,11 +7671,11 @@ TEST_P(index_test_case, consolidate_single_segment) {
     dir().visit(get_number_of_files_in_segments);
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // nothing to consolidate
     expected_consolidating_segments = {
       0};  // expect first segment to be marked for consolidation
     ASSERT_TRUE(writer->Consolidate(
-      check_consolidating_segments));  // check segments registered for
+      check_consolidating_segments, callbacks));  // check segments registered for
                                        // consolidation
     writer->Commit();
     AssertSnapshotEquality(*writer);
@@ -7788,10 +7788,10 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     // acquire directory lock, and block consolidation
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
+    std::thread consolidation_thread([&]() {
       // consolidate
       ASSERT_TRUE(writer->Consolidate(
-        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{})));
+        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{}), callbacks));
 
       const std::vector<size_t> expected_consolidating_segments{0, 1};
       auto check_consolidating_segments =
@@ -7808,7 +7808,7 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
           }
         };
       // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
     });
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir));
@@ -7972,10 +7972,10 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     // acquire directory lock, and block consolidation
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
+    std::thread consolidation_thread([&writer, &callbacks = this->callbacks]() {
       // consolidation will fail because of
       ASSERT_FALSE(writer->Consolidate(irs::index_utils::MakePolicy(
-        irs::index_utils::ConsolidateCount())));  // consolidate
+        irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
       auto check_consolidating_segments =
         [](irs::Consolidation& /*candidates*/, const irs::IndexReader& /*meta*/,
@@ -7984,7 +7984,7 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
           ASSERT_TRUE(consolidating_segments.empty());
         };
       // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
     });
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir));
@@ -8145,10 +8145,10 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     // acquire directory lock, and block consolidation
     dir.intermediate_commits_lock.lock();
 
-    std::thread consolidation_thread([&writer]() {
+    std::thread consolidation_thread([&writer, &callbacks = this->callbacks]() {
       // consolidation will fail because of
       ASSERT_TRUE(writer->Consolidate(
-        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+        irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
       const std::vector<size_t> expected_consolidating_segments{0, 1};
       auto check_consolidating_segments =
@@ -8165,7 +8165,7 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
           }
         };
       // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
     });
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir));
@@ -8307,10 +8307,10 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
     dir.intermediate_commits_lock
       .lock();  // acquire directory lock, and block consolidation
 
-    std::thread consolidation_thread([&writer]() {
+    std::thread consolidation_thread([&writer, &callbacks = this->callbacks]() {
       // consolidation will fail because of
       ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-        irs::index_utils::ConsolidateCount())));  // consolidate
+        irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
       const std::vector<size_t> expected_consolidating_segments{0, 1};
       auto check_consolidating_segments =
@@ -8327,7 +8327,7 @@ TEST_P(index_test_case, segment_consolidate_long_running) {
           }
         };
       // check segments registered for consolidation
-      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+      ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
     });
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir));
@@ -8498,7 +8498,7 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
     writer->Begin();
     writer->Clear();
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit transaction
 
@@ -8529,7 +8529,7 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
 
     writer->Begin();
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
     writer->Clear();
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit transaction
@@ -8556,17 +8556,17 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
     AssertSnapshotEquality(*writer);
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->Clear();
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit transaction
@@ -8594,11 +8594,11 @@ TEST_P(index_test_case, segment_consolidate_clear_commit) {
 
     writer->Clear();
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit transaction
@@ -8674,21 +8674,21 @@ TEST_P(index_test_case, segment_consolidate_commit) {
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
     // all segments are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -8698,7 +8698,7 @@ TEST_P(index_test_case, segment_consolidate_commit) {
     ASSERT_EQ(1 + count, irs::directory_cleaner::clean(
                            dir()));  // +1 for corresponding segments_* file
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // nothing to consolidate
     writer->Commit();
     AssertSnapshotEquality(
       *writer);  // commit transaction (will commit nothing)
@@ -8773,19 +8773,19 @@ TEST_P(index_test_case, segment_consolidate_commit) {
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
     writer->Commit();
@@ -8895,19 +8895,19 @@ TEST_P(index_test_case, segment_consolidate_commit) {
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));  // segments_1
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));  // segments_1
 
@@ -9020,7 +9020,7 @@ TEST_P(index_test_case, consolidate_check_consolidating_segments) {
                   bool /*favorCleanupOverMerge*/) {
         ASSERT_TRUE(consolidating_segments.empty());
       };
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
   }
 
   const size_t SEGMENTS_COUNT = 10;
@@ -9044,7 +9044,7 @@ TEST_P(index_test_case, consolidate_check_consolidating_segments) {
         candidates.emplace_back(&reader[j++]);
       };
 
-    ASSERT_TRUE(writer->Consolidate(merge_adjacent));
+    ASSERT_TRUE(writer->Consolidate(merge_adjacent, callbacks));
   }
 
   // check all segments registered
@@ -9059,7 +9059,7 @@ TEST_P(index_test_case, consolidate_check_consolidating_segments) {
             expected_consolidating_segment.Meta().name));
         }
       };
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
   }
 
   writer->Commit();
@@ -9073,7 +9073,7 @@ TEST_P(index_test_case, consolidate_check_consolidating_segments) {
                   bool /*favorCleanupOverMerge*/) {
         ASSERT_TRUE(consolidating_segments.empty());
       };
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
   }
 
   // validate structure
@@ -9210,20 +9210,20 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     ASSERT_FALSE(
       writer->Begin());  // begin transaction (will not start transaction)
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
     // all segments are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -9235,14 +9235,14 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // nothing to consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // nothing to consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(
@@ -9323,22 +9323,22 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
     writer->Commit();
@@ -9351,7 +9351,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit pending merge
@@ -9360,7 +9360,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure
     tests::index_t expected;
@@ -9469,22 +9469,22 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -9502,7 +9502,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(insert(*writer, doc6->indexed.begin(), doc6->indexed.end(),
                        doc6->stored.begin(), doc6->stored.end()));
@@ -9515,7 +9515,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure
     tests::index_t expected;
@@ -9655,22 +9655,22 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -9686,7 +9686,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     expected_consolidating_segments = {0, 1};
 
     // Check name only because of removals
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit pending merge
@@ -9696,7 +9696,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -9810,22 +9810,22 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -9836,7 +9836,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit pending merge
@@ -9847,7 +9847,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -9967,7 +9967,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     auto do_commit_and_consolidate_count =
       [&](irs::Consolidation& candidates, const irs::IndexReader& reader,
@@ -9980,15 +9980,15 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
         AssertSnapshotEquality(*writer);
       };
 
-    ASSERT_TRUE(writer->Consolidate(do_commit_and_consolidate_count));
+    ASSERT_TRUE(writer->Consolidate(do_commit_and_consolidate_count, callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     writer->GetBatch().Remove(*query_doc4);
 
@@ -9998,7 +9998,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -10104,7 +10104,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -10145,7 +10145,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -10155,14 +10155,14 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // this consolidation will be postponed
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
     // check consolidating segments are pending
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     auto do_commit_and_consolidate_count =
       [&](irs::Consolidation& candidates, const irs::IndexReader& reader,
@@ -10181,7 +10181,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // this should fail as segments 1 and 0 are actually consolidated on
     // previous  commit inside our test policy
-    ASSERT_FALSE(writer->Consolidate(do_commit_and_consolidate_count));
+    ASSERT_FALSE(writer->Consolidate(do_commit_and_consolidate_count, callbacks));
     ASSERT_NE(0, irs::directory_cleaner::clean(dir()));
     // check all data is deleted
     const auto one_segment_count = count;
@@ -10226,7 +10226,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -10236,14 +10236,14 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // this consolidation will be postponed
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
     // check consolidating segments are pending
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     auto do_commit_and_consolidate_count =
       [&](irs::Consolidation& candidates, const irs::IndexReader& reader,
@@ -10265,7 +10265,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // this should fail as segments 1 and 0 are actually consolidated on
     // previous  commit inside our test policy
-    ASSERT_FALSE(writer->Consolidate(do_commit_and_consolidate_count));
+    ASSERT_FALSE(writer->Consolidate(do_commit_and_consolidate_count, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
     ASSERT_NE(0, irs::directory_cleaner::clean(dir()));
@@ -10309,10 +10309,10 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
     ASSERT_TRUE(writer->Begin());  // begin transaction
     // this consolidation will be postponed
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
     // check consolidating segments are pending
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->Rollback();
 
@@ -10321,7 +10321,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // still pending
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->GetBatch().Remove(*query_doc1);
     // make next commit
@@ -10330,11 +10330,11 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // now no consolidating should be present
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // could consolidate successfully
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // cleanup should remove old files
     ASSERT_NE(0, irs::directory_cleaner::clean(dir()));
@@ -10390,22 +10390,22 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -10418,7 +10418,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments_name_only, callbacks));
 
     writer->Commit();
     AssertSnapshotEquality(*writer);  // commit pending merge
@@ -10429,7 +10429,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -10574,24 +10574,24 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Begin());  // begin transaction
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
@@ -10604,7 +10604,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->GetBatch().Remove(*query_doc1_doc4);
     writer->Commit();
@@ -10617,7 +10617,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // validate structure (doesn't take removals into account)
     tests::index_t expected;
@@ -10766,33 +10766,33 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     ASSERT_TRUE(writer->Begin());  // begin transaction
     ASSERT_EQ(0, irs::directory_cleaner::clean(dir()));
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // count number of files in segments
     count = 0;
     ASSERT_TRUE(dir().visit(get_number_of_files_in_segments));
 
     ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(
-      irs::index_utils::ConsolidateCount())));  // consolidate
+      irs::index_utils::ConsolidateCount()), callbacks));  // consolidate
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // can't consolidate segments that are already marked for consolidation
     ASSERT_FALSE(writer->Consolidate(
-      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+      irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     size_t num_files_consolidation_segment = count;
     count = 0;
@@ -10810,7 +10810,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {0, 1};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     writer->GetBatch().Remove(*query_doc3_doc4);
 
@@ -10822,7 +10822,7 @@ TEST_P(index_test_case, segment_consolidate_pending_commit) {
 
     // check consolidating segments
     expected_consolidating_segments = {};
-    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments));
+    ASSERT_TRUE(writer->Consolidate(check_consolidating_segments, callbacks));
 
     // +2 for segments_2 + unused column store, +1 for segments_2
     ASSERT_EQ(num_files_consolidation_segment + num_files_segment_2 + 2 + 1,
@@ -12694,8 +12694,10 @@ TEST_P(index_test_case, consolidate_progress) {
     ASSERT_EQ(1, reader[1].docs_count());
 
     irs::MergeWriter::FlushProgress progress;
+    auto tCallbacks = callbacks;
+    tCallbacks.flushProgress = std::move(progress);
 
-    ASSERT_TRUE(writer->Consolidate(policy, get_codec(), progress));
+    ASSERT_TRUE(writer->Consolidate(policy, tCallbacks, get_codec()));
     writer->Commit();  // write consolidated segment
     reader = irs::DirectoryReader(dir, get_codec());
 
@@ -12728,7 +12730,10 @@ TEST_P(index_test_case, consolidate_progress) {
 
     irs::MergeWriter::FlushProgress progress = []() -> bool { return false; };
 
-    ASSERT_FALSE(writer->Consolidate(policy, get_codec(), progress));
+    auto tCallbacks = callbacks;
+    tCallbacks.flushProgress = std::move(progress);
+
+    ASSERT_FALSE(writer->Consolidate(policy, tCallbacks, get_codec()));
     writer->Commit();  // write consolidated segment
     reader = writer->GetSnapshot();
     tests::AssertSnapshotEquality(reader,
@@ -12774,7 +12779,10 @@ TEST_P(index_test_case, consolidate_progress) {
       return true;
     };
 
-    ASSERT_TRUE(writer->Consolidate(policy, get_codec(), progress));
+    auto tCallbacks = callbacks;
+    tCallbacks.flushProgress = std::move(progress);
+
+    ASSERT_TRUE(writer->Consolidate(policy, tCallbacks, get_codec()));
     writer->Commit();  // write consolidated segment
     reader = writer->GetSnapshot();
     tests::AssertSnapshotEquality(reader,
@@ -12817,7 +12825,10 @@ TEST_P(index_test_case, consolidate_progress) {
       return --call_count;
     };
 
-    ASSERT_FALSE(writer->Consolidate(policy, get_codec(), progress));
+    auto tCallbacks = callbacks;
+    tCallbacks.flushProgress = std::move(progress);
+
+    ASSERT_FALSE(writer->Consolidate(policy, tCallbacks, get_codec()));
     writer->Commit();  // write consolidated segment
 
     reader = irs::DirectoryReader(dir, get_codec());
@@ -12901,7 +12912,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -12949,7 +12960,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -12999,7 +13010,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13049,7 +13060,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc2));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13107,7 +13118,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(merge_if_masked));
+    ASSERT_TRUE(writer->Consolidate(merge_if_masked, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13132,7 +13143,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->Commit();
     AssertSnapshotEquality(*writer);
     writer->GetBatch().Remove(std::move(query_doc1));
-    ASSERT_TRUE(writer->Consolidate(merge_if_masked));
+    ASSERT_TRUE(writer->Consolidate(merge_if_masked, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13144,7 +13155,7 @@ TEST_P(index_test_case, segment_consolidate) {
     }
 
     ASSERT_TRUE(writer->Consolidate(
-      merge_if_masked));  // previous removal now committed and considered
+      merge_if_masked, callbacks));  // previous removal now committed and considered
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13174,7 +13185,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13229,7 +13240,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13286,7 +13297,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13343,7 +13354,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc3));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13407,7 +13418,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc3_doc5));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13476,7 +13487,7 @@ TEST_P(index_test_case, segment_consolidate) {
     writer->GetBatch().Remove(std::move(query_doc1_doc3_doc5));
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13554,7 +13565,7 @@ TEST_P(index_test_case, segment_consolidate) {
     // defragment segments
     writer->Commit();
     AssertSnapshotEquality(*writer);
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13653,7 +13664,7 @@ TEST_P(index_test_case, segment_consolidate) {
     AssertSnapshotEquality(*writer);
 
     // defragment segments
-    ASSERT_TRUE(writer->Consolidate(always_merge));
+    ASSERT_TRUE(writer->Consolidate(always_merge, callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13759,7 +13770,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateBytes options;
     options.threshold = 1;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13842,7 +13853,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateBytes options;
     options.threshold = 0;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing non-merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -13919,7 +13930,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateBytesAccum options;
     options.threshold = 1;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
     // segments merged because segment[0] is a candidate and needs to be
@@ -13968,7 +13979,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateBytesAccum options;
     options.threshold = 0;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing non-merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -14053,7 +14064,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateDocsLive options;
     options.threshold = 1;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -14109,7 +14120,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateDocsLive options;
     options.threshold = 0;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing non-merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -14196,7 +14207,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateDocsFill options;
     options.threshold = 1;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -14251,7 +14262,7 @@ TEST_P(index_test_case, segment_consolidate_policy) {
     irs::index_utils::ConsolidateDocsFill options;
     options.threshold = 0;
     ASSERT_TRUE(writer->Consolidate(
-      irs::index_utils::MakePolicy(options)));  // value garanteeing non-merge
+      irs::index_utils::MakePolicy(options), callbacks));  // value garanteeing non-merge
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -14708,7 +14719,7 @@ TEST_P(index_test_case, writer_insert_immediate_remove) {
   // this consolidation should bring us to one consolidated segment without
   // removals.
   ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
   writer->Commit();
   AssertSnapshotEquality(*writer);
 
@@ -14776,7 +14787,7 @@ TEST_P(index_test_case, writer_insert_immediate_remove_all) {
   // this consolidation should bring us to one consolidated segment without
   // removes.
   ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
   writer->Commit();
   AssertSnapshotEquality(*writer);
 
@@ -14838,7 +14849,7 @@ TEST_P(index_test_case, writer_remove_all_from_last_segment) {
 
   // this consolidation should still be ok
   ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
   writer->Commit();
   AssertSnapshotEquality(*writer);
 }
@@ -14882,7 +14893,7 @@ TEST_P(index_test_case, writer_remove_all_from_last_segment_consolidation) {
   // this consolidation should bring us to one consolidated segment without
   // removes.
   ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
   // Remove all documents from 'new' segment
   auto query_doc4 = MakeByTerm("name", "D");
   writer->GetBatch().Remove(*(query_doc4.get()));
@@ -14910,7 +14921,7 @@ TEST_P(index_test_case, writer_remove_all_from_last_segment_consolidation) {
 
   // this consolidation should still be ok
   ASSERT_TRUE(writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount())));
+    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount()), callbacks));
   writer->Commit();
   AssertSnapshotEquality(*writer);
 }
@@ -15827,7 +15838,7 @@ TEST_P(index_test_case_14, consolidate_multiple_stored_features) {
 
   sNumCalls.clear();
   const auto res = writer->Consolidate(
-    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{}));
+    irs::index_utils::MakePolicy(irs::index_utils::ConsolidateCount{}), callbacks);
   ASSERT_TRUE(res);
   ASSERT_EQ(3, res.size);
   ASSERT_TRUE(writer->Commit());
@@ -16306,7 +16317,7 @@ TEST_P(index_test_case_11, consolidate_old_format) {
   auto old_codec = irs::formats::get("1_0");
   irs::index_utils::ConsolidateCount consolidate_all;
   ASSERT_TRUE(writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all),
-                                  old_codec));
+    callbacks, old_codec));
   writer->Commit();
   AssertSnapshotEquality(*writer);
   validate_codec(old_codec, 1);

--- a/lib/iresearch/tests/index/index_tests.hpp
+++ b/lib/iresearch/tests/index/index_tests.hpp
@@ -168,6 +168,23 @@ typedef std::tuple<tests::dir_param_f, format_info> index_test_context;
 void AssertSnapshotEquality(irs::DirectoryReader lhs, irs::DirectoryReader rhs);
 
 class index_test_base : public virtual test_param_base<index_test_context> {
+ protected:
+  irs::IndexWriter::ConsolidationProgress callbacks;
+
+ public:
+  index_test_base() {
+    auto beginCons = [](const auto& ) {
+    };
+    auto endCons = [](const auto& ) {
+    };
+    auto flushProgress = []() {
+      return true;
+    };
+
+    callbacks = { .beginConsolidation = beginCons,
+      .endConsolidation = endCons, .flushProgress = flushProgress };
+  }
+
  public:
   static std::string to_string(
     const testing::TestParamInfo<index_test_context>& info);

--- a/lib/iresearch/tests/index/merge_writer_tests.cpp
+++ b/lib/iresearch/tests/index/merge_writer_tests.cpp
@@ -173,6 +173,23 @@ using namespace tests;
 
 struct merge_writer_test_case
   : public tests::directory_test_case_base<std::string> {
+ protected:
+  irs::IndexWriter::ConsolidationProgress callbacks;
+
+ public:
+  merge_writer_test_case() {
+    auto beginCons = [](const auto& ) {
+    };
+    auto endCons = [](const auto& ) {
+    };
+    auto flushProgress = []() {
+      return true;
+    };
+
+    callbacks = { .beginConsolidation = beginCons,
+      .endConsolidation = endCons, .flushProgress = flushProgress };
+  }
+
   std::shared_ptr<const irs::format> codec() const {
     const auto& p = tests::directory_test_case_base<std::string>::GetParam();
     const auto& codec_name = std::get<std::string>(p);
@@ -281,7 +298,7 @@ void merge_writer_test_case::EnsureDocBlocksNotMixed(bool primary_sort) {
   // 2: 21..30
   const irs::index_utils::ConsolidateCount consolidate_all;
   ASSERT_EQ(!primary_sort || supports_sort(),
-            writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+            writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
   ASSERT_EQ(!primary_sort || supports_sort(), writer->Commit());
   AssertSnapshotEquality(writer->GetSnapshot(),
                          irs::DirectoryReader(dir, codec_ptr));

--- a/lib/iresearch/tests/index/norm_test.cpp
+++ b/lib/iresearch/tests/index/norm_test.cpp
@@ -675,7 +675,7 @@ TEST_P(Norm2TestCase, CheckNormsConsolidation) {
   {
     const irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -946,7 +946,7 @@ TEST_P(Norm2TestCase, CheckNormsConsolidationWithRemovals) {
   {
     const irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -1040,7 +1040,7 @@ TEST_P(Norm2TestCase, CheckNormsConsolidationWithRemovals) {
   {
     const irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
   }

--- a/lib/iresearch/tests/index/sorted_index_tests.cpp
+++ b/lib/iresearch/tests/index/sorted_index_tests.cpp
@@ -221,6 +221,21 @@ REGISTER_ATTRIBUTE(CustomFeature);
 
 class SortedIndexTestCase : public tests::index_test_base {
  protected:
+  irs::IndexWriter::ConsolidationProgress callbacks;
+ public:
+  SortedIndexTestCase() {
+    auto beginCons = [](const auto& ) {
+    };
+    auto endCons = [](const auto& ) {
+    };
+    auto flushProgress = []() {
+      return true;
+    };
+
+    callbacks = { .beginConsolidation = beginCons,
+      .endConsolidation = endCons, .flushProgress = flushProgress };
+  }
+ protected:
   bool supports_pluggable_features() const noexcept {
     // old formats don't support pluggable features
     constexpr std::string_view kOldFormats[]{"1_0", "1_1", "1_2", "1_3",
@@ -808,7 +823,7 @@ TEST_P(SortedIndexTestCase, simple_sequential_consolidate) {
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
 
@@ -1371,7 +1386,7 @@ TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_dense) {
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
   }
@@ -1659,7 +1674,7 @@ TEST_P(SortedIndexTestCase,
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
   }
@@ -2021,7 +2036,7 @@ TEST_P(SortedIndexTestCase,
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
   }
@@ -2240,7 +2255,7 @@ TEST_P(SortedIndexTestCase, check_document_order_after_consolidation_sparse) {
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     writer->Commit();
     AssertSnapshotEquality(*writer);
   }
@@ -2489,7 +2504,7 @@ TEST_P(SortedIndexTestCase,
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     ASSERT_TRUE(writer->Commit());
     AssertSnapshotEquality(*writer);
   }
@@ -2730,7 +2745,7 @@ TEST_P(SortedIndexTestCase,
   {
     irs::index_utils::ConsolidateCount consolidate_all;
     ASSERT_TRUE(
-      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+      writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
     ASSERT_TRUE(writer->Commit());
     AssertSnapshotEquality(*writer);
   }
@@ -3015,7 +3030,7 @@ TEST_P(SortedIndexStressTestCase, commit_on_tick) {
       EXPECT_LE(in_store_count, reader->docs_count());
       EXPECT_LE(reader->docs_count(), kLen);
 
-      writer->Consolidate(MakePolicy(irs::index_utils::ConsolidateCount{}));
+      writer->Consolidate(MakePolicy(irs::index_utils::ConsolidateCount{}), callbacks);
       writer->Commit({.tick = insert_time});
       AssertSnapshotEquality(*writer);
 

--- a/lib/iresearch/tests/search/wand_test.cpp
+++ b/lib/iresearch/tests/search/wand_test.cpp
@@ -244,7 +244,7 @@ void WandTestCase::ConsolidateAll(irs::ScorersView scorers, bool write_norms) {
   auto writer =
     open_writer(irs::OM_APPEND, GetWriterOptions(scorers, write_norms));
   ASSERT_TRUE(
-    writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all)));
+    writer->Consolidate(irs::index_utils::MakePolicy(consolidate_all), callbacks));
   ASSERT_TRUE(writer->Commit());
   ASSERT_EQ(1, writer->GetSnapshot().size());
 }


### PR DESCRIPTION
### Scope & Purpose

The activity reports information about the current candidate segments chosen for consolidation.
An iresearch test run was made on jenkins and the tests are green: https://jenkins.arangodb.biz/view/PR/job/iresearch-release/lastSuccessfulBuild/

- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-569
- [ ] Design document: 
