### PR TITLE
Fix UI, serve some aardvark paths waiving auth

### DIFF
--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -112,8 +112,28 @@ void RestActionHandler::executeAction() {
   }
 }
 
+// The aardvark web UI serves a handful of static assets and harmless
+// metadata that must be reachable before the user has logged in (so the
+// UI itself can load and offer a login form). Unlike the rest of
+// /_admin/aardvark/, none of these need any database access, so they must
+// never be granted superuser rights - doing so previously allowed
+// unauthenticated AQL execution and other superuser-level operations via
+// any path merely prefixed with /_admin/aardvark/.
+constexpr std::string_view aardvarkIndexHtml("/_admin/aardvark/index.html");
+constexpr std::string_view aardvarkConfigJs("/_admin/aardvark/config.js");
+constexpr std::string_view aardvarkWhoAmI("/_admin/aardvark/whoAmI");
+constexpr std::string_view aardvarkStaticPrefix("/_admin/aardvark/static/");
+constexpr std::string_view aardvarkImgPrefix("/_admin/aardvark/img/");
+
+bool isPublicAardvarkPath(std::string_view path) {
+  return path == aardvarkIndexHtml || path == aardvarkConfigJs ||
+         path == aardvarkWhoAmI || path.starts_with(aardvarkStaticPrefix) ||
+         path.starts_with(aardvarkImgPrefix);
+}
+
 async<Result> RestActionHandler::checkUserCanAccess() const {
-  if (request()->requestPath().starts_with("/_admin/aardvark/")) {
+  if (isPublicAardvarkPath(request()->requestPath())) {
+    // Note that we do **not** escalate to superuser for these!
     co_return Result{};
   }
 

--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -26,6 +26,7 @@
 #include "Actions/actions.h"
 #include "Basics/StaticStrings.h"
 #include "Basics/StringUtils.h"
+#include "GeneralServer/AuthenticationFeature.h"
 #include "Statistics/RequestStatistics.h"
 #include "GeneralServer/GeneralServerFeature.h"
 #include "VocBase/vocbase.h"
@@ -50,6 +51,8 @@ RestStatus RestActionHandler::execute() {
     generateNotImplemented(_request->fullUrl());
     return RestStatus::DONE;
   }
+
+  ExecContextSuperuserScope escope(_mustEscalateToSuperuser);
 
   // extract the sub-request type
   rest::RequestType type = _request->requestType();
@@ -132,12 +135,27 @@ bool isPublicAardvarkPath(std::string_view path) {
 }
 
 async<Result> RestActionHandler::checkUserCanAccess() const {
-  if (isPublicAardvarkPath(request()->requestPath())) {
+  auto const& path = request()->requestPath();
+  if (isPublicAardvarkPath(path)) {
     // Note that we do **not** escalate to superuser for these!
     co_return Result{};
   }
 
-  co_return co_await RestHandler::checkUserCanAccess();
+  auto r = co_await RestHandler::checkUserCanAccess();
+  if (r.ok()) {
+    co_return r;
+  }
+
+  auto const* const auth = AuthenticationFeature::instance();
+  ADB_PROD_ASSERT(auth->isActive());
+  if (auth->authenticationSystemOnly()) {  // TODO remove in 4.0
+    // check if path is / which is required for the web UI to get started
+    if (!path.empty() && !path.starts_with("/_")) {
+      _mustEscalateToSuperuser = true;
+      co_return Result{};
+    }
+  }
+  co_return r;
 }
 
 }  // namespace arangodb

--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -122,16 +122,21 @@ void RestActionHandler::executeAction() {
 // never be granted superuser rights - doing so previously allowed
 // unauthenticated AQL execution and other superuser-level operations via
 // any path merely prefixed with /_admin/aardvark/.
-constexpr std::string_view aardvarkIndexHtml("/_admin/aardvark/index.html");
-constexpr std::string_view aardvarkConfigJs("/_admin/aardvark/config.js");
-constexpr std::string_view aardvarkWhoAmI("/_admin/aardvark/whoAmI");
-constexpr std::string_view aardvarkStaticPrefix("/_admin/aardvark/static/");
-constexpr std::string_view aardvarkImgPrefix("/_admin/aardvark/img/");
 
 bool isPublicAardvarkPath(std::string_view path) {
-  return path == aardvarkIndexHtml || path == aardvarkConfigJs ||
-         path == aardvarkWhoAmI || path.starts_with(aardvarkStaticPrefix) ||
-         path.starts_with(aardvarkImgPrefix);
+  using namespace std::string_view_literals;
+  constexpr std::array exact = {
+      "/_admin/aardvark/index.html"sv,
+      "/_admin/aardvark/config.js"sv,
+      "/_admin/aardvark/whoAmI"sv,
+  };
+  constexpr std::array prefixes = {
+      "/_admin/aardvark/static/"sv,
+      "/_admin/aardvark/img/"sv,
+  };
+  return std::ranges::any_of(exact, [&](auto p) { return path == p; }) ||
+         std::ranges::any_of(prefixes,
+                             [&](auto p) { return path.starts_with(p); });
 }
 
 async<Result> RestActionHandler::checkUserCanAccess() const {

--- a/arangod/Actions/RestActionHandler.h
+++ b/arangod/Actions/RestActionHandler.h
@@ -57,5 +57,8 @@ class RestActionHandler : public RestVocbaseBaseHandler {
 
   // data for cancelation
   void* _data;
+
+  // Flag to remember to escalate to superuser:
+  bool _mustEscalateToSuperuser = false;
 };
 }  // namespace arangodb

--- a/arangod/Actions/RestActionHandler.h
+++ b/arangod/Actions/RestActionHandler.h
@@ -59,6 +59,6 @@ class RestActionHandler : public RestVocbaseBaseHandler {
   void* _data;
 
   // Flag to remember to escalate to superuser:
-  bool _mustEscalateToSuperuser = false;
+  mutable bool _mustEscalateToSuperuser = false;
 };
 }  // namespace arangodb

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -740,17 +740,9 @@ async<Result> RestHandler::checkUserCanAccess() const {
 
     if (not canAccess &&
         auth->authenticationSystemOnly()) {  // TODO remove in 4.0
-      // authentication required, but only for /_api, /_admin etc.
-      if (!path.empty()) {
-        // check if path starts with /_
-        // or path begins with /
-        if (path[0] != '/' || (path.size() > 1 && path[1] != '_')) {
-          // simon: upgrade rights for Foxx apps. FIXME
-          canAccess = true;
-          ec->forceSuperuser();
-          LOG_TOPIC("e2880", TRACE, Logger::AUTHORIZATION)
-              << "Upgrading rights for " << path;
-        }
+      // check if path is / which is required for the web UI to get started
+      if (path == "/") {
+        canAccess = true;
       }
     }
   }

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -737,14 +737,6 @@ async<Result> RestHandler::checkUserCanAccess() const {
       canAccess = true;
     }
 #endif
-
-    if (not canAccess &&
-        auth->authenticationSystemOnly()) {  // TODO remove in 4.0
-      // check if path is / which is required for the web UI to get started
-      if (path == "/") {
-        canAccess = true;
-      }
-    }
   }
 
   co_return canAccess

--- a/arangod/RestHandler/RestOpenApiHandler.cpp
+++ b/arangod/RestHandler/RestOpenApiHandler.cpp
@@ -49,6 +49,22 @@ RestOpenApiHandler::RestOpenApiHandler(
     GeneralResponse* response)
     : RestBaseHandler(server, request, response) {}
 
+namespace {
+constexpr std::string_view kOpenApiJsonPath("/openapi.json");
+}  // namespace
+
+// The OpenAPI spec must be reachable without authentication, so that
+// clients (and the API documentation) can retrieve it before logging in.
+// It contains no sensitive information, so this does not need to escalate
+// to superuser rights either.
+async<Result> RestOpenApiHandler::checkUserCanAccess() const {
+  if (request()->requestPath() == kOpenApiJsonPath) {
+    co_return Result{};
+  }
+
+  co_return co_await RestBaseHandler::checkUserCanAccess();
+}
+
 std::string_view RestOpenApiHandler::getOpenApiSpec(uint32_t apiVersion) const {
   switch (apiVersion) {
     case 0:

--- a/arangod/RestHandler/RestOpenApiHandler.cpp
+++ b/arangod/RestHandler/RestOpenApiHandler.cpp
@@ -55,8 +55,6 @@ constexpr std::string_view kOpenApiJsonPath("/openapi.json");
 
 // The OpenAPI spec must be reachable without authentication, so that
 // clients (and the API documentation) can retrieve it before logging in.
-// It contains no sensitive information, so this does not need to escalate
-// to superuser rights either.
 async<Result> RestOpenApiHandler::checkUserCanAccess() const {
   if (request()->requestPath() == kOpenApiJsonPath) {
     co_return Result{};

--- a/arangod/RestHandler/RestOpenApiHandler.h
+++ b/arangod/RestHandler/RestOpenApiHandler.h
@@ -37,6 +37,9 @@ class RestOpenApiHandler : public arangodb::RestBaseHandler {
   RequestLane lane() const override final { return RequestLane::CLIENT_FAST; }
   futures::Future<futures::Unit> executeAsync() override;
 
+ protected:
+  async<Result> checkUserCanAccess() const override;
+
  private:
   std::string_view getOpenApiSpec(uint32_t apiVersion) const;
 };

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -488,7 +488,6 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/openapi.json`);
       assertPermissions([
-        "UseDatabase name=_system level=read"
       ], endObserve());
     },
 


### PR DESCRIPTION
### Scope & Purpose

Allow some aardvark paths and / withtout authentication.
Do not escalate to superuser in this case.
Serve /openapi.json without auth, too.

This is to adjust behaviour to `devel`.

- [*] :hankey: Bugfix

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
