### PR TITLE
Remove `materialize-for-enumerate-near` rule disable mechanic

### DIFF
--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -932,7 +932,7 @@ filtering by using `storedValues`. This rule is only enabled by the
 
   registerRule("materialize-for-enumerate-near", materializeForEnumerateNear,
                OptimizerRule::materializeForEnumerateNearRule,
-               OptimizerRule::makeFlags(),
+               OptimizerRule::makeFlags(OptimizerRule::Flags::Hidden),
                R"(Choose how each EnumerateNearVectorNode emits its document.
 If the vector index storedValues cover the downstream projections, or if a
 pushed-down filter already loaded the document, the vector node produces the

--- a/arangod/Aql/OptimizerRulesFeature.cpp
+++ b/arangod/Aql/OptimizerRulesFeature.cpp
@@ -932,7 +932,7 @@ filtering by using `storedValues`. This rule is only enabled by the
 
   registerRule("materialize-for-enumerate-near", materializeForEnumerateNear,
                OptimizerRule::materializeForEnumerateNearRule,
-               OptimizerRule::makeFlags(OptimizerRule::Flags::CanBeDisabled),
+               OptimizerRule::makeFlags(),
                R"(Choose how each EnumerateNearVectorNode emits its document.
 If the vector index storedValues cover the downstream projections, or if a
 pushed-down filter already loaded the document, the vector node produces the


### PR DESCRIPTION
### Scope & Purpose

Disabling this rule should not be allowed since it breaks approx near queries.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
