### PR TITLE
COR-581: Added the isEncryptionEnabled() interface to StorageEngine

### DIFF
--- a/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
+++ b/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
@@ -2171,7 +2171,7 @@ std::unique_ptr<aql::ExecutionBlock> IResearchViewNode::createBlock(
   bool const heapsort = !_heapSort.empty();
   bool const emitSearchDoc = executorInfos.searchDocIdRegId().isValid();
 #ifdef USE_ENTERPRISE
-  bool const encrypted = _vocbase.engine<RocksDBEngine>().isEncryptionEnabled();
+  bool const encrypted = _vocbase.engine().isEncryptionEnabled();
 #endif
 
   auto const executorIdx =

--- a/arangod/RocksDBEngine/RocksDBEngine.h
+++ b/arangod/RocksDBEngine/RocksDBEngine.h
@@ -468,7 +468,7 @@ class RocksDBEngine final : public StorageEngine, public ICompactKeyRange {
 #ifdef USE_ENTERPRISE
   bool encryptionKeyRotationEnabled() const;
 
-  bool isEncryptionEnabled() const;
+  bool isEncryptionEnabled() const override;
 
   std::string const& getEncryptionKey();
 

--- a/arangod/StorageEngine/StorageEngine.h
+++ b/arangod/StorageEngine/StorageEngine.h
@@ -392,6 +392,10 @@ class StorageEngine : public application_features::ApplicationFeature {
   TransactionStatistics& transactionStatistics() noexcept;
   TransactionStatistics const& transactionStatistics() const noexcept;
 
+#if USE_ENTERPRISE
+  virtual bool isEncryptionEnabled() const { return false; }
+#endif
+
  protected:
   void initTransactionStatistics(metrics::IRegistry& metrics);
 


### PR DESCRIPTION
### Scope & Purpose

This fixes an issue in the unit tests where we have a StorageEngineMock instead of an actual RocksDBEngine, but the IResearchViewNode used to unconditionally cast to RocksDBEngine.

- [X] :hankey: Bugfix

#### Related Information

- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-581
