### PR TITLE
RBAC grantCurrentUser Bug

### DIFF
--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -149,36 +149,41 @@ Result Databases::grantCurrentUser(CreateDatabaseInfo const& info) {
   AuthenticationFeature* af = AuthenticationFeature::instance();
   auth::UserManager* um = af->userManager();
 
-  Result res;
+  // No user manager on DB servers/agents; nothing to grant when auth is off.
+  if (um == nullptr || !af->isActive()) {
+    return {};
+  }
 
-  if (um != nullptr) {
-    ExecContext const& exec = ExecContext::current();
-    // If the current user is empty (which happens if a Maintenance job
-    // called us, or when authentication is off), granting rights
-    // will fail. We hence ignore it here, but issue a warning below
-    if (!exec.user().empty() && af->isActive()) {
-      // This is no longer canWriteUser, but the old check from devel!
-      // TODO (Tobias) `exec.canWriteUser(exec.user())` is a very quirky
-      //      way to check for `exec.user().empty()`.
-      //      I'd like to understand a little bit better when this is
-      //      expected to happen, and maybe improve on the readability.
-      res = um->updateUser(
-          exec.user(),
-          [&](auth::User& entry) {
-            entry.grantDatabase(info.getName(), auth::Level::RW);
-            entry.grantCollection(info.getName(), "*", auth::Level::RW);
-            return TRI_ERROR_NO_ERROR;
-          },
-          auth::UserManager::RetryOnConflict::Yes);
-      return res;
-    }
+  ExecContext const& exec = ExecContext::current();
 
+  // If the current user is empty (which happens if a Maintenance job called
+  // us), granting rights will fail. We hence ignore it here.
+  if (exec.user().empty()) {
     LOG_TOPIC("2a4dd", DEBUG, Logger::FIXME)
         << "current ExecContext's user() is empty. "
         << "Database will be created without any user having permissions";
+    return {};
   }
 
-  return res;
+  // Don't write a redundant grant if the creator already has RW on the new
+  // database through existing rules (e.g. root's "*" wildcard grant). This
+  // was `!exec.isAdminUser()` before the RBAC merge; writing the grant anyway
+  // destroys the configured-vs-effective distinction that
+  // `GET /_api/user/<user>/database?full=true` reports, and accumulates one
+  // stale entry per database ever created in admin user documents.
+  if (um->databaseAuthLevel(exec.user(), info.getName(),
+                            /*configured*/ true) == auth::Level::RW) {
+    return {};
+  }
+
+  return um->updateUser(
+      exec.user(),
+      [&](auth::User& entry) {
+        entry.grantDatabase(info.getName(), auth::Level::RW);
+        entry.grantCollection(info.getName(), "*", auth::Level::RW);
+        return TRI_ERROR_NO_ERROR;
+      },
+      auth::UserManager::RetryOnConflict::Yes);
 }
 
 // Create database on cluster;

--- a/arangod/VocBase/Methods/Databases.cpp
+++ b/arangod/VocBase/Methods/Databases.cpp
@@ -143,49 +143,6 @@ Result Databases::info(TRI_vocbase_t* vocbase, velocypack::Builder& result) {
   return Result();
 }
 
-// Grant permissions on newly created database to current user
-// to be able to run the upgrade script
-Result Databases::grantCurrentUser(CreateDatabaseInfo const& info) {
-  AuthenticationFeature* af = AuthenticationFeature::instance();
-  auth::UserManager* um = af->userManager();
-
-  // No user manager on DB servers/agents; nothing to grant when auth is off.
-  if (um == nullptr || !af->isActive()) {
-    return {};
-  }
-
-  ExecContext const& exec = ExecContext::current();
-
-  // If the current user is empty (which happens if a Maintenance job called
-  // us), granting rights will fail. We hence ignore it here.
-  if (exec.user().empty()) {
-    LOG_TOPIC("2a4dd", DEBUG, Logger::FIXME)
-        << "current ExecContext's user() is empty. "
-        << "Database will be created without any user having permissions";
-    return {};
-  }
-
-  // Don't write a redundant grant if the creator already has RW on the new
-  // database through existing rules (e.g. root's "*" wildcard grant). This
-  // was `!exec.isAdminUser()` before the RBAC merge; writing the grant anyway
-  // destroys the configured-vs-effective distinction that
-  // `GET /_api/user/<user>/database?full=true` reports, and accumulates one
-  // stale entry per database ever created in admin user documents.
-  if (um->databaseAuthLevel(exec.user(), info.getName(),
-                            /*configured*/ true) == auth::Level::RW) {
-    return {};
-  }
-
-  return um->updateUser(
-      exec.user(),
-      [&](auth::User& entry) {
-        entry.grantDatabase(info.getName(), auth::Level::RW);
-        entry.grantCollection(info.getName(), "*", auth::Level::RW);
-        return TRI_ERROR_NO_ERROR;
-      },
-      auth::UserManager::RetryOnConflict::Yes);
-}
-
 // Create database on cluster;
 Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
   TRI_ASSERT(ServerState::instance()->isCoordinator());
@@ -265,11 +222,6 @@ Result Databases::createCoordinator(CreateDatabaseInfo const& info) {
     }
   });
 
-  res = grantCurrentUser(info);
-  if (!res.ok()) {
-    return res;
-  }
-
   LOG_TOPIC("54323", DEBUG, Logger::CLUSTER)
       << "createDatabase on coordinator: have granted current user for "
          "database: "
@@ -346,11 +298,6 @@ Result Databases::createOther(CreateDatabaseInfo const& info) {
   TRI_ASSERT(!vocbase->isDangling());
 
   auto sg = scopeGuard([&]() noexcept { vocbase->release(); });
-
-  Result res = grantCurrentUser(info);
-  if (!res.ok()) {
-    return res;
-  }
 
   VPackBuilder userBuilder;
   info.UsersToVelocyPack(userBuilder);

--- a/arangod/VocBase/Methods/Databases.h
+++ b/arangod/VocBase/Methods/Databases.h
@@ -55,9 +55,6 @@ struct Databases {
                      std::string const& dbName);
 
  private:
-  /// @brief will retry for at most <timeout> seconds
-  static Result grantCurrentUser(CreateDatabaseInfo const& info);
-
   static Result createCoordinator(CreateDatabaseInfo const& info);
   static Result createOther(CreateDatabaseInfo const& info);
 };

--- a/tests/js/client/authentication/auth-create-database-grants.js
+++ b/tests/js/client/authentication/auth-create-database-grants.js
@@ -1,0 +1,159 @@
+/*jshint globalstrict:false, strict:false */
+/* global getOptions, fail */
+
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+////////////////////////////////////////////////////////////////////////////////
+
+const jsunity = require('jsunity');
+const {assertEqual, assertNotUndefined} = jsunity.jsUnity.assertions;
+const arango = require("@arangodb").arango;
+const db = require("@arangodb").db;
+const users = require('@arangodb/users');
+const helper = require('@arangodb/testutils/user-helper');
+
+// configured (not effective) grants of `user`, keyed by database name
+function configuredGrants(user) {
+  const res = arango.GET(`/_api/user/${user}/database?full=true`);
+  assertEqual(false, res.error);
+  return res.result;
+}
+
+// effective (fallback-resolved) grant of `user` on `dbName`
+function effectiveGrant(user, dbName) {
+  const res = arango.GET(`/_api/user/${user}/database/${dbName}`);
+  assertEqual(false, res.error);
+  return res.result;
+}
+
+function testSuite() {
+  const system = '_system';
+  const dbName = 'AuthCreateDatabaseGrantsDb';
+  // `switchUser` only knows the empty password for 'root' and 'bob'
+  const admin = 'bob';
+
+  function dropTestDatabase() {
+    try {
+      db._dropDatabase(dbName);
+    } catch (err) {
+      // did not exist
+    }
+  }
+
+  return {
+    setUp: function () {
+      helper.switchUser('root', system);
+      dropTestDatabase();
+    },
+
+    tearDown: function () {
+      helper.switchUser('root', system);
+      dropTestDatabase();
+      try {
+        users.remove(admin);
+      } catch (err) {
+        // was not created
+      }
+      users.reload();
+    },
+
+    // root's access comes from its `*` wildcard grant, so no explicit grant
+    // may be written for the new database.
+    testRootGetsNoExplicitGrantOnCreatedDatabase: function () {
+      db._createDatabase(dbName);
+
+      const grants = configuredGrants('root');
+      assertNotUndefined(grants[dbName],
+                         `${dbName} missing from the full listing`);
+      assertEqual('undefined', grants[dbName].permission,
+                  `expected no configured grant for ${dbName}`);
+      assertEqual('undefined', grants[dbName].collections['*'],
+                  `expected no configured collection grant for ${dbName}`);
+      // this is what actually grants the access
+      assertEqual('rw', grants['*'].permission);
+    },
+
+    // Skipping the grant must not cost root any access.
+    testRootRetainsEffectiveAccessOnCreatedDatabase: function () {
+      db._createDatabase(dbName);
+
+      const res = arango.GET(`/_api/user/root/database/${dbName}`);
+      assertEqual(false, res.error);
+      assertEqual('rw', res.result);
+
+      db._useDatabase(dbName);
+      try {
+        db._create('someCollection');
+        assertNotUndefined(db._collection('someCollection'));
+      } finally {
+        db._useDatabase(system);
+      }
+    },
+
+    // The point of not writing the grant: the new database must keep following
+    // the grant it inherits. A redundant explicit `rw` grant would shadow the
+    // `_system` fallback and survive narrowing it.
+    testCreatedDatabaseKeepsFollowingTheInheritedGrant: function () {
+      users.save(admin, '');
+      users.grantDatabase(admin, system, 'rw');
+      users.reload();
+
+      helper.switchUser(admin, system);
+      try {
+        db._createDatabase(dbName);
+      } finally {
+        helper.switchUser('root', system);
+      }
+      assertEqual('rw', effectiveGrant(admin, dbName));
+
+      users.grantDatabase(admin, system, 'ro');
+      users.reload();
+      assertEqual('ro', effectiveGrant(admin, dbName),
+                  `${dbName} no longer follows the inherited _system grant`);
+    },
+
+    // An admin whose access to the new database comes from the `_system`
+    // fallback rather than a `*` wildcard grant must equally not get one.
+    testAdminWithoutWildcardGrantGetsNoExplicitGrant: function () {
+      users.save(admin, '');
+      users.grantDatabase(admin, system, 'rw');
+      users.reload();
+
+      helper.switchUser(admin, system);
+      try {
+        db._createDatabase(dbName);
+      } finally {
+        helper.switchUser('root', system);
+      }
+
+      const grants = configuredGrants(admin);
+      assertNotUndefined(grants[dbName],
+                         `${dbName} missing from the full listing`);
+      assertEqual('undefined', grants[dbName].permission,
+                  `expected no configured grant for ${dbName}`);
+      assertEqual('undefined', grants[dbName].collections['*'],
+                  `expected no configured collection grant for ${dbName}`);
+    },
+  }; // return
+
+} // end of suite
+
+jsunity.run(testSuite);
+return jsunity.done();

--- a/tests/js/client/server_permissions/authorization-questions/databases.js
+++ b/tests/js/client/server_permissions/authorization-questions/databases.js
@@ -153,8 +153,6 @@ function databaseApiAuthzSuite () {
         "UseCollection db=d2 name=_apps level=writemeta",
         "UseCollection db=d2 name=_jobs level=writemeta",
         ...singleOnly([
-          "UseCollection db=_system name=_users level=read",
-          "UseCollection db=_system name=_users level=writedata",
           "UseCollection db=d2 name=_apps level=read",
           "UseCollection db=d2 name=_apps level=writedata",
           "UseCollection db=d2 name=_jobs level=read",
@@ -174,10 +172,6 @@ function databaseApiAuthzSuite () {
         "UseDatabase name=_system level=read",
         "IsReadOnly",
         "DropDatabase name=d2",
-        ...singleOnly([
-          "UseCollection db=_system name=_users level=read",
-          "UseCollection db=_system name=_users level=writedata"
-        ])
       ], endObserve());
     },
   };


### PR DESCRIPTION
Remove `grantCurrentUser` compleltely, since it is essentially dead code. The user creating a database will always have access to it.