### PR TITLE
Update query-cache permissions based on previous review comments

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -595,8 +595,12 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
           // AdminQueryCache only requires RO access to _system, unlike every
           // other admin action, which requires RW (see below).
           [&](p::AdminQueryCache const&) -> Result {
-            return check(p::UseDatabase{.name = StaticStrings::SystemDatabase,
-                                        .level = DatabaseAccessLevel::Read});
+            if (_requestedApiVersion == 0) {
+              return check(p::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                          .level = DatabaseAccessLevel::Read});
+            } else {
+              return isAdmin();
+            }
           },
           // Every other admin action requires RW access to the _system
           // database.

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -592,7 +592,14 @@ auto AuthMode::Classic::check(auth::Permission permission) const -> Result {
                                      : DatabaseAccessLevel::Read;
             return check(p::UseDatabase{analyzer.db, dbLevel});
           },
-          // Classic admin action requires RW access to the _system database.
+          // AdminQueryCache only requires RO access to _system, unlike every
+          // other admin action, which requires RW (see below).
+          [&](p::AdminQueryCache const&) -> Result {
+            return check(p::UseDatabase{.name = StaticStrings::SystemDatabase,
+                                        .level = DatabaseAccessLevel::Read});
+          },
+          // Every other admin action requires RW access to the _system
+          // database.
           [&](p::AnyAdmin auto const&) -> Result { return isAdmin(); },
           [&](p::SeeDatabase const& database) -> Result {
             return check(

--- a/arangod/RestHandler/RestQueryCacheHandler.cpp
+++ b/arangod/RestHandler/RestQueryCacheHandler.cpp
@@ -59,13 +59,6 @@ RestStatus RestQueryCacheHandler::execute() {
 }
 
 void RestQueryCacheHandler::clearCache() {
-  if (_request->requestedApiVersion() > 0) {
-    if (!_vocbase.isSystem()) {
-      generateError(rest::ResponseCode::FORBIDDEN,
-                    TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE);
-      return;
-    }
-  }
   if (auto r = ExecContext::current().canUseAdminAction(
           auth::perms::AdminQueryCache{});
       r.fail()) {

--- a/arangod/RestHandler/RestQueryCacheHandler.cpp
+++ b/arangod/RestHandler/RestQueryCacheHandler.cpp
@@ -65,12 +65,12 @@ void RestQueryCacheHandler::clearCache() {
                     TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE);
       return;
     }
-    if (auto r = ExecContext::current().canUseAdminAction(
-            auth::perms::AdminQueryCache{});
-        r.fail()) {
-      generateError(r);
-      return;
-    }
+  }
+  if (auto r = ExecContext::current().canUseAdminAction(
+          auth::perms::AdminQueryCache{});
+      r.fail()) {
+    generateError(r);
+    return;
   }
   auto queryCache = arangodb::aql::QueryCache::instance();
   queryCache->invalidate(&_vocbase);
@@ -126,21 +126,18 @@ void RestQueryCacheHandler::replaceProperties() {
     return;
   }
 
-  // This check was introduced in 3.12.10 to have at least some
-  // restriction. So one needs RO access to _system to call this
-  // API. In later API versions, we require AdminQueryCache.
-  if (!_vocbase.isSystem()) {
-    generateError(rest::ResponseCode::FORBIDDEN,
-                  TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE);
-    return;
-  }
   if (_request->requestedApiVersion() > 0) {
-    if (auto r = ExecContext::current().canUseAdminAction(
-            auth::perms::AdminQueryCache{});
-        r.fail()) {
-      generateError(r);
+    if (!_vocbase.isSystem()) {
+      generateError(rest::ResponseCode::FORBIDDEN,
+                    TRI_ERROR_ARANGO_USE_SYSTEM_DATABASE);
       return;
     }
+  }
+  if (auto r = ExecContext::current().canUseAdminAction(
+          auth::perms::AdminQueryCache{});
+      r.fail()) {
+    generateError(r);
+    return;
   }
 
   bool validBody = false;

--- a/arangod/RestHandler/RestQueryCacheHandler.cpp
+++ b/arangod/RestHandler/RestQueryCacheHandler.cpp
@@ -50,7 +50,7 @@ RestStatus RestQueryCacheHandler::execute() {
       replaceProperties();
       break;
     default:
-      generateNotImplemented("ILLEGAL " + DOCUMENT_PATH);
+      generateNotImplemented("ILLEGAL /_api/query-cache");
       break;
   }
 

--- a/tests/Auth/ClassicAuthModeTest.cpp
+++ b/tests/Auth/ClassicAuthModeTest.cpp
@@ -941,7 +941,9 @@ TEST_F(ClassicAuthModeTest, UserOperationsAreForbiddenWithoutSystemReadWrite) {
 // ---------------------------------------------------------------------------
 // Admin actions
 //
-// All of them collapse into the same question: RW on _system.
+// All of them collapse into the same question: RW on _system. The one
+// exception is AdminQueryCache, which only needs RO on _system; see
+// AdminQueryCacheIsGrantedBySystemReadOnly below.
 // ---------------------------------------------------------------------------
 
 // Every alternative of auth::perms::detail::AdminList. Kept explicit so that
@@ -959,6 +961,21 @@ using AllAdminPermissions =
                p::AdminWalAccess, p::AdminReadAgency, p::AdminQueryCache>;
 
 static_assert(std::tuple_size_v<AllAdminPermissions> == 26);
+
+// Same as AllAdminPermissions, minus AdminQueryCache: used by the tests below
+// that pin "forbidden without RW", which no longer holds for AdminQueryCache.
+using AllAdminPermissionsExceptQueryCache =
+    std::tuple<p::AdminReadUsers, p::AdminMoveShards, p::AdminMonitoring,
+               p::AdminMonitoringInternal, p::AdminAuthReload,
+               p::AdminCrashHandler, p::AdminApiCalls, p::AdminAqlQueries,
+               p::AdminShutdown, p::AdminReadLogs, p::AdminSetLogLevel,
+               p::AdminOptions, p::AdminSupervisionState, p::AdminRemoveServer,
+               p::AdminClusterInfo, p::AdminMaintenance, p::AdminRebalance,
+               p::AdminLicense, p::AdminBackup, p::AdminReadReplicatedLog,
+               p::AdminWriteReplicatedLog, p::AdminDump, p::AdminRestore,
+               p::AdminWalAccess, p::AdminReadAgency>;
+
+static_assert(std::tuple_size_v<AllAdminPermissionsExceptQueryCache> == 25);
 
 TEST_F(ClassicAuthModeTest, EveryAdminActionIsGrantedBySystemReadWrite) {
   beAdmin();
@@ -987,7 +1004,7 @@ TEST_F(ClassicAuthModeTest, EveryAdminActionIsForbiddenWithoutSystemReadWrite) {
         };
         (expectDenied(admins), ...);
       },
-      AllAdminPermissions{});
+      AllAdminPermissionsExceptQueryCache{});
 }
 
 TEST_F(ClassicAuthModeTest, AdminReadUsersIsNotSpecialInClassic) {
@@ -995,6 +1012,18 @@ TEST_F(ClassicAuthModeTest, AdminReadUsersIsNotSpecialInClassic) {
   // and fails closed with TRI_ERROR_NOT_IMPLEMENTED.
   beAdmin();
   EXPECT_TRUE(check(p::AdminReadUsers{}).ok());
+}
+
+TEST_F(ClassicAuthModeTest, AdminQueryCacheIsGrantedBySystemReadOnly) {
+  // Unlike every other admin action, AdminQueryCache only needs RO on
+  // _system, not RW.
+  setGrants({{StaticStrings::SystemDatabase, RO}});
+  EXPECT_TRUE(check(p::AdminQueryCache{}).ok());
+}
+
+TEST_F(ClassicAuthModeTest, AdminQueryCacheIsForbiddenWithoutSystemAccess) {
+  setGrants({{StaticStrings::SystemDatabase, NONE}});
+  expectError(check(p::AdminQueryCache{}), TRI_ERROR_FORBIDDEN);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -330,6 +330,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.PUT_RAW(`/_db/_system/_api/query-cache/properties`, { mode: 'off' });
       assertPermissions([
+        "AdminQueryCache",
         "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());
@@ -339,6 +340,7 @@ function miscApiAuthzSuite () {
       beginObserve();
       arango.DELETE_RAW(`/_db/_system/_api/query-cache`);
       assertPermissions([
+        "AdminQueryCache",
         "UseApiVersion version=0",
         "UseDatabase name=_system level=read"
       ], endObserve());

--- a/tests/js/client/shell/shell-query-cache-noncluster.js
+++ b/tests/js/client/shell/shell-query-cache-noncluster.js
@@ -132,6 +132,47 @@ function AqlQueryCacheSuite () {
       assertEqual(245, p.maxEntrySize);
     },
 
+    testPropertiesDatabases : function () {
+      try {
+        db._createDatabase("UnitTestQueryCache1");
+        db._createDatabase("UnitTestQueryCache2");
+        
+        db._useDatabase("UnitTestQueryCache1");
+        cache.properties({ mode: "demand", maxResults: 98765, maxEntrySize: 4096 });
+        let p = cache.properties();
+        assertEqual("demand", p.mode);
+        assertEqual(98765, p.maxResults);
+        assertEqual(4096, p.maxEntrySize);
+        
+        db._useDatabase("UnitTestQueryCache2");
+        cache.properties({ mode: "off", maxResults: 12345, maxEntrySize: 8192 });
+        p = cache.properties();
+        assertEqual("off", p.mode);
+        assertEqual(12345, p.maxResults);
+        assertEqual(8192, p.maxEntrySize);
+        
+        db._useDatabase("UnitTestQueryCache1");
+        p = cache.properties();
+        assertEqual("off", p.mode);
+        assertEqual(12345, p.maxResults);
+        assertEqual(8192, p.maxEntrySize);
+        
+        db._useDatabase("UnitTestQueryCache2");
+        p = cache.properties();
+        assertEqual("off", p.mode);
+        assertEqual(12345, p.maxResults);
+        assertEqual(8192, p.maxEntrySize);
+      } finally {
+        db._useDatabase("_system");
+        try {
+          db._dropDatabase("UnitTestQueryCache1");
+        } catch (err) {}
+        try {
+          db._dropDatabase("UnitTestQueryCache2");
+        } catch (err) {}
+      }
+    },
+    
     testResultsDatabases : function () {
       const query = "FOR doc IN @@cn SORT doc.value RETURN doc.value";
       cache.properties({ mode: "demand", maxResults: 4 });


### PR DESCRIPTION
Driver tests that request `PUT /_db/mydb/_api/query-cache/properties` with mydb != _system failed with 403 "operation only allowed in system database".
Tobias requested an improvement of the permissions check in `RestQueryCacheHandler` [here](https://github.com/arangodb/arangodb/pull/22972/changes#r3656491007) which was only partly addressed in another [a follow-up PR](https://github.com/arangodb/arangodb/pull/22827).

Now the behaviour is the following:
- in v0 and classic we require only read access to _system db
- in v1 and classic this only works on the _system db and read access to _system db (is this correct? it used to be rw acces to _system before the changes in this PR)
- v0 rbac: request service for AdminQueryCache action
- v1 rbac: only works on _system db and request service for AdminQueryCache action