### PR TITLE
[COR-875] Get rid of noexcept

### DIFF
--- a/arangod/Auth/Rbac/Service.cpp
+++ b/arangod/Auth/Rbac/Service.cpp
@@ -26,8 +26,7 @@
 namespace arangodb::rbac {
 
 auto Service::check(Subject const& /*subject*/,
-                    std::span<ActionResource const> /*queries*/) noexcept
-    -> Result {
+                    std::span<ActionResource const> /*queries*/) -> Result {
   // The base implementation fails closed. The production ServiceImpl overrides
   // this to evaluate the batch against the RBAC backend; test mocks override it
   // with programmed answers.

--- a/arangod/Auth/Rbac/Service.h
+++ b/arangod/Auth/Rbac/Service.h
@@ -41,8 +41,7 @@ struct Service {
   // Virtual so that tests (in particular the RBAC auth-mode tests) can inject a
   // mock Service. The base implementation fails closed; see Service.cpp.
   virtual auto check(Subject const& subject,
-                     std::span<ActionResource const> queries) noexcept
-      -> Result;
+                     std::span<ActionResource const> queries) -> Result;
 };
 
 }  // namespace arangodb::rbac

--- a/arangod/Auth/Rbac/ServiceImpl.cpp
+++ b/arangod/Auth/Rbac/ServiceImpl.cpp
@@ -151,8 +151,7 @@ ServiceImpl::ServiceImpl(std::unique_ptr<Backend> backend)
     : _backend(std::move(backend)) {}
 
 auto ServiceImpl::check(Subject const& subject,
-                        std::span<ActionResource const> queries) noexcept
-    -> Result {
+                        std::span<ActionResource const> queries) -> Result {
   // An empty batch asks nothing, so it is trivially permitted; short-circuit to
   // avoid a needless network round-trip.
   if (queries.empty()) {

--- a/arangod/Auth/Rbac/ServiceImpl.h
+++ b/arangod/Auth/Rbac/ServiceImpl.h
@@ -32,8 +32,7 @@ namespace arangodb::rbac {
 struct ServiceImpl : Service {
   explicit ServiceImpl(std::unique_ptr<Backend> backend);
 
-  auto check(Subject const& subject,
-             std::span<ActionResource const> queries) noexcept
+  auto check(Subject const& subject, std::span<ActionResource const> queries)
       -> Result override;
 
  private:


### PR DESCRIPTION
Its body does throw-capable work (vector reserve/push_back, std::format, rethrowing exceptions from the awaited backend future).