### PR TITLE
[COR-815] Make validateOptionsImpl optional

### DIFF
--- a/arangod/Actions/ActionOptionsProvider.h
+++ b/arangod/Actions/ActionOptionsProvider.h
@@ -35,8 +35,6 @@ struct ActionOptionsProvider
     : OptionsProviderImpl<ActionOptionsProvider, ActionFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ActionFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ActionFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/Aql/OptimizerRulesOptionsProvider.h
+++ b/arangod/Aql/OptimizerRulesOptionsProvider.h
@@ -39,8 +39,6 @@ struct OptimizerRulesOptionsProvider
 
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           OptimizerRulesOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           OptimizerRulesOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/QueryInfoLoggerOptionsProvider.h
+++ b/arangod/Aql/QueryInfoLoggerOptionsProvider.h
@@ -32,8 +32,6 @@ struct QueryInfoLoggerOptionsProvider
                           QueryInfoLoggerOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           QueryInfoLoggerOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           QueryInfoLoggerOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::aql

--- a/arangod/Cluster/ClusterUpgradeOptionsProvider.h
+++ b/arangod/Cluster/ClusterUpgradeOptionsProvider.h
@@ -37,8 +37,6 @@ struct ClusterUpgradeOptionsProvider
                           ClusterUpgradeFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ClusterUpgradeFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ClusterUpgradeFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::upgrade

--- a/arangod/GeneralServer/ServerSecurityOptionsProvider.h
+++ b/arangod/GeneralServer/ServerSecurityOptionsProvider.h
@@ -34,8 +34,6 @@ struct ServerSecurityOptionsProvider
 
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ServerSecurityFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ServerSecurityFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb::security

--- a/arangod/Replication2/ReplicatedLog/ReplicatedLogOptionsProvider.h
+++ b/arangod/Replication2/ReplicatedLog/ReplicatedLogOptionsProvider.h
@@ -37,8 +37,6 @@ struct ReplicatedLogOptionsProvider
                           ReplicatedLogGlobalSettings> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ReplicatedLogGlobalSettings& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ReplicatedLogGlobalSettings& /*options*/) {}
 };
 
 }  // namespace arangodb::replication2

--- a/arangod/RestServer/BootstrapOptionsProvider.h
+++ b/arangod/RestServer/BootstrapOptionsProvider.h
@@ -36,8 +36,6 @@ struct BootstrapOptionsProvider
     : OptionsProviderImpl<BootstrapOptionsProvider, BootstrapFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           BootstrapFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           BootstrapFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::bootstrap

--- a/arangod/RestServer/CheckVersionOptionsProvider.h
+++ b/arangod/RestServer/CheckVersionOptionsProvider.h
@@ -39,8 +39,6 @@ struct CheckVersionOptionsProvider
                           CheckVersionFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           CheckVersionFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           CheckVersionFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb::check_version

--- a/arangod/RestServer/CrashHandlerOptionsProvider.h
+++ b/arangod/RestServer/CrashHandlerOptionsProvider.h
@@ -35,8 +35,6 @@ struct CrashHandlerOptionsProvider
 
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           CrashHandlerFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           CrashHandlerFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb::crash_handler

--- a/arangod/RestServer/FlushOptionsProvider.h
+++ b/arangod/RestServer/FlushOptionsProvider.h
@@ -32,8 +32,6 @@ struct FlushOptionsProvider
     : OptionsProviderImpl<FlushOptionsProvider, FlushFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FlushFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           FlushFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/FortuneOptionsProvider.h
+++ b/arangod/RestServer/FortuneOptionsProvider.h
@@ -31,8 +31,6 @@ struct FortuneOptionsProvider
     : OptionsProviderImpl<FortuneOptionsProvider, FortuneFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FortuneFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           FortuneFeatureOptions& options){};
 };
 
 }  // namespace arangodb::fortune

--- a/arangod/RestServer/FrontendOptionsProvider.h
+++ b/arangod/RestServer/FrontendOptionsProvider.h
@@ -31,8 +31,6 @@ struct FrontendOptionsProvider
     : OptionsProviderImpl<FrontendOptionsProvider, FrontendFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FrontendFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           FrontendFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/InitDatabaseOptionsProvider.h
+++ b/arangod/RestServer/InitDatabaseOptionsProvider.h
@@ -32,8 +32,6 @@ struct InitDatabaseOptionsProvider
                           InitDatabaseFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           InitDatabaseFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           InitDatabaseFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/LogBufferOptionsProvider.h
+++ b/arangod/RestServer/LogBufferOptionsProvider.h
@@ -31,8 +31,6 @@ struct LogBufferOptionsProvider
     : OptionsProviderImpl<LogBufferOptionsProvider, LogBufferFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           LogBufferFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           LogBufferFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/LogRotateOptionsProvider.h
+++ b/arangod/RestServer/LogRotateOptionsProvider.h
@@ -31,8 +31,6 @@ struct LogRotateOptionsProvider
     : OptionsProviderImpl<LogRotateOptionsProvider, LogRotateOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> prgOpts,
                           LogRotateOptions& logRotateOpts);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*prgOpts*/,
-                           LogRotateOptions& /*logRotateOpts*/) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/MaxMapCountOptionsProvider.h
+++ b/arangod/RestServer/MaxMapCountOptionsProvider.h
@@ -33,8 +33,6 @@ struct MaxMapCountOptionsProvider
                           MaxMapCountFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           MaxMapCountFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           MaxMapCountFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/NonceOptionsProvider.h
+++ b/arangod/RestServer/NonceOptionsProvider.h
@@ -32,8 +32,6 @@ struct NonceOptionsProvider
     : OptionsProviderImpl<NonceOptionsProvider, NonceFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           NonceFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           NonceFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/PrivilegeOptionsProvider.h
+++ b/arangod/RestServer/PrivilegeOptionsProvider.h
@@ -31,8 +31,6 @@ struct PrivilegeOptionsProvider
     : OptionsProviderImpl<PrivilegeOptionsProvider, PrivilegeFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           PrivilegeFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           PrivilegeFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/SupervisorOptionsProvider.h
+++ b/arangod/RestServer/SupervisorOptionsProvider.h
@@ -31,8 +31,6 @@ struct SupervisorOptionsProvider
     : OptionsProviderImpl<SupervisorOptionsProvider, SupervisorFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> options,
                           SupervisorFeatureOptions& opts);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*options*/,
-                           SupervisorFeatureOptions& /*opts*/){};
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/TemporaryStorageOptionsProvider.h
+++ b/arangod/RestServer/TemporaryStorageOptionsProvider.h
@@ -32,8 +32,6 @@ struct TemporaryStorageOptionsProvider
                           TemporaryStorageFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           TemporaryStorageFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           TemporaryStorageFeatureOptions& options) {}
 };
 
 }  // namespace arangodb

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillOptionsProvider.h
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillOptionsProvider.h
@@ -32,8 +32,6 @@ struct RocksDBIndexCacheRefillOptionsProvider
                           RocksDBIndexCacheRefillFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           RocksDBIndexCacheRefillFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           RocksDBIndexCacheRefillFeatureOptions& options){};
 };
 
 }  // namespace arangodb

--- a/arangod/SystemMonitor/Activities/OptionsProvider.h
+++ b/arangod/SystemMonitor/Activities/OptionsProvider.h
@@ -31,8 +31,6 @@ struct OptionsProvider
     : arangodb::OptionsProviderImpl<OptionsProvider, FeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           FeatureOptions& options){};
 };
 
 }  // namespace arangodb::activities

--- a/arangod/SystemMonitor/AsyncRegistry/OptionsProvider.h
+++ b/arangod/SystemMonitor/AsyncRegistry/OptionsProvider.h
@@ -31,8 +31,6 @@ struct OptionsProvider
     : arangodb::OptionsProviderImpl<OptionsProvider, FeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
-                           FeatureOptions& options){};
 };
 
 }  // namespace arangodb::async_registry

--- a/arangod/Transaction/ManagerOptionsProvider.h
+++ b/arangod/Transaction/ManagerOptionsProvider.h
@@ -37,8 +37,6 @@ struct ManagerOptionsProvider
     : OptionsProviderImpl<ManagerOptionsProvider, ManagerFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ManagerFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ManagerFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb::transaction

--- a/lib/ApplicationFeatures/ConfigOptionsProvider.h
+++ b/lib/ApplicationFeatures/ConfigOptionsProvider.h
@@ -40,8 +40,6 @@ struct ConfigOptionsProvider
                           ConfigFeatureOptions& options);
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> progOpts,
                           ConfigFeatureOptions& configOpts);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ConfigFeatureOptions& /*options*/) {}
 
  private:
   void loadConfigFile(std::shared_ptr<options::ProgramOptions> progOpts,

--- a/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
+++ b/lib/ApplicationFeatures/FeatureOptionProviderContainer.h
@@ -34,6 +34,14 @@ concept HasProcessOptions =
   provider.processOptionsImpl(programOptions,
                               std::declval<typename Provider::Options&>());
 };
+
+template<class Provider>
+concept HasValidateOptions =
+    requires(Provider& provider,
+             std::shared_ptr<options::ProgramOptions> programOptions) {
+  provider.validateOptionsImpl(programOptions,
+                               std::declval<typename Provider::Options&>());
+};
 }  // namespace
 
 template<class... Providers>
@@ -59,7 +67,7 @@ class FeatureOptionProviderContainer final {
       std::shared_ptr<options::ProgramOptions> programOptions) {
     std::apply(
         [&](auto&... providers) {
-          (providers.validateOptions(programOptions), ...);
+          (validateProviderOptions(programOptions, providers), ...);
         },
         _providers);
   }
@@ -83,6 +91,16 @@ class FeatureOptionProviderContainer final {
       provider.processOptions(programOptions);
     }
   }
+
+  template<class Provider>
+  void validateProviderOptions(
+      std::shared_ptr<options::ProgramOptions> programOptions,
+      Provider& provider) {
+    if constexpr (HasValidateOptions<Provider>) {
+      provider.validateOptions(programOptions);
+    }
+  }
+
   std::tuple<Providers...> _providers{};
 };
 }  // namespace arangodb::application_features

--- a/lib/ApplicationFeatures/FileSystemOptionsProvider.h
+++ b/lib/ApplicationFeatures/FileSystemOptionsProvider.h
@@ -35,8 +35,6 @@ struct FileSystemOptionsProvider
     : OptionsProviderImpl<FileSystemOptionsProvider, FileSystemFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           FileSystemFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           FileSystemFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/LanguageOptionsProvider.h
+++ b/lib/ApplicationFeatures/LanguageOptionsProvider.h
@@ -31,8 +31,6 @@ struct LanguageOptionsProvider
     : OptionsProviderImpl<LanguageOptionsProvider, LanguageFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           LanguageFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           LanguageFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/ProcessEnvironmentOptionsProvider.h
+++ b/lib/ApplicationFeatures/ProcessEnvironmentOptionsProvider.h
@@ -32,8 +32,6 @@ struct ProcessEnvironmentOptionsProvider
                           ProcessEnvironmentFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           ProcessEnvironmentFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           ProcessEnvironmentFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/ApplicationFeatures/VersionOptionsProvider.h
+++ b/lib/ApplicationFeatures/VersionOptionsProvider.h
@@ -33,8 +33,6 @@ struct VersionOptionsProvider
                           VersionFeatureOptions& options);
   void processOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           VersionFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           VersionFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/lib/Random/RandomOptionsProvider.h
+++ b/lib/Random/RandomOptionsProvider.h
@@ -31,8 +31,6 @@ struct RandomOptionsProvider
     : OptionsProviderImpl<RandomOptionsProvider, RandomFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           RandomFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           RandomFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/lib/V8/V8PlatformOptionsProvider.h
+++ b/lib/V8/V8PlatformOptionsProvider.h
@@ -31,8 +31,6 @@ struct V8PlatformOptionsProvider
     : OptionsProviderImpl<V8PlatformOptionsProvider, V8PlatformFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           V8PlatformFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           V8PlatformFeatureOptions& /*options*/) {}
 };
 
 }  // namespace arangodb

--- a/lib/V8/V8SecurityOptionsProvider.h
+++ b/lib/V8/V8SecurityOptionsProvider.h
@@ -35,8 +35,6 @@ struct V8SecurityOptionsProvider
     : OptionsProviderImpl<V8SecurityOptionsProvider, V8SecurityFeatureOptions> {
   void declareOptionsImpl(std::shared_ptr<options::ProgramOptions> opts,
                           V8SecurityFeatureOptions& options);
-  void validateOptionsImpl(std::shared_ptr<options::ProgramOptions> /*opts*/,
-                           V8SecurityFeatureOptions& /*options*/){};
 };
 
 }  // namespace arangodb

--- a/tests/RestServer/LanguageFeatureTest.cpp
+++ b/tests/RestServer/LanguageFeatureTest.cpp
@@ -204,7 +204,6 @@ TEST_F(ArangoLanguageFeatureTest, testResetLanguageDefault) {
       ->get<StringParameter>("default-language")
       ->set(language1.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -241,7 +240,6 @@ TEST_F(ArangoLanguageFeatureTest, testResetLanguageIcu) {
       ->get<StringParameter>("icu-language")
       ->set(language1.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -289,7 +287,6 @@ TEST_F(ArangoLanguageFeatureTest, testBothArgumentsSpecifiedLangCheckTrue) {
       ->get<StringParameter>("default-language")
       ->set(lang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -319,7 +316,6 @@ TEST_F(ArangoLanguageFeatureTest, testBothArgumentsSpecifiedLangCheckFalse) {
       ->get<StringParameter>("default-language")
       ->set(lang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
 
@@ -349,7 +345,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckTrue) {
       ->get<StringParameter>(defaultParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -447,7 +442,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultLangCheckFalse) {
       ->get<StringParameter>(defaultParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -548,7 +542,6 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckTrue) {
       ->set("");
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -650,7 +643,6 @@ TEST_F(ArangoLanguageFeatureTest, testEmptyLangCheckFalse) {
       ->set("");
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -749,7 +741,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -846,7 +837,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuLangCheckFalse) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -942,7 +932,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithVariantLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1039,7 +1028,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1137,7 +1125,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry1WithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1236,7 +1223,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry2WithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1334,7 +1320,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuCountry3WithCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(firstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1433,7 +1418,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithCollationLangCheckTrue) {
       ->set(inputFirstLang.data());
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1537,7 +1521,6 @@ TEST_F(ArangoLanguageFeatureTest,
       ->set(inputFirstLang.data());
   server.server().options()->get<StringParameter>(icuParameter.data())->set("");
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1643,7 +1626,6 @@ TEST_F(ArangoLanguageFeatureTest, testIcuWithWrongCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set(inputFirstLang.data());
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =
@@ -1749,7 +1731,6 @@ TEST_F(ArangoLanguageFeatureTest, testDefaultWithWrongCollationLangCheckTrue) {
       ->get<StringParameter>(icuParameter.data())
       ->set("");  // clear value for parameter
 
-  langOpProvider.validateOptions(server.server().options());
   auto& langFeature = server.addFeatureUntracked<arangodb::LanguageFeature>(
       langOpProvider.options());
   auto& langCheckFeature =


### PR DESCRIPTION
### Scope & Purpose

We have over 30 empty implementations of validateOptionsImpl. Make it optional and make headers leaner.

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [x] :hammer: Refactoring/simplification

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [x] Jira ticket: https://arangodb.atlassian.net/browse/COR-815
- [ ] Design document: 
