### PR TITLE
[COR-817] Make parser depend directly on QueryWarnings instead of via QueryContext

### DIFF
--- a/arangod/Aql/Parser/Parser.cpp
+++ b/arangod/Aql/Parser/Parser.cpp
@@ -38,7 +38,8 @@
 namespace arangodb::aql {
 
 /// @brief create the parser
-Parser::Parser(QueryContext& query, Ast& ast, QueryString& qs)
+Parser::Parser(QueryContext& query, QueryWarnings* warnings, Ast& ast,
+               QueryString& qs)
     : _query(query),
       _ast(ast),
       _queryString(qs),
@@ -48,7 +49,8 @@ Parser::Parser(QueryContext& query, Ast& ast, QueryString& qs)
       _remainingLength(0),
       _offset(0),
       _marker(nullptr),
-      _lazyConditions(ast) {
+      _lazyConditions(ast),
+      _warnings(std::move(warnings)) {
   _stack.reserve(4);
 
   _queryStringStart = _queryString.data();
@@ -175,7 +177,7 @@ void Parser::registerWarning(ErrorCode errorCode, std::string_view data,
                              [[maybe_unused]] int line,
                              [[maybe_unused]] int column) {
   // ignore line and column for now
-  _query.warnings().registerWarning(errorCode, data);
+  _warnings->registerWarning(errorCode, data);
 }
 
 /// @brief push an AstNode array element on top of the stack

--- a/arangod/Aql/Parser/Parser.cpp
+++ b/arangod/Aql/Parser/Parser.cpp
@@ -167,7 +167,7 @@ void Parser::registerParseError(ErrorCode errorCode, std::string_view data,
       absl::StrCat(data, " near '", queryString().extractRegion(line, column),
                    "' at position ", line, ":", (column + 1));
 
-  _query.warnings().registerError(errorCode, errorMessage);
+  THROW_ARANGO_EXCEPTION_MESSAGE(errorCode, errorMessage);
 }
 
 /// @brief register a warning

--- a/arangod/Aql/Parser/Parser.h
+++ b/arangod/Aql/Parser/Parser.h
@@ -34,6 +34,7 @@ struct AstNode;
 class QueryContext;
 struct QueryResult;
 class QueryString;
+class QueryWarnings;
 
 /// @brief the parser
 class Parser {
@@ -42,7 +43,7 @@ class Parser {
   Parser& operator=(Parser const&) = delete;
 
   /// @brief create the parser
-  explicit Parser(QueryContext&, Ast&, QueryString&);
+  explicit Parser(QueryContext&, QueryWarnings*, Ast&, QueryString&);
 
   /// @brief destroy the parser
   ~Parser();
@@ -173,6 +174,8 @@ class Parser {
 
   /// @brief stack for handling of lazy conditions
   LazyConditions _lazyConditions;
+
+  QueryWarnings* _warnings;
 };
 }  // namespace arangodb::aql
 

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -650,7 +650,7 @@ std::unique_ptr<ExecutionPlan> Query::preparePlan() {
       << " this: " << (uintptr_t)this;
 
   TRI_ASSERT(_ast != nullptr);
-  Parser parser(*this, *_ast, _queryString);
+  Parser parser(*this, &_warnings, *_ast, _queryString);
   parser.parse();
 
   // any usage of one of the following features make the query ineligible
@@ -1414,7 +1414,7 @@ QueryResult Query::parse() {
 
   try {
     init(/*createProfile*/ false);
-    Parser parser(*this, *_ast, _queryString);
+    Parser parser(*this, &_warnings, *_ast, _queryString);
     return parser.parseWithDetails();
 
   } catch (Exception const& ex) {
@@ -1468,7 +1468,7 @@ QueryResult Query::explain() {
     init(/*createProfile*/ false);
     enterState(QueryExecutionState::ValueType::PARSING);
 
-    Parser parser(*this, *_ast, _queryString);
+    Parser parser(*this, &_warnings, *_ast, _queryString);
     parser.parse();
 
     // any usage of one of the following features make the query ineligible

--- a/arangod/Aql/StandaloneCalculation.cpp
+++ b/arangod/Aql/StandaloneCalculation.cpp
@@ -271,7 +271,7 @@ Result StandaloneCalculation::validateQuery(
     auto ast = queryContext.ast();
     TRI_ASSERT(ast);
     auto qs = arangodb::aql::QueryString(queryString);
-    Parser parser(queryContext, *ast, qs);
+    Parser parser(queryContext, &queryContext.warnings(), *ast, qs);
     if (isComputedValue) {
       // force the condition of the ternary operator (condition ? truePart :
       // falsePart) to be always inlined and not be extracted into its own LET

--- a/arangod/IResearch/IResearchAqlAnalyzer.cpp
+++ b/arangod/IResearch/IResearchAqlAnalyzer.cpp
@@ -451,7 +451,7 @@ bool AqlAnalyzer::reset(std::string_view field) noexcept {
       auto queryString = arangodb::aql::QueryString(_options.queryString);
       auto ast = _query->ast();
       TRI_ASSERT(ast);
-      Parser parser(*_query, *ast, queryString);
+      Parser parser(*_query, &_query->warnings(), *ast, queryString);
       parser.parse();
       AstNode* astRoot = const_cast<AstNode*>(ast->root());
       TRI_ASSERT(astRoot);

--- a/arangod/VocBase/ComputedValues.cpp
+++ b/arangod/VocBase/ComputedValues.cpp
@@ -179,7 +179,7 @@ ComputedValues::ComputedValue::ComputedValue(
   aql::Ast* ast = _queryContext->ast();
 
   auto qs = aql::QueryString(expressionString);
-  aql::Parser parser(*_queryContext, *ast, qs);
+  aql::Parser parser(*_queryContext, &_queryContext->warnings(), *ast, qs);
   // force the condition of the ternary operator (condition ? truePart :
   // falsePart) to be always inlined and not be extracted into its own LET node.
   // if we don't set this boolean flag here, then a ternary operator could

--- a/tests/Aql/ParserTest.cpp
+++ b/tests/Aql/ParserTest.cpp
@@ -58,7 +58,8 @@ TEST_F(ParserTest, parseSimpleTernaryCondition) {
   auto queryString =
       aql::QueryString(std::string_view("RETURN true ? 'true' : 'false'"));
 
-  aql::Parser parser(*queryContext, ast, queryString);
+  aql::Parser parser(*queryContext, &queryContext->warnings(), ast,
+                     queryString);
   ASSERT_FALSE(parser.lazyConditions().forceInline());
   parser.parse();
 
@@ -97,7 +98,8 @@ TEST_F(ParserTest, parseSimpleTernaryConditionForceInline) {
   auto queryString =
       aql::QueryString(std::string_view("RETURN true ? 'true' : 'false'"));
 
-  aql::Parser parser(*queryContext, ast, queryString);
+  aql::Parser parser(*queryContext, &queryContext->warnings(), ast,
+                     queryString);
   parser.lazyConditions().pushForceInline();
   ASSERT_TRUE(parser.lazyConditions().forceInline());
   parser.parse();
@@ -137,7 +139,8 @@ TEST_F(ParserTest, parseTernaryWithSubquery) {
   auto queryString = aql::QueryString(std::string_view(
       "RETURN true ? (FOR i IN 1..10 RETURN i) : (FOR j IN 1..2 RETURN j)"));
 
-  aql::Parser parser(*queryContext, ast, queryString);
+  aql::Parser parser(*queryContext, &queryContext->warnings(), ast,
+                     queryString);
   ASSERT_FALSE(parser.lazyConditions().forceInline());
   parser.parse();
 
@@ -258,7 +261,8 @@ TEST_F(ParserTest, parseTernaryWithSubqueryForceInline) {
   auto queryString = aql::QueryString(std::string_view(
       "RETURN true ? (FOR i IN 1..10 RETURN i) : (FOR j IN 1..2 RETURN j)"));
 
-  aql::Parser parser(*queryContext, ast, queryString);
+  aql::Parser parser(*queryContext, &queryContext->warnings(), ast,
+                     queryString);
   parser.lazyConditions().pushForceInline();
   ASSERT_TRUE(parser.lazyConditions().forceInline());
   parser.parse();


### PR DESCRIPTION
### Scope & Purpose

This PR exposes the dependency of the AQL query parser on the QueryWarnings object directly.

The registration of errors is simplified by throwing directly when the error occurs and not going through the warning object.

Enterprise Companion: https://github.com/arangodb/enterprise/pull/1689