### PR TITLE
Fix view dropping

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -48,8 +48,6 @@
    - `GET /_arango/experimental/_admin/activities` will now return HTTP 404 and
      errorNum 1228 (database not found) rather than HTTP 401 and errorNum 11,
      if the user has no read access to the `_system` database.
-   - Dropping ArangoSearch views no longer needs read access to the linked
-     collections (which was pointless).
    - `POST /_api/token/<username>` and `DELETE /_api/token/<username>/<id>`
      will be rejected in read-only mode with HTTP 403 FORBIDDEN and errorNum
      1004 if the user has admin permissions (RW on the _system

--- a/Documentation/Differences_3.12.10_3.12.11_Classic.md
+++ b/Documentation/Differences_3.12.10_3.12.11_Classic.md
@@ -19,16 +19,6 @@ This is because the experimental API version is considered to be
 larger than 0 and we are doing this change from API V0 to API V1
 for security reasons.
 
-## Dropping views relaxes permissions
-
-Up to and including 3.12.10, one needed read access to all linked
-collections to drop a view. This lead to internal complexity and
-does not really make sense, since dropping a view does not really
-require access to the collections.
-
-Therefore, from 3.12.11 on, linked collection read access is no longer
-required to drop an ArangoSearch view.
-
 ## Changes to access tokens in read-only mode
 
 The two APIs:

--- a/arangod/IResearch/IResearchViewCoordinator.cpp
+++ b/arangod/IResearch/IResearchViewCoordinator.cpp
@@ -326,6 +326,15 @@ bool IResearchViewCoordinator::visitCollections(
   return true;
 }
 
+std::vector<std::string> IResearchViewCoordinator::linkedCollectionNames()
+    const {
+  std::vector<std::string> names;
+  for (auto const& pair : _collections) {
+    names.push_back(pair.second->collectionName);
+  }
+  return names;
+}
+
 bool IResearchViewCoordinator::isBuilding() const {
   std::shared_lock lock{_mutex};
   for (auto& entry : _collections) {

--- a/arangod/IResearch/IResearchViewCoordinator.h
+++ b/arangod/IResearch/IResearchViewCoordinator.h
@@ -80,6 +80,11 @@ class IResearchViewCoordinator final : public LogicalView {
 
   bool visitCollections(CollectionVisitor const& visitor) const final;
 
+  //////////////////////////////////////////////////////////////////////////////
+  /// @brief names of all collections currently linked to this view
+  //////////////////////////////////////////////////////////////////////////////
+  std::vector<std::string> linkedCollectionNames() const final;
+
   IResearchViewMeta const& meta() const noexcept { return _meta; }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/arangod/VocBase/LogicalView.h
+++ b/arangod/VocBase/LogicalView.h
@@ -128,7 +128,7 @@ class LogicalView : public LogicalDataSource {
   //////////////////////////////////////////////////////////////////////////////
   /// @brief names of all collections currently linked to this view
   //////////////////////////////////////////////////////////////////////////////
-  std::vector<std::string> linkedCollectionNames() const;
+  virtual std::vector<std::string> linkedCollectionNames() const;
 
   [[nodiscard]] virtual bool isBuilding() const { return false; }
 


### PR DESCRIPTION
### Scope & Purpose

Go back to the `devel` behaviour for both single server and cluster.
Dropping views needs read access to linked collections.

