### PR TITLE
[CHORE] Remove unused option member from FlushFeature, MaxMapCountFeature, NonceFeature

### DIFF
--- a/arangod/RestServer/ArangodServer.cpp
+++ b/arangod/RestServer/ArangodServer.cpp
@@ -240,8 +240,7 @@ void ArangodServer::addFeaturesWithOptionProvider() {
   auto& systemDatabaseFeature = addFeature<SystemDatabaseFeature>();
   addFeature<EnvironmentFeature>();
   addFeature<FileSystemFeature>(getOptions<FileSystemOptionsProvider>());
-  auto& flush =
-      addFeature<FlushFeature>(metrics, getOptions<FlushOptionsProvider>());
+  auto& flush = addFeature<FlushFeature>(metrics);
   addFeature<FortuneFeature>(getOptions<fortune::FortuneOptionsProvider>());
 #ifdef USE_V8
   addFeature<FoxxFeature>(getOptions<FoxxOptionsProvider>());
@@ -259,10 +258,10 @@ void ArangodServer::addFeaturesWithOptionProvider() {
   addFeature<LoggerFeature>(true, getOptions<LoggerOptionsProvider>());
   addFeature<MaintenanceFeature>(&clusterFeature,
                                  getOptions<MaintenanceOptionsProvider>());
-  addFeature<MaxMapCountFeature>(getOptions<MaxMapCountOptionsProvider>());
+  addFeature<MaxMapCountFeature>();
   auto& networkFeature =
       addFeature<NetworkFeature>(metrics, getOptions<NetworkOptionsProvider>());
-  addFeature<NonceFeature>(getOptions<NonceOptionsProvider>());
+  addFeature<NonceFeature>();
   addFeature<OptionsCheckFeature>();
   addFeature<PrivilegeFeature>(getOptions<PrivilegeOptionsProvider>());
   addFeature<QueryRegistryFeature>(metrics,

--- a/arangod/RestServer/FlushFeature.cpp
+++ b/arangod/RestServer/FlushFeature.cpp
@@ -44,13 +44,7 @@ namespace arangodb {
 
 FlushFeature::FlushFeature(ApplicationServer& server,
                            metrics::IRegistry& metricsRegistry)
-    : FlushFeature(server, metricsRegistry, FlushFeatureOptions{}) {}
-
-FlushFeature::FlushFeature(ApplicationServer& server,
-                           metrics::IRegistry& metricsRegistry,
-                           FlushFeatureOptions options)
     : ApplicationFeature{server, *this},
-      _options(std::move(options)),
       _stopped(false),
       _metricsFlushSubscriptions(
           metricsRegistry.add(arangodb_flush_subscriptions{})) {

--- a/arangod/RestServer/FlushFeature.h
+++ b/arangod/RestServer/FlushFeature.h
@@ -46,9 +46,6 @@ class FlushFeature final : public application_features::ApplicationFeature,
   static constexpr std::string_view name() noexcept { return "Flush"; }
 
   FlushFeature(application_features::ApplicationServer& server,
-               metrics::IRegistry& metricsRegistry,
-               FlushFeatureOptions options);
-  FlushFeature(application_features::ApplicationServer& server,
                metrics::IRegistry& metricsRegistry);
 
   ~FlushFeature();
@@ -74,7 +71,6 @@ class FlushFeature final : public application_features::ApplicationFeature,
   void stop() override;
 
  private:
-  FlushFeatureOptions _options;
   std::mutex _flushSubscriptionsMutex;
   std::vector<std::weak_ptr<FlushSubscription>> _flushSubscriptions;
   bool _stopped;

--- a/arangod/RestServer/MaxMapCountFeature.cpp
+++ b/arangod/RestServer/MaxMapCountFeature.cpp
@@ -35,13 +35,7 @@ using namespace arangodb::options;
 
 MaxMapCountFeature::MaxMapCountFeature(
     application_features::ApplicationServer& server)
-    : MaxMapCountFeature(server, MaxMapCountFeatureOptions{}) {}
-
-MaxMapCountFeature::MaxMapCountFeature(
-    application_features::ApplicationServer& server,
-    MaxMapCountFeatureOptions options)
-    : application_features::ApplicationFeature{server, *this},
-      _options(std::move(options)) {
+    : application_features::ApplicationFeature{server, *this} {
   setOptional(false);
   startsAfter<application_features::GreetingsFeaturePhase>();
 }

--- a/arangod/RestServer/MaxMapCountFeature.h
+++ b/arangod/RestServer/MaxMapCountFeature.h
@@ -32,17 +32,12 @@ class MaxMapCountFeature final
  public:
   static constexpr std::string_view name() noexcept { return "MaxMapCount"; }
 
-  explicit MaxMapCountFeature(application_features::ApplicationServer& server,
-                              MaxMapCountFeatureOptions options);
   explicit MaxMapCountFeature(application_features::ApplicationServer& server);
 
   static bool needsChecking() { return true; }
 
   static uint64_t actualMaxMappings();
   static uint64_t minimumExpectedMaxMappings();
-
- private:
-  MaxMapCountFeatureOptions _options;
 };
 
 }  // namespace arangodb

--- a/arangod/RestServer/NonceFeature.cpp
+++ b/arangod/RestServer/NonceFeature.cpp
@@ -30,12 +30,7 @@ using namespace arangodb::options;
 namespace arangodb {
 
 NonceFeature::NonceFeature(application_features::ApplicationServer& server)
-    : NonceFeature(server, NonceFeatureOptions{}) {}
-
-NonceFeature::NonceFeature(application_features::ApplicationServer& server,
-                           NonceFeatureOptions options)
-    : application_features::ApplicationFeature{server, *this},
-      _options(std::move(options)) {
+    : application_features::ApplicationFeature{server, *this} {
   setOptional(true);
   startsAfter<application_features::GreetingsFeaturePhase>();
 }

--- a/arangod/RestServer/NonceFeature.h
+++ b/arangod/RestServer/NonceFeature.h
@@ -31,12 +31,7 @@ class NonceFeature : public application_features::ApplicationFeature {
  public:
   static constexpr std::string_view name() noexcept { return "Nonce"; }
 
-  explicit NonceFeature(application_features::ApplicationServer& server,
-                        NonceFeatureOptions options);
   explicit NonceFeature(application_features::ApplicationServer& server);
-
- private:
-  NonceFeatureOptions _options;
 };
 
 }  // namespace arangodb


### PR DESCRIPTION
The options in
 - FlushFeature,
 - MaxMapCountFeature, and
 - NonceFeature are unused

remove the member variables

