### PR TITLE
Remove ExecContext::requestedApiVersion again

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -65,13 +65,6 @@ bool AuthMode::isUnauthenticated() const noexcept {
   return std::holds_alternative<Unauthenticated>(authMode);
 }
 
-uint32_t AuthMode::requestedApiVersion() const noexcept {
-  if (auto req = getIAuth().request(); req.has_value()) {
-    return req->get().requestedApiVersion();
-  }
-  return api_version::defaultApiVersion;
-}
-
 auto AuthMode::Superuser::username() const noexcept -> std::string_view {
   return "";
 }

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -215,10 +215,6 @@ struct AuthMode {
   [[nodiscard]] bool isDisabled() const noexcept;
   [[nodiscard]] bool isUnauthenticated() const noexcept;
 
-  /// @brief returns the API version requested by the associated
-  /// GeneralRequest, if any; otherwise returns the default API version.
-  [[nodiscard]] uint32_t requestedApiVersion() const noexcept;
-
   template<typename T, typename... Args>
   void reset(Args&&... args) {
     authMode.emplace<T>(std::forward<Args>(args)...);

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -119,12 +119,6 @@ class ExecContext {
     return _authMode.getIAuth().username();
   }
 
-  /// @brief returns the API version requested by the associated
-  /// GeneralRequest, if any; otherwise returns the default API version.
-  [[nodiscard]] uint32_t requestedApiVersion() const noexcept {
-    return _authMode.requestedApiVersion();
-  }
-
   // Unified permission-check entry point. Prefer this over the canXxx()
   // methods below for new code; eventually they are going to be removed.
   //

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -1023,12 +1023,8 @@ futures::Future<Result> Collections::updateProperties(
   if (auto r = exec.canUseCollection(collection.vocbase().name(),
                                      collection.name(), AccessLevel::WriteMeta);
       r.fail()) {
-    if (exec.requestedApiVersion() > 0) {
-      co_return r;
-    } else {
-      // Backwards compatibility!
-      co_return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
-    }
+    // Needed for backwards compatibility!
+    co_return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
   }
 
   if (ServerState::instance()->isCoordinator()) {

--- a/arangod/VocBase/Methods/Indexes.cpp
+++ b/arangod/VocBase/Methods/Indexes.cpp
@@ -496,14 +496,9 @@ futures::Future<arangodb::Result> Indexes::ensureIndex(
     if (auto r = exec.canUseCollection(collection.vocbase().name(),
                                        collection.name(), AccessLevel::Read);
         r.fail()) {
-      if (exec.requestedApiVersion() == 0) {
-        // Backwards compatibility!
-        ensureIndexResult = TRI_ERROR_FORBIDDEN;
-        co_return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
-      } else {
-        ensureIndexResult = r.errorNumber();
-        co_return r;
-      }
+      // Needed for backwards compatibility!
+      ensureIndexResult = TRI_ERROR_FORBIDDEN;
+      co_return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
     }
   }
 


### PR DESCRIPTION
### Scope & Purpose

Remove ExecContext::requestedApiVersion again.

This means that we have no means to adjust slightly unfortunate
return codes for API V >= 1 for `createIndex` and `Collection::updateProperties`
for now.

- [*] :hankey: Bugfix

