### PR TITLE
Fix user modification permissions

### DIFF
--- a/Documentation/path_permissions.md
+++ b/Documentation/path_permissions.md
@@ -264,8 +264,11 @@ return a `Result`, so that a decline can return the actual reason
  - `canUseGraph(std::string_view db, std::string_view graph, GraphAccessLevel const level) -> Result`
  
  - `canReadUser(std::string_view user) -> Result`
- - `canWriteUser(std::string_view user) -> Result`
  - `canReadUsers(std::span<std::string_view const> -> std::vector<bool>`
+ - `canCreateUser(std::string_view user) -> Result`
+ - `canDropUser(std::string_view user) -> Result`
+ - `canModifyUserProfile(std::string_view user) -> Result`
+ - `canGrantUserPermissions(std::string_view user) -> Result`
 
  - `isSuperuser() -> bool`
 
@@ -472,15 +475,28 @@ central implementation of these methods.
   
  - `canReadUser(std::string_view user) -> Result`
 
-   check RO access in system database
-  
- - `canWriteUser(std::string_view user) -> Result`
-
-   check RW access in system database
+  check RO access in system database
   
  - `canReadUsers(std::span<std::string_view const> -> std::vector<bool>`
 
-   check RO access in system database
+  check RO access in system database
+  
+ - `canCreateUser(std::string_view user) -> Result`
+
+  check RW access in system database
+  
+ - `canDropUser(std::string_view user) -> Result`
+
+  check RW access in system database
+  
+ - `canModifyUserProfile(std::string_view user) -> Result`
+
+  check RW access in system database (note: everybody may modify their own
+  profile)
+  
+ - `canGrantUserPermissions(std::string_view user) -> Result`
+
+  check RW access in system database
   
 - `isSuperuser() -> bool`
 
@@ -664,15 +680,27 @@ central implementation of these methods.
 
  - `canReadUser(std::string_view user) -> Result`
 
-   check RBAC action `db:ReadUser`
-  
- - `canWriteUser(std::string_view user) -> Result`
-
-   check RBAC action `db:WriteUser`
+  check RBAC action `db:ReadUser`
   
  - `canReadUsers(std::span<std::string_view const> -> std::vector<bool>`
 
-   check RBAC action `db:ReadUser`
+  check RBAC action `db:ReadUser`
+  
+ - `canCreateUser(std::string_view user) -> Result`
+
+  check RBAC action `db:CreateUser`
+  
+ - `canDropUser(std::string_view user) -> Result`
+
+  check RBAC action `db:DropUser`
+  
+ - `canModifyUserProfile(std::string_view user) -> Result`
+
+  check RBAC action `db:ModifyUserProfile`
+  
+ - `canGrantUserPermissions(std::string_view user) -> Result`
+
+  check RBAC action `db:GrantUserPermissions`
   
 - `isSuperuser() -> bool`
 
@@ -1035,29 +1063,29 @@ SA/SW/LEG    - API is switchable between SA (superuser needed for everything), S
 | X  |    | -  | PUT    | `/_api/tasks/{id}`                                           | RestTasksHandler           | canUseDb(Write)                          | DB RW                               | (V8 required)                            | NO FIX, tasks gone soon|
 | X  |    | X  | DELETE | `/_api/tasks/{id}`                                           | RestTasksHandler           | canUseDb(Write)                          | DB RW                               | (V8 required)                            | NO FIX, tasks gone soon|
 | X  |    | X  | GET    | `/_api/token/{user}`                                         | RestAccessTokenHandler     | canReadUser                              | canReadUser                         |                                          |                        |
-| X  |    | X  | POST   | `/_api/token/{user}`                                         | RestAccessTokenHandler     | canWriteUser                             | canWriteUser                        |                                          |                        |
-| X  |    | X  | DELETE | `/_api/token/{user}/{id}`                                    | RestAccessTokenHandler     | canWriteUser                             | canWriteUser                        |                                          |                        |
+| X  |    | X  | POST   | `/_api/token/{user}`                                         | RestAccessTokenHandler     | canModifyUserProfile                     | canModifyUserProfile                |                                          |                        |
+| X  |    | X  | DELETE | `/_api/token/{user}/{id}`                                    | RestAccessTokenHandler     | canModifyUserProfile                     | canModifyUserProfile                |                                          |                        |
 | X  |    | X  | GET    | `/_api/ttl/properties`                                       | RestTtlHandler             | _system                                  | AUTHEN, _system                     |                                          |                        |
 | X  |    | X  | GET    | `/_api/ttl/statistics`                                       | RestTtlHandler             | _system                                  | AUTHEN, _system                     |                                          |                        |
 | X  |    | X  | PUT    | `/_api/ttl/properties`                                       | RestTtlHandler             | _system                                  | AUTHEN, _system                     |                                          |                        |
 | X  |    | X  | POST   | `/_api/upload`                                               | RestUploadHandler          | -                                        | AUTHEN                              | Gone in 4.0                              | NO FIX                 |
 | X  |    | X  | GET    | `/_api/user`                                                 | RestUsersHandler           | canReadUsers(list)                       | AUTHEN, see only canReadUser(u)     |                                          |                        |
-| X  |    | X  | POST   | `/_api/user`                                                 | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
+| X  |    | X  | POST   | `/_api/user`                                                 | RestUsersHandler           | canCreateUser(u)                         | canCreateUser(u)                    |                                          |                        |
 | X  |    | X  | POST   | `/_api/user/{user}`                                          | RestUsersHandler           | -                                        | AUTHEN, just check credentials      |                                          |                        |
 | X  |    | X  | GET    | `/_api/user/{user}`                                          | RestUsersHandler           | canReadUser(u)                           | canReadUser(u)                      |                                          |                        |
 | X  |    | X  | GET    | `/_api/user/{user}/config`                                   | RestUsersHandler           | canReadUser(u)                           | canReadUser(u)                      |                                          |                        |
 | X  |    | X  | GET    | `/_api/user/{user}/database`                                 | RestUsersHandler           | canReadUser(u)                           | canReadUser(u)                      |                                          |                        |
 | X  |    | X  | GET    | `/_api/user/{user}/database/{db}`                            | RestUsersHandler           | canReadUser(u)                           | canReadUser(u)                      |                                          |                        |
 | X  |    | X  | GET    | `/_api/user/{user}/database/{db}/{coll}`                     | RestUsersHandler           | canReadUser(u)                           | canReadUser(u)                      |                                          |                        |
-| X  |    | X  | PUT    | `/_api/user/{user}`                                          | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | PUT    | `/_api/user/{user}/database/{db}`                            | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | PUT    | `/_api/user/{user}/database/{db}/{coll}`                     | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | PUT    | `/_api/user/{user}/config/{key}`                             | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | PATCH  | `/_api/user/{user}`                                          | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | DELETE | `/_api/user/{user}`                                          | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | DELETE | `/_api/user/{user}/config/{key}`                             | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | DELETE | `/_api/user/{user}/database/{db}`                            | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
-| X  |    | X  | DELETE | `/_api/user/{user}/database/{db}/{coll}`                     | RestUsersHandler           | canWriteUser(u)                          | canWriteUser(u)                     |                                          |                        |
+| X  |    | X  | PUT    | `/_api/user/{user}`                                          | RestUsersHandler           | canModifyUserProfile(u)                  | canModifyUserProfile(u)             |                                          |                        |
+| X  |    | X  | PUT    | `/_api/user/{user}/database/{db}`                            | RestUsersHandler           | canGrantUserPermissions(u)               | canGrantUserPermissions(u)          |                                          |                        |
+| X  |    | X  | PUT    | `/_api/user/{user}/database/{db}/{coll}`                     | RestUsersHandler           | canGrantUserPermissions(u)               | canGrantUserPermissions(u)          |                                          |                        |
+| X  |    | X  | PUT    | `/_api/user/{user}/config/{key}`                             | RestUsersHandler           | canModifyUserProfile(u)                  | canModifyUserProfile(u)             |                                          |                        |
+| X  |    | X  | PATCH  | `/_api/user/{user}`                                          | RestUsersHandler           | canModifyUserProfile(u)                  | canModifyUserProfile(u)             |                                          |                        |
+| X  |    | X  | DELETE | `/_api/user/{user}`                                          | RestUsersHandler           | canDropUser(u)                           | canDropUser(u)                      |                                          |                        |
+| X  |    | X  | DELETE | `/_api/user/{user}/config/{key}`                             | RestUsersHandler           | canModifyUserProfile(u)                  | canModifyUserProfile(u)             |                                          |                        |
+| X  |    | X  | DELETE | `/_api/user/{user}/database/{db}`                            | RestUsersHandler           | canGrantUserPermissions(u)               | canGrantUserPermissions(u)          |                                          |                        |
+| X  |    | X  | DELETE | `/_api/user/{user}/database/{db}/{coll}`                     | RestUsersHandler           | canGrantUserPermissions(u)               | canGrantUserPermissions(u)          |                                          |                        |
 | X  |    | X  | GET    | `/_api/version`                                              | RestVersionHandler         | canUseHard(MonitoringInt) for details    | AUTHEN, details (2)                 |                                          |                        |
 | X  |    | X  | GET    | `/_api/view`                                                 | RestViewHandler            | only see those with canSeeView           | canSeeView                          |                                          |                        |
 | X  |    | X  | POST   | `/_api/view`                                                 | RestViewHandler            | canCreateView                            | canCreateView                       |                                          |                        |
@@ -1105,18 +1133,18 @@ SA/SW/LEG    - API is switchable between SA (superuser needed for everything), S
 | X  |    |    | JS     | `JS_At`                                                      | v8-replicated-logs.cpp     | canUseAdmin(ReadReplicatedLog)           | AdminReadReplicatedLog              |                                          |                        |
 | X  |    |    | JS     | `JS_Release`                                                 | v8-replicated-logs.cpp     | canUseAdmin(WriteReplicatedLog)          | AdminWriteReplicatedLog             |                                          |                        |
 | X  |    |    | JS     | `JS_Compact`                                                 | v8-replicated-logs.cpp     | canUseAdmin(WriteReplicatedLog)          | AdminWriteReplicatedLog             |                                          |                        |
-| X  |    |    | JS     | `JS_RemoveUser`                                              | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
+| X  |    |    | JS     | `JS_RemoveUser`                                              | v8-users.cpp               | canDropUser()                            | canDropUser                         |                                          |                        |
 | X  |    |    | JS     | `JS_ReloadAuthData`                                          | v8-users.cpp               | canUseAdmin(AuthReload)                  | AdminAuthReload                     |                                          |                        |
-| X  |    |    | JS     | `JS_GrantDatabase`                                           | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
-| X  |    |    | JS     | `JS_RevokeDatabase`                                          | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
-| X  |    |    | JS     | `JS_GrantCollection`                                         | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
-| X  |    |    | JS     | `JS_RevokeCollection`                                        | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
-| X  |    |    | JS     | `StoreUser`                                                  | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
-| X  |    |    | JS     | `JS_UpdateUser`                                              | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
+| X  |    |    | JS     | `JS_GrantDatabase`                                           | v8-users.cpp               | canGrantUserPermissions()                | canGrantUserPermissions             |                                          |                        |
+| X  |    |    | JS     | `JS_RevokeDatabase`                                          | v8-users.cpp               | canGrantUserPermissions()                | canGrantUserPermissions             |                                          |                        |
+| X  |    |    | JS     | `JS_GrantCollection`                                         | v8-users.cpp               | canGrantUserPermissions()                | canGrantUserPermissions             |                                          |                        |
+| X  |    |    | JS     | `JS_RevokeCollection`                                        | v8-users.cpp               | canGrantUserPermissions()                | canGrantUserPermissions             |                                          |                        |
+| X  |    |    | JS     | `StoreUser`                                                  | v8-users.cpp               | canCreateUser()/canModifyUserProfile()   | canCreateUser/canModifyUserProfile  |                                          |                        |
+| X  |    |    | JS     | `JS_UpdateUser`                                              | v8-users.cpp               | canModifyUserProfile()                   | canModifyUserProfile                |                                          |                        |
 | X  |    |    | JS     | `JS_GetUser`                                                 | v8-users.cpp               | canReadUser()                            | canReadUser                         |                                          |                        |
-| X  |    |    | JS     | `JS_UpdateConfigData`                                        | v8-users.cpp               | canWriteUser()                           | canWriteUser                        |                                          |                        |
+| X  |    |    | JS     | `JS_UpdateConfigData`                                        | v8-users.cpp               | canModifyUserProfile()                   | canModifyUserProfile                |                                          |                        |
 | X  |    |    | JS     | `JS_GetConfigData`                                           | v8-users.cpp               | canReaduser()                            | canReadUser                         |                                          |                        |
-| X  |    |    | CPP    | `Databases::grantCurrentUser` (creation of database)         | Databases.Cpp              | canWriteUser()                           | canWriteUser                        |                                          |                        |
+| X  |    |    | CPP    | `Databases::grantCurrentUser` (creation of database)         | Databases.Cpp              | canGrantUserPermissions()                | canGrantUserPermissions             |                                          |                        |
 | X  |    |    | JS     | `JS_GetGraphKeys`                                            | v8-general-graph.cpp       | canSeeGraph                              | canSeeGraph, list only visible      |                                          |                        |
 
 

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -568,9 +568,35 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
                 auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
                                          .level = DatabaseAccessLevel::Write});
           },
-          [&](p::WriteUser const& /*writeUser*/) -> Result {
-            // Writing a user record requires RW access to the _system
-            // database (equivalent to being an admin).
+          [&](p::CreateUser const& /*createUser*/) -> Result {
+            // Creating a user requires RW access to the _system database
+            // (equivalent to being an admin).
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
+          },
+          [&](p::DropUser const& /*dropUser*/) -> Result {
+            // Dropping a user requires RW access to the _system database
+            // (equivalent to being an admin).
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
+          },
+          [&](p::ModifyUserProfile const& /*modifyUserProfile*/) -> Result {
+            // Modifying a user's own profile (password, active flag, config
+            // blob) requires RW access to the _system database (equivalent
+            // to being an admin). Note that the self-exception is already
+            // handled by ExecContext::canModifyUserProfile before this is
+            // ever reached.
+            return check(
+                auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                         .level = DatabaseAccessLevel::Write});
+          },
+          [&](p::GrantUserPermissions const& /*grantUserPermissions*/)
+              -> Result {
+            // Granting/revoking a user's permissions on databases and
+            // collections requires RW access to the _system database
+            // (equivalent to being an admin).
             return check(
                 auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
                                          .level = DatabaseAccessLevel::Write});

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -319,7 +319,24 @@ struct ReadUser {
   std::string name;
 };
 
-struct WriteUser {
+// Create a new user record.
+struct CreateUser {
+  std::string name;
+};
+
+// Drop (remove) an existing user record.
+struct DropUser {
+  std::string name;
+};
+
+// Modify a user's own profile data: password, active flag, config blob.
+// Note that (with Classic auth) everybody may modify their own profile.
+struct ModifyUserProfile {
+  std::string name;
+};
+
+// Grant or revoke a user's permissions on databases and collections.
+struct GrantUserPermissions {
   std::string name;
 };
 
@@ -340,7 +357,7 @@ using NonAdminList = meta::TypeList<
     // graph permissions
     SeeGraph, CreateGraph, DropGraph, UseGraph,
     // user permissions
-    ReadUser, WriteUser>;
+    ReadUser, CreateUser, DropUser, ModifyUserProfile, GrantUserPermissions>;
 
 using CompleteList = meta::detail::Union<AdminList, NonAdminList>::type;
 }  // namespace detail

--- a/arangod/RestHandler/RestAccessTokenHandler.cpp
+++ b/arangod/RestHandler/RestAccessTokenHandler.cpp
@@ -76,13 +76,13 @@ RestStatus RestAccessTokenHandler::execute() {
       }
       return showAccessTokens(um, user);
     case RequestType::POST:
-      if (auto r = exec.canWriteUser(user); !r.ok()) {
+      if (auto r = exec.canModifyUserProfile(user); !r.ok()) {
         generateError(r);
         return RestStatus::DONE;
       }
       return createAccessToken(um, user);
     case RequestType::DELETE_REQ:
-      if (auto r = exec.canWriteUser(user); !r.ok()) {
+      if (auto r = exec.canModifyUserProfile(user); !r.ok()) {
         generateError(r);
         return RestStatus::DONE;
       }

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -571,21 +571,25 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
     }
   } else if (suffixes.size() == 2) {
     std::string const& user = suffixes[0];
-    if (suffixes[1] == "config" && exec.canModifyUserProfile(user).ok()) {
-      Result r = um->updateUser(
-          user,
-          [&](auth::User& u) {
-            u.setConfigData(VPackBuilder());
-            return TRI_ERROR_NO_ERROR;
-          },
-          auth::UserManager::RetryOnConflict::No);
-      if (r.ok()) {
-        resetResponse(ResponseCode::OK);
+    if (suffixes[1] == "config") {
+      if (auto r2 = exec.canModifyUserProfile(user); r2.ok()) {
+        Result r = um->updateUser(
+            user,
+            [&](auth::User& u) {
+              u.setConfigData(VPackBuilder());
+              return TRI_ERROR_NO_ERROR;
+            },
+            auth::UserManager::RetryOnConflict::No);
+        if (r.ok()) {
+          resetResponse(ResponseCode::OK);
+        } else {
+          generateError(r);
+        }
       } else {
-        generateError(r);
+        generateError(r2);
       }
     } else {
-      generateError(rest::ResponseCode::BAD, TRI_ERROR_BAD_PARAMETER);
+      generateError(rest::ResponseCode::NOT_FOUND, TRI_ERROR_HTTP_NOT_FOUND);
     }
   } else if (suffixes.size() == 3 || suffixes.size() == 4) {
     std::string const& user = suffixes[0];

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -350,7 +350,7 @@ RestStatus RestUsersHandler::postRequest(auth::UserManager* um) {
     VPackSlice s = body.get("user");
     std::string user = s.isString() ? s.copyString() : "";
     auto& exec = ExecContext::current();
-    if (auto r = exec.canWriteUser(user); r.ok()) {
+    if (auto r = exec.canCreateUser(user); r.ok()) {
       // create user
       if (auto r = StoreUser(um, 0, user, body); r.ok()) {
         VPackBuilder doc = um->serializeUser(user);
@@ -395,7 +395,7 @@ RestStatus RestUsersHandler::putRequest(auth::UserManager* um) {
   if (suffixes.size() == 1) {
     // replace existing user
     std::string const& user = suffixes[0];
-    if (auto r = exec.canWriteUser(user); r.fail()) {
+    if (auto r = exec.canModifyUserProfile(user); r.fail()) {
       generateError(r);
       return RestStatus::DONE;
     }
@@ -416,7 +416,7 @@ RestStatus RestUsersHandler::putRequest(auth::UserManager* um) {
       std::string const& db = suffixes[2];
       std::string coll = suffixes.size() == 4 ? suffixes[3] : "";
 
-      if (auto r = exec.canWriteUser(name); r.fail()) {
+      if (auto r = exec.canGrantUserPermissions(name); r.fail()) {
         generateError(r);
         return RestStatus::DONE;
       }
@@ -468,7 +468,7 @@ RestStatus RestUsersHandler::putRequest(auth::UserManager* um) {
       }
     } else if (suffixes[1] == "config") {
       // update internal config data, used in the admin dashboard
-      if (auto r = exec.canWriteUser(name); r.fail()) {
+      if (auto r = exec.canModifyUserProfile(name); r.fail()) {
         generateError(r);
         return RestStatus::DONE;
       }
@@ -531,7 +531,7 @@ RestStatus RestUsersHandler::patchRequest(auth::UserManager* um) {
   auto& exec = ExecContext::current();
   if (suffixes.size() == 1) {
     std::string const& user = suffixes[0];
-    if (auto r = exec.canWriteUser(user); r.ok()) {
+    if (auto r = exec.canModifyUserProfile(user); r.ok()) {
       // update a user
       if (auto r = StoreUser(um, 2, user, body); r.ok()) {
         VPackBuilder doc = um->serializeUser(user);
@@ -554,7 +554,7 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
   auto& exec = ExecContext::current();
   if (suffixes.size() == 1) {
     std::string const& user = suffixes[0];
-    if (auto r = exec.canWriteUser(user); r.fail()) {
+    if (auto r = exec.canDropUser(user); r.fail()) {
       generateError(r);
       return RestStatus::DONE;
     }
@@ -571,7 +571,7 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
     }
   } else if (suffixes.size() == 2) {
     std::string const& user = suffixes[0];
-    if (suffixes[1] == "config" && exec.canWriteUser(user).ok()) {
+    if (suffixes[1] == "config" && exec.canModifyUserProfile(user).ok()) {
       Result r = um->updateUser(
           user,
           [&](auth::User& u) {
@@ -595,7 +595,7 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
       std::string const& db = suffixes[2];
       std::string coll = suffixes.size() == 4 ? suffixes[3] : "";
 
-      if (auto r = exec.canWriteUser(user); r.fail()) {
+      if (auto r = exec.canGrantUserPermissions(user); r.fail()) {
         generateError(r);
         return RestStatus::DONE;
       }
@@ -635,7 +635,7 @@ RestStatus RestUsersHandler::deleteRequest(auth::UserManager* um) {
       }
     } else if (suffixes[1] == "config") {
       // remove internal config data, used in the WebUI
-      if (auto r1 = exec.canWriteUser(user); r1.ok()) {
+      if (auto r1 = exec.canModifyUserProfile(user); r1.ok()) {
         std::string const& key = suffixes[2];
         Result r = um->updateUser(
             user,

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -447,18 +447,47 @@ Result ExecContext::canReadUser(std::string_view userName) const {
   return can(ReadUser{.name{userName}});
 }
 
-/// @brief returns true if the user can be modified, note that everybody
-/// can modify themselves (if only to change the password).
-Result ExecContext::canWriteUser(std::string_view userName) const {
+/// @brief returns true if the given user may be created.
+Result ExecContext::canCreateUser(std::string_view userName) const {
   using namespace auth::perms;
   if (!isSuperuser() && ServerState::readOnly()) {
     return {TRI_ERROR_FORBIDDEN, "Server is in read-only mode."};
   }
-  // We implement one exception here: A user can write itself:
+  return can(CreateUser{.name{userName}});
+}
+
+/// @brief returns true if the given user may be dropped.
+Result ExecContext::canDropUser(std::string_view userName) const {
+  using namespace auth::perms;
+  if (!isSuperuser() && ServerState::readOnly()) {
+    return {TRI_ERROR_FORBIDDEN, "Server is in read-only mode."};
+  }
+  return can(DropUser{.name{userName}});
+}
+
+/// @brief returns true if the given user's own profile (password, active
+/// flag, config blob) may be modified. Note that everybody can modify
+/// their own profile (if only to change the password).
+Result ExecContext::canModifyUserProfile(std::string_view userName) const {
+  using namespace auth::perms;
+  if (!isSuperuser() && ServerState::readOnly()) {
+    return {TRI_ERROR_FORBIDDEN, "Server is in read-only mode."};
+  }
+  // We implement one exception here: A user can modify their own profile:
   if (userName == user()) {
     return {};
   }
-  return can(WriteUser{.name{userName}});
+  return can(ModifyUserProfile{.name{userName}});
+}
+
+/// @brief returns true if the given user's permissions on databases and
+/// collections may be granted/revoked.
+Result ExecContext::canGrantUserPermissions(std::string_view userName) const {
+  using namespace auth::perms;
+  if (!isSuperuser() && ServerState::readOnly()) {
+    return {TRI_ERROR_FORBIDDEN, "Server is in read-only mode."};
+  }
+  return can(GrantUserPermissions{.name{userName}});
 }
 
 /// @brief returns true for each user which can be read

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -230,9 +230,20 @@ class ExecContext {
   // users. All we need is the bool.
   std::vector<bool> canReadUsers(std::span<std::string_view> users) const;
 
-  /// @brief returns true if the user can be modified, note that everybody
-  // can modify themselves (if only to change the password).
-  Result canWriteUser(std::string_view userName) const;
+  /// @brief returns true if the given user may be created.
+  Result canCreateUser(std::string_view userName) const;
+
+  /// @brief returns true if the given user may be dropped.
+  Result canDropUser(std::string_view userName) const;
+
+  /// @brief returns true if the given user's own profile (password, active
+  /// flag, config blob) may be modified. Note that everybody can modify
+  /// their own profile (if only to change the password).
+  Result canModifyUserProfile(std::string_view userName) const;
+
+  /// @brief returns true if the given user's permissions on databases and
+  /// collections may be granted/revoked.
+  Result canGrantUserPermissions(std::string_view userName) const;
 
   static std::shared_ptr<ExecContext const> set(
       std::shared_ptr<ExecContext const> ctx) {

--- a/arangod/V8Server/v8-users.cpp
+++ b/arangod/V8Server/v8-users.cpp
@@ -99,8 +99,14 @@ void StoreUser(v8::FunctionCallbackInfo<v8::Value> const& args, bool replace) {
   }
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
-    TRI_V8_THROW_EXCEPTION(r);
+  if (replace) {
+    if (auto r = exec.canModifyUserProfile(username); !r.ok()) {
+      TRI_V8_THROW_EXCEPTION(r);
+    }
+  } else {
+    if (auto r = exec.canCreateUser(username); !r.ok()) {
+      TRI_V8_THROW_EXCEPTION(r);
+    }
   }
   std::string pass = args.Length() > 1 && args[1]->IsString()
                          ? TRI_ObjectToString(isolate, args[1])
@@ -152,7 +158,7 @@ static void JS_UpdateUser(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
+  if (auto r = exec.canModifyUserProfile(username); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 
@@ -194,7 +200,7 @@ static void JS_RemoveUser(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
   std::string user = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(user); !r.ok()) {
+  if (auto r = exec.canDropUser(user); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 
@@ -271,7 +277,7 @@ static void JS_GrantDatabase(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
+  if (auto r = exec.canGrantUserPermissions(username); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 
@@ -310,7 +316,7 @@ static void JS_RevokeDatabase(v8::FunctionCallbackInfo<v8::Value> const& args) {
   }
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
+  if (auto r = exec.canGrantUserPermissions(username); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 
@@ -348,7 +354,7 @@ static void JS_GrantCollection(
 
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
+  if (auto r = exec.canGrantUserPermissions(username); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 
@@ -405,7 +411,7 @@ static void JS_RevokeCollection(
 
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
+  if (auto r = exec.canGrantUserPermissions(username); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 
@@ -453,7 +459,7 @@ static void JS_UpdateConfigData(
   }
   std::string username = TRI_ObjectToString(isolate, args[0]);
   auto const& exec = ExecContext::current();
-  if (auto r = exec.canWriteUser(username); !r.ok()) {
+  if (auto r = exec.canModifyUserProfile(username); !r.ok()) {
     TRI_V8_THROW_EXCEPTION(r);
   }
 

--- a/tests/V8Server/V8UsersTest.cpp
+++ b/tests/V8Server/V8UsersTest.cpp
@@ -251,7 +251,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_TRUE((slice.hasKey(arangodb::StaticStrings::ErrorNum) &&
                  slice.get(arangodb::StaticStrings::ErrorNum).isNumber<int>() &&
-                 TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
+                 TRI_ERROR_FORBIDDEN ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
     EXPECT_TRUE(execContext
@@ -300,7 +300,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     EXPECT_TRUE(slice.isObject());
     EXPECT_TRUE((slice.hasKey(arangodb::StaticStrings::ErrorNum) &&
                  slice.get(arangodb::StaticStrings::ErrorNum).isNumber<int>() &&
-                 TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
+                 TRI_ERROR_FORBIDDEN ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
     EXPECT_TRUE(execContext

--- a/tests/api/apitests/misc.mjs
+++ b/tests/api/apitests/misc.mjs
@@ -570,7 +570,7 @@ export default [
 
   // ── /_api/token ──────────────────────────────────────────────────────────
   // Handler: RestAccessTokenHandler
-  // Auth: canReadUser(user) for GET; canWriteUser(user) for POST/DELETE.
+  // Auth: canReadUser(user) for GET; canModifyUserProfile(user) for POST/DELETE.
   // In classic mode: isSuperuser || user==self || RW on _system.
   // Tests use "root" as the target user (always exists).
 

--- a/tests/api/apitests/users.mjs
+++ b/tests/api/apitests/users.mjs
@@ -7,14 +7,20 @@
 //
 // Auth model (without RBAC)
 // ──────────────────────────
-//   canReadUser(u)   → requires RO access to the _system database
-//   canWriteUser(u)  → requires RW access to the _system database
-//   AUTHEN           → any authenticated user (no further check)
+//   canReadUser(u)             → requires RO access to the _system database
+//   canCreateUser(u)           → requires RW access to the _system database
+//   canDropUser(u)             → requires RW access to the _system database
+//   canModifyUserProfile(u)    → requires RW access to the _system database
+//   canGrantUserPermissions(u) → requires RW access to the _system database
+//   AUTHEN                     → any authenticated user (no further check)
 //
 // Expected patterns for the admin user matrix:
-//   canReadUser  → AU:403, AN:403, AR:403, AW:200, superuser:200
-//   canWriteUser → AU:403, AN:403, AR:403, AW:200, superuser:200
-//   AUTHEN       → AU:403, AN:403, AR:403, AW:200, superuser:200
+//   canReadUser              → AU:403, AN:403, AR:403, AW:200, superuser:200
+//   canCreateUser            → AU:403, AN:403, AR:403, AW:200, superuser:200
+//   canDropUser              → AU:403, AN:403, AR:403, AW:200, superuser:200
+//   canModifyUserProfile     → AU:403, AN:403, AR:403, AW:200, superuser:200
+//   canGrantUserPermissions  → AU:403, AN:403, AR:403, AW:200, superuser:200
+//   AUTHEN                   → AU:403, AN:403, AR:403, AW:200, superuser:200
 //
 // Resources created per-test in setup / cleaned up in teardown:
 //   testuser  – a temporary user (user="testuser", passwd="testpasswd")
@@ -74,7 +80,7 @@ export default [
   // ── POST /_api/user ───────────────────────────────────────────────────────
   {
     // POST /_api/user
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canCreateUser(u) → RW on _system.
     // Creates user "testuser".
     // setup:    delete testuser if it already exists.
     // teardown: delete testuser regardless of whether the test succeeded.
@@ -221,7 +227,7 @@ export default [
   // ── PUT /_api/user/{user} (full replace) ──────────────────────────────────
   {
     // PUT /_api/user/testuser
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canModifyUserProfile(u) → RW on _system.
     // Replaces the "testuser" record (password change is a common use-case).
     // setup:    create testuser.
     // teardown: delete testuser.
@@ -242,7 +248,7 @@ export default [
   // ── PATCH /_api/user/{user} (partial update) ──────────────────────────────
   {
     // PATCH /_api/user/testuser
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canModifyUserProfile(u) → RW on _system.
     // Partially updates the "testuser" record (e.g. active flag).
     // setup:    create testuser.
     // teardown: delete testuser.
@@ -263,7 +269,7 @@ export default [
   // ── PUT /_api/user/{user}/config/{key} ────────────────────────────────────
   {
     // PUT /_api/user/testuser/config/testkey
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canModifyUserProfile(u) → RW on _system.
     // Stores a JSON value under the configuration key "testkey" for "testuser".
     // setup:    create testuser.
     // teardown: delete testuser (which removes all associated config entries).
@@ -284,7 +290,7 @@ export default [
   // ── PUT /_api/user/{user}/database/{db} ───────────────────────────────────
   {
     // PUT /_api/user/testuser/database/d2
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canGrantUserPermissions(u) → RW on _system.
     // Grants "testuser" the specified access level on database "d2".
     // setup:    create testuser and database d2.
     // teardown: delete testuser and drop d2.
@@ -307,7 +313,7 @@ export default [
   // ── PUT /_api/user/{user}/database/{db}/{coll} ────────────────────────────
   {
     // PUT /_api/user/testuser/database/d2/c2
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canGrantUserPermissions(u) → RW on _system.
     // Grants "testuser" the specified access level on collection "c2" in "d2".
     // setup:    create testuser, database d2, and collection c2 inside d2.
     // teardown: delete testuser and drop d2 (which also removes c2).
@@ -331,7 +337,7 @@ export default [
   // ── DELETE /_api/user/{user} ──────────────────────────────────────────────
   {
     // DELETE /_api/user/testuser
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canDropUser(u) → RW on _system.
     // Deletes the "testuser" account entirely.
     // setup:    create testuser so there is something to delete.
     // teardown: attempt deletion again (idempotent — 404 is fine) to ensure
@@ -352,7 +358,7 @@ export default [
   // ── DELETE /_api/user/{user}/config/{key} ─────────────────────────────────
   {
     // DELETE /_api/user/testuser/config/testkey
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canModifyUserProfile(u) → RW on _system.
     // Removes the configuration entry "testkey" from "testuser".
     // setup:    create testuser and store the config key so there is something
     //           to delete.
@@ -376,7 +382,7 @@ export default [
   // ── DELETE /_api/user/{user}/database/{db} ────────────────────────────────
   {
     // DELETE /_api/user/testuser/database/d2
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canGrantUserPermissions(u) → RW on _system.
     // Revokes all database-level permissions "testuser" has on "d2".
     // setup:    create testuser, database d2, and grant testuser ro access on d2
     //           so there is a permission to revoke.
@@ -402,7 +408,7 @@ export default [
   // ── DELETE /_api/user/{user}/database/{db}/{coll} ─────────────────────────
   {
     // DELETE /_api/user/testuser/database/d2/c2
-    // Auth: canWriteUser(u) → RW on _system.
+    // Auth: canGrantUserPermissions(u) → RW on _system.
     // Revokes all collection-level permissions "testuser" has on "c2" in "d2".
     // setup:    create testuser, database d2, collection c2 in d2, and grant
     //           testuser ro access on c2 so there is a permission to revoke.


### PR DESCRIPTION
### Scope & Purpose

Bug fix:

We want to address the following issue: The `ExecContext` currently
has one API call `canWriteUser` which is used for multiple completely
different issues:
 1. Modifying the user profile (password, active flag, config blob).
 2. Granting and revoking user permissions on databases and collections.
 3. Creating a user.
 4. Dropping a user.
This is too coarse. Even in Classic mode (see `AuthMode` class) this is not fine grained enough.

I think we need:

  - `canReadUser` (as before)
  - `canReadusers` (as before)
  - `canCreateUser`
  - `canDropUser`
  - `canModifyUserProfile`
  - `canGrantUserPermissions`

Can you please:

 - create all these methods in `ExecContext`
 - drop the `canWriteUser` method
 - adjust the `AuthMode` implementation accordingly
 - update @Documentation/path_permissions.md where `canWriteUser` occurs
 - adjust the `RestUsersHandler` and the @v8-users.cpp file to use these
   methods rather than `canWriteUser`
 - adjust the comments in @tests/api/apitests/users.mjs and @tests/api/apitests/misc.mjs for the auth model
 - update the `RestAccessTokenHandler` accordingly
 - make sure that everything builds again with `cd build ; cmake --build . -- -j 64`

This PR was assisted by Claude and reviewed by me.
