### PR TITLE
[COR-871 cleanup]

### DIFF
--- a/Documentation/DifferencesApiV0vsV1.md
+++ b/Documentation/DifferencesApiV0vsV1.md
@@ -158,7 +158,7 @@ hardening that is introduced with V1's RBAC semantics):
     errorNum 11) otherwise — the collection's existence is implicitly
     confirmed in both cases.
 
-* **`UseView` check** (line ~579): identical pattern to `UseDatabase` for
+* **`ReadView` check** (line ~579): identical pattern to `UseDatabase` for
   views: **V1** returns `TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND` (404) when
   the user has no database access at all; **V0** returns `TRI_ERROR_FORBIDDEN`
   (403).
@@ -248,7 +248,7 @@ authorization check that only applies starting with **V1**:
 | Generic authorization failure (`RestHandler::handleAuthorizationChecks`) | Always HTTP 401 + errorNum 11 (`TRI_ERROR_FORBIDDEN`), regardless of actual cause | HTTP/errorNum reflect the actual `Result` (401/403/404 as appropriate) |
 | No DB access at all (`AuthMode::UseDatabase`) | HTTP 403 / errorNum 11 | HTTP 404 / errorNum 1228 (`DATABASE_NOT_FOUND`) — hides existence |
 | No collection access at all (`AuthMode::UseCollection`) | HTTP 403 / errorNum 1004 or 11 | HTTP 404 / errorNum 1203 (`DATA_SOURCE_NOT_FOUND`) — hides existence |
-| No view/db access at all (`AuthMode::UseView`) | HTTP 403 / errorNum 11 | HTTP 404 / errorNum 1203 — hides existence |
+| No view/db access at all (`AuthMode::ReadView`) | HTTP 403 / errorNum 11 | HTTP 404 / errorNum 1203 — hides existence |
 | Drop collection, insufficient DB/collection access (`AuthMode::DropCollection`) | HTTP 403 / errorNum 11 (forced) | HTTP 403 / errorNum 11 or 1004, depending on actual cause |
 | Create graph, no DB write access (`AuthMode::CreateGraph`) | HTTP 403 / errorNum 1004 | HTTP 403 / errorNum 11 |
 | `/_api/index` collection lookup on coordinator | No per-collection read check | Requires `Read` access; otherwise collection "not found" |

--- a/Documentation/path_permissions.md
+++ b/Documentation/path_permissions.md
@@ -251,7 +251,7 @@ return a `Result`, so that a decline can return the actual reason
  - `canSeeView(std::string_view db, std::string_view view) -> Result`
  - `canCreateView(std::string_view db, std::string_view view) -> Result`
  - `canDropView(std::string_view db, std::string_view view) -> Result`
- - `canUseView(std::string_view db, std::string_view view) -> Result`
+ - `canReadView(std::string_view db, std::string_view view) -> Result`
  - `canRenameView(std::string_view db, std::string_view oldViewName,
                   std::string_view newViewName, std::vector<std::string> collections) -> Result`
 
@@ -414,19 +414,10 @@ central implementation of these methods.
 
    check RW access for database
 
- - `canUseView(std::string_view db, std::string_view view) -> Result`
+ - `canReadView(std::string_view db, std::string_view view) -> Result`
 
-   Just delegate to the access level of the database (as before) and use::
-  
-      - AccessLevel::Read: needs auth::Level::RO or more
-      - AccessLevel::WriteData: needs auth::Level::RW
-      - AccessLevel::WriteMeta: needs auth::Level::RW and auth::Level::RW on database!
+   check R access for database
 
-   Note that we leave the code as it is to additionally check if the user
-   has `canUseCollection(RO)` for all linked collections.
-  
-   If the user is not allowed to see the view, this must return NOT_FOUND!
-  
  - `canRenameView(std::string_view db, std::string_view oldViewName,
                   std::string_view newViewName, std::vector<std::string> collections) -> Result`
 
@@ -625,8 +616,8 @@ central implementation of these methods.
  - `canRenameView(std::string_view db, std::string_view oldViewName,
                   std::string_view newViewName, std::vector<std::string> collections) -> Result`
 
-   This should check that the new name is actually different from the old name.
-   Then it should do the same check as `canUseView` above with `AccessLevel::WriteMeta`.
+   This should check that the new name is actually different from the old name 
+	 and RW access for database.
   
  - `canSeeAnalyzer(std::string_view db, std::string_view analyzer) -> Result`
 
@@ -1094,11 +1085,11 @@ SA/SW/LEG    - API is switchable between SA (superuser needed for everything), S
 | X  |    | X  | GET    | `/_api/view`                                                 | RestViewHandler            | only see those with canSeeView           | canSeeView                          |                                          |                        |
 | X  |    | X  | POST   | `/_api/view`                                                 | RestViewHandler            | canCreateView                            | canCreateView                       |                                          |                        |
 | X  |    | X  | DELETE | `/_api/view/{name}`                                          | RestViewHandler            | canDropView                              | canDropView                         |                                          |                        |
-| X  |    | X  | GET    | `/_api/view/{name}`                                          | RestViewHandler            | canUseView(RO)                           | canUseView(RO)                      |                                          |                        |
-| X  |    | X  | GET    | `/_api/view/{name}/properties`                               | RestViewHandler            | canUseView(RO)                           | canUseView(RO)                      |                                          |                        |
-| X  |    | X  | PATCH  | `/_api/view/{name}/properties`                               | RestViewHandler            | canUseView(modify)                       | canUseView(modify)                  |                                          |                        |
+| X  |    | X  | GET    | `/_api/view/{name}`                                          | RestViewHandler            | canReadView                              | canReadView                         |                                          |                        |
+| X  |    | X  | GET    | `/_api/view/{name}/properties`                               | RestViewHandler            | canReadView                              | canReadView                         |                                          |                        |
+| X  |    | X  | PATCH  | `/_api/view/{name}/properties`                               | RestViewHandler            | canModifyView                            | canModifyView                       |                                          |                        |
 | X  |    | X  | PATCH  | `/_api/view/{name}/rename`                                   | RestViewHandler            | canRenameView                            | canRenameView                       |                                          |                        |
-| X  |    | X  | PUT    | `/_api/view/{name}/properties`                               | RestViewHandler            | canUseView(modify)                       | canUseView(modify)                  |                                          |                        |
+| X  |    | X  | PUT    | `/_api/view/{name}/properties`                               | RestViewHandler            | canModifyView                            | canModifyView                       |                                          |                        |
 | X  |    | X  | PUT    | `/_api/view/{name}/rename`                                   | RestViewHandler            | canRenameView                            | canRenameView                       |                                          |                        |
 | X  |    | X  | GET    | `/_api/wal/lastTick`                                         | RestWalAccessHandler       | -                                        | SUPER                               | only DBServer/Single, not on coord       |                        |
 | X  |    | X  | GET    | `/_api/wal/open-transactions`                                | RestWalAccessHandler       | -                                        | SUPER                               | only DBServer/Single, not on coord       |                        |

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -59,8 +59,8 @@ auto describe(auth::perms::UseCollection const& perm) -> std::string {
       "use collection '{}' in database '{}' with access level '{}'", perm.name,
       perm.db, to_string(perm.level));
 }
-auto describe(auth::perms::UseView const& perm) -> std::string {
-  return std::format("use view '{}' in database '{}'", perm.name, perm.db);
+auto describe(auth::perms::ReadView const& perm) -> std::string {
+  return std::format("read view '{}' in database '{}'", perm.name, perm.db);
 }
 auto describe(auth::perms::SeeView const& perm) -> std::string {
   return std::format("see view '{}' in database '{}'", perm.name, perm.db);
@@ -548,7 +548,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
             return check(p::UseCollection{data.db, data.collName,
                                           CollectionAccessLevel::WriteData});
           },
-          [&](p::UseView const& view) -> Result {
+          [&](p::ReadView const& view) -> Result {
             // In the classic system views delegate to database-level access
             // (per-view collection-level auth is not used for views).
             auto const effectiveLevel = effectiveDatabaseAuthLevel(view.db);
@@ -1095,7 +1095,7 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
                 rbac::resources::Collection{collection.db, collection.name});
           },
           // -- Views -----------------------------------------------------
-          [&](p::UseView const& view) -> Result {
+          [&](p::ReadView const& view) -> Result {
             return checkOne(rbac::Action::Read,
                             rbac::resources::View{view.db, view.name});
           },

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -338,8 +338,6 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
         switch (level) {
           case ViewAccessLevel::Read:
             return auth::Level::RO;
-          case ViewAccessLevel::Modify:
-            return auth::Level::RW;
         }
         ADB_PROD_CRASH();
       },
@@ -969,8 +967,6 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
     switch (level) {
       case ViewAccessLevel::Read:
         return rbac::Action::Read;
-      case ViewAccessLevel::Modify:
-        return rbac::Action::WriteMeta;
     }
     ADB_PROD_CRASH();
   };

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -60,8 +60,7 @@ auto describe(auth::perms::UseCollection const& perm) -> std::string {
       perm.db, to_string(perm.level));
 }
 auto describe(auth::perms::UseView const& perm) -> std::string {
-  return std::format("use view '{}' in database '{}' with access level '{}'",
-                     perm.name, perm.db, to_string(perm.level));
+  return std::format("use view '{}' in database '{}'", perm.name, perm.db);
 }
 auto describe(auth::perms::SeeView const& perm) -> std::string {
   return std::format("see view '{}' in database '{}'", perm.name, perm.db);
@@ -334,13 +333,6 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
         }
         ADB_PROD_CRASH();
       },
-      [](ViewAccessLevel level) {
-        switch (level) {
-          case ViewAccessLevel::Read:
-            return auth::Level::RO;
-        }
-        ADB_PROD_CRASH();
-      },
       [](AnalyzerAccessLevel level) {
         switch (level) {
           case AnalyzerAccessLevel::Read:
@@ -560,9 +552,8 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
             // In the classic system views delegate to database-level access
             // (per-view collection-level auth is not used for views).
             auto const effectiveLevel = effectiveDatabaseAuthLevel(view.db);
-            auto const requestedLevel = accessLevelToAuthLevel(view.level);
 
-            if (requestedLevel <= effectiveLevel) {
+            if (auth::Level::RO <= effectiveLevel) {
               return {};
             } else if (_requestedApiVersion > 0 &&
                        effectiveLevel == auth::Level::NONE) {
@@ -571,7 +562,7 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
               return {
                   TRI_ERROR_FORBIDDEN,
                   failureMessage(view, accessLevelMismatchReason(
-                                           "Request", "view", requestedLevel,
+                                           "Request", "view", auth::Level::RO,
                                            effectiveLevel))};
             }
           },
@@ -963,14 +954,6 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
     ADB_PROD_CRASH();
   };
 
-  auto viewAccessModeToAction = [](ViewAccessLevel level) -> rbac::Action {
-    switch (level) {
-      case ViewAccessLevel::Read:
-        return rbac::Action::Read;
-    }
-    ADB_PROD_CRASH();
-  };
-
   auto analyzerAccessModeToAction =
       [](AnalyzerAccessLevel level) -> rbac::Action {
     switch (level) {
@@ -1113,7 +1096,7 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
           },
           // -- Views -----------------------------------------------------
           [&](p::UseView const& view) -> Result {
-            return checkOne(viewAccessModeToAction(view.level),
+            return checkOne(rbac::Action::Read,
                             rbac::resources::View{view.db, view.name});
           },
           [&](p::SeeView const& view) -> Result {

--- a/arangod/Auth/Permissions.cpp
+++ b/arangod/Auth/Permissions.cpp
@@ -56,8 +56,6 @@ auto to_string(ViewAccessLevel level) -> std::string_view {
   switch (level) {
     case ViewAccessLevel::Read:
       return "read";
-    case ViewAccessLevel::Modify:
-      return "modify";
   }
   ADB_PROD_CRASH();
 }

--- a/arangod/Auth/Permissions.cpp
+++ b/arangod/Auth/Permissions.cpp
@@ -52,14 +52,6 @@ auto to_string(DatabaseAccessLevel level) -> std::string_view {
   ADB_PROD_CRASH();
 }
 
-auto to_string(ViewAccessLevel level) -> std::string_view {
-  switch (level) {
-    case ViewAccessLevel::Read:
-      return "read";
-  }
-  ADB_PROD_CRASH();
-}
-
 auto to_string(AnalyzerAccessLevel level) -> std::string_view {
   switch (level) {
     case AnalyzerAccessLevel::Read:
@@ -210,8 +202,7 @@ std::ostream& operator<<(std::ostream& os, Permission const& permission) {
             os << "DropView db=" << p.db << " name=" << p.name;
           },
           [&](UseView const& p) {
-            os << "UseView db=" << p.db << " name=" << p.name
-               << " level=" << to_string(p.level);
+            os << "UseView db=" << p.db << " name=" << p.name;
           },
 
           // analyzers

--- a/arangod/Auth/Permissions.cpp
+++ b/arangod/Auth/Permissions.cpp
@@ -201,8 +201,8 @@ std::ostream& operator<<(std::ostream& os, Permission const& permission) {
           [&](DropView const& p) {
             os << "DropView db=" << p.db << " name=" << p.name;
           },
-          [&](UseView const& p) {
-            os << "UseView db=" << p.db << " name=" << p.name;
+          [&](ReadView const& p) {
+            os << "ReadView db=" << p.db << " name=" << p.name;
           },
 
           // analyzers

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -258,7 +258,7 @@ struct DropView {
   std::vector<std::string> linkedCollections;
 };
 
-struct UseView {
+struct ReadView {
   std::string db;
   std::string name;
 };
@@ -365,7 +365,7 @@ using NonAdminList = meta::TypeList<
     DumpCollection, RestoreCollection, RestoreCreateIndex, RestoreCreateView,
     RestoreDropView, RestoreWriteData,
     // view permissions
-    SeeView, CreateView, ModifyView, RenameView, DropView, UseView,
+    SeeView, CreateView, ModifyView, RenameView, DropView, ReadView,
     // analyzer permissions
     SeeAnalyzer, CreateAnalyzer, DropAnalyzer, UseAnalyzer,
     // graph permissions

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -46,7 +46,6 @@ enum class CollectionAccessLevel { Read, WriteData, WriteMeta };
 // TODO We call ::Write for DB, but ::Modify for View and Analyzer.
 //      Should we keep it consistent?
 enum class DatabaseAccessLevel { Read, Write };
-enum class ViewAccessLevel { Read };
 enum class AnalyzerAccessLevel { Read, Modify };
 enum class GraphAccessLevel { Read, Modify };
 
@@ -54,7 +53,6 @@ using AccessLevel = CollectionAccessLevel;
 
 auto to_string(CollectionAccessLevel level) -> std::string_view;
 auto to_string(DatabaseAccessLevel level) -> std::string_view;
-auto to_string(ViewAccessLevel level) -> std::string_view;
 auto to_string(AnalyzerAccessLevel level) -> std::string_view;
 auto to_string(GraphAccessLevel level) -> std::string_view;
 
@@ -263,7 +261,6 @@ struct DropView {
 struct UseView {
   std::string db;
   std::string name;
-  ViewAccessLevel level;
 };
 
 // ---------------------------------------------------------------------------

--- a/arangod/Auth/Permissions.h
+++ b/arangod/Auth/Permissions.h
@@ -46,7 +46,7 @@ enum class CollectionAccessLevel { Read, WriteData, WriteMeta };
 // TODO We call ::Write for DB, but ::Modify for View and Analyzer.
 //      Should we keep it consistent?
 enum class DatabaseAccessLevel { Read, Write };
-enum class ViewAccessLevel { Read, Modify };
+enum class ViewAccessLevel { Read };
 enum class AnalyzerAccessLevel { Read, Modify };
 enum class GraphAccessLevel { Read, Modify };
 

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -28,16 +28,10 @@
 #include "IResearch/IResearchAnalyzerFeature.h"
 #include "Logger/LogMacros.h"
 #include "Rest/GeneralResponse.h"
-#include "RestServer/DatabaseFeature.h"
 #include "Transaction/OperationOrigin.h"
 #include "Utils/CollectionNameResolver.h"
 #include "Utils/Events.h"
 #include "VocBase/LogicalView.h"
-#include "VocBase/LogicalCollection.h"
-#include "VocBase/Methods/Collections.h"
-#include "StorageEngine/PhysicalCollection.h"
-#include "Transaction/IndexesSnapshot.h"
-#include "IResearch/IResearchDataStore.h"
 #include "VocBase/vocbase.h"
 
 #include <velocypack/Iterator.h>

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -59,8 +59,8 @@ void RestViewHandler::getView(std::string const& nameOrId, bool detailed) {
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(view->vocbase().name(),
-                                                 view->name());
+  if (auto r = ExecContext::current().canReadView(view->vocbase().name(),
+                                                  view->name());
       !r.ok()) {
     // check auth after ensuring that the view exists
     generateError(r);
@@ -458,15 +458,6 @@ void RestViewHandler::getViews() {
   // ...........................................................................
   // end of parameter parsing
   // ...........................................................................
-
-  // TODO check access right per view
-  //  if (auto const& can = ExecContext::current().can();
-  //  can.readView(_vocbase.name(), name)) {
-  //    generateError(
-  //        Result(TRI_ERROR_FORBIDDEN, "insufficient rights to get views"));
-  //
-  //    return;
-  //  }
 
   std::vector<LogicalView::ptr> views;
 

--- a/arangod/RestHandler/RestViewHandler.cpp
+++ b/arangod/RestHandler/RestViewHandler.cpp
@@ -65,8 +65,8 @@ void RestViewHandler::getView(std::string const& nameOrId, bool detailed) {
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(
-          view->vocbase().name(), view->name(), ViewAccessLevel::Read);
+  if (auto r = ExecContext::current().canUseView(view->vocbase().name(),
+                                                 view->name());
       !r.ok()) {
     // check auth after ensuring that the view exists
     generateError(r);

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -407,10 +407,10 @@ Result ExecContext::canDropView(
   return {};
 }
 
-Result ExecContext::canUseView(std::string_view db,
-                               std::string_view viewName) const {
+Result ExecContext::canReadView(std::string_view db,
+                                std::string_view viewName) const {
   using namespace auth::perms;
-  if (auto r = can(UseView{.db{db}, .name{viewName}}); r.fail()) {
+  if (auto r = can(ReadView{.db{db}, .name{viewName}}); r.fail()) {
     return r;
   }
   return {};

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -407,11 +407,10 @@ Result ExecContext::canDropView(
   return {};
 }
 
-Result ExecContext::canUseView(std::string_view db, std::string_view viewName,
-                               ViewAccessLevel requested) const {
+Result ExecContext::canUseView(std::string_view db,
+                               std::string_view viewName) const {
   using namespace auth::perms;
-  if (auto r = can(UseView{.db{db}, .name{viewName}, .level = requested});
-      r.fail()) {
+  if (auto r = can(UseView{.db{db}, .name{viewName}}); r.fail()) {
     return r;
   }
   return {};

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -414,11 +414,6 @@ Result ExecContext::canUseView(std::string_view db, std::string_view viewName,
       r.fail()) {
     return r;
   }
-  if (requested == ViewAccessLevel::Modify) {
-    if (auto r = checkNotReadOnly(); r.fail()) {
-      return r;
-    }
-  }
   return {};
 }
 

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -219,7 +219,7 @@ class ExecContext {
                        std::vector<std::string> const& linkedCollections) const;
   Result canDropView(std::string_view db, std::string_view view,
                      std::vector<std::string> const& linkedCollections) const;
-  Result canUseView(std::string_view db, std::string_view view) const;
+  Result canReadView(std::string_view db, std::string_view view) const;
 
   Result canSeeGraph(std::string_view db, std::string_view graph) const;
   Result canCreateGraph(std::string_view db, std::string_view graph,

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -219,8 +219,7 @@ class ExecContext {
                        std::vector<std::string> const& linkedCollections) const;
   Result canDropView(std::string_view db, std::string_view view,
                      std::vector<std::string> const& linkedCollections) const;
-  Result canUseView(std::string_view db, std::string_view view,
-                    ViewAccessLevel level) const;
+  Result canUseView(std::string_view db, std::string_view view) const;
 
   Result canSeeGraph(std::string_view db, std::string_view graph) const;
   Result canCreateGraph(std::string_view db, std::string_view graph,

--- a/arangod/V8Server/v8-views.cpp
+++ b/arangod/V8Server/v8-views.cpp
@@ -446,8 +446,7 @@ static void JS_ViewVocbase(v8::FunctionCallbackInfo<v8::Value> const& args) {
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(vocbase.name(), view->name(),
-                                                 ViewAccessLevel::Read);
+  if (auto r = ExecContext::current().canUseView(vocbase.name(), view->name());
       r.fail()) {  // check auth after ensuring
                    // that the view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
@@ -523,8 +522,7 @@ static void JS_ViewsVocbase(v8::FunctionCallbackInfo<v8::Value> const& args) {
     auto view = views[i];
 
     if (!view || ExecContext::current()
-                     .canUseView(vocbase.name(), view->name(),
-                                 ViewAccessLevel::Read)
+                     .canUseView(vocbase.name(), view->name())
                      .fail()) {  // check auth after ensuring
                                  // that the view exists
       continue;  // skip views that are not authorized to be read
@@ -581,8 +579,7 @@ static void JS_NameViewVocbase(
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(vocbase.name(), view->name(),
-                                                 ViewAccessLevel::Read);
+  if (auto r = ExecContext::current().canUseView(vocbase.name(), view->name());
       r.fail()) {  // check auth after ensuring that the
                    // view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
@@ -693,8 +690,7 @@ static void JS_PropertiesViewVocbase(
   }
 
   if (auto r = ExecContext::current().canUseView(view->vocbase().name(),
-                                                 view->name(),
-                                                 ViewAccessLevel::Read);
+                                                 view->name());
       r.fail()) {  // check auth after ensuring that the
                    // view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
@@ -803,8 +799,7 @@ static void JS_TypeViewVocbase(
   // ...........................................................................
 
   if (auto r = ExecContext::current().canUseView(view->vocbase().name(),
-                                                 view->name(),
-                                                 ViewAccessLevel::Read);
+                                                 view->name());
       r.fail()) {  // check auth after ensuring that the
                    // view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());

--- a/arangod/V8Server/v8-views.cpp
+++ b/arangod/V8Server/v8-views.cpp
@@ -446,7 +446,7 @@ static void JS_ViewVocbase(v8::FunctionCallbackInfo<v8::Value> const& args) {
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(vocbase.name(), view->name());
+  if (auto r = ExecContext::current().canReadView(vocbase.name(), view->name());
       r.fail()) {  // check auth after ensuring
                    // that the view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
@@ -522,7 +522,7 @@ static void JS_ViewsVocbase(v8::FunctionCallbackInfo<v8::Value> const& args) {
     auto view = views[i];
 
     if (!view || ExecContext::current()
-                     .canUseView(vocbase.name(), view->name())
+                     .canReadView(vocbase.name(), view->name())
                      .fail()) {  // check auth after ensuring
                                  // that the view exists
       continue;  // skip views that are not authorized to be read
@@ -579,7 +579,7 @@ static void JS_NameViewVocbase(
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(vocbase.name(), view->name());
+  if (auto r = ExecContext::current().canReadView(vocbase.name(), view->name());
       r.fail()) {  // check auth after ensuring that the
                    // view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
@@ -689,8 +689,8 @@ static void JS_PropertiesViewVocbase(
     TRI_V8_THROW_EXCEPTION(TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
   }
 
-  if (auto r = ExecContext::current().canUseView(view->vocbase().name(),
-                                                 view->name());
+  if (auto r = ExecContext::current().canReadView(view->vocbase().name(),
+                                                  view->name());
       r.fail()) {  // check auth after ensuring that the
                    // view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());
@@ -798,8 +798,8 @@ static void JS_TypeViewVocbase(
   // end of parameter parsing
   // ...........................................................................
 
-  if (auto r = ExecContext::current().canUseView(view->vocbase().name(),
-                                                 view->name());
+  if (auto r = ExecContext::current().canReadView(view->vocbase().name(),
+                                                  view->name());
       r.fail()) {  // check auth after ensuring that the
                    // view exists
     TRI_V8_THROW_EXCEPTION_MESSAGE(TRI_ERROR_FORBIDDEN, r.errorMessage());

--- a/tests/Auth/ClassicAuthModeTest.cpp
+++ b/tests/Auth/ClassicAuthModeTest.cpp
@@ -499,23 +499,23 @@ TEST_F(ClassicAuthModeTest, DropCollectionReadOnlyCollectionIsReadOnlyUnderV1) {
 // Views
 // ---------------------------------------------------------------------------
 
-TEST_F(ClassicAuthModeTest, UseViewFollowsTheDatabaseLevel) {
+TEST_F(ClassicAuthModeTest, ReadViewRequiresSystemReadAccess) {
   beUserWith(RO);
-  EXPECT_TRUE(check(p::UseView{.db = std::string{kDb}, .name = "v"}).ok());
+  EXPECT_TRUE(check(p::ReadView{.db = std::string{kDb}, .name = "v"}).ok());
   beUserWith(RW);
-  EXPECT_TRUE(check(p::UseView{.db = std::string{kDb}, .name = "v"}).ok());
+  EXPECT_TRUE(check(p::ReadView{.db = std::string{kDb}, .name = "v"}).ok());
 }
 
-TEST_F(ClassicAuthModeTest, UseViewWithoutAccessIsForbiddenUnderV0) {
+TEST_F(ClassicAuthModeTest, ReadViewWithoutAccessIsForbiddenUnderV0) {
   beUserWith(NONE);
-  expectError(check(p::UseView{.db = std::string{kDb}, .name = "v"}),
+  expectError(check(p::ReadView{.db = std::string{kDb}, .name = "v"}),
               TRI_ERROR_FORBIDDEN);
 }
 
-TEST_F(ClassicAuthModeTest, UseViewWithoutAccessIsNotFoundUnderV1) {
+TEST_F(ClassicAuthModeTest, ReadViewWithoutAccessIsNotFoundUnderV1) {
   beUserWith(NONE);
   useApiVersion(1);
-  expectError(check(p::UseView{.db = std::string{kDb}, .name = "v"}),
+  expectError(check(p::ReadView{.db = std::string{kDb}, .name = "v"}),
               TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 }
 
@@ -1379,7 +1379,7 @@ std::vector<PermCase> permissionCases() {
       {"DropView",
        p::DropView{.db = db, .name = "v", .linkedCollections = links},
        {{{Scope::Db, RW}, {Scope::Coll, RO}}}},
-      {"UseView", p::UseView{.db = db, .name = "v"}, {{{Scope::Db, RO}}}},
+      {"ReadView", p::ReadView{.db = db, .name = "v"}, {{{Scope::Db, RO}}}},
 
       // Analyzers.
       {"SeeAnalyzer", p::SeeAnalyzer{.db = db, .name = "a"},

--- a/tests/Auth/ClassicAuthModeTest.cpp
+++ b/tests/Auth/ClassicAuthModeTest.cpp
@@ -501,36 +501,22 @@ TEST_F(ClassicAuthModeTest, DropCollectionReadOnlyCollectionIsReadOnlyUnderV1) {
 
 TEST_F(ClassicAuthModeTest, UseViewFollowsTheDatabaseLevel) {
   beUserWith(RO);
-  EXPECT_TRUE(check(p::UseView{.db = std::string{kDb},
-                               .name = "v",
-                               .level = ViewAccessLevel::Read})
-                  .ok());
-  expectError(check(p::UseView{.db = std::string{kDb},
-                               .name = "v",
-                               .level = ViewAccessLevel::Modify}),
-              TRI_ERROR_FORBIDDEN);
+  EXPECT_TRUE(check(p::UseView{.db = std::string{kDb}, .name = "v"}).ok());
   beUserWith(RW);
-  EXPECT_TRUE(check(p::UseView{.db = std::string{kDb},
-                               .name = "v",
-                               .level = ViewAccessLevel::Modify})
-                  .ok());
+  EXPECT_TRUE(check(p::UseView{.db = std::string{kDb}, .name = "v"}).ok());
 }
 
 TEST_F(ClassicAuthModeTest, UseViewWithoutAccessIsForbiddenUnderV0) {
   beUserWith(NONE);
-  expectError(
-      check(p::UseView{
-          .db = std::string{kDb}, .name = "v", .level = ViewAccessLevel::Read}),
-      TRI_ERROR_FORBIDDEN);
+  expectError(check(p::UseView{.db = std::string{kDb}, .name = "v"}),
+              TRI_ERROR_FORBIDDEN);
 }
 
 TEST_F(ClassicAuthModeTest, UseViewWithoutAccessIsNotFoundUnderV1) {
   beUserWith(NONE);
   useApiVersion(1);
-  expectError(
-      check(p::UseView{
-          .db = std::string{kDb}, .name = "v", .level = ViewAccessLevel::Read}),
-      TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
+  expectError(check(p::UseView{.db = std::string{kDb}, .name = "v"}),
+              TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND);
 }
 
 TEST_F(ClassicAuthModeTest, SeeViewIsAlwaysGranted) {
@@ -1393,12 +1379,7 @@ std::vector<PermCase> permissionCases() {
       {"DropView",
        p::DropView{.db = db, .name = "v", .linkedCollections = links},
        {{{Scope::Db, RW}, {Scope::Coll, RO}}}},
-      {"UseViewRead",
-       p::UseView{.db = db, .name = "v", .level = ViewAccessLevel::Read},
-       {{{Scope::Db, RO}}}},
-      {"UseViewModify",
-       p::UseView{.db = db, .name = "v", .level = ViewAccessLevel::Modify},
-       {{{Scope::Db, RW}}}},
+      {"UseView", p::UseView{.db = db, .name = "v"}, {{{Scope::Db, RO}}}},
 
       // Analyzers.
       {"SeeAnalyzer", p::SeeAnalyzer{.db = db, .name = "a"},

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -218,15 +218,9 @@ TEST_F(RbacAuthModeTest, DropViewChecksViewThenLinkedCollections) {
   EXPECT_EQ(svc.queries[2].resource, "collection:mydb:c2");
 }
 
-TEST_F(RbacAuthModeTest, UseViewRead) {
-  check(p::UseView{.db = "mydb", .name = "v", .level = ViewAccessLevel::Read});
+TEST_F(RbacAuthModeTest, UseView) {
+  check(p::UseView{.db = "mydb", .name = "v"});
   expectSingle(rbac::Action::Read, "view:mydb:v");
-}
-
-TEST_F(RbacAuthModeTest, UseViewModify) {
-  check(
-      p::UseView{.db = "mydb", .name = "v", .level = ViewAccessLevel::Modify});
-  expectSingle(rbac::Action::WriteMeta, "view:mydb:v");
 }
 
 TEST_F(RbacAuthModeTest, CreateViewChecksViewThenLinkedCollections) {

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -218,8 +218,8 @@ TEST_F(RbacAuthModeTest, DropViewChecksViewThenLinkedCollections) {
   EXPECT_EQ(svc.queries[2].resource, "collection:mydb:c2");
 }
 
-TEST_F(RbacAuthModeTest, UseView) {
-  check(p::UseView{.db = "mydb", .name = "v"});
+TEST_F(RbacAuthModeTest, ReadView) {
+  check(p::ReadView{.db = "mydb", .name = "v"});
   expectSingle(rbac::Action::Read, "view:mydb:v");
 }
 

--- a/tests/RestHandler/RestUsersHandlerTest.cpp
+++ b/tests/RestHandler/RestUsersHandlerTest.cpp
@@ -438,7 +438,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
     ASSERT_FALSE(!logicalView);
 
     EXPECT_TRUE(
-        execContext->canUseView(vocbase->name(), "testDataSource").fail());
+        execContext->canReadView(vocbase->name(), "testDataSource").fail());
     giveUserAdmin();
     auto status = grantHandler.execute();
     takeUserAdmin();
@@ -462,7 +462,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
     EXPECT_TRUE(
-        execContext->canUseView(vocbase->name(), "testDataSource").fail());
+        execContext->canReadView(vocbase->name(), "testDataSource").fail());
   }
 
   // test auth view (revoke)
@@ -493,7 +493,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
     ASSERT_FALSE(!logicalView);
 
     EXPECT_TRUE(
-        execContext->canUseView(vocbase->name(), "testDataSource").fail());
+        execContext->canReadView(vocbase->name(), "testDataSource").fail());
     giveUserAdmin();
     auto status = revokeHandler.execute();
     takeUserAdmin();
@@ -516,7 +516,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
-    EXPECT_TRUE(execContext->canUseView(vocbase->name(), "testDataSource")
+    EXPECT_TRUE(execContext->canReadView(vocbase->name(), "testDataSource")
                     .fail());  // not modified from above
   }
 

--- a/tests/RestHandler/RestUsersHandlerTest.cpp
+++ b/tests/RestHandler/RestUsersHandlerTest.cpp
@@ -437,10 +437,8 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
         });
     ASSERT_FALSE(!logicalView);
 
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
-                    .fail());
+    EXPECT_TRUE(
+        execContext->canUseView(vocbase->name(), "testDataSource").fail());
     giveUserAdmin();
     auto status = grantHandler.execute();
     takeUserAdmin();
@@ -463,10 +461,8 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
-                    .fail());
+    EXPECT_TRUE(
+        execContext->canUseView(vocbase->name(), "testDataSource").fail());
   }
 
   // test auth view (revoke)
@@ -496,10 +492,8 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
         });
     ASSERT_FALSE(!logicalView);
 
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
-                    .fail());
+    EXPECT_TRUE(
+        execContext->canUseView(vocbase->name(), "testDataSource").fail());
     giveUserAdmin();
     auto status = revokeHandler.execute();
     takeUserAdmin();
@@ -522,9 +516,7 @@ TEST_F(RestUsersHandlerTest, test_collection_auth) {
                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
+    EXPECT_TRUE(execContext->canUseView(vocbase->name(), "testDataSource")
                     .fail());  // not modified from above
   }
 

--- a/tests/V8Server/V8UsersTest.cpp
+++ b/tests/V8Server/V8UsersTest.cpp
@@ -437,7 +437,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     ASSERT_FALSE(!logicalView);
 
     EXPECT_TRUE(
-        execContext->canUseView(vocbase->name(), "testDataSource").fail());
+        execContext->canReadView(vocbase->name(), "testDataSource").fail());
     userPtr->grantDatabase("_system", arangodb::auth::Level::RW);
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
@@ -457,7 +457,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
     EXPECT_TRUE(
-        execContext->canUseView(vocbase->name(), "testDataSource").fail());
+        execContext->canReadView(vocbase->name(), "testDataSource").fail());
   }
 
   // test auth view (revoke)
@@ -490,7 +490,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
     // database-level grant is set (only a collection-level grant), the view
     // is not accessible before or after the (failed) revoke.
     EXPECT_TRUE(
-        execContext->canUseView(vocbase->name(), "testDataSource").fail());
+        execContext->canReadView(vocbase->name(), "testDataSource").fail());
     userPtr->grantDatabase("_system", arangodb::auth::Level::RW);
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
@@ -509,7 +509,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
-    EXPECT_TRUE(execContext->canUseView(vocbase->name(), "testDataSource")
+    EXPECT_TRUE(execContext->canReadView(vocbase->name(), "testDataSource")
                     .fail());  // not modified from above
   }
 

--- a/tests/V8Server/V8UsersTest.cpp
+++ b/tests/V8Server/V8UsersTest.cpp
@@ -436,10 +436,8 @@ TEST_F(V8UsersTest, test_collection_auth) {
         });
     ASSERT_FALSE(!logicalView);
 
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
-                    .fail());
+    EXPECT_TRUE(
+        execContext->canUseView(vocbase->name(), "testDataSource").fail());
     userPtr->grantDatabase("_system", arangodb::auth::Level::RW);
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
@@ -458,10 +456,8 @@ TEST_F(V8UsersTest, test_collection_auth) {
                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
-                    .fail());
+    EXPECT_TRUE(
+        execContext->canUseView(vocbase->name(), "testDataSource").fail());
   }
 
   // test auth view (revoke)
@@ -493,10 +489,8 @@ TEST_F(V8UsersTest, test_collection_auth) {
     // In Classic auth mode, views use database-level access. Since no
     // database-level grant is set (only a collection-level grant), the view
     // is not accessible before or after the (failed) revoke.
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
-                    .fail());
+    EXPECT_TRUE(
+        execContext->canUseView(vocbase->name(), "testDataSource").fail());
     userPtr->grantDatabase("_system", arangodb::auth::Level::RW);
     arangodb::velocypack::Builder response;
     v8::TryCatch tryCatch(isolate.get());
@@ -515,9 +509,7 @@ TEST_F(V8UsersTest, test_collection_auth) {
                  TRI_ERROR_ARANGO_DATA_SOURCE_NOT_FOUND ==
                      ErrorCode{slice.get(arangodb::StaticStrings::ErrorNum)
                                    .getNumber<int>()}));
-    EXPECT_TRUE(execContext
-                    ->canUseView(vocbase->name(), "testDataSource",
-                                 arangodb::ViewAccessLevel::Read)
+    EXPECT_TRUE(execContext->canUseView(vocbase->name(), "testDataSource")
                     .fail());  // not modified from above
   }
 

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -181,7 +181,7 @@ TEST_F(LogicalViewTest, test_auth) {
     TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     EXPECT_TRUE(arangodb::ExecContext::current()
-                    .canUseView(vocbase.name(), logicalView->name())
+                    .canReadView(vocbase.name(), logicalView->name())
                     .ok());
   }
 
@@ -193,7 +193,7 @@ TEST_F(LogicalViewTest, test_auth) {
         "", "testVocbase", arangodb::auth::Level::NONE,
         arangodb::auth::Level::NONE);
     EXPECT_FALSE(
-        classicCtx.execContext->canUseView(vocbase.name(), logicalView->name())
+        classicCtx.execContext->canReadView(vocbase.name(), logicalView->name())
             .ok());
   }
 
@@ -205,7 +205,7 @@ TEST_F(LogicalViewTest, test_auth) {
         "", "testVocbase", arangodb::auth::Level::NONE,
         arangodb::auth::Level::RO);
     EXPECT_TRUE(
-        classicCtx.execContext->canUseView(vocbase.name(), logicalView->name())
+        classicCtx.execContext->canReadView(vocbase.name(), logicalView->name())
             .ok());
   }
 
@@ -217,7 +217,7 @@ TEST_F(LogicalViewTest, test_auth) {
         "", "testVocbase", arangodb::auth::Level::NONE,
         arangodb::auth::Level::RW);
     EXPECT_TRUE(
-        classicCtx.execContext->canUseView(vocbase.name(), logicalView->name())
+        classicCtx.execContext->canReadView(vocbase.name(), logicalView->name())
             .ok());
   }
 }

--- a/tests/VocBase/LogicalViewTest.cpp
+++ b/tests/VocBase/LogicalViewTest.cpp
@@ -181,8 +181,7 @@ TEST_F(LogicalViewTest, test_auth) {
     TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     EXPECT_TRUE(arangodb::ExecContext::current()
-                    .canUseView(vocbase.name(), logicalView->name(),
-                                arangodb::ViewAccessLevel::Modify)
+                    .canUseView(vocbase.name(), logicalView->name())
                     .ok());
   }
 
@@ -193,44 +192,32 @@ TEST_F(LogicalViewTest, test_auth) {
     auto classicCtx = arangodb::tests::mocks::makeClassicExecContext(
         "", "testVocbase", arangodb::auth::Level::NONE,
         arangodb::auth::Level::NONE);
-    EXPECT_FALSE(classicCtx.execContext
-                     ->canUseView(vocbase.name(), logicalView->name(),
-                                  arangodb::ViewAccessLevel::Read)
-                     .ok());
+    EXPECT_FALSE(
+        classicCtx.execContext->canUseView(vocbase.name(), logicalView->name())
+            .ok());
   }
 
-  // no write access
+  // read access
   {
     TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     auto classicCtx = arangodb::tests::mocks::makeClassicExecContext(
         "", "testVocbase", arangodb::auth::Level::NONE,
         arangodb::auth::Level::RO);
-    EXPECT_TRUE(classicCtx.execContext
-                    ->canUseView(vocbase.name(), logicalView->name(),
-                                 arangodb::ViewAccessLevel::Read)
-                    .ok());
-    EXPECT_FALSE(classicCtx.execContext
-                     ->canUseView(vocbase.name(), logicalView->name(),
-                                  arangodb::ViewAccessLevel::Modify)
-                     .ok());
+    EXPECT_TRUE(
+        classicCtx.execContext->canUseView(vocbase.name(), logicalView->name())
+            .ok());
   }
 
-  // write access (view access is db access as per
-  // https://github.com/arangodb/backlog/issues/459)
+  // write access
   {
     TRI_vocbase_t vocbase(testDBInfo(server), engine);
     auto logicalView = vocbase.createView(viewJson->slice(), false);
     auto classicCtx = arangodb::tests::mocks::makeClassicExecContext(
         "", "testVocbase", arangodb::auth::Level::NONE,
         arangodb::auth::Level::RW);
-    EXPECT_TRUE(classicCtx.execContext
-                    ->canUseView(vocbase.name(), logicalView->name(),
-                                 arangodb::ViewAccessLevel::Read)
-                    .ok());
-    EXPECT_TRUE(classicCtx.execContext
-                    ->canUseView(vocbase.name(), logicalView->name(),
-                                 arangodb::ViewAccessLevel::Modify)
-                    .ok());
+    EXPECT_TRUE(
+        classicCtx.execContext->canUseView(vocbase.name(), logicalView->name())
+            .ok());
   }
 }

--- a/tests/api/apitests/views.mjs
+++ b/tests/api/apitests/views.mjs
@@ -24,8 +24,7 @@
 //   canSeeView       → DB RO (no-op beyond the DB access check; all visible)
 //   canCreateView    → DB RW
 //   canDropView      → DB RW
-//   canUseView(RO)   → DB RO
-//   canUseView(modify)→ DB RW
+//   canReadView      → DB RO
 //   canRenameView    → DB RW
 //
 // Note: view operations additionally verify that the user has RO access to
@@ -124,7 +123,7 @@ export default [
   // ── GET /_db/d/_api/view/{name} ───────────────────────────────────────────
   {
     // GET /_api/view/{name}
-    // Auth: canUseView(RO) → DB RO.
+    // Auth: canReadView → DB RO.
     // Returns the identity and type of the view.
     // setup:    create v_apitest.
     // teardown: delete v_apitest.
@@ -144,7 +143,7 @@ export default [
   // ── GET /_db/d/_api/view/{name}/properties ────────────────────────────────
   {
     // GET /_api/view/{name}/properties
-    // Auth: canUseView(RO) → DB RO.
+    // Auth: canReadView → DB RO.
     // Returns the full properties (links, consolidation policy, etc.)
     // of the view.
     // setup:    create v_apitest.
@@ -165,7 +164,7 @@ export default [
   // ── PATCH /_db/d/_api/view/{name}/properties ──────────────────────────────
   {
     // PATCH /_api/view/{name}/properties
-    // Auth: canUseView(modify) → DB RW.
+    // Auth: canModifyView → DB RW and Coll R
     // Partially updates view properties; sending an empty object {} is a
     // valid no-op (leaves all properties unchanged).
     // setup:    create v_apitest.
@@ -187,7 +186,7 @@ export default [
   // ── PUT /_db/d/_api/view/{name}/properties ────────────────────────────────
   {
     // PUT /_api/view/{name}/properties
-    // Auth: canUseView(modify) → DB RW.
+    // Auth: canModifyView → DB RW and Coll R
     // Replaces all view properties with the supplied object; {} resets to
     // defaults (empty links map, default consolidation policy, etc.).
     // setup:    create v_apitest.

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -153,7 +153,7 @@ function viewApiAuthzSuite () {
       assertPermissions([
         "UseApiVersion version=0",
         "UseDatabase name=d level=read",
-        "UseView db=d name=v_apitest level=read",
+        "UseView db=d name=v_apitest",
         "UseCollection db=d name=c level=read",
         ...singleOnly([
           `UseCollection db=d name=${cId} level=read`
@@ -169,7 +169,7 @@ function viewApiAuthzSuite () {
       assertPermissions([
         "UseApiVersion version=0",
         "UseDatabase name=d level=read",
-        "UseView db=d name=v_apitest level=read",
+        "UseView db=d name=v_apitest",
         "UseCollection db=d name=c level=read",
         ...singleOnly([
           `UseCollection db=d name=${cId} level=read`

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -30,14 +30,7 @@
 //
 // Every request first asks `UseApiVersion version=0` and then
 // `UseDatabase name=d level=read`. The view handler then asks one dedicated
-// ExecContext question per operation (arangod/Utils/ExecContext.cpp):
-//   getViews (list)     -> canSeeView()   -> SeeView    (per visible view)
-//   getView             -> canUseView(RO) -> UseView ... level=read
-//   createView          -> canCreateView()-> CreateView ... linkedCollections=[..]
-//   modifyView (props)  -> canModifyView()-> ModifyView ... linkedCollections=[..]
-//   modifyView (rename) -> canRenameView()-> RenameView oldName=.. newName=..
-//   deleteView          -> canDropView()  -> DropView
-// The linkedCollections list is derived from the request body's `links` field.
+// ExecContext question per operation (arangod/Utils/ExecContext.cpp).
 
 if (getOptions === true) {
   return {
@@ -145,7 +138,7 @@ function viewApiAuthzSuite () {
       ], endObserve());
     },
 
-    // GET /_api/view/v_apitest - getView() -> canUseView(Read)
+    // GET /_api/view/v_apitest - getView() -> canReadView
     testGetView: function () {
       createView();
       beginObserve();
@@ -153,7 +146,7 @@ function viewApiAuthzSuite () {
       assertPermissions([
         "UseApiVersion version=0",
         "UseDatabase name=d level=read",
-        "UseView db=d name=v_apitest",
+        "ReadView db=d name=v_apitest",
         "UseCollection db=d name=c level=read",
         ...singleOnly([
           `UseCollection db=d name=${cId} level=read`
@@ -161,7 +154,7 @@ function viewApiAuthzSuite () {
       ], endObserve());
     },
 
-    // GET /_api/view/v_apitest/properties - getView(detailed) -> canUseView(Read)
+    // GET /_api/view/v_apitest/properties - getView(detailed) -> canReadView
     testGetViewProperties: function () {
       createView();
       beginObserve();
@@ -169,7 +162,7 @@ function viewApiAuthzSuite () {
       assertPermissions([
         "UseApiVersion version=0",
         "UseDatabase name=d level=read",
-        "UseView db=d name=v_apitest",
+        "ReadView db=d name=v_apitest",
         "UseCollection db=d name=c level=read",
         ...singleOnly([
           `UseCollection db=d name=${cId} level=read`


### PR DESCRIPTION
In [[COR-871] PR](https://github.com/arangodb/arangodb/pull/23134) we realized that `canUseView` check with `ViewAccessLevel::Modify` does not make sense: if we modify the view, we use either `canRenameView` or `canModifyView`. Since we got rid of the `Modify` option in the enum, we were left with only one item - `Read`, so this PR gets rid of this now unnecessary enum altogether.

[COR-871]: https://arangodb.atlassian.net/browse/COR-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ