### PR TITLE
disable statistics so they don't show up in the permissions

### DIFF
--- a/tests/js/client/server_permissions/authorization-questions/actions.js
+++ b/tests/js/client/server_permissions/authorization-questions/actions.js
@@ -41,7 +41,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/admin.js
+++ b/tests/js/client/server_permissions/authorization-questions/admin.js
@@ -44,7 +44,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/analyzers.js
+++ b/tests/js/client/server_permissions/authorization-questions/analyzers.js
@@ -53,7 +53,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/api-version.js
+++ b/tests/js/client/server_permissions/authorization-questions/api-version.js
@@ -48,7 +48,9 @@ if (getOptions === true) {
     // not be written by the logging thread
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/aql-functions.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql-functions.js
@@ -45,7 +45,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/aql.js
+++ b/tests/js/client/server_permissions/authorization-questions/aql.js
@@ -40,7 +40,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/backup.js
+++ b/tests/js/client/server_permissions/authorization-questions/backup.js
@@ -47,7 +47,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/catchall.js
+++ b/tests/js/client/server_permissions/authorization-questions/catchall.js
@@ -93,7 +93,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
+++ b/tests/js/client/server_permissions/authorization-questions/cluster-cluster.js
@@ -54,7 +54,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/collections.js
+++ b/tests/js/client/server_permissions/authorization-questions/collections.js
@@ -49,7 +49,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/cursor.js
+++ b/tests/js/client/server_permissions/authorization-questions/cursor.js
@@ -43,7 +43,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/databases.js
+++ b/tests/js/client/server_permissions/authorization-questions/databases.js
@@ -48,7 +48,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/debug.js
+++ b/tests/js/client/server_permissions/authorization-questions/debug.js
@@ -47,7 +47,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/documents.js
+++ b/tests/js/client/server_permissions/authorization-questions/documents.js
@@ -50,7 +50,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/dump.js
+++ b/tests/js/client/server_permissions/authorization-questions/dump.js
@@ -56,7 +56,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/edges.js
+++ b/tests/js/client/server_permissions/authorization-questions/edges.js
@@ -41,7 +41,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/failing-user-access-does-not-reveal-information.js
+++ b/tests/js/client/server_permissions/authorization-questions/failing-user-access-does-not-reveal-information.js
@@ -47,7 +47,11 @@
 if (getOptions === true) {
   return {
     'server.failure-point': 'ApiVersion::treatVersion1AsSupported',
-    'server.authentication': 'true'
+    'server.authentication': 'true',
+    // keep background threads from asking questions of their own
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/gharial.js
+++ b/tests/js/client/server_permissions/authorization-questions/gharial.js
@@ -70,7 +70,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/indexes.js
+++ b/tests/js/client/server_permissions/authorization-questions/indexes.js
@@ -50,7 +50,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/jobs.js
+++ b/tests/js/client/server_permissions/authorization-questions/jobs.js
@@ -42,7 +42,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/log.js
+++ b/tests/js/client/server_permissions/authorization-questions/log.js
@@ -42,7 +42,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/misc.js
+++ b/tests/js/client/server_permissions/authorization-questions/misc.js
@@ -47,7 +47,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/monitoring.js
+++ b/tests/js/client/server_permissions/authorization-questions/monitoring.js
@@ -45,7 +45,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/observability.js
+++ b/tests/js/client/server_permissions/authorization-questions/observability.js
@@ -41,7 +41,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/open.js
+++ b/tests/js/client/server_permissions/authorization-questions/open.js
@@ -42,7 +42,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/replication.js
+++ b/tests/js/client/server_permissions/authorization-questions/replication.js
@@ -55,7 +55,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/server.js
+++ b/tests/js/client/server_permissions/authorization-questions/server.js
@@ -45,7 +45,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/simple.js
+++ b/tests/js/client/server_permissions/authorization-questions/simple.js
@@ -44,7 +44,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/transactions.js
+++ b/tests/js/client/server_permissions/authorization-questions/transactions.js
@@ -48,7 +48,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/users.js
+++ b/tests/js/client/server_permissions/authorization-questions/users.js
@@ -67,7 +67,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/version.js
+++ b/tests/js/client/server_permissions/authorization-questions/version.js
@@ -51,7 +51,9 @@ if (getOptions === true) {
     // not be written by the logging thread
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/views.js
+++ b/tests/js/client/server_permissions/authorization-questions/views.js
@@ -44,7 +44,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 

--- a/tests/js/client/server_permissions/authorization-questions/wal.js
+++ b/tests/js/client/server_permissions/authorization-questions/wal.js
@@ -50,7 +50,9 @@ if (getOptions === true) {
     'server.authentication': 'true',
     'log.force-direct': 'true',
     // keep background threads from asking questions of their own
-    'foxx.queues': 'false'
+    'foxx.queues': 'false',
+    // disable so it doesn't spoil the test output:
+    'server.statistics': 'false'
   };
 }
 


### PR DESCRIPTION
### Scope & Purpose

Test could trip over statistics runnig creating additional collections, disable it

- [x] :hankey: Bugfix
