### PR TITLE
[COR-874] Get rid of user manager call in CommTask

### DIFF
--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -284,19 +284,7 @@ CommTask::Flow CommTask::prepareExecution(
                                _securityFeature,
                                req)) {  // false if db not found
     // We get here, if the requested database does not exist, in this case
-    // we do not want to return NOT FOUND unless we are the superuser.
-    // Otherwise, a user who has no access to a database could see from the
-    // error code if the database exists or not. Therefore:
-    if (_auth->isActive()) {
-      if ((req.authenticated() && !req.user().empty()) ||
-          !req.authenticated()) {
-        sendErrorResponse(rest::ResponseCode::UNAUTHORIZED,
-                          req.contentTypeResponse(), req.messageId(),
-                          TRI_ERROR_FORBIDDEN,
-                          "not authorized to execute this request");
-        return Flow::Abort;
-      }
-    }
+    // we simply want to return NOT FOUND.
     sendErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
                       req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
     return Flow::Abort;

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -283,8 +283,28 @@ CommTask::Flow CommTask::prepareExecution(
   if (!::resolveRequestContext(_databaseFeature, *_auth, _rbacFeature,
                                _securityFeature,
                                req)) {  // false if db not found
-    // We get here, if the requested database does not exist, in this case
-    // we simply want to return NOT FOUND.
+    if (_auth->isActive() && !_auth->rbacEnabled()) {
+      // prevent guessing database names (issue #5030)
+      auth::Level lvl = auth::Level::NONE;
+      if (req.authenticated()) {
+        // If we are authenticated and the user name is empty, then we must
+        // have been authenticated with a superuser JWT token. In this case,
+        // we must not check the databaseAuthLevel here.
+        if (_auth->userManager() != nullptr && !req.user().empty()) {
+          lvl = _auth->userManager()->databaseAuthLevel(
+              req.user(), req.databaseName(), false);
+        } else {
+          lvl = auth::Level::RW;
+        }
+      }
+      if (lvl == auth::Level::NONE) {
+        sendErrorResponse(rest::ResponseCode::UNAUTHORIZED,
+                          req.contentTypeResponse(), req.messageId(),
+                          TRI_ERROR_FORBIDDEN,
+                          "not authorized to execute this request");
+        return Flow::Abort;
+      }
+    }
     sendErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
                       req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
     return Flow::Abort;
@@ -511,8 +531,7 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
 }
 
 // -----------------------------------------------------------------------------
-// --SECTION-- statistics handling                             protected
-// methods
+// --SECTION-- statistics handling                             protected methods
 // -----------------------------------------------------------------------------
 
 void CommTask::setStatistics(uint64_t id, RequestStatistics::Item&& stat) {
@@ -600,8 +619,7 @@ void CommTask::sendErrorResponse(rest::ResponseCode code,
 }
 
 // -----------------------------------------------------------------------------
-// --SECTION--                                                   private
-// methods
+// --SECTION--                                                   private methods
 // -----------------------------------------------------------------------------
 
 // Handle a request during the server startup
@@ -649,8 +667,8 @@ void CommTask::handleRequestStartup(std::shared_ptr<RestHandler> handler) {
   });
 }
 
-// Execute a request by queueing it in the scheduler and having it executed
-// via a scheduler worker thread eventually.
+// Execute a request by queueing it in the scheduler and having it executed via
+// a scheduler worker thread eventually.
 void CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
   DTRACE_PROBE2(arangod, CommTaskHandleRequestSync, this, handler.get());
 
@@ -828,8 +846,8 @@ void CommTask::processCorsOptions(std::unique_ptr<GeneralRequest> req,
     if (!allowHeaders.empty()) {
       // allow all extra headers the client requested
       // we don't verify them here. the worst that can happen is that the
-      // client sends some broken headers and then later cannot access the
-      // data on the server. that's a client problem.
+      // client sends some broken headers and then later cannot access the data
+      // on the server. that's a client problem.
       resp->setHeaderNCIfNotSet(StaticStrings::AccessControlAllowHeaders,
                                 allowHeaders);
 
@@ -939,9 +957,9 @@ Result CommTask::handleContentEncoding(GeneralRequest& req) {
       VPackBuffer<uint8_t> dst;
       if (ErrorCode r = arangodb::encoding::gzipUncompress(src, len, dst);
           r != TRI_ERROR_NO_ERROR) {
-        return {r,
-                "a decoding error occurred while handling Content-Encoding: "
-                "gzip"};
+        return {
+            r,
+            "a decoding error occurred while handling Content-Encoding: gzip"};
       }
       req.setPayload(std::move(dst));
       // as we have decoded, remove the encoding header.

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -287,12 +287,15 @@ CommTask::Flow CommTask::prepareExecution(
     // we do not want to return NOT FOUND unless we are the superuser.
     // Otherwise, a user who has no access to a database could see from the
     // error code if the database exists or not. Therefore:
-    if (_auth->isActive() && req.authenticated() && !req.user().empty()) {
-      sendErrorResponse(rest::ResponseCode::UNAUTHORIZED,
-                        req.contentTypeResponse(), req.messageId(),
-                        TRI_ERROR_FORBIDDEN,
-                        "not authorized to execute this request");
-      return Flow::Abort;
+    if (_auth->isActive()) {
+      if ((req.authenticated() && !req.user().empty()) ||
+          !req.authenticated()) {
+        sendErrorResponse(rest::ResponseCode::UNAUTHORIZED,
+                          req.contentTypeResponse(), req.messageId(),
+                          TRI_ERROR_FORBIDDEN,
+                          "not authorized to execute this request");
+        return Flow::Abort;
+      }
     }
     sendErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
                       req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
@@ -520,7 +523,8 @@ void CommTask::executeRequest(std::unique_ptr<GeneralRequest> request,
 }
 
 // -----------------------------------------------------------------------------
-// --SECTION-- statistics handling                             protected methods
+// --SECTION-- statistics handling                             protected
+// methods
 // -----------------------------------------------------------------------------
 
 void CommTask::setStatistics(uint64_t id, RequestStatistics::Item&& stat) {
@@ -608,7 +612,8 @@ void CommTask::sendErrorResponse(rest::ResponseCode code,
 }
 
 // -----------------------------------------------------------------------------
-// --SECTION--                                                   private methods
+// --SECTION--                                                   private
+// methods
 // -----------------------------------------------------------------------------
 
 // Handle a request during the server startup
@@ -656,8 +661,8 @@ void CommTask::handleRequestStartup(std::shared_ptr<RestHandler> handler) {
   });
 }
 
-// Execute a request by queueing it in the scheduler and having it executed via
-// a scheduler worker thread eventually.
+// Execute a request by queueing it in the scheduler and having it executed
+// via a scheduler worker thread eventually.
 void CommTask::handleRequestSync(std::shared_ptr<RestHandler> handler) {
   DTRACE_PROBE2(arangod, CommTaskHandleRequestSync, this, handler.get());
 
@@ -835,8 +840,8 @@ void CommTask::processCorsOptions(std::unique_ptr<GeneralRequest> req,
     if (!allowHeaders.empty()) {
       // allow all extra headers the client requested
       // we don't verify them here. the worst that can happen is that the
-      // client sends some broken headers and then later cannot access the data
-      // on the server. that's a client problem.
+      // client sends some broken headers and then later cannot access the
+      // data on the server. that's a client problem.
       resp->setHeaderNCIfNotSet(StaticStrings::AccessControlAllowHeaders,
                                 allowHeaders);
 
@@ -946,9 +951,9 @@ Result CommTask::handleContentEncoding(GeneralRequest& req) {
       VPackBuffer<uint8_t> dst;
       if (ErrorCode r = arangodb::encoding::gzipUncompress(src, len, dst);
           r != TRI_ERROR_NO_ERROR) {
-        return {
-            r,
-            "a decoding error occurred while handling Content-Encoding: gzip"};
+        return {r,
+                "a decoding error occurred while handling Content-Encoding: "
+                "gzip"};
       }
       req.setPayload(std::move(dst));
       // as we have decoded, remove the encoding header.

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -283,6 +283,17 @@ CommTask::Flow CommTask::prepareExecution(
   if (!::resolveRequestContext(_databaseFeature, *_auth, _rbacFeature,
                                _securityFeature,
                                req)) {  // false if db not found
+    // We get here, if the requested database does not exist, in this case
+    // we do not want to return NOT FOUND unless we are the superuser.
+    // Otherwise, a user who has no access to a database could see from the
+    // error code if the database exists or not. Therefore:
+    if (_auth->isActive() && req.authenticated() && !req.user().empty()) {
+      sendErrorResponse(rest::ResponseCode::UNAUTHORIZED,
+                        req.contentTypeResponse(), req.messageId(),
+                        TRI_ERROR_FORBIDDEN,
+                        "not authorized to execute this request");
+      return Flow::Abort;
+    }
     sendErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
                       req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
     return Flow::Abort;

--- a/arangod/GeneralServer/CommTask.cpp
+++ b/arangod/GeneralServer/CommTask.cpp
@@ -283,28 +283,6 @@ CommTask::Flow CommTask::prepareExecution(
   if (!::resolveRequestContext(_databaseFeature, *_auth, _rbacFeature,
                                _securityFeature,
                                req)) {  // false if db not found
-    if (_auth->isActive()) {
-      // prevent guessing database names (issue #5030)
-      auth::Level lvl = auth::Level::NONE;
-      if (req.authenticated()) {
-        // If we are authenticated and the user name is empty, then we must
-        // have been authenticated with a superuser JWT token. In this case,
-        // we must not check the databaseAuthLevel here.
-        if (_auth->userManager() != nullptr && !req.user().empty()) {
-          lvl = _auth->userManager()->databaseAuthLevel(
-              req.user(), req.databaseName(), false);
-        } else {
-          lvl = auth::Level::RW;
-        }
-      }
-      if (lvl == auth::Level::NONE) {
-        sendErrorResponse(rest::ResponseCode::UNAUTHORIZED,
-                          req.contentTypeResponse(), req.messageId(),
-                          TRI_ERROR_FORBIDDEN,
-                          "not authorized to execute this request");
-        return Flow::Abort;
-      }
-    }
     sendErrorResponse(rest::ResponseCode::NOT_FOUND, req.contentTypeResponse(),
                       req.messageId(), TRI_ERROR_ARANGO_DATABASE_NOT_FOUND);
     return Flow::Abort;

--- a/tests/js/client/authentication/auth.js
+++ b/tests/js/client/authentication/auth.js
@@ -1200,7 +1200,7 @@ function UnauthorizedAccesSuite() {
       assertEqual(res.parsedBody.errorMessage, "No read access to database.");
       res = arango.GET_RAW("/_db/dbTest4/_api/database/current");
       assertEqual(404, res.code);
-      assertEqual(res.parsedBody.errorMessage, "not authorized to execute this request");
+      assertEqual(res.parsedBody.errorMessage, "database not found");
     },
   };
 }

--- a/tests/js/client/authentication/auth.js
+++ b/tests/js/client/authentication/auth.js
@@ -962,14 +962,14 @@ function AuthSuite() {
         }
       });
       expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 401);
+      expect(res).to.have.property('statusCode', 404);
 
       // should prevent name guessing by unauthorized users
       res = request.get({
         url: baseUrl() + "/_db/nonexisting/_api/version"
       });
       expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 401);
+      expect(res).to.have.property('statusCode', 404);
     },
 
     testDatabaseGuessingSuperUser: function () {
@@ -992,7 +992,7 @@ function AuthSuite() {
         url: baseUrl() + "/_db/nonexisting/_api/version"
       });
       expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 401);
+      expect(res).to.have.property('statusCode', 404);
     },
 
     testDatabaseListNonSystem: function () {

--- a/tests/js/client/authentication/auth.js
+++ b/tests/js/client/authentication/auth.js
@@ -962,7 +962,7 @@ function AuthSuite() {
         }
       });
       expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 404);
+      expect(res).to.have.property('statusCode', 401);
 
       // should prevent name guessing by unauthorized users
       res = request.get({

--- a/tests/js/client/authentication/auth.js
+++ b/tests/js/client/authentication/auth.js
@@ -969,7 +969,7 @@ function AuthSuite() {
         url: baseUrl() + "/_db/nonexisting/_api/version"
       });
       expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 404);
+      expect(res).to.have.property('statusCode', 401);
     },
 
     testDatabaseGuessingSuperUser: function () {
@@ -992,7 +992,7 @@ function AuthSuite() {
         url: baseUrl() + "/_db/nonexisting/_api/version"
       });
       expect(res).to.be.an.instanceof(request.Response);
-      expect(res).to.have.property('statusCode', 404);
+      expect(res).to.have.property('statusCode', 401);
     },
 
     testDatabaseListNonSystem: function () {
@@ -1199,8 +1199,8 @@ function UnauthorizedAccesSuite() {
       assertEqual(401, res.code);
       assertEqual(res.parsedBody.errorMessage, "No read access to database.");
       res = arango.GET_RAW("/_db/dbTest4/_api/database/current");
-      assertEqual(404, res.code);
-      assertEqual(res.parsedBody.errorMessage, "database not found");
+      assertEqual(401, res.code);
+      assertEqual(res.parsedBody.errorMessage, "not authorized to execute this request");
     },
   };
 }

--- a/tests/js/client/authentication/auth.js
+++ b/tests/js/client/authentication/auth.js
@@ -1199,7 +1199,7 @@ function UnauthorizedAccesSuite() {
       assertEqual(401, res.code);
       assertEqual(res.parsedBody.errorMessage, "No read access to database.");
       res = arango.GET_RAW("/_db/dbTest4/_api/database/current");
-      assertEqual(401, res.code);
+      assertEqual(404, res.code);
       assertEqual(res.parsedBody.errorMessage, "not authorized to execute this request");
     },
   };


### PR DESCRIPTION
Still needs to be verified:
If we cannot resolve a request context - which gives us the ExecContext, we cannot check the permissions via the ExecContext.
Anyways, the deleted check only created a different error message in case the user had level none on the requested database. Nothing else changes, BUT currently two tests are failing in the CI because of the changed error code.

_P.S._: Fully removing this requires more fundamental changes we've decided to postpone. So for now we restrict it to Classic authentication, so the user manager is not used when RBAC is enabled.