### PR TITLE
Update CircleCI arangodb/trivy-scan orb to v0.2

### DIFF
--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -142,7 +142,7 @@ version: 2.1
 orbs:
   aws-cli: circleci/aws-cli@4.1.1
   aws-ecr: circleci/aws-ecr@9.0.1
-  trivy-scan: arangodb/trivy-scan@0.1.1
+  trivy-scan: arangodb/trivy-scan@0.2
 
 parameters:
   enterprise-branch:


### PR DESCRIPTION
### Scope & Purpose

Update CircleCI `arangodb/trivy-scan` orb to v0.2.
