### PR TITLE
Make reloading analyzers execute on superuser

### DIFF
--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -2061,6 +2061,7 @@ Result IResearchAnalyzerFeature::loadAvailableAnalyzers(
   // an internal cache and does not expose any information to the caller.
   // Authorization for seeing/using individual analyzers is enforced where
   // analyzers are actually read or listed.
+  ExecContextSuperuserScope scope;
   Result res = loadAnalyzers(operationOrigin, dbName);
   if (res.fail()) {
     return res;

--- a/arangod/IResearch/IResearchAnalyzerFeature.cpp
+++ b/arangod/IResearch/IResearchAnalyzerFeature.cpp
@@ -2057,11 +2057,6 @@ Result IResearchAnalyzerFeature::loadAvailableAnalyzers(
     // and dbservers never should start ddl by themselves.
     return {};
   }
-  // No authorization is required here: loading analyzers merely (re-)fills
-  // an internal cache and does not expose any information to the caller.
-  // Authorization for seeing/using individual analyzers is enforced where
-  // analyzers are actually read or listed.
-  ExecContextSuperuserScope scope;
   Result res = loadAnalyzers(operationOrigin, dbName);
   if (res.fail()) {
     return res;
@@ -2077,6 +2072,11 @@ Result IResearchAnalyzerFeature::loadAvailableAnalyzers(
 Result IResearchAnalyzerFeature::loadAnalyzers(
     transaction::OperationOrigin operationOrigin,
     std::string_view database /*= std::string_view{}*/) {
+  // No authorization is required here: loading analyzers merely (re-)fills
+  // an internal cache and does not expose any information to the caller.
+  // Authorization for seeing/using individual analyzers is enforced where
+  // analyzers are actually read or listed.
+  ExecContextSuperuserScope scope;
   try {
     // '_analyzers'/'_lastLoad' can be asynchronously read
     WRITE_LOCKER(lock, _mutex);


### PR DESCRIPTION
Fixes driver-failure in POST `/_api/view/` due to merge of the [rbac pr](https://github.com/arangodb/arangodb/pull/22734).

Creating a view reloads the analyzers via `IResearchAnalyzerFeature::loadAvailableAnalyzers`, but with the current user permission on the _analyzers collection (the actual permission request is done in `TransactionState::checkCollectionPermissions` which also gives the error we currently see in the drivers - "forbidden: _analyzers [read]"). The reloading should actually be done as a superuser as already suggested by the comment above the code-line this PR adds (the comments was added in the rbac pr).

I validated the fix locally against the python-driver test `test_view.py` in the python-driver library.