### PR TITLE
[COR-740] Add KEEP projections to relationship (edge) patterns in AQL MATCH

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,13 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
+* COR-740: AQL `MATCH` relationship patterns now support the optional `KEEP`
+  clause for inline edge projections.
+  Example: `MATCH (u:users)-[e:follows KEEP since]->(v:users) RETURN e` binds
+  `e` to `{ "_id", "_from", "_to", "since" }` instead of the full edge document.
+  System attributes `_id`, `_from`, and `_to` are always retained on projected
+  edges. The `MATCH` statement remains experimental (`matchStatement:
+  "experimental"`).
+
 * COR-572: BugFix - Resolved unintended warnings raised by eager evaluation in 
   the ternary operator during traversal and optimization.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,8 @@
 4.0.0 (XXXX-XX-XX)
 ------------------
-* COR-740: AQL `MATCH` relationship patterns now support the optional `KEEP`
-  clause for inline edge projections.
-  Example: `MATCH (u:users)-[e:follows KEEP since]->(v:users) RETURN e` binds
+* COR-740: AQL `MATCH` relationship patterns now support an optional inline
+  projection clause using `RETURN` (placeholder keyword, may change later).
+  Example: `MATCH (u:users)-[e:follows RETURN since]->(v:users) RETURN e` binds
   `e` to `{ "_id", "_from", "_to", "since" }` instead of the full edge document.
   System attributes `_id`, `_from`, and `_to` are always retained on projected
   edges. The `MATCH` statement remains experimental (`matchStatement:

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1990,7 +1990,7 @@ AstNode* Ast::createPatternEdge(AstNode const* outVariable,
                                 AstNode const* label, AstNode const* properties,
                                 AstNode const* filterExpression,
                                 AstNode const* rangeExpression, bool isInbound,
-                                bool isOutbound) {
+                                bool isOutbound, AstNode const* projections) {
   auto node = createNode(NODE_TYPE_PATTERN_EDGE);
   node->addMember(outVariable ? outVariable : createNodeValueNull());
   node->addMember(label ? label : createNodeValueNull());
@@ -2004,6 +2004,9 @@ AstNode* Ast::createPatternEdge(AstNode const* outVariable,
 
   node->addMember(createNodeValueInt(!isInbound << 1 | !isOutbound));
   node->addMember(rangeExpression ? rangeExpression : createNodeNop());
+  // projections are appended last (member 6) so the existing member indices
+  // (direction=4, range=5) stay valid.
+  node->addMember(projections ? projections : createNodeNop());
   return node;
 }
 AstNode* Ast::createPatternNodePattern(AstNode const* outVariable,

--- a/arangod/Aql/Ast.h
+++ b/arangod/Aql/Ast.h
@@ -464,7 +464,8 @@ class Ast {
                              AstNode const* properties,
                              AstNode const* filterExpression,
                              AstNode const* rangeExpression, bool isInbound,
-                             bool isOutbound);
+                             bool isOutbound,
+                             AstNode const* projections = nullptr);
   AstNode* createPatternNodePattern(AstNode const* outVariable,
                                     AstNode const* labels,
                                     AstNode const* properties,

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2728,23 +2728,34 @@ ExecutionNode* ExecutionPlan::fromNodeMatch(ExecutionNode* previous,
         // FOR <outvariable> IN <collection>
         //  FILTER <outvariable>.property1 == xxx && ....
         ExecutionNode* lastNode;
-        auto fullDocumentVariable =
-            _ast->variables()->createTemporaryVariable();
         auto destinationVariable =
             static_cast<Variable const*>(member->getMember(0)->getData());
 
-        variableSubstitutions.emplace(destinationVariable->id,
-                                      fullDocumentVariable);
+        // Without an inline projection we enumerate directly into the
+        // user-facing variable (as the non-projection lowering does), so that
+        // downstream rules and outputs observe the expected variable. With a
+        // projection we enumerate into a temporary full-document variable and
+        // copy the projected attributes into the user variable.
+        bool const hasProjection = member->getMember(4)->type != NODE_TYPE_NOP;
+        Variable const* enumOutputVariable =
+            hasProjection ? _ast->variables()->createTemporaryVariable()
+                          : destinationVariable;
+        if (hasProjection) {
+          variableSubstitutions.emplace(destinationVariable->id,
+                                        enumOutputVariable);
+        }
 
         std::tie(en, lastNode, prevVar) = createCollectionAccess(
-            member, fullDocumentVariable, variableSubstitutions);
+            member, enumOutputVariable, variableSubstitutions);
         en->addDependency(previous);
         previous = en = lastNode;
 
         pathVertices.push_back(_ast->createNodeReference(destinationVariable));
 
-        auto projection = createPatternProjection(member, prevVar);
-        projections.push_back(projection);
+        if (hasProjection) {
+          auto projection = createPatternProjection(member, prevVar);
+          projections.push_back(projection);
+        }
       } else if (member->type == NODE_TYPE_PATTERN_PATH_VARIABLE) {
         pathVariable = static_cast<Variable const*>(member->getData());
       } else if (member->type == NODE_TYPE_REFERENCE) {
@@ -2766,22 +2777,34 @@ ExecutionNode* ExecutionPlan::fromNodeMatch(ExecutionNode* previous,
           ExecutionNode* lastNodeFilter;
           Variable const* edgeVar;
 
-          auto fullEdgeDocumentVariable =
-              _ast->variables()->createTemporaryVariable();
           auto edgeDestinationVariable =
               static_cast<Variable const*>(edge->getMember(0)->getData());
-          variableSubstitutions.emplace(edgeDestinationVariable->id,
-                                        fullEdgeDocumentVariable);
+
+          // Same reasoning as for vertices: only introduce a temporary
+          // full-document variable plus a projection copy when an inline
+          // projection is actually requested. Otherwise enumerate straight
+          // into the user-facing edge variable.
+          bool const edgeHasProjection =
+              edge->getMember(6)->type != NODE_TYPE_NOP;
+          Variable const* edgeEnumOutputVariable =
+              edgeHasProjection ? _ast->variables()->createTemporaryVariable()
+                                : edgeDestinationVariable;
+          if (edgeHasProjection) {
+            variableSubstitutions.emplace(edgeDestinationVariable->id,
+                                          edgeEnumOutputVariable);
+          }
 
           std::tie(en, lastNodeFilter, edgeVar) = createCollectionAccess(
-              edge, fullEdgeDocumentVariable, variableSubstitutions);
+              edge, edgeEnumOutputVariable, variableSubstitutions);
 
           en->addDependency(previous);
           previous = en = lastNodeFilter;
 
-          auto edgeProjection =
-              createPatternProjection(edge, fullEdgeDocumentVariable);
-          projections.push_back(edgeProjection);
+          if (edgeHasProjection) {
+            auto edgeProjection =
+                createPatternProjection(edge, edgeEnumOutputVariable);
+            projections.push_back(edgeProjection);
+          }
 
           Variable const* rightVertexVar;
           Variable const* vertexDestinationVariable = nullptr;
@@ -2796,18 +2819,27 @@ ExecutionNode* ExecutionPlan::fromNodeMatch(ExecutionNode* previous,
 
             vertexDestinationVariable =
                 static_cast<Variable const*>(node->getMember(0)->getData());
-            auto fullVertexDocumentVariable =
-                _ast->variables()->createTemporaryVariable();
-            variableSubstitutions.emplace(vertexDestinationVariable->id,
-                                          fullVertexDocumentVariable);
+
+            bool const vertexHasProjection =
+                node->getMember(4)->type != NODE_TYPE_NOP;
+            Variable const* vertexEnumOutputVariable =
+                vertexHasProjection
+                    ? _ast->variables()->createTemporaryVariable()
+                    : vertexDestinationVariable;
+            if (vertexHasProjection) {
+              variableSubstitutions.emplace(vertexDestinationVariable->id,
+                                            vertexEnumOutputVariable);
+            }
 
             std::tie(en, lastNodeFilter, rightVertexVar) =
-                createCollectionAccess(node, fullVertexDocumentVariable,
+                createCollectionAccess(node, vertexEnumOutputVariable,
                                        variableSubstitutions);
             en->addDependency(previous);
 
-            auto projection = createPatternProjection(node, rightVertexVar);
-            projections.push_back(projection);
+            if (vertexHasProjection) {
+              auto projection = createPatternProjection(node, rightVertexVar);
+              projections.push_back(projection);
+            }
 
             previous = en = lastNodeFilter;
           }

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -2444,27 +2444,42 @@ ExecutionNode* ExecutionPlan::fromNodeMatch(ExecutionNode* previous,
     auto variable =
         static_cast<Variable const*>(member->getMember(0)->getData());
 
-    auto projections = member->getMember(4);
+    // Vertices store projections at member 4 and edges store them at member 6
+    // (appended after direction/range by createPatternEdge).
+    AstNode const* projections = nullptr;
+    bool const isEdge = member->type == NODE_TYPE_PATTERN_EDGE;
+    if (isEdge) {
+      ADB_PROD_ASSERT(member->numMembers() > 6)
+          << "pattern edge missing projection member";
+      projections = member->getMember(6);
+    } else {
+      projections = member->getMember(4);
+    }
 
     if (projections->type != NODE_TYPE_NOP) {
       auto* root = _ast->createNodeObject();
 
       auto* ref = _ast->createNodeReference(fullDocumentVar);
 
-      auto* attrAccess = _ast->createNodeAttributeAccess(  //
-          ref,                                             //
-          "_id");                                          //
-      auto* elt = _ast->createNodeObjectElement("_id", attrAccess);
-      root->addMember(elt);
+      auto addProjectedAttribute = [&](std::string_view path) {
+        auto* attrAccess = _ast->createNodeAttributeAccess(ref, path);
+        auto* elt = _ast->createNodeObjectElement(path, attrAccess);
+        root->addMember(elt);
+      };
+
+      // Implicit system attributes required for graph topology.
+      addProjectedAttribute("_id");
+      if (isEdge) {
+        addProjectedAttribute("_from");
+        addProjectedAttribute("_to");
+      }
 
       for (auto i = size_t{0}; i < projections->numMembers(); ++i) {
         auto path = projections->getMemberUnchecked(i)->getStringView();
-        auto* attrAccess = _ast->createNodeAttributeAccess(  //
-            ref,                                             //
-            path);                                           //
-
-        auto* elt = _ast->createNodeObjectElement(path, attrAccess);
-        root->addMember(elt);
+        if (path == "_id" || (isEdge && (path == "_from" || path == "_to"))) {
+          continue;
+        }
+        addProjectedAttribute(path);
       }
       auto* calc = createNode<CalculationNode>(
           this, nextId(), std::make_unique<Expression>(_ast, root), variable);
@@ -2764,21 +2779,27 @@ ExecutionNode* ExecutionPlan::fromNodeMatch(ExecutionNode* previous,
           en->addDependency(previous);
           previous = en = lastNodeFilter;
 
+          auto edgeProjection =
+              createPatternProjection(edge, fullEdgeDocumentVariable);
+          projections.push_back(edgeProjection);
+
           Variable const* rightVertexVar;
-          auto vertexDestinationVariable =
-              static_cast<Variable const*>(node->getMember(0)->getData());
+          Variable const* vertexDestinationVariable = nullptr;
 
           if (node->type == NODE_TYPE_REFERENCE) {
             // todo: possibly replace?
             rightVertexVar = static_cast<Variable*>(node->getData());
+            vertexDestinationVariable = rightVertexVar;
           } else {
             ADB_PROD_ASSERT(node->type == NODE_TYPE_PATTERN_NODE_PATTERN)
                 << member->type;
 
+            vertexDestinationVariable =
+                static_cast<Variable const*>(node->getMember(0)->getData());
             auto fullVertexDocumentVariable =
                 _ast->variables()->createTemporaryVariable();
-            variableSubstitutions.emplace(fullVertexDocumentVariable->id,
-                                          vertexDestinationVariable);
+            variableSubstitutions.emplace(vertexDestinationVariable->id,
+                                          fullVertexDocumentVariable);
 
             std::tie(en, lastNodeFilter, rightVertexVar) =
                 createCollectionAccess(node, fullVertexDocumentVariable,
@@ -2798,7 +2819,8 @@ ExecutionNode* ExecutionPlan::fromNodeMatch(ExecutionNode* previous,
           previous = en = lastNode;
           prevVar = rightVertexVar;
 
-          pathEdges.push_back(_ast->createNodeReference(edgeVar));
+          pathEdges.push_back(
+              _ast->createNodeReference(edgeDestinationVariable));
 
           pathVertices.push_back(
               _ast->createNodeReference(vertexDestinationVariable));

--- a/arangod/Aql/Parser/grammar.y
+++ b/arangod/Aql/Parser/grammar.y
@@ -487,6 +487,7 @@ AstNode* transformOutputVariables(Parser* parser, AstNode const* names) {
 %token T_IN "IN keyword"
 %token T_WITH "WITH keyword"
 %token T_INTO "INTO keyword"
+%token T_KEEP "KEEP keyword"
 %token T_AGGREGATE "AGGREGATE keyword"
 
 %token T_GRAPH "GRAPH keyword"
@@ -1149,10 +1150,10 @@ pattern_projection_list:
 
 %type <node> pattern_maybe_projection;
 pattern_maybe_projection:
-    T_RETURN {
-			auto node = parser->ast()->createNodeArray();
+    T_KEEP {
+      auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
-		} pattern_projection_list {
+    } pattern_projection_list {
       $$ = static_cast<AstNode*>(parser->popStack());
     }
   | /* empty */ { $$ = nullptr; }
@@ -1238,9 +1239,15 @@ pattern_close_relation:
   | T_ARRAY_CLOSE T_MINUS T_GT { $$ = true; }
 
 %type <node> pattern_edge;
-pattern_edge: pattern_open_relation pattern_out_variable pattern_label pattern_maybe_property_key_value_expression
-    pattern_maybe_where_expression pattern_close_relation {
-        $$ = parser->ast()->createPatternEdge($2, $3, $4, $5, nullptr, $1, $6);
+pattern_edge: pattern_open_relation[inbound] pattern_out_variable[variable]
+              pattern_label[label]
+              pattern_maybe_property_key_value_expression[kv_expr]
+              pattern_maybe_where_expression[where]
+              pattern_maybe_projection[projection]
+              pattern_close_relation[outbound] {
+        $$ = parser->ast()->createPatternEdge($variable, $label, $kv_expr, $where,
+                                              nullptr, $inbound, $outbound,
+                                              $projection);
     }
     | pattern_open_relation pattern_out_variable pattern_label pattern_variable_length_relationship pattern_close_relation {
         $$ = parser->ast()->createPatternEdge($2, $3, nullptr, nullptr, $4, $1, $5);
@@ -1630,12 +1637,7 @@ variable_list:
   ;
 
 keep:
-    T_STRING {
-      std::string_view operation($1.value, $1.length);
-      if (!::caseInsensitiveEqual(operation, "KEEP")) {
-        parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'KEEP'", operation, yylloc.first_line, yylloc.first_column);
-      }
-
+    T_KEEP {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     } variable_list {

--- a/arangod/Aql/Parser/grammar.y
+++ b/arangod/Aql/Parser/grammar.y
@@ -487,7 +487,6 @@ AstNode* transformOutputVariables(Parser* parser, AstNode const* names) {
 %token T_IN "IN keyword"
 %token T_WITH "WITH keyword"
 %token T_INTO "INTO keyword"
-%token T_KEEP "KEEP keyword"
 %token T_AGGREGATE "AGGREGATE keyword"
 
 %token T_GRAPH "GRAPH keyword"
@@ -1150,7 +1149,7 @@ pattern_projection_list:
 
 %type <node> pattern_maybe_projection;
 pattern_maybe_projection:
-    T_KEEP {
+    T_RETURN {
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     } pattern_projection_list {
@@ -1637,7 +1636,12 @@ variable_list:
   ;
 
 keep:
-    T_KEEP {
+    T_STRING {
+      std::string_view operation($1.value, $1.length);
+      if (!::caseInsensitiveEqual(operation, "KEEP")) {
+        parser->registerParseError(TRI_ERROR_QUERY_PARSE, "unexpected qualifier '%s', expecting 'KEEP'", operation, yylloc.first_line, yylloc.first_column);
+      }
+
       auto node = parser->ast()->createNodeArray();
       parser->pushStack(node);
     } variable_list {

--- a/arangod/Aql/Parser/tokens.ll
+++ b/arangod/Aql/Parser/tokens.ll
@@ -148,6 +148,10 @@ class Parser;
   return T_INTO;
 }
 
+(?i:KEEP) {
+  return T_KEEP;
+}
+
 (?i:WITH) {
   yylval->strval.value = yyextra->ast()->resources().registerString(yytext, yyleng);
   yylval->strval.length = yyleng;

--- a/arangod/Aql/Parser/tokens.ll
+++ b/arangod/Aql/Parser/tokens.ll
@@ -148,10 +148,6 @@ class Parser;
   return T_INTO;
 }
 
-(?i:KEEP) {
-  return T_KEEP;
-}
-
 (?i:WITH) {
   yylval->strval.value = yyextra->ast()->resources().registerString(yytext, yyleng);
   yylval->strval.length = yyleng;

--- a/tests/js/client/aql/aql-match-statement.js
+++ b/tests/js/client/aql/aql-match-statement.js
@@ -177,6 +177,72 @@ function aqlMatchStatementTestSuite() {
             }
         },
 
+        testSelectVerticesWithKeep: function () {
+            const result = db._query("MATCH (v :vc KEEP i) RETURN v", {}, options).toArray();
+            assertEqual(result.length, 100);
+
+            for (const v of result) {
+                assertTrue(v.hasOwnProperty("_id"));
+                assertTrue(v.hasOwnProperty("i"));
+                assertTrue(!v.hasOwnProperty("j"));
+                assertTrue(!v.hasOwnProperty("_key"));
+            }
+        },
+
+        testSelectEdgesWithKeep: function () {
+            const result = db._query(
+                "MATCH (u :vc)-[e :ec KEEP i]->(v :vc) RETURN e",
+                {},
+                options
+            ).toArray();
+            assertEqual(result.length, 50);
+
+            for (const e of result) {
+                assertTrue(e.hasOwnProperty("_id"));
+                assertTrue(e.hasOwnProperty("_from"));
+                assertTrue(e.hasOwnProperty("_to"));
+                assertTrue(e.hasOwnProperty("i"));
+                assertTrue(!e.hasOwnProperty("j"));
+                assertTrue(!e.hasOwnProperty("_key"));
+            }
+        },
+
+        testSelectEdgesWithKeepAndWhere: function () {
+            // WHERE may access attributes that are not kept on the bound variable.
+            const result = db._query(
+                "MATCH (u :vc)-[e :ec WHERE e.j == 0 KEEP i]->(v :vc) RETURN e",
+                {},
+                options
+            ).toArray();
+            assertEqual(result.length, 5);
+
+            for (const e of result) {
+                assertTrue(e.hasOwnProperty("_id"));
+                assertTrue(e.hasOwnProperty("_from"));
+                assertTrue(e.hasOwnProperty("_to"));
+                assertTrue(e.hasOwnProperty("i"));
+                assertTrue(!e.hasOwnProperty("j"));
+            }
+        },
+
+        testMatchPathVariableWithEdgeKeep: function () {
+            const result = db._query(
+                "MATCH p = (v :vc) -[ e :ec KEEP i ]-> (w :vc) RETURN p",
+                {},
+                options
+            ).toArray();
+            assertEqual(result.length, 50);
+
+            for (const {edges, vertices} of result) {
+                assertEqual(edges.length, 1);
+                assertEqual(vertices.length, 2);
+                assertEqual(edges[0]._from, vertices[0]._id);
+                assertEqual(edges[0]._to, vertices[1]._id);
+                assertTrue(edges[0].hasOwnProperty("i"));
+                assertTrue(!edges[0].hasOwnProperty("j"));
+            }
+        },
+
         testSelectEdgeLoops: function () {
             const result = db._query("MATCH (v :vc) -[ e :ec_loops ]-> (v) RETURN [v, e]", {}, options).toArray();
             assertEqual(result.length, 10);

--- a/tests/js/client/aql/aql-match-statement.js
+++ b/tests/js/client/aql/aql-match-statement.js
@@ -1,5 +1,5 @@
 /*jshint globalstrict:false, strict:false, maxlen: 500 */
-/*global assertEqual, assertTrue, print, fail */
+/*global assertEqual, assertTrue, assertFalse, print, fail */
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DISCLAIMER
@@ -178,20 +178,20 @@ function aqlMatchStatementTestSuite() {
         },
 
         testSelectVerticesWithKeep: function () {
-            const result = db._query("MATCH (v :vc KEEP i) RETURN v", {}, options).toArray();
+            const result = db._query("MATCH (v :vc RETURN i) RETURN v", {}, options).toArray();
             assertEqual(result.length, 100);
 
             for (const v of result) {
                 assertTrue(v.hasOwnProperty("_id"));
                 assertTrue(v.hasOwnProperty("i"));
-                assertTrue(!v.hasOwnProperty("j"));
-                assertTrue(!v.hasOwnProperty("_key"));
+                assertFalse(v.hasOwnProperty("j"));
+                assertFalse(v.hasOwnProperty("_key"));
             }
         },
 
         testSelectEdgesWithKeep: function () {
             const result = db._query(
-                "MATCH (u :vc)-[e :ec KEEP i]->(v :vc) RETURN e",
+                "MATCH (u :vc)-[e :ec RETURN i]->(v :vc) RETURN e",
                 {},
                 options
             ).toArray();
@@ -202,15 +202,15 @@ function aqlMatchStatementTestSuite() {
                 assertTrue(e.hasOwnProperty("_from"));
                 assertTrue(e.hasOwnProperty("_to"));
                 assertTrue(e.hasOwnProperty("i"));
-                assertTrue(!e.hasOwnProperty("j"));
-                assertTrue(!e.hasOwnProperty("_key"));
+                assertFalse(e.hasOwnProperty("j"));
+                assertFalse(e.hasOwnProperty("_key"));
             }
         },
 
         testSelectEdgesWithKeepAndWhere: function () {
             // WHERE may access attributes that are not kept on the bound variable.
             const result = db._query(
-                "MATCH (u :vc)-[e :ec WHERE e.j == 0 KEEP i]->(v :vc) RETURN e",
+                "MATCH (u :vc)-[e :ec WHERE e.j == 0 RETURN i]->(v :vc) RETURN e",
                 {},
                 options
             ).toArray();
@@ -221,13 +221,13 @@ function aqlMatchStatementTestSuite() {
                 assertTrue(e.hasOwnProperty("_from"));
                 assertTrue(e.hasOwnProperty("_to"));
                 assertTrue(e.hasOwnProperty("i"));
-                assertTrue(!e.hasOwnProperty("j"));
+                assertFalse(e.hasOwnProperty("j"));
             }
         },
 
         testMatchPathVariableWithEdgeKeep: function () {
             const result = db._query(
-                "MATCH p = (v :vc) -[ e :ec KEEP i ]-> (w :vc) RETURN p",
+                "MATCH p = (v :vc) -[ e :ec RETURN i ]-> (w :vc) RETURN p",
                 {},
                 options
             ).toArray();
@@ -239,7 +239,7 @@ function aqlMatchStatementTestSuite() {
                 assertEqual(edges[0]._from, vertices[0]._id);
                 assertEqual(edges[0]._to, vertices[1]._id);
                 assertTrue(edges[0].hasOwnProperty("i"));
-                assertTrue(!edges[0].hasOwnProperty("j"));
+                assertFalse(edges[0].hasOwnProperty("j"));
             }
         },
 


### PR DESCRIPTION
This PR extends the inline MATCH projection support introduced in Draft PR #22792 to relationship (edge) patterns. Edge patterns ([...]) now support the same optional KEEP clause as vertex patterns, allowing only the requested attributes, along with the required system attributes, to be bound to the edge variable.
The projection clause continues to use the existing RETURN keyword instead of introducing KEEP as a reserved keyword. This avoids potential compatibility issues with the existing KEEP() function and queries that use keep as a variable name, while providing a consistent projection syntax for both vertex and edge patterns.

Example: MATCH (u:users)-[e:follows RETURN since]->(v:users) RETURN e
Result: {"_id": "...", "_from": "...", "_to": "...", "since": "..."} instead of returning the complete edge document.

Updated grammar.y with below changes:
- Extended pattern_edge to support an optional pattern_maybe_projection clause.
- Continued using T_RETURN as the projection keyword, matching the existing syntax for vertex patterns and avoiding the introduction of a new reserved keyword.
- Passed the projection list to createPatternEdge().
- Left the existing COLLECT ... KEEP grammar unchanged, as the projection clause now reuses the existing RETURN syntax instead of introducing T_KEEP.

- Extended createPatternEdge() with an optional projections parameter (defaulting to nullptr), matching the existing createPatternNodePattern() interface in Ast.h
- Updated createPatternEdge() to append the projection node as member 6, preserving the existing member layout. When no projection is specified, a NOP node is stored to maintain a consistent AST structure in Ast.cpp

Enhanced ExecutionPlan.cpp with:
- Extended createPatternProjection() to support both vertex and edge patterns:
              Reads projections from member 4 for vertex patterns.
              Reads projections from member 6 for edge patterns.
-  Automatically injects the required system attributes:
              Vertices: _id
              Edges: _id, _from, _to
- Avoids duplicate system attributes when they are explicitly included in the projection clause.
- Applies edge projections when constructing the bound edge variable for single-edge match segments.
- Corrected the vertex variableSubstitutions mapping (destination → full document).
- Uses destination variables when constructing path vertices and edges so that path variables (MATCH p = ...) expose the projected documents rather than the full documents.

- Locked test cases for below:
            Vertex projections using the RETURN projection clause.
            Edge projections using the RETURN projection clause.
            Projections combined with WHERE predicates that reference non-projected attributes.
            Projected edge documents within path variables (MATCH p = ...).
            RETURN-based projection syntax for both vertex and edge patterns.
            Negative hasOwnProperty() assertions using assertFalse(...), as suggested in review.
- Verified the existing tests in both aql-match-statement.js, and aql-optimizer-keep.js.