### PR TITLE
[CHORE] Rename TraversalEnumerator to ITraversalEnumerator

### DIFF
--- a/arangod/Aql/Executor/TraversalExecutor.cpp
+++ b/arangod/Aql/Executor/TraversalExecutor.cpp
@@ -30,7 +30,6 @@
 #include "Aql/SingleRowFetcher.h"
 #include "Basics/ThreadLocalLeaser.h"
 #include "Basics/system-compiler.h"
-#include "Graph/Enumerators/OneSidedEnumeratorInterface.h"
 #include "Graph/Providers/SingleServerProvider.h"
 #include "Graph/Steps/SingleServerProviderStep.h"
 #include "Graph/Providers/ClusterProvider.h"
@@ -150,7 +149,7 @@ TraversalExecutorInfos::TraversalExecutorInfos(
 }
 
 // REFACTOR
-arangodb::graph::TraversalEnumerator*
+arangodb::graph::ITraversalEnumerator*
 TraversalExecutorInfos::traversalEnumerator() const {
   TRI_ASSERT(_traversalEnumerator != nullptr);
   return _traversalEnumerator.get();
@@ -293,7 +292,7 @@ auto TraversalExecutorInfos::parseTraversalEnumeratorSingleServer(
   TRI_ASSERT(!isSmart);
   TRI_ASSERT(_traversalEnumerator == nullptr);
 
-  _traversalEnumerator = TraversalEnumerator::createEnumerator<
+  _traversalEnumerator = ITraversalEnumerator::createEnumerator<
       SingleServerProvider<SingleServerProviderStep>>(
       order, uniqueVertices, uniqueEdges, query, std::move(baseProviderOptions),
       std::move(pathValidatorOptions), std::move(enumeratorOptions));
@@ -341,20 +340,20 @@ auto TraversalExecutorInfos::parseTraversalEnumeratorCluster(
     baseProviderOptions.setRPCCommunicator(
         std::make_unique<aql::enterprise::SmartGraphRPCCommunicator>(
             query, query.resourceMonitor(), baseProviderOptions.engines()));
-    _traversalEnumerator = TraversalEnumerator::createEnumerator<
+    _traversalEnumerator = ITraversalEnumerator::createEnumerator<
         aql::enterprise::SmartGraphProvider<ClusterProviderStep>>(
         order, uniqueVertices, uniqueEdges, query,
         std::move(baseProviderOptions), std::move(pathValidatorOptions),
         std::move(enumeratorOptions));
   } else {
-    _traversalEnumerator = TraversalEnumerator::createEnumerator<
+    _traversalEnumerator = ITraversalEnumerator::createEnumerator<
         ClusterProvider<ClusterProviderStep>>(
         order, uniqueVertices, uniqueEdges, query,
         std::move(baseProviderOptions), std::move(pathValidatorOptions),
         std::move(enumeratorOptions));
   }
 #else
-  _traversalEnumerator = TraversalEnumerator::createEnumerator<
+  _traversalEnumerator = ITraversalEnumerator::createEnumerator<
       ClusterProvider<ClusterProviderStep>>(
       order, uniqueVertices, uniqueEdges, query, std::move(baseProviderOptions),
       std::move(pathValidatorOptions), std::move(enumeratorOptions));
@@ -535,7 +534,8 @@ bool TraversalExecutor::initTraverser(AqlItemBlockInputRange& input) {
   return traversalEnumerator()->stealStats();
 }
 
-arangodb::graph::TraversalEnumerator* TraversalExecutor::traversalEnumerator() {
+arangodb::graph::ITraversalEnumerator*
+TraversalExecutor::traversalEnumerator() {
   TRI_ASSERT(_traversalEnumerator != nullptr);
   return _traversalEnumerator;
 }

--- a/arangod/Aql/Executor/TraversalExecutor.h
+++ b/arangod/Aql/Executor/TraversalExecutor.h
@@ -30,7 +30,7 @@
 #include "Aql/RegisterInfos.h"
 #include "Aql/TraversalStats.h"
 #include "Aql/Variable.h"
-#include "Graph/Enumerators/OneSidedEnumeratorInterface.h"
+#include "Graph/Enumerators/ITraversalEnumerator.h"
 #include "Graph/Options/OneSidedEnumeratorOptions.h"
 #include "Graph/PathManagement/PathValidatorOptions.h"
 #include "Graph/Providers/BaseProviderOptions.h"
@@ -102,7 +102,7 @@ class TraversalExecutorInfos {
   ~TraversalExecutorInfos() = default;
 
   [[nodiscard]] auto traversalEnumerator() const
-      -> arangodb::graph::TraversalEnumerator*;
+      -> arangodb::graph::ITraversalEnumerator*;
 
   bool usesOutputRegister(TraversalExecutorInfosHelper::OutputName type) const;
 
@@ -163,7 +163,7 @@ class TraversalExecutorInfos {
       TraversalExecutorInfosHelper::OutputName type) const;
 
  private:
-  std::unique_ptr<arangodb::graph::TraversalEnumerator> _traversalEnumerator =
+  std::unique_ptr<arangodb::graph::ITraversalEnumerator> _traversalEnumerator =
       nullptr;
 
   std::unordered_map<TraversalExecutorInfosHelper::OutputName, RegisterId,
@@ -213,7 +213,7 @@ class TraversalExecutor {
 
   [[nodiscard]] auto stats() -> Stats;
 
-  auto traversalEnumerator() -> arangodb::graph::TraversalEnumerator*;
+  auto traversalEnumerator() -> arangodb::graph::ITraversalEnumerator*;
 
   Infos& _infos;
 
@@ -223,7 +223,7 @@ class TraversalExecutor {
   InputAqlItemRow _inputRow;
 
   /// @brief the finder variant.
-  arangodb::graph::TraversalEnumerator* _traversalEnumerator;
+  arangodb::graph::ITraversalEnumerator* _traversalEnumerator;
 };
 
 }  // namespace aql

--- a/arangod/Graph/Enumerators/CMakeLists.txt
+++ b/arangod/Graph/Enumerators/CMakeLists.txt
@@ -1,6 +1,6 @@
 target_sources(arango_graph PRIVATE
+	ITraversalEnumerator.cpp
   OneSidedEnumerator.cpp
-  OneSidedEnumeratorInterface.cpp
   WeightedShortestPathEnumerator.cpp
   WeightedTwoSidedEnumerator.cpp
   TwoSidedEnumerator.cpp

--- a/arangod/Graph/Enumerators/ITraversalEnumerator.cpp
+++ b/arangod/Graph/Enumerators/ITraversalEnumerator.cpp
@@ -20,7 +20,7 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "OneSidedEnumeratorInterface.h"
+#include "Graph/Enumerators/ITraversalEnumerator.h"
 
 #include "Aql/QueryContext.h"
 #include "Graph/algorithm-aliases.h"
@@ -93,7 +93,7 @@ using namespace arangodb::graph;
   }
 
 template<class ProviderName>
-auto TraversalEnumerator::createEnumerator(
+auto ITraversalEnumerator::createEnumerator(
     traverser::TraverserOptions::Order order,
     traverser::TraverserOptions::UniquenessLevel uniqueVertices,
     traverser::TraverserOptions::UniquenessLevel uniqueEdges,
@@ -101,13 +101,13 @@ auto TraversalEnumerator::createEnumerator(
     typename ProviderName::Options&& baseProviderOptions,
     arangodb::graph::PathValidatorOptions&& pathValidatorOptions,
     arangodb::graph::OneSidedEnumeratorOptions&& enumeratorOptions)
-    -> std::unique_ptr<TraversalEnumerator> {
+    -> std::unique_ptr<ITraversalEnumerator> {
   GENERATE_ORDER_SWITCH(ProviderName)
   THROW_ARANGO_EXCEPTION(TRI_ERROR_INTERNAL);
 }
 
 #define INSTANTIATE_FACTORY(ProviderName)                              \
-  template auto TraversalEnumerator::createEnumerator<ProviderName>(   \
+  template auto ITraversalEnumerator::createEnumerator<ProviderName>(  \
       traverser::TraverserOptions::Order order,                        \
       traverser::TraverserOptions::UniquenessLevel uniqueVertices,     \
       traverser::TraverserOptions::UniquenessLevel uniqueEdges,        \
@@ -115,7 +115,7 @@ auto TraversalEnumerator::createEnumerator(
       ProviderName::Options && baseProviderOptions,                    \
       arangodb::graph::PathValidatorOptions && pathValidatorOptions,   \
       arangodb::graph::OneSidedEnumeratorOptions && enumeratorOptions) \
-      ->std::unique_ptr<TraversalEnumerator>;
+      ->std::unique_ptr<ITraversalEnumerator>;
 
 INSTANTIATE_FACTORY(
     arangodb::graph::ClusterProvider<arangodb::graph::ClusterProviderStep>)

--- a/arangod/Graph/Enumerators/ITraversalEnumerator.h
+++ b/arangod/Graph/Enumerators/ITraversalEnumerator.h
@@ -62,7 +62,7 @@ class PathResultInterface {
   virtual auto lastEdgeToVelocyPack(velocypack::Builder& builder) -> void = 0;
 };
 
-class TraversalEnumerator {
+class ITraversalEnumerator {
  public:
   template<class Provider>
   static auto createEnumerator(
@@ -73,10 +73,10 @@ class TraversalEnumerator {
       typename Provider::Options&& baseProviderOptions,
       graph::PathValidatorOptions&& pathValidatorOptions,
       graph::OneSidedEnumeratorOptions&& enumeratorOptions)
-      -> std::unique_ptr<TraversalEnumerator>;
+      -> std::unique_ptr<ITraversalEnumerator>;
 
-  TraversalEnumerator() {}
-  virtual ~TraversalEnumerator() {}
+  ITraversalEnumerator() {}
+  virtual ~ITraversalEnumerator() {}
 
   virtual void clear(bool keepPathStore) = 0;
   [[nodiscard]] virtual bool isDone() const = 0;

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.h
@@ -24,7 +24,7 @@
 
 #include "Aql/TraversalStats.h"
 #include "Basics/ResourceUsage.h"
-#include "Graph/Enumerators/OneSidedEnumeratorInterface.h"
+#include "Graph/Enumerators/ITraversalEnumerator.h"
 #include "Graph/Options/OneSidedEnumeratorOptions.h"
 #include "Graph/PathManagement/SingleProviderPathResult.h"
 #include "Graph/Types/VertexRef.h"
@@ -55,7 +55,7 @@ struct OneSidedEnumeratorOptions;
 class PathValidatorOptions;
 
 template<class Configuration>
-class OneSidedEnumerator final : public TraversalEnumerator {
+class OneSidedEnumerator final : public ITraversalEnumerator {
  public:
   using Step = typename Configuration::Step;  // public due to tracer access
   using Provider = typename Configuration::Provider;

--- a/arangod/Graph/PathManagement/SingleProviderPathResult.h
+++ b/arangod/Graph/PathManagement/SingleProviderPathResult.h
@@ -25,7 +25,7 @@
 #include <velocypack/HashedStringRef.h>
 #include "Containers/HashSet.h"
 
-#include "Graph/Enumerators/OneSidedEnumeratorInterface.h"
+#include "Graph/Enumerators/ITraversalEnumerator.h"
 #include "Graph/Providers/TypeAliases.h"
 #include "Graph/TraverserOptions.h"
 


### PR DESCRIPTION
### Scope & Purpose

Make it clear(er) that this is an interface class. Also rename the file containing the class to reflect the class name. 

Enterprise part: https://github.com/arangodb/enterprise/pull/1692