### PR TITLE
CI: scan JS dependency trees on the PR path, bump trivy-scan orb to 1.6.0

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -5,7 +5,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@9.0.1
   # Exact pin: a floating orb range silently changes what runs. Keep in
   # sync with base_nightly_packages.yml.
-  trivy-scan: arangodb/trivy-scan@1.5.0
+  trivy-scan: arangodb/trivy-scan@1.6.0
 
 parameters:
   enterprise-commit:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -5,7 +5,7 @@ orbs:
   aws-ecr: circleci/aws-ecr@9.0.1
   # Exact pin: a floating orb range silently changes what runs. Keep in
   # sync with base_nightly_packages.yml.
-  trivy-scan: arangodb/trivy-scan@1.2.0
+  trivy-scan: arangodb/trivy-scan@1.5.0
 
 parameters:
   enterprise-commit:
@@ -695,6 +695,35 @@ jobs:
               exit 1
             fi
 
+  # PR-time CVE scan of the vendored JS dependency trees the PR path
+  # builds but nothing scans (the nightly gates cover packages and images,
+  # not these lockfiles). Warn-only until a measured baseline justifies a
+  # gate. scan-path stays pinned inside js/: the workspace also carries
+  # the enterprise checkout.
+  js-dependency-scan:
+    docker:
+      - image: cimg/base:current
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: .
+      - trivy-scan/scan:
+          scan-type: fs
+          scan-path: js/apps/system/_admin/aardvark/APP/react
+          scanners: vuln
+          expect-targets: yarn.lock
+          report-severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+          db-cache-fallback-branch: devel
+          output-prefix: aardvark-
+      - trivy-scan/scan:
+          scan-type: fs
+          scan-path: js/node
+          scanners: vuln
+          expect-targets: package-lock.json
+          report-severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+          db-cache-fallback-branch: devel
+          output-prefix: js-node-
+
   build-frontend:
     docker:
       - image: << pipeline.parameters.build-docker-image >>
@@ -1306,6 +1335,10 @@ workflows:
       - security-governance:
           name: security-governance
           context: [circleci-token]
+          requires:
+            - minimal-checkout
+      - js-dependency-scan:
+          name: js-dependency-scan
           requires:
             - minimal-checkout
 # all other workflows are defined in generate_config.py

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -168,7 +168,7 @@ orbs:
   # Exact pin: a floating orb range silently changes what gates the nightly
   # publish. 1.2.0 is the floor: 1.1.2's kev-epss-check fails closed on a
   # clean report and fails open on an empty threshold.
-  trivy-scan: arangodb/trivy-scan@1.2.0
+  trivy-scan: arangodb/trivy-scan@1.5.0
 
 parameters:
   enterprise-branch:

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -168,7 +168,7 @@ orbs:
   # Exact pin: a floating orb range silently changes what gates the nightly
   # publish. 1.2.0 is the floor: 1.1.2's kev-epss-check fails closed on a
   # clean report and fails open on an empty threshold.
-  trivy-scan: arangodb/trivy-scan@1.5.0
+  trivy-scan: arangodb/trivy-scan@1.6.0
 
 parameters:
   enterprise-branch:


### PR DESCRIPTION
### Scope & Purpose

CI only, two parts:

- Bump the pinned `trivy-scan` orb 1.2.0 to 1.5.0 in both base configs (kept in sync per the pin comments). The delta is parameter-gated and inert for the existing jobs: `disposition-check` and the nightly gate commands are unchanged and trivy itself stays pinned at v0.72.0.
- Add `js-dependency-scan` to the `lint` workflow: a warn-only Trivy fs scan of the two vendored JS dependency trees the PR path builds but nothing scans today, `js/apps/system/_admin/aardvark/APP/react` (yarn.lock) and `js/node` (package-lock.json). The nightly gates scan packages and images post-build; these lockfiles are the class of surface fixed recently in #23042/#23043. Scanners are pinned to `vuln` and scan-path to the two trees. Artifacts record the full severity band; the gate band stays CRITICAL/HIGH and `fail-on-findings` stays off, so the job reports and cannot go red on findings. Gate posture can be revisited once a baseline exists.

Notes for review: workflow names are unchanged, so the required checks (`x64-pr`, `aarch64-pr`) and `.circleci/required-checks.txt` are untouched; `lint` remains advisory. The generated continuation config was validated locally (generator run plus `circleci config validate`).

### Checklist

- Tests: not applicable, CI-only change
- CHANGELOG: not applicable
- Orb pin moved to 1.6.0 in this branch (engine trivy v0.73.0, checksum-paired).