### PR TITLE
Validate crash dump IDs before filesystem access

### DIFF
--- a/arangod/RestHandler/RestCrashHandler.cpp
+++ b/arangod/RestHandler/RestCrashHandler.cpp
@@ -66,6 +66,12 @@ futures::Future<futures::Unit> RestCrashHandler::executeAsync() {
     // /_admin/crashes/{id}
     auto const& crashId = suffixes[0];
 
+    if (!DumpManager::isValidCrashId(crashId)) {
+      generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER,
+                    "invalid crash ID");
+      co_return;
+    }
+
     if (_request->requestType() == rest::RequestType::GET) {
       handleGetCrash(dumpManager, crashId);
     } else if (_request->requestType() == rest::RequestType::DELETE_REQ) {

--- a/lib/CrashHandler/DumpManager.cpp
+++ b/lib/CrashHandler/DumpManager.cpp
@@ -23,8 +23,8 @@
 #include "CrashHandler/DumpManager.h"
 
 #include <filesystem>
-#include <queue>
 #include <fstream>
+#include <queue>
 #include <sstream>
 
 #include <boost/uuid/uuid.hpp>
@@ -37,6 +37,34 @@ namespace arangodb::crash_handler {
 
 DumpManager::DumpManager(std::shared_ptr<DataSourceRegistry> dataSourceRegistry)
     : _dataSourceRegistry(std::move(dataSourceRegistry)) {}
+
+bool DumpManager::isValidCrashId(std::string_view crashId) noexcept {
+  if (crashId.size() != 36) {
+    return false;
+  }
+
+  for (size_t idx = 0; idx < crashId.size(); ++idx) {
+    if (idx == 8 || idx == 13 || idx == 18 || idx == 23) {
+      if (crashId[idx] != '-') {
+        return false;
+      }
+    } else if (!((crashId[idx] >= '0' && crashId[idx] <= '9') ||
+                 (crashId[idx] >= 'a' && crashId[idx] <= 'f'))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::optional<std::filesystem::path> DumpManager::resolveCrashDirectory(
+    std::string_view crashId) const {
+  if (_crashesDirectory.empty() || !isValidCrashId(crashId)) {
+    return std::nullopt;
+  }
+
+  return _crashesDirectory / std::string(crashId);
+}
 
 void DumpManager::setCrashesDirectory(
     std::filesystem::path const& crashesDirectory) {
@@ -57,8 +85,9 @@ std::vector<std::string> DumpManager::listCrashes() const {
 
   for (auto const& entry :
        std::filesystem::directory_iterator(_crashesDirectory)) {
-    if (entry.is_directory()) {
-      crashes.push_back(entry.path().filename().string());
+    auto const crashId = entry.path().filename().string();
+    if (entry.is_directory() && isValidCrashId(crashId)) {
+      crashes.push_back(crashId);
     }
   }
   return crashes;
@@ -66,16 +95,16 @@ std::vector<std::string> DumpManager::listCrashes() const {
 
 std::unordered_map<std::string, std::string> DumpManager::getCrashContents(
     std::string_view crashId) const {
-  if (_crashesDirectory.empty()) {
+  auto const crashDir = resolveCrashDirectory(crashId);
+  if (!crashDir.has_value()) {
     return {};
   }
 
   std::unordered_map<std::string, std::string> contents;
-  auto const crashDir = _crashesDirectory / std::string(crashId);
-  if (!std::filesystem::is_directory(crashDir)) {
+  if (!std::filesystem::is_directory(*crashDir)) {
     return contents;
   }
-  for (auto const& entry : std::filesystem::directory_iterator(crashDir)) {
+  for (auto const& entry : std::filesystem::directory_iterator(*crashDir)) {
     if (entry.is_regular_file()) {
       try {
         std::ifstream file(entry.path(), std::ios::binary);
@@ -93,15 +122,15 @@ std::unordered_map<std::string, std::string> DumpManager::getCrashContents(
 }
 
 bool DumpManager::deleteCrash(std::string_view crashId) {
-  if (_crashesDirectory.empty()) {
+  auto const crashDir = resolveCrashDirectory(crashId);
+  if (!crashDir.has_value()) {
     return false;
   }
-  auto const crashDir = _crashesDirectory / std::string(crashId);
-  if (!std::filesystem::is_directory(crashDir)) {
+  if (!std::filesystem::is_directory(*crashDir)) {
     return false;
   }
   std::error_code ec;
-  std::filesystem::remove_all(crashDir, ec);
+  std::filesystem::remove_all(*crashDir, ec);
   return !ec;
 }
 

--- a/lib/CrashHandler/DumpManager.cpp
+++ b/lib/CrashHandler/DumpManager.cpp
@@ -39,22 +39,13 @@ DumpManager::DumpManager(std::shared_ptr<DataSourceRegistry> dataSourceRegistry)
     : _dataSourceRegistry(std::move(dataSourceRegistry)) {}
 
 bool DumpManager::isValidCrashId(std::string_view crashId) noexcept {
-  if (crashId.size() != 36) {
+  try {
+    boost::uuids::string_generator gen;
+    gen(crashId.begin(), crashId.end());
+    return true;
+  } catch (...) {
     return false;
   }
-
-  for (size_t idx = 0; idx < crashId.size(); ++idx) {
-    if (idx == 8 || idx == 13 || idx == 18 || idx == 23) {
-      if (crashId[idx] != '-') {
-        return false;
-      }
-    } else if (!((crashId[idx] >= '0' && crashId[idx] <= '9') ||
-                 (crashId[idx] >= 'a' && crashId[idx] <= 'f'))) {
-      return false;
-    }
-  }
-
-  return true;
 }
 
 std::optional<std::filesystem::path> DumpManager::resolveCrashDirectory(

--- a/lib/CrashHandler/DumpManager.h
+++ b/lib/CrashHandler/DumpManager.h
@@ -25,9 +25,11 @@
 #include <cstddef>
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <vector>
 
 #include "CrashHandler/DataSourceRegistry.h"
 
@@ -39,6 +41,9 @@ static constexpr size_t kMaxCrashDirectories{10};
 class DumpManager {
  public:
   DumpManager(std::shared_ptr<DataSourceRegistry> dataSourceRegistry);
+
+  /// @brief checks whether a crash ID is a canonical lowercase UUID
+  static bool isValidCrashId(std::string_view crashId) noexcept;
 
   /// @brief lists all crash directories (returns UUIDs)
   std::vector<std::string> listCrashes() const;
@@ -58,6 +63,9 @@ class DumpManager {
   void dumpCrashData(std::string_view backtrace) const;
 
  private:
+  std::optional<std::filesystem::path> resolveCrashDirectory(
+      std::string_view crashId) const;
+
   std::filesystem::path _crashesDirectory;
   std::shared_ptr<DataSourceRegistry> _dataSourceRegistry;
 };

--- a/tests/js/client/recovery/cluster/crash/dump-api-coordinator.js
+++ b/tests/js/client/recovery/cluster/crash/dump-api-coordinator.js
@@ -109,6 +109,23 @@ function recoverySuite () {
       const verifyResponse = arango.GET(crashesEndpoint);
       const verifyCrashes = verifyResponse.result || verifyResponse;
       assertEqual(0, verifyCrashes.length, 'Crash should be deleted');
+    },
+
+    testCrashDumpRejectsInvalidIds: function () {
+      ['.', '..', 'not-a-boost-uuid'].forEach((invalidCrashId) => {
+        const response = arango.GET(crashesEndpoint + '/' + invalidCrashId);
+        assertTrue(response.error,
+                   `Crash ID '${invalidCrashId}' should be rejected`);
+        assertEqual(400, response.code,
+                    `Crash ID '${invalidCrashId}' should return HTTP 400`);
+      });
+
+      const missingCrashId = '00000000-0000-4000-8000-000000000000';
+      const response = arango.GET(crashesEndpoint + '/' + missingCrashId);
+      assertTrue(response.error,
+                 `Missing crash ID '${missingCrashId}' should return an error`);
+      assertEqual(404, response.code,
+                  `Missing crash ID '${missingCrashId}' should return HTTP 404`);
     }
   };
 }


### PR DESCRIPTION
### Scope & Purpose

**Issue**

The crash API accepts paths like `_admin/crashes/<uuid>`. Normally, `<uuid>` is expected to be a Boost UUID string of the form `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, but this is not enforced. Two things can happen if the `<uuid>` is a filesystem path component:
- Some immediate files may be exposed through a GET request.
- Some folders may be deleted (including the database) through a DELETE request.

**Repro**

```bash
curl --path-as-is -i -X DELETE \
    http://localhost:8630/_db/_system/_admin/crashes/../
```

This is **not exploitable in practice** because:
- The crash API requires admin access to the database.
-  The `RestCrashHandler` already accepts only 0 or 1 path suffixes. Something with more than one level (e.g. `_admin/crashes/foo/bar`) gets rejected.

**Fix**

This PR adds the following rules:
1. Invalid UUID: HTTP 400 with `TRI_ERROR_BAD_PARAMETER`.
2. Valid UUID with no corresponding directory: HTTP 404.
3. Valid UUID and existing crash directory: preserve the current GET or DELETE
   behavior.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
