### PR TITLE
[COR-873] Get rid of ExecContext::forceSuperuser

### DIFF
--- a/arangod/RestHandler/RestAdminServerHandler.cpp
+++ b/arangod/RestHandler/RestAdminServerHandler.cpp
@@ -83,9 +83,6 @@ async<RestHandler::AuthenticationGrant>
 RestAdminServerHandler::checkUserAuthentication() const {
   auto const& suffixes = _request->suffixes();
   if (suffixes.size() == 1 && suffixes[0] == "availability") {
-    auto ec = _request->requestContext();
-    TRI_ASSERT(ec != nullptr);
-    ec->forceSuperuser();
     co_return AuthenticationGrant::GRANTED_EARLY;
   }
 
@@ -152,6 +149,8 @@ void RestAdminServerHandler::handleAvailability() {
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     return;
   }
+
+  ExecContextSuperuserScope scope;
 
   bool available = false;
   switch (ServerState::mode()) {

--- a/arangod/RestHandler/RestAuthHandler.cpp
+++ b/arangod/RestHandler/RestAuthHandler.cpp
@@ -32,6 +32,7 @@
 #include "Logger/LoggerStream.h"
 #include "Utils/Events.h"
 #include "Ssl/jwt.h"
+#include "Utils/ExecContext.h"
 
 #include <velocypack/Builder.h>
 
@@ -55,6 +56,8 @@ RestStatus RestAuthHandler::execute() {
                   TRI_ERROR_HTTP_METHOD_NOT_ALLOWED);
     return RestStatus::DONE;
   }
+
+  ExecContextSuperuserScope scope;
 
   if (!AuthenticationFeature::instance()->isActive()) {
     // Since 3.12.6 we actually mount this RestHandler in the case that
@@ -203,9 +206,6 @@ RestStatus RestAuthHandler::execute() {
 
 async<RestHandler::AuthenticationGrant>
 RestAuthHandler::checkUserAuthentication() const {
-  auto ec = _request->requestContext();
-  TRI_ASSERT(ec != nullptr);
-  ec->forceSuperuser();
   co_return AuthenticationGrant::GRANTED;
 }
 

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -133,8 +133,6 @@ ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
       /*hasRequestInfo*/ true);
 }
 
-void ExecContext::forceSuperuser() { _authMode.reset<AuthMode::Superuser>(); }
-
 std::optional<std::reference_wrapper<TRI_vocbase_t>> ExecContext::vocbase()
     const noexcept {
   if (_vocbase) {

--- a/arangod/Utils/ExecContext.h
+++ b/arangod/Utils/ExecContext.h
@@ -110,9 +110,6 @@ class ExecContext {
   /// @brief cancel execution
   void cancel() noexcept { _canceled.store(true, std::memory_order_relaxed); }
 
-  /// @brief upgrade to internal superuser, preserving request/vocbase refs
-  void forceSuperuser();
-
   /// @brief returns the vocbase associated with this context, if any
   [[nodiscard]] std::optional<std::reference_wrapper<Database>> vocbase()
       const noexcept;

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -192,13 +192,10 @@ function serverApiAuthzSuite () {
       ], endObserve());
     },
 
-    // GET /_admin/server/availability - OPEN endpoint: the handler forces
-    // superuser and returns before the base implementation runs, so not even
-    // an authenticated request asks anything.
+    // GET /_admin/server/availability - OPEN endpoint
     testAvailability: function () {
       beginObserve();
       arango.GET_RAW(`/_db/_system/_admin/server/availability`);
-      // this endpoint bypasses RestHandler::checkUserCanAccess()
       assertPermissions([
       ], endObserve());
     },


### PR DESCRIPTION
Gets rid of `forceSuperuser`. Then we also do not have to keep track of `ServerState::readOnly` setting at the same time.