### PR TITLE
[COR-780] Introduce processOptions phase

### DIFF
--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -189,6 +189,8 @@ void ApplicationServer::run(int argc, char* argv[]) {
   // seal the options
   _options->seal();
 
+  processOptions();
+
   // validate options of all features
   _state.store(State::IN_VALIDATE_OPTIONS, std::memory_order_release);
   reportServerProgress(State::IN_VALIDATE_OPTIONS);

--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -342,6 +342,8 @@ class ApplicationServer {
   // parse options
   void parseOptions(int argc, char* argv[]);
 
+  virtual void processOptions() {}
+
   // allows features to cross-validate their program options
   virtual void validateOptions();
 

--- a/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
+++ b/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
@@ -26,6 +26,16 @@
 
 namespace arangodb::application_features {
 
+namespace {
+template<class Provider>
+concept HasProcessOptions =
+    requires(Provider& provider,
+             std::shared_ptr<options::ProgramOptions> programOptions) {
+  {provider.processOptions(programOptions,
+                           std::declval<typename Provider::Options&>())};
+};
+}  // namespace
+
 template<class... Providers>
 class FeatureOptionProviderContainer final {
  public:
@@ -33,6 +43,14 @@ class FeatureOptionProviderContainer final {
     std::apply(
         [&](auto&... providers) {
           (providers.declareOptions(programOptions), ...);
+        },
+        _providers);
+  }
+
+  void processOptions(std::shared_ptr<options::ProgramOptions> programOptions) {
+    std::apply(
+        [&](auto&... providers) {
+          (processProviderOptions(programOptions, providers), ...);
         },
         _providers);
   }
@@ -47,11 +65,17 @@ class FeatureOptionProviderContainer final {
   }
 
   template<typename ProviderType>
-  auto& getOptions() const {
+  auto const& getOptions() const {
     return std::get<ProviderType>(_providers).options();
   }
 
  private:
+  void processProviderOptions(
+      std::shared_ptr<options::ProgramOptions> programOptions, auto& provider) {
+    if constexpr (HasProcessOptions<decltype(provider)>) {
+      provider.processOptions(programOptions, getOptions<decltype(provider)>());
+    }
+  }
   std::tuple<Providers...> _providers{};
 };
 }  // namespace arangodb::application_features

--- a/lib/ApplicationFeatures/OptionProvidingServer.h
+++ b/lib/ApplicationFeatures/OptionProvidingServer.h
@@ -39,6 +39,11 @@ class OptionProvidingServer : public application_features::ApplicationServer {
     _optionProviders.declareOptions(options());
   }
 
+  void processOptions() override {
+    ApplicationServer::processOptions();
+    _optionProviders.processOptions(options());
+  }
+
   void validateOptions() override {
     ApplicationServer::validateOptions();
     _optionProviders.validateOptions(options());

--- a/lib/ApplicationFeatures/OptionsProvider.h
+++ b/lib/ApplicationFeatures/OptionsProvider.h
@@ -28,6 +28,8 @@ namespace arangodb {
 
 template<class Derived, class OptionsT>
 struct OptionsProviderImpl {
+  using Options = OptionsT;
+
   void declareOptions(std::shared_ptr<options::ProgramOptions> prgOptions) {
     static_cast<Derived*>(this)->declareOptionsImpl(prgOptions, _options);
   }


### PR DESCRIPTION
### Scope & Purpose

Introduce processOptions phase which sits between parseOptions and validateOptions.
This allows us do to some processing/computation/loading of additional content/etc. which should not be part of validateOptions (where this is usually done now).

- [x] :hammer: Refactoring/simplification
