### PR TITLE
[COR-859] Run RestHandler code in the user's ExecContext

### DIFF
--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -24,9 +24,9 @@
 
 #include "Activities/GenericActivity.h"
 #include "Activities/RegistryGlobalVariable.h"
+#include "Agency/RestAgencyHandler.h"
 #include "ApplicationFeatures/ApplicationServer.h"
 #include "Auth/TokenCache.h"
-#include "Basics/DownCast.h"
 #include "Basics/dtrace-wrapper.h"
 #include "Basics/error.h"
 #include "Basics/voc-errors.h"
@@ -39,7 +39,6 @@
 #include "GeneralServer/GeneralServerFeature.h"
 #include "GeneralServer/RestHandlerActivity.h"
 #include "Logger/LogMacros.h"
-#include "Logger/LogStructuredParamsAllowList.h"
 #include "Network/Methods.h"
 #include "Network/NetworkFeature.h"
 #include "Network/Utils.h"
@@ -52,12 +51,11 @@
 #include "VocBase/Identifiers/TransactionId.h"
 #include "VocBase/ticks.h"
 
-#include <Agency/RestAgencyHandler.h>
 #include <Async/async.h>
+#include <Ssl/jwt.h>
 #include <absl/strings/str_cat.h>
-#include "Ssl/jwt.h"
-#include <velocypack/Exception.h>
 #include <unordered_map>
+#include <velocypack/Exception.h>
 
 using namespace arangodb;
 using namespace arangodb::basics;
@@ -530,8 +528,7 @@ bool RestHandler::wakeupHandler() { return !_suspensionCounter.notify(); }
 
 auto RestHandler::executeEngine() -> async<void> {
   DTRACE_PROBE1(arangod, RestHandlerExecuteEngine, this);
-  ExecContextScope scope(
-      basics::downCast<ExecContext>(_request->requestContext()));
+  TRI_ASSERT(ExecContext::currentAsShared() == _request->requestContext());
 
   try {
     co_await executeAsync();
@@ -801,8 +798,13 @@ RestStatus RestHandler::execute() {
 }
 
 void RestHandler::runHandler(
-    std::function<void(rest::RestHandler*)> responseCallback) {
+    std::function<void(RestHandler*)> responseCallback) {
   _sendResponseCallback = std::move(responseCallback);
+
+  // set the scope for the state machine. note that the following
+  // .thenFinal does not automatically inherit the scope; but it does
+  // not need it, either.
+  auto scope = ExecContextScope(_request->requestContext());
 
   runHandlerStateMachine().
       // Swallow all exceptions. It would be desirable to guarantee no
@@ -811,7 +813,7 @@ void RestHandler::runHandler(
       thenFinal([self = shared_from_this()](auto&& tryResult) noexcept {
         try {
           std::move(tryResult).throwIfFailed();
-        } catch (basics::Exception const& exception) {
+        } catch (Exception const& exception) {
           LOG_TOPIC("e0b25", ERR, Logger::FIXME)
               << "Uncaught exception in RestHandler " << self->name() << ": "
               << "[" << exception.code() << "] " << exception.message()

--- a/arangod/RestHandler/RestHandlerCreator.h
+++ b/arangod/RestHandler/RestHandlerCreator.h
@@ -40,29 +40,33 @@ class GeneralResponse;
 template<typename H>
 class RestHandlerCreator : public H {
   template<typename... Args>
-  static auto createUnique(application_features::ApplicationServer& server, GeneralRequest* request,
-      GeneralResponse* response, Args&&... args) {
-    using Deleter = decltype([](H* h) {
+  static auto createAsSharedPtr(application_features::ApplicationServer& server,
+                                GeneralRequest* request,
+                                GeneralResponse* response, Args&&... args)
+      -> std::shared_ptr<rest::RestHandler> {
+    auto const deleter = [](H* h) {
       auto* request = h->request();
       // Call the destructor under the user's ExecContext, if any.
-      auto guard = ExecContextScope(request != nullptr ? request->requestContext() : nullptr);
+      auto guard = ExecContextScope(
+          request != nullptr ? request->requestContext() : nullptr);
       delete h;
-    });
+    };
 
     // Call the constructor under the user's ExecContext, if any.
-    auto guard = ExecContextScope(request != nullptr ? request->requestContext() : nullptr);
+    auto guard = ExecContextScope(request != nullptr ? request->requestContext()
+                                                     : nullptr);
 
     // use the ExecContext-aware deleter
-    return std::unique_ptr<H, Deleter>(new H(server, request, response, std::forward<Args>(args)...));
+    return {new H(server, request, response, std::forward<Args>(args)...),
+            deleter};
   }
 
-public:
+ public:
   template<typename D>
   static std::shared_ptr<rest::RestHandler> createData(
       application_features::ApplicationServer& server, GeneralRequest* request,
       GeneralResponse* response, void* data) {
-    // The shared_ptr inherits the unique_ptr's Deleter.
-    auto h = std::shared_ptr(createUnique(server, request, response, (D)data));
+    auto h = createAsSharedPtr(server, request, response, (D)data);
     h->startActivity();
     return h;
   }
@@ -70,8 +74,7 @@ public:
   static std::shared_ptr<rest::RestHandler> createNoData(
       application_features::ApplicationServer& server, GeneralRequest* request,
       GeneralResponse* response, void*) {
-    // The shared_ptr inherits the unique_ptr's Deleter.
-    auto h = std::shared_ptr(createUnique(server, request, response));
+    auto h = createAsSharedPtr(server, request, response);
     h->startActivity();
     return h;
   }

--- a/arangod/RestHandler/RestHandlerCreator.h
+++ b/arangod/RestHandler/RestHandlerCreator.h
@@ -22,6 +22,10 @@
 
 #pragma once
 
+#include "Rest/GeneralRequest.h"
+#include "SystemMonitor/Activities/RestHandler.h"
+#include "Utils/ExecContext.h"
+
 #include <memory>
 
 namespace arangodb {
@@ -31,17 +35,34 @@ class ApplicationServer;
 namespace rest {
 class RestHandler;
 }
-class GeneralRequest;
 class GeneralResponse;
 
 template<typename H>
 class RestHandlerCreator : public H {
- public:
+  template<typename... Args>
+  static auto createUnique(application_features::ApplicationServer& server, GeneralRequest* request,
+      GeneralResponse* response, Args&&... args) -> std::shared_ptr<rest::RestHandler> {
+    using Deleter = decltype([](H* h) {
+      auto* request = h->request();
+      // Call the destructor under the user's ExecContext, if any.
+      auto guard = ExecContextScope(request != nullptr ? request->requestContext() : nullptr);
+      delete h;
+    });
+
+    // Call the constructor under the user's ExecContext, if any.
+    auto guard = ExecContextScope(request != nullptr ? request->requestContext() : nullptr);
+
+    // use the ExecContext-aware deleter
+    return std::unique_ptr<H, Deleter>(new H(server, request, response, std::forward<Args>(args)...));
+  }
+
+public:
   template<typename D>
   static std::shared_ptr<rest::RestHandler> createData(
       application_features::ApplicationServer& server, GeneralRequest* request,
       GeneralResponse* response, void* data) {
-    auto h = std::make_shared<H>(server, request, response, (D)data);
+    // The shared_ptr inherits the unique_ptr's Deleter.
+    auto h = std::shared_ptr(createUnique(server, request, response, (D)data));
     h->startActivity();
     return h;
   }
@@ -49,7 +70,8 @@ class RestHandlerCreator : public H {
   static std::shared_ptr<rest::RestHandler> createNoData(
       application_features::ApplicationServer& server, GeneralRequest* request,
       GeneralResponse* response, void*) {
-    auto h = std::make_shared<H>(server, request, response);
+    // The shared_ptr inherits the unique_ptr's Deleter.
+    auto h = std::shared_ptr(createUnique(server, request, response));
     h->startActivity();
     return h;
   }

--- a/arangod/RestHandler/RestHandlerCreator.h
+++ b/arangod/RestHandler/RestHandlerCreator.h
@@ -41,7 +41,7 @@ template<typename H>
 class RestHandlerCreator : public H {
   template<typename... Args>
   static auto createUnique(application_features::ApplicationServer& server, GeneralRequest* request,
-      GeneralResponse* response, Args&&... args) -> std::shared_ptr<rest::RestHandler> {
+      GeneralResponse* response, Args&&... args) {
     using Deleter = decltype([](H* h) {
       auto* request = h->request();
       // Call the destructor under the user's ExecContext, if any.

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -636,12 +636,15 @@ std::vector<bool> ExecContext::canReadUsers(
   return std::vector<bool>{view.begin(), view.end()};
 }
 
-ExecContextScope::ExecContextScope(std::shared_ptr<ExecContext const> exe)
+ExecContextScope::ExecContextScope(
+    std::shared_ptr<ExecContext const> exe) noexcept
     : _old(std::move(exe)) {
   std::swap(ExecContext::CURRENT, _old);
 }
 
-ExecContextScope::~ExecContextScope() { std::swap(ExecContext::CURRENT, _old); }
+ExecContextScope::~ExecContextScope() noexcept {
+  std::swap(ExecContext::CURRENT, _old);
+}
 
 ExecContextSuperuserScope::ExecContextSuperuserScope()
     : _old(ExecContext::CURRENT) {

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -293,9 +293,9 @@ class ExecContext {
 
 /// @brief scope guard for the exec context
 struct ExecContextScope {
-  explicit ExecContextScope(std::shared_ptr<ExecContext const> exe);
+  explicit ExecContextScope(std::shared_ptr<ExecContext const> exe) noexcept;
 
-  ~ExecContextScope();
+  ~ExecContextScope() noexcept;
 
  private:
   std::shared_ptr<ExecContext const> _old;


### PR DESCRIPTION
### Scope & Purpose

Run RestHandlers' constructors, destructors, and the complete state machine (not just the engine) under the user's ExecContext.