### PR TITLE
[3.12.10.1] [COR-584] Add explicit permission checks in transaction methods

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,14 @@
 3.12.10.1 (XXXX-XX-XX)
 ----------------------
 
+* Add explicit permission checks for operations on streaming transactions.
+  Previously trying to do modifications and forbidden collections that were not
+  part of the transaction already produced an error 400 (UNREGISTERED_COLLECTION).
+  Now this produces instead an error 403 (FORBIDDEN).
+  Trying to read a single document by key from a forbidden collection actually
+  worked. Now this produces instead an error 403 (FORBIDDEN).
+
+
 * Upgraded included rclone to v1.75.0 with go1.25.12 and non-vulnerable
   dependencies.
 

--- a/arangod/StorageEngine/TransactionState.h
+++ b/arangod/StorageEngine/TransactionState.h
@@ -186,6 +186,12 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
       DataSourceId cid, std::string_view cname, AccessMode::Type accessType,
       bool lockUsage);
 
+  /// @brief check that the current user may access the given collection in the
+  /// requested mode
+  [[nodiscard]] Result checkCollectionPermission(DataSourceId cid,
+                                                 std::string_view cname,
+                                                 AccessMode::Type accessType);
+
   /// @brief use all participating collections of a transaction
   [[nodiscard]] futures::Future<Result> useCollections();
 
@@ -413,10 +419,6 @@ class TransactionState : public std::enable_shared_from_this<TransactionState> {
     }
     callbacks.clear();
   }
-
-  /// @brief check if current user can access this collection
-  Result checkCollectionPermission(DataSourceId cid, std::string_view cname,
-                                   AccessMode::Type);
 
   /// @brief helper function for addCollection
   futures::Future<Result> addCollectionInternal(DataSourceId cid,

--- a/arangod/Transaction/Methods.cpp
+++ b/arangod/Transaction/Methods.cpp
@@ -2208,6 +2208,21 @@ Future<OperationResult> Methods::documentAsync(
                           MethodsApi::Asynchronous);
 }
 
+Result Methods::checkCollectionPermission(std::string const& collectionName,
+                                          AccessMode::Type accessType) {
+  DataSourceId cid = resolver()->getCollectionId(collectionName);
+  if (cid.empty()) {
+    // unknown collection: leave the not-found reporting to the operation itself
+    return {};
+  }
+  if (trxCollection(cid, accessType) != nullptr) {
+    // the collection is already a declared member of the transaction with
+    // sufficient access; it was permission-checked when it was added
+    return {};
+  }
+  return _state->checkCollectionPermission(cid, collectionName, accessType);
+}
+
 /// @brief read one or multiple documents in a collection, coordinator
 #ifndef USE_ENTERPRISE
 Future<OperationResult> Methods::documentCoordinator(
@@ -3868,6 +3883,14 @@ Future<OperationResult> Methods::documentInternal(
     OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
 
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::READ);
+      res.fail()) {
+    events::ReadDocument(vocbase().name(), collectionName, value, options,
+                         res.errorNumber());
+    co_return OperationResult(std::move(res), options);
+  }
+
   if (!value.isObject() && !value.isArray()) {
     // must provide a document object or an array of documents
     events::ReadDocument(vocbase().name(), collectionName, value, options,
@@ -3891,6 +3914,14 @@ Future<OperationResult> Methods::insertInternal(
     std::string const& collectionName, VPackSlice value,
     OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
+
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::WRITE);
+      res.fail()) {
+    events::CreateDocument(vocbase().name(), collectionName, value, options,
+                           res.errorNumber());
+    co_return OperationResult(std::move(res), options);
+  }
 
   if (!value.isObject() && !value.isArray()) {
     // must provide a document object or an array of documents
@@ -3927,6 +3958,14 @@ Future<OperationResult> Methods::updateInternal(
     OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
 
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::WRITE);
+      res.fail()) {
+    events::ModifyDocument(vocbase().name(), collectionName, newValue, options,
+                           res.errorNumber());
+    co_return OperationResult(std::move(res), options);
+  }
+
   if (!newValue.isObject() && !newValue.isArray()) {
     // must provide a document object or an array of documents
     events::ModifyDocument(vocbase().name(), collectionName, newValue, options,
@@ -3959,6 +3998,14 @@ Future<OperationResult> Methods::replaceInternal(
     std::string const& collectionName, VPackSlice newValue,
     OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
+
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::WRITE);
+      res.fail()) {
+    events::ReplaceDocument(vocbase().name(), collectionName, newValue, options,
+                            res.errorNumber());
+    co_return OperationResult(std::move(res), options);
+  }
 
   if (!newValue.isObject() && !newValue.isArray()) {
     // must provide a document object or an array of documents
@@ -3994,6 +4041,14 @@ Future<OperationResult> Methods::removeInternal(
     OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
 
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::WRITE);
+      res.fail()) {
+    events::DeleteDocument(vocbase().name(), collectionName, value, options,
+                           res.errorNumber());
+    co_return OperationResult(std::move(res), options);
+  }
+
   if (!value.isObject() && !value.isArray() && !value.isString()) {
     // must provide a document object or an array of documents
     events::DeleteDocument(vocbase().name(), collectionName, value, options,
@@ -4025,6 +4080,11 @@ Future<OperationResult> Methods::truncateInternal(
     MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
 
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::WRITE);
+      res.fail()) {
+    co_return OperationResult(std::move(res), options);
+  }
   auto opRes = co_await [&] {
     if (_state->isCoordinator()) {
       return truncateCoordinator(collectionName, options, api);
@@ -4042,6 +4102,12 @@ futures::Future<OperationResult> Methods::countInternal(
     std::string const& collectionName, CountType type,
     OperationOptions const& options, MethodsApi api) {
   TRI_ASSERT(_state->status() == Status::RUNNING);
+
+  if (Result res =
+          checkCollectionPermission(collectionName, AccessMode::Type::READ);
+      res.fail()) {
+    return {OperationResult(std::move(res), options)};
+  }
 
   if (_state->isCoordinator()) {
     return countCoordinator(collectionName, type, options, api);

--- a/arangod/Transaction/Methods.h
+++ b/arangod/Transaction/Methods.h
@@ -434,6 +434,17 @@ class Methods {
   futures::Future<Result> performIntermediateCommitIfRequired(
       DataSourceId collectionId);
 
+  // Check that the current user may access the given collection in the
+  // requested mode. This closes the gap for operations that run within an
+  // already existing transaction and target a collection that was not declared
+  // when the transaction was started: on a coordinator such a collection is
+  // never added at runtime, and on a DB server it is only added lazily in
+  // superuser context, where the permission check is a no-op. It is a no-op for
+  // collections that are already declared members of the transaction (they were
+  // permission-checked when they were added).
+  Result checkCollectionPermission(std::string const& collectionName,
+                                   AccessMode::Type accessType);
+
   futures::Future<OperationResult> documentCoordinator(
       std::string const& collectionName, VPackSlice value,
       OperationOptions options, MethodsApi api);

--- a/tests/js/client/authentication/auth-transaction-collection-permission.js
+++ b/tests/js/client/authentication/auth-transaction-collection-permission.js
@@ -1,0 +1,228 @@
+/*jshint globalstrict:false, strict:false */
+/*global assertEqual */
+
+// //////////////////////////////////////////////////////////////////////////////
+// / DISCLAIMER
+// /
+// / Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+// /
+// / Licensed under the Business Source License 1.1 (the "License");
+// / you may not use this file except in compliance with the License.
+// / You may obtain a copy of the License at
+// /
+// /     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+// /
+// / Unless required by applicable law or agreed to in writing, software
+// / distributed under the License is distributed on an "AS IS" BASIS,
+// / WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// / See the License for the specific language governing permissions and
+// / limitations under the License.
+// /
+// / Copyright holder is ArangoDB GmbH, Cologne, Germany
+// /
+// //////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require("jsunity");
+const arango = require("@arangodb").arango;
+const db = require("internal").db;
+const users = require("@arangodb/users");
+const ERRORS = require("internal").errors;
+const IM = require("@arangodb/test-helper").getInstanceInfo();
+
+// A document operation on the coordinator must perform a collection-level
+// permission check even when it runs within an already existing transaction.
+// The collection-level permission check normally happens when a collection is
+// added to the transaction (on the coordinator, against the real user). When a
+// single document operation runs inside an existing transaction and targets a
+// collection that was not declared, that check used to be skipped entirely: on
+// the coordinator the collection is not added at runtime, and on the DB server
+// it is only added lazily in superuser context, where the check is a no-op.
+// This suite pins down that such a read is denied for a user that lacks access.
+function authTransactionCollectionPermissionSuite() {
+  const dbName = "UnitTestsTrxPerm";
+  const secret = "secretCollection";   // user has no access
+  const allowed = "allowedCollection"; // user has read access
+  const user = "trxPermUser";
+  const pw = "pw";
+  const key = "test1";
+
+  return {
+
+    setUpAll: function () {
+      IM.rememberConnection();  // remember the root connection
+
+      try {
+        db._dropDatabase(dbName);
+      } catch (err) { }
+      try {
+        users.remove(user);
+      } catch (err) { }
+
+      db._createDatabase(dbName);
+      db._useDatabase(dbName);
+      db._create(secret);
+      db._create(allowed);
+      db._useDatabase("_system");
+
+      users.save(user, pw);
+      users.grantDatabase(user, dbName, "rw");
+      // explicitly deny access to the secret collection, allow the other one
+      users.grantCollection(user, dbName, allowed, "ro");
+      users.grantCollection(user, dbName, secret, "none");
+    },
+
+    tearDownAll: function () {
+      IM.reconnectMe();  // reconnect as root
+      db._useDatabase("_system");
+      try {
+        db._dropDatabase(dbName);
+      } catch (err) { }
+      try {
+        users.remove(user);
+      } catch (err) { }
+    },
+
+    setUp: function () {
+      IM.reconnectMe();  // reconnect as root
+      db._useDatabase(dbName);
+      db._collection(secret).truncate();
+      db._collection(secret).insert({ _key: key, value: 42 });
+      db._collection(allowed).truncate();
+      db._collection(allowed).insert({ _key: key, value: 1 });
+      db._useDatabase("_system");
+    },
+
+    tearDown: function () {
+      IM.reconnectMe();  // reconnect as root
+      db._useDatabase("_system");
+    },
+
+    // these tests intentionally use raw REST requests instead of the arangojs client
+    // because the client uses explicit transaction collections which perform permission
+    // checks at the time they are requested, which is not what we want to test here.
+
+    testReadForbiddenCollectionInExistingTransaction: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let trx = db._createTransaction({ collections: {} });
+      try {
+        let ok = arango.GET_RAW(`/_api/document/${allowed}/${key}`,
+          { "x-arango-trx-id": trx._id });
+        assertEqual(200, ok.code);
+
+        let res = arango.GET_RAW(`/_api/document/${secret}/${key}`,
+          { "x-arango-trx-id": trx._id });
+        assertEqual(403, res.code);
+        assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+      } finally {
+        trx.abort();
+      }
+    },
+
+    testReadForbiddenCollectionStandalone: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let res = arango.GET_RAW(`/_api/document/${secret}/${key}`);
+      assertEqual(403, res.code);
+      assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+    },
+
+    testInsertForbiddenCollectionInExistingTransaction: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let trx = db._createTransaction({ collections: {} });
+      try {
+        let res = arango.POST_RAW(`/_api/document/${secret}`, { value: 1 },
+          { "x-arango-trx-id": trx._id });
+        assertEqual(403, res.code);
+        assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+      } finally {
+        trx.abort();
+      }
+    },
+
+    testInsertForbiddenCollectionStandalone: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let res = arango.POST_RAW(`/_api/document/${secret}`, { value: 1 });
+      assertEqual(403, res.code);
+      assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+    },
+
+    testUpdateForbiddenCollectionInExistingTransaction: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let trx = db._createTransaction({ collections: {} });
+      try {
+        let res = arango.PATCH_RAW(`/_api/document/${secret}/${key}`,
+          { value: 2 }, { "x-arango-trx-id": trx._id });
+        assertEqual(403, res.code);
+        assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+      } finally {
+        trx.abort();
+      }
+    },
+
+    testUpdateForbiddenCollectionStandalone: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let res = arango.PATCH_RAW(`/_api/document/${secret}/${key}`,
+        { value: 2 });
+      assertEqual(403, res.code);
+      assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+    },
+
+    testRemoveForbiddenCollectionInExistingTransaction: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let trx = db._createTransaction({ collections: {} });
+      try {
+        let res = arango.DELETE_RAW(`/_api/document/${secret}/${key}`,
+          {}, { "x-arango-trx-id": trx._id });
+        assertEqual(403, res.code);
+        assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+      } finally {
+        trx.abort();
+      }
+    },
+
+    testRemoveForbiddenCollectionStandalone: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let res = arango.DELETE_RAW(`/_api/document/${secret}/${key}`, {});
+      assertEqual(403, res.code);
+      assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+    },
+
+    testCountForbiddenCollectionInExistingTransaction: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let trx = db._createTransaction({ collections: {} });
+      try {
+        let ok = arango.GET_RAW(`/_api/collection/${allowed}/count`,
+          { "x-arango-trx-id": trx._id });
+        assertEqual(200, ok.code);
+
+        let res = arango.GET_RAW(`/_api/collection/${secret}/count`,
+          { "x-arango-trx-id": trx._id });
+        assertEqual(403, res.code);
+        assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+      } finally {
+        trx.abort();
+      }
+    },
+
+    testCountForbiddenCollectionStandalone: function () {
+      arango.reconnect(arango.getEndpoint(), dbName, user, pw);
+
+      let res = arango.GET_RAW(`/_api/collection/${secret}/count`);
+      assertEqual(403, res.code);
+      assertEqual(ERRORS.ERROR_FORBIDDEN.code, res.parsedBody.errorNum);
+    },
+
+  };
+}
+
+jsunity.run(authTransactionCollectionPermissionSuite);
+
+return jsunity.done();


### PR DESCRIPTION
### Scope & Purpose

Add explicit permission checks for operations on streaming transactions.

Previously trying to do modifications and forbidden collections that were not part of the transaction already produced an error 400 (UNREGISTERED_COLLECTION). Now this produces instead an error 403 (FORBIDDEN).
Trying to read a single document by key from a forbidden collection actually worked. Now this produces instead an error 403 (FORBIDDEN).

- [x] :hankey: Bugfix
### Checklist

- [x] Tests
  - [x] **Regression tests**
- [x] :book: CHANGELOG entry made
