### PR TITLE
BTS-2417: Traversal Condition Pessimisation Fix

### DIFF
--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -503,6 +503,15 @@ void TraversalNode::replaceAttributeAccess(
 
 /// @brief getVariablesUsedHere
 void TraversalNode::getVariablesUsedHere(VarSet& result) const {
+  getConditionVariables(result);
+
+  if (usesInVariable()) {
+    result.emplace(_inVariable);
+  }
+}
+
+/// @brief getConditionVariables
+void TraversalNode::getConditionVariables(VarSet& result) const {
   auto validateVariable = [this](const aql::Variable* var) {
     return ((!vertexOutVariable() || var != vertexOutVariable()) &&
             (!edgeOutVariable() || var != edgeOutVariable()) &&
@@ -561,10 +570,6 @@ void TraversalNode::getVariablesUsedHere(VarSet& result) const {
 
   if (_postFilterExpression && _postFilterExpression->node()) {
     fetchVarsFromNode(_postFilterExpression->node());
-  }
-
-  if (usesInVariable()) {
-    result.emplace(_inVariable);
   }
 }
 
@@ -1128,13 +1133,13 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
   }
 
   // Optimized condition
+  VarSet conditionVars;
+  getConditionVariables(conditionVars);
+
   std::vector<std::pair<Variable const*, RegisterId>> filterConditionVariables;
-  filterConditionVariables.reserve(_conditionVariables.size());
+  filterConditionVariables.reserve(conditionVars.size());
 
-  VarSet usedVars;
-  getVariablesUsedHere(usedVars);
-
-  for (const auto* variable : usedVars) {
+  for (const auto* variable : conditionVars) {
     if (variable == _tmpObjVariable) continue;
 
     auto itVarInfo = varInfo.find(variable->id);

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -516,7 +516,7 @@ void TraversalNode::getConditionVariables(VarSet& result) const {
     return ((!vertexOutVariable() || var != vertexOutVariable()) &&
             (!edgeOutVariable() || var != edgeOutVariable()) &&
             (!pathOutVariable() || var != pathOutVariable()) &&
-            (getTemporaryVariable() && var != getTemporaryVariable()) &&
+            (!getTemporaryVariable() || var != getTemporaryVariable()) &&
             !_optimizedOutVariables.contains(var->id));
   };
 

--- a/arangod/Aql/ExecutionNode/TraversalNode.h
+++ b/arangod/Aql/ExecutionNode/TraversalNode.h
@@ -159,6 +159,14 @@ class TraversalNode : public virtual GraphNode {
   /// @brief getVariablesUsedHere
   void getVariablesUsedHere(VarSet& result) const override final;
 
+  /// @brief all variables referenced by the conditions, prune and post-filter
+  /// expressions of this traversal. These are the variables whose values have
+  /// to be made available to the condition evaluation at run time (and, in the
+  /// cluster, have to be shipped to the DB servers). This is a subset of
+  /// getVariablesUsedHere(), which additionally contains the start vertex
+  /// input variable.
+  void getConditionVariables(VarSet& result) const;
+
   /// @brief getVariablesSetHere
   std::vector<Variable const*> getVariablesSetHere() const override final;
 


### PR DESCRIPTION
After condition variable cleanup, the input variable was always added to conditions. This variable was included in every request in the traversal. The measured overhead was ~15%, which was enough to trigger a timeout in the tsan version of the test `testTailRecursion`. 

Related Pull Request: https://github.com/arangodb/arangodb/pull/22899