### PR TITLE
Fix compilation error due to merge error

### DIFF
--- a/arangod/V8Server/v8-views.cpp
+++ b/arangod/V8Server/v8-views.cpp
@@ -753,8 +753,9 @@ static void JS_RenameViewVocbase(
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canRenameView(view->vocbase().name(),
-                                                    view->name(), name);
+  if (auto r = ExecContext::current().canRenameView(
+          view->vocbase().name(), view->name(), name,
+          view->linkedCollectionNames());
       r.fail()) {
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
   }


### PR DESCRIPTION
https://github.com/arangodb/arangodb/pull/23137 added a parameter to `canRenameView` and https://github.com/arangodb/arangodb/pull/23134 adds a call to `canRenameView` without the added parameter.