### PR TITLE
[CHORE] Fix clang-22/gcc-15 compilation errors

### DIFF
--- a/lib/Activities/include/Activities/Activity.h
+++ b/lib/Activities/include/Activities/Activity.h
@@ -46,7 +46,8 @@ struct Activity : std::enable_shared_from_this<Activity> {
       : _id(std::move(id)),
         _parent(std::move(parent)),
         _type(std::move(type)),
-        _created(std::chrono::system_clock::now()) {}
+        _created(std::chrono::system_clock::now()),
+        _threads{} {}
   virtual ~Activity() = default;
 
   auto id() const noexcept -> ActivityId { return _id; };

--- a/lib/Containers/Concurrent/shared.h
+++ b/lib/Containers/Concurrent/shared.h
@@ -48,8 +48,11 @@ struct SharedResource {
       delete this;
     }
   }
+
   template<class... Input>
-  SharedResource(Input... args) : _data{args...} {}
+  explicit SharedResource(Input&&... args)
+      : _data{std::forward<Input>(args)...} {}
+
   auto get() -> T* { return &_data; }
   auto get_ref() -> T& { return _data; }
   auto ref_count() const -> size_t {
@@ -92,8 +95,11 @@ struct SharedPtr {
       _resource->decrement();
     }
   }
+
   template<class... Input>
-  SharedPtr(Input... args) : _resource{new SharedResource<T>(args...)} {}
+  explicit SharedPtr(Input&&... args)
+      : _resource{new SharedResource<T>(std::forward<Input>(args)...)} {}
+
   auto operator*() -> std::optional<std::reference_wrapper<T>> {
     if (_resource) {
       return {_resource->get_ref()};


### PR DESCRIPTION
Making the constructors of SharedResource and SharedPtr explicit and taking rvalue-references as arguments fixes template instantiation errors in compilation with clang-22 and gcc-15.

