### PR TITLE
Fix endpoint for external rbac service

### DIFF
--- a/arangod/GeneralServer/AuthenticationOptionsProvider.cpp
+++ b/arangod/GeneralServer/AuthenticationOptionsProvider.cpp
@@ -27,6 +27,7 @@
 #include "Logger/Logger.h"
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
+#include "absl/strings/str_cat.h"
 
 #include <limits>
 
@@ -264,8 +265,13 @@ void AuthenticationOptionsProvider::validateOptionsImpl(
   }
 
   if (!options.externalRbacService.empty()) {
-    if (!options.externalRbacService.starts_with("http://") &&
-        !options.externalRbacService.starts_with("https://")) {
+    if (options.externalRbacService.starts_with("http://")) {
+      options.externalRbacService =
+          absl::StrCat("tcp://", options.externalRbacService.substr(7));
+    } else if (options.externalRbacService.starts_with("https://")) {
+      options.externalRbacService =
+          absl::StrCat("ssl://", options.externalRbacService.substr(8));
+    } else {
       LOG_TOPIC("1aaaf", FATAL, arangodb::Logger::AUTHENTICATION)
           << "--server.external-rbac-service must start with http:// or "
              "https://";

--- a/arangod/GeneralServer/AuthenticationOptionsProvider.cpp
+++ b/arangod/GeneralServer/AuthenticationOptionsProvider.cpp
@@ -27,7 +27,6 @@
 #include "Logger/Logger.h"
 #include "ProgramOptions/Parameters.h"
 #include "ProgramOptions/ProgramOptions.h"
-#include "absl/strings/str_cat.h"
 
 #include <limits>
 
@@ -265,13 +264,8 @@ void AuthenticationOptionsProvider::validateOptionsImpl(
   }
 
   if (!options.externalRbacService.empty()) {
-    if (options.externalRbacService.starts_with("http://")) {
-      options.externalRbacService =
-          absl::StrCat("tcp://", options.externalRbacService.substr(7));
-    } else if (options.externalRbacService.starts_with("https://")) {
-      options.externalRbacService =
-          absl::StrCat("ssl://", options.externalRbacService.substr(8));
-    } else {
+    if (!options.externalRbacService.starts_with("http://") &&
+        !options.externalRbacService.starts_with("https://")) {
       LOG_TOPIC("1aaaf", FATAL, arangodb::Logger::AUTHENTICATION)
           << "--server.external-rbac-service must start with http:// or "
              "https://";

--- a/arangod/Network/Utils.cpp
+++ b/arangod/Network/Utils.cpp
@@ -61,6 +61,14 @@ futures::Future<ErrorCode> resolveDestination(ClusterInfo& ci,
     spec.endpoint = dest;
     co_return TRI_ERROR_NO_ERROR;  // all good
   }
+  if (dest.starts_with("http://")) {
+    spec.endpoint = absl::StrCat("tcp://", dest.substr(7));
+    co_return TRI_ERROR_NO_ERROR;
+  }
+  if (dest.starts_with("https://")) {
+    spec.endpoint = absl::StrCat("ssl://", dest.substr(8));
+    co_return TRI_ERROR_NO_ERROR;
+  }
 
   if (dest.starts_with("http+tcp://") || dest.starts_with("http+ssl://")) {
     spec.endpoint = dest.substr(5);


### PR DESCRIPTION
### Scope & Purpose

We accepted only endpoints starting with "http://" or "https://", but then
do not internally understand these. So the easiest fix is to accept these in `resolveDestination`, which is a sensible fix anyway.