### PR TITLE
COR-791: Add stop token to methods::Collections::enumerate

### DIFF
--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -710,10 +710,11 @@ bool analyzerInUse(std::string_view dbName,
 
     bool found = false;
 
-    auto visitor = [&found, analyzer](
-                       std::shared_ptr<LogicalCollection> const& collection) {
+    auto visitor =
+        [&found, analyzer](
+            std::shared_ptr<LogicalCollection> const& collection) -> bool {
       if (!collection) {
-        return;
+        return true;
       }
 
       for (auto const& index : collection->getPhysical()->getAllIndexes()) {
@@ -733,9 +734,12 @@ bool analyzerInUse(std::string_view dbName,
         if (nullptr != link->findAnalyzer(*analyzer)) {
           // found referenced analyzer
           found = true;
-          return;
+
+          // abort collection enumeration
+          return false;
         }
       }
+      return true;
     };
 
     methods::Collections::enumerate(vocbase, visitor);

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -217,12 +217,13 @@ void RestUsersHandler::generateDatabaseResult(auth::UserManager* um,
 
             methods::Collections::enumerate(
                 &vocbase,
-                [&](std::shared_ptr<LogicalCollection> const& c) -> void {
+                [&](std::shared_ptr<LogicalCollection> const& c) -> bool {
                   TRI_ASSERT(c);
                   lvl = user.configuredCollectionAuthLevel(vocbase.name(),
                                                            c->name());
                   data.add(c->name(),
                            velocypack::Value(convertFromAuthLevel(lvl)));
+                  return true;
                 });
             lvl = user.configuredCollectionAuthLevel(vocbase.name(), "*");
             data.add("*", velocypack::Value(convertFromAuthLevel(lvl)));

--- a/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
+++ b/arangod/RocksDBEngine/RocksDBIndexCacheRefillFeature.cpp
@@ -188,6 +188,8 @@ void RocksDBIndexCacheRefillFeature::buildStartupIndexRefillTasks() {
               _indexFillTasks.emplace_back(
                   IndexFillTask{database, collection->name(), index->id()});
             }
+
+            return true;
           });
     } catch (...) {
       // must ignore any errors here in case a database or collection

--- a/arangod/VocBase/Methods/Collections.cpp
+++ b/arangod/VocBase/Methods/Collections.cpp
@@ -482,11 +482,14 @@ std::vector<std::shared_ptr<LogicalCollection>> Collections::sorted(
 
 void Collections::enumerate(
     TRI_vocbase_t* vocbase,
-    std::function<void(std::shared_ptr<LogicalCollection> const&)> const&
+    std::function<bool(std::shared_ptr<LogicalCollection> const&)> const&
         func) {
   auto const collections = getNotDeleted(*vocbase);
   for (auto& collection : collections) {
-    func(collection);
+    auto continueEnumeration = func(collection);
+    if (!continueEnumeration) {
+      break;
+    }
   }
 }
 

--- a/arangod/VocBase/Methods/Collections.h
+++ b/arangod/VocBase/Methods/Collections.h
@@ -91,7 +91,7 @@ struct Collections {
 
   static void enumerate(
       Database* vocbase,
-      std::function<void(std::shared_ptr<LogicalCollection> const&)> const&);
+      std::function<bool(std::shared_ptr<LogicalCollection> const&)> const&);
 
   static std::vector<std::shared_ptr<LogicalCollection>> getNotDeleted(
       const Database& vocbase);


### PR DESCRIPTION
### Scope & Purpose

Added a stop token to methods::Collections::enumerate()

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [X] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [X] Enterprise PR: https://github.com/arangodb/enterprise/pull/1687
- [X] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-791
- [ ] Design document: 
