### PR TITLE
[COR-870] Validate new name when renaming view

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -1144,9 +1144,14 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
               return {TRI_ERROR_BAD_PARAMETER,
                       "new view name must be different from old view name"};
             }
-            // Renaming modifies the existing (old) view.
-            return checkOne(rbac::Action::WriteMeta,
-                            rbac::resources::View{view.db, view.oldName});
+            // Renaming modifies the existing (old) view and gives access to
+            // resource with new name
+            auto queries = std::vector<rbac::ActionResource>{
+                {rbac::Action::WriteMeta,
+                 rbac::resources::View{view.db, view.oldName}},
+                {rbac::Action::Create,
+                 rbac::resources::View{view.db, view.newName}}};
+            return checkAll(queries);
           },
           [&](p::DropView const& view) -> Result {
             // Dropping a view additionally requires read access to every

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -1144,13 +1144,19 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
               return {TRI_ERROR_BAD_PARAMETER,
                       "new view name must be different from old view name"};
             }
-            // Renaming modifies the existing (old) view and gives access to
-            // resource with new name
-            auto queries = std::vector<rbac::ActionResource>{
-                {rbac::Action::WriteMeta,
-                 rbac::resources::View{view.db, view.oldName}},
-                {rbac::Action::Create,
-                 rbac::resources::View{view.db, view.newName}}};
+            // Renaming drops the existing (old) view and creates new one (check
+            // here same permissions as in CreateView)
+            std::vector<rbac::ActionResource> queries;
+            queries.reserve(2 + view.linkedCollections.size());
+            queries.push_back({rbac::Action::Drop,
+                               rbac::resources::View{view.db, view.oldName}});
+            queries.push_back({rbac::Action::Create,
+                               rbac::resources::View{view.db, view.newName}});
+
+            for (auto const& coll : view.linkedCollections) {
+              queries.push_back({rbac::Action::Read,
+                                 rbac::resources::Collection{view.db, coll}});
+            }
             return checkAll(queries);
           },
           [&](p::DropView const& view) -> Result {

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -251,6 +251,7 @@ struct RenameView {
   std::string db;
   std::string oldName;
   std::string newName;
+  std::vector<std::string> linkedCollections;
 };
 
 struct DropView {

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -309,9 +309,9 @@ void RestViewHandler::modifyView(bool partialUpdate) {
   auto const& execContext = ExecContext::current();
 
   if (isRename) {
-    if (auto r = execContext.canRenameView(_vocbase.name(), name,
-                                           body.stringView(),
-                                           view->linkedCollectionNames());
+    if (auto r =
+            execContext.canRenameView(_vocbase.name(), name, body.stringView(),
+                                      view->linkedCollectionNames());
         !r.ok()) {
       return generateError(r);
     }

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -309,8 +309,9 @@ void RestViewHandler::modifyView(bool partialUpdate) {
   auto const& execContext = ExecContext::current();
 
   if (isRename) {
-    if (auto r =
-            execContext.canRenameView(_vocbase.name(), name, body.stringView());
+    if (auto r = execContext.canRenameView(_vocbase.name(), name,
+                                           body.stringView(),
+                                           view->linkedCollectionNames());
         !r.ok()) {
       return generateError(r);
     }

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -424,12 +424,15 @@ Result ExecContext::canUseView(std::string_view db, std::string_view viewName,
   return {};
 }
 
-Result ExecContext::canRenameView(std::string_view db,
-                                  std::string_view oldViewName,
-                                  std::string_view newViewName) const {
+Result ExecContext::canRenameView(
+    std::string_view db, std::string_view oldViewName,
+    std::string_view newViewName,
+    std::vector<std::string> const& linkedCollections) const {
   using namespace auth::perms;
-  if (auto r = can(
-          RenameView{.db{db}, .oldName{oldViewName}, .newName{newViewName}});
+  if (auto r = can(RenameView{.db{db},
+                              .oldName{oldViewName},
+                              .newName{newViewName},
+                              .linkedCollections{linkedCollections}});
       r.fail()) {
     return r;
   }

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -234,7 +234,8 @@ class ExecContext {
   Result canUseGraph(std::string_view db, std::string_view graph,
                      GraphAccessLevel const level) const;
   Result canRenameView(std::string_view db, std::string_view oldViewName,
-                       std::string_view newViewName) const;
+                       std::string_view newViewName,
+                       std::vector<std::string> const& linkedCollections) const;
 
   Result canSeeAnalyzer(std::string_view db, std::string_view analyzer) const;
   Result canCreateAnalyzer(std::string_view db,

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -255,9 +255,14 @@ TEST_F(RbacAuthModeTest, ModifyViewChecksViewThenLinkedCollections) {
   EXPECT_EQ(svc.queries[1].resource, "collection:mydb:c1");
 }
 
-TEST_F(RbacAuthModeTest, RenameViewChecksOldName) {
+TEST_F(RbacAuthModeTest, RenameViewChecksOldAndNewName) {
   check(p::RenameView{.db = "mydb", .oldName = "old", .newName = "new"});
-  expectSingle(rbac::Action::WriteMeta, "view:mydb:old");
+  EXPECT_EQ(svc.checkCalls, 1);
+  ASSERT_EQ(svc.queries.size(), 2u);
+  EXPECT_EQ(svc.queries[0].action, rbac::Action::WriteMeta);
+  EXPECT_EQ(svc.queries[0].resource, "view:mydb:old");
+  EXPECT_EQ(svc.queries[1].action, rbac::Action::Create);
+  EXPECT_EQ(svc.queries[1].resource, "view:mydb:new");
 }
 
 TEST_F(RbacAuthModeTest, RenameViewToSameNameIsBadParameterAndAsksNothing) {

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -259,10 +259,29 @@ TEST_F(RbacAuthModeTest, RenameViewChecksOldAndNewName) {
   check(p::RenameView{.db = "mydb", .oldName = "old", .newName = "new"});
   EXPECT_EQ(svc.checkCalls, 1);
   ASSERT_EQ(svc.queries.size(), 2u);
-  EXPECT_EQ(svc.queries[0].action, rbac::Action::WriteMeta);
+  EXPECT_EQ(svc.queries[0].action, rbac::Action::Drop);
   EXPECT_EQ(svc.queries[0].resource, "view:mydb:old");
   EXPECT_EQ(svc.queries[1].action, rbac::Action::Create);
   EXPECT_EQ(svc.queries[1].resource, "view:mydb:new");
+}
+
+TEST_F(RbacAuthModeTest, RenameViewChecksOldAndNewNameThenLinkedCollections) {
+  std::vector<std::string> links{"c1", "c2"};
+  EXPECT_TRUE(check(p::RenameView{.db = "mydb",
+                                  .oldName = "old",
+                                  .newName = "new",
+                                  .linkedCollections = links})
+                  .ok());
+  EXPECT_EQ(svc.checkCalls, 1);  // old + new + linked collections in one batch
+  ASSERT_EQ(svc.queries.size(), 4u);
+  EXPECT_EQ(svc.queries[0].action, rbac::Action::Drop);
+  EXPECT_EQ(svc.queries[0].resource, "view:mydb:old");
+  EXPECT_EQ(svc.queries[1].action, rbac::Action::Create);
+  EXPECT_EQ(svc.queries[1].resource, "view:mydb:new");
+  EXPECT_EQ(svc.queries[2].action, rbac::Action::Read);
+  EXPECT_EQ(svc.queries[2].resource, "collection:mydb:c1");
+  EXPECT_EQ(svc.queries[3].action, rbac::Action::Read);
+  EXPECT_EQ(svc.queries[3].resource, "collection:mydb:c2");
 }
 
 TEST_F(RbacAuthModeTest, RenameViewToSameNameIsBadParameterAndAsksNothing) {


### PR DESCRIPTION
RBAC resources are identified by name, and policies are scoped by name pattern. A policy granting `WriteMeta` on `db:view:mydb:team-a-*` is meant to sandbox a user to view names prefixed `team-a-`. This was not enforced when renaming a view: we could change this name to `team-a-` without having the permission to create a view with this name and is now fixed.