### PR TITLE
[COR-808] Apply concept to `validateOptionsImpl`

### DIFF
--- a/arangod/Actions/ActionOptionsProvider.h
+++ b/arangod/Actions/ActionOptionsProvider.h
@@ -35,8 +35,6 @@ struct ActionOptionsProvider
     : OptionsProviderImpl<ActionOptionsProvider, ActionFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ActionFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ActionFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/Aql/OptimizerRulesOptionsProvider.h
+++ b/arangod/Aql/OptimizerRulesOptionsProvider.h
@@ -39,8 +39,6 @@ struct OptimizerRulesOptionsProvider
 
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           OptimizerRulesOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           OptimizerRulesOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/QueryInfoLoggerOptionsProvider.h
+++ b/arangod/Aql/QueryInfoLoggerOptionsProvider.h
@@ -32,8 +32,6 @@ struct QueryInfoLoggerOptionsProvider
                           QueryInfoLoggerOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           QueryInfoLoggerOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           QueryInfoLoggerOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Cluster/ClusterUpgradeOptionsProvider.h
+++ b/arangod/Cluster/ClusterUpgradeOptionsProvider.h
@@ -37,8 +37,6 @@ struct ClusterUpgradeOptionsProvider
                           ClusterUpgradeFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ClusterUpgradeFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ClusterUpgradeFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::upgrade

--- a/arangod/Cluster/MaintenanceOptionsProvider.cpp
+++ b/arangod/Cluster/MaintenanceOptionsProvider.cpp
@@ -138,8 +138,4 @@ void MaintenanceOptionsProvider::processOptionsImpl(
   }
 }
 
-void MaintenanceOptionsProvider::validateOptionsImpl(
-    std::shared_ptr<ProgramOptions> /*opts*/,
-    MaintenanceOptions const& /*options*/) {}
-
 }  // namespace arangodb

--- a/arangod/Cluster/MaintenanceOptionsProvider.h
+++ b/arangod/Cluster/MaintenanceOptionsProvider.h
@@ -34,9 +34,6 @@ struct MaintenanceOptionsProvider
 
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           MaintenanceOptions& options);
-
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           MaintenanceOptions const& options);
 };
 
 }  // namespace arangodb

--- a/arangod/GeneralServer/ServerSecurityOptionsProvider.h
+++ b/arangod/GeneralServer/ServerSecurityOptionsProvider.h
@@ -34,8 +34,6 @@ struct ServerSecurityOptionsProvider
 
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ServerSecurityFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ServerSecurityFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb::security

--- a/arangod/Replication/ReplicationOptionsProvider.cpp
+++ b/arangod/Replication/ReplicationOptionsProvider.cpp
@@ -110,8 +110,4 @@ void ReplicationOptionsProvider::processOptionsImpl(
   }
 }
 
-void ReplicationOptionsProvider::validateOptionsImpl(
-    std::shared_ptr<ProgramOptions> /*opts*/,
-    ReplicationOptions const& /*options*/) {}
-
 }  // namespace arangodb

--- a/arangod/Replication/ReplicationOptionsProvider.h
+++ b/arangod/Replication/ReplicationOptionsProvider.h
@@ -33,8 +33,6 @@ struct ReplicationOptionsProvider
                           ReplicationOptions& options);
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ReplicationOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           ReplicationOptions const& options);
 };
 
 }  // namespace arangodb

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogOptionsProvider.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogOptionsProvider.h
@@ -37,8 +37,6 @@ struct ReplicatedLogOptionsProvider
                           ReplicatedLogGlobalSettings> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ReplicatedLogGlobalSettings& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ReplicatedLogGlobalSettings& /*options*/) {}
 };
 
 }  // namespace arangodb::replication2

--- a/arangod/RestServer/BootstrapOptionsProvider.h
+++ b/arangod/RestServer/BootstrapOptionsProvider.h
@@ -36,8 +36,6 @@ struct BootstrapOptionsProvider
     : OptionsProviderImpl<BootstrapOptionsProvider, BootstrapFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           BootstrapFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           BootstrapFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::bootstrap

--- a/arangod/RestServer/CheckVersionOptionsProvider.h
+++ b/arangod/RestServer/CheckVersionOptionsProvider.h
@@ -39,8 +39,6 @@ struct CheckVersionOptionsProvider
                           CheckVersionFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           CheckVersionFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           CheckVersionFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb::check_version

--- a/arangod/RestServer/CrashHandlerOptionsProvider.h
+++ b/arangod/RestServer/CrashHandlerOptionsProvider.h
@@ -35,8 +35,6 @@ struct CrashHandlerOptionsProvider
 
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           CrashHandlerFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           CrashHandlerFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb::crash_handler

--- a/arangod/RestServer/FlushOptionsProvider.h
+++ b/arangod/RestServer/FlushOptionsProvider.h
@@ -32,8 +32,6 @@ struct FlushOptionsProvider
     : OptionsProviderImpl<FlushOptionsProvider, FlushFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FlushFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           FlushFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/FortuneOptionsProvider.h
+++ b/arangod/RestServer/FortuneOptionsProvider.h
@@ -31,8 +31,6 @@ struct FortuneOptionsProvider
     : OptionsProviderImpl<FortuneOptionsProvider, FortuneFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FortuneFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           FortuneFeatureOptions& options){};
 };
 
 }  // namespace arangodb::fortune

--- a/arangod/RestServer/FrontendOptionsProvider.h
+++ b/arangod/RestServer/FrontendOptionsProvider.h
@@ -31,8 +31,6 @@ struct FrontendOptionsProvider
     : OptionsProviderImpl<FrontendOptionsProvider, FrontendFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FrontendFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           FrontendFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/InitDatabaseOptionsProvider.h
+++ b/arangod/RestServer/InitDatabaseOptionsProvider.h
@@ -32,8 +32,6 @@ struct InitDatabaseOptionsProvider
                           InitDatabaseFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           InitDatabaseFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           InitDatabaseFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/LogBufferOptionsProvider.h
+++ b/arangod/RestServer/LogBufferOptionsProvider.h
@@ -31,8 +31,6 @@ struct LogBufferOptionsProvider
     : OptionsProviderImpl<LogBufferOptionsProvider, LogBufferFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           LogBufferFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           LogBufferFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/LogRotateOptionsProvider.h
+++ b/arangod/RestServer/LogRotateOptionsProvider.h
@@ -31,8 +31,6 @@ struct LogRotateOptionsProvider
     : OptionsProviderImpl<LogRotateOptionsProvider, LogRotateOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> prgOpts,
                           LogRotateOptions& logRotateOpts);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*prgOpts*/,
-                           LogRotateOptions& /*logRotateOpts*/) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/MaxMapCountOptionsProvider.h
+++ b/arangod/RestServer/MaxMapCountOptionsProvider.h
@@ -33,8 +33,6 @@ struct MaxMapCountOptionsProvider
                           MaxMapCountFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           MaxMapCountFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           MaxMapCountFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/NonceOptionsProvider.h
+++ b/arangod/RestServer/NonceOptionsProvider.h
@@ -32,8 +32,6 @@ struct NonceOptionsProvider
     : OptionsProviderImpl<NonceOptionsProvider, NonceFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           NonceFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           NonceFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/PrivilegeOptionsProvider.h
+++ b/arangod/RestServer/PrivilegeOptionsProvider.h
@@ -31,8 +31,6 @@ struct PrivilegeOptionsProvider
     : OptionsProviderImpl<PrivilegeOptionsProvider, PrivilegeFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           PrivilegeFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           PrivilegeFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/SupervisorOptionsProvider.h
+++ b/arangod/RestServer/SupervisorOptionsProvider.h
@@ -31,8 +31,6 @@ struct SupervisorOptionsProvider
     : OptionsProviderImpl<SupervisorOptionsProvider, SupervisorFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> options,
                           SupervisorFeatureOptions& opts);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*options*/,
-                           SupervisorFeatureOptions& /*opts*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/TemporaryStorageOptionsProvider.h
+++ b/arangod/RestServer/TemporaryStorageOptionsProvider.h
@@ -32,8 +32,6 @@ struct TemporaryStorageOptionsProvider
                           TemporaryStorageFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           TemporaryStorageFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           TemporaryStorageFeatureOptions& options) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillOptionsProvider.h
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillOptionsProvider.h
@@ -32,8 +32,6 @@ struct RocksDBIndexCacheRefillOptionsProvider
                           RocksDBIndexCacheRefillFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           RocksDBIndexCacheRefillFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           RocksDBIndexCacheRefillFeatureOptions& options){};
 };
 
 }  // namespace arangodb

--- a/arangod/Statistics/StatisticsOptionsProvider.cpp
+++ b/arangod/Statistics/StatisticsOptionsProvider.cpp
@@ -85,8 +85,4 @@ void StatisticsOptionsProvider::processOptionsImpl(
       opts->processingResult().touched("server.statistics-history");
 }
 
-void StatisticsOptionsProvider::validateOptionsImpl(
-    std::shared_ptr<ProgramOptions> /*opts*/,
-    StatisticsFeatureOptions const& /*options*/) {}
-
 }  // namespace arangodb::statistics

--- a/arangod/Statistics/StatisticsOptionsProvider.h
+++ b/arangod/Statistics/StatisticsOptionsProvider.h
@@ -42,8 +42,6 @@ struct StatisticsOptionsProvider
                           StatisticsFeatureOptions& options);
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           StatisticsFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           StatisticsFeatureOptions const& options);
 };
 
 }  // namespace statistics

--- a/arangod/SystemMonitor/Activities/OptionsProvider.h
+++ b/arangod/SystemMonitor/Activities/OptionsProvider.h
@@ -31,8 +31,6 @@ struct OptionsProvider
     : arangodb::OptionsProviderImpl<OptionsProvider, FeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           FeatureOptions& options){};
 };
 
 }  // namespace arangodb::activities

--- a/arangod/SystemMonitor/AsyncRegistry/OptionsProvider.h
+++ b/arangod/SystemMonitor/AsyncRegistry/OptionsProvider.h
@@ -31,8 +31,6 @@ struct OptionsProvider
     : arangodb::OptionsProviderImpl<OptionsProvider, FeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           FeatureOptions& options){};
 };
 
 }  // namespace arangodb::async_registry

--- a/arangod/Transaction/ManagerOptionsProvider.h
+++ b/arangod/Transaction/ManagerOptionsProvider.h
@@ -37,8 +37,6 @@ struct ManagerOptionsProvider
     : OptionsProviderImpl<ManagerOptionsProvider, ManagerFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ManagerFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ManagerFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::transaction

--- a/lib/ApplicationFeatures/ConfigOptionsProvider.h
+++ b/lib/ApplicationFeatures/ConfigOptionsProvider.h
@@ -40,8 +40,6 @@ struct ConfigOptionsProvider
                           ConfigFeatureOptions& options);
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> progOpts,
                           ConfigFeatureOptions& configOpts);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ConfigFeatureOptions& /*options*/) {}
 
  private:
   void loadConfigFile(std::shared_ptr<options::ProgramOptions> progOpts,

--- a/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
+++ b/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
@@ -29,8 +29,9 @@ namespace arangodb::application_features {
 namespace {
 template <class Provider>
 concept HasValidateOptions =
-    requires(Provider& provider, std::shared_ptr<options::ProgramOptions> programOptions) {
-  provider.validateOptionsImpl(programOptions, 
+    requires(Provider& provider,
+             std::shared_ptr<options::ProgramOptions> programOptions) {
+  provider.validateOptionsImpl(programOptions,
                                std::declval<typename Provider::Options&>());
 };
 

--- a/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
+++ b/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
@@ -27,7 +27,7 @@
 namespace arangodb::application_features {
 
 namespace {
-template <class Provider>
+template<class Provider>
 concept HasValidateOptions =
     requires(Provider& provider,
              std::shared_ptr<options::ProgramOptions> programOptions) {

--- a/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
+++ b/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
@@ -27,6 +27,13 @@
 namespace arangodb::application_features {
 
 namespace {
+template <class Provider>
+concept HasValidateOptions =
+    requires(Provider& provider, std::shared_ptr<options::ProgramOptions> programOptions) {
+  provider.validateOptionsImpl(programOptions, 
+                               std::declval<typename Provider::Options&>());
+};
+
 template<class Provider>
 concept HasProcessOptions =
     requires(Provider& provider,
@@ -59,7 +66,7 @@ class FeatureOptionProviderContainer final {
       std::shared_ptr<options::ProgramOptions> programOptions) {
     std::apply(
         [&](auto&... providers) {
-          (providers.validateOptions(programOptions), ...);
+          (validateProviderOptions(programOptions, providers), ...);
         },
         _providers);
   }
@@ -75,6 +82,14 @@ class FeatureOptionProviderContainer final {
   }
 
  private:
+  template<class Provider>
+  void validateProviderOptions(
+      std::shared_ptr<options::ProgramOptions> programOptions,
+      Provider& provider) {
+    if constexpr (HasValidateOptions<Provider>) {
+      provider.validateOptions(programOptions);
+    }
+  }
   template<class Provider>
   void processProviderOptions(
       std::shared_ptr<options::ProgramOptions> programOptions,

--- a/lib/ApplicationFeatures/FileSystemOptionsProvider.h
+++ b/lib/ApplicationFeatures/FileSystemOptionsProvider.h
@@ -35,8 +35,6 @@ struct FileSystemOptionsProvider
     : OptionsProviderImpl<FileSystemOptionsProvider, FileSystemFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FileSystemFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           FileSystemFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/LanguageOptionsProvider.h
+++ b/lib/ApplicationFeatures/LanguageOptionsProvider.h
@@ -31,8 +31,6 @@ struct LanguageOptionsProvider
     : OptionsProviderImpl<LanguageOptionsProvider, LanguageFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           LanguageFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           LanguageFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/ProcessEnvironmentOptionsProvider.h
+++ b/lib/ApplicationFeatures/ProcessEnvironmentOptionsProvider.h
@@ -32,8 +32,6 @@ struct ProcessEnvironmentOptionsProvider
                           ProcessEnvironmentFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ProcessEnvironmentFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ProcessEnvironmentFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/VersionOptionsProvider.h
+++ b/lib/ApplicationFeatures/VersionOptionsProvider.h
@@ -33,8 +33,6 @@ struct VersionOptionsProvider
                           VersionFeatureOptions& options);
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           VersionFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           VersionFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/lib/Random/RandomOptionsProvider.h
+++ b/lib/Random/RandomOptionsProvider.h
@@ -31,8 +31,6 @@ struct RandomOptionsProvider
     : OptionsProviderImpl<RandomOptionsProvider, RandomFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           RandomFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           RandomFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/V8/V8PlatformOptionsProvider.h
+++ b/lib/V8/V8PlatformOptionsProvider.h
@@ -31,8 +31,6 @@ struct V8PlatformOptionsProvider
     : OptionsProviderImpl<V8PlatformOptionsProvider, V8PlatformFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           V8PlatformFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           V8PlatformFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/lib/V8/V8SecurityOptionsProvider.h
+++ b/lib/V8/V8SecurityOptionsProvider.h
@@ -35,8 +35,6 @@ struct V8SecurityOptionsProvider
     : OptionsProviderImpl<V8SecurityOptionsProvider, V8SecurityFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           V8SecurityFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           V8SecurityFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -204,7 +204,6 @@ TEST_F(ArangoLanguageFeatureTest, testResetLanguageDefault) {
       ->get<StringParameter>("default-language")
       ->set(language1.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -241,7 +240,6 @@ TEST_F(ArangoLanguageFeatureTest, testResetLanguageIcu) {
       ->get<StringParameter>("icu-language")
       ->set(language1.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -289,7 +287,6 @@ TEST_F(ArangoLanguageFeatureTest, testBothArgumentsSpecifiedLangCheckTrue) {
       ->get<StringParameter>("default-language")
       ->set(lang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -319,7 +316,6 @@ TEST_F(ArangoLanguageFeatureTest, testBothArgumentsSpecifiedLangCheckFalse) {
       ->get<StringParameter>("default-language")
       ->set(lang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -349,7 +345,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
       ->get<StringParameter>(defaultParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -447,7 +442,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
       ->get<StringParameter>(defaultParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -548,7 +542,6 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
       ->set("");
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -650,7 +643,6 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
       ->set("");
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -749,7 +741,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -846,7 +837,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -942,7 +932,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1039,7 +1028,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1137,7 +1125,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1236,7 +1223,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1334,7 +1320,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1433,7 +1418,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
       ->set(inputFirstLang.data());
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1537,7 +1521,6 @@ TEST_F(ArangoLanguageFeatureTest,
       ->set(inputFirstLang.data());
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1643,7 +1626,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1749,7 +1731,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set("");  // clear value for parameter
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =


### PR DESCRIPTION
### Scope & Purpose

**_There's an Enterprise companion PR!_**

More than half of the `OptionsProvider`s don't implement `validateOptionsImpl`. Just applied the same logic of `processOptionsImpl` to `validateOptionsImpl` -> Deleted no-op `validateOptionsImpl`.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [x] Enterprise PR: https://github.com/arangodb/enterprise/pull/1686
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
