### PR TITLE
Remove unnecessary isSuperuser calls

### DIFF
--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -414,14 +414,12 @@ bool Query::tryLoadPlanFromCache() {
         // check if the current user has permissions on all the collections
         ExecContext const& exec = ExecContext::current();
 
-        if (!exec.isSuperuserOrDisabled()) {
-          for (auto const& dataSource : cacheEntry->dataSources) {
-            if (exec.canUseCollection(_vocbase.name(), dataSource.second.name,
-                                      dataSource.second.level)
-                    .fail()) {
-              // cannot use query cache result because of permissions
-              return false;
-            }
+        for (auto const& dataSource : cacheEntry->dataSources) {
+          if (exec.canUseCollection(_vocbase.name(), dataSource.second.name,
+                                    dataSource.second.level)
+                  .fail()) {
+            // cannot use query cache result because of permissions
+            return false;
           }
         }
 

--- a/arangod/Aql/QueryCache.cpp
+++ b/arangod/Aql/QueryCache.cpp
@@ -171,14 +171,12 @@ bool QueryCacheResultEntry::currentUserHasPermissions() const {
   ExecContext const& exec = ExecContext::current();
 
   // got a result from the query cache
-  if (!exec.isSuperuserOrDisabled()) {
-    for (auto const& dataSource : _dataSources) {
-      if (exec.canUseCollection(_databaseName, dataSource.second,
-                                AccessLevel::Read)
-              .fail()) {
-        // cannot use query cache result because of permissions
-        return false;
-      }
+  for (auto const& dataSource : _dataSources) {
+    if (exec.canUseCollection(_databaseName, dataSource.second,
+                              AccessLevel::Read)
+            .fail()) {
+      // cannot use query cache result because of permissions
+      return false;
     }
   }
 

--- a/arangod/IResearch/IResearchView.cpp
+++ b/arangod/IResearch/IResearchView.cpp
@@ -415,15 +415,13 @@ Result IResearchView::dropImpl() {
   }
   if (!stale.empty()) {
     // check link auth as per https://github.com/arangodb/backlog/issues/459
-    if (!ExecContext::current().isSuperuserOrDisabled()) {
-      for (auto& entry : stale) {
-        auto collection = vocbase().lookupCollection(entry);
-        if (collection) {
-          if (auto r = ExecContext::current().canUseCollection(
-                  vocbase().name(), collection->name(), AccessLevel::Read);
-              !r.ok()) {
-            return r;
-          }
+    for (auto& entry : stale) {
+      auto collection = vocbase().lookupCollection(entry);
+      if (collection) {
+        if (auto r = ExecContext::current().canUseCollection(
+                vocbase().name(), collection->name(), AccessLevel::Read);
+            !r.ok()) {
+          return r;
         }
       }
     }
@@ -599,17 +597,15 @@ Result IResearchView::updateProperties(velocypack::Slice slice,
     }
     boost::unique_lock uniqueLock{_mutex};
     // check link auth as per https://github.com/arangodb/backlog/issues/459
-    if (!ExecContext::current().isSuperuserOrDisabled()) {
-      for (auto& entry : _links) {
-        auto collection = vocbase().lookupCollection(entry.first);
-        if (collection) {
-          if (auto r = ExecContext::current().canUseCollection(
-                  vocbase().name(), collection->name(), AccessLevel::Read);
-              !r.ok()) {
-            return {TRI_ERROR_FORBIDDEN,
-                    absl::StrCat("while updating view definition: ",
-                                 r.errorMessage())};
-          }
+    for (auto& entry : _links) {
+      auto collection = vocbase().lookupCollection(entry.first);
+      if (collection) {
+        if (auto r = ExecContext::current().canUseCollection(
+                vocbase().name(), collection->name(), AccessLevel::Read);
+            !r.ok()) {
+          return {TRI_ERROR_FORBIDDEN,
+                  absl::StrCat("while updating view definition: ",
+                               r.errorMessage())};
         }
       }
     }

--- a/arangod/IResearch/IResearchViewCoordinator.cpp
+++ b/arangod/IResearch/IResearchViewCoordinator.cpp
@@ -178,17 +178,15 @@ Result IResearchViewCoordinator::appendVPackImpl(VPackBuilder& build,
     std::shared_lock lock{_mutex};
     // verify that the current user has access on all linked collections
     ExecContext const& exec = ExecContext::current();
-    if (!exec.isSuperuserOrDisabled()) {
-      // TODO This should be changed into a more semantic exec.can().... call;
-      //      but I don't know which, because I don't know where this is being
-      //      called from (createView? modifyView? both?)
-      for (auto& entry : _collections) {
-        if (auto r = exec.canUseCollection(vocbase().name(),
-                                           entry.second->collectionName,
-                                           AccessLevel::Read);
-            !r.ok()) {
-          return r;
-        }
+    // TODO This should be changed into a more semantic exec.can().... call;
+    //      but I don't know which, because I don't know where this is being
+    //      called from (createView? modifyView? both?)
+    for (auto& entry : _collections) {
+      if (auto r = exec.canUseCollection(vocbase().name(),
+                                         entry.second->collectionName,
+                                         AccessLevel::Read);
+          !r.ok()) {
+        return r;
       }
     }
     VPackBuilder tmp;
@@ -362,7 +360,7 @@ Result IResearchViewCoordinator::properties(velocypack::Slice slice,
     }
     // check link auth as per https://github.com/arangodb/backlog/issues/459
     auto const& exec = ExecContext::current();
-    if (!exec.isSuperuserOrDisabled()) {  // check existing links
+    {
       std::shared_lock lock{_mutex};
       // TODO This should be changed into a more semantic exec.can().... call;
       //      but I don't know which, because I don't know where this is being

--- a/arangod/IResearch/Search.cpp
+++ b/arangod/IResearch/Search.cpp
@@ -593,8 +593,7 @@ Result Search::appendVPackImpl(velocypack::Builder& build, Serialization ctx,
     // we may need to check the permissions of the underlying
     // collections
     auto const& execCtx = ExecContext::current();
-    bool const checkPermissions =
-        ctx == Serialization::Properties && !execCtx.isSuperuserOrDisabled();
+    bool const checkPermissions = ctx == Serialization::Properties;
 
     for (auto& [cid, handles] : _indexes) {
       for (auto& handle : handles) {
@@ -692,8 +691,8 @@ Result Search::updateProperties(CollectionNameResolver& resolver,
       }
       return {TRI_ERROR_BAD_PARAMETER, "Cannot find collection"};
     }
-    if (auto const& ctx = ExecContext::current();
-        !ctx.isSuperuserOrDisabled()) {
+    {
+      auto const& ctx = ExecContext::current();
       if (auto r = ctx.canUseCollection(vocbase().name(), collection->name(),
                                         AccessLevel::Read);
           !r.ok()) {

--- a/arangod/RestHandler/RestQueryPlanCacheHandler.cpp
+++ b/arangod/RestHandler/RestQueryPlanCacheHandler.cpp
@@ -86,16 +86,14 @@ void RestQueryPlanCacheHandler::readPlans() {
                     aql::QueryPlanCache::Key const& key,
                     aql::QueryPlanCache::Value const& value) -> bool {
     auto const& context = ExecContext::current();
-    if (!context.isSuperuserOrDisabled()) {
-      // check if non-superusers have at least read permissions on all
-      // collections/views used in the query
-      for (auto const& dataSource : value.dataSources) {
-        if (!context
-                 .canUseCollection(databaseName, dataSource.second.name,
-                                   AccessLevel::Read)
-                 .ok()) {
-          return false;
-        }
+    // check if non-superusers have at least read permissions on all
+    // collections/views used in the query
+    for (auto const& dataSource : value.dataSources) {
+      if (!context
+               .canUseCollection(databaseName, dataSource.second.name,
+                                 AccessLevel::Read)
+               .ok()) {
+        return false;
       }
     }
     return true;

--- a/arangod/StorageEngine/TransactionState.cpp
+++ b/arangod/StorageEngine/TransactionState.cpp
@@ -715,11 +715,6 @@ Result TransactionState::checkCollectionPermission(
   TRI_ASSERT(!cname.empty());
   ExecContext const& exec = ExecContext::current();
 
-  // no need to check for superuser, cluster_sync tests break otherwise
-  if (exec.isSuperuserOrDisabled()) {
-    return {};
-  }
-
   if (accessType == AccessMode::Type::READ) {
     if (auto r =
             exec.canUseCollection(_vocbase.name(), cname, AccessLevel::Read);

--- a/arangod/V8Server/v8-vocbase.cpp
+++ b/arangod/V8Server/v8-vocbase.cpp
@@ -1356,20 +1356,17 @@ static void JS_QueryPlanCachePlans(
 
   auto filter = [&vocbase](aql::QueryPlanCache::Key const& key,
                            aql::QueryPlanCache::Value const& value) -> bool {
-    auto const& execContext = ExecContext::current();
-    if (!execContext.isSuperuserOrDisabled()) {
-      // check if non-superusers have at least read permissions on all
-      // collections/views used in the query
-      for (auto const& dataSource : value.dataSources) {
-        // TODO Should this be a separate permission/action?
-        // TODO `dataSource` can be either a collection or view; we need to
-        //      distinguish what it is to determine its permissions!
-        if (ExecContext::current()
-                .canUseCollection(vocbase.name(), dataSource.second.name,
-                                  CollectionAccessLevel::Read)
-                .fail()) {
-          return false;
-        }
+    // check if non-superusers have at least read permissions on all
+    // collections/views used in the query
+    for (auto const& dataSource : value.dataSources) {
+      // TODO Should this be a separate permission/action?
+      // TODO `dataSource` can be either a collection or view; we need to
+      //      distinguish what it is to determine its permissions!
+      if (ExecContext::current()
+              .canUseCollection(vocbase.name(), dataSource.second.name,
+                                CollectionAccessLevel::Read)
+              .fail()) {
+        return false;
       }
     }
     return true;

--- a/tests/js/client/server_permissions/authorization-questions.js
+++ b/tests/js/client/server_permissions/authorization-questions.js
@@ -102,7 +102,8 @@ function authorizationQuestionsSuite () {
         // the single server also revokes the collection's permissions from all
         // users; in the cluster that happens without an ExecContext
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/collections.js
+++ b/tests/js/client/server_permissions/authorization-questions/collections.js
@@ -293,6 +293,7 @@ function collectionApiAuthzSuite () {
           "IsReadOnly",
           "UseCollection db=d name=c_apitest level=writemeta",
           "UseCollection db=d name=_graphs level=read",
+          "UseCollection db=d name=_graphs level=writedata",
           "UseCollection db=d name=c_apitest_renamed level=read"
         ])
       ], endObserve());
@@ -311,7 +312,8 @@ function collectionApiAuthzSuite () {
         "CreateCollection db=d name=c_apitest",
         "UseCollection db=d name=c_apitest level=read",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -331,7 +333,8 @@ function collectionApiAuthzSuite () {
         "UseCollection db=d name=c_apitest level=read",
         "UseCollection db=d name=_graphs level=read",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/databases.js
+++ b/tests/js/client/server_permissions/authorization-questions/databases.js
@@ -149,8 +149,11 @@ function databaseApiAuthzSuite () {
         "UseCollection db=d2 name=_jobs level=writemeta",
         ...singleOnly([
           "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata",
           "UseCollection db=d2 name=_apps level=read",
-          "UseCollection db=d2 name=_jobs level=read"
+          "UseCollection db=d2 name=_apps level=writedata",
+          "UseCollection db=d2 name=_jobs level=read",
+          "UseCollection db=d2 name=_jobs level=writedata"
         ])
       ], endObserve());
       dropD2();
@@ -166,7 +169,8 @@ function databaseApiAuthzSuite () {
         "IsReadOnly",
         "DropDatabase name=d2",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -562,7 +562,8 @@ function miscApiAuthzSuite () {
       assertPermissions([
         "IsReadOnly",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
       if (res.parsedBody && res.parsedBody.id) {
@@ -579,7 +580,8 @@ function miscApiAuthzSuite () {
       assertPermissions([
         "IsReadOnly",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/users.js
+++ b/tests/js/client/server_permissions/authorization-questions/users.js
@@ -142,7 +142,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "CreateUser name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
       dropTestuser();
@@ -224,7 +225,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -238,7 +240,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -253,7 +256,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -269,7 +273,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -287,7 +292,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -301,7 +307,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "DropUser name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -317,7 +324,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -334,7 +342,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },
@@ -353,7 +362,8 @@ function userApiAuthzSuite () {
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read"
+          "UseCollection db=_system name=_users level=read",
+          "UseCollection db=_system name=_users level=writedata"
         ])
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -134,7 +134,8 @@ function viewApiAuthzSuite () {
         "CreateView db=d name=v_apitest linkedCollections=[c]",
         "UseCollection db=d name=c level=read",
         ...singleOnly([
-          `UseCollection db=d name=${cId} level=read`
+          `UseCollection db=d name=${cId} level=read`,
+          "UseCollection db=d name=c level=writedata"
         ]),
         ...clusterOnly([
           "UseCollection db=d name=c level=writemeta"


### PR DESCRIPTION
### Scope & Purpose

Remove unnecessary calls to `isSuperuser` and `isSuperuserOrDisabled`.
This will do some more checks but is cleaner.

- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
  - [*] **integration tests**

#### Related Information

- [*] GitHub issue / Jira ticket: COR-592
