### PR TITLE
[BTS-2429] Drain queue in Storage Engine tests

### DIFF
--- a/tests/RocksDBEngine/StorageEngineFixture.cpp
+++ b/tests/RocksDBEngine/StorageEngineFixture.cpp
@@ -25,4 +25,10 @@ namespace arangodb::tests {
 
 std::unique_ptr<StorageEngineFixtureSuite> StorageEngineFixture::_suite;
 
+StorageEngineFixtureSuite::~StorageEngineFixtureSuite() {
+  while (!scheduler.queueEmpty()) {
+    scheduler.runOnce();
+  }
+}
+
 }  // namespace arangodb::tests

--- a/tests/RocksDBEngine/StorageEngineFixture.h
+++ b/tests/RocksDBEngine/StorageEngineFixture.h
@@ -75,6 +75,7 @@ struct TestSchedulerProvider final : ISchedulerProvider {
 };
 
 struct StorageEngineFixtureSuite {
+  ~StorageEngineFixtureSuite();
   metrics::FakeRegistry metricsRegistry;
   application_features::ApplicationServer server{nullptr, nullptr};
   ScopedServerStateReset serverStateReset;


### PR DESCRIPTION
### Scope & Purpose

Make sure we drain the fixtures queue before terminating to avoid assertion failures in the FakeScheduler destructor

- [x] :hankey: Bugfix
