### PR TITLE
Docs | Startup options: Remove indentation from `setLongDescription` Markdown raw strings

### DIFF
--- a/arangod/Aql/OptimizerRulesOptionsProvider.cpp
+++ b/arangod/Aql/OptimizerRulesOptionsProvider.cpp
@@ -58,9 +58,8 @@ state.)");
       ->addObsoleteOption(
           "--query.parallelize-gather-writes",
           "Whether to enable write parallelization for gather nodes.", false)
-      .setLongDescription(
-          R"(Starting with 3.11 almost all queries support parallelization of
-gather nodes, making this option obsolete.)");
+      .setLongDescription(R"(Starting with 3.11 almost all queries support
+parallelization of gather nodes, making this option obsolete.)");
 }
 
 }  // namespace arangodb::aql

--- a/arangod/Aql/QueryInfoLoggerOptionsProvider.cpp
+++ b/arangod/Aql/QueryInfoLoggerOptionsProvider.cpp
@@ -76,10 +76,9 @@ void QueryInfoLoggerOptionsProvider::declareOptionsImpl(
           makeDefaultFlags(Flags::DefaultNoComponents, Flags::OnCoordinator,
                            Flags::OnSingle))
       .setIntroducedIn(31202)
-      .setLongDescription(
-          R"(A value of `100` logs all queries, whereas a value of `1`
-approximately logs every 100th query and ignores the rest. The minimum value
-is `0` and means no logging.)");
+      .setLongDescription(R"(A value of `100` logs all queries, whereas a value
+of `1` approximately logs every 100th query and ignores the rest. The minimum
+value is `0` and means no logging.)");
 
   options
       ->addOption("--query.collection-logger-retention-time",

--- a/arangod/Cache/CacheFeatureOptionsProvider.cpp
+++ b/arangod/Cache/CacheFeatureOptionsProvider.cpp
@@ -50,8 +50,8 @@ void CacheFeatureOptionsProvider::declareOptions(
       .setLongDescription(R"(The global caching system, all caches, and all the
 data contained therein are constrained to this limit.
 
-If there is less than 4 GiB of RAM in the system, default value is 256 MiB.
-If there is more, the default is `(system RAM size - 2 GiB) * 0.25`.)");
+- If there is less than 4 GiB of RAM in the system, default value is 256 MiB.
+- If there is more, the default is `(system RAM size - 2 GiB) * 0.25`.)");
 
   opts->addOption(
           "--cache.rebalancing-interval",
@@ -99,14 +99,17 @@ value will be inflated in size by the cache rebalancer.)")
                       arangodb::options::Flags::DefaultNoComponents,
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
-      .setLongDescription(
-          R"(By transparently compressing values in the in-memory
-edge index cache, more data can be held in memory than without compression.
-Storing compressed values can increase CPU usage for the on-the-fly compression
-and decompression. In case compression is undesired, this option can be set to a
-very high value, which will effectively disable it. To use compression, set the
-option to a value that is lower than medium-to-large average payload sizes.
-It is normally not that useful to compress values that are smaller than 100 bytes.)")
+      .setLongDescription(R"(By transparently compressing values in the
+in-memory edge index cache, more data can be held in memory than without
+compression. Storing compressed values can increase CPU usage for the on-the-fly
+compression and decompression.
+
+In case compression is undesired, this option can be set to a very high value,
+which effectively disables it.
+
+To use compression, set the option to a value that is lower than medium-to-large
+average payload sizes. It is normally not that useful to compress values that
+are smaller than 100 bytes.)")
       .setIntroducedIn(31102);
 
   opts->addOption(
@@ -120,12 +123,11 @@ It is normally not that useful to compress values that are smaller than 100 byte
               arangodb::options::Flags::DefaultNoComponents,
               arangodb::options::Flags::OnDBServer,
               arangodb::options::Flags::OnSingle))
-      .setLongDescription(
-          R"(This value controls the LZ4-internal acceleration factor for the
-LZ4 compression. Higher values typically yield less compression in exchange
-for faster compression and decompression speeds. An increase of 1 commonly leads
-to a compression speed increase of 3%, and could slightly increase decompression
-speed.)")
+      .setLongDescription(R"(This value controls the LZ4-internal acceleration
+factor for the LZ4 compression. Higher values typically yield less compression
+in exchange for faster compression and decompression speeds. An increase of 1
+commonly leads to a compression speed increase of 3%, and could slightly
+increase decompression speed.)")
       .setIntroducedIn(31102);
 
   opts->addOption(
@@ -138,11 +140,10 @@ speed.)")
               arangodb::options::Flags::DefaultNoComponents,
               arangodb::options::Flags::OnDBServer,
               arangodb::options::Flags::OnSingle))
-      .setLongDescription(
-          R"(This value controls the cache's effective memory usage limit.
-The user-defined memory limit (i.e. `--cache.size`) is multiplied with this
-value to create the effective memory limit, from which on the cache will
-try to free up memory by evicting the oldest entries.)")
+      .setLongDescription(R"(This value controls the cache's effective memory
+usage limit. The user-defined memory limit (i.e. `--cache.size`) is multiplied
+with this value to create the effective memory limit, from which on the cache
+tries to free up memory by evicting the oldest entries.)")
       .setIntroducedIn(31200);
 
   opts->addOption(

--- a/arangod/GeneralServer/GeneralServerOptionsProvider.cpp
+++ b/arangod/GeneralServer/GeneralServerOptionsProvider.cpp
@@ -118,15 +118,16 @@ and also react on overload.)");
                   "transparently compressed in case the client asks for it.",
                   new UInt64Parameter(&options.compressResponseThreshold))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Automatically compress outgoing HTTP responses with the
-deflate or gzip compression format, in case the client request advertises
-support for this. Compression will only happen for HTTP/1.1 and HTTP/2
-connections, if the size of the uncompressed response body exceeds
-the threshold value controlled by this startup option,
-and if the response body size after compression is less than the original
-response body size.
-Using the value 0 disables the automatic response compression.)");
+      .setLongDescription(R"(Automatically compress outgoing HTTP responses with
+the deflate or gzip compression format, in case the client request advertises
+support for this.
+
+Compression only happens for HTTP/1.1 and HTTP/2 connections, if the size of the
+uncompressed response body exceeds the threshold value controlled by this
+startup option, and if the response body size after compression is less than the
+original response body size.
+
+Using the value `0` disables the automatic response compression.)");
 
   opts->addOption("--server.early-connections",
                   "Allow requests to a limited set of APIs early during the "
@@ -172,10 +173,9 @@ Using the value 0 disables the automatic response compression.)");
           new BooleanParameter(
               &options.handleContentEncodingForUnauthenticatedRequests))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(If the option is set to `true`, the server will automatically
-uncompress incoming HTTP requests with Content-Encodings gzip and deflate
-even if the request is not authenticated.)");
+      .setLongDescription(R"(If the option is set to `true`, the server
+automatically decompresses incoming HTTP requests with `gzip` or `deflate` in
+the `Content-Encoding` header even if the request is not authenticated.)");
 }
 
 void GeneralServerOptionsProvider::validateOptionsImpl(

--- a/arangod/GeneralServer/ServerSecurityOptionsProvider.cpp
+++ b/arangod/GeneralServer/ServerSecurityOptionsProvider.cpp
@@ -53,7 +53,7 @@ void ServerSecurityOptionsProvider::declareOptionsImpl(
   options
       ->addOption(
           "--foxx.allow-install-from-remote",
-          "Allow installing Foxx apps from remote URLs other than Github.",
+          "Allow installing Foxx apps from remote URLs other than GitHub.",
           new BooleanParameter(&opts.foxxAllowInstallFromRemote),
           makeFlags(Flags::DefaultNoComponents, Flags::OnCoordinator,
                     Flags::OnSingle))

--- a/arangod/IResearch/IResearchOptionsProvider.cpp
+++ b/arangod/IResearch/IResearchOptionsProvider.cpp
@@ -82,7 +82,7 @@ void IResearchOptionsProvider::declareOptions(
                   "tasks (0 = auto-detect).",
                   new options::UInt32Parameter(&opts.threads))
       .setDeprecatedIn(30705)
-      .setLongDescription(R"(From version 3.7.5 on, you should set the commit
+      .setLongDescription(R"(From v3.7.5 onward, you should set the commit
 and consolidation thread counts separately via the following options instead:
 
 - `--arangosearch.commit-threads`
@@ -104,7 +104,7 @@ then the commit and consolidation thread counts are calculated as follows:
           "for asynchronous tasks (0 = use default).",
           new options::UInt32Parameter(&opts.threadsLimit))
       .setDeprecatedIn(30705)
-      .setLongDescription(R"(From version 3.7.5 on, you should set the commit
+      .setLongDescription(R"(From v3.7.5 onward, you should set the commit
 and consolidation thread counts separately via the following options instead:
 
 - `--arangosearch.commit-threads`

--- a/arangod/Network/NetworkOptionsProvider.cpp
+++ b/arangod/Network/NetworkOptionsProvider.cpp
@@ -87,14 +87,15 @@ void NetworkOptionsProvider::declareOptionsImpl(
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnCoordinator))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Automatically compress outgoing HTTP requests in cluster-internal
-traffic with the deflate, gzip or lz4 compression format.
-Compression will only happen if the size of the uncompressed request body
+      .setLongDescription(R"(Automatically compress outgoing HTTP requests in
+cluster-internal traffic with the deflate, gzip or lz4 compression format.
+
+Compression only happens if the size of the uncompressed request body
 exceeds the threshold value controlled by this startup option,
 and if the request body size after compression is less than the original
 request body size.
-Using the value 0 disables the automatic compression.)");
+
+Using the value `0` disables the automatic compression.)");
 
   std::unordered_set<std::string> types = {
       StaticStrings::EncodingGzip, StaticStrings::EncodingDeflate,
@@ -109,21 +110,23 @@ Using the value 0 disables the automatic compression.)");
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnCoordinator))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Setting this option to 'none' will disable compression for
-cluster-internal requests.
+      .setLongDescription(R"(Set this option to `none` to disable compression
+for cluster-internal requests.
+
 To enable compression for cluster-internal requests, set this option to either
-'deflate', 'gzip', 'lz4' or 'auto'.
-The 'deflate' and 'gzip' compression methods are general purpose,
-but have significant CPU overhead for performing the compression work.
-The 'lz4' compression method compresses slightly worse, but has a lot lower
-CPU overhead for performing the compression.
-The 'auto' compression method will use 'deflate' by default, and 'lz4' for
-requests which have a size that is at least 3 times the configured threshold
-size.
+`deflate`, `gzip`, `lz4`, or `auto`.
+
+- The `deflate` and `gzip` compression methods are general purpose,
+  but have significant CPU overhead for performing the compression work.
+- The `lz4` compression method compresses slightly worse, but has a lot lower
+  CPU overhead for performing the compression.
+- The `auto` compression method uses `deflate` by default, and `lz4` for
+  requests which have a size that is at least 3 times the configured threshold
+  size.
+
 The compression method only matters if `--network.compress-request-threshold`
-is set to value greater than zero. If the threshold is set to value of 0,
-then no compression will be performed.)");
+is set to value greater than zero. If the threshold is set to value of `0`,
+then no compression is performed.)");
 }
 
 void NetworkOptionsProvider::validateOptionsImpl(

--- a/arangod/RestServer/DumpLimitsOptionsProvider.cpp
+++ b/arangod/RestServer/DumpLimitsOptionsProvider.cpp
@@ -45,9 +45,8 @@ void DumpLimitsOptionsProvider::declareOptionsImpl(
           makeFlags(Flags::Dynamic, Flags::DefaultNoComponents,
                     Flags::OnDBServer, Flags::OnSingle))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(The approximate per-server maximum allowed memory usage value
-for all ongoing dump actions combined.)");
+      .setLongDescription(R"(The approximate per-server maximum allowed memory
+usage value for all ongoing dump actions combined.)");
 
   options
       ->addOption(
@@ -58,8 +57,8 @@ for all ongoing dump actions combined.)");
           makeFlags(Flags::Uncommon, Flags::DefaultNoComponents,
                     Flags::OnDBServer, Flags::OnSingle))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Each batch in a dump can grow to at most this size.)");
+      .setLongDescription(R"(Each batch in a dump can grow to at most
+this size.)");
 
   options
       ->addOption(
@@ -70,8 +69,8 @@ for all ongoing dump actions combined.)");
           makeFlags(Flags::Uncommon, Flags::DefaultNoComponents,
                     Flags::OnDBServer, Flags::OnSingle))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Each batch in a dump can grow to at most this size.)");
+      .setLongDescription(R"(Each batch in a dump can grow to at most
+this size.)");
 
   options
       ->addOption("--dump.max-parallelism",

--- a/arangod/RestServer/LogApiOptionsProvider.cpp
+++ b/arangod/RestServer/LogApiOptionsProvider.cpp
@@ -35,20 +35,20 @@ void LogApiOptionsProvider::declareOptionsImpl(
                   "only enabled for the superuser (jwt).",
                   new options::StringParameter(&apiOpts.apiSwitch))
       .setLongDescription(R"(Credentials are not written to log files.
-        Nevertheless, some logged data might be sensitive depending on the context of
-        the deployment. For example, if request logging is switched on, user requests
-        and corresponding data might end up in log files. Therefore, a certain care
-        with log files is recommended.
-        
-        Since the database server offers an API to control logging and query logging
-        data, this API has to be secured properly. By default, the API is accessible
-        for admin users (administrative access to the `_system` database).
-        However, you can restrict it further to the superuser or disable it altogether:
-        
-         - `true`: The `/_admin/log` API is accessible for admin users.
-         - `jwt`: The `/_admin/log` API is accessible for the superuser only
-           (authentication with JWT superuser token and empty username).
-         - `false`: The `/_admin/log` API is not accessible at all.)");
+Nevertheless, some logged data might be sensitive depending on the context of
+the deployment. For example, if request logging is switched on, user requests
+and corresponding data might end up in log files. Therefore, a certain care
+with log files is recommended.
+
+Since the database server offers an API to control logging and query logging
+data, this API has to be secured properly. By default, the API is accessible
+for admin users (administrative access to the `_system` database).
+However, you can restrict it further to the superuser or disable it altogether:
+
+  - `true`: The `/_admin/log` API is accessible for admin users.
+  - `jwt`: The `/_admin/log` API is accessible for the superuser only
+    (authentication with JWT superuser token and empty username).
+  - `false`: The `/_admin/log` API is not accessible at all.)");
 }
 
 void LogApiOptionsProvider::validateOptionsImpl(

--- a/arangod/RestServer/UpgradeOptionsProvider.cpp
+++ b/arangod/RestServer/UpgradeOptionsProvider.cpp
@@ -83,7 +83,7 @@ in the `VERSION` file, the server refuses to start.)");
                   "Perform a full RocksDB compaction after database upgrade.",
                   new BooleanParameter(&opts.upgradeFullCompaction))
       .setLongDescription(R"(If this option is specified together with
---database.auto-upgrade, the server will perform a full RocksDB compaction
+`--database.auto-upgrade`, the server performs a full RocksDB compaction
 after the database upgrade has completed successfully but before shutting down.
 
 This performs a complete compaction of all column families with both

--- a/arangod/RocksDBEngine/RocksDBOptionFeatureOptionsProvider.cpp
+++ b/arangod/RocksDBEngine/RocksDBOptionFeatureOptionsProvider.cpp
@@ -810,9 +810,8 @@ version.)");
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
       .setIntroducedIn(31000)
-      .setLongDescription(
-          R"(Note that format version 6 can only be read by RocksDB
-versions >= 8.6.0. Thus switching to format version 6 will make the database
+      .setLongDescription(R"(Note that format version 6 can only be read by
+RocksDB versions >= 8.6.0. Thus switching to format version 6 makes the database
 files incompatible with ArangoDB versions with a lower RocksDB version in case
 of downgrading.)");
 
@@ -984,10 +983,10 @@ of downgrading.)");
                                        arangodb::options::Flags::OnDBServer,
                                        arangodb::options::Flags::OnSingle))
       .setIntroducedIn(31100)
-      .setLongDescription(
-          R"(The jemalloc-based memory allocator for the RocksDB block cache
-will also exclude the block cache contents from coredumps, potentially making
-generated coredumps a lot smaller.
+      .setLongDescription(R"(The jemalloc-based memory allocator for the RocksDB
+block cache also excludes the block cache contents from coredumps, potentially
+making generated coredumps a lot smaller.
+
 In order to use this option, the executable needs to be compiled with jemalloc
 support (which is the default on Linux).)");
 
@@ -1062,23 +1061,25 @@ option to `0`.)");
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
       .setIntroducedIn(31200)
-      .setLongDescription(R"(Enabling this option will make RocksDB's
+      .setLongDescription(R"(Enabling this option makes RocksDB's
 compaction write the document data for different collections/shards
 into different .sst files. Otherwise the document data from different
 collections/shards can be mixed and written into the same .sst files.
 
-Enabling this option usually has the benefit of making the RocksDB
-compaction more efficient when a lot of different collections/shards
-are written to in parallel.
-The disavantage of enabling this option is that there can be more .sst
-files than when the option is turned off, and the disk space used by
-these .sst files can be higher than if there are fewer .sst files (this
-is because there is some per-.sst file overhead).
-In particular on deployments with many collections/shards
-this can lead to a very high number of .sst files, with the potential
-of outgrowing the maximum number of file descriptors the ArangoDB process
-can open. Thus the option should only be enabled on deployments with a
-limited number of collections/shards.)");
+- Enabling this option usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different collections/shards
+  are written to in parallel.
+
+- The disadvantage of enabling this option is that there can be more .sst
+  files than when the option is turned off, and the disk space used by
+  these .sst files can be higher than if there are fewer .sst files (this
+  is because there is some per-.sst file overhead).
+
+  In particular on deployments with many collections/shards
+  this can lead to a very high number of .sst files, with the potential
+  of outgrowing the maximum number of file descriptors the ArangoDB process
+  can open. Thus the option should only be enabled on deployments with a
+  limited number of collections/shards.)");
 
   opts->addOption(
           "--rocksdb.partition-files-for-primary-index",
@@ -1094,23 +1095,25 @@ limited number of collections/shards.)");
               arangodb::options::Flags::OnDBServer,
               arangodb::options::Flags::OnSingle))
       .setIntroducedIn(31200)
-      .setLongDescription(R"(Enabling this option will make RocksDB's
+      .setLongDescription(R"(Enabling this option makes RocksDB's
 compaction write the primary index data for different collections/shards
 into different .sst files. Otherwise the primary index data from different
 collections/shards can be mixed and written into the same .sst files.
 
-Enabling this option usually has the benefit of making the RocksDB
-compaction more efficient when a lot of different collections/shards
-are written to in parallel.
-The disavantage of enabling this option is that there can be more .sst
-files than when the option is turned off, and the disk space used by
-these .sst files can be higher than if there are fewer .sst files (this
-is because there is some per-.sst file overhead).
-In particular on deployments with many collections/shards
-this can lead to a very high number of .sst files, with the potential
-of outgrowing the maximum number of file descriptors the ArangoDB process
-can open. Thus the option should only be enabled on deployments with a
-limited number of collections/shards.)");
+- Enabling this option usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different collections/shards
+  are written to in parallel.
+
+- The disadvantage of enabling this option is that there can be more .sst
+  files than when the option is turned off, and the disk space used by
+  these .sst files can be higher than if there are fewer .sst files (this
+  is because there is some per-.sst file overhead).
+
+  In particular on deployments with many collections/shards
+  this can lead to a very high number of .sst files, with the potential
+  of outgrowing the maximum number of file descriptors the ArangoDB process
+  can open. Thus the option should only be enabled on deployments with a
+  limited number of collections/shards.)");
 
   opts->addOption("--rocksdb.partition-files-for-edge-index",
                   "If enabled, the index data for different edge "
@@ -1124,23 +1127,25 @@ limited number of collections/shards.)");
                       arangodb::options::Flags::OnDBServer,
                       arangodb::options::Flags::OnSingle))
       .setIntroducedIn(31200)
-      .setLongDescription(R"(Enabling this option will make RocksDB's
+      .setLongDescription(R"(Enabling this option makes RocksDB's
 compaction write the edge index data for different edge collections/shards
 into different .sst files. Otherwise the edge index data from different
 edge collections/shards can be mixed and written into the same .sst files.
 
-Enabling this option usually has the benefit of making the RocksDB
-compaction more efficient when a lot of different edge collections/shards
-are written to in parallel.
-The disavantage of enabling this option is that there can be more .sst
-files than when the option is turned off, and the disk space used by
-these .sst files can be higher than if there are fewer .sst files (this
-is because there is some per-.sst file overhead).
-In particular on deployments with many edge collections/shards
-this can lead to a very high number of .sst files, with the potential
-of outgrowing the maximum number of file descriptors the ArangoDB process
-can open. Thus the option should only be enabled on deployments with a
-limited number of edge collections/shards.)");
+- Enabling this option usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different edge collections/shards
+  are written to in parallel.
+
+- The disadvantage of enabling this option is that there can be more .sst
+  files than when the option is turned off, and the disk space used by
+  these .sst files can be higher than if there are fewer .sst files (this
+  is because there is some per-.sst file overhead).
+
+  In particular on deployments with many edge collections/shards,
+  this can lead to a very high number of .sst files, with the potential
+  of outgrowing the maximum number of file descriptors the ArangoDB process
+  can open. Thus the option should only be enabled on deployments with a
+  limited number of edge collections/shards.)");
 
   opts->addOption("--rocksdb.partition-files-for-persistent-index",
                   "If enabled, the index data for different persistent "
@@ -1160,18 +1165,20 @@ indexes (also indexes from different collections/shards) into different
 .sst files. Otherwise the persistent index data from different
 collections/shards/indexes can be mixed and written into the same .sst files.
 
-Enabling this option usually has the benefit of making the RocksDB
-compaction more efficient when a lot of different collections/shards/indexes
-are written to in parallel.
-The disavantage of enabling this option is that there can be more .sst
-files than when the option is turned off, and the disk space used by
-these .sst files can be higher than if there are fewer .sst files (this
-is because there is some per-.sst file overhead).
-In particular on deployments with many collections/shards/indexes
-this can lead to a very high number of .sst files, with the potential
-of outgrowing the maximum number of file descriptors the ArangoDB process
-can open. Thus the option should only be enabled on deployments with a
-limited number of edge collections/shards/indexes.)");
+- Enabling this option usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different collections/shards/indexes
+  are written to in parallel.
+
+- The disadvantage of enabling this option is that there can be more .sst
+  files than when the option is turned off, and the disk space used by
+  these .sst files can be higher than if there are fewer .sst files (this
+  is because there is some per-.sst file overhead).
+
+  In particular on deployments with many collections/shards/indexes
+  this can lead to a very high number of .sst files, with the potential
+  of outgrowing the maximum number of file descriptors the ArangoDB process
+  can open. Thus the option should only be enabled on deployments with a
+  limited number of edge collections/shards/indexes.)");
 
   opts->addOption("--rocksdb.partition-files-for-mdi-index",
                   "If enabled, the index data for different mdi "
@@ -1191,19 +1198,20 @@ indexes (also indexes from different collections/shards) into different
 `.sst` files. Otherwise the persistent index data from different
 collections/shards/indexes can be mixed and written into the same `.sst` files.
 
-Enabling this option usually has the benefit of making the RocksDB
-compaction more efficient when a lot of different collections/shards/indexes
-are written to in parallel.
-The disadvantage of enabling this option is that there can be more `.sst`
-files than when the option is turned off, and the disk space used by
-these `.sst` files can be higher than if there are fewer `.sst` files (this
-is because there is some per-`.sst` file overhead).
+- Enabling this option usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different collections/shards/indexes
+  are written to in parallel.
 
-In particular on deployments with many collections/shards/indexes
-this can lead to a very high number of `.sst` files, with the potential
-of outgrowing the maximum number of file descriptors the ArangoDB process
-can open. Thus the option should only be enabled on deployments with a
-limited number of edge collections/shards/indexes.)");
+- The disadvantage of enabling this option is that there can be more `.sst`
+  files than when the option is turned off, and the disk space used by
+  these `.sst` files can be higher than if there are fewer `.sst` files (this
+  is because there is some per-`.sst` file overhead).
+
+  In particular on deployments with many collections/shards/indexes
+  this can lead to a very high number of `.sst` files, with the potential
+  of outgrowing the maximum number of file descriptors the ArangoDB process
+  can open. Thus the option should only be enabled on deployments with a
+  limited number of edge collections/shards/indexes.)");
 
   opts->addOption("--rocksdb.partition-files-for-vector-index",
                   "If enabled, the index data for different vector "
@@ -1222,18 +1230,20 @@ indexes (also indexes from different collections/shards) into different
 .sst files. Otherwise, the index data from different
 collections/shards/indexes can be mixed and written into the same .sst files.
 
-Enabling this option usually has the benefit of making the RocksDB
-compaction more efficient when a lot of different collections/shards/indexes
-are written to in parallel.
-The disadvantage of enabling this option is that there can be more .sst
-files than when the option is disabled, and the disk space used by
-these .sst files can be higher than if there are fewer .sst files
-because there is some overhead per .sst file.
-For deployments with many collections/shards/indexes in particular,
-this can lead to a very high number of .sst files, with the potential
-of outgrowing the maximum number of file descriptors the ArangoDB process
-can open. The option should thus only be enabled for deployments with a
-limited number of edge collections/shards/indexes.)");
+- Enabling this option usually has the benefit of making the RocksDB
+  compaction more efficient when a lot of different collections/shards/indexes
+  are written to in parallel.
+
+- The disadvantage of enabling this option is that there can be more .sst
+  files than when the option is disabled, and the disk space used by
+  these .sst files can be higher than if there are fewer .sst files
+  because there is some overhead per .sst file.
+
+  For deployments with many collections/shards/indexes in particular,
+  this can lead to a very high number of .sst files, with the potential
+  of outgrowing the maximum number of file descriptors the ArangoDB process
+  can open. The option should thus only be enabled for deployments with a
+  limited number of edge collections/shards/indexes.)");
 
   options.ioUringEnabled = _ioUringEnabled;
   opts->addOption(

--- a/arangod/SystemMonitor/AsyncRegistry/OptionsProvider.cpp
+++ b/arangod/SystemMonitor/AsyncRegistry/OptionsProvider.cpp
@@ -39,11 +39,10 @@ void OptionsProvider::declareOptionsImpl(std::shared_ptr<ProgramOptions> opts,
           "swipes.",
           new SizeTParameter(&options.gc_timeout, /*base*/ 1,
                              /*minValue*/ 1))
-      .setLongDescription(
-          R"(Each thread that is involved in the async-registry needs to
-garbage collect its finished async function calls regularly. This option
-controls how often this is done in seconds. This can possibly be performance
-relevant because each involved thread acquires a lock.)");
+      .setLongDescription(R"(Each thread that is involved in the async-registry
+needs to garbage collect its finished async function calls regularly. This
+option controls how often this is done in seconds. This can possibly be
+performance relevant because each involved thread acquires a lock.)");
 }
 
 }  // namespace arangodb::async_registry

--- a/arangod/VectorIndex/VectorIndexOptionsProvider.cpp
+++ b/arangod/VectorIndex/VectorIndexOptionsProvider.cpp
@@ -41,8 +41,8 @@ void VectorIndexOptionsProvider::declareOptions(
                             Flags::OnDBServer, Flags::OnSingle))
       .setIntroducedIn(31204)
       .setLongDescription(R"(This startup option should not be enabled for
-  Agents in a cluster as it has no effect on them other than that you need to
-  leave the option enabled.)");
+Agents in a cluster as it has no effect on them other than that you need to
+leave the option enabled.)");
 
   programOptions
       ->addOption(

--- a/client-tools/Import/ImportOptionsProvider.cpp
+++ b/client-tools/Import/ImportOptionsProvider.cpp
@@ -109,14 +109,11 @@ void ImportOptionsProvider::declareOptions(
           "The maximum number of errors after which the import will stop.",
           new UInt64Parameter(&opts.maxErrors))
       .setIntroducedIn(31200)
-      .setLongDescription(R"(The maximum number of errors after which the
-import is stopped.
-
-Note that this is not an exact limit for the number of errors.
-arangoimport will send data to the server in batches, and likely also in parallel.
-The server will process these in-flight batches regardless of the maximum number
-of errors configured here. arangoimport will however stop processing more input
-data once the server reported at least this many errors back.)");
+      .setLongDescription(R"(This is not an exact limit for the number of
+errors. arangoimport sends data to the server in batches, and likely also in
+parallel. The server processes these in-flight batches regardless of the maximum
+number of errors configured here. However, arangoimport stops processing more
+input data once the server reported at least this many errors back.)");
 
   options->addOption(
       "--convert",

--- a/client-tools/Restore/RestoreOptionsProvider.cpp
+++ b/client-tools/Restore/RestoreOptionsProvider.cpp
@@ -84,11 +84,10 @@ void RestoreOptionsProvider::declareOptions(
                   arangodb::options::makeDefaultFlags(
                       arangodb::options::Flags::Uncommon))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Maximum cumulated size of in-memory buffers to keep around for
-sending batches.
-A value > 0 will increase the memory usage of arangorestore, but can help in
-avoiding repeated memory allocations for building new in-memory buffers.)");
+      .setLongDescription(R"(Maximum cumulated size of in-memory buffers to keep
+around for sending batches. A value greater than `0` increases the memory usage
+of arangorestore, but can help in avoiding repeated memory allocations for
+building new in-memory buffers.)");
 
   options->addOption(
       "--force-same-database",

--- a/client-tools/Shell/ClientOptionsProvider.cpp
+++ b/client-tools/Shell/ClientOptionsProvider.cpp
@@ -183,14 +183,15 @@ received by an ArangoDB server.)");
                   "transparently compressed when sending them to the server.",
                   new UInt64Parameter(&options.compressRequestThreshold))
       .setIntroducedIn(31200)
-      .setLongDescription(
-          R"(Automatically compress outgoing HTTP requests
-with the deflate compression format. Compression will only happen for
-HTTP/1.1 and HTTP/2 connections, if the size of the uncompressed request
-body exceeds the threshold value controlled by this startup option,
-and if the request body size after compression is less than the original
-request body size.
-Using the value 0 disables the automatic request compression.)");
+      .setLongDescription(R"(Automatically compress outgoing HTTP requests
+with the deflate compression format.
+
+Compression only happens for HTTP/1.1 and HTTP/2 connections, if the size of the
+uncompressed request body exceeds the threshold value controlled by this
+startup option, and if the request body size after compression is less than the
+original request body size.
+
+Using the value `0` disables the automatic request compression.)");
 }
 
 void ClientOptionsProvider::validateOptions(

--- a/lib/Logger/LoggerOptionsProvider.cpp
+++ b/lib/Logger/LoggerOptionsProvider.cpp
@@ -104,7 +104,7 @@ logged as `犬`.
 
 If you set this options to `true`, any Unicode characters are escaped, and the
 hex codes for all Unicode characters are logged instead. For example, `犬` is
-logged as `犬`.
+logged as `\u72AC`.
 
 The default value for this option is set to `false` for compatibility with
 previous versions.


### PR DESCRIPTION
This also reverts a Japanese character back to an escape sequence, which was a mistake/misunderstanding in https://github.com/arangodb/arangodb/pull/22824/changes#diff-79a66133641edca09fda67b5f6d20a1158545a7d3ceff240aff5da742b90ec4dR97-R107

Moreover, it improves some of the descriptions and the formatting.

Enterprise companion: https://github.com/arangodb/enterprise/pull/1688