### PR TITLE
[CHORE] PathResultInterface changes

### DIFF
--- a/arangod/Graph/Enumerators/ITraversalEnumerator.cpp
+++ b/arangod/Graph/Enumerators/ITraversalEnumerator.cpp
@@ -115,7 +115,7 @@ auto ITraversalEnumerator::createEnumerator(
       ProviderName::Options && baseProviderOptions,                    \
       arangodb::graph::PathValidatorOptions && pathValidatorOptions,   \
       arangodb::graph::OneSidedEnumeratorOptions && enumeratorOptions) \
-      -> std::unique_ptr<ITraversalEnumerator>;
+      ->std::unique_ptr<ITraversalEnumerator>;
 
 INSTANTIATE_FACTORY(
     arangodb::graph::ClusterProvider<arangodb::graph::ClusterProviderStep>)

--- a/arangod/Graph/Enumerators/ITraversalEnumerator.cpp
+++ b/arangod/Graph/Enumerators/ITraversalEnumerator.cpp
@@ -115,7 +115,7 @@ auto ITraversalEnumerator::createEnumerator(
       ProviderName::Options && baseProviderOptions,                    \
       arangodb::graph::PathValidatorOptions && pathValidatorOptions,   \
       arangodb::graph::OneSidedEnumeratorOptions && enumeratorOptions) \
-      ->std::unique_ptr<ITraversalEnumerator>;
+      -> std::unique_ptr<ITraversalEnumerator>;
 
 INSTANTIATE_FACTORY(
     arangodb::graph::ClusterProvider<arangodb::graph::ClusterProviderStep>)

--- a/arangod/Graph/Enumerators/ITraversalEnumerator.h
+++ b/arangod/Graph/Enumerators/ITraversalEnumerator.h
@@ -24,6 +24,7 @@
 
 #include "Graph/TraverserOptions.h"
 #include "Graph/Types/VertexRef.h"
+#include "Graph/PathManagement/IPathResult.h"
 
 #include <memory>
 #include <numeric>
@@ -44,23 +45,6 @@ namespace graph {
 struct VertexDescription;
 struct OneSidedEnumeratorOptions;
 class PathValidatorOptions;
-
-#ifdef USE_ENTERPRISE
-namespace enterprise {
-template<class Provider>
-struct SmartGraphResponse;
-}
-#endif
-
-class PathResultInterface {
- public:
-  PathResultInterface() {}
-  virtual ~PathResultInterface() = default;
-
-  virtual auto toVelocyPack(velocypack::Builder& builder) -> void = 0;
-  virtual auto lastVertexToVelocyPack(velocypack::Builder& builder) -> void = 0;
-  virtual auto lastEdgeToVelocyPack(velocypack::Builder& builder) -> void = 0;
-};
 
 class ITraversalEnumerator {
  public:
@@ -88,7 +72,7 @@ class ITraversalEnumerator {
       std::vector<VertexDescription> const& vertices) = 0;
 
   virtual auto prepareIndexExpressions(aql::Ast* ast) -> void = 0;
-  virtual auto getNextPath() -> std::unique_ptr<PathResultInterface> = 0;
+  virtual auto getNextPath() -> std::unique_ptr<IPathResult> = 0;
 #ifdef USE_ENTERPRISE
   virtual auto smartSearch(size_t amountOfExpansions,
                            velocypack::Builder& result) -> void = 0;

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.cpp
@@ -261,7 +261,7 @@ void OneSidedEnumerator<Configuration>::resetManyStartVertices(
  */
 template<class Configuration>
 auto OneSidedEnumerator<Configuration>::getNextPath()
-    -> std::unique_ptr<PathResultInterface> {
+    -> std::unique_ptr<IPathResult> {
   if constexpr (std::is_same_v<ResultList,
                                enterprise::SmartGraphResponse<Provider>>) {
     // Not implemented and used

--- a/arangod/Graph/Enumerators/OneSidedEnumerator.h
+++ b/arangod/Graph/Enumerators/OneSidedEnumerator.h
@@ -25,6 +25,7 @@
 #include "Aql/TraversalStats.h"
 #include "Basics/ResourceUsage.h"
 #include "Graph/Enumerators/ITraversalEnumerator.h"
+#include "Graph/PathManagement/IPathResult.h"
 #include "Graph/Options/OneSidedEnumeratorOptions.h"
 #include "Graph/PathManagement/SingleProviderPathResult.h"
 #include "Graph/Types/VertexRef.h"
@@ -121,7 +122,7 @@ class OneSidedEnumerator final : public ITraversalEnumerator {
    * @return true Found and written a path, result is modified.
    * @return false No path found, result has not been changed.
    */
-  auto getNextPath() -> std::unique_ptr<PathResultInterface> override;
+  auto getNextPath() -> std::unique_ptr<IPathResult> override;
 
 #ifdef USE_ENTERPRISE
   auto smartSearch(size_t amountOfExpansions, velocypack::Builder&)

--- a/arangod/Graph/PathManagement/IPathResult.h
+++ b/arangod/Graph/PathManagement/IPathResult.h
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace arangodb {
+namespace velocypack {
+class HashedStringRef;
+class Builder;
+}  // namespace velocypack
+
+namespace graph {
+class IPathResult {
+ public:
+  IPathResult() {}
+  virtual ~IPathResult() = default;
+
+  virtual auto toVelocyPack(velocypack::Builder& builder) -> void = 0;
+  virtual auto lastVertexToVelocyPack(velocypack::Builder& builder) -> void = 0;
+  virtual auto lastEdgeToVelocyPack(velocypack::Builder& builder) -> void = 0;
+};
+
+}  // namespace graph
+}  // namespace arangodb

--- a/arangod/Graph/PathManagement/PathValidator.cpp
+++ b/arangod/Graph/PathManagement/PathValidator.cpp
@@ -303,7 +303,7 @@ auto PathValidator<ProviderType, PathStore, vertexUniqueness, edgeUniqueness>::
     if (evaluator->needsPath()) {
       using ResultPathType =
           SingleProviderPathResult<ProviderType, PathStore, Step>;
-      std::unique_ptr<PathResultInterface> currentPath =
+      std::unique_ptr<IPathResult> currentPath =
           std::make_unique<ResultPathType>(step, _provider, _store);
       currentPath->toVelocyPack(pathBuilder);
       evaluator->injectPath(pathBuilder.slice());

--- a/arangod/Graph/PathManagement/SingleProviderPathResult.h
+++ b/arangod/Graph/PathManagement/SingleProviderPathResult.h
@@ -25,9 +25,10 @@
 #include <velocypack/HashedStringRef.h>
 #include "Containers/HashSet.h"
 
-#include "Graph/Enumerators/ITraversalEnumerator.h"
+#include "Graph/PathManagement/IPathResult.h"
 #include "Graph/Providers/TypeAliases.h"
 #include "Graph/TraverserOptions.h"
+#include "Graph/Types/VertexRef.h"
 
 #include <numeric>
 #include <unordered_map>
@@ -41,7 +42,7 @@ class Builder;
 namespace graph {
 
 template<class ProviderType, class PathStoreType, class Step>
-class SingleProviderPathResult : public PathResultInterface {
+class SingleProviderPathResult : public IPathResult {
  public:
   SingleProviderPathResult(Step step, ProviderType& provider,
                            PathStoreType& store);


### PR DESCRIPTION
### Scope & Purpose

 * PathResultInterface is now called IPathResult
 * Defined in its own file
 * Moved to PathManagement subdirectory


Enterprise: https://github.com/arangodb/enterprise/pull/1695