### PR TITLE
Fix 3.12 RPM package creation within Ubuntu build image

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -22,7 +22,7 @@ parameters:
     default: ""
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-d2eb28e68"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-f7032bef0"
     description: "Docker image to use for building ArangoDB - only relevant when trying new build images"
   test-docker-image:
     type: string

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -177,7 +177,7 @@ parameters:
     description: "Nightly date (YYYYMMDD), pinned once by the setup config so all jobs derive the same version even when the workflow runs across midnight. Cannot be set at trigger time (the setup config does not declare it)."
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-d2eb28e68"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-f7032bef0"
     description: "Ubuntu build image (compiler toolchain + packaging/scan tools) the compile, packaging, scan, and sign jobs run in. The tag is bumped automatically by the infrastructure pipeline's build-image rebuild; override only to try a new build image."
   build-debian-packages:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ parameters:
     description: "Docker image to use for testing ArangoDB - only relevant when trying new test images"
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-d2eb28e68"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-f7032bef0"
     description: "Docker image to use for building ArangoDB - only relevant when trying new build images"
   # Rarely used options
   replication-two:

--- a/.circleci/nightly_packages.yml
+++ b/.circleci/nightly_packages.yml
@@ -36,7 +36,7 @@ parameters:
     description: "Enterprise repo branch to use. Defaults to the same branch as arangodb, falling back to devel."
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-d2eb28e68"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-f7032bef0"
     description: "Ubuntu build image (compiler toolchain + packaging/scan tools) the compile, packaging, scan, and sign jobs run in. The tag is bumped automatically by the infrastructure pipeline's build-image rebuild; override only to try a new build image."
   build-debian-packages:
     type: boolean

--- a/scripts/docker/build/linux/Dockerfile.arm64
+++ b/scripts/docker/build/linux/Dockerfile.arm64
@@ -23,7 +23,7 @@ RUN apt-get update --fix-missing && \
       gcovr prometheus bc tcpdump liburing-dev cppcheck libopenblas-dev gfortran \
       cmake ninja-build git liblapack-dev python3-pip libgd3 linux-libc-dev libcrypt-dev \
       libnsl-dev rpcsvc-proto libtirpc-dev curl gnupg gnupg2 \
-      rpm debugedit dwz clamav cpio \
+      rpm debugedit dwz elfutils clamav cpio \
   && rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 COPY --from=glibcdebs /root/debs /debs

--- a/scripts/docker/build/linux/Dockerfile.x86-64
+++ b/scripts/docker/build/linux/Dockerfile.x86-64
@@ -23,7 +23,7 @@ RUN apt-get update --fix-missing && \
       gcovr prometheus bc tcpdump liburing-dev cppcheck libopenblas-dev gfortran \
       cmake ninja-build git liblapack-dev python3-pip libgd3 linux-libc-dev libcrypt-dev \
       libnsl-dev rpcsvc-proto libtirpc-dev curl gnupg gnupg2 \
-      rpm debugedit dwz clamav cpio \
+      rpm debugedit dwz elfutils clamav cpio \
   && rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 COPY --from=glibcdebs /root/debs /debs

--- a/scripts/docker/build/linux/amd64-build-tag.txt
+++ b/scripts/docker/build/linux/amd64-build-tag.txt
@@ -1,1 +1,1 @@
-public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-d2eb28e68
+public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-f7032bef0

--- a/scripts/packaging/build-rpm.sh
+++ b/scripts/packaging/build-rpm.sh
@@ -23,6 +23,19 @@ if [ ! -d "${PROJECT_DIR}/build/install" ]; then
   exit 1
 fi
 
+# Preflight: the strip/verify toolchain must be complete. eu-strip is not
+# called by the spec itself (it strips explicitly with objcopy/strip, see
+# arangodb3e.spec.in), but a build image without eu-strip is one where
+# rpm's own debuginfo machinery is silently broken — that once shipped
+# unstripped client tools and an empty debuginfo package. Refuse to build
+# on such an image instead of relying on the machinery staying unused.
+for tool in eu-strip objcopy strip file readelf rpm2cpio cpio cmp; do
+  if ! command -v "${tool}" > /dev/null; then
+    echo "build-rpm: required tool '${tool}' is missing from the build image" >&2
+    exit 1
+  fi
+done
+
 if [ -z "${ARANGODB_RPM_UPSTREAM:-}" ]; then
   source "${SCRIPT_DIR}/../ci/helpers.bash"
   find_arangodb_version "${PROJECT_DIR}/CMakeLists.txt" > /dev/null
@@ -81,3 +94,69 @@ rpmbuild -bb -vv \
 mkdir -p "${PACKAGES_OUT}"
 mv "${TOPDIR}"/RPMS/*/*.rpm "${PACKAGES_OUT}/"
 ls -l "${PACKAGES_OUT}"
+
+# ── Verify the strip policy on the built packages ────────────────────────────
+# The outcome is asserted instead of trusting the toolchain: rpm's strip
+# machinery has failed silently before (find-debuginfo was a no-op without
+# eu-strip while brp-strip -g'ed every binary regardless of exec bits), and
+# wrong packages must fail the build here, not ship and fail RTA later.
+# Policy: client tools stripped with a .gnu_debuglink and their .debug in
+# the debuginfo package; arangod byte-identical to the install tree
+# (minimal debug info) unless PACKAGE_STRIP=All; the starter and rclone
+# always byte-identical; PACKAGE_STRIP=None leaves every binary untouched.
+CLIENT_TOOLS="arangobackup arangobench arangodump arangoexport arangoimport arangorestore arangosh arangovpack"
+
+SERVER_RPM="$(ls "${PACKAGES_OUT}"/*.rpm | grep -v -e '-client-' -e '-debuginfo-')"
+DEBUG_RPM="$(ls "${PACKAGES_OUT}"/*-debuginfo-*.rpm)"
+
+VER_TREE="${WORK}/verify"
+mkdir -p "${VER_TREE}/main" "${VER_TREE}/debug"
+( cd "${VER_TREE}/main"  && rpm2cpio "${SERVER_RPM}" | cpio -idm --quiet )
+( cd "${VER_TREE}/debug" && rpm2cpio "${DEBUG_RPM}"  | cpio -idm --quiet )
+
+fail_verify() { echo "build-rpm: STRIP POLICY VIOLATION: $*" >&2; exit 1; }
+
+expect_untouched() {
+  if ! cmp -s "${PROJECT_DIR}/build/install/$1" "${VER_TREE}/main/$1"; then
+    fail_verify "$1 differs from the install tree but must not be touched"
+  fi
+}
+
+expect_stripped() {
+  local f="${VER_TREE}/main/$1"
+  if [ ! -f "${f}" ]; then
+    fail_verify "$1 is missing from the package"
+  fi
+  if file -b "${f}" | grep -q ", not stripped"; then
+    fail_verify "$1 must be stripped, but it is not"
+  fi
+  if ! readelf -S "${f}" | grep -q '\.gnu_debuglink'; then
+    fail_verify "$1 lacks the .gnu_debuglink to its debug file"
+  fi
+  if [ ! -f "${VER_TREE}/debug/usr/lib/debug/$1.debug" ]; then
+    fail_verify "the debuginfo package lacks usr/lib/debug/$1.debug"
+  fi
+}
+
+expect_untouched usr/bin/arangodb
+expect_untouched usr/sbin/rclone-arangodb
+case "${PACKAGE_STRIP}" in
+  All)
+    expect_stripped usr/sbin/arangod
+    ;;
+  ExceptArangod)
+    expect_untouched usr/sbin/arangod
+    ;;
+  *)
+    expect_untouched usr/sbin/arangod
+    ;;
+esac
+for tool in ${CLIENT_TOOLS}; do
+  [ -f "${PROJECT_DIR}/build/install/usr/bin/${tool}" ] || continue
+  if [ "${PACKAGE_STRIP}" = "All" ] || [ "${PACKAGE_STRIP}" = "ExceptArangod" ]; then
+    expect_stripped "usr/bin/${tool}"
+  else
+    expect_untouched "usr/bin/${tool}"
+  fi
+done
+echo "build-rpm: strip policy verified (PACKAGE_STRIP=${PACKAGE_STRIP})"

--- a/scripts/packaging/rpm/arangodb3e.spec.in
+++ b/scripts/packaging/rpm/arangodb3e.spec.in
@@ -21,21 +21,24 @@
 # Use 'alldebug' to keep Build-ID links only in the debuginfo package.
 # This prevents the main packages from containing the /usr/lib/.build-id directory.
 %global _build_id_links alldebug
-%global _debuginfo_subpackages 0
-%undefine _unique_debug_names
-%undefine _unique_debug_srcs
-%undefine _debugsource_packages
 
-# Custom post-install macro to fix file permissions.
-# Since we 'hide' files from find-debuginfo using chmod -x, we must restore
-# the executable bit (+x) here so they are packaged correctly as binaries.
-%define __spec_install_post \
-    %{?__debug_package:%{__debug_install_post}} \
-    %{__arch_install_post} \
-    %{__os_install_post} \
-    find %{buildroot}/usr/bin -type f -exec chmod +x {} + \
-    find %{buildroot}/usr/sbin -type f -exec chmod +x {} + \
-    :
+# rpm's own strip machinery is unusable on the Ubuntu build image and is
+# disabled entirely:
+#   - find-debuginfo (via %%debug_package) needs eu-strip from elfutils,
+#     which the image does not carry; its per-file failures are masked by
+#     parallelism, leaving binaries unstripped and the debuginfo package
+#     empty, while debugedit still rewrites the Build-IDs,
+#   - brp-strip (in __os_install_post) ignores executable bits, so the
+#     historical chmod -x trick cannot protect arangod and the starter
+#     from it: it would strip their minimal (-g1) debug info.
+# All stripping is done explicitly in %%install instead (mirroring what
+# dh_strip does on the DEB side), so binaries end up identical across
+# DEB, RPM and TAR.GZ.
+%global __os_install_post \
+    /usr/lib/rpm/brp-compress /usr \
+    /usr/lib/rpm/brp-elfperms \
+    /usr/lib/rpm/brp-remove-la-files \
+    %{nil}
 
 %define _cfgdir %{_sysconfdir}/arangodb3
 %define _databasedir %{_localstatedir}/lib/arangodb3
@@ -57,7 +60,13 @@ Conflicts:      arangodb3, arangodb3-client, arangodb3e-client
 Url:            https://arango.ai
 Vendor:         ArangoDB
 
-%debug_package
+# Explicit debuginfo package instead of %%debug_package: it is filled by
+# the explicit strip loop in %%install, not by find-debuginfo (see the
+# __os_install_post comment above).
+%package debuginfo
+Summary:        Debug symbols for the stripped ArangoDB client tools
+Group:          Development/Debug
+AutoReqProv:    0
 
 %package client
 Summary:        ArangoDB shell as stand-alone package
@@ -76,6 +85,11 @@ Native graphs, an integrated search engine, and JSON support, via a single query
 
 %description client
 The ArangoDB shell as stand-alone program. It also contains the utility programs: arangobench (benchmark), arangorestore & arangodump (backup), arangoimport & arangoexport.
+
+%description debuginfo
+Debug symbols extracted from the stripped ArangoDB binaries (the client
+tools; arangod keeps its minimal debug info in the main package). Install
+this package to symbolize stack traces or debug the stripped binaries.
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                              prep
@@ -104,21 +118,37 @@ mkdir -p %{buildroot}%{_piddir}
 cp -a $INNERWORKDIR/ArangoDB/build/install/* %{buildroot}
 rm -f %{buildroot}/README
 
-# STRIP BYPASS LOGIC:
-# The 'find-debuginfo' script only processes files with the executable bit (+x).
-# We temporarily remove this bit to prevent 'strip' from removing internal symbols.
+# Strip policy (PACKAGE_STRIP, substituted by build-rpm.sh):
+#   None           nothing is stripped
+#   ExceptArangod  client tools are stripped, their debug info goes into
+#                  the debuginfo package; arangod keeps its minimal (-g1)
+#                  debug info  (the nightly/release default)
+#   All            like ExceptArangod, plus arangod itself
+# The starter (usr/bin/arangodb) and rclone (usr/sbin/rclone-arangodb)
+# are never touched. Symlinked tool names (arangoimp, arangoinspect,
+# foxx-manager, ...) are skipped via the -L test; the debuglink of their
+# target covers them. rpm's own strip machinery is disabled — see the
+# __os_install_post comment at the top of this file.
+mkdir -p %{buildroot}/usr/lib/debug
 
-# Always exclude Starter binary from stripping
-chmod -x %{buildroot}/usr/bin/arangodb
-
-# Optional stripping based on external build parameters
+STRIP_LIST=""
 if [ "@RPM_STRIP_NONE@" != "# " ]; then
-    # Disable stripping for everything by removing +x from all executables
-    find %{buildroot}/usr/*bin/ -type f -executable -exec chmod -x {} +
+    STRIP_LIST=""
 elif [ "@RPM_STRIP_EXCEPT_ARANGOD@" != "# " ]; then
-    # Disable stripping specifically for the main server binary
-    chmod -x %{buildroot}/usr/sbin/arangod 2>/dev/null || :
+    STRIP_LIST="usr/bin/arangobackup usr/bin/arangobench usr/bin/arangodump usr/bin/arangoexport usr/bin/arangoimport usr/bin/arangorestore usr/bin/arangosh usr/bin/arangovpack"
+else
+    STRIP_LIST="usr/bin/arangobackup usr/bin/arangobench usr/bin/arangodump usr/bin/arangoexport usr/bin/arangoimport usr/bin/arangorestore usr/bin/arangosh usr/bin/arangovpack usr/sbin/arangod"
 fi
+
+for rel in $STRIP_LIST; do
+    bin="%{buildroot}/$rel"
+    { [ -f "$bin" ] && [ ! -L "$bin" ]; } || continue
+    dbg="%{buildroot}/usr/lib/debug/$rel.debug"
+    mkdir -p "$(dirname "$dbg")"
+    objcopy --only-keep-debug "$bin" "$dbg"
+    strip --remove-section=.comment --remove-section=.note "$bin"
+    objcopy --add-gnu-debuglink="$dbg" "$bin"
+done
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                             check
@@ -184,6 +214,10 @@ echo check: We assume that there is nothing to check.
 %{_datadir}/arangodb3/js@JS_DIR@/client
 %{_datadir}/arangodb3/js@JS_DIR@/node
 %{_datadir}/arangodb3/icudtl*.dat
+
+%files debuginfo
+%defattr(-,root,root,0755)
+/usr/lib/debug
 
 ## -----------------------------------------------------------------------------
 ## --SECTION--                                                         changelog


### PR DESCRIPTION
### Scope & Purpose

- Fix nightly RPMs shipping unstripped client tools with an empty debuginfo package ("expected /usr/bin/arangosh to be stripped" in RTA): on the Ubuntu build image, find-debuginfo silently failed (no eu-strip) and brp-strip ignored exec bits, also stripping arangod's minimal debug info
- RPM spec now strips explicitly in %install (objcopy + debuglink, mirroring dh_strip on DEB) with rpm's own strip machinery disabled; explicit debuginfo package owns /usr/lib/debug — arangod keeps minimal (-g1) debug info, Starter/rclone stay untouched, client tools stripped with symbols in arangodb3e-debuginfo
- Add elfutils (eu-strip) to the build images; build-rpm.sh gains a toolchain preflight and a post-build strip-policy verifier (byte-compares untouchables, asserts stripped+debuglink+.debug), so wrong packages fail the build instead of shipping — verified end-to-end in the CI build image for all PACKAGE_STRIP modes

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [x] **Regression tests**
  - [x] C++ **Unit tests**
  - [x] **integration tests**