### PR TITLE
Fix JWT secret validation

### DIFF
--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -125,6 +125,20 @@ AuthenticationFeature::AuthenticationFeature(
       FATAL_ERROR_EXIT();
     }
   }
+
+  if (!_options.jwtSecretProgramOption.empty()) {
+    // Only check length for non-PEM (HS256) secrets
+    // ES256 keys in PEM format can be longer
+    if (!_options.jwtSecretIsES256 &&
+        _options.jwtSecretProgramOption.length() >
+            AuthenticationOptions::kMaxSecretLength) {
+      LOG_TOPIC("9abfc", FATAL, arangodb::Logger::STARTUP)
+          << "Given JWT secret too long. Max length is "
+          << AuthenticationOptions::kMaxSecretLength << " have "
+          << _options.jwtSecretProgramOption.length();
+      FATAL_ERROR_EXIT();
+    }
+  }
 }
 
 AuthenticationFeature::~AuthenticationFeature() = default;

--- a/arangod/GeneralServer/AuthenticationOptionsProvider.cpp
+++ b/arangod/GeneralServer/AuthenticationOptionsProvider.cpp
@@ -229,20 +229,6 @@ void AuthenticationOptionsProvider::validateOptionsImpl(
     FATAL_ERROR_EXIT();
   }
 
-  if (!options.jwtSecretProgramOption.empty()) {
-    // Only check length for non-PEM (HS256) secrets
-    // ES256 keys in PEM format can be longer
-    if (!options.jwtSecretIsES256 &&
-        options.jwtSecretProgramOption.length() >
-            AuthenticationOptions::kMaxSecretLength) {
-      LOG_TOPIC("9abfc", FATAL, arangodb::Logger::STARTUP)
-          << "Given JWT secret too long. Max length is "
-          << AuthenticationOptions::kMaxSecretLength << " have "
-          << options.jwtSecretProgramOption.length();
-      FATAL_ERROR_EXIT();
-    }
-  }
-
   if (opts->processingResult().touched("server.jwt-secret")) {
     LOG_TOPIC("1aaae", WARN, arangodb::Logger::AUTHENTICATION)
         << "--server.jwt-secret is insecure. Use --server.jwt-secret-keyfile "


### PR DESCRIPTION
### Scope & Purpose

Validation must be performed after we have loaded the secret from the file/folder.
This PR just fixes what was broken in a recent refactoring.

- [x] :hankey: Bugfix