### PR TITLE
COR-784: Missing Variable in Collect Query

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
+
+* COR-784: Missing Variable in Collect Query
+  Fixed an issue where certain invalid COLLECT statements could trigger an internal query planning error instead of reporting a user-facing query validation error.
+  
 * BTS-2400: Added the `--vector-index-build-retry-backoff` startup option (seconds) to
   configure the vector index build retry backoff (default: 60). Additionally, a
   DBServer now marks the database dirty when a vector index build reports or

--- a/arangod/Aql/Parser/grammar.y
+++ b/arangod/Aql/Parser/grammar.y
@@ -358,6 +358,42 @@ bool validateAggregates(Parser* parser, AstNode const* aggregates,
   return true;
 }
 
+/// @brief validate COLLECT grouping assignments do not refer to each other.
+/// Group expressions are evaluated before any COLLECT output variables exist.
+/// Therefore no grouping expression may reference a variable introduced by the
+/// same COLLECT statement.
+void validateCollectGroupVariables(Parser* parser, AstNode const* groupAssignments, int line,
+                           int column) {
+  TRI_ASSERT(groupAssignments != nullptr);
+
+  VarSet collectVariables;
+  size_t const n = groupAssignments->numMembers();
+  collectVariables.reserve(n);
+
+  // First pass: collect all variables introduced by the COLLECT clause.
+  for (size_t i = 0; i < n; ++i) {
+    auto member = groupAssignments->getMemberUnchecked(i);
+    if (member != nullptr) {
+      TRI_ASSERT(member->type == NODE_TYPE_ASSIGN);
+
+      collectVariables.emplace(
+        static_cast<Variable const*>(member->getMember(0)->getData()));
+    }
+  }
+
+  // Second pass: ensure no grouping expression references any COLLECT
+  // variable introduced by this statement.
+  for (size_t i = 0; i < n; ++i) {
+    auto member = groupAssignments->getMemberUnchecked(i);
+    if (member != nullptr) {
+      TRI_ASSERT(member->type == NODE_TYPE_ASSIGN);
+      
+      ::checkCollectVariables(parser, "COLLECT", member->getMember(1), line,
+                            column, collectVariables);
+    }
+  }
+}
+
 /// @brief validate the WINDOW specification
 bool validateWindowSpec(Parser* parser, AstNode const* spec,
                         int line, int column) {
@@ -1228,6 +1264,8 @@ collect_variable_list:
     } collect_list {
       auto list = static_cast<AstNode*>(parser->popStack());
       TRI_ASSERT(list != nullptr);
+      ::validateCollectGroupVariables(parser, list, yylloc.first_line,
+                              yylloc.first_column);
       $$ = list;
     }
   ;

--- a/tests/js/client/aql/aql-collect-subquery-scope-regression.js
+++ b/tests/js/client/aql/aql-collect-subquery-scope-regression.js
@@ -81,6 +81,40 @@ function subqueryCollectScopeSuite() {
       });
     },
 
+    // Regression: group assignments must not reference other group outputs from
+    // the same COLLECT. Those outputs only exist after CollectNode; evaluating
+    // them earlier produced an invalid plan and MissingVariablesException.
+    testCollectUsingItsOwnVariablesInGroupExpression : function () {
+      const queries = [
+        "FOR x IN [] COLLECT a = 1, b = a RETURN b",
+        "FOR x IN [] COLLECT a = 1, b = [a] RETURN b",
+        "FOR x IN [] COLLECT a = 1, b = 2, c = [a, b] RETURN c",
+        "FOR x IN [] COLLECT a = 1, b = (RETURN a) RETURN b",
+        "FOR x IN [] COLLECT a = 1, b = (FOR j IN [] RETURN a) RETURN b",
+        `FOR br IN [
+           { name: "Magic Hat", abv: 5.0 },
+           { name: "Midnight Sun Brewing Co.", abv: 6.5 }
+         ]
+         COLLECT
+           br_name = br.name,
+           nestedVar = 1,
+           nestedVar_1 = 2,
+           nestedVar_2 = 3,
+           a_1_2_3_ = [nestedVar, nestedVar_1, nestedVar_2]
+         AGGREGATE max = MAX(br.abv)
+         RETURN { br_name, a_1_2_3_, max }`,
+      ];
+
+      queries.forEach((query) => {
+        try {
+          db._query(query);
+          fail();
+        } catch (e) {
+          assertEqual(e.errorNum, errors.ERROR_QUERY_VARIABLE_NAME_UNKNOWN.code, query);
+        }
+      });
+    },
+
   };
 }
 


### PR DESCRIPTION
This PR addressing one of the customer issue.

**Problem:**
The following query produces an internal error MissingVariablesException during RegisterPlan:

FOR br IN [
  { name: "Magic Hat", abv: 5.0 },
  { name: "Midnight Sun Brewing Co.", abv: 6.5 }
]
COLLECT
  br_name = br.name,
  nestedVar = 1,
  nestedVar_1 = 2,
  nestedVar_2 = 3,
  a_1_2_3_ = [nestedVar, nestedVar_1, nestedVar_2]
AGGREGATE max = MAX(br.abv)
RETURN { br_name, a_1_2_3_, max }

**Root cause:**
Parser gap: each collect_element immediately registers its output variable in scope (createNodeAssign). Later group expressions can therefore resolve earlier COLLECT outputs. There was validation for AGGREGATE and INTO, but none for the group list itself, so an invalid plan was built and RegisterPlan threw MissingVariablesException.

**Fix:**
Instead of allowing the planner to construct an invalid execution plan and fail later in RegisterPlan, validating the query during parsing/AST construction and reporting a user-facing error.

**Output After Fix:**
127.0.0.1:8529@_system> db._query(`LET brs = [{ name : "Magic Hat", abv : 5.0 }, { name : "Midnight Sun Brewing Co.", abv : 6.5 }]FOR br IN brs    COLLECT  br_name = br.name,  nestedVar = 1,  nestedVar_1 = 2,  nestedVar_2 = 3,   a_1_2_3_ = [nestedVar, nestedVar_1, nestedVar_2] AGGREGATE max = MAX(br.abv)    SORT a_1_2_3_  RETURN { br1: br_name, max_br: max, x: a_1_2_3_ } `).toArray();
JavaScript exception in file '/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arangosh.js' at 92,9: **ArangoError 1512:** use of COLLECT variable 'nestedVar' inside same COLLECT's expression near 'AGGREGATE max = MAX(br.abv)    S...' at position 1:244
!        throw error;
!        ^
stacktrace: ArangoError: use of COLLECT variable 'nestedVar' inside same COLLECT's expression near 'AGGREGATE max = MAX(br.abv)    S...' at position 1:244
    at exports.checkRequestResult (/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arangosh.js:90:23)
    at ArangoStatement.execute (/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arango-statement.js:170:12)
    at ArangoDatabase._query (/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arango-database.js:1015:45)
    at <shell command>:1:4