### PR TITLE
[COR-764] rest interface to fetch arango search segment info

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 3.12.11-devel (XXXX-XX-XX)
 --------------------------
 
+* COR-764: Added REST API to access ArangoSearch segment stats
+
+* COR-569: Added activity to report ArangoSearch consolidation
+
 * BTS-2425: Updated node modules:
  - fast-uri to 3.1.5 to resolve CVE-2026-18446
  - brace-expansion to 5.0.9 to resolve CVE-2026-69152

--- a/arangod/GeneralServer/GeneralServerFeature.cpp
+++ b/arangod/GeneralServer/GeneralServerFeature.cpp
@@ -118,6 +118,7 @@
 #include "RestHandler/RestVersionHandler.h"
 #include "RestHandler/RestOpenApiHandler.h"
 #include "RestHandler/RestViewHandler.h"
+#include "RestHandler/RestIResearchHandler.h"
 #include "RestHandler/RestWalAccessHandler.h"
 #include "RestServer/EndpointFeature.h"
 #include "Metrics/HistogramBuilder.h"
@@ -656,6 +657,10 @@ void GeneralServerFeature::defineRemainingHandlers(
 
   f.addPrefixHandler(RestVocbaseBaseHandler::VIEW_PATH,
                      RestHandlerCreator<RestViewHandler>::createNoData, {0, 1});
+
+  f.addPrefixHandler(RestVocbaseBaseHandler::STATS_ARANGOSEARCH_PATH,
+                     RestHandlerCreator<RestIResearchHandler>::createNoData,
+                     {api_version::experimentalApiVersion});
 
   if (::arangodb::replication2::EnableReplication2 && cluster.isEnabled()) {
     f.addPrefixHandler(std::string{StaticStrings::ApiLogExternal},

--- a/arangod/IResearch/CMakeLists.txt
+++ b/arangod/IResearch/CMakeLists.txt
@@ -96,7 +96,9 @@ add_library(arango_iresearch STATIC
   Wildcard/Options.cpp
   Wildcard/Options.h
   ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestAnalyzerHandler.cpp
-  ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestAnalyzerHandler.h)
+  ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestAnalyzerHandler.h
+  ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestIResearchHandler.cpp
+  ${PROJECT_SOURCE_DIR}/arangod/RestHandler/RestIResearchHandler.h)
 
 add_dependencies(arango_iresearch
   v8_build # for ICU required by iResearch

--- a/arangod/IResearch/IResearchDataStore.cpp
+++ b/arangod/IResearch/IResearchDataStore.cpp
@@ -1892,7 +1892,7 @@ void IResearchDataStore::truncateCommit(TruncateGuard&& guard,
   }
 }
 
-IResearchDataStore::Stats IResearchDataStore::stats() const {
+IResearchDataStore::Stats IResearchDataStore::getStats() const {
   auto linkLock = _asyncSelf->lock();
   if (!linkLock) {
     return {};
@@ -1901,10 +1901,18 @@ IResearchDataStore::Stats IResearchDataStore::stats() const {
     return _metricStats->load();
   }
   TRI_ASSERT(_dataStore);
-  return updateStatsUnsafe(_dataStore.loadSnapshot());
+  return getStatsUnsafe(_dataStore.loadSnapshot());
 }
 
-IResearchDataStore::Stats IResearchDataStore::updateStatsUnsafe(
+void IResearchDataStore::updateStatsUnsafe(DataSnapshotPtr data) const {
+  if (!_metricStats) {
+    return;
+  }
+  auto stats = getStatsUnsafe(data);
+  _metricStats->store(stats);
+}
+
+IResearchDataStore::Stats IResearchDataStore::getStatsUnsafe(
     DataSnapshotPtr data) const {
   TRI_ASSERT(data);
   auto& reader = data->_reader;
@@ -1931,16 +1939,43 @@ IResearchDataStore::Stats IResearchDataStore::updateStatsUnsafe(
     stats.indexSize += meta.byte_size;
     stats.numFiles += meta.files.size();
   }
-  if (_metricStats) {
-    _metricStats->store(stats);
-  }
   return stats;
+}
+
+IResearchDataStore::DatastoreStats IResearchDataStore::getDatastoreStatsUnsafe(
+    DataSnapshotPtr data) const {
+  TRI_ASSERT(data);
+  auto& reader = data->_reader;
+  TRI_ASSERT(reader);
+
+  DatastoreStats dsStats;
+  dsStats.summary = getStatsUnsafe(data);
+  const auto& segments = reader->Meta().index_meta.segments;
+  std::for_each(segments.begin(), segments.end(),
+                [&dsStats](const irs::IndexSegment& segment) {
+                  irs::SegmentInfo segInfo;
+                  segInfo = segment.meta;
+                  dsStats.segments.push_back(segInfo);
+                });
+
+  return dsStats;
+}
+
+IResearchDataStore::DatastoreStats IResearchDataStore::getDatastoreStats()
+    const {
+  auto linkLock = _asyncSelf->lock();
+  if (!linkLock) {
+    return {};
+  }
+
+  TRI_ASSERT(_dataStore);
+  return getDatastoreStatsUnsafe(_dataStore.loadSnapshot());
 }
 
 void IResearchDataStore::toVelocyPackStats(VPackBuilder& builder) const {
   TRI_ASSERT(builder.isOpenObject());
 
-  auto const stats = this->stats();
+  auto const stats = this->getStats();
 
   builder.add("numDocs", VPackValue(stats.numDocs));
   builder.add("numPrimaryDocs", VPackValue(stats.numPrimaryDocs));

--- a/arangod/IResearch/IResearchDataStore.h
+++ b/arangod/IResearch/IResearchDataStore.h
@@ -293,7 +293,14 @@ class IResearchDataStore {
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief get index stats for current snapshot
   ////////////////////////////////////////////////////////////////////////////////
-  virtual Stats stats() const;
+  virtual Stats getStats() const;
+
+  struct DatastoreStats {
+    Stats summary;
+    std::vector<irs::SegmentInfo> segments;
+  };
+
+  virtual DatastoreStats getDatastoreStats() const;
 
   //////////////////////////////////////////////////////////////////////////////
   /// @brief set the data store to out of sync. if a data store is out of sync,
@@ -472,7 +479,14 @@ class IResearchDataStore {
   /// @brief Update index stats for current snapshot
   /// @note Unsafe, can only be called is _asyncSelf is locked
   ////////////////////////////////////////////////////////////////////////////////
-  Stats updateStatsUnsafe(DataSnapshotPtr data) const;
+  void updateStatsUnsafe(DataSnapshotPtr data) const;
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /// @brief Fetch index stats for current snapshot
+  /// @note Unsafe, can only be called is _asyncSelf is locked
+  ////////////////////////////////////////////////////////////////////////////////
+  virtual DatastoreStats getDatastoreStatsUnsafe(DataSnapshotPtr data) const;
+  virtual Stats getStatsUnsafe(DataSnapshotPtr data) const;
 
   void initClusterMetrics() const;
 

--- a/arangod/IResearch/IResearchInvertedClusterIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedClusterIndex.cpp
@@ -93,7 +93,7 @@ std::string IResearchInvertedClusterIndex::getCollectionName() const {
   return collection().name();
 }
 
-IResearchDataStore::Stats IResearchInvertedClusterIndex::stats() const {
+IResearchDataStore::Stats IResearchInvertedClusterIndex::getStats() const {
   auto& cmf = collection()
                   .vocbase()
                   .server()

--- a/arangod/IResearch/IResearchInvertedClusterIndex.h
+++ b/arangod/IResearch/IResearchInvertedClusterIndex.h
@@ -49,9 +49,9 @@ class IResearchInvertedClusterIndex final : public Index,
 
   std::string getCollectionName() const;
 
-  Stats stats() const final;
+  Stats getStats() const final;
 
-  size_t memory() const final { return stats().indexSize; }
+  size_t memory() const final { return getStats().indexSize; }
 
   bool isHidden() const final { return false; }
 

--- a/arangod/IResearch/IResearchLinkCoordinator.cpp
+++ b/arangod/IResearch/IResearchLinkCoordinator.cpp
@@ -69,7 +69,7 @@ Result IResearchLinkCoordinator::init(velocypack::Slice definition) {
   return r;
 }
 
-IResearchDataStore::Stats IResearchLinkCoordinator::stats() const {
+IResearchDataStore::Stats IResearchLinkCoordinator::getStats() const {
   auto& cmf = collection()
                   .vocbase()
                   .server()

--- a/arangod/IResearch/IResearchLinkCoordinator.h
+++ b/arangod/IResearch/IResearchLinkCoordinator.h
@@ -86,9 +86,9 @@ class IResearchLinkCoordinator final : public Index, public IResearchLink {
     return IResearchLink::matchesDefinition(slice);
   }
 
-  Stats stats() const final;
+  Stats getStats() const final;
 
-  size_t memory() const final { return stats().indexSize; }
+  size_t memory() const final { return getStats().indexSize; }
   ////////////////////////////////////////////////////////////////////////////////
   /// @brief fill and return a JSON description of a IResearchLink object
   /// @param withFigures output 'figures' section with e.g. memory size

--- a/arangod/IResearch/IResearchRocksDBInvertedIndex.h
+++ b/arangod/IResearch/IResearchRocksDBInvertedIndex.h
@@ -76,7 +76,7 @@ class IResearchRocksDBInvertedIndex final : public RocksDBIndex,
   void toVelocyPack(VPackBuilder& builder,
                     std::underlying_type_t<Index::Serialize> flags) const final;
 
-  size_t memory() const final { return stats().indexSize; }
+  size_t memory() const final { return getStats().indexSize; }
 
   bool isHidden() const final { return false; }
 

--- a/arangod/IResearch/IResearchRocksDBLink.h
+++ b/arangod/IResearch/IResearchRocksDBLink.h
@@ -99,7 +99,7 @@ class IResearchRocksDBLink final : public RocksDBIndex, public IResearchLink {
 
   size_t memory() const final {
     // FIXME return in memory size
-    return stats().indexSize;
+    return getStats().indexSize;
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/arangod/RestHandler/RestIResearchHandler.cpp
+++ b/arangod/RestHandler/RestIResearchHandler.cpp
@@ -1,0 +1,194 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Koushal Kawade
+////////////////////////////////////////////////////////////////////////////////
+
+#include <cmath>
+#include "RestIResearchHandler.h"
+
+#include "ApplicationFeatures/ApplicationServer.h"
+#include "Basics/StringUtils.h"
+#include "Basics/VelocyPackHelper.h"
+#include "IResearch/IResearchFeature.h"
+#include "IResearch/IResearchDataStore.h"
+#include "IResearch/IResearchInvertedIndex.h"
+#include "IResearch/IResearchRocksDBInvertedIndex.h"
+#include "Logger/LogMacros.h"
+#include "VocBase/LogicalCollection.h"
+#include "VocBase/vocbase.h"
+#include "VocBase/Methods/Collections.h"
+#include "StorageEngine/PhysicalCollection.h"
+#include "Transaction/IndexesSnapshot.h"
+#include "IResearch/IResearchDataStore.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+
+using namespace arangodb;
+using namespace arangodb::basics;
+using namespace arangodb::rest;
+
+namespace arangodb {
+
+RestIResearchHandler::RestIResearchHandler(
+    application_features::ApplicationServer& server, GeneralRequest* request,
+    GeneralResponse* response)
+    : RestVocbaseBaseHandler(server, request, response) {}
+
+std::shared_ptr<iresearch::IResearchDataStore>
+RestIResearchHandler::getIResearchDatastore() {
+  std::shared_ptr<iresearch::IResearchDataStore> datastorePtr;
+
+  //  Callback to process each enumerated collection
+  auto processCollection =
+      [&](std::shared_ptr<LogicalCollection> const& coll) -> bool {
+    const IndexesSnapshot& idxSnapshot =
+        coll->getPhysical()->getIndexesSnapshot();
+    auto idxs = idxSnapshot.getIndexes();
+
+    //  Find an inverted index or a view.
+    //  It will lead us to IResearchDataStore.
+    for (size_t i = 0; i < idxs.size(); i++) {
+      const auto& idx = idxs[i];
+
+      if (!idx || (Index::TRI_IDX_TYPE_IRESEARCH_LINK != idx->type() &&
+                   Index::TRI_IDX_TYPE_INVERTED_INDEX != idx->type())) {
+        continue;
+      }
+
+      // TODO(MBkkt) find a better way to retrieve an IResearchDataStore
+      //  cannot use downCast since Index is not related to IResearchDataStore
+      datastorePtr =
+          std::dynamic_pointer_cast<iresearch::IResearchDataStore>(idx);
+      break;
+    }
+
+    return !datastorePtr;
+  };
+
+  methods::Collections::enumerate(&_vocbase, processCollection);
+  return datastorePtr;
+}
+
+RestStatus RestIResearchHandler::execute() {
+  if (!_request) {
+    generateError(rest::ResponseCode::BAD, TRI_ERROR_HTTP_BAD_PARAMETER);
+    return RestStatus::DONE;
+  }
+
+  if (_request->requestType() != rest::RequestType::GET) {
+    generateError(rest::ResponseCode::METHOD_NOT_ALLOWED,
+                  TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
+    return RestStatus::DONE;
+  }
+
+  if (!ServerState::instance()->isSingleServer()) {
+    generateError(rest::ResponseCode::NOT_IMPLEMENTED,
+                  TRI_ERROR_CLUSTER_UNSUPPORTED);
+    return RestStatus::DONE;
+  }
+
+  try {
+    IResearchDatastoreStats result;
+    if (!getDatastoreStats(result)) {
+      generateResult(rest::ResponseCode::OK, VPackSlice::emptyObjectSlice());
+      return RestStatus::DONE;
+    }
+
+    VPackBuilder builder;
+    if (!toVelocyPack(result, builder)) {
+      generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
+                    "failed to serialize ArangoSearch stats");
+      return RestStatus::DONE;
+    }
+    generateResult(rest::ResponseCode::OK, builder.slice());
+
+  } catch (std::exception const& ex) {
+    generateError(rest::ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
+                  ex.what());
+  }
+
+  return RestStatus::DONE;
+}
+
+bool RestIResearchHandler::getDatastoreStats(IResearchDatastoreStats& result) {
+  auto dataStore = getIResearchDatastore();
+  if (!dataStore) {
+    //  Looks like no inverted index or views exist
+    return false;
+  }
+
+  auto stats = dataStore->getDatastoreStats();
+  auto& summary = stats.summary;
+
+  result.numDocs = summary.numDocs;
+  result.numLiveDocs = summary.numLiveDocs;
+
+  if (summary.numDocs > 0) {
+    auto deletionRatio =
+        static_cast<double>(summary.numDocs - summary.numLiveDocs) /
+        summary.numDocs;
+    result.deletionRatio = std::round(deletionRatio * 100.0) / 100.0;
+  } else {
+    result.deletionRatio = 0.0;
+  }
+
+  result.numPrimaryDocs = summary.numPrimaryDocs;
+  result.numSegments = summary.numSegments;
+  result.numFiles = summary.numFiles;
+  result.indexSize = summary.indexSize;
+
+  auto& rSegments = result.segments;
+  const auto& segments = stats.segments;
+  for (const auto& segment : segments) {
+    IResearchDatastoreSegmentInfo rSegment;
+    rSegment.numDocs = segment.docs_count;
+    rSegment.numLiveDocs = segment.live_docs_count;
+
+    if (segment.docs_count > 0) {
+      auto deletionRatio =
+          static_cast<double>(segment.docs_count - segment.live_docs_count) /
+          segment.docs_count;
+      rSegment.deletionRatio = std::round(deletionRatio * 100.0) / 100.0;
+    } else {
+      rSegment.deletionRatio = 0.0;
+    }
+
+    rSegment.name = segment.name;
+    rSegment.byteSize = segment.byte_size;
+
+    rSegments.push_back(rSegment);
+  }
+
+  return true;
+}
+
+template<class T>
+bool RestIResearchHandler::toVelocyPack(
+    T& value, arangodb::velocypack::Builder& builder) {
+  arangodb::inspection::VPackSaveInspector<> inspector{builder};
+  if (auto status = inspector.apply(value); !status.ok()) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace arangodb

--- a/arangod/RestHandler/RestIResearchHandler.h
+++ b/arangod/RestHandler/RestIResearchHandler.h
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+/// @author Koushal Kawade
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "RestHandler/RestVocbaseBaseHandler.h"
+#include "RestServer/ArangodServer.h"
+#include "IResearch/IResearchDataStore.h"
+
+namespace arangodb {
+
+class IResearchFeature;
+
+struct IResearchDatastoreSegmentInfo {
+  std::string name;      //  segment name
+  uint64_t numDocs;      //  no. of docs in the segment
+  uint64_t numLiveDocs;  //  no. of live docs in the segment
+  double deletionRatio;  //  deletion ratio = ((docs - liveDocs) / docs)
+  uint64_t byteSize;     //  segment size in bytes
+
+  template<class Inspector>
+  friend inline auto inspect(Inspector& f, IResearchDatastoreSegmentInfo& x) {
+    return f.object(x).fields(
+        f.field("name", x.name), f.field("numDocs", x.numDocs),
+        f.field("numLiveDocs", x.numLiveDocs), f.field("byteSize", x.byteSize),
+        f.field("deletionRatio", x.deletionRatio));
+  }
+};
+
+//  Structure to hold the stats of the entire
+//  IResearch data store which may comprise of multiple
+//  segments.
+struct IResearchDatastoreStats {
+  uint64_t numDocs;         //  total no. of docs in the store
+  uint64_t numLiveDocs;     //  total no. of live docs
+  double deletionRatio;     //  deletion ratio of the store
+  uint64_t numPrimaryDocs;  //  total no. of primary docs
+  uint64_t numSegments;     //  total no. of segments
+  uint64_t numFiles;        //  total no. of files representing all segments
+  uint64_t indexSize;       //  index size in bytes
+  std::vector<IResearchDatastoreSegmentInfo> segments;  //  segments info
+
+  template<class Inspector>
+  friend inline auto inspect(Inspector& f, IResearchDatastoreStats& x) {
+    return f.object(x).fields(
+        f.field("numDocs", x.numDocs), f.field("numLiveDocs", x.numLiveDocs),
+        f.field("deletionRatio", x.deletionRatio),
+        f.field("numPrimaryDocs", x.numPrimaryDocs),
+        f.field("numSegments", x.numSegments), f.field("numFiles", x.numFiles),
+        f.field("indexSize", x.indexSize), f.field("segments", x.segments));
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+/// @brief REST handler for accessing internal IResearch functionality
+///
+/// This handler provides access to internal IResearch operations and statistics
+/// that are not available through the standard ArangoDB APIs.
+///
+/// Endpoints:
+/// GET /_arango/experimental/_db/${db}/_admin/arangosearch/stats
+/// Get IResearch feature statistics
+///
+/// TODO: COR-800
+/// GET /_api/iresearch/threads - Get thread pool information
+///
+/// TODO: COR-801
+/// GET /_api/iresearch/datastore/<collection>/<index> - Get data store stats
+////////////////////////////////////////////////////////////////////////////////
+class RestIResearchHandler : public RestVocbaseBaseHandler {
+ public:
+  RestIResearchHandler(application_features::ApplicationServer& server,
+                       GeneralRequest* request, GeneralResponse* response);
+
+  virtual RestStatus execute() override;
+
+  virtual RequestLane lane() const override { return RequestLane::CLIENT_SLOW; }
+
+  virtual char const* name() const override { return "RestIResearchHandler"; }
+
+  template<typename T>
+  static bool toVelocyPack(T& value, arangodb::velocypack::Builder& builder);
+
+ protected:
+  /// @brief Get data store statistics for a specific index
+  bool getDatastoreStats(IResearchDatastoreStats& stats);
+
+ private:
+  std::shared_ptr<iresearch::IResearchDataStore> getIResearchDatastore();
+};
+
+}  // namespace arangodb

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -33,6 +33,11 @@
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/Events.h"
 #include "VocBase/LogicalView.h"
+#include "VocBase/LogicalCollection.h"
+#include "VocBase/Methods/Collections.h"
+#include "StorageEngine/PhysicalCollection.h"
+#include "Transaction/IndexesSnapshot.h"
+#include "IResearch/IResearchDataStore.h"
 #include "VocBase/vocbase.h"
 
 namespace {

--- a/arangod/RestHandler/RestVocbaseBaseHandler.cpp
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.cpp
@@ -130,6 +130,10 @@ std::string const RestVocbaseBaseHandler::USERS_PATH = "/_api/user";
 // view path
 std::string const RestVocbaseBaseHandler::VIEW_PATH = "/_api/view";
 
+// stats arangosearch path
+std::string const RestVocbaseBaseHandler::STATS_ARANGOSEARCH_PATH =
+    "/_admin/arangosearch/stats";
+
 // Internal Traverser path
 
 std::string const RestVocbaseBaseHandler::INTERNAL_TRAVERSER_PATH =

--- a/arangod/RestHandler/RestVocbaseBaseHandler.h
+++ b/arangod/RestHandler/RestVocbaseBaseHandler.h
@@ -118,6 +118,9 @@ class RestVocbaseBaseHandler : public RestBaseHandler {
   // view path
   static std::string const VIEW_PATH;
 
+  // stats arangosearch path
+  static std::string const STATS_ARANGOSEARCH_PATH;
+
   // Internal Traverser path
   static std::string const INTERNAL_TRAVERSER_PATH;
 

--- a/tests/IResearch/IResearchLinkTest.cpp
+++ b/tests/IResearch/IResearchLinkTest.cpp
@@ -2557,7 +2557,7 @@ arangodb_search_index_size{{db="testVocbase",view="h3039/42",collection="{0}",in
     // should increase numFiles in expected stat
     ++expectedStats.numFiles;
 
-    LinkStats actualStats = l->stats();
+    LinkStats actualStats = l->getStats();
     EXPECT_TRUE(expectedStats == actualStats);
   }
   {
@@ -2584,7 +2584,7 @@ TEST_F(IResearchLinkMetricsTest, WriteAndMetrics2) {
                        expectedStats.numFiles);
     ++expectedStats.numFiles;
     expectedStats.numSegments = 1;
-    LinkStats actualStats = l->stats();
+    LinkStats actualStats = l->getStats();
     EXPECT_TRUE(expectedStats == actualStats);
   }
   {
@@ -2599,7 +2599,7 @@ TEST_F(IResearchLinkMetricsTest, WriteAndMetrics2) {
 
     ++expectedStats.numFiles;
     expectedStats.numSegments = 2;
-    LinkStats actualStats = l->stats();
+    LinkStats actualStats = l->getStats();
     EXPECT_TRUE(expectedStats == actualStats);
   }
   {
@@ -2641,7 +2641,7 @@ arangodb_search_index_size{{db="testVocbase",view="h3039/42",collection="{0}",in
     expectedStats.numSegments = 2;  // we have 2 segments
     expectedStats.indexSize = 1561;
 
-    LinkStats actualStats = l->stats();
+    LinkStats actualStats = l->getStats();
     EXPECT_TRUE(expectedStats == actualStats);
   }
   {
@@ -2972,7 +2972,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest,
     EXPECT_NE(nullptr, link.get());
 
     // Data store should contain at least segments file
-    ASSERT_GT(link->stats().numFiles, 0);
+    ASSERT_GT(link->getStats().numFiles, 0);
 
     // collection in view on destruct
     {
@@ -3019,7 +3019,7 @@ TEST_F(IResearchLinkInRecoveryDBServerOnUpgradeTest, test_init_in_recovery) {
     EXPECT_NE(nullptr, link.get());
 
     // Data store should contain at least segments file
-    ASSERT_GT(link->stats().numFiles, 0);
+    ASSERT_GT(link->getStats().numFiles, 0);
 
     // no collection in view after
     {

--- a/tests/Mocks/IResearchInvertedIndexMock.cpp
+++ b/tests/Mocks/IResearchInvertedIndexMock.cpp
@@ -70,7 +70,7 @@ bool IResearchInvertedIndexMock::needsReversal() const { return true; }
 
 size_t IResearchInvertedIndexMock::memory() const {
   // FIXME return in memory size
-  return stats().indexSize;
+  return getStats().indexSize;
 }
 
 bool IResearchInvertedIndexMock::isHidden() const { return false; }

--- a/tests/Mocks/IResearchLinkMock.h
+++ b/tests/Mocks/IResearchLinkMock.h
@@ -87,7 +87,7 @@ class IResearchLinkMock final : public Index, public IResearchLink {
 
   size_t memory() const final {
     // FIXME return in memory size
-    return stats().indexSize;
+    return getStats().indexSize;
   }
 
   ////////////////////////////////////////////////////////////////////////////////

--- a/tests/js/client/shell/api/observe-arangosearch.js
+++ b/tests/js/client/shell/api/observe-arangosearch.js
@@ -1,0 +1,197 @@
+/* jshint globalstrict:false, strict:false, maxlen: 200 */
+/* global db, fail, arango, assertTrue, assertFalse, assertEqual, assertNotUndefined */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// //////////////////////////////////////////////////////////////////////////////
+
+'use strict';
+const arangodb = require("@arangodb");
+const internal = require('internal');
+const isCluster = internal.isCluster();
+let db = arangodb.db;
+const jsunity = require("jsunity");
+
+////////////////////////////////////////////////////////////////////////////////;
+// error handling;
+////////////////////////////////////////////////////////////////////////////////;
+function creationSuite () {
+  let cn = "test";
+  let vn = "vtest";
+  let systemDb = '_system';
+  let testDb = 'test';
+
+  function getArangoSearchStats (dbName) {
+
+    if (dbName == null || dbName === "") {
+      dbName = systemDb;
+    }
+    let api = `/_arango/experimental/_db/${dbName}/_admin/arangosearch/stats`;
+    return arango.GET(api);
+  }
+
+  return {
+    setUpAll: function() {
+
+      if (isCluster) {
+        return;
+      }
+
+      //  Set up testArangosearchViewStats
+      {
+        let coll = db._create(cn);
+        db._createView(vn, "arangosearch", {
+          consolidationIntervalMsec: 5000,
+          consolidationPolicy: {
+              type: "tier",
+              maxSkewThreshold: 0.2,
+          },
+          links: {
+            [cn]: {includeAllFields: true}
+          }
+        });
+      }
+
+      //  Set up testDifferentDbAndInvertedIndexStats
+      {
+        db._createDatabase(testDb);
+        db._useDatabase(testDb);
+        let coll = db._create(cn);
+        coll.ensureIndex({"type": "inverted", "name": "inverted", "fields": ["name", "age"]});
+      }
+    },
+
+    tearDownAll: function() {
+
+      if (isCluster) {
+        return;
+      }
+
+      //  Cleanup testArangosearchViewStats
+      db._useDatabase(systemDb);
+      db._dropView(vn);
+      db._drop(cn);
+
+      //  Cleanup testDifferentDbAndInvertedIndexStats
+      db._useDatabase(testDb);
+      db._drop(cn);
+      db._useDatabase(systemDb);
+      db._dropDatabase(testDb);
+    },
+
+    testArangosearchViewStats: function() {
+
+      if (isCluster) {
+        return;
+      }
+
+      //  Add a few docs to the collection and get ArangoSearch stats.
+      //  Then add another doc which will create a new segment.
+      //  Run a search query with waitForSync: true to ensure the view is synced.
+      //  Then delete a doc and check that the stats are updated accordingly.
+      db._useDatabase(systemDb);
+      let coll = db._collection(cn);
+      coll.insert({ name: "Gustavo", age: 21 });
+      coll.insert({ name: "Tyrus", age: 29 });
+      let jimmy = coll.insert({ name: "Jimmy", age: 31 });
+      coll.insert({ name: "Kim", age: 15 });
+      coll.insert({ name: "Nacho", age: 18 });
+
+      //  wait till view is updated
+      db._query("FOR d IN " + vn + " OPTIONS { waitForSync: true } RETURN d");
+      let result = getArangoSearchStats();
+
+      //  general stats
+      assertEqual(result.numDocs, 5);
+      assertEqual(result.numFiles, 6);
+      assertEqual(result.numSegments, 1);
+      assertEqual(result.deletionRatio, 0.0);
+
+      //  segment info
+      let segment = result.segments[0];
+      assertEqual(segment.name, "_1");
+      assertEqual(segment.deletionRatio, 0.0);
+      assertEqual(segment.numDocs, 5);
+      assertEqual(segment.numLiveDocs, 5);
+
+      //  Add one more doc to create a new segment.
+      coll.insert({ name: "Francesca", age: 35 });
+
+      db._query("FOR d IN " + vn + " OPTIONS { waitForSync: true } RETURN d");
+      result = getArangoSearchStats("_system");
+      assertEqual(result.numDocs, 6);
+      assertEqual(result.numSegments, 2);
+
+      let segment1 = result.segments[0];
+      let segment2 = result.segments[1];
+      assertEqual(segment1.name, "_1");
+      assertEqual(segment2.name, "_2");
+
+      assertEqual(segment1.numDocs, 5);
+      assertEqual(segment2.numLiveDocs, 1);
+
+      //  Delete a doc.
+      db._remove(jimmy._id);
+
+      db._query("FOR d IN " + vn + " OPTIONS { waitForSync: true } RETURN d");
+      result = getArangoSearchStats("_system");
+
+      //  general stats
+      assertEqual(result.numDocs, 6);
+      assertEqual(result.numLiveDocs, 5);
+      assertEqual(result.deletionRatio, 0.17);
+
+      //  segment stats
+      let segments = result.segments;
+      assertEqual(segments[0].deletionRatio, 0.2);
+      assertEqual(segments[1].deletionRatio, 0);
+    },
+
+    testDifferentDbAndInvertedIndexStats : function() {
+
+      if (isCluster) {
+        return;
+      }
+
+      db._useDatabase(testDb);
+      let result = getArangoSearchStats(testDb);
+
+      //  general stats
+      assertEqual(result.numDocs, 0);
+      assertEqual(result.numFiles, 1);
+      assertEqual(result.numSegments, 0);
+
+      let coll = db._collection(cn);
+      coll.insert({ name: "Lalo", age: 39 });
+      coll.insert({ name: "Bolsa", age: 40 });
+      db._query("for d in " + cn + " OPTIONS { indexHint: 'inverted', forceIndexHint: true," +
+          "waitForSync: true } filter d.name == 'Bolsa' return d");
+
+      result = getArangoSearchStats(testDb);
+      assertEqual(result.numDocs, 2);
+      assertEqual(result.numFiles, 6);
+      assertEqual(result.numSegments, 1);
+    }
+  };
+}
+
+jsunity.run(creationSuite);
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

This PR adds observability into ArangoSearch. More details can be found here:
https://hackmd.io/IdSOTRwjSrysti1OIIeB4Q#6-Tentative-API-Design
Currently only the interface to fetch all the index stats is implemented.

- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [X] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information
https://arangodb.atlassian.net/browse/COR-764

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-764
- [ ] Design document: 
