### PR TITLE
[COR-378] Extended _id access for persistent indexes

### DIFF
--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -476,8 +476,10 @@ void Projections::toVelocyPackFromIndexCompactArray(
 
   for (size_t k = 0; k < _projections.size(); k++) {
     auto& it = _projections[k];
-    // _id cannot be part of a user-defined index
-    TRI_ASSERT(it.type != AttributeNamePath::Type::IdAttribute);
+    // note: `_id` projections are valid here: while _id cannot be part of a
+    // user-defined index, it can be served from stored values or from a
+    // covered `_key` value (cf. Index::covers); it is rebuilt via
+    // makeIdFromParts below
 
     // we will get a Slice with an array of index values. now we need
     // to look up the array values from the correct positions to

--- a/arangod/Aql/Projections.cpp
+++ b/arangod/Aql/Projections.cpp
@@ -476,10 +476,6 @@ void Projections::toVelocyPackFromIndexCompactArray(
 
   for (size_t k = 0; k < _projections.size(); k++) {
     auto& it = _projections[k];
-    // note: `_id` projections are valid here: while _id cannot be part of a
-    // user-defined index, it can be served from stored values or from a
-    // covered `_key` value (cf. Index::covers); it is rebuilt via
-    // makeIdFromParts below
 
     // we will get a Slice with an array of index values. now we need
     // to look up the array values from the correct positions to

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -30,12 +30,18 @@
 #include "Basics/StaticStrings.h"
 #include "Basics/VelocyPackHelper.h"
 #include "Basics/datetime.h"
+#include "Cluster/ServerState.h"
 #include "Containers/HashSet.h"
 #include "IResearch/IResearchCommon.h"
 #include "StorageEngine/StorageEngine.h"
+#include "Transaction/Methods.h"
 #include "Utilities/NameValidator.h"
 #include "VocBase/LogicalCollection.h"
 #include "VocBase/ticks.h"
+
+#ifdef USE_ENTERPRISE
+#include "Enterprise/VocBase/VirtualClusterSmartEdgeCollection.h"
+#endif
 
 #include <date/date.h>
 #include <velocypack/Iterator.h>
@@ -981,9 +987,37 @@ bool Index::covers(aql::Projections& projections) const {
   auto const& covered = coveredFields();
 
   for (size_t i = 0; i < n; ++i) {
+    // `_id` and `_key` are interchangeable for covering purposes: a covered
+    // `_id` entry physically stores the document's key value (cf.
+    // transaction::extractAttributeValues and the storedValues handling in
+    // RocksDBVPackIndex::insert), and the covering producers in
+    // Projections.cpp rebuild `_id` projections from the covered key value
+    // via transaction::helpers::makeIdFromParts, using the collection set
+    // by Projections::setCoveringContext. so any covered `_key` or `_id`
+    // entry can serve projections on either attribute. this rule only
+    // applies to the exact top-level attributes, not to sub-attributes
+    // that happen to be named alike (e.g. a covered field `a._id`).
+    bool const isKeyOrIdProjection =
+        projections[i].type == aql::AttributeNamePath::Type::IdAttribute ||
+        projections[i].type == aql::AttributeNamePath::Type::KeyAttribute;
+    TRI_ASSERT(!isKeyOrIdProjection || projections[i].path.size() == 1);
+
     bool found = false;
     for (size_t j = 0; j < covered.size(); ++j) {
       auto const& field = covered[j];
+
+      if (isKeyOrIdProjection) {
+        if (field.size() == 1 && !field[0].shouldExpand &&
+            (field[0].name == StaticStrings::KeyString ||
+             field[0].name == StaticStrings::IdString)) {
+          projections[i].coveringIndexPosition = static_cast<uint16_t>(j);
+          projections[i].coveringIndexCutoff = 1;
+          found = true;
+          break;
+        }
+        continue;
+      }
+
       size_t k = 0;
       for (auto const& part : field) {
         if (part.shouldExpand) {
@@ -1016,6 +1050,61 @@ bool Index::covers(aql::Projections& projections) const {
   }
 
   return true;
+}
+
+std::optional<std::string_view> Index::extractKeyFromIdLookupValue(
+    transaction::Methods& trx, LogicalCollection const& collection,
+    std::string_view id) {
+  char const* key = nullptr;
+  size_t outLength = 0;
+  std::shared_ptr<LogicalCollection> resolved;
+  Result res = trx.resolveId(id.data(), id.size(), resolved, key, outLength);
+
+  if (!res.ok()) {
+    return std::nullopt;
+  }
+
+  TRI_ASSERT(resolved != nullptr);
+  TRI_ASSERT(key != nullptr);
+
+  if (!ServerState::instance()->isRunningInCluster()) {
+    if (resolved->id() != collection.id()) {
+      // the id value is syntactically correct, but refers to a different
+      // collection, using local collection id
+      return std::nullopt;
+    }
+    return std::string_view(key, outLength);
+  }
+
+#ifdef USE_ENTERPRISE
+  if (resolved->isSmart() && resolved->type() == TRI_COL_TYPE_EDGE) {
+    auto c =
+        dynamic_cast<VirtualClusterSmartEdgeCollection const*>(resolved.get());
+    if (c == nullptr) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "unable to cast smart edge collection");
+    }
+
+    if (!c->isDisjoint() && (collection.planId() != c->getLocalCid() &&
+                             collection.planId() != c->getFromCid() &&
+                             collection.planId() != c->getToCid())) {
+      // invalid planId
+      return std::nullopt;
+    } else if (c->isDisjoint() && collection.planId() != c->getLocalCid()) {
+      // invalid planId
+      return std::nullopt;
+    }
+    return std::string_view(key, outLength);
+  }
+#endif
+
+  if (resolved->planId() != collection.planId()) {
+    // the id value is syntactically correct, but refers to a different
+    // collection, using cluster collection id
+    return std::nullopt;
+  }
+
+  return std::string_view(key, outLength);
 }
 
 bool Index::canWarmup() const noexcept { return false; }

--- a/arangod/Indexes/Index.cpp
+++ b/arangod/Indexes/Index.cpp
@@ -987,16 +987,11 @@ bool Index::covers(aql::Projections& projections) const {
   auto const& covered = coveredFields();
 
   for (size_t i = 0; i < n; ++i) {
-    // `_id` and `_key` are interchangeable for covering purposes: a covered
-    // `_id` entry physically stores the document's key value (cf.
-    // transaction::extractAttributeValues and the storedValues handling in
-    // RocksDBVPackIndex::insert), and the covering producers in
-    // Projections.cpp rebuild `_id` projections from the covered key value
-    // via transaction::helpers::makeIdFromParts, using the collection set
-    // by Projections::setCoveringContext. so any covered `_key` or `_id`
-    // entry can serve projections on either attribute. this rule only
-    // applies to the exact top-level attributes, not to sub-attributes
-    // that happen to be named alike (e.g. a covered field `a._id`).
+    // top-level `_id` and `_key` are interchangeable for covering purposes:
+    // covered `_id` entries physically store the key value (cf.
+    // transaction::extractAttributeValues), and the covering producers in
+    // Projections.cpp rebuild `_id` projections from a covered key value
+    // via makeIdFromParts
     bool const isKeyOrIdProjection =
         projections[i].type == aql::AttributeNamePath::Type::IdAttribute ||
         projections[i].type == aql::AttributeNamePath::Type::KeyAttribute;

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -36,6 +36,7 @@
 #include <cstdint>
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -211,6 +212,18 @@ class Index {
   /// the function may modify the projections by setting the
   /// coveringIndexPosition value in it.
   virtual bool covers(aql::Projections& projections) const;
+
+  /// @brief translates the value of a lookup on `_id` into a `_key` lookup
+  /// value for the given collection: resolves the id, verifies that it
+  /// refers to `collection` (by local id, or by planId in a cluster,
+  /// including SmartGraph edge collections), and returns the key part.
+  /// returns std::nullopt if the value cannot refer to a document of
+  /// `collection`, in which case the lookup must produce no results.
+  /// shared by all indexes that answer `_id` lookups via an indexed `_key`
+  /// (the primary index, and persistent indexes with a `_key` field).
+  static std::optional<std::string_view> extractKeyFromIdLookupValue(
+      transaction::Methods& trx, LogicalCollection const& collection,
+      std::string_view id);
 
   virtual size_t numFieldsToConsiderInIndexSelection() const noexcept {
     return _fields.size();

--- a/arangod/Indexes/Index.h
+++ b/arangod/Indexes/Index.h
@@ -213,14 +213,9 @@ class Index {
   /// coveringIndexPosition value in it.
   virtual bool covers(aql::Projections& projections) const;
 
-  /// @brief translates the value of a lookup on `_id` into a `_key` lookup
-  /// value for the given collection: resolves the id, verifies that it
-  /// refers to `collection` (by local id, or by planId in a cluster,
-  /// including SmartGraph edge collections), and returns the key part.
-  /// returns std::nullopt if the value cannot refer to a document of
-  /// `collection`, in which case the lookup must produce no results.
-  /// shared by all indexes that answer `_id` lookups via an indexed `_key`
-  /// (the primary index, and persistent indexes with a `_key` field).
+  /// @brief translates an `_id` lookup value into a `_key` lookup value,
+  /// returning std::nullopt if the value cannot refer to a document of
+  /// `collection`
   static std::optional<std::string_view> extractKeyFromIdLookupValue(
       transaction::Methods& trx, LogicalCollection const& collection,
       std::string_view id);

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -131,8 +131,7 @@ bool idLookupSupportedViaKeyField(
 
 // same, for any field of the index
 bool idLookupSupportedViaKeyField(
-    Index const* idx,
-    std::vector<basics::AttributeName> const& attribute,
+    Index const* idx, std::vector<basics::AttributeName> const& attribute,
     aql::AstNode const* op) {
   for (size_t i = 0; i < idx->fields().size(); ++i) {
     if (idLookupSupportedViaKeyField(idx, i, attribute, op)) {

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -98,6 +98,36 @@ std::tuple<size_t, size_t, double, double> analyzeConditions(
 
 }  // namespace
 
+namespace {
+
+// whether `attribute` is exactly `_id` and `idx` has a single-attribute
+// `_key` field, so that lookups on `_id` can be answered by the index after
+// translating the lookup values (cf. Index::extractKeyFromIdLookupValue and
+// the corresponding rule in accessFitsIndex below)
+bool idLookupSupportedViaKeyField(
+    arangodb::Index const* idx,
+    std::vector<arangodb::basics::AttributeName> const& attribute) {
+  if (attribute.size() != 1 || attribute[0].shouldExpand ||
+      attribute[0].name != arangodb::StaticStrings::IdString) {
+    return false;
+  }
+  if (idx->type() !=
+          arangodb::Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX &&
+      idx->type() !=
+          arangodb::Index::IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX) {
+    return false;
+  }
+  for (size_t i = 0; i < idx->fields().size(); ++i) {
+    if (idx->fields()[i].size() == 1 && !idx->isAttributeExpanded(i) &&
+        idx->fields()[i][0].name == arangodb::StaticStrings::KeyString) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 bool SortedIndexAttributeMatcher::accessFitsIndex(
     arangodb::Index const* idx,            // index
     arangodb::aql::AstNode const* access,  // attribute access
@@ -158,7 +188,8 @@ bool SortedIndexAttributeMatcher::accessFitsIndex(
         attributeData.first == reference &&
         !arangodb::basics::TRI_AttributeNamesHaveExpansion(
             attributeData.second) &&
-        idx->attributeMatches(attributeData.second, isPrimaryIndex)) {
+        (idx->attributeMatches(attributeData.second, isPrimaryIndex) ||
+         ::idLookupSupportedViaKeyField(idx, attributeData.second))) {
       // doc.value IN 'value'
       // can use this index
     } else if (other->isAttributeAccessForVariable(attributeData) &&
@@ -189,10 +220,25 @@ bool SortedIndexAttributeMatcher::accessFitsIndex(
     bool match = arangodb::basics::AttributeName::isIdentical(idx->fields()[i],
                                                               fieldNames, true);
 
-    // make exception for primary index as we do not need to match "_key, _id"
-    // but can go directly for "_id"
-    if (!match && isPrimaryIndex && i == 0 &&
-        fieldNames[i].name == StaticStrings::IdString) {
+    // an access to `_id` can be answered by an index whose field is `_key`:
+    // the lookup value is translated from an `_id` string into a `_key`
+    // string - including verification that the value refers to this
+    // collection - by the index implementations, via the shared
+    // Index::extractKeyFromIdLookupValue. this covers the primary index
+    // (its single field is `_key`) as well as persistent indexes with a
+    // `_key` field. the primary index keeps its legacy behavior of
+    // accepting all operators; for persistent indexes the rule is
+    // restricted to == and IN, because range comparisons on `_id` must not
+    // be mapped onto `_key` ordering.
+    if (!match && fieldNames.size() == 1 && !fieldNames[0].shouldExpand &&
+        fieldNames[0].name == StaticStrings::IdString &&
+        idx->fields()[i].size() == 1 && !idx->isAttributeExpanded(i) &&
+        idx->fields()[i][0].name == StaticStrings::KeyString &&
+        (isPrimaryIndex ||
+         (idx->type() ==
+              arangodb::Index::IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX &&
+          (op->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_EQ ||
+           op->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_IN)))) {
       match = true;
     }
 

--- a/arangod/Indexes/SortedIndexAttributeMatcher.cpp
+++ b/arangod/Indexes/SortedIndexAttributeMatcher.cpp
@@ -100,26 +100,42 @@ std::tuple<size_t, size_t, double, double> analyzeConditions(
 
 namespace {
 
-// whether `attribute` is exactly `_id` and `idx` has a single-attribute
-// `_key` field, so that lookups on `_id` can be answered by the index after
-// translating the lookup values (cf. Index::extractKeyFromIdLookupValue and
-// the corresponding rule in accessFitsIndex below)
+// whether an access to `_id` can be answered by index field `i`, which
+// must be a single-attribute `_key` field; the lookup values are then
+// translated via Index::extractKeyFromIdLookupValue. the primary index
+// accepts all operators (legacy behavior); persistent indexes are
+// restricted to == and IN, as range comparisons on `_id` must not be
+// mapped onto `_key` ordering.
 bool idLookupSupportedViaKeyField(
-    arangodb::Index const* idx,
-    std::vector<arangodb::basics::AttributeName> const& attribute) {
+    Index const* idx, size_t i,
+    std::vector<basics::AttributeName> const& attribute,
+    aql::AstNode const* op) {
   if (attribute.size() != 1 || attribute[0].shouldExpand ||
-      attribute[0].name != arangodb::StaticStrings::IdString) {
+      attribute[0].name != StaticStrings::IdString) {
     return false;
   }
-  if (idx->type() !=
-          arangodb::Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX &&
-      idx->type() !=
-          arangodb::Index::IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX) {
+  if (idx->fields()[i].size() != 1 || idx->isAttributeExpanded(i) ||
+      idx->fields()[i][0].name != StaticStrings::KeyString) {
     return false;
   }
+  switch (idx->type()) {
+    case Index::IndexType::TRI_IDX_TYPE_PRIMARY_INDEX:
+      return true;
+    case Index::IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX:
+      return op->type == aql::NODE_TYPE_OPERATOR_BINARY_EQ ||
+             op->type == aql::NODE_TYPE_OPERATOR_BINARY_IN;
+    default:
+      return false;
+  }
+}
+
+// same, for any field of the index
+bool idLookupSupportedViaKeyField(
+    Index const* idx,
+    std::vector<basics::AttributeName> const& attribute,
+    aql::AstNode const* op) {
   for (size_t i = 0; i < idx->fields().size(); ++i) {
-    if (idx->fields()[i].size() == 1 && !idx->isAttributeExpanded(i) &&
-        idx->fields()[i][0].name == arangodb::StaticStrings::KeyString) {
+    if (idLookupSupportedViaKeyField(idx, i, attribute, op)) {
       return true;
     }
   }
@@ -189,7 +205,7 @@ bool SortedIndexAttributeMatcher::accessFitsIndex(
         !arangodb::basics::TRI_AttributeNamesHaveExpansion(
             attributeData.second) &&
         (idx->attributeMatches(attributeData.second, isPrimaryIndex) ||
-         ::idLookupSupportedViaKeyField(idx, attributeData.second))) {
+         ::idLookupSupportedViaKeyField(idx, attributeData.second, op))) {
       // doc.value IN 'value'
       // can use this index
     } else if (other->isAttributeAccessForVariable(attributeData) &&
@@ -220,26 +236,9 @@ bool SortedIndexAttributeMatcher::accessFitsIndex(
     bool match = arangodb::basics::AttributeName::isIdentical(idx->fields()[i],
                                                               fieldNames, true);
 
-    // an access to `_id` can be answered by an index whose field is `_key`:
-    // the lookup value is translated from an `_id` string into a `_key`
-    // string - including verification that the value refers to this
-    // collection - by the index implementations, via the shared
-    // Index::extractKeyFromIdLookupValue. this covers the primary index
-    // (its single field is `_key`) as well as persistent indexes with a
-    // `_key` field. the primary index keeps its legacy behavior of
-    // accepting all operators; for persistent indexes the rule is
-    // restricted to == and IN, because range comparisons on `_id` must not
-    // be mapped onto `_key` ordering.
-    if (!match && fieldNames.size() == 1 && !fieldNames[0].shouldExpand &&
-        fieldNames[0].name == StaticStrings::IdString &&
-        idx->fields()[i].size() == 1 && !idx->isAttributeExpanded(i) &&
-        idx->fields()[i][0].name == StaticStrings::KeyString &&
-        (isPrimaryIndex ||
-         (idx->type() ==
-              arangodb::Index::IndexType::TRI_IDX_TYPE_PERSISTENT_INDEX &&
-          (op->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_EQ ||
-           op->type == arangodb::aql::NODE_TYPE_OPERATOR_BINARY_IN)))) {
-      match = true;
+    // an access to `_id` also matches an index field that is `_key`
+    if (!match) {
+      match = ::idLookupSupportedViaKeyField(idx, i, fieldNames, op);
     }
 
     if (match) {

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -55,10 +55,6 @@
 #include "VocBase/KeyGenerator.h"
 #include "VocBase/LogicalCollection.h"
 
-#ifdef USE_ENTERPRISE
-#include "Enterprise/VocBase/VirtualClusterSmartEdgeCollection.h"
-#endif
-
 #include <absl/strings/str_cat.h>
 
 #include <rocksdb/iterator.h>
@@ -1251,61 +1247,16 @@ void RocksDBPrimaryIndex::handleValNode(transaction::Methods* trx,
   }
 
   if (isId) {
-    // lookup by _id. now validate if the lookup is performed for the
-    // correct collection (i.e. _collection)
-    char const* key = nullptr;
-    size_t outLength = 0;
-    std::shared_ptr<LogicalCollection> collection;
-    Result res =
-        trx->resolveId(valNode->getStringValue(), valNode->getStringLength(),
-                       collection, key, outLength);
-
-    if (!res.ok()) {
+    // lookup by _id. validate that the lookup value refers to "our"
+    // collection (i.e. _collection) and extract the _key part from it
+    auto key = Index::extractKeyFromIdLookupValue(*trx, _collection,
+                                                  valNode->getStringView());
+    if (!key.has_value()) {
       return;
-    }
-
-    TRI_ASSERT(collection != nullptr);
-    TRI_ASSERT(key != nullptr);
-
-    bool isRunningInCluster = ServerState::instance()->isRunningInCluster();
-
-    if (!isRunningInCluster && collection->id() != _collection.id()) {
-      // only continue lookup if the id value is syntactically correct and
-      // refers to "our" collection, using local collection id
-      return;
-    }
-
-    if (isRunningInCluster) {
-#ifdef USE_ENTERPRISE
-      if (collection->isSmart() && collection->type() == TRI_COL_TYPE_EDGE) {
-        auto c = dynamic_cast<VirtualClusterSmartEdgeCollection const*>(
-            collection.get());
-        if (c == nullptr) {
-          THROW_ARANGO_EXCEPTION_MESSAGE(
-              TRI_ERROR_INTERNAL, "unable to cast smart edge collection");
-        }
-
-        if (!c->isDisjoint() && (_collection.planId() != c->getLocalCid() &&
-                                 _collection.planId() != c->getFromCid() &&
-                                 _collection.planId() != c->getToCid())) {
-          // invalid planId
-          return;
-        } else if (c->isDisjoint() &&
-                   _collection.planId() != c->getLocalCid()) {
-          // invalid planId
-          return;
-        }
-      } else
-#endif
-          if (collection->planId() != _collection.planId()) {
-        // only continue lookup if the id value is syntactically correct and
-        // refers to "our" collection, using cluster collection id
-        return;
-      }
     }
 
     // use _key value from _id
-    keys.add(VPackValuePair(key, outLength, VPackValueType::String));
+    keys.add(VPackValuePair(key->data(), key->size(), VPackValueType::String));
   } else {
     keys.add(VPackValuePair(valNode->getStringValue(),
                             valNode->getStringLength(),

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -229,10 +229,12 @@ class RocksDBVPackIndexInIterator final : public IndexIterator {
 
     RocksDBVPackIndexSearchValueFormat format =
         RocksDBVPackIndexSearchValueFormat::kDetect;
-    _index->buildSearchValues(_resourceMonitor, _trx, node, variable,
-                              _indexIteratorOptions, _searchValues, format);
+    bool canProduceResults =
+        _index->buildSearchValues(_resourceMonitor, _trx, node, variable,
+                                  _indexIteratorOptions, _searchValues, format);
 
-    if (_format == RocksDBVPackIndexSearchValueFormat::kValuesOnly &&
+    if (canProduceResults &&
+        _format == RocksDBVPackIndexSearchValueFormat::kValuesOnly &&
         format == RocksDBVPackIndexSearchValueFormat::kIn) {
       reformatLookupCondition();
     }
@@ -243,6 +245,14 @@ class RocksDBVPackIndexInIterator final : public IndexIterator {
     size_t newMemoryUsage = _searchValues.size();
     _resourceMonitor.increaseMemoryUsage(newMemoryUsage);
     _memoryUsage += newMemoryUsage;
+
+    if (!canProduceResults) {
+      // the rebuilt lookup cannot produce any results (e.g. an empty IN
+      // list, or an `_id` lookup value that cannot refer to this
+      // collection). signal the caller that this lookup only produces an
+      // empty result.
+      return false;
+    }
 
     adjustIterator();
     return true;
@@ -360,8 +370,15 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
     auto searchValues = ThreadLocalBuilderLeaser::lease();
     RocksDBVPackIndexSearchValueFormat format =
         RocksDBVPackIndexSearchValueFormat::kValuesOnly;
-    _index->buildSearchValues(_resourceMonitor, _trx, node, variable,
-                              _indexIteratorOptions, *searchValues, format);
+    if (!_index->buildSearchValues(_resourceMonitor, _trx, node, variable,
+                                   _indexIteratorOptions, *searchValues,
+                                   format)) {
+      // the rebuilt lookup cannot produce any results (e.g. an `_id`
+      // lookup value that cannot refer to this collection). signal the
+      // caller that this lookup only produces an empty result.
+      return false;
+    }
+
     // note: we only support the simplified format when building index search
     // values! format must not have changed!
     TRI_ASSERT(format == RocksDBVPackIndexSearchValueFormat::kValuesOnly);
@@ -613,8 +630,15 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
 
     auto searchValues = ThreadLocalBuilderLeaser::lease();
     RocksDBVPackIndexSearchValueFormat format = _format;
-    _index->buildSearchValues(_resourceMonitor, _trx, node, variable,
-                              _indexIteratorOptions, *searchValues, format);
+    if (!_index->buildSearchValues(_resourceMonitor, _trx, node, variable,
+                                   _indexIteratorOptions, *searchValues,
+                                   format)) {
+      // the rebuilt lookup cannot produce any results (e.g. an `_id`
+      // lookup value that cannot refer to this collection). signal the
+      // caller that this lookup only produces an empty result.
+      return false;
+    }
+
     // note: we support two formats when building index search values:
     // - a generic format that supports < > <= >= and ==
     // - a simplified format that only supports ==
@@ -2424,9 +2448,17 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
   auto searchValues = ThreadLocalBuilderLeaser::lease();
   RocksDBVPackIndexSearchValueFormat format =
       RocksDBVPackIndexSearchValueFormat::kDetect;
-  buildSearchValues(monitor, trx, node, reference, opts, *searchValues, format);
+  bool canProduceResults = buildSearchValues(monitor, trx, node, reference,
+                                             opts, *searchValues, format);
   // format must have been set to something valid now.
   TRI_ASSERT(format != RocksDBVPackIndexSearchValueFormat::kDetect);
+
+  if (!canProduceResults) {
+    // the lookup cannot produce any results (e.g. an IN lookup with no
+    // or invalid values, or an `_id` lookup value that cannot refer to
+    // a document of this collection)
+    return std::make_unique<EmptyIndexIterator>(&_collection, trx);
+  }
 
   VPackSlice searchSlice = searchValues->slice();
 
@@ -2434,12 +2466,6 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
 
   if (format == RocksDBVPackIndexSearchValueFormat::kIn) {
     // IN!
-    if (searchSlice.length() == 0 ||
-        (searchSlice.length() == 1 && searchSlice.at(0).isArray() &&
-         searchSlice.at(0).length() == 0)) {
-      // IN with no/invalid condition
-      return std::make_unique<EmptyIndexIterator>(&_collection, trx);
-    }
 
     // build the actual lookup iterator, which can only handle a single
     // equality lookup. however, we will then wrap this lookup iterator
@@ -2476,17 +2502,64 @@ void RocksDBVPackIndex::buildEmptySearchValues(
   result.close();
 }
 
-void RocksDBVPackIndex::buildSearchValues(
+bool RocksDBVPackIndex::isIdLookupOnKeyField(
+    size_t fieldIndex,
+    std::vector<basics::AttributeName> const& accessPath) const {
+  // detect conditions on `doc._id` that were matched against an indexed
+  // `_key` field (cf. the corresponding rule in
+  // SortedIndexAttributeMatcher::accessFitsIndex)
+  return fieldIndex < _fields.size() && _fields[fieldIndex].size() == 1 &&
+         _fields[fieldIndex][0].name == StaticStrings::KeyString &&
+         accessPath.size() == 1 &&
+         accessPath[0].name == StaticStrings::IdString;
+}
+
+bool RocksDBVPackIndex::tryAddIdLookupValue(transaction::Methods* trx,
+                                            aql::AstNode const* value,
+                                            VPackBuilder& searchValues) const {
+  // translate a single `_id` lookup value into a `_key` lookup value,
+  // verifying that it refers to this collection. shared with the primary
+  // index via Index::extractKeyFromIdLookupValue.
+  if (value->isStringValue() && value->getStringLength() > 0) {
+    auto key = Index::extractKeyFromIdLookupValue(*trx, _collection,
+                                                  value->getStringView());
+    if (key.has_value()) {
+      searchValues.add(
+          VPackValuePair(key->data(), key->size(), VPackValueType::String));
+      return true;
+    }
+  }
+  // lookup value is not a string, not a valid document id, or refers to a
+  // different collection: it cannot match any document of this collection.
+  // the lookup must be omitted by the caller, analogous to the primary
+  // index producing no lookup keys for such values.
+  return false;
+}
+
+bool RocksDBVPackIndex::addEqualityLookupValue(
+    transaction::Methods* trx, size_t fieldIndex,
+    std::vector<basics::AttributeName> const& accessPath,
+    aql::AstNode const* value, VPackBuilder& searchValues) const {
+  if (isIdLookupOnKeyField(fieldIndex, accessPath) && value->isConstant()) {
+    return tryAddIdLookupValue(trx, value, searchValues);
+  }
+
+  value->toVelocyPackValue(searchValues);
+  return true;
+}
+
+bool RocksDBVPackIndex::buildSearchValues(
     ResourceMonitor& monitor, transaction::Methods* trx,
     aql::AstNode const* node, aql::Variable const* reference,
     IndexIteratorOptions const& opts, VPackBuilder& searchValues,
     RocksDBVPackIndexSearchValueFormat& format) const {
+  bool canProduceResults = true;
   if (node == nullptr) {
     // We only use this index for sort. Empty searchValue
     buildEmptySearchValues(searchValues);
   } else {
-    buildSearchValuesInner(monitor, trx, node, reference, opts, searchValues,
-                           format);
+    canProduceResults = buildSearchValuesInner(monitor, trx, node, reference,
+                                               opts, searchValues, format);
   }
 
   TRI_IF_FAILURE("PersistentIndex::noIterator") {
@@ -2498,9 +2571,10 @@ void RocksDBVPackIndex::buildSearchValues(
     // simple (values only) format!
     format = RocksDBVPackIndexSearchValueFormat::kValuesOnly;
   }
+  return canProduceResults;
 }
 
-void RocksDBVPackIndex::buildSearchValuesInner(
+bool RocksDBVPackIndex::buildSearchValuesInner(
     ResourceMonitor& monitor, transaction::Methods* trx,
     aql::AstNode const* node, aql::Variable const* reference,
     IndexIteratorOptions const& opts, VPackBuilder& searchValues,
@@ -2564,7 +2638,13 @@ void RocksDBVPackIndex::buildSearchValuesInner(
 
     if (format == RocksDBVPackIndexSearchValueFormat::kValuesOnly) {
       TRI_ASSERT(comp->type == aql::NODE_TYPE_OPERATOR_BINARY_EQ);
-      value->toVelocyPackValue(searchValues);
+      if (!addEqualityLookupValue(trx, usedFields, paramPair.second, value,
+                                  searchValues)) {
+        // the lookup value cannot refer to a document of this collection.
+        // we will not produce any result then
+        buildEmptySearchValues(searchValues);
+        return false;
+      }
       continue;
     }
 
@@ -2590,9 +2670,8 @@ void RocksDBVPackIndex::buildSearchValuesInner(
         if (!value->isArray() || value->numMembers() == 0) {
           // IN lookup value is not an array or empty. we will not
           // produce any result then
-          format = RocksDBVPackIndexSearchValueFormat::kIn;
           buildEmptySearchValues(searchValues);
-          return;
+          return false;
         }
 
         needNormalize = true;
@@ -2603,7 +2682,38 @@ void RocksDBVPackIndex::buildSearchValuesInner(
       break;
     }
     // We have to add the value always, the key was added before
-    value->toVelocyPackValue(searchValues);
+    if (comp->type == aql::NODE_TYPE_OPERATOR_BINARY_EQ) {
+      if (!addEqualityLookupValue(trx, usedFields, paramPair.second, value,
+                                  searchValues)) {
+        // the lookup value cannot refer to a document of this collection.
+        // we will not produce any result then
+        buildEmptySearchValues(searchValues);
+        return false;
+      }
+    } else if (comp->type == aql::NODE_TYPE_OPERATOR_BINARY_IN &&
+               !isAttributeExpanded(usedFields) && value->isArray() &&
+               isIdLookupOnKeyField(usedFields, paramPair.second)) {
+      // translate every `_id` lookup value in the IN list into a `_key`
+      // lookup value, omitting values that cannot refer to a document of
+      // this collection
+      size_t numAdded = 0;
+      searchValues.openArray();
+      for (size_t m = 0; m < value->numMembers(); ++m) {
+        if (tryAddIdLookupValue(trx, value->getMemberUnchecked(m),
+                                searchValues)) {
+          ++numAdded;
+        }
+      }
+      searchValues.close();
+      if (numAdded == 0) {
+        // none of the lookup values can refer to a document of this
+        // collection. we will not produce any result then
+        buildEmptySearchValues(searchValues);
+        return false;
+      }
+    } else {
+      value->toVelocyPackValue(searchValues);
+    }
     searchValues.close();
   }
 
@@ -2695,6 +2805,8 @@ void RocksDBVPackIndex::buildSearchValuesInner(
                RocksDBVPackIndexSearchValueFormat::kOperatorsAndValues);
     format = RocksDBVPackIndexSearchValueFormat::kIn;
   }
+
+  return true;
 }
 
 /// @brief Transform the list of search slices to search values.

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -247,10 +247,6 @@ class RocksDBVPackIndexInIterator final : public IndexIterator {
     _memoryUsage += newMemoryUsage;
 
     if (!canProduceResults) {
-      // the rebuilt lookup cannot produce any results (e.g. an empty IN
-      // list, or an `_id` lookup value that cannot refer to this
-      // collection). signal the caller that this lookup only produces an
-      // empty result.
       return false;
     }
 
@@ -373,9 +369,6 @@ class RocksDBVPackUniqueIndexIterator final : public IndexIterator {
     if (!_index->buildSearchValues(_resourceMonitor, _trx, node, variable,
                                    _indexIteratorOptions, *searchValues,
                                    format)) {
-      // the rebuilt lookup cannot produce any results (e.g. an `_id`
-      // lookup value that cannot refer to this collection). signal the
-      // caller that this lookup only produces an empty result.
       return false;
     }
 
@@ -633,9 +626,6 @@ class RocksDBVPackIndexIterator final : public IndexIterator {
     if (!_index->buildSearchValues(_resourceMonitor, _trx, node, variable,
                                    _indexIteratorOptions, *searchValues,
                                    format)) {
-      // the rebuilt lookup cannot produce any results (e.g. an `_id`
-      // lookup value that cannot refer to this collection). signal the
-      // caller that this lookup only produces an empty result.
       return false;
     }
 
@@ -2454,9 +2444,6 @@ std::unique_ptr<IndexIterator> RocksDBVPackIndex::iteratorForCondition(
   TRI_ASSERT(format != RocksDBVPackIndexSearchValueFormat::kDetect);
 
   if (!canProduceResults) {
-    // the lookup cannot produce any results (e.g. an IN lookup with no
-    // or invalid values, or an `_id` lookup value that cannot refer to
-    // a document of this collection)
     return std::make_unique<EmptyIndexIterator>(&_collection, trx);
   }
 
@@ -2505,9 +2492,7 @@ void RocksDBVPackIndex::buildEmptySearchValues(
 bool RocksDBVPackIndex::isIdLookupOnKeyField(
     size_t fieldIndex,
     std::vector<basics::AttributeName> const& accessPath) const {
-  // detect conditions on `doc._id` that were matched against an indexed
-  // `_key` field (cf. the corresponding rule in
-  // SortedIndexAttributeMatcher::accessFitsIndex)
+  // cf. the corresponding rule in SortedIndexAttributeMatcher::accessFitsIndex
   return fieldIndex < _fields.size() && _fields[fieldIndex].size() == 1 &&
          _fields[fieldIndex][0].name == StaticStrings::KeyString &&
          accessPath.size() == 1 &&
@@ -2517,9 +2502,6 @@ bool RocksDBVPackIndex::isIdLookupOnKeyField(
 bool RocksDBVPackIndex::tryAddIdLookupValue(transaction::Methods* trx,
                                             aql::AstNode const* value,
                                             VPackBuilder& searchValues) const {
-  // translate a single `_id` lookup value into a `_key` lookup value,
-  // verifying that it refers to this collection. shared with the primary
-  // index via Index::extractKeyFromIdLookupValue.
   if (value->isStringValue() && value->getStringLength() > 0) {
     auto key = Index::extractKeyFromIdLookupValue(*trx, _collection,
                                                   value->getStringView());
@@ -2529,10 +2511,6 @@ bool RocksDBVPackIndex::tryAddIdLookupValue(transaction::Methods* trx,
       return true;
     }
   }
-  // lookup value is not a string, not a valid document id, or refers to a
-  // different collection: it cannot match any document of this collection.
-  // the lookup must be omitted by the caller, analogous to the primary
-  // index producing no lookup keys for such values.
   return false;
 }
 
@@ -2640,8 +2618,6 @@ bool RocksDBVPackIndex::buildSearchValuesInner(
       TRI_ASSERT(comp->type == aql::NODE_TYPE_OPERATOR_BINARY_EQ);
       if (!addEqualityLookupValue(trx, usedFields, paramPair.second, value,
                                   searchValues)) {
-        // the lookup value cannot refer to a document of this collection.
-        // we will not produce any result then
         buildEmptySearchValues(searchValues);
         return false;
       }
@@ -2685,17 +2661,14 @@ bool RocksDBVPackIndex::buildSearchValuesInner(
     if (comp->type == aql::NODE_TYPE_OPERATOR_BINARY_EQ) {
       if (!addEqualityLookupValue(trx, usedFields, paramPair.second, value,
                                   searchValues)) {
-        // the lookup value cannot refer to a document of this collection.
-        // we will not produce any result then
         buildEmptySearchValues(searchValues);
         return false;
       }
     } else if (comp->type == aql::NODE_TYPE_OPERATOR_BINARY_IN &&
                !isAttributeExpanded(usedFields) && value->isArray() &&
                isIdLookupOnKeyField(usedFields, paramPair.second)) {
-      // translate every `_id` lookup value in the IN list into a `_key`
-      // lookup value, omitting values that cannot refer to a document of
-      // this collection
+      // translate the `_id` lookup values in the IN list into `_key`
+      // lookup values, omitting values that cannot match
       size_t numAdded = 0;
       searchValues.openArray();
       for (size_t m = 0; m < value->numMembers(); ++m) {
@@ -2706,8 +2679,6 @@ bool RocksDBVPackIndex::buildSearchValuesInner(
       }
       searchValues.close();
       if (numAdded == 0) {
-        // none of the lookup values can refer to a document of this
-        // collection. we will not produce any result then
         buildEmptySearchValues(searchValues);
         return false;
       }

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -167,21 +167,53 @@ class RocksDBVPackIndex : public RocksDBIndex {
   void buildEmptySearchValues(velocypack::Builder& result) const;
 
   // build new search values. this can also be called from the
-  // VPackIndexIterator
-  void buildSearchValues(ResourceMonitor& monitor, transaction::Methods* trx,
+  // VPackIndexIterator.
+  // returns true if the search values were built successfully. returns
+  // false if the lookup cannot produce any results (e.g. an empty IN
+  // list, or an `_id` lookup value that cannot refer to a document of
+  // this collection); in that case the contents of `searchValues` must
+  // not be used.
+  bool buildSearchValues(ResourceMonitor& monitor, transaction::Methods* trx,
                          aql::AstNode const* node,
                          aql::Variable const* reference,
                          IndexIteratorOptions const& opts,
                          velocypack::Builder& searchValues,
                          RocksDBVPackIndexSearchValueFormat& format) const;
 
-  void buildSearchValuesInner(ResourceMonitor& monitor,
+  bool buildSearchValuesInner(ResourceMonitor& monitor,
                               transaction::Methods* trx,
                               aql::AstNode const* node,
                               aql::Variable const* reference,
                               IndexIteratorOptions const& opts,
                               velocypack::Builder& searchValues,
                               RocksDBVPackIndexSearchValueFormat& format) const;
+
+  // whether a condition accessing `accessPath` that was matched against
+  // index field `fieldIndex` is a lookup on `_id` answered by an indexed
+  // `_key` field. such lookups need their values translated from `_id`
+  // strings into `_key` strings (cf. Index::extractKeyFromIdLookupValue).
+  bool isIdLookupOnKeyField(
+      size_t fieldIndex,
+      std::vector<basics::AttributeName> const& accessPath) const;
+
+  // add a single `_id` lookup value, translated into a `_key` lookup value
+  // with collection verification. returns true if a lookup value was
+  // added. returns false - without adding anything - if the value cannot
+  // refer to a document of this collection (not a string, not a valid
+  // document id, or a different collection); such a lookup must be omitted
+  // by the caller, as it cannot produce any results.
+  bool tryAddIdLookupValue(transaction::Methods* trx,
+                           aql::AstNode const* value,
+                           velocypack::Builder& searchValues) const;
+
+  // add the lookup value for an equality condition on field `fieldIndex`,
+  // translating `_id` values into `_key` values where needed. returns
+  // false - without adding anything - if the lookup cannot produce any
+  // results (cf. tryAddIdLookupValue).
+  bool addEqualityLookupValue(
+      transaction::Methods* trx, size_t fieldIndex,
+      std::vector<basics::AttributeName> const& accessPath,
+      aql::AstNode const* value, velocypack::Builder& searchValues) const;
 
  protected:
   Result insert(transaction::Methods& trx, RocksDBMethods* methods,

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -166,13 +166,8 @@ class RocksDBVPackIndex : public RocksDBIndex {
 
   void buildEmptySearchValues(velocypack::Builder& result) const;
 
-  // build new search values. this can also be called from the
-  // VPackIndexIterator.
-  // returns true if the search values were built successfully. returns
-  // false if the lookup cannot produce any results (e.g. an empty IN
-  // list, or an `_id` lookup value that cannot refer to a document of
-  // this collection); in that case the contents of `searchValues` must
-  // not be used.
+  // build new search values; returns false if the lookup cannot produce
+  // any results (the contents of `searchValues` must not be used then)
   bool buildSearchValues(ResourceMonitor& monitor, transaction::Methods* trx,
                          aql::AstNode const* node,
                          aql::Variable const* reference,
@@ -188,28 +183,22 @@ class RocksDBVPackIndex : public RocksDBIndex {
                               velocypack::Builder& searchValues,
                               RocksDBVPackIndexSearchValueFormat& format) const;
 
-  // whether a condition accessing `accessPath` that was matched against
-  // index field `fieldIndex` is a lookup on `_id` answered by an indexed
-  // `_key` field. such lookups need their values translated from `_id`
-  // strings into `_key` strings (cf. Index::extractKeyFromIdLookupValue).
+  // whether the condition is a lookup on `_id` matched against an indexed
+  // `_key` field, so that the lookup values need translation
   bool isIdLookupOnKeyField(
       size_t fieldIndex,
       std::vector<basics::AttributeName> const& accessPath) const;
 
-  // add a single `_id` lookup value, translated into a `_key` lookup value
-  // with collection verification. returns true if a lookup value was
-  // added. returns false - without adding anything - if the value cannot
-  // refer to a document of this collection (not a string, not a valid
-  // document id, or a different collection); such a lookup must be omitted
-  // by the caller, as it cannot produce any results.
+  // add an `_id` lookup value translated into a `_key` lookup value;
+  // returns false (adding nothing) if the value cannot refer to a
+  // document of this collection
   bool tryAddIdLookupValue(transaction::Methods* trx,
                            aql::AstNode const* value,
                            velocypack::Builder& searchValues) const;
 
-  // add the lookup value for an equality condition on field `fieldIndex`,
-  // translating `_id` values into `_key` values where needed. returns
-  // false - without adding anything - if the lookup cannot produce any
-  // results (cf. tryAddIdLookupValue).
+  // add the lookup value for an equality condition, translating `_id`
+  // values into `_key` values where needed; returns false if the lookup
+  // cannot produce any results
   bool addEqualityLookupValue(
       transaction::Methods* trx, size_t fieldIndex,
       std::vector<basics::AttributeName> const& accessPath,

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.h
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.h
@@ -192,8 +192,7 @@ class RocksDBVPackIndex : public RocksDBIndex {
   // add an `_id` lookup value translated into a `_key` lookup value;
   // returns false (adding nothing) if the value cannot refer to a
   // document of this collection
-  bool tryAddIdLookupValue(transaction::Methods* trx,
-                           aql::AstNode const* value,
+  bool tryAddIdLookupValue(transaction::Methods* trx, aql::AstNode const* value,
                            velocypack::Builder& searchValues) const;
 
   // add the lookup value for an equality condition, translating `_id`

--- a/tests/js/client/aql/aql-projections.js
+++ b/tests/js/client/aql/aql-projections.js
@@ -489,7 +489,72 @@ function projectionsPlansTestSuite () {
         assertEqual(query[4], nodes[0].strategy, query);
       });
     },
-    
+
+    testPersistentIdFromCoveredKey : function () {
+      // single-attribute `_id` and `_key` are interchangeable for covering
+      // purposes: a projection on `_id` can be satisfied by a covered `_key`
+      // value (indexed field or stored value), and a projection on `_key`
+      // can be satisfied by a covered `_id` entry (which physically stores
+      // the key value)
+      c.ensureIndex({ type: "persistent", fields: ["value1", "_key"], name: "value1_key" });
+      c.ensureIndex({ type: "persistent", fields: ["value3"], storedValues: ["_key"], name: "value3_sv_key" });
+      c.ensureIndex({ type: "persistent", fields: ["value2"], storedValues: ["_id"], name: "value2_sv_id" });
+      let queries = [
+        [`FOR doc IN ${cn} FILTER doc.value1 == 93 RETURN doc._id`, 'value1_key', ['_id'], true, "covering" ],
+        [`FOR doc IN ${cn} FILTER doc.value1 == 93 RETURN [doc._id, doc._key]`, 'value1_key', ['_id', '_key'], true, "covering" ],
+        [`FOR doc IN ${cn} FILTER doc.value1 == 93 RETURN [doc._id, doc.value1]`, 'value1_key', ['_id', 'value1'], true, "covering" ],
+        [`FOR doc IN ${cn} FILTER doc.value3 == 93 RETURN doc._id`, 'value3_sv_key', ['_id'], true, "covering" ],
+        [`FOR doc IN ${cn} FILTER doc.value2 == 'test93' RETURN doc._key`, 'value2_sv_id', ['_key'], true, "covering" ],
+        [`FOR doc IN ${cn} FILTER doc.value2 == 'test93' RETURN doc._id`, 'value2_sv_id', ['_id'], true, "covering" ],
+      ];
+
+      queries.forEach(function([query, indexName, projections, indexCoversProjections, strategy]) {
+        let plan = db._createStatement({query: query, options: { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }}).explain().plan;
+        let nodes = plan.nodes.filter(function(node) { return node.type === 'IndexNode'; });
+        assertEqual(1, nodes.length, query);
+        assertEqual(1, nodes[0].indexes.length, query);
+        assertEqual(indexName, nodes[0].indexes[0].name, query);
+        assertEqual(normalize(projections), normalize(nodes[0].projections), query);
+        assertEqual(indexCoversProjections, nodes[0].indexCoversProjections, query);
+        assertEqual(strategy, nodes[0].strategy, query);
+      });
+
+      // the rebuilt `_id` values must equal the real ones
+      assertEqual([ cn + "/test93" ],
+                  db._query(`FOR doc IN ${cn} FILTER doc.value1 == 93 RETURN doc._id`).toArray());
+      assertEqual([ cn + "/test93" ],
+                  db._query(`FOR doc IN ${cn} FILTER doc.value3 == 93 RETURN doc._id`).toArray());
+      assertEqual([ [ cn + "/test93", "test93", 93 ] ],
+                  db._query(`FOR doc IN ${cn} FILTER doc.value1 == 93 RETURN [doc._id, doc._key, doc.value1]`).toArray());
+      // `_key` projection served from a covered `_id` entry (stores the key)
+      assertEqual([ "test93" ],
+                  db._query(`FOR doc IN ${cn} FILTER doc.value2 == 'test93' RETURN doc._key`).toArray());
+      assertEqual([ cn + "/test93" ],
+                  db._query(`FOR doc IN ${cn} FILTER doc.value2 == 'test93' RETURN doc._id`).toArray());
+    },
+
+    testPersistentIdLookupOnKeyField : function () {
+      // lookups on `_id` can be answered by a persistent index with a
+      // `_key` field, analogous to the primary index. values that refer to
+      // other collections or are not valid document ids match nothing.
+      c.ensureIndex({ type: "persistent", fields: ["_key"], storedValues: ["value1"], name: "key_sv_value1" });
+      let query = `FOR doc IN ${cn} OPTIONS { indexHint: "key_sv_value1", forceIndexHint: true } FILTER doc._id IN @ids RETURN doc.value1`;
+      let ids = [ cn + "/test93", cn + "/test94", "otherCollection/test93", "not-an-id", null, 42 ];
+
+      let plan = db._createStatement({query, bindVars: { ids }, options: { optimizer: { rules: ["-optimize-cluster-single-document-operations"] } }}).explain().plan;
+      let nodes = plan.nodes.filter(function(node) { return node.type === 'IndexNode'; });
+      assertEqual(1, nodes.length, query);
+      assertEqual('key_sv_value1', nodes[0].indexes[0].name, query);
+      assertEqual(true, nodes[0].indexCoversProjections, query);
+
+      assertEqual([ 93, 94 ], db._query(query, { ids }).toArray().sort());
+
+      // equality lookup through the same index
+      let eqQuery = `FOR doc IN ${cn} OPTIONS { indexHint: "key_sv_value1", forceIndexHint: true } FILTER doc._id == @id RETURN doc.value1`;
+      assertEqual([ 93 ], db._query(eqQuery, { id: cn + "/test93" }).toArray());
+      assertEqual([ ], db._query(eqQuery, { id: "otherCollection/test93" }).toArray());
+    },
+
     testMaterialize : function () {
       if (!IM.debugCanUseFailAt()) {
         // cant execute this test as failure points are not available here


### PR DESCRIPTION
### Scope & Purpose
If an index has `_key` in either its fields or stored values, it can be used to server queries and projections on `_id`. See tests for more.