### PR TITLE
Fix AsyncTest failure

### DIFF
--- a/arangod/Actions/ActionFeature.cpp
+++ b/arangod/Actions/ActionFeature.cpp
@@ -56,5 +56,3 @@ bool ActionFeature::allowUseDatabase() const {
 }
 
 }  // namespace arangodb
-
-

--- a/arangod/Actions/ActionFeature.cpp
+++ b/arangod/Actions/ActionFeature.cpp
@@ -56,3 +56,5 @@ bool ActionFeature::allowUseDatabase() const {
 }
 
 }  // namespace arangodb
+
+

--- a/tests/Async/AsyncTestLineNumbers.tpp
+++ b/tests/Async/AsyncTestLineNumbers.tpp
@@ -20,12 +20,10 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-// This tests for specific line numbers, so be aware that you have to adapt the
-// lines numbers if you change the code inside the test.
-
 TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
   {
     async_tests::NoWait wait;
+    constexpr int kCoReturnLine = __LINE__ + 5;
     auto fn = [&]() -> async<void> {
       auto void_fn = []() {};
       co_await wait;
@@ -38,13 +36,15 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 34);
+          EXPECT_EQ(promise.source_location.line, kCoReturnLine);
         });
     EXPECT_EQ(count, 1);
   }
   arangodb::async_registry::get_thread_registry().garbage_collect();
   {
     async_tests::WaitSlot wait;
+    constexpr int kCoAwaitLine = __LINE__ + 4;
+    constexpr int kCoReturnLine = __LINE__ + 5;
     auto fn = [&]() -> async<void> {
       auto void_fn = []() {};
       co_await wait;
@@ -57,7 +57,7 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 51);
+          EXPECT_EQ(promise.source_location.line, kCoAwaitLine);
         });
     EXPECT_EQ(count, 1);
     wait.resume();
@@ -66,13 +66,15 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 53);
+          EXPECT_EQ(promise.source_location.line, kCoReturnLine);
         });
     EXPECT_EQ(count, 1);
   }
   arangodb::async_registry::get_thread_registry().garbage_collect();
   {
     async_tests::ConcurrentNoWait wait;
+    constexpr int kCoAwaitLine = __LINE__ + 4;
+    constexpr int kCoReturnLine = __LINE__ + 5;
     auto fn = [&]() -> async<void> {
       auto void_fn = []() {};
       co_await wait;
@@ -85,7 +87,7 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 79);
+          EXPECT_EQ(promise.source_location.line, kCoAwaitLine);
         });
     EXPECT_EQ(count, 1);
     wait.await();
@@ -94,7 +96,7 @@ TEST(AsyncTest, source_location_in_registry_is_co_await_line) {
     arangodb::async_registry::registry.for_node(
         [&](arangodb::async_registry::PromiseSnapshot promise) {
           count++;
-          EXPECT_EQ(promise.source_location.line, 81);
+          EXPECT_EQ(promise.source_location.line, kCoReturnLine);
         });
     EXPECT_EQ(count, 1);
   }


### PR DESCRIPTION
### Scope & Purpose

The problem was in `tests/Async/AsyncTestLineNumbers.tpp`. When the previous PR (author name removal) deleted a line from the test file, the line number was decreased by 1. This hardcoded line number mismatched with the numbers the compiler reported.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
