### PR TITLE
[BTS-2426] Fix symlink regression

### DIFF
--- a/arangod/GeneralServer/AuthenticationFeature.cpp
+++ b/arangod/GeneralServer/AuthenticationFeature.cpp
@@ -336,24 +336,17 @@ Result AuthenticationFeature::loadJwtSecretFolder() try {
   auto list =
       basics::FileUtils::listFiles(_options.jwtSecretFolderProgramOption);
 
-  // filter out empty filenames, hidden files, tmp files and symlinks
-  list.erase(std::remove_if(
-                 list.begin(), list.end(),
-                 [this](std::string const& file) {
-                   if (file.empty() || file[0] == '.') {
-                     return true;
-                   }
-                   if (file.ends_with(".tmp")) {
-                     return true;
-                   }
-                   auto p =
-                       std::filesystem::path(basics::FileUtils::buildFilename(
-                           _options.jwtSecretFolderProgramOption, file));
-                   if (std::filesystem::is_symlink(p)) {
-                     return true;
-                   }
-                   return false;
-                 }),
+  // filter out empty filenames, hidden files, tmp files
+  list.erase(std::remove_if(list.begin(), list.end(),
+                            [](std::string const& file) {
+                              if (file.empty() || file[0] == '.') {
+                                return true;
+                              }
+                              if (file.ends_with(".tmp")) {
+                                return true;
+                              }
+                              return false;
+                            }),
              list.end());
 
   if (list.empty()) {


### PR DESCRIPTION
### Scope & Purpose

#22595 changed from bespoke C-API functions to `std::filesystem` for some functionality in `arangod`; amongst other changes, the function `FileUtils::isSymbolicLink` was removed and its uses replaced by `std::filesystem::is_symlink`.

These two functions differ in their output: if the path handed to `FileUtils::isSymbolicLink` is indeed a symbolic link, the underlying call to `stat` follows this symlink and returns the `stat` result for the linked entity.

`std::filesystem::is_symlink` identifies the path as symlink (as `lstat` would).

With some archaeology the symlink detection code was introduced in https://github.com/arangodb/arangodb/pull/11738 (BTS-83) to address a crash in kubernetes. 

This code never worked correctly and is hence just removed.