### PR TITLE
Fix use-after-free

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -309,7 +309,8 @@ AuthMode::Classic::Classic(auth::UserManager& userManager, std::string username,
                            GeneralRequest& req)
     : _userManager(userManager),
       _username(std::move(username)),
-      _request(req) {}
+      _request(req),
+      _requestedApiVersion(req.requestedApiVersion()) {}
 
 auto AuthMode::Classic::username() const noexcept -> std::string_view {
   return _username;
@@ -385,7 +386,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
 
             if (requestedLevel <= effectiveLevel) {
               return {};
-            } else if (_request.requestedApiVersion() > 0 &&
+            } else if (_requestedApiVersion > 0 &&
                        effectiveLevel == auth::Level::NONE) {
               // User has no access to the database at all: report as not found
               // to avoid revealing its existence.
@@ -449,7 +450,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
             if (requestedLevel > effectiveLevel) {
               // If we are using API version > 0, then we return NOT_FOUND to
               // hide the fact that the collection exists:
-              if (_request.requestedApiVersion() > 0) {
+              if (_requestedApiVersion > 0) {
                 if (effectiveLevel == auth::Level::NONE) {
                   // User has no access to this collection: report as not found
                   // to avoid revealing its existence.
@@ -579,7 +580,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
 
             if (requestedLevel <= effectiveLevel) {
               return {};
-            } else if (_request.requestedApiVersion() > 0 &&
+            } else if (_requestedApiVersion > 0 &&
                        effectiveLevel == auth::Level::NONE) {
               return {TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND};
             } else {
@@ -650,7 +651,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
               // `TRI_ERROR_ARANGO_READ_ONLY`, but we **must** hand on
               // `TRI_ERROR_FORBIDDEN` here for API compatibility for the
               // API version 0!
-              if (_request.requestedApiVersion() == 0) {
+              if (_requestedApiVersion == 0) {
                 return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
               } else {
                 return r;
@@ -663,7 +664,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
               // `TRI_ERROR_ARANGO_READ_ONLY`, but we **must** hand on
               // `TRI_ERROR_FORBIDDEN` here for API compatibility for
               // the API Version 0!
-              if (_request.requestedApiVersion() == 0) {
+              if (_requestedApiVersion == 0) {
                 return {TRI_ERROR_FORBIDDEN, r.errorMessage()};
               } else {
                 return r;
@@ -814,7 +815,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
                 r.ok()) {
               return {};
             }
-            if (_request.requestedApiVersion() > 0) {
+            if (_requestedApiVersion > 0) {
               return {TRI_ERROR_FORBIDDEN,
                       failureMessage(graph, "Cannot write to database.")};
             } else {

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -297,28 +297,14 @@ auto AuthMode::Superuser::check(auth::Permission permission) const -> Result {
   return {};
 }
 
-auto AuthMode::Superuser::request() const noexcept
-    -> std::optional<std::reference_wrapper<GeneralRequest>> {
-  if (_request != nullptr) {
-    return *_request;
-  }
-  return std::nullopt;
-}
-
 AuthMode::Classic::Classic(auth::UserManager& userManager, std::string username,
                            GeneralRequest& req)
     : _userManager(userManager),
       _username(std::move(username)),
-      _request(req),
       _requestedApiVersion(req.requestedApiVersion()) {}
 
 auto AuthMode::Classic::username() const noexcept -> std::string_view {
   return _username;
-}
-
-auto AuthMode::Classic::request() const noexcept
-    -> std::optional<std::reference_wrapper<GeneralRequest>> {
-  return _request;
 }
 
 auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
@@ -1307,22 +1293,11 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
       permission);
 }
 
-auto AuthMode::Rbac::request() const noexcept
-    -> std::optional<std::reference_wrapper<GeneralRequest>> {
-  return _request;
-}
-
-AuthMode::Unauthenticated::Unauthenticated(std::string username,
-                                           GeneralRequest& req)
-    : _username(std::move(username)), _request(req) {}
+AuthMode::Unauthenticated::Unauthenticated(std::string username)
+    : _username(std::move(username)) {}
 
 auto AuthMode::Unauthenticated::username() const noexcept -> std::string_view {
   return _username;
-}
-
-auto AuthMode::Unauthenticated::request() const noexcept
-    -> std::optional<std::reference_wrapper<GeneralRequest>> {
-  return _request;
 }
 
 auto AuthMode::Unauthenticated::check(auth::Permission permission) const
@@ -1340,16 +1315,11 @@ auto AuthMode::Unauthenticated::check(auth::Permission permission) const
       permission);
 }
 
-AuthMode::Disabled::Disabled(std::string username, GeneralRequest& req)
-    : _username(std::move(username)), _request(req) {}
+AuthMode::Disabled::Disabled(std::string username)
+    : _username(std::move(username)) {}
 
 auto AuthMode::Disabled::username() const noexcept -> std::string_view {
   return _username;
-}
-
-auto AuthMode::Disabled::request() const noexcept
-    -> std::optional<std::reference_wrapper<GeneralRequest>> {
-  return _request;
 }
 
 auto AuthMode::Disabled::check(auth::Permission permission) const -> Result {
@@ -1365,12 +1335,6 @@ auto AuthMode::Mockable::username() const noexcept -> std::string_view {
 auto AuthMode::Mockable::check(auth::Permission permission) const -> Result {
   ADB_PROD_ASSERT(mock != nullptr);
   return mock->check(permission);
-}
-
-auto AuthMode::Mockable::request() const noexcept
-    -> std::optional<std::reference_wrapper<GeneralRequest>> {
-  ADB_PROD_ASSERT(mock != nullptr);
-  return mock->request();
 }
 #endif
 

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -94,6 +94,13 @@ struct AuthMode {
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
 
+#ifdef ARANGODB_USE_GOOGLE_TESTS
+    // Only used in tests.
+    void setRequestedApiVersion(uint32_t apiVersion) {
+      _requestedApiVersion = apiVersion;
+    }
+#endif
+
    protected:
     // has _system RW access
     [[nodiscard]] Result isAdmin() const;

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -26,8 +26,6 @@
 #include "Basics/Result.h"
 
 #include <cstdint>
-#include <functional>
-#include <optional>
 #include <variant>
 
 namespace arangodb::auth {
@@ -72,35 +70,21 @@ struct AuthMode {
     // TODO Make this async
     [[nodiscard]] virtual auto check(auth::Permission permission) const
         -> Result = 0;
-
-    // Returns the GeneralRequest associated with this auth context, if any.
-    [[nodiscard]] virtual auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> = 0;
   };
 
   // Superuser; may do anything, without further checks.
-  // Optionally holds a reference to a request (when created from
-  // a superuser JWT token on a real request).
   struct Superuser : IAuth {
-    // For the static singleton superuser (no request).
     Superuser() = default;
-    // For a dynamically created superuser context with request.
-    Superuser(GeneralRequest& req) : _request(&req) {}
 
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
-    [[nodiscard]] auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> override;
-
-    GeneralRequest* _request{nullptr};
   };
 
   // Classic, arangodb-internal authorization, based on permissions in _users.
   struct Classic : IAuth {
     auth::UserManager& _userManager;
     std::string const _username;
-    GeneralRequest& _request;
 
     Classic(auth::UserManager& userManager, std::string username,
             GeneralRequest& req);
@@ -109,9 +93,6 @@ struct AuthMode {
 
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
-
-    [[nodiscard]] auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> override;
 
    protected:
     // has _system RW access
@@ -127,55 +108,41 @@ struct AuthMode {
     rbac::Service& _rbacService;
     std::string const _username;
     std::string const _jwtToken;
-    GeneralRequest& _request;
 
-    Rbac(rbac::Service& rbacService, std::string username, std::string jwtToken,
-         GeneralRequest& req)
+    Rbac(rbac::Service& rbacService, std::string username, std::string jwtToken)
         : _rbacService(rbacService),
           _username(std::move(username)),
-          _jwtToken(std::move(jwtToken)),
-          _request(req) {}
+          _jwtToken(std::move(jwtToken)) {}
 
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
 
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
-
-    [[nodiscard]] auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> override;
   };
 
   // Authentication is on, but the current user is without authentication.
   // Has basically no permissions.
   struct Unauthenticated : IAuth {
     std::string _username;
-    GeneralRequest& _request;
 
-    explicit Unauthenticated(std::string username, GeneralRequest& req);
+    explicit Unauthenticated(std::string username);
 
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
 
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
-
-    [[nodiscard]] auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> override;
   };
 
   // Authentication is disabled, barely any restrictions.
   struct Disabled : IAuth {
     std::string _username;
-    GeneralRequest& _request;
 
-    explicit Disabled(std::string username, GeneralRequest& req);
+    explicit Disabled(std::string username);
 
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
 
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
-
-    [[nodiscard]] auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> override;
   };
 
 #ifdef ARANGODB_USE_GOOGLE_TESTS
@@ -198,8 +165,6 @@ struct AuthMode {
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
     [[nodiscard]] auto check(auth::Permission permission) const
         -> Result override;
-    [[nodiscard]] auto request() const noexcept
-        -> std::optional<std::reference_wrapper<GeneralRequest>> override;
   };
 #define MOCKABLE , Mockable
 #else

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -116,6 +116,9 @@ struct AuthMode {
    protected:
     // has _system RW access
     [[nodiscard]] Result isAdmin() const;
+
+    // Recall requested API version:
+    uint32_t _requestedApiVersion;
   };
 
   // Role-based access control, based on an external authorization service.

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -117,6 +117,7 @@ struct AuthMode {
     // has _system RW access
     [[nodiscard]] Result isAdmin() const;
 
+   private:
     // Recall requested API version:
     uint32_t _requestedApiVersion;
   };

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -65,10 +65,16 @@ std::shared_ptr<ExecContext const> ExecContext::superuserAsShared() {
 }
 
 ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
-                         bool isRestApiHardened, VocbasePtr vocbase)
+                         bool isRestApiHardened, VocbasePtr vocbase,
+                         std::string clientAddress, std::string requestUrl,
+                         std::string authMethod, bool hasRequestInfo)
     : _authMode(std::move(authMode)),
       _isRestApiHardened(isRestApiHardened),
-      _vocbase(std::move(vocbase)) {}
+      _vocbase(std::move(vocbase)),
+      _clientAddress(std::move(clientAddress)),
+      _requestUrl(std::move(requestUrl)),
+      _authMethod(std::move(authMethod)),
+      _hasRequestInfo(hasRequestInfo) {}
 
 /*static*/ std::shared_ptr<ExecContext> ExecContext::create(
     AuthenticationFeature& authenticationFeature, RbacFeature& rbacFeature,
@@ -85,13 +91,11 @@ ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
         req.authenticated() && req.user().empty() &&
         req.authenticationMethod() == rest::AuthenticationMethod::JWT;
     if (isSuperUser) {
-      // For a superuser JWT request, create a dynamic Superuser context that
-      // preserves the request reference (for auditing etc.).
-      return AuthMode::Superuser(req);
+      return AuthMode::Superuser();
     }
 
     if (!authenticationFeature.isActive()) {
-      return AuthMode::Disabled(req.user(), req);
+      return AuthMode::Disabled(req.user());
     }
 
     auto* userManager = authenticationFeature.userManager();
@@ -99,33 +103,37 @@ ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
     // there is no UserManager, but at least the SuperUser can be
     // authenticated. In that case we treat the request as unauthenticated.
     if (!req.authenticated() || userManager == nullptr) {
-      return AuthMode::Unauthenticated(req.user(), req);
+      return AuthMode::Unauthenticated(req.user());
     }
 
     if (auto* rbacService = rbacFeature.service(); rbacService != nullptr) {
-      return AuthMode::Rbac(*rbacService, req.user(), req.jwtToken(), req);
+      return AuthMode::Rbac(*rbacService, req.user(), req.jwtToken());
     }
 
     ADB_PROD_ASSERT(userManager != nullptr);
     return AuthMode::Classic(*userManager, req.user(), req);
   }()};
 
-  return std::make_shared<ExecContext>(ConstructorToken{}, std::move(authMode),
-                                       securityFeature.isRestApiHardened(),
-                                       std::move(vocbase));
+  std::string authMethod = "n/a";
+  switch (req.authenticationMethod()) {
+    case rest::AuthenticationMethod::BASIC:
+      authMethod = "http basic";
+      break;
+    case rest::AuthenticationMethod::JWT:
+      authMethod = "http jwt";
+      break;
+    case rest::AuthenticationMethod::NONE:
+      break;
+  }
+
+  return std::make_shared<ExecContext>(
+      ConstructorToken{}, std::move(authMode),
+      securityFeature.isRestApiHardened(), std::move(vocbase),
+      req.connectionInfo().fullClient(), req.fullUrl(), std::move(authMethod),
+      /*hasRequestInfo*/ true);
 }
 
-void ExecContext::forceSuperuser() {
-  // Preserve any existing request/vocbase references in the new Superuser
-  // mode so that the destructor can still release the vocbase correctly,
-  // and auditing information remains accessible.
-  auto req = _authMode.getIAuth().request();
-  if (_vocbase && req.has_value()) {
-    _authMode.reset<AuthMode::Superuser>(req->get());
-  } else {
-    _authMode.reset<AuthMode::Superuser>();
-  }
-}
+void ExecContext::forceSuperuser() { _authMode.reset<AuthMode::Superuser>(); }
 
 std::optional<std::reference_wrapper<TRI_vocbase_t>> ExecContext::vocbase()
     const noexcept {
@@ -136,33 +144,11 @@ std::optional<std::reference_wrapper<TRI_vocbase_t>> ExecContext::vocbase()
 }
 
 #ifdef USE_ENTERPRISE
-std::string ExecContext::clientAddress() const {
-  if (auto req = request(); req.has_value()) {
-    return req->get().connectionInfo().fullClient();
-  }
-  return {};
-}
+std::string ExecContext::clientAddress() const { return _clientAddress; }
 
-std::string ExecContext::requestUrl() const {
-  if (auto req = request(); req.has_value()) {
-    return req->get().fullUrl();
-  }
-  return {};
-}
+std::string ExecContext::requestUrl() const { return _requestUrl; }
 
-std::string ExecContext::authMethod() const {
-  if (auto req = request(); req.has_value()) {
-    switch (req->get().authenticationMethod()) {
-      case rest::AuthenticationMethod::BASIC:
-        return "http basic";
-      case rest::AuthenticationMethod::JWT:
-        return "http jwt";
-      case rest::AuthenticationMethod::NONE:
-        break;
-    }
-  }
-  return "n/a";
-}
+std::string ExecContext::authMethod() const { return _authMethod; }
 #endif
 
 Result ExecContext::can(auth::Permission permission) const {
@@ -668,16 +654,14 @@ ExecContextSuperuserScope::ExecContextSuperuserScope(bool cond)
 
 auto ExecContextSuperuserScope::getSuperuserContextFrom(
     ExecContext const* const old) -> std::shared_ptr<ExecContext const> {
-  // save the original request for audit logging, if there is one
-  if (old != nullptr && old->request().has_value()) {
+  // save the original request information for audit logging, if there is any
+  if (old != nullptr && old->_hasRequestInfo) {
     // NOTE we could store the vocbase as well, but I'm unsure if that's
     // helpful
-    //      (note that an exec context contains a request iff it
-    //      contains a vocbase)
     return std::make_shared<ExecContext>(
-        ExecContext::ConstructorToken{},
-        AuthMode{AuthMode::Superuser{*old->request()}}, old->_isRestApiHardened,
-        nullptr);
+        ExecContext::ConstructorToken{}, AuthMode{AuthMode::Superuser{}},
+        old->_isRestApiHardened, nullptr, old->_clientAddress, old->_requestUrl,
+        old->_authMethod, true);
   } else {
     return ExecContext::Superuser;
   }

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -60,7 +60,9 @@ class ExecContext {
 
  public:
   ExecContext(ConstructorToken, AuthMode authMode, bool isRestApiHardened,
-              VocbasePtr vocbase);
+              VocbasePtr vocbase, std::string clientAddress = {},
+              std::string requestUrl = {}, std::string authMethod = "n/a",
+              bool hasRequestInfo = false);
   ExecContext(ExecContext const&) = delete;
   ExecContext(ExecContext&&) = delete;
 
@@ -114,12 +116,6 @@ class ExecContext {
   /// @brief returns the vocbase associated with this context, if any
   [[nodiscard]] std::optional<std::reference_wrapper<Database>> vocbase()
       const noexcept;
-
-  /// @brief returns the request associated with this context, if any
-  [[nodiscard]] std::optional<std::reference_wrapper<GeneralRequest>> request()
-      const noexcept {
-    return _authMode.getIAuth().request();
-  }
 
   /// @brief current user, may be empty for internal users
   [[nodiscard]] std::string_view user() const {
@@ -292,6 +288,15 @@ class ExecContext {
   AuthMode _authMode;
   bool const _isRestApiHardened;
   VocbasePtr _vocbase;
+
+  // Client address, request URL and authentication method of the request
+  // this context was created from, if any (see ExecContext::create()).
+  // Preserved across forceSuperuser()/ExecContextSuperuserScope so that
+  // auditing keeps working after a privilege upgrade.
+  std::string _clientAddress;
+  std::string _requestUrl;
+  std::string _authMethod{"n/a"};
+  bool _hasRequestInfo{false};
 
   // TODO (Tobias) this feels out of place. Look into it.
   /// should be used to indicate a canceled request / thread

--- a/tests/Auth/ClassicAuthModeTest.cpp
+++ b/tests/Auth/ClassicAuthModeTest.cpp
@@ -157,11 +157,8 @@ struct ClassicAuthModeTest : ::testing::Test {
 // Accessors
 // ---------------------------------------------------------------------------
 
-TEST_F(ClassicAuthModeTest, UsernameAndRequestAreExposed) {
+TEST_F(ClassicAuthModeTest, UsernameIsExposed) {
   EXPECT_EQ(classic.username(), kUser);
-  auto r = classic.request();
-  ASSERT_TRUE(r.has_value());
-  EXPECT_EQ(&r->get(), &req);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/Auth/ClassicAuthModeTest.cpp
+++ b/tests/Auth/ClassicAuthModeTest.cpp
@@ -146,7 +146,9 @@ struct ClassicAuthModeTest : ::testing::Test {
   // [[nodiscard]].
   Result check(auth::Permission perm) { return classic.check(std::move(perm)); }
 
-  void useApiVersion(uint32_t version) { req.setRequestedApiVersion(version); }
+  void useApiVersion(uint32_t version) {
+    classic.setRequestedApiVersion(version);
+  }
 
   static void expectError(Result const& r, ErrorCode expected) {
     EXPECT_EQ(r.errorNumber(), expected) << r.errorMessage();

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -25,8 +25,6 @@
 // is mocked: it records every question it is asked and returns a programmed
 // answer, so these tests never talk to a real authorization backend.
 
-#include "ExecContextFactory.h"
-
 #include "gtest/gtest.h"
 
 #include <span>
@@ -38,8 +36,6 @@
 #include "Auth/Rbac/Service.h"
 #include "Basics/overload.h"
 #include "Basics/voc-errors.h"
-#include "Endpoint/ConnectionInfo.h"
-#include "Rest/GeneralRequest.h"
 
 using namespace arangodb;
 namespace p = arangodb::auth::perms;
@@ -109,12 +105,10 @@ struct MockService : rbac::Service {
   }
 };
 
-// Fixture bundling a mock service, a stub request and the Rbac auth mode under
-// test.
+// Fixture bundling a mock service and the Rbac auth mode under test.
 struct RbacAuthModeTest : ::testing::Test {
   MockService svc;
-  tests::mocks::FakeGeneralRequest req;
-  AuthMode::Rbac rbac{svc, "myuser", "mytoken", req};
+  AuthMode::Rbac rbac{svc, "myuser", "mytoken"};
 
   // Discarding wrapper around rbac.check(). IAuth::check is [[nodiscard]], so
   // tests that only inspect the recorded queries would otherwise not compile

--- a/tests/Mocks/ExecContextFactory.h
+++ b/tests/Mocks/ExecContextFactory.h
@@ -77,8 +77,8 @@ struct FakeGeneralRequest final : GeneralRequest {
 
 /// @brief Bundled ownership for a Classic-auth ExecContext created by the
 /// factory. All three members must outlive any ExecContextScope that uses
-/// execContext, because AuthMode::Classic holds raw references to userManager
-/// and request.
+/// execContext, because AuthMode::Classic holds a raw reference to
+/// userManager.
 struct ClassicExecContext {
   std::shared_ptr<auth::UserManagerTester> userManager;
   std::shared_ptr<FakeGeneralRequest> request;

--- a/tests/Utils/ExecContextTest.cpp
+++ b/tests/Utils/ExecContextTest.cpp
@@ -66,10 +66,8 @@ TEST(ExecContextTest, disabled_is_not_superuser_authmode) {
   // In the new API, isSuperuserOrDisabled() is true only for
   // AuthMode::Superuser (or AuthMode::Disabled). The old Type::Internal+RW/RW
   // maps to Superuser here.
-  FakeGeneralRequest fakeRequest;
-  auto ctx = createSharedExecContext(
-      AuthMode{AuthMode::Disabled{"dummy", fakeRequest}}, false,
-      VocbasePtr{nullptr});
+  auto ctx = createSharedExecContext(AuthMode{AuthMode::Disabled{"dummy"}},
+                                     false, VocbasePtr{nullptr});
 
   EXPECT_TRUE(ctx->isSuperuserOrDisabled());
   EXPECT_FALSE(ctx->isSuperuser());
@@ -140,10 +138,8 @@ TEST(ExecContextTest, canUseApiVersion_superuser_grants_every_version) {
 }
 
 TEST(ExecContextTest, canUseApiVersion_unauthenticated_is_denied) {
-  FakeGeneralRequest fakeRequest;
   auto ctx = createSharedExecContext(
-      AuthMode{AuthMode::Unauthenticated{"dummy", fakeRequest}}, false,
-      VocbasePtr{nullptr});
+      AuthMode{AuthMode::Unauthenticated{"dummy"}}, false, VocbasePtr{nullptr});
 
   auto const result = ctx->canUseApiVersion(1);
   EXPECT_EQ(result.errorNumber(), TRI_ERROR_FORBIDDEN);


### PR DESCRIPTION
### Scope & Purpose

Fix use-after free.

The problem is that sometimes an `ExecContext` can outlive the `GeneralRequest`
which has been handed in for the `AuthMode::Classic` constructor.

This fires in ASAN, when we access the `GeneralRequest` to find out the
`requestedApiVersion` of the request.

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
