### PR TITLE
[COR-767] Explicit DI for LicenseFeature and its delegated services

### DIFF
--- a/arangod/RestServer/ArangodServer.cpp
+++ b/arangod/RestServer/ArangodServer.cpp
@@ -185,9 +185,13 @@ void ArangodServer::addFeaturesWithOptionProvider() {
       _dataSourceRegistry, getOptions<async_registry::OptionsProvider>());
   addFeature<ActionFeature>(getOptions<ActionOptionsProvider>());
 
+  auto& databasePath = addFeature<DatabasePathFeature>(
+      getOptions<DatabasePathOptionsProvider>());
+
 #ifdef USE_ENTERPRISE
   addFeature<AuditFeature>(getOptions<AuditOptionsProvider>());
-  addFeature<LicenseFeature>(getOptions<LicenseOptionsProvider>());
+  addFeature<LicenseFeature>(databasePath,
+                             getOptions<LicenseOptionsProvider>());
   addFeature<RCloneFeature>(getOptions<RCloneOptionsProvider>());
   addFeature<HotBackupFeature>(getOptions<HotBackupOptionsProvider>());
   addFeature<EncryptionFeature>(getOptions<EncryptionOptionsProvider>());
@@ -262,9 +266,6 @@ void ArangodServer::addFeaturesWithOptionProvider() {
 
   auto& rocksdbOption = addFeature<RocksDBOptionFeature>(
       &agency, getOptions<RocksDBOptionFeatureOptionsProvider>());
-
-  auto& databasePath = addFeature<DatabasePathFeature>(
-      getOptions<DatabasePathOptionsProvider>());
 
   addFeature<TemporaryStorageFeature>(
       databasePath, getOptions<TemporaryStorageOptionsProvider>());

--- a/tests/Mocks/Servers.cpp
+++ b/tests/Mocks/Servers.cpp
@@ -188,7 +188,8 @@ static void SetupDatabaseFeaturePhase(MockServer& server) {
 
 #if USE_ENTERPRISE
   // required for AuthenticationFeature with USE_ENTERPRISE
-  server.addFeature<LicenseFeature>(false);
+  server.addFeature<LicenseFeature>(false,
+                                    server.getFeature<DatabasePathFeature>());
   server.addFeature<EncryptionFeature>(false);
 #endif
 }

--- a/tests/sepp/Server.cpp
+++ b/tests/sepp/Server.cpp
@@ -263,7 +263,7 @@ void Server::Impl::setupServer(std::string const& name, int& result) {
 #endif
 #ifdef USE_ENTERPRISE
   _server.addFeature<AuditFeature>();
-  _server.addFeature<LicenseFeature>();
+  _server.addFeature<LicenseFeature>(databasePath);
   _server.addFeature<RCloneFeature>();
   _server.addFeature<HotBackupFeature>();
   _server.addFeature<EncryptionFeature>();


### PR DESCRIPTION
### Scope & Purpose

**_There's an Enterprise companion PR!_**

`DiskUsageCalculator` and `DiskUsageStorageForSingleServer` take 'ApplicationServer' only to call
`_server.getFeature<DatabasePathFeature>().directory()`.
Instead, They should use `IDatabasePathProvider`. It is passed down from `LicenseFeature`. Therefore, `LicenseFeature` should take `IDatabasePathProvider` explicitly.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1683
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
