### PR TITLE
[COR-806] implement can use api version

### DIFF
--- a/Documentation/path_permissions.md
+++ b/Documentation/path_permissions.md
@@ -270,6 +270,8 @@ return a `Result`, so that a decline can return the actual reason
  - `canModifyUserProfile(std::string_view user) -> Result`
  - `canGrantUserPermissions(std::string_view user) -> Result`
 
+ - `canUseApiVersion(uint32_t version) -> Result`
+
  - `isSuperuser() -> bool`
 
 Note that for now, `canSee*` is equivalent to `canUse*(RO)`. For

--- a/Documentation/path_permissions.md
+++ b/Documentation/path_permissions.md
@@ -206,20 +206,9 @@ enabled:
  - Every other change is an exception, which we (grudgingly) make because we
    found some issue with the current system.
  - There is an additional action `db:UseApiVersion` to configure, which roles
-   are allowed to use which API versions.
-   Every request of an authenticated identity is gated. It is asked in
-   `RestHandler::checkUserCanAccess`, right next to the database question, so
-   that the two can later be merged into a single question and hence a single
-   call to the RBAC service. Handlers that override `checkUserCanAccess` and
-   let an authenticated identity through without calling the base
-   implementation ask `ExecContext::canUseApiVersion` themselves
-   (`RestUsersHandler`, `RestClusterHandler`, `RestAccessTokenHandler`). 
-	 Requests without an identity are exempt: a login
-   via `/_open/auth`, a public path such as the Aardvark entry points or
-   `/_api/openapi.json`, and any request served while the server is still
-   starting up or in maintenance mode. There is no identity whose roles could
-   grant them a version, and whether they may proceed at all is decided by the
-   handler.
+   are allowed to use which API versions. Every request of an authenticated 
+	 identity is gated by an api version check. It is asked in
+   `RestHandler::checkApiVersionAccess`.
  
 This philosophy helps in the following ways:
  

--- a/Documentation/path_permissions.md
+++ b/Documentation/path_permissions.md
@@ -206,7 +206,20 @@ enabled:
  - Every other change is an exception, which we (grudgingly) make because we
    found some issue with the current system.
  - There is an additional action `db:UseApiVersion` to configure, which roles
-   are allowed to use which API versions (the API version is the resource)
+   are allowed to use which API versions.
+   Every request of an authenticated identity is gated. It is asked in
+   `RestHandler::checkUserCanAccess`, right next to the database question, so
+   that the two can later be merged into a single question and hence a single
+   call to the RBAC service. Handlers that override `checkUserCanAccess` and
+   let an authenticated identity through without calling the base
+   implementation ask `ExecContext::canUseApiVersion` themselves
+   (`RestUsersHandler`, `RestClusterHandler`, `RestAccessTokenHandler`). 
+	 Requests without an identity are exempt: a login
+   via `/_open/auth`, a public path such as the Aardvark entry points or
+   `/_api/openapi.json`, and any request served while the server is still
+   starting up or in maintenance mode. There is no identity whose roles could
+   grant them a version, and whether they may proceed at all is decided by the
+   handler.
  
 This philosophy helps in the following ways:
  

--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -140,12 +140,24 @@ bool isPublicAardvarkPath(std::string_view path) {
 }
 
 async<Result> RestActionHandler::checkUserCanAccess() const {
+  auto const canUseApiVersion = [this]() -> Result {
+    // this function is reachable before logging in when there is no identity to
+    // check api version against
+    if (!request()->authenticated()) {
+      return {};
+    }
+    auto const ec = request()->requestContext();
+    TRI_ASSERT(ec != nullptr);
+    return ec->canUseApiVersion(request()->requestedApiVersion());
+  };
+
   auto const& path = request()->requestPath();
   if (isPublicAardvarkPath(path)) {
     // Note that we do **not** escalate to superuser for these!
-    co_return Result{};
+    co_return canUseApiVersion();
   }
 
+  // does api version check internally
   auto r = co_await RestHandler::checkUserCanAccess();
   if (r.ok()) {
     co_return r;
@@ -156,6 +168,11 @@ async<Result> RestActionHandler::checkUserCanAccess() const {
   if (auth->authenticationSystemOnly()) {  // TODO remove in 4.0
     // check if path is / which is required for the web UI to get started
     if (!path.empty() && !path.starts_with("/_")) {
+      // Escalating to superuser must not hand out an API version the identity
+      // is not allowed to use - `r` may well be that very denial.
+      if (auto res = canUseApiVersion(); res.fail()) {
+        co_return res;
+      }
       _mustEscalateToSuperuser = true;
       co_return Result{};
     }

--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -140,24 +140,12 @@ bool isPublicAardvarkPath(std::string_view path) {
 }
 
 async<Result> RestActionHandler::checkUserCanAccess() const {
-  auto const canUseApiVersion = [this]() -> Result {
-    // this function is reachable before logging in when there is no identity to
-    // check api version against
-    if (!request()->authenticated()) {
-      return {};
-    }
-    auto const ec = request()->requestContext();
-    TRI_ASSERT(ec != nullptr);
-    return ec->canUseApiVersion(request()->requestedApiVersion());
-  };
-
   auto const& path = request()->requestPath();
   if (isPublicAardvarkPath(path)) {
     // Note that we do **not** escalate to superuser for these!
-    co_return canUseApiVersion();
+    co_return Result{};
   }
 
-  // does api version check internally
   auto r = co_await RestHandler::checkUserCanAccess();
   if (r.ok()) {
     co_return r;
@@ -168,11 +156,6 @@ async<Result> RestActionHandler::checkUserCanAccess() const {
   if (auth->authenticationSystemOnly()) {  // TODO remove in 4.0
     // check if path is / which is required for the web UI to get started
     if (!path.empty() && !path.starts_with("/_")) {
-      // Escalating to superuser must not hand out an API version the identity
-      // is not allowed to use - `r` may well be that very denial.
-      if (auto res = canUseApiVersion(); res.fail()) {
-        co_return res;
-      }
       _mustEscalateToSuperuser = true;
       co_return Result{};
     }

--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -139,26 +139,42 @@ bool isPublicAardvarkPath(std::string_view path) {
                              [&](auto p) { return path.starts_with(p); });
 }
 
-async<Result> RestActionHandler::checkUserCanAccess() const {
-  auto const& path = request()->requestPath();
-  if (isPublicAardvarkPath(path)) {
+async<RestHandler::AuthenticationGrant>
+RestActionHandler::checkUserAuthentication() const {
+  if (isPublicAardvarkPath(request()->requestPath())) {
     // Note that we do **not** escalate to superuser for these!
+    co_return AuthenticationGrant::GRANTED_EARLY;
+  }
+
+  co_return co_await RestHandler::checkUserAuthentication();
+}
+
+bool RestActionHandler::hasAllowedUnauthenticatedPath() const {
+  auto const* const auth = AuthenticationFeature::instance();
+  ADB_PROD_ASSERT(auth->isActive());
+  auto const& path = request()->requestPath();
+  return auth->authenticationSystemOnly() &&  // TODO remove in 4.0
+         !path.empty() && !path.starts_with("/_");
+}
+
+async<Result> RestActionHandler::checkApiVersionAccess() const {
+  if (hasAllowedUnauthenticatedPath()) {
     co_return Result{};
   }
 
-  auto r = co_await RestHandler::checkUserCanAccess();
+  co_return co_await RestHandler::checkApiVersionAccess();
+}
+
+async<Result> RestActionHandler::checkDatabaseAccess() const {
+  auto r = co_await RestHandler::checkDatabaseAccess();
   if (r.ok()) {
-    co_return r;
+    co_return Result{};
   }
 
-  auto const* const auth = AuthenticationFeature::instance();
-  ADB_PROD_ASSERT(auth->isActive());
-  if (auth->authenticationSystemOnly()) {  // TODO remove in 4.0
+  if (hasAllowedUnauthenticatedPath()) {
     // check if path is / which is required for the web UI to get started
-    if (!path.empty() && !path.starts_with("/_")) {
-      _mustEscalateToSuperuser = true;
-      co_return Result{};
-    }
+    _mustEscalateToSuperuser = true;
+    co_return Result{};
   }
   co_return r;
 }

--- a/arangod/Actions/RestActionHandler.cpp
+++ b/arangod/Actions/RestActionHandler.cpp
@@ -139,6 +139,14 @@ bool isPublicAardvarkPath(std::string_view path) {
                              [&](auto p) { return path.starts_with(p); });
 }
 
+bool RestActionHandler::hasAllowedUnauthenticatedPath() const {
+  auto const* const auth = AuthenticationFeature::instance();
+  ADB_PROD_ASSERT(auth->isActive());
+  auto const& path = request()->requestPath();
+  return auth->authenticationSystemOnly() &&  // TODO remove in 4.0
+         !path.empty() && !path.starts_with("/_");
+}
+
 async<RestHandler::AuthenticationGrant>
 RestActionHandler::checkUserAuthentication() const {
   if (isPublicAardvarkPath(request()->requestPath())) {
@@ -146,15 +154,14 @@ RestActionHandler::checkUserAuthentication() const {
     co_return AuthenticationGrant::GRANTED_EARLY;
   }
 
-  co_return co_await RestHandler::checkUserAuthentication();
-}
+  auto auth = co_await RestHandler::checkUserAuthentication();
+  if (auth == AuthenticationGrant::DENIED) {
+    if (hasAllowedUnauthenticatedPath()) {
+      co_return AuthenticationGrant::GRANTED;
+    }
+  }
 
-bool RestActionHandler::hasAllowedUnauthenticatedPath() const {
-  auto const* const auth = AuthenticationFeature::instance();
-  ADB_PROD_ASSERT(auth->isActive());
-  auto const& path = request()->requestPath();
-  return auth->authenticationSystemOnly() &&  // TODO remove in 4.0
-         !path.empty() && !path.starts_with("/_");
+  co_return auth;
 }
 
 async<Result> RestActionHandler::checkApiVersionAccess() const {
@@ -166,6 +173,11 @@ async<Result> RestActionHandler::checkApiVersionAccess() const {
 }
 
 async<Result> RestActionHandler::checkDatabaseAccess() const {
+  if (isPublicAardvarkPath(request()->requestPath())) {
+    // Note that we do **not** escalate to superuser for these!
+    co_return Result{};
+  }
+
   auto r = co_await RestHandler::checkDatabaseAccess();
   if (r.ok()) {
     co_return Result{};

--- a/arangod/Actions/RestActionHandler.h
+++ b/arangod/Actions/RestActionHandler.h
@@ -42,11 +42,15 @@ class RestActionHandler : public RestVocbaseBaseHandler {
   void cancel() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override;
+  async<Result> checkApiVersionAccess() const override;
+  async<Result> checkDatabaseAccess() const override;
 
  private:
   // executes an action
   void executeAction();
+  bool hasAllowedUnauthenticatedPath() const;
 
  protected:
   // action

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -241,6 +241,9 @@ auto describe(auth::perms::ModifyUserProfile const& perm) -> std::string {
 auto describe(auth::perms::GrantUserPermissions const& perm) -> std::string {
   return std::format("grant permissions to user '{}'", perm.name);
 }
+auto describe(auth::perms::UseApiVersion const& perm) -> std::string {
+  return std::format("use API version '{}'", perm.version);
+}
 auto failureMessage(auto const& request, std::string_view reason)
     -> std::string {
   return std::format("Failed to {}. {}", describe(request), reason);
@@ -916,6 +919,10 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
                 auth::perms::UseDatabase{.name = StaticStrings::SystemDatabase,
                                          .level = DatabaseAccessLevel::Write});
           },
+          [&](p::UseApiVersion const& /*apiVersion*/) -> Result {
+            // The classic system does not restrict API versions
+            return {};
+          },
       },
       permission);
 }
@@ -1289,6 +1296,11 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
           [&](p::GrantUserPermissions const& user) -> Result {
             return checkOne(rbac::Action::WriteMeta,
                             rbac::resources::User{user.name});
+          },
+          // -- API versions ----------------------------------------------
+          [&](p::UseApiVersion const& apiVersion) -> Result {
+            return checkOne(rbac::Action::UseApiVersion,
+                            rbac::resources::ApiVersion{apiVersion.version});
           },
       },
       permission);

--- a/arangod/Auth/Permissions.cpp
+++ b/arangod/Auth/Permissions.cpp
@@ -262,6 +262,11 @@ std::ostream& operator<<(std::ostream& os, Permission const& permission) {
           [&](GrantUserPermissions const& p) {
             os << "GrantUserPermissions name=" << p.name;
           },
+
+          // api versions
+          [&](UseApiVersion const& p) {
+            os << "UseApiVersion version=" << p.version;
+          },
       },
       permission);
   return os;

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -24,6 +24,7 @@
 
 #include "Basics/Meta/TypeList.h"
 
+#include <cstdint>
 #include <iosfwd>
 #include <span>
 #include <string>
@@ -346,6 +347,15 @@ struct GrantUserPermissions {
   std::string name;
 };
 
+// ---------------------------------------------------------------------------
+// API versions
+// ---------------------------------------------------------------------------
+
+// Grant permission to a specific api version
+struct UseApiVersion {
+  uint32_t version;
+};
+
 namespace detail {
 // Currently there's no need to subdivide this list, but feel free to
 // do that when it becomes useful.
@@ -363,7 +373,9 @@ using NonAdminList = meta::TypeList<
     // graph permissions
     SeeGraph, CreateGraph, DropGraph, UseGraph,
     // user permissions
-    ReadUser, CreateUser, DropUser, ModifyUserProfile, GrantUserPermissions>;
+    ReadUser, CreateUser, DropUser, ModifyUserProfile, GrantUserPermissions,
+    // api version permissions
+    UseApiVersion>;
 
 using CompleteList = meta::detail::Union<AdminList, NonAdminList>::type;
 }  // namespace detail

--- a/arangod/Auth/Rbac/Actions.h
+++ b/arangod/Auth/Rbac/Actions.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <variant>
 
@@ -103,12 +104,16 @@ struct User {
   std::string_view name;
 };
 
+struct ApiVersion {
+  uint32_t version;
+};
+
 }  // namespace resources
 
 using Resource =
     std::variant<resources::NoResource, resources::Database,
                  resources::Collection, resources::View, resources::Analyzer,
-                 resources::Graph, resources::User>;
+                 resources::Graph, resources::User, resources::ApiVersion>;
 
 // A single authorization question: may the token perform `action` on
 // `resource`? A permission check may consist of several of these, which are

--- a/arangod/Auth/Rbac/ServiceImpl.cpp
+++ b/arangod/Auth/Rbac/ServiceImpl.cpp
@@ -138,6 +138,9 @@ auto resourceToWireString(Resource const& resource) -> std::string {
           [](resources::User const& r) {
             return std::format("db:user:{}", r.name);
           },
+          [](resources::ApiVersion const& r) {
+            return std::format("db:apiversion:{}", r.version);
+          },
       },
       resource);
 }

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -136,11 +136,8 @@ async<Result> RestClusterHandler::checkUserCanAccess() const {
   auto const& suffixes = _request->suffixes();
   if (_request->authenticated() && suffixes.size() == 1 &&
       suffixes[0] == "endpoints") {
-    // endpoint shall be available to all authenticated users - but still only
-    // via an API version they may use
-    auto const ec = _request->requestContext();
-    ADB_PROD_ASSERT(ec != nullptr);
-    co_return ec->canUseApiVersion(_request->requestedApiVersion());
+    // endpoint shall be available to all authenticated users
+    co_return Result{};
   }
 
   co_return co_await RestBaseHandler::checkUserCanAccess();

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -132,7 +132,7 @@ RestStatus RestClusterHandler::execute() {
   return RestStatus::DONE;
 }
 
-async<Result> RestClusterHandler::checkUserCanAccess() const {
+async<Result> RestClusterHandler::checkDatabaseAccess() const {
   auto const& suffixes = _request->suffixes();
   if (_request->authenticated() && suffixes.size() == 1 &&
       suffixes[0] == "endpoints") {
@@ -140,7 +140,7 @@ async<Result> RestClusterHandler::checkUserCanAccess() const {
     co_return Result{};
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  co_return co_await RestHandler::checkDatabaseAccess();
 }
 
 void RestClusterHandler::handleAgencyDump() {

--- a/arangod/Cluster/RestClusterHandler.cpp
+++ b/arangod/Cluster/RestClusterHandler.cpp
@@ -136,8 +136,11 @@ async<Result> RestClusterHandler::checkUserCanAccess() const {
   auto const& suffixes = _request->suffixes();
   if (_request->authenticated() && suffixes.size() == 1 &&
       suffixes[0] == "endpoints") {
-    // endpoint shall be available to all authenticated users
-    co_return Result{};
+    // endpoint shall be available to all authenticated users - but still only
+    // via an API version they may use
+    auto const ec = _request->requestContext();
+    ADB_PROD_ASSERT(ec != nullptr);
+    co_return ec->canUseApiVersion(_request->requestedApiVersion());
   }
 
   co_return co_await RestBaseHandler::checkUserCanAccess();

--- a/arangod/Cluster/RestClusterHandler.h
+++ b/arangod/Cluster/RestClusterHandler.h
@@ -36,7 +36,7 @@ class RestClusterHandler : public arangodb::RestBaseHandler {
   RestStatus execute() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<Result> checkDatabaseAccess() const override;
 
  private:
   /// _api/cluster/endpoints

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -747,6 +747,15 @@ async<Result> RestHandler::checkApiVersionAccess() const {
     // the allowed api version
     co_return Result{};
   }
+
+  // During startup (or in maintenance mode) the AuthenticationFeature might not
+  // yet be available for authorization, and must not be consulted.
+  if (auto const mode = ServerState::instance()->mode();
+      mode == ServerState::Mode::STARTUP ||
+      mode == ServerState::Mode::MAINTENANCE) {
+    co_return Result{};
+  }
+
   auto ec = request()->requestContext();
   TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
   auto res = ec->canUseApiVersion(request()->requestedApiVersion());

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -703,11 +703,12 @@ void RestHandler::compressResponse() {
   }
 }
 
-async<Result> RestHandler::checkUserCanAccess() const {
+async<RestHandler::AuthenticationGrant> RestHandler::checkUserAuthentication()
+    const {
   auto const* const auth = AuthenticationFeature::instance();
   ADB_PROD_ASSERT(auth != nullptr);
   if (!auth->isActive()) {
-    co_return Result();
+    co_return AuthenticationGrant::GRANTED_EARLY;
   }
 
 #ifdef ARANGODB_HAVE_DOMAIN_SOCKETS
@@ -715,14 +716,29 @@ async<Result> RestHandler::checkUserCanAccess() const {
   if (ci.endpointType == Endpoint::DomainType::UNIX &&
       !auth->authenticationUnixSockets()) {
     // no authentication required for unix domain socket connections
-    co_return Result{};
+    co_return AuthenticationGrant::GRANTED_EARLY;
   }
 #endif
 
-  if (not request()->authenticated()) {
-    co_return Result(TRI_ERROR_HTTP_UNAUTHORIZED, "User not authenticated.");
+  if (request()->authenticated()) {
+    co_return AuthenticationGrant::GRANTED;
   }
 
+  co_return AuthenticationGrant::DENIED;
+}
+
+async<Result> RestHandler::checkApiVersionAccess() const {
+  auto ec = request()->requestContext();
+  TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
+  auto res = ec->canUseApiVersion(request()->requestedApiVersion());
+  if (res.fail()) {
+    LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
+        << "API version forbidden for " << request()->requestPath();
+  }
+  co_return res;
+}
+
+async<Result> RestHandler::checkDatabaseAccess() const {
   auto ec = request()->requestContext();
   TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
   auto canUseDB =
@@ -741,39 +757,28 @@ async<Result> RestHandler::checkUserCanAccess() const {
   }
 }
 
-async<Result> RestHandler::checkApiVersionAccess() const {
-  if (not request()->authenticated()) {
-    // if we are not authenticated, we don't have a user for which to check
-    // the allowed api version
-    co_return Result{};
-  }
-
-  // During startup (or in maintenance mode) the AuthenticationFeature might not
-  // yet be available for authorization, and must not be consulted.
-  if (auto const mode = ServerState::instance()->mode();
-      mode == ServerState::Mode::STARTUP ||
-      mode == ServerState::Mode::MAINTENANCE) {
-    co_return Result{};
-  }
-
-  auto ec = request()->requestContext();
-  TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
-  auto res = ec->canUseApiVersion(request()->requestedApiVersion());
-  if (res.fail()) {
-    LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
-        << "API version forbidden for " << request()->requestPath();
-  }
-  co_return res;
-}
-
 async<void> RestHandler::handleAuthorizationChecks() {
+  auto auth = co_await checkUserAuthentication();
+  if (auth == AuthenticationGrant::GRANTED_EARLY) {
+    co_return;
+  }
+
+  if (auth == AuthenticationGrant::DENIED) {
+    _state = HandlerState::FAILED;
+    events::NotAuthorized(*_request);
+    generateError(rest::ResponseCode::UNAUTHORIZED, TRI_ERROR_FORBIDDEN,
+                  "User not authenticated");
+    co_return;
+  }
+
   if (auto res = co_await checkApiVersionAccess(); res.fail()) {
     _state = HandlerState::FAILED;
     events::NotAuthorized(*_request);
     generateError(res);
     co_return;
   }
-  if (auto res = co_await checkUserCanAccess(); res.fail()) {
+
+  if (auto res = co_await checkDatabaseAccess(); res.fail()) {
     _state = HandlerState::FAILED;
     events::NotAuthorized(*_request);
     if (_request->requestedApiVersion() == 0) {

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -723,6 +723,13 @@ async<Result> RestHandler::checkUserCanAccess() const {
 
   auto ec = request()->requestContext();
   TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
+  if (auto res = ec->canUseApiVersion(request()->requestedApiVersion());
+      res.fail()) {
+    LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
+        << "API version forbidden for " << request()->requestPath();
+    co_return res;
+  }
+
   auto canUseDB =
       ec->canUseDatabase(request()->databaseName(), DatabaseAccessLevel::Read);
   if (canUseDB.ok()) {

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -725,13 +725,6 @@ async<Result> RestHandler::checkUserCanAccess() const {
 
   auto ec = request()->requestContext();
   TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
-  if (auto res = ec->canUseApiVersion(request()->requestedApiVersion());
-      res.fail()) {
-    LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
-        << "API version forbidden for " << request()->requestPath();
-    co_return res;
-  }
-
   auto canUseDB =
       ec->canUseDatabase(request()->databaseName(), DatabaseAccessLevel::Read);
   if (canUseDB.ok()) {
@@ -748,7 +741,29 @@ async<Result> RestHandler::checkUserCanAccess() const {
   }
 }
 
+async<Result> RestHandler::checkApiVersionAccess() const {
+  if (not request()->authenticated()) {
+    // if we are not authenticated, we don't have a user for which to check
+    // the allowed api version
+    co_return Result{};
+  }
+  auto ec = request()->requestContext();
+  TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
+  auto res = ec->canUseApiVersion(request()->requestedApiVersion());
+  if (res.fail()) {
+    LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
+        << "API version forbidden for " << request()->requestPath();
+  }
+  co_return res;
+}
+
 async<void> RestHandler::handleAuthorizationChecks() {
+  if (auto res = co_await checkApiVersionAccess(); res.fail()) {
+    _state = HandlerState::FAILED;
+    events::NotAuthorized(*_request);
+    generateError(res);
+    co_return;
+  }
   if (auto res = co_await checkUserCanAccess(); res.fail()) {
     _state = HandlerState::FAILED;
     events::NotAuthorized(*_request);

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -25,6 +25,7 @@
 #include "Activities/GenericActivity.h"
 #include "Activities/RegistryGlobalVariable.h"
 #include "ApplicationFeatures/ApplicationServer.h"
+#include "Assertions/ProdAssert.h"
 #include "Auth/TokenCache.h"
 #include "Basics/DownCast.h"
 #include "Basics/dtrace-wrapper.h"
@@ -704,6 +705,7 @@ void RestHandler::compressResponse() {
 
 async<Result> RestHandler::checkUserCanAccess() const {
   auto const* const auth = AuthenticationFeature::instance();
+  ADB_PROD_ASSERT(auth != nullptr);
   if (!auth->isActive()) {
     co_return Result();
   }

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -191,12 +191,10 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   auto executeEngine() -> async<void>;
   void compressResponse();
 
-  /// @brief some rest handlers want specific user checks. by default,
-  ///        check that user is authenticated and has db access
-  virtual async<Result> checkUserCanAccess() const;
-
-  /// @brif some rest handlers want specific api version checks
+  enum class AuthenticationGrant { DENIED, GRANTED, GRANTED_EARLY };
+  virtual async<AuthenticationGrant> checkUserAuthentication() const;
   virtual async<Result> checkApiVersionAccess() const;
+  virtual async<Result> checkDatabaseAccess() const;
 
   // The ValueBuilder, as it is, is unsuitable for composition. By composition,
   // I mean, for example, creating a builder in the base class with certain

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -56,6 +56,7 @@ class Future;
 template<typename>
 struct async;
 
+class AuthenticationFeature;
 class GeneralRequest;
 class RequestStatistics;
 class Result;

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -192,9 +192,11 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   void compressResponse();
 
   /// @brief some rest handlers want specific user checks. by default,
-  ///        check that user is authenticated, has db access and whether the
-  ///        identity may use the API version this request addresses.
+  ///        check that user is authenticated and has db access
   virtual async<Result> checkUserCanAccess() const;
+
+  /// @brif some rest handlers want specific api version checks
+  virtual async<Result> checkApiVersionAccess() const;
 
   // The ValueBuilder, as it is, is unsuitable for composition. By composition,
   // I mean, for example, creating a builder in the base class with certain

--- a/arangod/GeneralServer/RestHandler.h
+++ b/arangod/GeneralServer/RestHandler.h
@@ -191,7 +191,8 @@ class RestHandler : public std::enable_shared_from_this<RestHandler> {
   void compressResponse();
 
   /// @brief some rest handlers want specific user checks. by default,
-  ///        check db access
+  ///        check that user is authenticated, has db access and whether the
+  ///        identity may use the API version this request addresses.
   virtual async<Result> checkUserCanAccess() const;
 
   // The ValueBuilder, as it is, is unsuitable for composition. By composition,

--- a/arangod/RestHandler/RestAccessTokenHandler.cpp
+++ b/arangod/RestHandler/RestAccessTokenHandler.cpp
@@ -99,12 +99,9 @@ RestStatus RestAccessTokenHandler::execute() {
 }
 
 async<Result> RestAccessTokenHandler::checkUserCanAccess() const {
-  // This API only requires the user to be authenticated and use an allowed
-  // api version
+  // This API only requires the user to be authenticated
   if (request()->authenticated()) {
-    auto const ec = request()->requestContext();
-    ADB_PROD_ASSERT(ec != nullptr);
-    co_return ec->canUseApiVersion(request()->requestedApiVersion());
+    co_return Result{};
   }
 
   co_return Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};

--- a/arangod/RestHandler/RestAccessTokenHandler.cpp
+++ b/arangod/RestHandler/RestAccessTokenHandler.cpp
@@ -99,9 +99,12 @@ RestStatus RestAccessTokenHandler::execute() {
 }
 
 async<Result> RestAccessTokenHandler::checkUserCanAccess() const {
-  // This API only requires the user to be authenticated
+  // This API only requires the user to be authenticated and use an allowed
+  // api version
   if (request()->authenticated()) {
-    co_return Result{};
+    auto const ec = request()->requestContext();
+    ADB_PROD_ASSERT(ec != nullptr);
+    co_return ec->canUseApiVersion(request()->requestedApiVersion());
   }
 
   co_return Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};

--- a/arangod/RestHandler/RestAccessTokenHandler.cpp
+++ b/arangod/RestHandler/RestAccessTokenHandler.cpp
@@ -98,15 +98,6 @@ RestStatus RestAccessTokenHandler::execute() {
   }
 }
 
-async<Result> RestAccessTokenHandler::checkUserCanAccess() const {
-  // This API only requires the user to be authenticated
-  if (request()->authenticated()) {
-    co_return Result{};
-  }
-
-  co_return Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};
-}
-
 RestStatus RestAccessTokenHandler::showAccessTokens(auth::UserManager* um,
                                                     std::string const& user) {
   VPackBuilder tokens;

--- a/arangod/RestHandler/RestAccessTokenHandler.h
+++ b/arangod/RestHandler/RestAccessTokenHandler.h
@@ -39,7 +39,7 @@ class RestAccessTokenHandler : public RestVocbaseBaseHandler {
   RestStatus execute() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<Result> checkDatabaseAccess() const override { co_return Result{}; }
 
  private:
   RestStatus createAccessToken(auth::UserManager*, std::string const& user);

--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -79,16 +79,17 @@ RestStatus RestAdminServerHandler::execute() {
   return RestStatus::DONE;
 }
 
-async<Result> RestAdminServerHandler::checkUserCanAccess() const {
+async<RestHandler::AuthenticationGrant>
+RestAdminServerHandler::checkUserAuthentication() const {
   auto const& suffixes = _request->suffixes();
   if (suffixes.size() == 1 && suffixes[0] == "availability") {
     auto ec = _request->requestContext();
     TRI_ASSERT(ec != nullptr);
     ec->forceSuperuser();
-    co_return Result{};
+    co_return AuthenticationGrant::GRANTED_EARLY;
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  co_return co_await RestBaseHandler::checkUserAuthentication();
 }
 
 void RestAdminServerHandler::writeModeResult(bool readOnly) {

--- a/arangod/RestHandler/RestAdminServerHandler.h
+++ b/arangod/RestHandler/RestAdminServerHandler.h
@@ -44,7 +44,8 @@ class RestAdminServerHandler : public RestBaseHandler {
   RestStatus execute() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override;
 
  private:
   void handleMode();

--- a/arangod/RestHandler/RestAuthHandler.cpp
+++ b/arangod/RestHandler/RestAuthHandler.cpp
@@ -201,11 +201,12 @@ RestStatus RestAuthHandler::execute() {
   return RestStatus::DONE;
 }
 
-async<Result> RestAuthHandler::checkUserCanAccess() const {
+async<RestHandler::AuthenticationGrant>
+RestAuthHandler::checkUserAuthentication() const {
   auto ec = _request->requestContext();
   TRI_ASSERT(ec != nullptr);
   ec->forceSuperuser();
-  co_return Result{};
+  co_return AuthenticationGrant::GRANTED;
 }
 
 std::string RestAuthHandler::generateJwt(

--- a/arangod/RestHandler/RestAuthHandler.h
+++ b/arangod/RestHandler/RestAuthHandler.h
@@ -38,7 +38,10 @@ class RestAuthHandler : public RestVocbaseBaseHandler {
   RestStatus execute() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override;
+  async<Result> checkApiVersionAccess() const override { co_return Result{}; }
+  async<Result> checkDatabaseAccess() const override { co_return Result{}; }
 
  private:
   std::string generateJwt(std::string const& username,

--- a/arangod/RestHandler/RestDebugHandler.cpp
+++ b/arangod/RestHandler/RestDebugHandler.cpp
@@ -36,19 +36,20 @@ RestDebugHandler::RestDebugHandler(
     GeneralResponse* response)
     : RestBaseHandler(server, request, response) {}
 
-async<Result> RestDebugHandler::checkUserCanAccess() const {
+async<RestHandler::AuthenticationGrant>
+RestDebugHandler::checkUserAuthentication() const {
   // Note that this particular RestHandler might be called during startup (or
   // in maintenance mode). The AuthenticationFeature might not yet be available
   // for authorization, and must not be consulted.
-  if (auto const mode = ServerState::instance()->mode();
+  if (auto const mode = ServerState::mode();
       mode == ServerState::Mode::STARTUP ||
       mode == ServerState::Mode::MAINTENANCE) {
-    co_return request()->authenticated()
-        ? Result{}
-        : Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};
+    co_return request()->authenticated()  // with JWT can also be authenticated
+        ? AuthenticationGrant::GRANTED_EARLY
+        : AuthenticationGrant::DENIED;
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  co_return co_await RestBaseHandler::checkUserAuthentication();
 }
 
 // Mounted at /_admin/debug (prefix, only when ARANGODB_ENABLE_FAILURE_TESTS is

--- a/arangod/RestHandler/RestDebugHandler.h
+++ b/arangod/RestHandler/RestDebugHandler.h
@@ -31,7 +31,8 @@ class RestDebugHandler : public arangodb::RestBaseHandler {
                    GeneralResponse*);
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override;
 
  public:
   char const* name() const override final { return "RestDebugHandler"; }

--- a/arangod/RestHandler/RestOpenApiHandler.cpp
+++ b/arangod/RestHandler/RestOpenApiHandler.cpp
@@ -49,20 +49,6 @@ RestOpenApiHandler::RestOpenApiHandler(
     GeneralResponse* response)
     : RestBaseHandler(server, request, response) {}
 
-namespace {
-constexpr std::string_view kOpenApiJsonPath("/openapi.json");
-}  // namespace
-
-// The OpenAPI spec must be reachable without authentication, so that
-// clients (and the API documentation) can retrieve it before logging in.
-async<Result> RestOpenApiHandler::checkUserCanAccess() const {
-  if (request()->requestPath() == kOpenApiJsonPath) {
-    co_return Result{};
-  }
-
-  co_return co_await RestBaseHandler::checkUserCanAccess();
-}
-
 std::string_view RestOpenApiHandler::getOpenApiSpec(uint32_t apiVersion) const {
   switch (apiVersion) {
     case 0:

--- a/arangod/RestHandler/RestOpenApiHandler.h
+++ b/arangod/RestHandler/RestOpenApiHandler.h
@@ -38,7 +38,14 @@ class RestOpenApiHandler : public arangodb::RestBaseHandler {
   futures::Future<futures::Unit> executeAsync() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  // The OpenAPI spec must be reachable without authentication, so that
+  // clients (and the API documentation) can retrieve it before logging in.
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override {
+    co_return AuthenticationGrant::GRANTED;
+  }
+  async<Result> checkApiVersionAccess() const override { co_return Result{}; }
+  async<Result> checkDatabaseAccess() const override { co_return Result{}; }
 
  private:
   std::string_view getOpenApiSpec(uint32_t apiVersion) const;

--- a/arangod/RestHandler/RestStatusHandler.cpp
+++ b/arangod/RestHandler/RestStatusHandler.cpp
@@ -86,19 +86,20 @@ RestStatus RestStatusHandler::execute() {
   }
 }
 
-async<Result> RestStatusHandler::checkUserCanAccess() const {
+async<RestHandler::AuthenticationGrant>
+RestStatusHandler::checkUserAuthentication() const {
   // Note that this particular RestHandler might be called during startup (or
   // in maintenance mode). The AuthenticationFeature might not yet be available
   // for authorization, and must not be consulted.
-  if (auto const mode = ServerState::instance()->mode();
+  if (auto const mode = ServerState::mode();
       mode == ServerState::Mode::STARTUP ||
       mode == ServerState::Mode::MAINTENANCE) {
-    co_return request()->authenticated()
-        ? Result{}
-        : Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};
+    co_return request()->authenticated()  // with JWT can also be authenticated
+        ? AuthenticationGrant::GRANTED_EARLY
+        : AuthenticationGrant::DENIED;
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  co_return co_await RestBaseHandler::checkUserAuthentication();
 }
 
 RestStatus RestStatusHandler::executeStandard(ServerSecurityFeature& security) {

--- a/arangod/RestHandler/RestStatusHandler.h
+++ b/arangod/RestHandler/RestStatusHandler.h
@@ -39,7 +39,8 @@ class RestStatusHandler : public arangodb::RestBaseHandler {
   RestStatus execute() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override;
 
  private:
   RestStatus executeStandard(ServerSecurityFeature&);

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -110,7 +110,7 @@ RestStatus RestUsersHandler::execute() {
   }
 }
 
-async<Result> RestUsersHandler::checkUserCanAccess() const {
+async<Result> RestUsersHandler::checkDatabaseAccess() const {
   constexpr std::string_view pathPrefixApiUser("/_api/user/");
 
   auto const& path = _request->requestPath();
@@ -121,7 +121,7 @@ async<Result> RestUsersHandler::checkUserCanAccess() const {
     co_return Result{};
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  co_return co_await RestBaseHandler::checkDatabaseAccess();
 }
 
 /// helper to generate a compliant response for individual user requests

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -116,7 +116,11 @@ async<Result> RestUsersHandler::checkUserCanAccess() const {
   auto const& path = _request->requestPath();
 
   if (_request->authenticated() && path.starts_with(pathPrefixApiUser)) {
-    co_return Result{};
+    // No database access is required here (everybody may e.g. change their own
+    // password), but the API version gate still applies
+    auto const ec = _request->requestContext();
+    TRI_ASSERT(ec != nullptr);
+    co_return ec->canUseApiVersion(_request->requestedApiVersion());
   }
 
   co_return co_await RestBaseHandler::checkUserCanAccess();

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -117,10 +117,8 @@ async<Result> RestUsersHandler::checkUserCanAccess() const {
 
   if (_request->authenticated() && path.starts_with(pathPrefixApiUser)) {
     // No database access is required here (everybody may e.g. change their own
-    // password), but the API version gate still applies
-    auto const ec = _request->requestContext();
-    TRI_ASSERT(ec != nullptr);
-    co_return ec->canUseApiVersion(_request->requestedApiVersion());
+    // password)
+    co_return Result{};
   }
 
   co_return co_await RestBaseHandler::checkUserCanAccess();

--- a/arangod/RestHandler/RestUsersHandler.h
+++ b/arangod/RestHandler/RestUsersHandler.h
@@ -40,7 +40,7 @@ class RestUsersHandler : public arangodb::RestBaseHandler {
   RestStatus execute() override;
 
  protected:
-  async<Result> checkUserCanAccess() const override;
+  async<Result> checkDatabaseAccess() const override;
 
  private:
   // helper to generate a compliant response for individual user requests

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -139,7 +139,7 @@ async<Result> RestVersionHandler::checkUserCanAccess() const {
   auto version = request()->requestedApiVersion();
   if (auto res = ec->canUseApiVersion(version); res.fail()) {
     if (version != api_version::defaultApiVersion) {
-      LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
+      LOG_TOPIC("4b1a7", TRACE, Logger::AUTHORIZATION)
           << "API version forbidden for " << request()->requestPath();
       co_return res;
     }

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -22,7 +22,9 @@
 
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Cluster/ServerState.h"
+#include "GeneralServer/AuthenticationFeature.h"
 #include "GeneralServer/ServerSecurityFeature.h"
+#include "Logger/LogMacros.h"
 #include "Rest/ApiVersion.h"
 #include "Rest/Version.h"
 #include "RestServer/ServerFeature.h"
@@ -112,7 +114,51 @@ async<Result> RestVersionHandler::checkUserCanAccess() const {
         : Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  auto const* const auth = AuthenticationFeature::instance();
+  ADB_PROD_ASSERT(auth != nullptr);
+  if (!auth->isActive()) {
+    co_return Result();
+  }
+
+#ifdef ARANGODB_HAVE_DOMAIN_SOCKETS
+  auto const& ci = request()->connectionInfo();
+  if (ci.endpointType == Endpoint::DomainType::UNIX &&
+      !auth->authenticationUnixSockets()) {
+    // no authentication required for unix domain socket connections
+    co_return Result{};
+  }
+#endif
+
+  if (not request()->authenticated()) {
+    Result(TRI_ERROR_HTTP_UNAUTHORIZED, "User not authenticated.");
+  }
+
+  auto ec = request()->requestContext();
+  TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
+  // here we allow default version
+  auto version = request()->requestedApiVersion();
+  if (auto res = ec->canUseApiVersion(version); res.fail()) {
+    if (version != api_version::defaultApiVersion) {
+      LOG_TOPIC("3b1a7", TRACE, Logger::AUTHORIZATION)
+          << "API version forbidden for " << request()->requestPath();
+      co_return res;
+    }
+  }
+
+  auto canUseDB =
+      ec->canUseDatabase(request()->databaseName(), DatabaseAccessLevel::Read);
+  if (canUseDB.ok()) {
+    co_return Result{};
+  }
+
+  LOG_TOPIC("0898a", TRACE, Logger::AUTHORIZATION)
+      << "Access forbidden to " << request()->requestPath();
+  if (_request->requestedApiVersion() == 0 && ec->isClassic()) {
+    co_return Result(TRI_ERROR_HTTP_UNAUTHORIZED,
+                     "No read access to database.");
+  } else {
+    co_return canUseDB;
+  }
 }
 
 void RestVersionHandler::getVersion(

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -102,19 +102,20 @@ RestVersionHandler::RestVersionHandler(
     GeneralResponse* response)
     : RestBaseHandler(server, request, response) {}
 
-async<Result> RestVersionHandler::checkUserCanAccess() const {
+async<RestHandler::AuthenticationGrant>
+RestVersionHandler::checkUserAuthentication() const {
   // Note that this particular RestHandler might be called during startup (or
   // in maintenance mode). The AuthenticationFeature might not yet be available
   // for authorization, and must not be consulted.
   if (auto const mode = ServerState::mode();
       mode == ServerState::Mode::STARTUP ||
       mode == ServerState::Mode::MAINTENANCE) {
-    co_return request()->authenticated()
-        ? Result{}
-        : Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};
+    co_return request()->authenticated()  // with JWT can also be authenticated
+        ? AuthenticationGrant::GRANTED_EARLY
+        : AuthenticationGrant::DENIED;
   }
 
-  co_return co_await RestBaseHandler::checkUserCanAccess();
+  co_return co_await RestBaseHandler::checkUserAuthentication();
 }
 
 async<Result> RestVersionHandler::checkApiVersionAccess() const {

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -114,51 +114,17 @@ async<Result> RestVersionHandler::checkUserCanAccess() const {
         : Result{TRI_ERROR_HTTP_UNAUTHORIZED, "Not authenticated."};
   }
 
-  auto const* const auth = AuthenticationFeature::instance();
-  ADB_PROD_ASSERT(auth != nullptr);
-  if (!auth->isActive()) {
-    co_return Result();
-  }
+  co_return co_await RestBaseHandler::checkUserCanAccess();
+}
 
-#ifdef ARANGODB_HAVE_DOMAIN_SOCKETS
-  auto const& ci = request()->connectionInfo();
-  if (ci.endpointType == Endpoint::DomainType::UNIX &&
-      !auth->authenticationUnixSockets()) {
-    // no authentication required for unix domain socket connections
-    co_return Result{};
-  }
-#endif
-
-  if (not request()->authenticated()) {
-    Result(TRI_ERROR_HTTP_UNAUTHORIZED, "User not authenticated.");
-  }
-
-  auto ec = request()->requestContext();
-  TRI_ASSERT(ec != nullptr) << "no exec context in request: " << this->name();
-  // here we allow default version
+async<Result> RestVersionHandler::checkApiVersionAccess() const {
   auto version = request()->requestedApiVersion();
-  if (auto res = ec->canUseApiVersion(version); res.fail()) {
-    if (version != api_version::defaultApiVersion) {
-      LOG_TOPIC("4b1a7", TRACE, Logger::AUTHORIZATION)
-          << "API version forbidden for " << request()->requestPath();
-      co_return res;
-    }
-  }
-
-  auto canUseDB =
-      ec->canUseDatabase(request()->databaseName(), DatabaseAccessLevel::Read);
-  if (canUseDB.ok()) {
+  if (version == api_version::defaultApiVersion) {
+    // default api-version is always allowed
     co_return Result{};
   }
 
-  LOG_TOPIC("0898a", TRACE, Logger::AUTHORIZATION)
-      << "Access forbidden to " << request()->requestPath();
-  if (_request->requestedApiVersion() == 0 && ec->isClassic()) {
-    co_return Result(TRI_ERROR_HTTP_UNAUTHORIZED,
-                     "No read access to database.");
-  } else {
-    co_return canUseDB;
-  }
+  co_return co_await RestBaseHandler::checkApiVersionAccess();
 }
 
 void RestVersionHandler::getVersion(

--- a/arangod/RestHandler/RestVersionHandler.h
+++ b/arangod/RestHandler/RestVersionHandler.h
@@ -31,8 +31,9 @@ class RestVersionHandler : public arangodb::RestBaseHandler {
                      GeneralResponse*);
 
  protected:
-  async<Result> checkUserCanAccess() const override;
   async<Result> checkApiVersionAccess() const override;
+  async<RestHandler::AuthenticationGrant> checkUserAuthentication()
+      const override;
 
  public:
   static void getVersion(application_features::ApplicationServer& server,

--- a/arangod/RestHandler/RestVersionHandler.h
+++ b/arangod/RestHandler/RestVersionHandler.h
@@ -32,6 +32,7 @@ class RestVersionHandler : public arangodb::RestBaseHandler {
 
  protected:
   async<Result> checkUserCanAccess() const override;
+  async<Result> checkApiVersionAccess() const override;
 
  public:
   static void getVersion(application_features::ApplicationServer& server,

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -624,6 +624,14 @@ Result ExecContext::canGrantUserPermissions(std::string_view userName) const {
   return {};
 }
 
+/// @brief returns whether the given REST API version may be used
+Result ExecContext::canUseApiVersion(uint32_t version) const {
+  using namespace auth::perms;
+  // Using an API version never modifies anything, so the read-only gate does
+  // not apply here.
+  return can(UseApiVersion{.version = version});
+}
+
 /// @brief returns true for each user which can be read
 std::vector<bool> ExecContext::canReadUsers(
     std::span<std::string_view> users) const {

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -266,6 +266,11 @@ class ExecContext {
   /// collections may be granted/revoked.
   Result canGrantUserPermissions(std::string_view userName) const;
 
+  /// @brief returns whether the given REST API version may be used, e.g. 1 for
+  /// `/_arango/v1`. Note that this does not ask whether the version exists -
+  /// that is decided by the handler factory.
+  Result canUseApiVersion(uint32_t version) const;
+
   static std::shared_ptr<ExecContext const> set(
       std::shared_ptr<ExecContext const> ctx) {
     std::swap(CURRENT, ctx);

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -77,6 +77,10 @@ std::string resourceStr(rbac::Resource const& resource) {
                         [](rbac::resources::User const& r) {
                           return std::string{"user:"} + std::string{r.name};
                         },
+                        [](rbac::resources::ApiVersion const& r) {
+                          return std::string{"apiversion:"} +
+                                 std::to_string(r.version);
+                        },
                     },
                     resource);
 }
@@ -454,6 +458,26 @@ TEST_F(RbacAuthModeTest, AdminBackup) {
 TEST_F(RbacAuthModeTest, AdminQueryCache) {
   check(p::AdminQueryCache{});
   expectSingle(rbac::Action::AdminQueryCache, "<none>");
+}
+
+// ---------------------------------------------------------------------------
+// API versions
+// ---------------------------------------------------------------------------
+
+TEST_F(RbacAuthModeTest, UseApiVersionAsksForTheVersionAsResource) {
+  EXPECT_TRUE(check(p::UseApiVersion{.version = 1}).ok());
+  expectSingle(rbac::Action::UseApiVersion, "apiversion:1");
+}
+
+TEST_F(RbacAuthModeTest, UseApiVersionDistinguishesVersions) {
+  check(p::UseApiVersion{.version = 0});
+  expectSingle(rbac::Action::UseApiVersion, "apiversion:0");
+}
+
+TEST_F(RbacAuthModeTest, UseApiVersionDenialIsPropagated) {
+  svc.answer = {TRI_ERROR_FORBIDDEN, "nope"};
+  EXPECT_EQ(check(p::UseApiVersion{.version = 1}).errorNumber(),
+            TRI_ERROR_FORBIDDEN);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/Auth/RbacServiceImplTest.cpp
+++ b/tests/Auth/RbacServiceImplTest.cpp
@@ -151,6 +151,16 @@ TEST(RbacServiceImplCheckTest, translatesUserRead) {
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:user:alice");
 }
 
+TEST(RbacServiceImplCheckTest, translatesUseApiVersion) {
+  auto f = CheckFixture::make();
+  std::array queries{rbac::ActionResource{
+      rbac::Action::UseApiVersion, rbac::resources::ApiVersion{.version = 1}}};
+  f.svc.check({testToken}, queries);
+  ASSERT_EQ(f.mock->lastItems.size(), 1u);
+  EXPECT_EQ(f.mock->lastItems[0].action, "db:UseApiVersion");
+  EXPECT_EQ(f.mock->lastItems[0].resource, "db:apiversion:1");
+}
+
 TEST(RbacServiceImplCheckTest, adminActionHasNoResource) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{rbac::Action::AdminQueryCache,

--- a/tests/Utils/ExecContextTest.cpp
+++ b/tests/Utils/ExecContextTest.cpp
@@ -119,6 +119,39 @@ TEST(ExecContextTest, canUseDatabase_same_db_uses_dbAuthLevel) {
       cec.execContext->canUseDatabase("mydb", DatabaseAccessLevel::Write).ok());
 }
 
+// --- canUseApiVersion ---
+
+TEST(ExecContextTest, canUseApiVersion_classic_grants_every_version) {
+  // Classic auth knows no per-identity API version restrictions: which
+  // versions exist is decided by the handler factory, not by permissions. So
+  // even an identity without any access grants may use any API version.
+  auto cec = makeClassicExecContext("user", "mydb", auth::Level::NONE,
+                                    auth::Level::NONE);
+
+  EXPECT_TRUE(cec.execContext->canUseApiVersion(0).ok());
+  EXPECT_TRUE(cec.execContext->canUseApiVersion(1).ok());
+}
+
+TEST(ExecContextTest, canUseApiVersion_superuser_grants_every_version) {
+  auto ctx = createSharedExecContext(AuthMode{AuthMode::Superuser{}}, false,
+                                     VocbasePtr{nullptr});
+
+  EXPECT_TRUE(ctx->canUseApiVersion(1).ok());
+}
+
+TEST(ExecContextTest, canUseApiVersion_unauthenticated_is_denied) {
+  FakeGeneralRequest fakeRequest;
+  auto ctx = createSharedExecContext(
+      AuthMode{AuthMode::Unauthenticated{"dummy", fakeRequest}}, false,
+      VocbasePtr{nullptr});
+
+  auto const result = ctx->canUseApiVersion(1);
+  EXPECT_EQ(result.errorNumber(), TRI_ERROR_FORBIDDEN);
+  EXPECT_TRUE(result.errorMessage().find("API version '1'") !=
+              std::string_view::npos)
+      << result.errorMessage();
+}
+
 // --- Static superuser singleton ---
 
 TEST(ExecContextTest, superuser_singleton) {

--- a/tests/js/client/server_permissions/authorization-questions.js
+++ b/tests/js/client/server_permissions/authorization-questions.js
@@ -112,12 +112,13 @@ function authorizationQuestionsSuite () {
     },
 
     // a handler that asks nothing beyond the database access every request
-    // checks - proves the observer does not pick up ambient traffic
+    // checks - proves the observer does not pick up ambient traffic.
+    // RestVersionHandler exempts the default API version from the api-version
+    // question, so not even that one shows up here (see api-version.js).
     testVersion: function () {
       beginObserve();
       arango.GET_RAW('/_api/version');
       assertPermissions([
-        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions.js
+++ b/tests/js/client/server_permissions/authorization-questions.js
@@ -69,6 +69,7 @@ function authorizationQuestionsSuite () {
       beginObserve();
       arango.GET_RAW(`/_api/collection/${cn}/count`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "UseCollection db=_system name=UnitTestsAuthzQuestions level=read"
       ], endObserve());
@@ -78,6 +79,7 @@ function authorizationQuestionsSuite () {
       beginObserve();
       arango.POST_RAW(`/_api/document/${cn}`, { value: 1 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "UseCollection db=_system name=UnitTestsAuthzQuestions level=writedata",
@@ -94,6 +96,7 @@ function authorizationQuestionsSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_api/collection/${cn}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "DropCollection db=_system name=UnitTestsAuthzQuestions",
@@ -114,6 +117,7 @@ function authorizationQuestionsSuite () {
       beginObserve();
       arango.GET_RAW('/_api/version');
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/actions.js
+++ b/tests/js/client/server_permissions/authorization-questions/actions.js
@@ -67,6 +67,7 @@ function actionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/actions`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -76,6 +77,7 @@ function actionApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/actions`, { execute: 'proceed' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -86,6 +88,7 @@ function actionApiAuthzSuite () {
       arango.POST_RAW(`/_db/_system/_admin/actions`,
                       { execute: 'pause', duration: 1 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       arango.POST_RAW(`/_db/_system/_admin/actions`, { execute: 'proceed' });
@@ -96,6 +99,7 @@ function actionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/actions`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -106,6 +110,7 @@ function actionApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/actions/999999`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/actions.js
+++ b/tests/js/client/server_permissions/authorization-questions/actions.js
@@ -104,6 +104,8 @@ function actionApiAuthzSuite () {
       ], endObserve());
     },
 
+    // Bug: calls RestActionHandler instead of MaintenanceRestHandler
+    //      because handler is not installed as prefix-handler
     // DELETE /_admin/actions/999999 - non-existent action -> 400, base check
     // is still asked
     testDeleteNonExistent: function () {

--- a/tests/js/client/server_permissions/authorization-questions/admin.js
+++ b/tests/js/client/server_permissions/authorization-questions/admin.js
@@ -30,7 +30,8 @@
 // Handlers: RestAuthReloadHandler, RestAdminClusterHandler, RestCompactHandler,
 // RestCrashHandler, RestAdminDatabaseHandler, RestShutdownHandler.
 //
-// Every request first asks `UseDatabase name=<db> level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=<db> level=read` in
 // RestHandler::checkUserCanAccess(). Beyond that, the cluster handler is the
 // interesting case: several sub-handlers reject non-coordinator requests BEFORE
 // they run the per-user auth check, so on a single server those endpoints emit

--- a/tests/js/client/server_permissions/authorization-questions/admin.js
+++ b/tests/js/client/server_permissions/authorization-questions/admin.js
@@ -82,6 +82,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/auth/reload`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminAuthReload",
         ...singleOnly([
@@ -98,6 +99,7 @@ function adminApiAuthzSuite () {
       arango.GET_RAW(`/_db/${DB}/_admin/cluster/collectionShardDistribution?collection=${DOC_COLLECTION}`);
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         ...clusterOnly([
           "AdminClusterInfo"
@@ -110,6 +112,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/health`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -121,6 +124,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/maintenance`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMaintenance"
       ], endObserve());
@@ -132,6 +136,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/cluster/maintenance`, "off");
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMaintenance"
       ], endObserve());
@@ -143,6 +148,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/nodeEngine`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -152,6 +158,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/nodeStatistics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -161,6 +168,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/nodeVersion`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -171,6 +179,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/numberOfServers`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -183,6 +192,7 @@ function adminApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_admin/cluster/numberOfServers`, {});
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminMaintenance"
@@ -197,6 +207,7 @@ function adminApiAuthzSuite () {
       arango.GET_RAW(`/_db/_system/_admin/cluster/rebalance`);
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminRebalance"
@@ -210,6 +221,7 @@ function adminApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_admin/cluster/rebalance`, {});
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminRebalance"
@@ -224,6 +236,7 @@ function adminApiAuthzSuite () {
       arango.GET_RAW(`/_db/_system/_admin/cluster/shardDistribution`);
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminClusterInfo"
@@ -238,6 +251,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/shardStatistics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -249,6 +263,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/statistics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -260,6 +275,7 @@ function adminApiAuthzSuite () {
       arango.POST_RAW(`/_db/_system/_admin/cluster/cancelAgencyJob`,
                       { id: "nonexistent-job-apitester" });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMoveShards"
       ], endObserve());
@@ -271,6 +287,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/cluster/cleanOutServer`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMoveShards"
       ], endObserve());
@@ -282,6 +299,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/maintenance/nonexistent`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMaintenance"
       ], endObserve());
@@ -294,6 +312,7 @@ function adminApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_admin/cluster/maintenance/nonexistent`,
                      { mode: "normal" });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMaintenance"
       ], endObserve());
@@ -308,6 +327,7 @@ function adminApiAuthzSuite () {
                         shard: "s1", fromServer: "from", toServer: "to" });
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminMoveShards"
@@ -321,6 +341,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/queryAgencyJob?id=nonexistent-job-apitester-99999`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMoveShards"
       ], endObserve());
@@ -334,6 +355,7 @@ function adminApiAuthzSuite () {
       arango.POST_RAW(`/_db/_system/_admin/cluster/rebalanceShards`, {});
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminRebalance"
@@ -348,6 +370,7 @@ function adminApiAuthzSuite () {
       arango.POST_RAW(`/_db/_system/_admin/cluster/removeServer`,
                       { server: "PRMR-nonexistent-apitester" });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminRemoveServer"
       ], endObserve());
@@ -359,6 +382,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/cluster/resignLeadership`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMoveShards"
       ], endObserve());
@@ -371,6 +395,7 @@ function adminApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_admin/cluster/uniqId?number=1`, {});
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminMaintenance"
@@ -384,6 +409,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/cluster/vpackSortMigration/check`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -395,6 +421,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/compact`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -405,6 +432,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/crashes`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminCrashHandler"
       ], endObserve());
@@ -415,6 +443,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/crashes/nonexistent`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminCrashHandler"
       ], endObserve());
@@ -425,6 +454,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/crashes/nonexistent`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminCrashHandler"
       ], endObserve());
@@ -435,6 +465,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/database/target-version`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -446,6 +477,7 @@ function adminApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/shutdown`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminShutdown"
       ], endObserve());

--- a/tests/js/client/server_permissions/authorization-questions/admin.js
+++ b/tests/js/client/server_permissions/authorization-questions/admin.js
@@ -31,8 +31,7 @@
 // RestCrashHandler, RestAdminDatabaseHandler, RestShutdownHandler.
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=<db> level=read` in
-// RestHandler::checkUserCanAccess(). Beyond that, the cluster handler is the
+// `UseDatabase name=<db> level=read`. Beyond that, the cluster handler is the
 // interesting case: several sub-handlers reject non-coordinator requests BEFORE
 // they run the per-user auth check, so on a single server those endpoints emit
 // ONLY the base question. Sub-handlers that run canUseAdminAction FIRST still

--- a/tests/js/client/server_permissions/authorization-questions/analyzers.js
+++ b/tests/js/client/server_permissions/authorization-questions/analyzers.js
@@ -100,6 +100,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/analyzer`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseDatabase name=_system level=read",
         "UseCollection db=d name=_analyzers level=read",
@@ -113,6 +114,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/analyzer/identity`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -127,6 +129,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/analyzer`, { name: NAME, type: 'identity' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseAnalyzer db=d name=apitest_analyzer level=modify",
@@ -145,6 +148,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/analyzer/${NAME}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseAnalyzer db=d name=apitest_analyzer level=modify",
@@ -162,6 +166,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_api/analyzer`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -171,6 +176,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_api/analyzer/identity`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -182,6 +188,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_api/analyzer`, { name: NAME, type: 'identity' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "UseAnalyzer db=_system name=apitest_analyzer level=modify",
@@ -200,6 +207,7 @@ function analyzerApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_api/analyzer/${NAME}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "UseAnalyzer db=_system name=apitest_analyzer level=modify",

--- a/tests/js/client/server_permissions/authorization-questions/analyzers.js
+++ b/tests/js/client/server_permissions/authorization-questions/analyzers.js
@@ -29,7 +29,8 @@
 // Handler: arangod/RestHandler/RestAnalyzerHandler.cpp
 //          arangod/IResearch/IResearchAnalyzerFeature.cpp
 //
-// Every request first asks `UseDatabase name=<db> level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=<db> level=read` in
 // RestHandler::checkUserCanAccess(), where <db> is the database in the path
 // (d for /_db/d/..., _system for the plain /_api/... routes).
 //

--- a/tests/js/client/server_permissions/authorization-questions/analyzers.js
+++ b/tests/js/client/server_permissions/authorization-questions/analyzers.js
@@ -30,8 +30,7 @@
 //          arangod/IResearch/IResearchAnalyzerFeature.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=<db> level=read` in
-// RestHandler::checkUserCanAccess(), where <db> is the database in the path
+// `UseDatabase name=<db> level=read`, where <db> is the database in the path
 // (d for /_db/d/..., _system for the plain /_api/... routes).
 //
 // getAnalyzers (list): visits static analyzers (no question - null vocbase),

--- a/tests/js/client/server_permissions/authorization-questions/api-version.js
+++ b/tests/js/client/server_permissions/authorization-questions/api-version.js
@@ -1,0 +1,93 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+// The api-version question itself, which has no endpoint of its own: every
+// request of an authenticated identity passes through
+// RestHandler::checkApiVersionAccess(), which asks
+// ExecContext::canUseApiVersion() for the version the request addresses. That
+// is why `UseApiVersion version=<n>` heads nearly every observation in this
+// directory - including the default version, which is not exempt anywhere
+// except in RestVersionHandler (see version.js).
+//
+// /_api/engine serves as the sample endpoint here: RestEngineHandler asks only
+// canUseHardenedAction(MonitoringInternal), which is silent without
+// --server.harden, so nothing but the two base questions is observed.
+//
+// API version 1 is not in ApiVersion.h's supportedApiVersions yet, so it is
+// normally rejected before any handler runs. The
+// 'ApiVersion::treatVersion1AsSupported' failure point makes the version
+// checks treat it as supported; it must be armed before the server registers
+// its routes at startup, hence the startup option (see also
+// failing-user-access-does-not-reveal-information.js).
+if (getOptions === true) {
+  return {
+    'server.authentication': 'true',
+    'server.failure-point': 'ApiVersion::treatVersion1AsSupported',
+    // the observer reads the log file right after the request, so the log must
+    // not be written by the logging thread
+    'log.force-direct': 'true',
+    // keep background threads from asking questions of their own
+    'foxx.queues': 'false'
+  };
+}
+
+const jsunity = require('jsunity');
+const {
+  beginObserve,
+  endObserve,
+  disableObserve,
+  assertPermissions
+} = require('@arangodb/testutils/permissions-observer');
+
+function apiVersionAuthzSuite () {
+  return {
+    tearDown: function () {
+      // in case a test failed in the middle of an observation
+      disableObserve();
+    },
+
+    // the default API version is asked about like any other
+    testDefaultApiVersion: function () {
+      beginObserve();
+      arango.GET_RAW(`/_api/engine`);
+      assertPermissions([
+        "UseApiVersion version=0",
+        "UseDatabase name=_system level=read"
+      ], endObserve());
+    },
+
+    // a versioned request asks about the version it addresses
+    testNonDefaultApiVersion: function () {
+      beginObserve();
+      arango.GET_RAW(`/_arango/v1/_api/engine`);
+      assertPermissions([
+        "UseApiVersion version=1",
+        "UseDatabase name=_system level=read"
+      ], endObserve());
+    },
+  };
+}
+
+jsunity.run(apiVersionAuthzSuite);
+return jsunity.done();

--- a/tests/js/client/server_permissions/authorization-questions/aql-functions.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql-functions.js
@@ -38,8 +38,7 @@
 // A WRITE transaction on a collection asks both the read and the writedata
 // question for that collection (cf. documents.js / authorization-questions.js
 // testInsertDocument). Every request additionally asks
-// `UseApiVersion version=0` and `UseDatabase name=<db> level=read` first
-// in RestHandler::checkUserCanAccess().
+// `UseApiVersion version=0` and `UseDatabase name=<db> level=read` first.
 
 if (getOptions === true) {
   return {

--- a/tests/js/client/server_permissions/authorization-questions/aql-functions.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql-functions.js
@@ -101,6 +101,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/aqlfunction`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=_aqlfunctions level=read"
       ], endObserve());
@@ -111,6 +112,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/aqlfunction/APITESTNS`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=_aqlfunctions level=read"
       ], endObserve());
@@ -124,6 +126,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/aqlfunction`, fnBody);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=_aqlfunctions level=writedata",
@@ -140,6 +143,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/aqlfunction/${fnName}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=_aqlfunctions level=writedata",
@@ -154,6 +158,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/aqlfunction`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "UseCollection db=_system name=_aqlfunctions level=read"
       ], endObserve());
@@ -164,6 +169,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/aqlfunction/APITESTNS`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "UseCollection db=_system name=_aqlfunctions level=read"
       ], endObserve());
@@ -177,6 +183,7 @@ function aqlFunctionApiAuthzSuite () {
       arango.POST_RAW(`/_db/_system/_api/aqlfunction`, fnBody);
       // creating a function in _system asks the read in both deployment modes
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "UseCollection db=_system name=_aqlfunctions level=read",
         "IsReadOnly",
@@ -191,6 +198,7 @@ function aqlFunctionApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/aqlfunction/${fnName}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "UseCollection db=_system name=_aqlfunctions level=writedata",

--- a/tests/js/client/server_permissions/authorization-questions/aql-functions.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql-functions.js
@@ -38,7 +38,8 @@
 // A WRITE transaction on a collection asks both the read and the writedata
 // question for that collection (cf. documents.js / authorization-questions.js
 // testInsertDocument). Every request additionally asks
-// `UseDatabase name=<db> level=read` first in RestHandler::checkUserCanAccess().
+// `UseApiVersion version=0` and `UseDatabase name=<db> level=read` first
+// in RestHandler::checkUserCanAccess().
 
 if (getOptions === true) {
   return {

--- a/tests/js/client/server_permissions/authorization-questions/aql.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql.js
@@ -30,8 +30,7 @@
 //
 // RestAqlFunctionsHandler just serialises the list of built-in AQL functions
 // and returns it; it performs no in-handler authorization check. The only
-// questions are the universal base checks in
-// RestHandler::checkUserCanAccess(): `UseApiVersion version=0` and
+// questions are the universal base checks: `UseApiVersion version=0` and
 // `UseDatabase name=<db> level=read` for the database in the request path.
 // The endpoint has no /_db/ prefix in the apitest and runs in the connected
 // database context; here we address it explicitly in _system.

--- a/tests/js/client/server_permissions/authorization-questions/aql.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql.js
@@ -72,6 +72,7 @@ function aqlApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/aql-builtin`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/aql.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql.js
@@ -30,7 +30,8 @@
 //
 // RestAqlFunctionsHandler just serialises the list of built-in AQL functions
 // and returns it; it performs no in-handler authorization check. The only
-// question is the universal base check in RestHandler::checkUserCanAccess():
+// questions are the universal base checks in
+// RestHandler::checkUserCanAccess(): `UseApiVersion version=0` and
 // `UseDatabase name=<db> level=read` for the database in the request path.
 // The endpoint has no /_db/ prefix in the apitest and runs in the connected
 // database context; here we address it explicitly in _system.

--- a/tests/js/client/server_permissions/authorization-questions/backup.js
+++ b/tests/js/client/server_permissions/authorization-questions/backup.js
@@ -94,6 +94,7 @@ function backupApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/backup/list`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminBackup"
       ], endObserve());
@@ -105,6 +106,7 @@ function backupApiAuthzSuite () {
       const res = arango.POST_RAW(`/_db/_system/_admin/backup/create`,
                                   { label: 'apitestcreate' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminBackup"
       ], endObserve());
@@ -121,6 +123,7 @@ function backupApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/backup/delete`, { id: id });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminBackup"
       ], endObserve());

--- a/tests/js/client/server_permissions/authorization-questions/backup.js
+++ b/tests/js/client/server_permissions/authorization-questions/backup.js
@@ -33,8 +33,9 @@
 //     canUseAdminAction(AdminBackup)   ->  logs `AdminBackup`
 // In jwt mode (--backup.api-enabled=jwt) it instead does an isSuperuserOrDisabled()
 // check which asks NOTHING. Our suites run in the default mode, so `AdminBackup`
-// is asked. Every request additionally asks `UseDatabase name=_system level=read`
-// first in RestHandler::checkUserCanAccess() (the routes have no /_db/ prefix, so
+// is asked. Every request additionally asks `UseApiVersion version=0` and
+// `UseDatabase name=_system level=read` first in
+// RestHandler::checkUserCanAccess() (the routes have no /_db/ prefix, so
 // the database is the connected _system).
 //
 // AUDIT: enterprise-only endpoints. On a Community Edition build the /_admin/backup

--- a/tests/js/client/server_permissions/authorization-questions/backup.js
+++ b/tests/js/client/server_permissions/authorization-questions/backup.js
@@ -34,8 +34,7 @@
 // In jwt mode (--backup.api-enabled=jwt) it instead does an isSuperuserOrDisabled()
 // check which asks NOTHING. Our suites run in the default mode, so `AdminBackup`
 // is asked. Every request additionally asks `UseApiVersion version=0` and
-// `UseDatabase name=_system level=read` first in
-// RestHandler::checkUserCanAccess() (the routes have no /_db/ prefix, so
+// `UseDatabase name=_system level=read` first (the routes have no /_db/ prefix, so
 // the database is the connected _system).
 //
 // AUDIT: enterprise-only endpoints. On a Community Edition build the /_admin/backup

--- a/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
+++ b/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
@@ -33,8 +33,9 @@
 // cluster configurations only (see filterTestcaseByOptions() in
 // js/client/modules/@arangodb/testutils/test-utils.js).
 //
-// Every request except `endpoints` first asks
-// `UseDatabase name=_system level=read` in RestHandler::checkUserCanAccess()
+// Every request first asks `UseApiVersion version=0`; every request
+// except `endpoints` then asks `UseDatabase name=_system level=read` in
+// RestHandler::checkUserCanAccess()
 // (the routes have no /_db/ prefix, so the database is the connected _system).
 // Per-route ExecContext::can() questions:
 //

--- a/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
+++ b/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
@@ -86,6 +86,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/agency-cache`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadAgency"
       ], endObserve());
@@ -97,6 +98,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/agency-dump`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadAgency"
       ], endObserve());
@@ -107,6 +109,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -118,6 +121,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`${base}/cluster-info/flush`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -129,6 +133,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/get_collection_info/d/c`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -139,6 +144,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/get_collection_info_current/d/c/s1`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -149,6 +155,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`${base}/cluster-info/get_responsible_servers`, []);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -160,6 +167,7 @@ function clusterApiAuthzSuite () {
       arango.POST_RAW(`${base}/cluster-info/get_responsible_shard/d/c/true`,
                       { _key: 'testkey' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -170,6 +178,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/get_analyzers_revision/_system`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -180,6 +189,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/wait_for_plan_version/1`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -190,6 +200,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/get_max_number_of_shards`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -200,6 +211,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/get_max_replication_factor`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -210,6 +222,7 @@ function clusterApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`${base}/cluster-info/get_min_replication_factor`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminClusterInfo"
       ], endObserve());
@@ -221,7 +234,7 @@ function clusterApiAuthzSuite () {
     testEndpoints: function () {
       beginObserve();
       arango.GET_RAW(`${base}/endpoints`);
-      assertPermissions([], endObserve());
+      assertPermissions(["UseApiVersion version=0"], endObserve());
     },
   };
 }

--- a/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
+++ b/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
@@ -34,8 +34,7 @@
 // js/client/modules/@arangodb/testutils/test-utils.js).
 //
 // Every request first asks `UseApiVersion version=0`; every request
-// except `endpoints` then asks `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess()
+// except `endpoints` then asks `UseDatabase name=_system level=read`
 // (the routes have no /_db/ prefix, so the database is the connected _system).
 // Per-route ExecContext::can() questions:
 //

--- a/tests/js/client/server_permissions/authorization-questions/collections.js
+++ b/tests/js/client/server_permissions/authorization-questions/collections.js
@@ -32,8 +32,7 @@
 // Handler: arangod/RestHandler/RestCollectionHandler.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=d level=read` in
-// RestHandler::checkUserCanAccess(). Read metadata endpoints then look the
+// `UseDatabase name=d level=read`. Read metadata endpoints then look the
 // collection up via methods::Collections::lookup(), which asks
 // `UseCollection ... level=read`. Write/metadata endpoints additionally ask a
 // higher level (writedata/writemeta), and drop revokes permissions + cleans up

--- a/tests/js/client/server_permissions/authorization-questions/collections.js
+++ b/tests/js/client/server_permissions/authorization-questions/collections.js
@@ -98,6 +98,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "SeeCollection db=d name=c",
         "SeeCollection db=d name=e",
@@ -117,6 +118,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -127,6 +129,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}/checksum`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -137,6 +140,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}/count`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -147,6 +151,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}/figures`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -157,6 +162,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}/properties`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -167,6 +173,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}/revision`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -177,6 +184,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/collection/${c}/shards`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -187,6 +195,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/load`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -197,6 +206,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/unload`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -208,6 +218,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/loadIndexesIntoMemory`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -219,6 +230,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/compact`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -232,6 +244,7 @@ function collectionApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/properties`,
                      { waitForSync: false });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read",
         "IsReadOnly",
@@ -249,6 +262,7 @@ function collectionApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/responsibleShard`,
                      { _key: 'k1' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -260,6 +274,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/collection/${c}/truncate`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read",
         "IsReadOnly",
@@ -285,6 +300,7 @@ function collectionApiAuthzSuite () {
       // AUDIT: a coordinator only resolves the collection - neither the
       // writemeta question nor the graph cleanup is asked
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c_apitest level=read",
         ...singleOnly([
@@ -307,6 +323,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/collection`, { name: tmp });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "CreateCollection db=d name=c_apitest",
@@ -327,6 +344,7 @@ function collectionApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/collection/${tmp}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "DropCollection db=d name=c_apitest",

--- a/tests/js/client/server_permissions/authorization-questions/collections.js
+++ b/tests/js/client/server_permissions/authorization-questions/collections.js
@@ -31,7 +31,8 @@
 //
 // Handler: arangod/RestHandler/RestCollectionHandler.cpp
 //
-// Every request first asks `UseDatabase name=d level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=d level=read` in
 // RestHandler::checkUserCanAccess(). Read metadata endpoints then look the
 // collection up via methods::Collections::lookup(), which asks
 // `UseCollection ... level=read`. Write/metadata endpoints additionally ask a

--- a/tests/js/client/server_permissions/authorization-questions/cursor.js
+++ b/tests/js/client/server_permissions/authorization-questions/cursor.js
@@ -90,6 +90,7 @@ function cursorApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/cursor`, { query: `FOR d IN ${c} RETURN d` });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -102,6 +103,7 @@ function cursorApiAuthzSuite () {
       const res = arango.POST_RAW(`/_db/${DB}/_api/cursor`,
                                   { query: `FOR d IN ${c} RETURN d`, batchSize: 10 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -117,6 +119,7 @@ function cursorApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/cursor/${cur.id}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       dropCursor(cur.id);
@@ -129,6 +132,7 @@ function cursorApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/cursor/${cur.id}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       dropCursor(cur.id);
@@ -141,6 +145,7 @@ function cursorApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/cursor/${cur.id}/${cur.nextBatchId}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       dropCursor(cur.id);
@@ -152,6 +157,7 @@ function cursorApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/cursor/${cur.id}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/databases.js
+++ b/tests/js/client/server_permissions/authorization-questions/databases.js
@@ -91,6 +91,7 @@ function databaseApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/database`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -100,6 +101,7 @@ function databaseApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/database/current`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -110,6 +112,7 @@ function databaseApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/database/user`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "SeeDatabase name=_system",
         "SeeDatabase name=d"
@@ -124,6 +127,7 @@ function databaseApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/database/shardStatistics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -134,6 +138,7 @@ function databaseApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_api/database`, { name: 'd2' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "CreateDatabase name=d2",
@@ -165,6 +170,7 @@ function databaseApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/database/d2`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "DropDatabase name=d2",

--- a/tests/js/client/server_permissions/authorization-questions/databases.js
+++ b/tests/js/client/server_permissions/authorization-questions/databases.js
@@ -28,7 +28,8 @@
 //
 // Handler: arangod/RestHandler/RestDatabaseHandler.cpp
 //
-// Every request first asks the base `UseDatabase name=<db> level=read` in
+// Every request first asks the base `UseApiVersion version=0` and then
+// `UseDatabase name=<db> level=read` in
 // RestHandler::checkUserCanAccess(), where <db> is the database in the request
 // path prefix. Beyond that:
 //   - GET (list / current / user / shardStatistics) go through

--- a/tests/js/client/server_permissions/authorization-questions/databases.js
+++ b/tests/js/client/server_permissions/authorization-questions/databases.js
@@ -29,8 +29,7 @@
 // Handler: arangod/RestHandler/RestDatabaseHandler.cpp
 //
 // Every request first asks the base `UseApiVersion version=0` and then
-// `UseDatabase name=<db> level=read` in
-// RestHandler::checkUserCanAccess(), where <db> is the database in the request
+// `UseDatabase name=<db> level=read`, where <db> is the database in the request
 // path prefix. Beyond that:
 //   - GET (list / current / user / shardStatistics) go through
 //     methods::Databases::list()/toVelocyPack(), which do NOT call the

--- a/tests/js/client/server_permissions/authorization-questions/debug.js
+++ b/tests/js/client/server_permissions/authorization-questions/debug.js
@@ -30,9 +30,7 @@
 //
 // RestDebugHandler contains NO ExecContext permission check at all (auth level
 // is AUTHEN: any authenticated user), so the only observed questions are
-// the base `UseApiVersion version=0` and
-// `UseDatabase name=_system level=read` from
-// RestHandler::checkUserCanAccess().
+// the base `UseApiVersion version=0` and `UseDatabase name=_system level=read`.
 //
 // AUDIT: RestDebugHandler is only compiled in when ARANGODB_ENABLE_FAILURE_TESTS
 // is defined at build time. On a release build every /_admin/debug route is

--- a/tests/js/client/server_permissions/authorization-questions/debug.js
+++ b/tests/js/client/server_permissions/authorization-questions/debug.js
@@ -29,8 +29,9 @@
 // Handler: arangod/RestHandler/RestDebugHandler.cpp
 //
 // RestDebugHandler contains NO ExecContext permission check at all (auth level
-// is AUTHEN: any authenticated user), so the only observed question is the
-// base `UseDatabase name=_system level=read` from
+// is AUTHEN: any authenticated user), so the only observed questions are
+// the base `UseApiVersion version=0` and
+// `UseDatabase name=_system level=read` from
 // RestHandler::checkUserCanAccess().
 //
 // AUDIT: RestDebugHandler is only compiled in when ARANGODB_ENABLE_FAILURE_TESTS

--- a/tests/js/client/server_permissions/authorization-questions/debug.js
+++ b/tests/js/client/server_permissions/authorization-questions/debug.js
@@ -75,6 +75,7 @@ function debugApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/debug/failat`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -84,6 +85,7 @@ function debugApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/debug/failat/all`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -95,6 +97,7 @@ function debugApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/debug/failat/${failPoint}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       arango.DELETE_RAW(`/_db/_system/_admin/debug/failat/${failPoint}`);
@@ -107,6 +110,7 @@ function debugApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/debug/failat/${failPoint}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -116,6 +120,7 @@ function debugApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/debug/failat`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -125,6 +130,7 @@ function debugApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/debug/raceControl`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/documents.js
+++ b/tests/js/client/server_permissions/authorization-questions/documents.js
@@ -39,8 +39,8 @@
 //                `UseCollection ... level=writedata` when the collection is
 //                registered in the transaction with write access.
 // A pure read operation only loads the collection, so it asks read alone.
-// Every request additionally asks `UseDatabase name=d level=read` first
-// (RestHandler::checkUserCanAccess).
+// Every request additionally asks `UseApiVersion version=0` and
+// `UseDatabase name=d level=read` first (RestHandler::checkUserCanAccess).
 //
 // The writedata question is accompanied by the server-wide read-only gate, which
 // shows up as the pseudo-question `IsReadOnly`; a pure read never triggers it.

--- a/tests/js/client/server_permissions/authorization-questions/documents.js
+++ b/tests/js/client/server_permissions/authorization-questions/documents.js
@@ -96,6 +96,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/document/${c}/${key}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -107,6 +108,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.HEAD_RAW(`/_db/${DB}/_api/document/${c}/${key}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -118,6 +120,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/document/${c}`, { _key: key, value: 1 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",
@@ -133,6 +136,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/document/${c}/${key}`, { value: 2 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",
@@ -148,6 +152,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/document/${c}`, [{ _key: key, value: 2 }]);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",
@@ -163,6 +168,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.PATCH_RAW(`/_db/${DB}/_api/document/${c}/${key}`, { value: 3 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",
@@ -178,6 +184,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.PATCH_RAW(`/_db/${DB}/_api/document/${c}`, [{ _key: key, value: 3 }]);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",
@@ -193,6 +200,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/document/${c}/${key}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",
@@ -208,6 +216,7 @@ function documentApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/document/${c}`, [{ _key: key }]);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",

--- a/tests/js/client/server_permissions/authorization-questions/documents.js
+++ b/tests/js/client/server_permissions/authorization-questions/documents.js
@@ -40,7 +40,7 @@
 //                registered in the transaction with write access.
 // A pure read operation only loads the collection, so it asks read alone.
 // Every request additionally asks `UseApiVersion version=0` and
-// `UseDatabase name=d level=read` first (RestHandler::checkUserCanAccess).
+// `UseDatabase name=d level=read` first.
 //
 // The writedata question is accompanied by the server-wide read-only gate, which
 // shows up as the pseudo-question `IsReadOnly`; a pure read never triggers it.

--- a/tests/js/client/server_permissions/authorization-questions/dump.js
+++ b/tests/js/client/server_permissions/authorization-questions/dump.js
@@ -28,7 +28,8 @@
 //
 // Handler: arangod/RestHandler/RestDumpHandler.cpp
 //
-// Every request first asks `UseDatabase name=d level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=d level=read` in
 // RestHandler::checkUserCanAccess() (the paths carry the /_db/d/ prefix).
 //
 //   POST /_api/dump/start   validateRequest() iterates the requested shards and

--- a/tests/js/client/server_permissions/authorization-questions/dump.js
+++ b/tests/js/client/server_permissions/authorization-questions/dump.js
@@ -29,8 +29,7 @@
 // Handler: arangod/RestHandler/RestDumpHandler.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=d level=read` in
-// RestHandler::checkUserCanAccess() (the paths carry the /_db/d/ prefix).
+// `UseDatabase name=d level=read` (the paths carry the /_db/d/ prefix).
 //
 //   POST /_api/dump/start   validateRequest() iterates the requested shards and
 //                           asks canDumpCollection(db, coll) for each ->

--- a/tests/js/client/server_permissions/authorization-questions/dump.js
+++ b/tests/js/client/server_permissions/authorization-questions/dump.js
@@ -115,6 +115,7 @@ function dumpApiAuthzSuite () {
       // AUDIT: on a coordinator the question carries an empty collection
       // name, and AdminDump is not asked at all
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         ...singleOnly([
           "DumpCollection db=d name=c",
@@ -142,6 +143,7 @@ function dumpApiAuthzSuite () {
       arango.POST_RAW(
         `/_db/${DB}/_api/dump/next/${dumpId}?batchId=${batchId}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       abortDump(dumpId);
@@ -156,6 +158,7 @@ function dumpApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/dump/${dumpId}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       abortDump(dumpId);

--- a/tests/js/client/server_permissions/authorization-questions/edges.js
+++ b/tests/js/client/server_permissions/authorization-questions/edges.js
@@ -75,6 +75,7 @@ function edgesApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/edges/${e}?vertex=c%2Fk1&direction=any`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=e level=read"
       ], endObserve());
@@ -86,6 +87,7 @@ function edgesApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/edges/${e}`, ['c/k1', 'c/k2']);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=e level=read"
       ], endObserve());

--- a/tests/js/client/server_permissions/authorization-questions/edges.js
+++ b/tests/js/client/server_permissions/authorization-questions/edges.js
@@ -34,7 +34,7 @@
 // StandaloneContext, so the collection access check happens in the transaction
 // layer (StorageEngine/TransactionState.cpp checkCollectionPermission): a READ
 // transaction asks `UseCollection ... level=read`. Every request additionally
-// asks `UseDatabase name=d level=read` first.
+// asks `UseApiVersion version=0` and `UseDatabase name=d level=read` first.
 
 if (getOptions === true) {
   return {

--- a/tests/js/client/server_permissions/authorization-questions/gharial.js
+++ b/tests/js/client/server_permissions/authorization-questions/gharial.js
@@ -30,7 +30,8 @@
 //           arangod/Graph/GraphManager.cpp
 //           arangod/Graph/GraphOperations.cpp
 //
-// Every request first asks `UseDatabase name=d level=read`
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=d level=read`
 // (RestHandler::checkUserCanAccess).
 //
 // Any request that names a graph in the path first runs RestGraphHandler::

--- a/tests/js/client/server_permissions/authorization-questions/gharial.js
+++ b/tests/js/client/server_permissions/authorization-questions/gharial.js
@@ -176,6 +176,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/gharial`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=_graphs level=read",
         "SeeGraph db=d name=g"
@@ -201,6 +202,7 @@ function gharialApiAuthzSuite () {
         edgeDefinitions: [{ collection: E_APITEST, from: [c], to: [c] }]
       });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=_graphs level=read",
         "IsReadOnly",
@@ -218,6 +220,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/gharial/${g}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read"
@@ -233,6 +236,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/gharial/${G_APITEST}?dropCollections=false`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g_apitest level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -247,6 +251,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/gharial/${g}/edge`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read"
@@ -266,6 +271,7 @@ function gharialApiAuthzSuite () {
       arango.POST_RAW(`/_db/${DB}/_api/gharial/${G_APITEST}/edge`,
                       { collection: E2_APITEST, from: [c], to: [c] });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g_apitest level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -284,6 +290,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/gharial/${g}/edge/${e}/${EDGE_KEY}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -300,6 +307,7 @@ function gharialApiAuthzSuite () {
       arango.POST_RAW(`/_db/${DB}/_api/gharial/${g}/edge/${e}`,
                       { _key: EDGE_KEY, _from: `${c}/k1`, _to: `${c}/k2` });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -323,6 +331,7 @@ function gharialApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/gharial/${G_APITEST}/edge/${E_APITEST}`,
                      { collection: E_APITEST, from: [c], to: [c] });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseDatabase name=d level=write",
@@ -345,6 +354,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/gharial/${G_APITEST}/edge/${E_APITEST}?dropCollection=false`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g_apitest level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -362,6 +372,7 @@ function gharialApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/gharial/${g}/edge/${e}/${EDGE_KEY}`,
                      { _from: `${c}/k2`, _to: `${c}/k3` });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -384,6 +395,7 @@ function gharialApiAuthzSuite () {
       arango.PATCH_RAW(`/_db/${DB}/_api/gharial/${g}/edge/${e}/${EDGE_KEY}`,
                        { extra: 1 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -405,6 +417,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/gharial/${g}/edge/${e}/${EDGE_KEY}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -421,6 +434,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/gharial/${g}/vertex`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read"
@@ -437,6 +451,7 @@ function gharialApiAuthzSuite () {
       arango.POST_RAW(`/_db/${DB}/_api/gharial/${G_APITEST}/vertex`,
                       { collection: C_ORPHAN });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g_apitest level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -454,6 +469,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/gharial/${g}/vertex/${c}/k1`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -468,6 +484,7 @@ function gharialApiAuthzSuite () {
       arango.POST_RAW(`/_db/${DB}/_api/gharial/${g}/vertex/${c}`,
                       { _key: VERTEX_KEY, value: 9999 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -486,6 +503,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/gharial/${G_APITEST}/vertex/${C_ORPHAN}?dropCollection=false`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g_apitest level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -503,6 +521,7 @@ function gharialApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/gharial/${g}/vertex/${c}/${VERTEX_KEY}`,
                      { value: 10000 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -521,6 +540,7 @@ function gharialApiAuthzSuite () {
       arango.PATCH_RAW(`/_db/${DB}/_api/gharial/${g}/vertex/${c}/${VERTEX_KEY}`,
                        { extra: 42 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",
@@ -542,6 +562,7 @@ function gharialApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/gharial/${g}/vertex/${c}/${VERTEX_KEY}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseGraph db=d name=g level=read",
         "UseCollection db=d name=_graphs level=read",

--- a/tests/js/client/server_permissions/authorization-questions/gharial.js
+++ b/tests/js/client/server_permissions/authorization-questions/gharial.js
@@ -31,8 +31,7 @@
 //           arangod/Graph/GraphOperations.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=d level=read`
-// (RestHandler::checkUserCanAccess).
+// `UseDatabase name=d level=read`.
 //
 // Any request that names a graph in the path first runs RestGraphHandler::
 // getGraph() -> GraphManager::lookupGraphByName(), which asks:

--- a/tests/js/client/server_permissions/authorization-questions/indexes.js
+++ b/tests/js/client/server_permissions/authorization-questions/indexes.js
@@ -42,7 +42,8 @@
 //   `UseDatabase ... level=write` and canUseCollection(WriteMeta) ->
 //   `UseCollection ... level=writemeta`, then begins an EXCLUSIVE transaction
 //   whose permission check maps to `UseCollection ... level=writedata`.
-// Every request additionally asks `UseDatabase name=d level=read` first.
+// Every request additionally asks `UseApiVersion version=0` and
+// `UseDatabase name=d level=read` first.
 
 if (getOptions === true) {
   return {

--- a/tests/js/client/server_permissions/authorization-questions/indexes.js
+++ b/tests/js/client/server_permissions/authorization-questions/indexes.js
@@ -97,6 +97,7 @@ function indexApiAuthzSuite () {
       arango.GET_RAW(`/_db/${DB}/_api/index?collection=${c}`);
       // only a single server resolves the collection under the ExecContext
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         ...singleOnly([
           "UseCollection db=d name=c level=read"
@@ -109,6 +110,7 @@ function indexApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/index/selectivity?collection=${c}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -123,6 +125,7 @@ function indexApiAuthzSuite () {
       const res = arango.POST_RAW(`/_db/${DB}/_api/index?collection=${c}`,
                                   { type: 'persistent', fields: ['value'] });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writemeta",
@@ -141,6 +144,7 @@ function indexApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/index/sync-caches`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -154,6 +158,7 @@ function indexApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/index/${handle}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseDatabase name=d level=write",

--- a/tests/js/client/server_permissions/authorization-questions/jobs.js
+++ b/tests/js/client/server_permissions/authorization-questions/jobs.js
@@ -30,8 +30,7 @@
 //
 // RestJobHandler performs NO ExecContext checks of its own. The only
 // authorization questions are the base `UseApiVersion version=0` and
-// `UseDatabase name=_system level=read` asked by
-// RestHandler::checkUserCanAccess() for every request (the job
+// `UseDatabase name=_system level=read` for every request (the job
 // endpoints carry no /_db prefix, so the connected database _system applies;
 // we spell it out explicitly). The per-job ownership filtering inside
 // AsyncJobManager uses exec.user()/exec.isSuperuser(), which do not call can()

--- a/tests/js/client/server_permissions/authorization-questions/jobs.js
+++ b/tests/js/client/server_permissions/authorization-questions/jobs.js
@@ -29,8 +29,9 @@
 // Handler: arangod/RestHandler/RestJobHandler.cpp
 //
 // RestJobHandler performs NO ExecContext checks of its own. The only
-// authorization question is the base `UseDatabase name=_system level=read`
-// asked by RestHandler::checkUserCanAccess() for every request (the job
+// authorization questions are the base `UseApiVersion version=0` and
+// `UseDatabase name=_system level=read` asked by
+// RestHandler::checkUserCanAccess() for every request (the job
 // endpoints carry no /_db prefix, so the connected database _system applies;
 // we spell it out explicitly). The per-job ownership filtering inside
 // AsyncJobManager uses exec.user()/exec.isSuperuser(), which do not call can()

--- a/tests/js/client/server_permissions/authorization-questions/jobs.js
+++ b/tests/js/client/server_permissions/authorization-questions/jobs.js
@@ -81,6 +81,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/job/done`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -90,6 +91,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/job/pending`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -100,6 +102,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/job/${jobId}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       deleteJob(jobId);
@@ -111,6 +114,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_api/job/${jobId}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       deleteJob(jobId);
@@ -122,6 +126,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_api/job/${jobId}/cancel`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       deleteJob(jobId);
@@ -132,6 +137,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/job/all`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -141,6 +147,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/job/expired?stamp=0`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -151,6 +158,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/job/${jobId}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       deleteJob(jobId);
@@ -161,6 +169,7 @@ function jobApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/job/done`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/log.js
+++ b/tests/js/client/server_permissions/authorization-questions/log.js
@@ -29,8 +29,7 @@
 // Handler: arangod/RestHandler/RestAdminLogHandler.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess(). RestAdminLogHandler::verifyPermitted()
+// `UseDatabase name=_system level=read`. RestAdminLogHandler::verifyPermitted()
 // then, in the default configuration (--log.api-enabled=true,
 // --log.api-jwt-policy=true i.e. admin mode), asks:
 //   GET requests  -> canUseAdminAction(AdminReadLogs)

--- a/tests/js/client/server_permissions/authorization-questions/log.js
+++ b/tests/js/client/server_permissions/authorization-questions/log.js
@@ -28,7 +28,8 @@
 //
 // Handler: arangod/RestHandler/RestAdminLogHandler.cpp
 //
-// Every request first asks `UseDatabase name=_system level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=_system level=read` in
 // RestHandler::checkUserCanAccess(). RestAdminLogHandler::verifyPermitted()
 // then, in the default configuration (--log.api-enabled=true,
 // --log.api-jwt-policy=true i.e. admin mode), asks:

--- a/tests/js/client/server_permissions/authorization-questions/log.js
+++ b/tests/js/client/server_permissions/authorization-questions/log.js
@@ -66,6 +66,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/log`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadLogs"
       ], endObserve());
@@ -76,6 +77,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/log/entries`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadLogs"
       ], endObserve());
@@ -86,6 +88,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/log/level`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadLogs"
       ], endObserve());
@@ -96,6 +99,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/log/structured`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadLogs"
       ], endObserve());
@@ -106,6 +110,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/log/level`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminSetLogLevel"
       ], endObserve());
@@ -116,6 +121,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/log/structured`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminSetLogLevel"
       ], endObserve());
@@ -126,6 +132,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/log`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminSetLogLevel"
       ], endObserve());
@@ -136,6 +143,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/log/entries`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminSetLogLevel"
       ], endObserve());
@@ -146,6 +154,7 @@ function logApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/log/level`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminSetLogLevel"
       ], endObserve());

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -509,6 +509,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/openapi.json`);
       assertPermissions([
+        "UseApiVersion version=0",
       ], endObserve());
     },
 

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -87,6 +87,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/document-state/99999/shards`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "AdminReadReplicatedLog"
       ], endObserve());
@@ -96,6 +97,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/document-state/99999/snapshot/start`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "AdminWriteReplicatedLog"
       ], endObserve());
@@ -106,6 +108,7 @@ function miscApiAuthzSuite () {
       arango.DELETE_RAW(
         `/_db/${DB}/_api/document-state/99999/snapshot/finish/99999`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "AdminWriteReplicatedLog"
       ], endObserve());
@@ -117,6 +120,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/endpoint`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -128,6 +132,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/engine`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -136,6 +141,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/engine/stats`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -149,6 +155,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/explain`, { query: `FOR d IN ${c} RETURN d` });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -160,6 +167,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/key-generators`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -173,6 +181,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/log`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "AdminReadReplicatedLog"
       ], endObserve());
@@ -182,6 +191,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/log`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "AdminWriteReplicatedLog"
       ], endObserve());
@@ -191,6 +201,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/log`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "AdminWriteReplicatedLog"
       ], endObserve());
@@ -205,6 +216,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/log-internal`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -216,6 +228,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query/slow`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -224,6 +237,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query/current`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -232,6 +246,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query/properties`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -242,6 +257,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query/registry`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -250,6 +266,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query/rules`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -259,6 +276,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/query`, { query: `FOR d IN ${c} RETURN d` });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -268,6 +286,7 @@ function miscApiAuthzSuite () {
       arango.DELETE_RAW(
         `/_db/${DB}/_api/query/nonexistent-query-apitester-99999`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -276,6 +295,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/query/slow`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -286,6 +306,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query-cache/entries`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -294,6 +315,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query-cache/properties`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -308,6 +330,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_api/query-cache/properties`, { mode: 'off' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -316,6 +339,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/query-cache`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -329,6 +353,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/query-plan-cache`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -338,6 +363,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/query-plan-cache`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseDatabase name=d level=write"
@@ -350,6 +376,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/ttl/properties`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -358,6 +385,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/ttl/statistics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -367,6 +395,7 @@ function miscApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_api/ttl/properties`,
                      { enable: true, frequency: 30000 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -377,6 +406,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/upload`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -389,6 +419,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/version`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -401,6 +432,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/wal/lastTick`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...singleOnly([
           "AdminWalAccess"
@@ -412,6 +444,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/wal/open-transactions`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...singleOnly([
           "AdminWalAccess"
@@ -423,6 +456,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/wal/range`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...singleOnly([
           "AdminWalAccess"
@@ -436,6 +470,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/wal/tail`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...singleOnly([
           "AdminWalAccess",
@@ -459,6 +494,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_api/wal/tail`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...singleOnly([
           "AdminWalAccess"
@@ -470,6 +506,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/wal/tail`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...singleOnly([
           "AdminWalAccess"
@@ -499,6 +536,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/tasks`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -507,6 +545,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/tasks/nonexistent-task-apitester-99999`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -516,6 +555,7 @@ function miscApiAuthzSuite () {
       const res = arango.POST_RAW(`/_db/${DB}/_api/tasks`,
         { name: 'apitester-task', command: '1+1;', offset: 0 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseDatabase name=d level=write"
@@ -532,6 +572,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/tasks/${id}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseDatabase name=d level=write"
@@ -552,7 +593,7 @@ function miscApiAuthzSuite () {
     testListAccessTokens: function () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/token/root`);
-      assertPermissions([], endObserve());
+      assertPermissions(["UseApiVersion version=0"], endObserve());
     },
 
     testCreateAccessToken: function () {
@@ -560,6 +601,7 @@ function miscApiAuthzSuite () {
       const res = arango.POST_RAW(`/_db/_system/_api/token/root`,
                                   { name: 'apitester-token' });
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         ...singleOnly([
           "UseCollection db=_system name=_users level=read",
@@ -578,6 +620,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/token/root/${id}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         ...singleOnly([
           "UseCollection db=_system name=_users level=read",

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -28,13 +28,12 @@
 // Observation-based counterpart of tests/api/apitests/misc.mjs.
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=<db> level=read` in
-// RestHandler::checkUserCanAccess() (the base check fires for any authenticated
+// `UseDatabase name=<db> level=read` (the base check fires for any authenticated
 // request while authentication is on), where <db> is derived from the
 // /_db/<name>/ path prefix. Individual handlers then ask further questions:
 //   - canUseAdminAction(X)   -> logs X (always, RBAC not required)
 //   - canUseHardenedAction(X) -> logs X ONLY with --server.harden=true; we do
-//     not set harden, so those handlers (engine, version) ask nothing extra.
+//     not set harden, so those handlers (engine) ask nothing extra.
 //   - canUseDatabase(db, Write) -> `UseDatabase name=<db> level=write`
 //   - a read/write transaction over a collection -> UseCollection questions in
 //     StorageEngine/TransactionState.cpp checkCollectionPermission.
@@ -412,19 +411,6 @@ function miscApiAuthzSuite () {
       ], endObserve());
     },
 
-    // ── /_api/version ────────────────────────────────────────────────────
-    // RestVersionHandler falls through to the base check, then
-    // canUseHardenedAction(MonitoringInternal) for full details. Not hardened
-    // here -> asks nothing beyond the base check.
-    testVersion: function () {
-      beginObserve();
-      arango.GET_RAW(`/_db/${DB}/_api/version`);
-      assertPermissions([
-        "UseApiVersion version=0",
-        "UseDatabase name=d level=read"
-      ], endObserve());
-    },
-
     // ── /_api/wal/* ──────────────────────────────────────────────────────
     // RestWalAccessHandler: canUseAdminAction(AdminWalAccess) (always logged).
     // AUDIT: on a coordinator the handler returns 501 before the check; on a
@@ -516,9 +502,9 @@ function miscApiAuthzSuite () {
     },
 
     // ── /openapi.json ────────────────────────────────────────────────────
-    // RestOpenApiHandler::checkUserCanAccess neither checks API version nor
-    // database for exactly this path - the spec must be readable before
-    // 1logging in.
+    // RestOpenApiHandler::checkUserCanAccess does not check database
+    // for exactly this path - the spec must be readable before
+    // logging in.
     testOpenApiSpec: function () {
       beginObserve();
       arango.GET_RAW(`/openapi.json`);

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -509,7 +509,6 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/openapi.json`);
       assertPermissions([
-        "UseApiVersion version=0",
       ], endObserve());
     },
 

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -27,7 +27,8 @@
 //
 // Observation-based counterpart of tests/api/apitests/misc.mjs.
 //
-// Every request first asks `UseDatabase name=<db> level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=<db> level=read` in
 // RestHandler::checkUserCanAccess() (the base check fires for any authenticated
 // request while authentication is on), where <db> is derived from the
 // /_db/<name>/ path prefix. Individual handlers then ask further questions:
@@ -515,12 +516,12 @@ function miscApiAuthzSuite () {
     },
 
     // ── /openapi.json ────────────────────────────────────────────────────
-    // RestOpenApiHandler (extends RestBaseHandler) does not override
-    // checkUserCanAccess, so the base UseDatabase check fires; the request has
-    // no /_db/ prefix, so it addresses the _system database. execute() itself
-    // asks no can().
-    // AUDIT: documented as OPEN (unauthenticated -> 200), but an authenticated
-    // root request still triggers the base UseDatabase(_system, read) check.
+    // RestOpenApiHandler::checkUserCanAccess returns early for exactly this
+    // path - the spec must be readable before logging in - so the base
+    // implementation never runs and neither the API version nor the database
+    // is asked about. execute() itself asks no can() either.
+    // AUDIT: nothing is observed even for an authenticated root request; for
+    // any other path of this handler the base questions would fire.
     testOpenApiSpec: function () {
       beginObserve();
       arango.GET_RAW(`/openapi.json`);

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -516,12 +516,9 @@ function miscApiAuthzSuite () {
     },
 
     // ── /openapi.json ────────────────────────────────────────────────────
-    // RestOpenApiHandler::checkUserCanAccess returns early for exactly this
-    // path - the spec must be readable before logging in - so the base
-    // implementation never runs and neither the API version nor the database
-    // is asked about. execute() itself asks no can() either.
-    // AUDIT: nothing is observed even for an authenticated root request; for
-    // any other path of this handler the base questions would fire.
+    // RestOpenApiHandler::checkUserCanAccess neither checks API version nor
+    // database for exactly this path - the spec must be readable before
+    // 1logging in.
     testOpenApiSpec: function () {
       beginObserve();
       arango.GET_RAW(`/openapi.json`);

--- a/tests/js/client/server_permissions/authorization-questions/monitoring.js
+++ b/tests/js/client/server_permissions/authorization-questions/monitoring.js
@@ -70,6 +70,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/statistics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -80,6 +81,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/statistics-description`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -90,6 +92,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/status`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -101,6 +104,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/supervisionState`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminSupervisionState"
       ], endObserve());
@@ -115,6 +119,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/support-info`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMonitoring"
       ], endObserve());
@@ -128,6 +133,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/system-report`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -141,6 +147,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/telemetrics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -151,6 +158,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_admin/telemetrics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -160,6 +168,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/time`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -170,6 +179,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/usage-metrics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -182,6 +192,7 @@ function monitoringApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/version`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/monitoring.js
+++ b/tests/js/client/server_permissions/authorization-questions/monitoring.js
@@ -29,11 +29,10 @@
 //
 // Handlers: RestAdminStatisticsHandler, RestAdminStatusHandler,
 // RestSupervisionStateHandler, RestSupportInfoHandler, RestSystemReportHandler,
-// RestTimeHandler, RestUsageMetricsHandler, RestVersionHandler.
+// RestTimeHandler, RestUsageMetricsHandler.
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess(). Beyond that:
+// `UseDatabase name=_system level=read`. Beyond that:
 //   - Hardened actions (canUseHardenedAction) ask nothing without
 //     --server.harden=true (our suites do not set it), so only the base
 //     question remains.
@@ -179,19 +178,6 @@ function monitoringApiAuthzSuite () {
     testUsageMetrics: function () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/usage-metrics`);
-      assertPermissions([
-        "UseApiVersion version=0",
-        "UseDatabase name=_system level=read"
-      ], endObserve());
-    },
-
-    // GET /_admin/version - RestVersionHandler always returns 200 and only uses
-    // canUseHardenedAction(AdminMonitoringInternal) internally to decide whether
-    // to include the version field.
-    // hardened action -> no question without --server.harden
-    testVersion: function () {
-      beginObserve();
-      arango.GET_RAW(`/_db/_system/_admin/version`);
       assertPermissions([
         "UseApiVersion version=0",
         "UseDatabase name=_system level=read"

--- a/tests/js/client/server_permissions/authorization-questions/monitoring.js
+++ b/tests/js/client/server_permissions/authorization-questions/monitoring.js
@@ -31,7 +31,8 @@
 // RestSupervisionStateHandler, RestSupportInfoHandler, RestSystemReportHandler,
 // RestTimeHandler, RestUsageMetricsHandler, RestVersionHandler.
 //
-// Every request first asks `UseDatabase name=_system level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=_system level=read` in
 // RestHandler::checkUserCanAccess(). Beyond that:
 //   - Hardened actions (canUseHardenedAction) ask nothing without
 //     --server.harden=true (our suites do not set it), so only the base

--- a/tests/js/client/server_permissions/authorization-questions/observability.js
+++ b/tests/js/client/server_permissions/authorization-questions/observability.js
@@ -31,7 +31,8 @@
 //   arangod/SystemMonitor/Activities/RestHandler.cpp
 //   arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
 //
-// Every request first asks `UseDatabase name=_system level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=_system level=read` in
 // RestHandler::checkUserCanAccess() (connected database is _system). Both
 // handlers then ask canUseAdminAction(AdminMonitoringInternal), so the
 // observed question is AdminMonitoringInternal.

--- a/tests/js/client/server_permissions/authorization-questions/observability.js
+++ b/tests/js/client/server_permissions/authorization-questions/observability.js
@@ -72,6 +72,8 @@ function observabilityApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_arango/experimental/_admin/activities`);
       assertPermissions([
+        // the experimental prefix addresses api version 2
+        "UseApiVersion version=2",
         "UseDatabase name=_system level=read",
         "AdminMonitoringInternal"
       ], endObserve());
@@ -83,6 +85,7 @@ function observabilityApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/async-registry`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMonitoringInternal"
       ], endObserve());

--- a/tests/js/client/server_permissions/authorization-questions/observability.js
+++ b/tests/js/client/server_permissions/authorization-questions/observability.js
@@ -32,8 +32,7 @@
 //   arangod/SystemMonitor/AsyncRegistry/RestHandler.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess() (connected database is _system). Both
+// `UseDatabase name=_system level=read` (connected database is _system). Both
 // handlers then ask canUseAdminAction(AdminMonitoringInternal), so the
 // observed question is AdminMonitoringInternal.
 

--- a/tests/js/client/server_permissions/authorization-questions/open.js
+++ b/tests/js/client/server_permissions/authorization-questions/open.js
@@ -30,7 +30,8 @@
 //
 // These are OPEN (public) endpoints. RestAuthHandler overrides
 // checkUserCanAccess() to unconditionally forceSuperuser() and return OK, so
-// the universal `UseDatabase name=... level=read` base check is NOT asked.
+// neither the universal `UseApiVersion version=0` nor the
+// `UseDatabase name=... level=read` base check is asked.
 // execute() only inspects the request body / JWT and generates a token; it
 // never consults the ExecContext. Hence these endpoints ask NOTHING at all -
 // the observed set is empty for every request, regardless of the credentials

--- a/tests/js/client/server_permissions/authorization-questions/open.js
+++ b/tests/js/client/server_permissions/authorization-questions/open.js
@@ -30,8 +30,7 @@
 //
 // These are OPEN (public) endpoints. RestAuthHandler overrides
 // checkUserCanAccess() to unconditionally forceSuperuser() and return OK, so
-// neither the universal `UseApiVersion version=0` nor the
-// `UseDatabase name=... level=read` base check is asked.
+// the universal `UseDatabase name=... level=read` base check is NOT asked.
 // execute() only inspects the request body / JWT and generates a token; it
 // never consults the ExecContext. Hence these endpoints ask NOTHING at all -
 // the observed set is empty for every request, regardless of the credentials

--- a/tests/js/client/server_permissions/authorization-questions/open.js
+++ b/tests/js/client/server_permissions/authorization-questions/open.js
@@ -28,6 +28,7 @@
 //
 // Handler: arangod/RestHandler/RestAuthHandler.cpp
 //
+// TODO fix
 // These are OPEN (public) endpoints. RestAuthHandler overrides
 // checkUserCanAccess() to unconditionally forceSuperuser() and return OK, so
 // the universal `UseDatabase name=... level=read` base check is NOT asked.
@@ -66,9 +67,9 @@ function openApiAuthzSuite () {
     // but that does not change which questions are asked (none).
     testObtainToken: function () {
       beginObserve();
-      arango.POST_RAW(`/_open/auth`, { username: 'AR', password: 'AR' });
+      arango.POST_RAW(`/_open/auth`, { username: 'AR', password: 'AR' },
+                      { 'Authorization': 'Bearer not-a-real-token' });
       assertPermissions([
-        "UseApiVersion version=0",
       ], endObserve());
     },
 
@@ -85,9 +86,9 @@ function openApiAuthzSuite () {
     // POST /_open/auth/renew without a proper token - OPEN, asks nothing.
     testRenewWithoutToken: function () {
       beginObserve();
-      arango.POST_RAW(`/_open/auth/renew`, {});
+      arango.POST_RAW(`/_open/auth/renew`, {},
+                      { 'Authorization': 'Bearer not-a-real-token' });
       assertPermissions([
-        "UseApiVersion version=0",
       ], endObserve());
     },
   };

--- a/tests/js/client/server_permissions/authorization-questions/open.js
+++ b/tests/js/client/server_permissions/authorization-questions/open.js
@@ -67,7 +67,9 @@ function openApiAuthzSuite () {
     testObtainToken: function () {
       beginObserve();
       arango.POST_RAW(`/_open/auth`, { username: 'AR', password: 'AR' });
-      assertPermissions([], endObserve());
+      assertPermissions([
+        "UseApiVersion version=0",
+      ], endObserve());
     },
 
     // POST /_open/auth/renew with a bearer token - still OPEN, asks nothing.
@@ -84,7 +86,9 @@ function openApiAuthzSuite () {
     testRenewWithoutToken: function () {
       beginObserve();
       arango.POST_RAW(`/_open/auth/renew`, {});
-      assertPermissions([], endObserve());
+      assertPermissions([
+        "UseApiVersion version=0",
+      ], endObserve());
     },
   };
 }

--- a/tests/js/client/server_permissions/authorization-questions/replication.js
+++ b/tests/js/client/server_permissions/authorization-questions/replication.js
@@ -92,6 +92,7 @@ function replicationApiAuthzSuite () {
       const res = arango.POST_RAW(
         `/_db/_system/_api/replication/batch`, { ttl: 30 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       if (res.parsedBody && res.parsedBody.id) {
@@ -106,6 +107,7 @@ function replicationApiAuthzSuite () {
       arango.PUT_RAW(
         `/_db/_system/_api/replication/batch/${id}`, { ttl: 30 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
       deleteBatch(id);
@@ -117,6 +119,7 @@ function replicationApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/replication/batch/${id}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -131,6 +134,7 @@ function replicationApiAuthzSuite () {
       arango.GET_RAW(`/_db/_system/_api/replication/clusterInventory`);
       // a single server rejects the request before asking
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         ...clusterOnly([
           "AdminClusterInfo"

--- a/tests/js/client/server_permissions/authorization-questions/replication.js
+++ b/tests/js/client/server_permissions/authorization-questions/replication.js
@@ -29,7 +29,8 @@
 // Handler: arangod/RestHandler/RestReplicationHandler.cpp
 //          arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp (batch)
 //
-// Every request first asks `UseDatabase name=_system level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=_system level=read` in
 // RestHandler::checkUserCanAccess() (the paths carry the /_db/_system/ prefix).
 //
 //   batch (POST/PUT/DELETE)  RestReplicationHandler::testPermissions() does not

--- a/tests/js/client/server_permissions/authorization-questions/replication.js
+++ b/tests/js/client/server_permissions/authorization-questions/replication.js
@@ -30,8 +30,7 @@
 //          arangod/RocksDBEngine/RocksDBRestReplicationHandler.cpp (batch)
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess() (the paths carry the /_db/_system/ prefix).
+// `UseDatabase name=_system level=read` (the paths carry the /_db/_system/ prefix).
 //
 //   batch (POST/PUT/DELETE)  RestReplicationHandler::testPermissions() does not
 //                            check the batch command (only Dump GET and

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -32,7 +32,8 @@
 // RestOptionsDescriptionHandler, RestPublicOptionsHandler,
 // RestAdminRoutingHandler, RestAdminServerHandler.
 //
-// Every request first asks `UseDatabase name=_system level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=_system level=read` in
 // RestHandler::checkUserCanAccess(). Beyond that:
 //   - Hardened actions (license, metrics) ask nothing without --server.harden.
 //   - isSuperuser / isSuperuserOrDisabled checks do not call can().

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -199,7 +199,9 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/availability`);
       // this endpoint bypasses RestHandler::checkUserCanAccess()
-      assertPermissions([], endObserve());
+      assertPermissions([
+        "UseApiVersion version=0",
+      ], endObserve());
     },
 
     // GET /_admin/server/databaseDefaults - no check (AUTHEN)

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -200,7 +200,6 @@ function serverApiAuthzSuite () {
       arango.GET_RAW(`/_db/_system/_admin/server/availability`);
       // this endpoint bypasses RestHandler::checkUserCanAccess()
       assertPermissions([
-        "UseApiVersion version=0",
       ], endObserve());
     },
 

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -33,8 +33,7 @@
 // RestAdminRoutingHandler, RestAdminServerHandler.
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess(). Beyond that:
+// `UseDatabase name=_system level=read`. Beyond that:
 //   - Hardened actions (license, metrics) ask nothing without --server.harden.
 //   - isSuperuser / isSuperuserOrDisabled checks do not call can().
 //   - The real extra questions come from RestAdminServerHandler:

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -69,6 +69,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/deployment/id`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -81,6 +82,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/execute`, "1");
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -91,6 +93,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/license`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -101,6 +104,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/license`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -111,6 +115,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/metrics`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -124,6 +129,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/options`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -134,6 +140,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/options-description`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -143,6 +150,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/options-public`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -152,6 +160,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/routing/reload`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -164,6 +173,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/api-calls`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminApiCalls"
       ], endObserve());
@@ -176,13 +186,15 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/aql-queries`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminAqlQueries"
       ], endObserve());
     },
 
-    // GET /_admin/server/availability - OPEN endpoint, but an authenticated
-    // request still passes through checkUserCanAccess() (base question only).
+    // GET /_admin/server/availability - OPEN endpoint: the handler forces
+    // superuser and returns before the base implementation runs, so not even
+    // an authenticated request asks anything.
     testAvailability: function () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/availability`);
@@ -195,6 +207,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/databaseDefaults`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -204,6 +217,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/id`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -213,6 +227,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/mode`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -224,6 +239,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/server/mode`, { mode: "default" });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminMaintenance"
       ], endObserve());
@@ -234,6 +250,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/role`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -243,6 +260,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/tls`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -252,6 +270,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/server/tls`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -262,6 +281,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/jwt`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -272,6 +292,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/server/jwt`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -282,6 +303,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/encryption`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -292,6 +314,7 @@ function serverApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_admin/server/encryption`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/simple.js
+++ b/tests/js/client/server_permissions/authorization-questions/simple.js
@@ -79,6 +79,7 @@ function simpleApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/simple/all`, { collection: c, limit: 1 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -90,6 +91,7 @@ function simpleApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/simple/all-keys`,
                      { collection: c, limit: 1 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -102,6 +104,7 @@ function simpleApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/simple/by-example`,
                      { collection: c, example: { Hallo: 1 } });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -114,6 +117,7 @@ function simpleApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/simple/lookup-by-keys`,
                      { collection: c, keys: ['nonexistent-key-apitester-99999'] });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -127,6 +131,7 @@ function simpleApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/simple/remove-by-keys`,
                      { collection: c, keys: ['nonexistent-key-apitester-99999'] });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "UseCollection db=d name=c level=writedata",

--- a/tests/js/client/server_permissions/authorization-questions/transactions.js
+++ b/tests/js/client/server_permissions/authorization-questions/transactions.js
@@ -39,7 +39,8 @@
 //   via the manager, so they ask no collection question.
 // - The JS transaction (POST /_api/transaction) runs its action inside a
 //   transaction over the declared read collections.
-// Every request additionally asks `UseDatabase name=d level=read` first.
+// Every request additionally asks `UseApiVersion version=0` and
+// `UseDatabase name=d level=read` first.
 // Transactions used as preconditions are created as root BEFORE beginObserve().
 
 if (getOptions === true) {

--- a/tests/js/client/server_permissions/authorization-questions/transactions.js
+++ b/tests/js/client/server_permissions/authorization-questions/transactions.js
@@ -93,6 +93,7 @@ function transactionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/transaction`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -103,6 +104,7 @@ function transactionApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/transaction/${id}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       abortTrx(id);
@@ -118,6 +120,7 @@ function transactionApiAuthzSuite () {
         action: 'function () { return 1; }'
       });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -129,6 +132,7 @@ function transactionApiAuthzSuite () {
       const res = arango.POST_RAW(`/_db/${DB}/_api/transaction/begin`,
                                   { collections: { read: [c] } });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read"
       ], endObserve());
@@ -146,6 +150,7 @@ function transactionApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/transaction/${id}`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
       // committed -> the document now exists; remove it again
@@ -158,6 +163,7 @@ function transactionApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/transaction/${id}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },
@@ -167,6 +173,7 @@ function transactionApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/transaction/write`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read"
       ], endObserve());
     },

--- a/tests/js/client/server_permissions/authorization-questions/users.js
+++ b/tests/js/client/server_permissions/authorization-questions/users.js
@@ -37,9 +37,8 @@
 //   - POST /_api/user           (path "/_api/user")
 //     DO go through the base check -> `UseApiVersion version=0` and
 //     `UseDatabase name=_system level=read`.
-//   - every /_api/user/<user>[/...] request SKIPS the base check, but the
-//     override asks `UseApiVersion version=0` itself, so beyond that only
-//     the questions of the handler body are observed.
+//   - every /_api/user/<user>[/...] request SKIPS the base check, so the
+//     only quesions observed are the ones the handler body asks itself.
 //
 // Handler body questions (ExecContext helpers):
 //   canReadUser(u)            -> `ReadUser name=<u>`

--- a/tests/js/client/server_permissions/authorization-questions/users.js
+++ b/tests/js/client/server_permissions/authorization-questions/users.js
@@ -121,6 +121,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/user`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminReadUsers",
         "ReadUser name=root",
@@ -138,6 +139,7 @@ function userApiAuthzSuite () {
       arango.POST_RAW(`/_db/_system/_api/user`,
                       { user: testuser, passwd: 'testpasswd' });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "CreateUser name=testuser",
@@ -158,7 +160,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/_system/_api/user/${testuser}`,
                       { passwd: 'testpasswd' });
-      assertPermissions([], endObserve());
+      assertPermissions(["UseApiVersion version=0"], endObserve());
     },
 
     // GET /_api/user/testuser - canReadUser(testuser)
@@ -167,6 +169,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/user/${testuser}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "ReadUser name=testuser"
       ], endObserve());
     },
@@ -177,6 +180,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/user/${testuser}/config`);
       assertPermissions([
+        "UseApiVersion version=0",
         "ReadUser name=testuser"
       ], endObserve());
     },
@@ -188,6 +192,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/user/${testuser}/database`);
       assertPermissions([
+        "UseApiVersion version=0",
         "ReadUser name=testuser"
       ], endObserve());
     },
@@ -199,6 +204,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/user/${testuser}/database/d2`);
       assertPermissions([
+        "UseApiVersion version=0",
         "ReadUser name=testuser"
       ], endObserve());
     },
@@ -211,6 +217,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_api/user/${testuser}/database/d2/c2`);
       assertPermissions([
+        "UseApiVersion version=0",
         "ReadUser name=testuser"
       ], endObserve());
     },
@@ -222,6 +229,7 @@ function userApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_api/user/${testuser}`,
                      { passwd: 'newpasswd' });
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
@@ -237,6 +245,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.PATCH_RAW(`/_db/_system/_api/user/${testuser}`, { active: true });
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
@@ -253,6 +262,7 @@ function userApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_api/user/${testuser}/config/testkey`,
                      { value: 42 });
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
@@ -270,6 +280,7 @@ function userApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_api/user/${testuser}/database/d2`,
                      { grant: 'ro' });
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
@@ -289,6 +300,7 @@ function userApiAuthzSuite () {
       arango.PUT_RAW(`/_db/_system/_api/user/${testuser}/database/d2/c2`,
                      { grant: 'ro' });
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
@@ -304,6 +316,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/user/${testuser}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "DropUser name=testuser",
         ...singleOnly([
@@ -321,6 +334,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/user/${testuser}/config/testkey`);
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "ModifyUserProfile name=testuser",
         ...singleOnly([
@@ -339,6 +353,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/user/${testuser}/database/d2`);
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([
@@ -359,6 +374,7 @@ function userApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/user/${testuser}/database/d2/c2`);
       assertPermissions([
+        "UseApiVersion version=0",
         "IsReadOnly",
         "GrantUserPermissions name=testuser",
         ...singleOnly([

--- a/tests/js/client/server_permissions/authorization-questions/users.js
+++ b/tests/js/client/server_permissions/authorization-questions/users.js
@@ -35,9 +35,11 @@
 // check. Consequently:
 //   - GET  /_api/user           (path "/_api/user",  no trailing slash) and
 //   - POST /_api/user           (path "/_api/user")
-//     DO go through the base check -> `UseDatabase name=_system level=read`.
-//   - every /_api/user/<user>[/...] request SKIPS the base check, so the only
-//     questions observed are the ones the handler body asks itself.
+//     DO go through the base check -> `UseApiVersion version=0` and
+//     `UseDatabase name=_system level=read`.
+//   - every /_api/user/<user>[/...] request SKIPS the base check, but the
+//     override asks `UseApiVersion version=0` itself, so beyond that only
+//     the questions of the handler body are observed.
 //
 // Handler body questions (ExecContext helpers):
 //   canReadUser(u)            -> `ReadUser name=<u>`

--- a/tests/js/client/server_permissions/authorization-questions/version.js
+++ b/tests/js/client/server_permissions/authorization-questions/version.js
@@ -1,0 +1,140 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, arango */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+// / Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// //////////////////////////////////////////////////////////////////////////////
+
+// Authorization questions asked by the version endpoints /_api/version and
+// /_admin/version.
+//
+// Handler: arangod/RestHandler/RestVersionHandler.cpp
+//
+// Unlike every other handler, RestVersionHandler overrides
+// checkApiVersionAccess() and lets the *default* API version pass without
+// asking ExecContext::canUseApiVersion(). An identity that is not allowed to
+// use that version can therefore still ask the server for its version. Only
+// the database question of the base implementation remains, plus
+// canUseHardenedAction(AdminMonitoringInternal) internally to decide whether
+// the detailed version information is included - that one is silent without
+// --server.harden.
+//
+// Any other API version is gated as everywhere else, on this route too. API
+// version 1 is not in ApiVersion.h's supportedApiVersions yet, so it is
+// normally rejected before any handler runs; the
+// 'ApiVersion::treatVersion1AsSupported' failure point makes the version
+// checks treat it as supported. It must be armed before the server registers
+// its routes at startup, hence the startup option (see also
+// failing-user-access-does-not-reveal-information.js).
+if (getOptions === true) {
+  return {
+    'server.authentication': 'true',
+    'server.failure-point': 'ApiVersion::treatVersion1AsSupported',
+    // the observer reads the log file right after the request, so the log must
+    // not be written by the logging thread
+    'log.force-direct': 'true',
+    // keep background threads from asking questions of their own
+    'foxx.queues': 'false'
+  };
+}
+
+const jsunity = require('jsunity');
+const {
+  beginObserve,
+  endObserve,
+  disableObserve,
+  assertPermissions
+} = require('@arangodb/testutils/permissions-observer');
+const {
+  setUpApiTestData,
+  tearDownApiTestData,
+  DB
+} = require('@arangodb/testutils/apitest-fixtures');
+
+function versionApiAuthzSuite () {
+  return {
+    setUpAll: setUpApiTestData,
+    tearDownAll: tearDownApiTestData,
+
+    tearDown: function () {
+      // in case a test failed in the middle of an observation
+      disableObserve();
+    },
+
+    // GET /_api/version - the api-version question is not asked at all, so
+    // whichever versions the identity may use, it gets the version.
+    testVersion: function () {
+      beginObserve();
+      arango.GET_RAW(`/_api/version`);
+      assertPermissions([
+        "UseDatabase name=_system level=read"
+      ], endObserve());
+    },
+
+    // the database question follows the /_db/ prefix, the exemption does not
+    // depend on it
+    testVersionInOtherDatabase: function () {
+      beginObserve();
+      arango.GET_RAW(`/_db/${DB}/_api/version`);
+      assertPermissions([
+        "UseDatabase name=d level=read"
+      ], endObserve());
+    },
+
+    // GET /_arango/v1/_api/version - the exemption covers the default version
+    // only, so a versioned request to the very same handler is gated.
+    testVersionWithNonDefaultApiVersion: function () {
+      beginObserve();
+      arango.GET_RAW(`/_arango/v1/_api/version`);
+      assertPermissions([
+        "UseApiVersion version=1",
+        "UseDatabase name=_system level=read"
+      ], endObserve());
+    },
+
+    // GET /_admin/version - the handler's second route, same exemption. It
+    // always returns 200 and only uses
+    // canUseHardenedAction(AdminMonitoringInternal) internally to decide
+    // whether to include the version field - a hardened action, hence no
+    // question without --server.harden.
+    testAdminVersion: function () {
+      beginObserve();
+      arango.GET_RAW(`/_db/_system/_admin/version`);
+      assertPermissions([
+        "UseDatabase name=_system level=read"
+      ], endObserve());
+    },
+
+    // GET /_arango/v1/admon/version - also here for non-default api-version
+    // we check the api-version permission
+    testAdminVersionWithNonDefaultApiVersion: function () {
+      beginObserve();
+      arango.GET_RAW(`/_arango/v1/_admin/version`);
+      assertPermissions([
+        "UseApiVersion version=1",
+        "UseDatabase name=_system level=read"
+      ], endObserve());
+    },
+
+  };
+}
+
+jsunity.run(versionApiAuthzSuite);
+return jsunity.done();

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -113,6 +113,7 @@ function viewApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/view`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseCollection db=d name=c level=read",
         "SeeView db=d name=v_apitest",
@@ -129,6 +130,7 @@ function viewApiAuthzSuite () {
       beginObserve();
       arango.POST_RAW(`/_db/${DB}/_api/view`, viewBody);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "CreateView db=d name=v_apitest linkedCollections=[c]",
@@ -149,6 +151,7 @@ function viewApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseView db=d name=v_apitest level=read",
         "UseCollection db=d name=c level=read",
@@ -164,6 +167,7 @@ function viewApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}/properties`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "UseView db=d name=v_apitest level=read",
         "UseCollection db=d name=c level=read",
@@ -184,6 +188,7 @@ function viewApiAuthzSuite () {
       arango.PATCH_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}/properties`,
                        { cleanupIntervalStep: 2 });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "ModifyView db=d name=v_apitest linkedCollections=[]",
@@ -203,6 +208,7 @@ function viewApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}/properties`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "ModifyView db=d name=v_apitest linkedCollections=[]",
@@ -225,6 +231,7 @@ function viewApiAuthzSuite () {
       arango.PATCH_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}/rename`,
                        { name: TEST_VIEW_NEW });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "RenameView db=d oldName=v_apitest newName=v_apitest_new",
@@ -243,6 +250,7 @@ function viewApiAuthzSuite () {
       arango.PUT_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}/rename`,
                      { name: TEST_VIEW_NEW });
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "RenameView db=d oldName=v_apitest newName=v_apitest_new",
@@ -259,6 +267,7 @@ function viewApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/${DB}/_api/view/${TEST_VIEW}`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=d level=read",
         "IsReadOnly",
         "DropView db=d name=v_apitest",

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -28,7 +28,8 @@
 //
 // Handler: arangod/RestHandler/RestViewHandler.cpp
 //
-// Every request first asks `UseDatabase name=d level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=d level=read` in
 // RestHandler::checkUserCanAccess(). The view handler then asks one dedicated
 // ExecContext question per operation (arangod/Utils/ExecContext.cpp):
 //   getViews (list)     -> canSeeView()   -> SeeView    (per visible view)

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -29,8 +29,7 @@
 // Handler: arangod/RestHandler/RestViewHandler.cpp
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=d level=read` in
-// RestHandler::checkUserCanAccess(). The view handler then asks one dedicated
+// `UseDatabase name=d level=read`. The view handler then asks one dedicated
 // ExecContext question per operation (arangod/Utils/ExecContext.cpp):
 //   getViews (list)     -> canSeeView()   -> SeeView    (per visible view)
 //   getView             -> canUseView(RO) -> UseView ... level=read

--- a/tests/js/client/server_permissions/authorization-questions/wal.js
+++ b/tests/js/client/server_permissions/authorization-questions/wal.js
@@ -29,7 +29,8 @@
 // Handler: arangod/RocksDBEngine/RocksDBRestWalHandler.cpp (single-server/DBServer)
 //          arangod/ClusterEngine/ClusterRestWalHandler.cpp   (coordinator)
 //
-// Every request first asks `UseDatabase name=_system level=read` in
+// Every request first asks `UseApiVersion version=0` and then
+// `UseDatabase name=_system level=read` in
 // RestHandler::checkUserCanAccess() (the routes have no /_db/ prefix, so the
 // database is the connected _system).
 //

--- a/tests/js/client/server_permissions/authorization-questions/wal.js
+++ b/tests/js/client/server_permissions/authorization-questions/wal.js
@@ -30,8 +30,7 @@
 //          arangod/ClusterEngine/ClusterRestWalHandler.cpp   (coordinator)
 //
 // Every request first asks `UseApiVersion version=0` and then
-// `UseDatabase name=_system level=read` in
-// RestHandler::checkUserCanAccess() (the routes have no /_db/ prefix, so the
+// `UseDatabase name=_system level=read` (the routes have no /_db/ prefix, so the
 // database is the connected _system).
 //
 //   GET  /properties               no in-handler auth check (returns 501)

--- a/tests/js/client/server_permissions/authorization-questions/wal.js
+++ b/tests/js/client/server_permissions/authorization-questions/wal.js
@@ -74,6 +74,7 @@ function walApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/wal/properties`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -83,6 +84,7 @@ function walApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/wal/properties`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -92,6 +94,7 @@ function walApiAuthzSuite () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/wal/transactions`);
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -101,6 +104,7 @@ function walApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/wal/flush`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
     },
@@ -115,6 +119,7 @@ function walApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_admin/wal/wait_for_estimator_sync`, {});
       assertPermissions([
+        "UseApiVersion version=0",
         "UseDatabase name=_system level=read",
         "AdminWalAccess"
       ], endObserve());


### PR DESCRIPTION
Implements a new permission `CanUseApiVersion` that grants a user the use of a specific api-version (defined via a uint32_t version number).

I split `RestHandler::checkUserCanAccess` with the default permission checks (authentication and database access) that are done in almost every rest handler into 3 separate functions:
- `checkUserAuthentication`
- `checkApiVersionAccess`
- `checkDatabaseAccess`

Each of these functions can now be overridden independently by each rest handler and are executed in the order above in `RestHandler::handleAuthorizationChecks`. If one of the functions denies access, the latter ones are not executed any more. A special case is `checkUserAuthentication`: it can GRANT permission early (when returning GRANTED_EARLY, such that the latter functions are not exectued any more.

### Endpoints that do not check the api-version:
- All endpoints that default to `RestHandler::checkApiVersionAccess` that have no active authentication-feature or have a unix endpoint type
- The open endpoints "/openapi.json" (`RestOpenApiHandler`), "/_open/auth" (`RestAuthHandler`) and "/_admin/server/availability" (`RestAdminServerHandler`)
- "/_admin/version" (`RestVersionHandler`), "/_admin/debug" (`RestDebugHandler`) and "/_admin/status" (`RestStatusHandler`) if their server is in startup or maintenance mode and the request is authenticated (via a JWT token)
- "/" (`RestActionHandler`) if we have sytem-only authentication and path does not start with "/_"

### Special case
The `RestVersionHandler` always accepts the default api version although the user could have no permission for this api version (for backwards compatibility).

### Tests
Added some unit tests.
Adapted the authorization-questions, added some more tests for the version endpoint (moved all other tests for this endpoint into the new version.js file) and for the api-version in general. Also updated some stale comments.
