### PR TITLE
[BTS-2421] Fix dump vector index

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@
 
 * BTS-2421: Fixed a bug where a dump taken while a background vector index build
   was in its ingestion phase omitted the index, causing a restore to silently
-  drop it. Vector indexes now stay visible throughout the build.
+  drop it. Vector indexes are now always included in dumps.
 
 * Updated ArangoDB Starter to v0.19.25.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 3.12.10-devel (XXXX-XX-XX)
 --------------------------
 
+* BTS-2421: Fixed a bug where a dump taken while a background vector index build
+  was in its ingestion phase omitted the index, causing a restore to silently
+  drop it. Vector indexes now stay visible throughout the build.
+
 * Updated ArangoDB Starter to v0.19.25.
 
 * COR-726/COR-787/COR-792: Removed the deprecated replication applier's REST API,

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -250,6 +250,11 @@ RocksDBBuilderIndex::RocksDBBuilderIndex(std::shared_ptr<RocksDBIndex> wp,
 /// @brief return a VelocyPack representation of the index
 void RocksDBBuilderIndex::toVelocyPack(
     VPackBuilder& builder, std::underlying_type<Serialize>::type flags) const {
+  // If is Inventory just return the index defintion
+  if (Index::hasFlag(flags, Index::Serialize::Inventory)) {
+    _wrapped->toVelocyPack(builder, flags);
+    return;
+  }
   VPackBuilder inner;
   _wrapped->toVelocyPack(inner, flags);
   TRI_ASSERT(inner.slice().isObject());
@@ -874,6 +879,8 @@ futures::Future<Result> RocksDBBuilderIndex::fillIndexBackground(
       /*granularity*/ RocksDBMethodsMemoryTracker::kDefaultGranularity);
 
   Result res;
+  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
+            << " fill1: starting snapshot fill";
   // Step 1. Capture with snapshot
   rocksdb::DB* db = engine.db()->GetRootDB();
   if (internal->unique()) {
@@ -900,6 +907,8 @@ futures::Future<Result> RocksDBBuilderIndex::fillIndexBackground(
                              _engine.idxPath(), std::move(progress));
   }
 
+  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
+            << " fill2: snapshot fill done fail=" << res.fail();
   if (res.fail()) {
     co_return res;
   }
@@ -947,9 +956,13 @@ futures::Future<Result> RocksDBBuilderIndex::fillIndexBackground(
     scanFrom = lastScanned;
   } while (maxCatchups-- > 0 && numScanned > 5000);
 
+  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
+            << " fill3: lockless catchup done -> re-acquiring exclusive lock";
   if (!co_await locker.lock()) {  // acquire exclusive collection lock
     co_return res.reset(TRI_ERROR_LOCK_TIMEOUT);
   }
+  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
+            << " fill4: exclusive lock re-acquired -> final WAL scan";
 
   // Step 3. Scan the WAL for documents with a lock
 

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -250,7 +250,8 @@ RocksDBBuilderIndex::RocksDBBuilderIndex(std::shared_ptr<RocksDBIndex> wp,
 /// @brief return a VelocyPack representation of the index
 void RocksDBBuilderIndex::toVelocyPack(
     VPackBuilder& builder, std::underlying_type<Serialize>::type flags) const {
-  // If is Inventory just return the index defintion
+  // For inventory (dump/restore) emit the wrapped index definition as-is, so
+  // the builder-only fields below never leak into the external shape.
   if (Index::hasFlag(flags, Index::Serialize::Inventory)) {
     _wrapped->toVelocyPack(builder, flags);
     return;

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -879,8 +879,6 @@ futures::Future<Result> RocksDBBuilderIndex::fillIndexBackground(
       /*granularity*/ RocksDBMethodsMemoryTracker::kDefaultGranularity);
 
   Result res;
-  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
-            << " fill1: starting snapshot fill";
   // Step 1. Capture with snapshot
   rocksdb::DB* db = engine.db()->GetRootDB();
   if (internal->unique()) {
@@ -907,8 +905,6 @@ futures::Future<Result> RocksDBBuilderIndex::fillIndexBackground(
                              _engine.idxPath(), std::move(progress));
   }
 
-  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
-            << " fill2: snapshot fill done fail=" << res.fail();
   if (res.fail()) {
     co_return res;
   }
@@ -956,13 +952,9 @@ futures::Future<Result> RocksDBBuilderIndex::fillIndexBackground(
     scanFrom = lastScanned;
   } while (maxCatchups-- > 0 && numScanned > 5000);
 
-  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
-            << " fill3: lockless catchup done -> re-acquiring exclusive lock";
   if (!co_await locker.lock()) {  // acquire exclusive collection lock
     co_return res.reset(TRI_ERROR_LOCK_TIMEOUT);
   }
-  LOG_DEVEL << "WEDGEPROBE idx=" << internal->id().id()
-            << " fill4: exclusive lock re-acquired -> final WAL scan";
 
   // Step 3. Scan the WAL for documents with a lock
 

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.cpp
@@ -250,8 +250,8 @@ RocksDBBuilderIndex::RocksDBBuilderIndex(std::shared_ptr<RocksDBIndex> wp,
 /// @brief return a VelocyPack representation of the index
 void RocksDBBuilderIndex::toVelocyPack(
     VPackBuilder& builder, std::underlying_type<Serialize>::type flags) const {
-  // For inventory (dump/restore) emit the wrapped index definition as-is, so
-  // the builder-only fields below never leak into the external shape.
+  // inventory (dump/restore) gets the wrapped definition, without the
+  // builder-only fields below
   if (Index::hasFlag(flags, Index::Serialize::Inventory)) {
     _wrapped->toVelocyPack(builder, flags);
     return;

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -97,9 +97,8 @@ class RocksDBBuilderIndex final : public RocksDBIndex {
   /// @brief whether or not the index is sorted
   bool isSorted() const override { return _wrapped->isSorted(); }
 
-  /// @brief if true this index should not be shown externally
-  // do not show building indexes, except the vector index since it has multiple
-  // states in which it can exist, and this one is only the ingestion phase
+  /// @brief hide building indexes, except the vector index which stays visible
+  /// through its build phases
   bool isHidden() const override {
     return _wrapped->type() != Index::TRI_IDX_TYPE_VECTOR_INDEX;
   }

--- a/arangod/RocksDBEngine/RocksDBBuilderIndex.h
+++ b/arangod/RocksDBEngine/RocksDBBuilderIndex.h
@@ -98,8 +98,10 @@ class RocksDBBuilderIndex final : public RocksDBIndex {
   bool isSorted() const override { return _wrapped->isSorted(); }
 
   /// @brief if true this index should not be shown externally
+  // do not show building indexes, except the vector index since it has multiple
+  // states in which it can exist, and this one is only the ingestion phase
   bool isHidden() const override {
-    return true;  // do not show building indexes
+    return _wrapped->type() != Index::TRI_IDX_TYPE_VECTOR_INDEX;
   }
 
   bool inProgress() const override {

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -789,7 +789,8 @@ Result VectorIndexBuilder::build(
     metrics::Histogram<metrics::LogScale<double>>& trainingDuration,
     metrics::Histogram<metrics::LogScale<double>>& ingestionDuration,
     std::stop_token stopToken) {
-  // Keep the database and collection alive for the whole build
+  // Keep the database and collection from being dropped out from under the
+  // build
   auto& vocbase = _index.collection().vocbase();
   DatabaseGuard dbGuard(vocbase);
   CollectionGuard collGuard(&vocbase, _index.collection().id());

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -58,6 +58,8 @@
 #include "RocksDBEngine/RocksDBValue.h"
 #include "RocksDBEngine/RocksDBVectorIndexList.h"
 #include "Transaction/Helpers.h"
+#include "Utils/CollectionGuard.h"
+#include "Utils/DatabaseGuard.h"
 #include "VectorIndex/VectorIndexTrainingSampler.h"
 #include "VocBase/LogicalCollection.h"
 
@@ -787,6 +789,11 @@ Result VectorIndexBuilder::build(
     metrics::Histogram<metrics::LogScale<double>>& trainingDuration,
     metrics::Histogram<metrics::LogScale<double>>& ingestionDuration,
     std::stop_token stopToken) {
+  // Keep the database and collection alive for the whole build
+  auto& vocbase = _index.collection().vocbase();
+  DatabaseGuard dbGuard(vocbase);
+  CollectionGuard collGuard(&vocbase, _index.collection().id());
+
   auto const shouldAbort = [&]() -> bool {
     return stopToken.stop_requested() || _index.collection().deleted();
   };
@@ -874,6 +881,14 @@ Result VectorIndexBuilder::build(
     }
   }
 #endif
+
+  // The collection may have been dropped while training/paused. Bail out before
+  // taking the write lock: lockWrite() on a dropped collection blocks and would
+  // wedge this (single) build thread, starving all later vector index builds.
+  if (shouldAbort()) {
+    _index.resetTrainingState();
+    return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
+  }
 
   RocksDBBuilderIndex::Locker locker(_rcoll);
   if (!locker.lock().waitAndGet()) {

--- a/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
+++ b/arangod/RocksDBEngine/RocksDBVectorIndexBuilder.cpp
@@ -874,6 +874,12 @@ Result VectorIndexBuilder::build(
     _rcoll->swapIndex(buildIdx, indexPtr);
   });
 
+  if (shouldAbort()) {
+    _index.resetTrainingState();
+    return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
+  }
+
+// This needs to happen after shouldAbort check
 #ifdef ARANGODB_ENABLE_FAILURE_TESTS
   while (TRI_ShouldFailDebugging("RocksDBVectorIndex::pauseBeforeIngestion")) {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
@@ -882,14 +888,6 @@ Result VectorIndexBuilder::build(
     }
   }
 #endif
-
-  // The collection may have been dropped while training/paused. Bail out before
-  // taking the write lock: lockWrite() on a dropped collection blocks and would
-  // wedge this (single) build thread, starving all later vector index builds.
-  if (shouldAbort()) {
-    _index.resetTrainingState();
-    return Result{TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
-  }
 
   RocksDBBuilderIndex::Locker locker(_rcoll);
   if (!locker.lock().waitAndGet()) {

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -659,7 +659,7 @@ void LogicalCollection::toVelocyPackForInventory(VPackBuilder& result) const {
           case Index::TRI_IDX_TYPE_EDGE_INDEX:
             return false;
           case Index::TRI_IDX_TYPE_VECTOR_INDEX:
-            // we always show vector index
+            // Always include the vector index
             flags = Index::makeFlags(Index::Serialize::Inventory);
             return true;
           default:

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -658,6 +658,10 @@ void LogicalCollection::toVelocyPackForInventory(VPackBuilder& result) const {
           case Index::TRI_IDX_TYPE_PRIMARY_INDEX:
           case Index::TRI_IDX_TYPE_EDGE_INDEX:
             return false;
+          case Index::TRI_IDX_TYPE_VECTOR_INDEX:
+            // we always show vector index
+            flags = Index::makeFlags(Index::Serialize::Inventory);
+            return true;
           default:
             flags = Index::makeFlags(Index::Serialize::Inventory);
             return !idx->isHidden();

--- a/tests/js/client/aql/vector/aql-vector-create-and-remove.js
+++ b/tests/js/client/aql/vector/aql-vector-create-and-remove.js
@@ -887,10 +887,96 @@ function VectorIndexInsertDuringTrainingSuite() {
     };
 }
 
+// Dropping a collection mid-build must not wedge the single build thread.
+function VectorIndexDropDuringBuildSuite() {
+    const IM = global.instanceManager;
+    const dim = 100;
+    const nLists = 10;
+    const numDocs = nLists + 500;
+    const indexName = "vec_l2";
+    const ingestionPauseFP = "RocksDBVectorIndex::pauseBeforeIngestion";
+    const docs = generateDocs(randomNumberGeneratorFloat(generateSeed()),
+        numDocs, dim);
+
+    function createIndexedCollection(name) {
+        const collection = db._create(name, {numberOfShards: 1});
+        collection.insert(docs);
+        collection.ensureIndex({
+            name: indexName,
+            type: "vector",
+            fields: ["vector"],
+            inBackground: true,
+            params: {metric: "l2", dimension: dim, nLists, trainingIterations: 10},
+        });
+        return collection;
+    }
+
+    function startPausedBuildAndDrop(name) {
+        IM.debugSetFailAt(ingestionPauseFP);
+        const collection = createIndexedCollection(name);
+        assertTrue(
+            waitForVectorIndexState(collection, indexName,
+                VectorIndexTrainingState.kIngesting),
+            "Index should reach ingesting state and pause at the FP");
+        db._drop(name);
+    }
+
+    return {
+        setUp: function() {
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+            db._createDatabase(dbName);
+            db._useDatabase(dbName);
+        },
+
+        tearDown: function() {
+            if (IM && IM.debugCanUseFailAt()) {
+                IM.debugClearFailAt();
+            }
+            db._useDatabase("_system");
+            try { db._dropDatabase(dbName); } catch (e) {}
+        },
+
+        testReleaseFpAfterDropAllowsNewBuildToComplete: function() {
+            if (!IM || !IM.debugCanUseFailAt() || isCluster) {
+                return;
+            }
+            startPausedBuildAndDrop("pausedColl");
+            IM.debugClearFailAt();
+
+            const fresh = createIndexedCollection("freshColl");
+            assertTrue(
+                waitForVectorIndexState(fresh, indexName,
+                    VectorIndexTrainingState.kReady),
+                "New vector index must reach ready, proving the build thread " +
+                "was not wedged by the drop");
+        },
+
+        testKeepFpAfterDropStillPicksUpNewBuild: function() {
+            if (!IM || !IM.debugCanUseFailAt() || isCluster) {
+                return;
+            }
+            startPausedBuildAndDrop("pausedColl");
+
+            const fresh = createIndexedCollection("freshColl");
+            assertTrue(
+                waitForVectorIndexState(fresh, indexName,
+                    VectorIndexTrainingState.kIngesting),
+                "New vector index must reach ingesting, proving the build " +
+                "thread was not wedged by the drop");
+            assertFalse(
+                waitForVectorIndexState(fresh, indexName,
+                    VectorIndexTrainingState.kReady),
+                "New vector index must not reach ready while the FP is set");
+        },
+    };
+}
+
 jsunity.run(VectorIndexCreateAndRemoveTestSuite);
 jsunity.run(VectorIndexStoredValuesTestSuite);
 
 jsunity.run(VectorIndexTestCreationWithVectors);
 jsunity.run(VectorIndexInsertDuringTrainingSuite);
+jsunity.run(VectorIndexDropDuringBuildSuite);
 
 return jsunity.done();

--- a/tests/js/client/server_parameters/dump-vector-index.js
+++ b/tests/js/client/server_parameters/dump-vector-index.js
@@ -25,15 +25,14 @@
 
 if (getOptions === true) {
   return {
-    'vector-index': 'true'
+    'vector-index': true
   };
 }
 
 const jsunity = require('jsunity');
-const { assertTrue, assertEqual, assertNotNull } = jsunity.jsUnity.assertions;
+const { assertTrue, assertFalse, assertEqual, assertNotNull } = jsunity.jsUnity.assertions;
 const arangodb = require('@arangodb');
 const fs = require('fs');
-const internal = require('internal');
 const pu = require('@arangodb/testutils/process-utils');
 const db = arangodb.db;
 const arango = arangodb.arango;
@@ -49,6 +48,8 @@ const FP_PAUSE_INGESTION = 'RocksDBVectorIndex::pauseBeforeIngestion';
 function dumpVectorIndexSuite() {
   'use strict';
   const cn = 'UnitTestsVectorIndexDump';
+  const dim = 4;
+  const docCount = 100;
   const arangodump = pu.ARANGODUMP_BIN;
 
   assertTrue(fs.isFile(arangodump), 'arangodump not found!');
@@ -56,17 +57,14 @@ function dumpVectorIndexSuite() {
   const vectorIndexOf = (indexes) =>
     indexes.filter((i) => i.type === 'vector')[0] || null;
 
-  const fillCollection = function (c, n, dim) {
+  const fillCollection = function () {
     let docs = [];
-    for (let i = 0; i < n; ++i) {
+    for (let i = 0; i < docCount; ++i) {
       let v = [];
-      for (let d = 0; d < dim; ++d) {
-        v.push((i + d) / (n + dim));
-      }
+      for (let d = 0; d < dim; ++d) { v.push((i + d) / (docCount + dim)); }
       docs.push({ value: i, vector: v });
-      if (docs.length >= 5000) { c.insert(docs); docs = []; }
     }
-    if (docs.length) { c.insert(docs); }
+    db._collection(cn).insert(docs);
   };
 
   // Dump the collection and return the vector index from its structure file,
@@ -103,46 +101,27 @@ function dumpVectorIndexSuite() {
     }
   };
 
-  const createBackgroundVectorIndex = function (nLists) {
+  const createBackgroundVectorIndex = function (name, nLists) {
     return db._collection(cn).ensureIndex({
-      name: 'vector',
+      name: name,
       type: 'vector',
       fields: ['vector'],
       inBackground: true,
-      params: { metric: 'l2', dimension: 4, nLists: nLists }
+      params: { metric: 'l2', dimension: dim, nLists: nLists }
     });
   };
 
-  const waitForState = function (indexName, states) {
-    assertTrue(
-      waitForVectorIndexState(db._collection(cn), indexName, states, 60),
-      'vector index did not reach state ' + JSON.stringify(states));
-  };
-
   // A dump in any phase must carry the vector index, else dump/restore loses it.
+  // The builder-only fields must not leak into the external (dump) shape.
   const assertVectorIndexInDump = function (phase) {
     let idx = dumpVectorIndex();
-    assertNotNull(idx, 'vector index missing from dump taken in phase: ' + phase);
+    assertNotNull(idx, `vector index missing from dump taken in phase: ${phase}`);
     assertEqual('vector', idx.type);
     assertEqual(['vector'], idx.fields);
-  };
-
-  // Wait until no background build is in flight (index in a terminal state, or
-  // gone) so we never drop the collection mid-build. indexes(false, true)
-  // includes the hidden builder wrapper present during ingestion.
-  const waitBuildSettled = function () {
-    const end = internal.time() + 60;
-    while (internal.time() < end) {
-      let c = db._collection(cn);
-      if (c === null) { return; }
-      let v = vectorIndexOf(c.indexes(false, true));
-      if (v === null ||
-          v.trainingState === VectorIndexTrainingState.kReady ||
-          v.trainingState === VectorIndexTrainingState.kUnusable) {
-        return;
-      }
-      internal.sleep(0.05);
-    }
+    assertFalse(idx.hasOwnProperty('_inprogress'),
+                `_inprogress leaked into dump in phase ${phase}: ${JSON.stringify(idx._inprogress)}`);
+    assertFalse(idx.hasOwnProperty('documentsProcessed'),
+                `documentsProcessed leaked into dump in phase ${phase}: ${JSON.stringify(idx.documentsProcessed)}`);
   };
 
   return {
@@ -158,39 +137,45 @@ function dumpVectorIndexSuite() {
 
     tearDown: function () {
       IM.debugClearFailAt();
-      waitBuildSettled();
       db._drop(cn);
     },
 
     testDumpWhileUnusable: function () {
-      let idx = createBackgroundVectorIndex(5);
-      waitForState(idx.name, VectorIndexTrainingState.kUnusable);
+      const idx = createBackgroundVectorIndex('vecIdxUnusable', 5);
+      assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
+                                         VectorIndexTrainingState.kUnusable, 60));
       assertVectorIndexInDump('unusable');
     },
 
     testDumpWhileTraining: function () {
-      fillCollection(db._collection(cn), 100, 4);
+      fillCollection();
+      assertEqual(db._collection(cn).count(), docCount);
       IM.debugSetFailAt(FP_PAUSE_TRAINING);
 
-      let idx = createBackgroundVectorIndex(1);
-      waitForState(idx.name, VectorIndexTrainingState.kTraining);
+      const idx = createBackgroundVectorIndex('vecIdxTraining', 1);
+      assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
+                                         VectorIndexTrainingState.kTraining, 60));
       assertVectorIndexInDump('training');
     },
 
     testDumpWhileIngesting: function () {
-      fillCollection(db._collection(cn), 100, 4);
+      fillCollection();
+      assertEqual(db._collection(cn).count(), docCount);
       IM.debugSetFailAt(FP_PAUSE_INGESTION);
 
-      let idx = createBackgroundVectorIndex(1);
-      waitForState(idx.name, VectorIndexTrainingState.kIngesting);
+      const idx = createBackgroundVectorIndex('vecIdxIngesting', 1);
+      assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
+                                         VectorIndexTrainingState.kIngesting, 60));
       assertVectorIndexInDump('ingesting');
     },
 
     testDumpWhileReady: function () {
-      fillCollection(db._collection(cn), 100, 4);
+      fillCollection();
+      assertEqual(db._collection(cn).count(), docCount);
 
-      let idx = createBackgroundVectorIndex(1);
-      waitForState(idx.name, VectorIndexTrainingState.kReady);
+      const idx = createBackgroundVectorIndex('vecIdxReady', 1);
+      assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
+                                         VectorIndexTrainingState.kReady));
       assertVectorIndexInDump('ready');
     }
   };

--- a/tests/js/client/server_parameters/dump-vector-index.js
+++ b/tests/js/client/server_parameters/dump-vector-index.js
@@ -146,15 +146,18 @@ function dumpVectorIndexSuite() {
   };
 
   return {
+    setUpAll: function () {
+      assertTrue(IM.debugCanUseFailAt(),
+                 'this test requires failure points to be enabled');
+    },
+
     setUp: function () {
       db._drop(cn);
       db._create(cn);
     },
 
     tearDown: function () {
-      if (IM.debugCanUseFailAt()) {
-        IM.debugClearFailAt();
-      }
+      IM.debugClearFailAt();
       waitBuildSettled();
       db._drop(cn);
     },
@@ -166,7 +169,6 @@ function dumpVectorIndexSuite() {
     },
 
     testDumpWhileTraining: function () {
-      assertTrue(IM.debugCanUseFailAt(), 'failure points must be enabled');
       fillCollection(db._collection(cn), 100, 4);
       IM.debugSetFailAt(FP_PAUSE_TRAINING);
 
@@ -176,7 +178,6 @@ function dumpVectorIndexSuite() {
     },
 
     testDumpWhileIngesting: function () {
-      assertTrue(IM.debugCanUseFailAt(), 'failure points must be enabled');
       fillCollection(db._collection(cn), 100, 4);
       IM.debugSetFailAt(FP_PAUSE_INGESTION);
 

--- a/tests/js/client/server_parameters/dump-vector-index.js
+++ b/tests/js/client/server_parameters/dump-vector-index.js
@@ -33,9 +33,11 @@ const jsunity = require('jsunity');
 const { assertTrue, assertFalse, assertEqual, assertNotNull } = jsunity.jsUnity.assertions;
 const arangodb = require('@arangodb');
 const fs = require('fs');
+const internal = require('internal');
 const pu = require('@arangodb/testutils/process-utils');
 const db = arangodb.db;
 const arango = arangodb.arango;
+const isCluster = internal.isCluster();
 const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
 const { VectorIndexTrainingState, waitForVectorIndexState } =
   require('@arangodb/testutils/vector-index-common');
@@ -45,11 +47,16 @@ let IM = global.instanceManager;
 const FP_PAUSE_TRAINING = 'RocksDBVectorIndex::pauseBeforeTraining';
 const FP_PAUSE_INGESTION = 'RocksDBVectorIndex::pauseBeforeIngestion';
 
+// A dump must carry the vector index through every build phase. Single-server
+// dumps go through toVelocyPackForInventory(), cluster dumps through
+// toVelocyPackForClusterInventory(); this suite runs in both modes.
 function dumpVectorIndexSuite() {
   'use strict';
   const cn = 'UnitTestsVectorIndexDump';
   const dim = 4;
-  const docCount = 100;
+  const numberOfShards = isCluster ? 3 : 1;
+  const docCount = 100 * numberOfShards;
+  const buildRole = isCluster ? 'dbserver' : undefined;
   const arangodump = pu.ARANGODUMP_BIN;
 
   assertTrue(fs.isFile(arangodump), 'arangodump not found!');
@@ -67,8 +74,7 @@ function dumpVectorIndexSuite() {
     db._collection(cn).insert(docs);
   };
 
-  // Dump the collection and return the vector index from its structure file,
-  // or null if the dump does not contain one.
+  // Returns the vector index from the dump's structure file, or null.
   const dumpVectorIndex = function () {
     let path = fs.getTempFile();
     fs.makeDirectory(path);
@@ -111,7 +117,6 @@ function dumpVectorIndexSuite() {
     });
   };
 
-  // A dump in any phase must carry the vector index, else dump/restore loses it.
   // The builder-only fields must not leak into the external (dump) shape.
   const assertVectorIndexInDump = function (phase) {
     let idx = dumpVectorIndex();
@@ -132,7 +137,7 @@ function dumpVectorIndexSuite() {
 
     setUp: function () {
       db._drop(cn);
-      db._create(cn);
+      db._create(cn, { numberOfShards, replicationFactor: 1 });
     },
 
     tearDown: function () {
@@ -140,7 +145,13 @@ function dumpVectorIndexSuite() {
       db._drop(cn);
     },
 
+    // Single-server tests wait for a transient build phase, then dump. The
+    // per-shard state cannot be observed reliably in the cluster, so the
+    // paused-build tests below cover those phases there instead.
     testDumpWhileUnusable: function () {
+      if (isCluster) {
+        return;
+      }
       const idx = createBackgroundVectorIndex('vecIdxUnusable', 5);
       assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
                                          VectorIndexTrainingState.kUnusable, 60));
@@ -148,9 +159,12 @@ function dumpVectorIndexSuite() {
     },
 
     testDumpWhileTraining: function () {
+      if (isCluster) {
+        return;
+      }
       fillCollection();
       assertEqual(db._collection(cn).count(), docCount);
-      IM.debugSetFailAt(FP_PAUSE_TRAINING);
+      IM.debugSetFailAt(FP_PAUSE_TRAINING, buildRole);
 
       const idx = createBackgroundVectorIndex('vecIdxTraining', 1);
       assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
@@ -159,14 +173,44 @@ function dumpVectorIndexSuite() {
     },
 
     testDumpWhileIngesting: function () {
+      if (isCluster) {
+        return;
+      }
       fillCollection();
       assertEqual(db._collection(cn).count(), docCount);
-      IM.debugSetFailAt(FP_PAUSE_INGESTION);
+      IM.debugSetFailAt(FP_PAUSE_INGESTION, buildRole);
 
       const idx = createBackgroundVectorIndex('vecIdxIngesting', 1);
       assertTrue(waitForVectorIndexState(db._collection(cn), idx.name,
                                          VectorIndexTrainingState.kIngesting, 60));
       assertVectorIndexInDump('ingesting');
+    },
+
+    // In the cluster ensureIndex() returns once `isBuilding` clears (before the
+    // build finishes), so the dbserver failure point still holds the build
+    // paused at dump time.
+    testClusterDumpWhileBuildPausedBeforeTraining: function () {
+      if (!isCluster) {
+        return;
+      }
+      fillCollection();
+      assertEqual(db._collection(cn).count(), docCount);
+      IM.debugSetFailAt(FP_PAUSE_TRAINING, buildRole);
+
+      createBackgroundVectorIndex('vecIdxTraining', 1);
+      assertVectorIndexInDump('build paused before training');
+    },
+
+    testClusterDumpWhileBuildPausedBeforeIngestion: function () {
+      if (!isCluster) {
+        return;
+      }
+      fillCollection();
+      assertEqual(db._collection(cn).count(), docCount);
+      IM.debugSetFailAt(FP_PAUSE_INGESTION, buildRole);
+
+      createBackgroundVectorIndex('vecIdxIngesting', 1);
+      assertVectorIndexInDump('build paused before ingestion');
     },
 
     testDumpWhileReady: function () {

--- a/tests/js/client/server_parameters/dump-vector-index.js
+++ b/tests/js/client/server_parameters/dump-vector-index.js
@@ -1,0 +1,200 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global getOptions */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2025 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// //////////////////////////////////////////////////////////////////////////////
+
+if (getOptions === true) {
+  return {
+    'vector-index': 'true'
+  };
+}
+
+const jsunity = require('jsunity');
+const { assertTrue, assertEqual, assertNotNull } = jsunity.jsUnity.assertions;
+const arangodb = require('@arangodb');
+const fs = require('fs');
+const internal = require('internal');
+const pu = require('@arangodb/testutils/process-utils');
+const db = arangodb.db;
+const arango = arangodb.arango;
+const { executeExternalAndWaitWithSanitizer } = require('@arangodb/test-helper');
+const { VectorIndexTrainingState, waitForVectorIndexState } =
+  require('@arangodb/testutils/vector-index-common');
+
+let IM = global.instanceManager;
+
+const FP_PAUSE_TRAINING = 'RocksDBVectorIndex::pauseBeforeTraining';
+const FP_PAUSE_INGESTION = 'RocksDBVectorIndex::pauseBeforeIngestion';
+
+function dumpVectorIndexSuite() {
+  'use strict';
+  const cn = 'UnitTestsVectorIndexDump';
+  const arangodump = pu.ARANGODUMP_BIN;
+
+  assertTrue(fs.isFile(arangodump), 'arangodump not found!');
+
+  const vectorIndexOf = (indexes) =>
+    indexes.filter((i) => i.type === 'vector')[0] || null;
+
+  const fillCollection = function (c, n, dim) {
+    let docs = [];
+    for (let i = 0; i < n; ++i) {
+      let v = [];
+      for (let d = 0; d < dim; ++d) {
+        v.push((i + d) / (n + dim));
+      }
+      docs.push({ value: i, vector: v });
+      if (docs.length >= 5000) { c.insert(docs); docs = []; }
+    }
+    if (docs.length) { c.insert(docs); }
+  };
+
+  // Dump the collection and return the vector index from its structure file,
+  // or null if the dump does not contain one.
+  const dumpVectorIndex = function () {
+    let path = fs.getTempFile();
+    fs.makeDirectory(path);
+    try {
+      let args = ['--collection', cn, '--output-directory', path,
+                  '--overwrite', 'true'];
+      args.push('--server.endpoint');
+      args.push(IM.endpoint);
+      args.push('--server.database');
+      args.push(arango.getDatabaseName());
+      args.push('--server.username');
+      args.push(arango.connectedUser());
+
+      const rc = executeExternalAndWaitWithSanitizer(
+        arangodump, args, 'dump-vector-index');
+      assertTrue(rc.hasOwnProperty('exit'), rc);
+      assertEqual(0, rc.exit, rc);
+
+      let structFile = fs.list(path).filter(
+        (f) => f.endsWith('.structure.json'))[0];
+      assertTrue(structFile !== undefined, 'no structure file in dump: ' +
+                 JSON.stringify(fs.list(path)));
+      let s = JSON.parse(fs.read(fs.join(path, structFile)));
+      let indexes = (s.indexes && s.indexes.length)
+        ? s.indexes
+        : (s.parameters.indexes || []);
+      return vectorIndexOf(indexes);
+    } finally {
+      fs.removeDirectoryRecursive(path, true);
+    }
+  };
+
+  const createBackgroundVectorIndex = function (nLists) {
+    return db._collection(cn).ensureIndex({
+      name: 'vector',
+      type: 'vector',
+      fields: ['vector'],
+      inBackground: true,
+      params: { metric: 'l2', dimension: 4, nLists: nLists }
+    });
+  };
+
+  const waitForState = function (indexName, states) {
+    assertTrue(
+      waitForVectorIndexState(db._collection(cn), indexName, states, 60),
+      'vector index did not reach state ' + JSON.stringify(states));
+  };
+
+  // A dump in any phase must carry the vector index, else dump/restore loses it.
+  const assertVectorIndexInDump = function (phase) {
+    let idx = dumpVectorIndex();
+    assertNotNull(idx, 'vector index missing from dump taken in phase: ' + phase);
+    assertEqual('vector', idx.type);
+    assertEqual(['vector'], idx.fields);
+  };
+
+  // Wait until no background build is in flight (index in a terminal state, or
+  // gone) so we never drop the collection mid-build. indexes(false, true)
+  // includes the hidden builder wrapper present during ingestion.
+  const waitBuildSettled = function () {
+    const end = internal.time() + 60;
+    while (internal.time() < end) {
+      let c = db._collection(cn);
+      if (c === null) { return; }
+      let v = vectorIndexOf(c.indexes(false, true));
+      if (v === null ||
+          v.trainingState === VectorIndexTrainingState.kReady ||
+          v.trainingState === VectorIndexTrainingState.kUnusable) {
+        return;
+      }
+      internal.sleep(0.05);
+    }
+  };
+
+  return {
+    setUp: function () {
+      db._drop(cn);
+      db._create(cn);
+    },
+
+    tearDown: function () {
+      if (IM.debugCanUseFailAt()) {
+        IM.debugClearFailAt();
+      }
+      waitBuildSettled();
+      db._drop(cn);
+    },
+
+    testDumpWhileUnusable: function () {
+      let idx = createBackgroundVectorIndex(5);
+      waitForState(idx.name, VectorIndexTrainingState.kUnusable);
+      assertVectorIndexInDump('unusable');
+    },
+
+    testDumpWhileTraining: function () {
+      assertTrue(IM.debugCanUseFailAt(), 'failure points must be enabled');
+      fillCollection(db._collection(cn), 100, 4);
+      IM.debugSetFailAt(FP_PAUSE_TRAINING);
+
+      let idx = createBackgroundVectorIndex(1);
+      waitForState(idx.name, VectorIndexTrainingState.kTraining);
+      assertVectorIndexInDump('training');
+    },
+
+    testDumpWhileIngesting: function () {
+      assertTrue(IM.debugCanUseFailAt(), 'failure points must be enabled');
+      fillCollection(db._collection(cn), 100, 4);
+      IM.debugSetFailAt(FP_PAUSE_INGESTION);
+
+      let idx = createBackgroundVectorIndex(1);
+      waitForState(idx.name, VectorIndexTrainingState.kIngesting);
+      assertVectorIndexInDump('ingesting');
+    },
+
+    testDumpWhileReady: function () {
+      fillCollection(db._collection(cn), 100, 4);
+
+      let idx = createBackgroundVectorIndex(1);
+      waitForState(idx.name, VectorIndexTrainingState.kReady);
+      assertVectorIndexInDump('ready');
+    }
+  };
+}
+
+jsunity.run(dumpVectorIndexSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Fixes the issue that dumping the vector index during the ingestion phase does not give the vector index, since it is hidden during that phase. The vector index ingestion part is the third step in its creation; therefore, it should be shown during that time, and here we show the vector index during the ingestion phase.

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [x] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/BTS-2421
- [ ] Design document: 
