### PR TITLE
Don't reuse captures variable but use new local one

### DIFF
--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -385,7 +385,7 @@ Result Databases::create(application_features::ApplicationServer& server,
       createInfo.strictValidation(false);
     }
 
-    res = createInfo.load(dbName, options, users);
+    auto res = createInfo.load(dbName, options, users);
 
     if (!res.ok()) {
       return res;


### PR DESCRIPTION
alubsan found this memory leak (https://app.circleci.com/pipelines/gh/arangodb/arangodb/54920/details?useNewPipelines=true&workflowId=fd4e35db-7610-4d22-a8e4-4c966fe7c08e&job=bc45ad91-ee48-4762-aeb7-37d6c61d01f9&buildNumber=4593241&jobType=build#step-106-):

```
==arangod==7808==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 2 object(s) allocated from:
    #0 0x55cf59ea4501 in operator new(unsigned long) (/root/project/build/bin/arangod+0x63d6501) (BuildId: a6808001fa1acc28558088fd8b333bcac5b58c9b)
    #1 0x55cf654dc295 in make_unique<arangodb::result::Error, ErrorCode &, const char *&> /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/unique_ptr.h:1070
    #2 0x55cf654dc295 in arangodb::Result::Result(ErrorCode, char const*) /root/project/lib/Basics/Result.cpp:67
    #3 0x55cf5e6023cf in arangodb::CreateDatabaseInfo::extractOptions(arangodb::velocypack::Slice, bool, bool) /root/project/arangod/VocBase/VocbaseInfo.cpp:275
    #4 0x55cf5e604486 in arangodb::CreateDatabaseInfo::load(std::basic_string_view<char, std::char_traits<char>>, arangodb::velocypack::Slice, arangodb::velocypack::Slice) /root/project/arangod/VocBase/VocbaseInfo.cpp:104
    #5 0x55cf5e6d7b43 in operator() /root/project/arangod/VocBase/Methods/Databases.cpp:388
    #6 0x55cf5e6d7b43 in catchToResult<(lambda at /root/project/arangod/VocBase/Methods/Databases.cpp:362:38)> /root/project/lib/Basics/Exceptions.h:146
    #7 0x55cf5e6d7b43 in arangodb::methods::Databases::create(arangodb::application_features::ApplicationServer&, arangodb::StorageEngine&, arangodb::ExecContext const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, arangodb::velocypack::Slice, arangodb::velocypack::Slice) /root/project/arangod/VocBase/Methods/Databases.cpp:362
    #8 0x55cf5ac7d817 in arangodb::RestDatabaseHandler::createDatabase() /root/project/arangod/RestHandler/RestDatabaseHandler.cpp:157
    #9 0x55cf5ac7c61b in arangodb::RestDatabaseHandler::execute() /root/project/arangod/RestHandler/RestDatabaseHandler.cpp:54
    #10 0x55cf5a97dddb in arangodb::rest::RestHandler::executeAsync() /root/project/arangod/GeneralServer/RestHandler.cpp:828
    #11 0x55cf5a978a06 in arangodb::rest::RestHandler::executeEngine() /root/project/arangod/GeneralServer/RestHandler.cpp:535
    #12 0x55cf5a975484 in arangodb::rest::RestHandler::runHandlerStateMachine() /root/project/arangod/GeneralServer/RestHandler.cpp:481
    #13 0x55cf5a97e60e in arangodb::rest::RestHandler::runHandler(std::function<void (arangodb::rest::RestHandler*)>) /root/project/arangod/GeneralServer/RestHandler.cpp:847
    #14 0x55cf5ab1831d in operator() /root/project/arangod/GeneralServer/CommTask.cpp:694
    #15 0x55cf5ab1831d in arangodb::Scheduler::WorkItem<arangodb::rest::CommTask::handleRequestSync(std::shared_ptr<arangodb::rest::RestHandler>)::$_0>::invoke() /root/project/arangod/Scheduler/Scheduler.h:222
    #16 0x55cf5f68ae15 in arangodb::SupervisedScheduler::runWorker() /root/project/arangod/Scheduler/SupervisedScheduler.cpp:474
    #17 0x55cf654c3d27 in arangodb::BasicThread::runMe() /root/project/lib/Basics/BasicThread.cpp:329
    #18 0x55cf654c363b in arangodb::BasicThread::startThread(void*) /root/project/lib/Basics/BasicThread.cpp:136
    #19 0x55cf65534676 in ThreadStarter(void*) /root/project/lib/Basics/threads-posix.cpp:77
    #20 0x55cf59e6077a in asan_thread_start(void*) crtbegin.c

Indirect leak of 159 byte(s) in 2 object(s) allocated from:
    #0 0x55cf59ea4501 in operator new(unsigned long) (/root/project/build/bin/arangod+0x63d6501) (BuildId: a6808001fa1acc28558088fd8b333bcac5b58c9b)
    #1 0x55cf59eaac59 in allocate /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:151
    #2 0x55cf59eaac59 in allocate /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/allocator.h:198
    #3 0x55cf59eaac59 in allocate /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:482
    #4 0x55cf59eaac59 in _S_allocate /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:126
    #5 0x55cf59eaac59 in _M_create /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:159
    #6 0x55cf59eaac59 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:229
    #7 0x55cf654dc2ba in make_unique<arangodb::result::Error, ErrorCode &, const char *&> /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/unique_ptr.h:1070
    #8 0x55cf654dc2ba in arangodb::Result::Result(ErrorCode, char const*) /root/project/lib/Basics/Result.cpp:67
    #9 0x55cf5e6023cf in arangodb::CreateDatabaseInfo::extractOptions(arangodb::velocypack::Slice, bool, bool) /root/project/arangod/VocBase/VocbaseInfo.cpp:275
    #10 0x55cf5e604486 in arangodb::CreateDatabaseInfo::load(std::basic_string_view<char, std::char_traits<char>>, arangodb::velocypack::Slice, arangodb::velocypack::Slice) /root/project/arangod/VocBase/VocbaseInfo.cpp:104
    #11 0x55cf5e6d7b43 in operator() /root/project/arangod/VocBase/Methods/Databases.cpp:388
    #12 0x55cf5e6d7b43 in catchToResult<(lambda at /root/project/arangod/VocBase/Methods/Databases.cpp:362:38)> /root/project/lib/Basics/Exceptions.h:146
    #13 0x55cf5e6d7b43 in arangodb::methods::Databases::create(arangodb::application_features::ApplicationServer&, arangodb::StorageEngine&, arangodb::ExecContext const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, arangodb::velocypack::Slice, arangodb::velocypack::Slice) /root/project/arangod/VocBase/Methods/Databases.cpp:362
    #14 0x55cf5ac7d817 in arangodb::RestDatabaseHandler::createDatabase() /root/project/arangod/RestHandler/RestDatabaseHandler.cpp:157
    #15 0x55cf5ac7c61b in arangodb::RestDatabaseHandler::execute() /root/project/arangod/RestHandler/RestDatabaseHandler.cpp:54
    #16 0x55cf5a97dddb in arangodb::rest::RestHandler::executeAsync() /root/project/arangod/GeneralServer/RestHandler.cpp:828
    #17 0x55cf5a978a06 in arangodb::rest::RestHandler::executeEngine() /root/project/arangod/GeneralServer/RestHandler.cpp:535
    #18 0x55cf5a975484 in arangodb::rest::RestHandler::runHandlerStateMachine() /root/project/arangod/GeneralServer/RestHandler.cpp:481
    #19 0x55cf5a97e60e in arangodb::rest::RestHandler::runHandler(std::function<void (arangodb::rest::RestHandler*)>) /root/project/arangod/GeneralServer/RestHandler.cpp:847
    #20 0x55cf5ab1831d in operator() /root/project/arangod/GeneralServer/CommTask.cpp:694
    #21 0x55cf5ab1831d in arangodb::Scheduler::WorkItem<arangodb::rest::CommTask::handleRequestSync(std::shared_ptr<arangodb::rest::RestHandler>)::$_0>::invoke() /root/project/arangod/Scheduler/Scheduler.h:222
    #22 0x55cf5f68ae15 in arangodb::SupervisedScheduler::runWorker() /root/project/arangod/Scheduler/SupervisedScheduler.cpp:474
    #23 0x55cf654c3d27 in arangodb::BasicThread::runMe() /root/project/lib/Basics/BasicThread.cpp:329
    #24 0x55cf654c363b in arangodb::BasicThread::startThread(void*) /root/project/lib/Basics/BasicThread.cpp:136
    #25 0x55cf65534676 in ThreadStarter(void*) /root/project/lib/Basics/threads-posix.cpp:77
    #26 0x55cf59e6077a in asan_thread_start(void*) crtbegin.c
```

Reason:  we do 
```
Result res = basics::catchToResult([&]() { 
  ...; 
  res = ...;
  ...; 
  return res;
});
```
So we reuse the captured variable (which is not fully constructed when reusing it) and when returning it it is not eligible to named return value optimization, therefore the `Result`s copy constructor is invoked with `this == &other`, creates a new unique ptr and writes that pointer into `_error` without destroying whatever was already there.
In devel the code is different:
```
Result res = basics::catchToResult([&]() { 
  Res res;
  ...; 
  res = ...;
  ...; 
  return res;
});
```
So here we have a local variable shadowing `res`, everything is fine.