### PR TITLE
Use central error message from authorization [COR-596]

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -371,11 +371,15 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
           },
           [&](p::CreateDatabase const& /*database*/) -> Result {
             // Creating a database requires RW access to the _system database.
-            return isAdmin();
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
           },
           [&](p::DropDatabase const& /*database*/) -> Result {
             // Dropping a database requires RW access to the _system database.
-            return isAdmin();
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
           },
           [&](p::SeeCollection const& /*collection*/) -> Result {
             // Database RO access is the only prerequisite and has already been
@@ -560,20 +564,29 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
           [&](p::ReadUser const& /*readUser*/) -> Result {
             // Reading any user record requires at least RW access to the
             // _system database.
-            return isAdmin();
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
           },
           [&](p::WriteUser const& /*writeUser*/) -> Result {
             // Writing a user record requires RW access to the _system
             // database (equivalent to being an admin).
-            return isAdmin();
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
           },
       },
       permission);
 }
 
 Result AuthMode::Classic::isAdmin() const {
-  return check(auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
-                                        .level = DatabaseAccessLevel::Write});
+  auto r = check(auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                          .level = DatabaseAccessLevel::Write});
+  if (r.ok()) {
+    return {};
+  }
+  return {TRI_ERROR_FORBIDDEN,
+          "Missing RW permissions on _system database for admin purposes!"};
 }
 
 auto AuthMode::Rbac::username() const noexcept -> std::string_view {

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -582,10 +582,10 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
 Result AuthMode::Classic::isAdmin() const {
   auto r = check(auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
                                           .level = DatabaseAccessLevel::Write});
-  return r.ok() ? {}
-                : {TRI_ERROR_FORBIDDEN,
-                   "Missing RW permissions on _system database for admin "
-                   "purposes!"};
+  return r.ok() ? Result{}
+                : Result{TRI_ERROR_FORBIDDEN,
+                         "Missing RW permissions on _system database for admin "
+                         "purposes!"};
 }
 
 auto AuthMode::Rbac::username() const noexcept -> std::string_view {

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -582,8 +582,10 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
 Result AuthMode::Classic::isAdmin() const {
   auto r = check(auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
                                           .level = DatabaseAccessLevel::Write});
-  return r.ok() ?  {} : {TRI_ERROR_FORBIDDEN,
-          "Missing RW permissions on _system database for admin purposes!"};
+  return r.ok() ? {}
+                : {TRI_ERROR_FORBIDDEN,
+                   "Missing RW permissions on _system database for admin "
+                   "purposes!"};
 }
 
 auto AuthMode::Rbac::username() const noexcept -> std::string_view {

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -582,10 +582,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
 Result AuthMode::Classic::isAdmin() const {
   auto r = check(auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
                                           .level = DatabaseAccessLevel::Write});
-  if (r.ok()) {
-    return {};
-  }
-  return {TRI_ERROR_FORBIDDEN,
+  return r.ok() ?  {} : {TRI_ERROR_FORBIDDEN,
           "Missing RW permissions on _system database for admin purposes!"};
 }
 

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -55,8 +55,7 @@ RestStatus RestClusterHandler::execute() {
       if (auto r = ExecContext::current().canUseAdminAction(
               auth::perms::AdminClusterInfo{});
           r.fail()) {
-        generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                      r.errorMessage());
+        generateError(r);
         return RestStatus::DONE;
       }
       if (suffixes.size() == 1) {
@@ -155,8 +154,7 @@ void RestClusterHandler::handleAgencyDump() {
   auto const& exec = ExecContext::current();
   if (auto r = exec.canUseAdminAction(auth::perms::AdminReadAgency{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return;
   }
 
@@ -175,8 +173,7 @@ void RestClusterHandler::handleAgencyCache() {
   auto const& exec = ExecContext::current();
   if (auto r = exec.canUseAdminAction(auth::perms::AdminReadAgency{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return;
   }
 

--- a/arangod/ClusterEngine/ClusterRestWalHandler.cpp
+++ b/arangod/ClusterEngine/ClusterRestWalHandler.cpp
@@ -80,8 +80,7 @@ RestStatus ClusterRestWalHandler::execute() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminWalAccess{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return RestStatus::DONE;
     }
 #endif

--- a/arangod/RestHandler/RestAdminClusterHandler.cpp
+++ b/arangod/RestHandler/RestAdminClusterHandler.cpp
@@ -651,8 +651,7 @@ async<void> RestAdminClusterHandler::handleRemoveServer() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminRemoveServer{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -696,8 +695,7 @@ void RestAdminClusterHandler::handleShardStatistics() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminClusterInfo{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return;
   }
 
@@ -991,8 +989,7 @@ async<void> RestAdminClusterHandler::handleQueryJobStatus() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMoveShards{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -1072,8 +1069,7 @@ async<void> RestAdminClusterHandler::handleCancelJob() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMoveShards{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -1245,8 +1241,7 @@ async<void> RestAdminClusterHandler::handleSingleServerJob(
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMoveShards{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -1416,8 +1411,7 @@ void RestAdminClusterHandler::handleShardDistribution() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminClusterInfo{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return;
   }
 
@@ -1468,8 +1462,7 @@ void RestAdminClusterHandler::handleCollectionShardDistribution() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminClusterInfo{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return;
   }
 
@@ -1856,8 +1849,7 @@ async<void> RestAdminClusterHandler::handleMaintenance() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMaintenance{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -1891,8 +1883,7 @@ async<void> RestAdminClusterHandler::handleDBServerMaintenance(
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMaintenance{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -1972,8 +1963,7 @@ async<void> RestAdminClusterHandler::handlePutNumberOfServers() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMaintenance{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -2093,8 +2083,7 @@ async<void> RestAdminClusterHandler::handleNumberOfServers() {
     if (auto r = ExecContext::current().canUseHardenedAction(
             auth::perms::AdminMaintenance{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       co_return;
     }
   }
@@ -2122,8 +2111,7 @@ async<void> RestAdminClusterHandler::handleUniqId() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMaintenance{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -2545,8 +2533,7 @@ async<void> RestAdminClusterHandler::handleRebalanceShards() {
   ExecContext const& exec = ExecContext::current();
   if (auto r = exec.canUseAdminAction(auth::perms::AdminRebalance{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 
@@ -2877,8 +2864,7 @@ async<void> RestAdminClusterHandler::handleRebalance() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminRebalance{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -201,8 +201,7 @@ void RestAdminServerHandler::handleMode() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminMaintenance{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return;
     }
 
@@ -331,8 +330,7 @@ void RestAdminServerHandler::handleApiCalls() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminApiCalls{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return;
     }
   }
@@ -386,8 +384,7 @@ void RestAdminServerHandler::handleAqlRecordedQueries() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminAqlQueries{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return;
     }
   }

--- a/arangod/RestHandler/RestAdminStatisticsHandler.cpp
+++ b/arangod/RestHandler/RestAdminStatisticsHandler.cpp
@@ -54,8 +54,7 @@ RestStatus RestAdminStatisticsHandler::execute() {
           auth::perms::AdminMonitoring{});
       r.fail()) {
     // dont leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestAuthReloadHandler.cpp
+++ b/arangod/RestHandler/RestAuthReloadHandler.cpp
@@ -44,8 +44,7 @@ RestStatus RestAuthReloadHandler::execute() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminAuthReload{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestCrashHandler.cpp
+++ b/arangod/RestHandler/RestCrashHandler.cpp
@@ -42,8 +42,7 @@ futures::Future<futures::Unit> RestCrashHandler::executeAsync() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminCrashHandler{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 

--- a/arangod/RestHandler/RestDocumentStateHandler.cpp
+++ b/arangod/RestHandler/RestDocumentStateHandler.cpp
@@ -75,16 +75,14 @@ RestStatus RestDocumentStateHandler::execute() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminReadReplicatedLog{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return RestStatus::DONE;
     }
   } else {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminWriteReplicatedLog{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return RestStatus::DONE;
     }
   }

--- a/arangod/RestHandler/RestEngineHandler.cpp
+++ b/arangod/RestHandler/RestEngineHandler.cpp
@@ -72,8 +72,7 @@ void RestEngineHandler::handleGet() {
           auth::perms::AdminMonitoringInternal{});
       r.fail()) {
     // dont leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return;
   }
 

--- a/arangod/RestHandler/RestLogHandler.cpp
+++ b/arangod/RestHandler/RestLogHandler.cpp
@@ -52,16 +52,14 @@ auto RestLogHandler::executeAsync() -> futures::Future<futures::Unit> {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminReadReplicatedLog{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       co_return;
     }
   } else {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminWriteReplicatedLog{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       co_return;
     }
   }

--- a/arangod/RestHandler/RestMetricsHandler.cpp
+++ b/arangod/RestHandler/RestMetricsHandler.cpp
@@ -95,8 +95,7 @@ auto RestMetricsHandler::executeAsync() -> futures::Future<futures::Unit> {
           auth::perms::AdminMonitoring{});
       r.fail()) {
     // don't leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 

--- a/arangod/RestHandler/RestOptionsBaseHandler.cpp
+++ b/arangod/RestHandler/RestOptionsBaseHandler.cpp
@@ -52,8 +52,7 @@ bool RestOptionsBaseHandler::checkAuthentication() {
   if (auto r =
           ExecContext::current().canUseAdminAction(auth::perms::AdminOptions{});
       apiPolicy == "admin" && r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return false;
   }
 

--- a/arangod/RestHandler/RestReplicationHandler.cpp
+++ b/arangod/RestHandler/RestReplicationHandler.cpp
@@ -3251,8 +3251,7 @@ bool RestReplicationHandler::prepareCollectionForRevisionOperation(
   if (auto r = ExecContext::current().canUseCollection(
           _vocbase.name(), ctx.cname, AccessLevel::Read);
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return false;
   }
 

--- a/arangod/RestHandler/RestShutdownHandler.cpp
+++ b/arangod/RestHandler/RestShutdownHandler.cpp
@@ -59,8 +59,7 @@ RestStatus RestShutdownHandler::execute() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminShutdown{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -71,8 +71,7 @@ RestStatus RestStatusHandler::execute() {
           auth::perms::AdminMonitoring{});
       r.fail()) {
     // dont leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestSupervisionStateHandler.cpp
+++ b/arangod/RestHandler/RestSupervisionStateHandler.cpp
@@ -44,8 +44,7 @@ futures::Future<futures::Unit> RestSupervisionStateHandler::executeAsync() {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminSupervisionState{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 

--- a/arangod/RestHandler/RestSupportInfoHandler.cpp
+++ b/arangod/RestHandler/RestSupportInfoHandler.cpp
@@ -57,8 +57,7 @@ RestStatus RestSupportInfoHandler::execute() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminMonitoring{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return RestStatus::DONE;
     }
   }

--- a/arangod/RestHandler/RestSystemReportHandler.cpp
+++ b/arangod/RestHandler/RestSystemReportHandler.cpp
@@ -78,8 +78,7 @@ RestStatus RestSystemReportHandler::execute() {
           arangodb::auth::perms::AdminMonitoringInternal{});
       r.fail()) {
     // dont leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     return RestStatus::DONE;
   }
 

--- a/arangod/RestHandler/RestUsageMetricsHandler.cpp
+++ b/arangod/RestHandler/RestUsageMetricsHandler.cpp
@@ -49,8 +49,7 @@ auto RestUsageMetricsHandler::executeAsync() -> futures::Future<futures::Unit> {
           auth::perms::AdminMonitoringInternal{});
       r.fail()) {
     // don't leak information about server internals here
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 

--- a/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
+++ b/arangod/RocksDBEngine/RocksDBRestWalHandler.cpp
@@ -80,8 +80,7 @@ RestStatus RocksDBRestWalHandler::execute() {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminWalAccess{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       return RestStatus::DONE;
     }
 #endif

--- a/arangod/SystemMonitor/Activities/RestHandler.cpp
+++ b/arangod/SystemMonitor/Activities/RestHandler.cpp
@@ -126,8 +126,7 @@ auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
     if (auto r = ExecContext::current().canUseAdminAction(
             auth::perms::AdminMonitoringInternal{});
         r.fail()) {
-      generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                    r.errorMessage());
+      generateError(r);
       co_return;
     }
   }

--- a/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
+++ b/arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
@@ -37,8 +37,7 @@ auto RestHandler::executeAsync() -> futures::Future<futures::Unit> {
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminMonitoringInternal{});
       r.fail()) {
-    generateError(rest::ResponseCode::FORBIDDEN, TRI_ERROR_HTTP_FORBIDDEN,
-                  r.errorMessage());
+    generateError(r);
     co_return;
   }
 

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -490,7 +490,7 @@ futures::Future<arangodb::Result> Indexes::ensureIndex(
             exec.canCreateIndex(collection.vocbase().name(), collection.name());
         r.fail()) {
       ensureIndexResult = TRI_ERROR_FORBIDDEN;
-      co_return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
+      co_return r;
     }
   } else {
     if (auto r = exec.canUseCollection(collection.vocbase().name(),

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -490,7 +490,7 @@ futures::Future<arangodb::Result> Indexes::ensureIndex(
             exec.canCreateIndex(collection.vocbase().name(), collection.name());
         r.fail()) {
       ensureIndexResult = TRI_ERROR_FORBIDDEN;
-      co_return r;
+      co_return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
     }
   } else {
     if (auto r = exec.canUseCollection(collection.vocbase().name(),


### PR DESCRIPTION
Use centrally generated error messages from authorization.
This addresses https://arangodb.atlassian.net/browse/COR-596

Also: In Classic mode, generate a good central error message for `isAdmin`.

### Scope & Purpose

- [*] :hankey: Bugfix

