### PR TITLE
[COR-907] RBAC Username only Auth

### DIFF
--- a/Documentation/Metrics/arangodb_rbac_request_duration.yaml
+++ b/Documentation/Metrics/arangodb_rbac_request_duration.yaml
@@ -10,7 +10,7 @@ exposedBy:
   - coordinator
   - single
 description: |
-  Histogram of the time spent on a single `evaluate-token-many` request to the
+  Histogram of the time spent on a single batch permission-check request to the
   external RBAC authorization service, in microseconds. This covers serializing
   the request body, the round trip to the authorization service, and parsing the
   response. The buckets start at 10 microseconds and double up to about 21

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -938,8 +938,24 @@ auto AuthMode::Rbac::username() const noexcept -> std::string_view {
   return _username;
 }
 
+namespace {
+
+auto subjectOf(AuthMode::Rbac const& mode) -> rbac::Subject {
+  if (!mode._jwtToken.empty()) {
+    return rbac::JwtToken{mode._jwtToken};
+  }
+  return rbac::Username{mode._username};
+}
+
+}  // namespace
+
 auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
   namespace p = auth::perms;
+
+  if (_jwtToken.empty() && _username.empty()) {
+    return {TRI_ERROR_FORBIDDEN,
+            "no authenticated subject for RBAC permission check"};
+  }
 
   auto databaseAccessModeToAction =
       [](DatabaseAccessLevel level) -> rbac::Action {
@@ -1063,8 +1079,9 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
   // case is passed as a span over a stack-local pair and needs no allocation;
   // only the composite permissions (create/modify view, create/drop graph)
   // build a small vector.
-  auto checkAll = [&](std::span<rbac::ActionResource const> queries) -> Result {
-    return _rbacService.check(rbac::JwtToken{_jwtToken}, queries);
+  auto checkAll = [&, subject = subjectOf(*this)](
+                      std::span<rbac::ActionResource const> queries) -> Result {
+    return _rbacService.check(subject, queries);
   };
   auto checkOne = [&](rbac::Action action, rbac::Resource resource) -> Result {
     rbac::ActionResource query{action, std::move(resource)};

--- a/arangod/Auth/Rbac/Actions.h
+++ b/arangod/Auth/Rbac/Actions.h
@@ -115,7 +115,7 @@ using Resource =
                  resources::Collection, resources::View, resources::Analyzer,
                  resources::Graph, resources::User, resources::ApiVersion>;
 
-// A single authorization question: may the token perform `action` on
+// A single authorization question: may the subject perform `action` on
 // `resource`? A permission check may consist of several of these, which are
 // evaluated together (see Service::check).
 struct ActionResource {
@@ -129,5 +129,17 @@ struct ActionResource {
 struct JwtToken {
   std::string jwtToken;
 };
+
+// The name of a caller that authenticated without a JWT, i.e. via HTTP Basic
+// or a personal access token. arangod has already verified the credentials at
+// this point; the authorization service resolves the user's bindings by name.
+// Owns its string for the same reason as JwtToken.
+struct Username {
+  std::string name;
+};
+
+// Who a permission check is asked for. Also selects the endpoint used to ask
+// it: a JwtToken goes to evaluate-token-many, a Username to evaluate-many.
+using Subject = std::variant<JwtToken, Username>;
 
 }  // namespace arangodb::rbac

--- a/arangod/Auth/Rbac/Backend.cpp
+++ b/arangod/Auth/Rbac/Backend.cpp
@@ -24,18 +24,17 @@
 
 namespace arangodb::rbac {
 
-auto Backend::evaluateTokenMany(JwtToken const& jwtToken,
-                                Backend::RequestItems const& items)
+auto Backend::evaluateMany(Subject const& subject,
+                           Backend::RequestItems const& items)
     -> futures::Future<ResultT<EvaluateResponseMany>> {
-  return evaluateTokenManyImpl(jwtToken, items,
-                               transaction::MethodsApi::Asynchronous);
+  return evaluateManyImpl(subject, items,
+                          transaction::MethodsApi::Asynchronous);
 }
 
-auto Backend::evaluateTokenManySync(JwtToken const& jwtToken,
-                                    Backend::RequestItems const& items)
+auto Backend::evaluateManySync(Subject const& subject,
+                               Backend::RequestItems const& items)
     -> ResultT<EvaluateResponseMany> {
-  return evaluateTokenManyImpl(jwtToken, items,
-                               transaction::MethodsApi::Synchronous)
+  return evaluateManyImpl(subject, items, transaction::MethodsApi::Synchronous)
       .waitAndGet();
 }
 

--- a/arangod/Auth/Rbac/Backend.h
+++ b/arangod/Auth/Rbac/Backend.h
@@ -54,19 +54,20 @@ struct Backend {
     std::vector<RequestItem> items;
   };
 
-  // Batched token evaluation, in both an asynchronous and a synchronous form.
-  // The synchronous form sets `skipScheduler` and blocks for the response; the
-  // asynchronous form is currently unused but kept for a future async check().
-  auto evaluateTokenMany(JwtToken const&, RequestItems const&)
+  // Batched evaluation for one subject, in both an asynchronous and a
+  // synchronous form. The synchronous form sets `skipScheduler` and blocks for
+  // the response; the asynchronous form is currently unused but kept for a
+  // future async check().
+  auto evaluateMany(Subject const&, RequestItems const&)
       -> futures::Future<ResultT<EvaluateResponseMany>>;
-  auto evaluateTokenManySync(JwtToken const&, RequestItems const&)
+  auto evaluateManySync(Subject const&, RequestItems const&)
       -> ResultT<EvaluateResponseMany>;
 
  protected:
   // Implementation seam. `transaction::MethodsApi` selects the synchronous vs
   // asynchronous transport behaviour (see BackendImpl).
-  virtual auto evaluateTokenManyImpl(JwtToken const&, RequestItems const&,
-                                     transaction::MethodsApi api)
+  virtual auto evaluateManyImpl(Subject const&, RequestItems const&,
+                                transaction::MethodsApi api)
       -> futures::Future<ResultT<EvaluateResponseMany>> = 0;
 };
 

--- a/arangod/Auth/Rbac/BackendImpl.cpp
+++ b/arangod/Auth/Rbac/BackendImpl.cpp
@@ -25,6 +25,7 @@
 #include "Basics/Result.h"
 #include "Basics/ScopeGuard.h"
 #include "Basics/StaticStrings.h"
+#include "Basics/overload.h"
 #include "Basics/voc-errors.h"
 #include "Inspection/JsonPrintInspector.h"
 #include "Inspection/VPackLoadInspector.h"
@@ -42,6 +43,8 @@
 
 #include <chrono>
 #include <sstream>
+#include <utility>
+#include <variant>
 
 namespace arangodb::rbac {
 
@@ -88,6 +91,11 @@ BackendImpl::BackendImpl(network::Sender sendRequest,
       _requestDuration(requestDuration) {}
 
 namespace {
+
+constexpr std::string_view kEvaluateTokenManyPath =
+    "/_integration/authorization/v1/evaluate-token-many";
+constexpr std::string_view kEvaluateManyPath =
+    "/_integration/authorization/v1/evaluate-many";
 
 template<typename T>
 auto buildJsonBody(T& value) -> std::string {
@@ -151,9 +159,9 @@ auto jsonToPayload(std::string_view json) -> velocypack::Buffer<uint8_t> {
 
 }  // namespace
 
-auto BackendImpl::evaluateTokenManyImpl(JwtToken const& token,
-                                        RequestItems const& items,
-                                        transaction::MethodsApi api)
+auto BackendImpl::evaluateManyImpl(Subject const& subject,
+                                   RequestItems const& items,
+                                   transaction::MethodsApi api)
     -> futures::Future<ResultT<EvaluateResponseMany>> {
   // Measures the whole call: serializing the request, the round trip to the
   // authorization service, and parsing the response. The guard fires when the
@@ -169,16 +177,29 @@ auto BackendImpl::evaluateTokenManyImpl(JwtToken const& token,
     }
   }};
 
-  auto requestBody = EvaluateTokenManyRequest{
-      .token = token.jwtToken,
-      .items = items.items,
-  };
+  auto [path, bodyResult] =
+      std::visit(overload{
+                     [&](JwtToken const& t) {
+                       auto request = EvaluateTokenManyRequest{
+                           .token = t.jwtToken,
+                           .items = items.items,
+                       };
+                       return std::pair{std::string{kEvaluateTokenManyPath},
+                                        buildJsonBody(request)};
+                     },
+                     [&](Username const& u) {
+                       auto request = EvaluateManyRequest{
+                           .user = u.name,
+                           .items = items.items,
+                       };
+                       return std::pair{std::string{kEvaluateManyPath},
+                                        buildJsonBody(request)};
+                     },
+                 },
+                 subject);
 
-  auto bodyResult = buildJsonBody(requestBody);
-
-  auto response = co_await sendRequest(
-      fuerte::RestVerb::Post,
-      "/_integration/authorization/v1/evaluate-token-many", bodyResult, api);
+  auto response = co_await sendRequest(fuerte::RestVerb::Post, std::move(path),
+                                       bodyResult, api);
 
   if (auto result = response.combinedResult(); result.fail()) {
     co_return result;

--- a/arangod/Auth/Rbac/BackendImpl.h
+++ b/arangod/Auth/Rbac/BackendImpl.h
@@ -47,8 +47,8 @@ struct BackendImpl : Backend {
   BackendImpl(network::Sender sendRequest, std::string authorizationEndpoint,
               RequestDurationMetric* requestDuration = nullptr);
 
-  auto evaluateTokenManyImpl(JwtToken const& token, RequestItems const& items,
-                             transaction::MethodsApi api)
+  auto evaluateManyImpl(Subject const& subject, RequestItems const& items,
+                        transaction::MethodsApi api)
       -> futures::Future<ResultT<EvaluateResponseMany>> override;
 
  protected:
@@ -156,6 +156,7 @@ auto inspect(Inspector& f, Backend::EvaluateResponseMany& v) {
 }
 
 // Request body for POST /_integration/authorization/v1/evaluate-token-many
+// (AuthorizationV1PermissionTokenManyRequest).
 struct EvaluateTokenManyRequest {
   std::string token;
   std::vector<Backend::RequestItem> items;
@@ -165,6 +166,18 @@ template<class Inspector>
 auto inspect(Inspector& f, EvaluateTokenManyRequest& v) {
   return f.object(v).fields(f.field("token", v.token),
                             f.field("items", v.items));
+}
+
+// Request body for POST /_integration/authorization/v1/evaluate-many
+// (AuthorizationV1PermissionManyRequest)
+struct EvaluateManyRequest {
+  std::string user;
+  std::vector<Backend::RequestItem> items;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, EvaluateManyRequest& v) {
+  return f.object(v).fields(f.field("user", v.user), f.field("items", v.items));
 }
 
 }  // namespace arangodb::rbac

--- a/arangod/Auth/Rbac/Service.cpp
+++ b/arangod/Auth/Rbac/Service.cpp
@@ -25,7 +25,7 @@
 
 namespace arangodb::rbac {
 
-auto Service::check(JwtToken const& /*token*/,
+auto Service::check(Subject const& /*subject*/,
                     std::span<ActionResource const> /*queries*/) noexcept
     -> Result {
   // The base implementation fails closed. The production ServiceImpl overrides

--- a/arangod/Auth/Rbac/Service.h
+++ b/arangod/Auth/Rbac/Service.h
@@ -32,15 +32,15 @@ namespace arangodb::rbac {
 struct Service {
   virtual ~Service() = default;
 
-  // Ask a batch of authorization questions for a single token at once. A real
-  // implementation performs a single network round-trip, so callers that need
-  // several (action, resource) pairs for one logical permission should pass
-  // them together rather than calling check() repeatedly. Returns ok iff every
-  // pair is permitted; otherwise the first/aggregated denial.
+  // Ask a batch of authorization questions for a single subject at once. A
+  // real implementation performs a single network round-trip, so callers that
+  // need several (action, resource) pairs for one logical permission should
+  // pass them together rather than calling check() repeatedly. Returns ok iff
+  // every pair is permitted; otherwise the first/aggregated denial.
   //
   // Virtual so that tests (in particular the RBAC auth-mode tests) can inject a
   // mock Service. The base implementation fails closed; see Service.cpp.
-  virtual auto check(JwtToken const& token,
+  virtual auto check(Subject const& subject,
                      std::span<ActionResource const> queries) noexcept
       -> Result;
 };

--- a/arangod/Auth/Rbac/ServiceImpl.cpp
+++ b/arangod/Auth/Rbac/ServiceImpl.cpp
@@ -150,7 +150,7 @@ auto resourceToWireString(Resource const& resource) -> std::string {
 ServiceImpl::ServiceImpl(std::unique_ptr<Backend> backend)
     : _backend(std::move(backend)) {}
 
-auto ServiceImpl::check(JwtToken const& token,
+auto ServiceImpl::check(Subject const& subject,
                         std::span<ActionResource const> queries) noexcept
     -> Result {
   // An empty batch asks nothing, so it is trivially permitted; short-circuit to
@@ -170,7 +170,7 @@ auto ServiceImpl::check(JwtToken const& token,
 
   // Service::check (and the whole IAuth::check chain) is synchronous for now,
   // so we use the synchronous backend call directly.
-  auto result = _backend->evaluateTokenManySync(token, items);
+  auto result = _backend->evaluateManySync(subject, items);
 
   if (!result.ok()) {
     // Transport or parsing error: propagate it verbatim.

--- a/arangod/Auth/Rbac/ServiceImpl.h
+++ b/arangod/Auth/Rbac/ServiceImpl.h
@@ -32,7 +32,7 @@ namespace arangodb::rbac {
 struct ServiceImpl : Service {
   explicit ServiceImpl(std::unique_ptr<Backend> backend);
 
-  auto check(JwtToken const& token,
+  auto check(Subject const& subject,
              std::span<ActionResource const> queries) noexcept
       -> Result override;
 

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -29,6 +29,7 @@
 
 #include <span>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "Auth/AuthMode.h"
@@ -92,11 +93,13 @@ struct MockService : rbac::Service {
   std::vector<Query> queries;  // all pairs, flattened across all check() calls
   int checkCalls = 0;          // number of check() invocations
   Result answer{};             // returned from every check(); {} == ok
+  rbac::Subject lastSubject;   // subject of the most recent check() call
 
-  auto check(rbac::JwtToken const& /*token*/,
+  auto check(rbac::Subject const& subject,
              std::span<rbac::ActionResource const> qs) noexcept
       -> Result override {
     ++checkCalls;
+    lastSubject = subject;
     for (auto const& q : qs) {
       queries.push_back({q.action, resourceStr(q.resource)});
     }
@@ -526,6 +529,42 @@ TEST_F(RbacAuthModeTest, CompositeCheckIsSentAsOneBatchAndDenialPropagates) {
   EXPECT_EQ(svc.queries[0].resource, "graph:mydb:g");
   EXPECT_EQ(svc.queries[1].resource, "collection:mydb:cc");
   EXPECT_EQ(svc.queries[2].resource, "collection:mydb:cr");
+}
+
+// ---------------------------------------------------------------------------
+// Which subject the authorization service is asked about (COR-907)
+// ---------------------------------------------------------------------------
+
+TEST_F(RbacAuthModeTest, JwtAuthenticatedRequestIsIdentifiedByToken) {
+  // The fixture's mode has both a username and a token, as a Bearer-
+  // authenticated request does. The token is the more precise identity.
+  auto r = check(p::SeeDatabase{.name = "mydb"});
+  ASSERT_TRUE(r.ok()) << r.errorMessage();
+  ASSERT_TRUE(std::holds_alternative<rbac::JwtToken>(svc.lastSubject));
+  EXPECT_EQ(std::get<rbac::JwtToken>(svc.lastSubject).jwtToken, "mytoken");
+}
+
+TEST(RbacAuthModeSubjectTest, BasicAuthenticatedRequestIsIdentifiedByUsername) {
+  // HTTP Basic authentication (and personal access tokens) produce no JWT, so
+  // the verified username has to identify the caller. Before COR-907 this sent
+  // an empty token, which the authorization service always denied.
+  MockService svc;
+  AuthMode::Rbac rbac{svc, "myuser", ""};
+
+  auto r = rbac.check(p::SeeDatabase{.name = "mydb"});
+  ASSERT_TRUE(r.ok()) << r.errorMessage();
+  EXPECT_EQ(svc.checkCalls, 1);
+  ASSERT_TRUE(std::holds_alternative<rbac::Username>(svc.lastSubject));
+  EXPECT_EQ(std::get<rbac::Username>(svc.lastSubject).name, "myuser");
+}
+
+TEST(RbacAuthModeSubjectTest, NoSubjectFailsClosedWithoutAskingTheService) {
+  MockService svc;
+  AuthMode::Rbac rbac{svc, "", ""};
+
+  auto r = rbac.check(p::SeeDatabase{.name = "mydb"});
+  EXPECT_EQ(r.errorNumber(), TRI_ERROR_FORBIDDEN);
+  EXPECT_EQ(svc.checkCalls, 0);
 }
 
 }  // namespace

--- a/tests/Auth/RbacBackendTest.cpp
+++ b/tests/Auth/RbacBackendTest.cpp
@@ -114,7 +114,8 @@ auto totalObservations(rbac::BackendImpl::RequestDurationMetric const& metric)
 // Tests
 // ---------------------------------------------------------------------------
 
-TEST(RbacBackendTest, evaluateTokenMany_sendsCorrectRequestAndParsesResponse) {
+TEST(RbacBackendTest,
+     evaluateMany_withToken_sendsCorrectRequestAndParsesResponse) {
   auto responseJson = buildAllowResponseJson();
 
   auto sendRequestMock = [&](network::DestinationId const& dest,
@@ -135,18 +136,98 @@ TEST(RbacBackendTest, evaluateTokenMany_sendsCorrectRequestAndParsesResponse) {
   };
   auto testee = rbac::BackendImpl{sendRequestMock, "http://localhost:8080"};
 
-  auto result =
-      testee
-          .evaluateTokenMany(rbac::JwtToken{.jwtToken = "my.jwt.token"},
-                             rbac::Backend::RequestItems{})
-          .waitAndGet();
+  auto result = testee
+                    .evaluateMany(rbac::JwtToken{.jwtToken = "my.jwt.token"},
+                                  rbac::Backend::RequestItems{})
+                    .waitAndGet();
 
   ASSERT_TRUE(result.ok());
   EXPECT_EQ(result.get().effect, rbac::Backend::Effect::Allow);
   EXPECT_TRUE(result.get().items.empty());
 }
 
-TEST(RbacBackendTest, evaluateTokenMany_returnsErrorOnNonOkHttpStatus) {
+// A caller that authenticated without a JWT (HTTP Basic, or a personal access
+// token) is identified by name instead, which goes to the other batch endpoint
+// of the AuthorizationV1 API. Only the subject field of the envelope differs.
+TEST(RbacBackendTest, evaluateMany_withUsername_sendsToEvaluateManyPath) {
+  auto responseJson = buildAllowResponseJson();
+
+  auto sendRequestMock = [&](network::DestinationId const& dest,
+                             fuerte::RestVerb verb, std::string const& path,
+                             velocypack::Buffer<uint8_t> const& payload,
+                             network::RequestOptions const& opts,
+                             network::Headers const&) -> network::FutureRes {
+    EXPECT_EQ(dest, "http://localhost:8080");
+    EXPECT_EQ(verb, fuerte::RestVerb::Post);
+    EXPECT_EQ(path, "/_integration/authorization/v1/evaluate-many");
+    EXPECT_EQ(opts.contentType, "application/json; charset=utf-8");
+    EXPECT_EQ(opts.acceptType, "application/json; charset=utf-8");
+    EXPECT_EQ(normalizeJson(payloadToString(payload)), normalizeJson(R"({
+                    "user": "alice",
+                    "items": []
+                  })"));
+    return makeNetworkResponse(fuerte::StatusOK, responseJson);
+  };
+  auto testee = rbac::BackendImpl{sendRequestMock, "http://localhost:8080"};
+
+  auto result = testee
+                    .evaluateMany(rbac::Username{.name = "alice"},
+                                  rbac::Backend::RequestItems{})
+                    .waitAndGet();
+
+  ASSERT_TRUE(result.ok());
+  EXPECT_EQ(result.get().effect, rbac::Backend::Effect::Allow);
+}
+
+// The items are the same message type on both endpoints, so they must be
+// encoded identically no matter how the subject is given.
+TEST(RbacBackendTest, evaluateMany_encodesItemsIdenticallyForBothSubjects) {
+  auto responseJson = buildAllowResponseJson({rbac::Backend::Effect::Allow});
+  auto items = rbac::Backend::RequestItems{
+      .items = {rbac::Backend::RequestItem{.action = "db:Read",
+                                           .resource = "db:database:mydb",
+                                           .attributeValues = {"a", "b"}}}};
+
+  auto capture = [&](std::string& path, std::string& body) {
+    return [&](network::DestinationId const&, fuerte::RestVerb,
+               std::string const& p, velocypack::Buffer<uint8_t> const& payload,
+               network::RequestOptions const&,
+               network::Headers const&) -> network::FutureRes {
+      path = p;
+      body = payloadToString(payload);
+      return makeNetworkResponse(fuerte::StatusOK, responseJson);
+    };
+  };
+
+  std::string tokenPath, tokenBody;
+  auto tokenSender = capture(tokenPath, tokenBody);
+  auto withToken = rbac::BackendImpl{tokenSender, "http://localhost:8080"};
+  ASSERT_TRUE(
+      withToken.evaluateManySync(rbac::JwtToken{.jwtToken = "t"}, items).ok());
+
+  std::string userPath, userBody;
+  auto userSender = capture(userPath, userBody);
+  auto withUser = rbac::BackendImpl{userSender, "http://localhost:8080"};
+  ASSERT_TRUE(
+      withUser.evaluateManySync(rbac::Username{.name = "alice"}, items).ok());
+
+  EXPECT_EQ(tokenPath, "/_integration/authorization/v1/evaluate-token-many");
+  EXPECT_EQ(userPath, "/_integration/authorization/v1/evaluate-many");
+
+  auto expectedItems = normalizeJson(R"([{
+    "action": "db:Read",
+    "resource": "db:database:mydb",
+    "context": {"parameters": {"attribute": {"values": ["a", "b"]}}}
+  }])");
+  auto itemsOf = [](std::string const& body) {
+    auto builder = velocypack::Parser::fromJson(body);
+    return velocypack::Dumper::toString(builder->slice().get("items"));
+  };
+  EXPECT_EQ(itemsOf(tokenBody), expectedItems);
+  EXPECT_EQ(itemsOf(userBody), expectedItems);
+}
+
+TEST(RbacBackendTest, evaluateMany_returnsErrorOnNonOkHttpStatus) {
   auto sendRequestMock =
       [](network::DestinationId const&, fuerte::RestVerb, std::string const&,
          velocypack::Buffer<uint8_t> const&, network::RequestOptions const&,
@@ -157,14 +238,14 @@ TEST(RbacBackendTest, evaluateTokenMany_returnsErrorOnNonOkHttpStatus) {
       rbac::BackendImpl{std::move(sendRequestMock), "http://localhost:8080"};
 
   auto result = testee
-                    .evaluateTokenMany(rbac::JwtToken{.jwtToken = "bad.token"},
-                                       rbac::Backend::RequestItems{})
+                    .evaluateMany(rbac::JwtToken{.jwtToken = "bad.token"},
+                                  rbac::Backend::RequestItems{})
                     .waitAndGet();
 
   EXPECT_FALSE(result.ok());
 }
 
-TEST(RbacBackendTest, evaluateTokenManySync_setsSkipSchedulerAndReturnsResult) {
+TEST(RbacBackendTest, evaluateManySync_setsSkipSchedulerAndReturnsResult) {
   auto responseJson = buildAllowResponseJson();
 
   auto sendRequestMock = [&](network::DestinationId const&, fuerte::RestVerb,
@@ -178,13 +259,13 @@ TEST(RbacBackendTest, evaluateTokenManySync_setsSkipSchedulerAndReturnsResult) {
   auto testee = rbac::BackendImpl{sendRequestMock, "http://localhost:8080"};
 
   auto result =
-      testee.evaluateTokenManySync(rbac::JwtToken{.jwtToken = "my.jwt.token"},
-                                   rbac::Backend::RequestItems{});
+      testee.evaluateManySync(rbac::JwtToken{.jwtToken = "my.jwt.token"},
+                              rbac::Backend::RequestItems{});
 
   EXPECT_TRUE(result.ok());
 }
 
-TEST(RbacBackendTest, evaluateTokenMany_measuresRequestDuration) {
+TEST(RbacBackendTest, evaluateMany_measuresRequestDuration) {
   auto responseJson = buildAllowResponseJson();
   auto requestDuration = makeRequestDurationMetric();
 
@@ -200,23 +281,23 @@ TEST(RbacBackendTest, evaluateTokenMany_measuresRequestDuration) {
   ASSERT_EQ(totalObservations(requestDuration), 0);
 
   auto result =
-      testee.evaluateTokenManySync(rbac::JwtToken{.jwtToken = "my.jwt.token"},
-                                   rbac::Backend::RequestItems{});
+      testee.evaluateManySync(rbac::JwtToken{.jwtToken = "my.jwt.token"},
+                              rbac::Backend::RequestItems{});
 
   ASSERT_TRUE(result.ok());
   EXPECT_EQ(totalObservations(requestDuration), 1);
 
   auto asyncResult =
       testee
-          .evaluateTokenMany(rbac::JwtToken{.jwtToken = "my.jwt.token"},
-                             rbac::Backend::RequestItems{})
+          .evaluateMany(rbac::JwtToken{.jwtToken = "my.jwt.token"},
+                        rbac::Backend::RequestItems{})
           .waitAndGet();
 
   ASSERT_TRUE(asyncResult.ok());
   EXPECT_EQ(totalObservations(requestDuration), 2);
 }
 
-TEST(RbacBackendTest, evaluateTokenMany_measuresRequestDurationOnError) {
+TEST(RbacBackendTest, evaluateMany_measuresRequestDurationOnError) {
   auto requestDuration = makeRequestDurationMetric();
 
   auto sendRequestMock =
@@ -228,8 +309,8 @@ TEST(RbacBackendTest, evaluateTokenMany_measuresRequestDurationOnError) {
   auto testee = rbac::BackendImpl{sendRequestMock, "http://localhost:8080",
                                   &requestDuration};
 
-  auto result = testee.evaluateTokenManySync(
-      rbac::JwtToken{.jwtToken = "bad.token"}, rbac::Backend::RequestItems{});
+  auto result = testee.evaluateManySync(rbac::JwtToken{.jwtToken = "bad.token"},
+                                        rbac::Backend::RequestItems{});
 
   ASSERT_FALSE(result.ok());
   EXPECT_EQ(totalObservations(requestDuration), 1);

--- a/tests/Auth/RbacIntegrationTest.cpp
+++ b/tests/Auth/RbacIntegrationTest.cpp
@@ -70,6 +70,8 @@ auto getSmockerConfig() -> SmockerConfig {
 
 constexpr auto kEvaluateTokenManyPath =
     "/_integration/authorization/v1/evaluate-token-many";
+constexpr auto kEvaluateManyPath =
+    "/_integration/authorization/v1/evaluate-many";
 
 auto buildAllowResponse(std::size_t numItems) -> std::string {
   std::string items;
@@ -174,7 +176,7 @@ TEST_F(RbacIntegrationTest, ServiceCheck_Allow) {
 
   std::vector<rbac::ActionResource> queries{
       {rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  auto result = service->check({"test.jwt.token"}, queries);
+  auto result = service->check(rbac::JwtToken{"test.jwt.token"}, queries);
 
   ASSERT_TRUE(result.ok()) << result.errorMessage();
 
@@ -198,7 +200,45 @@ TEST_F(RbacIntegrationTest, ServiceCheck_Deny) {
 
   std::vector<rbac::ActionResource> queries{
       {rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  auto result = service->check({"test.jwt.token"}, queries);
+  auto result = service->check(rbac::JwtToken{"test.jwt.token"}, queries);
+
+  EXPECT_EQ(result.errorNumber(), TRI_ERROR_FORBIDDEN);
+}
+
+// A Basic-authenticated caller has no JWT, so it is identified by name and the
+// request goes to the other batch endpoint. The items are unchanged; only the
+// envelope's subject field differs (COR-907).
+TEST_F(RbacIntegrationTest, ServiceCheck_UsernameSubjectUsesEvaluateMany) {
+  _smocker->addMock(kEvaluateManyPath, 200, buildAllowResponse(1));
+  auto service = makeService();
+
+  std::vector<rbac::ActionResource> queries{
+      {rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
+  auto result = service->check(rbac::Username{"alice"}, queries);
+
+  ASSERT_TRUE(result.ok()) << result.errorMessage();
+
+  auto history = _smocker->getHistory();
+  ASSERT_EQ(history.size(), 1u);
+  EXPECT_EQ(history[0].method, "POST");
+  EXPECT_EQ(history[0].path, kEvaluateManyPath);
+  EXPECT_EQ(normalizeJson(history[0].body), normalizeJson(R"({
+    "user": "alice",
+    "items": [{
+      "action": "db:Read",
+      "resource": "db:database:mydb",
+      "context": {"parameters": {"attribute": {"values": []}}}
+    }]
+  })"));
+}
+
+TEST_F(RbacIntegrationTest, ServiceCheck_UsernameSubjectDeny) {
+  _smocker->addMock(kEvaluateManyPath, 200, buildDenyResponse(1));
+  auto service = makeService();
+
+  std::vector<rbac::ActionResource> queries{
+      {rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
+  auto result = service->check(rbac::Username{"alice"}, queries);
 
   EXPECT_EQ(result.errorNumber(), TRI_ERROR_FORBIDDEN);
 }
@@ -216,7 +256,7 @@ TEST_F(RbacIntegrationTest, ServiceCheck_BatchUsesNewVocabulary) {
        rbac::resources::Collection{.db = "mydb", .name = "c1"}},
       {rbac::Action::Read,
        rbac::resources::Collection{.db = "mydb", .name = "c2"}}};
-  auto result = service->check({"test.jwt.token"}, queries);
+  auto result = service->check(rbac::JwtToken{"test.jwt.token"}, queries);
 
   ASSERT_TRUE(result.ok()) << result.errorMessage();
 

--- a/tests/Auth/RbacSerializationTest.cpp
+++ b/tests/Auth/RbacSerializationTest.cpp
@@ -96,6 +96,14 @@ TEST(RbacSerializationTest, EvaluateTokenManyRequest) {
   })");
 }
 
+TEST(RbacSerializationTest, EvaluateManyRequest) {
+  auto req = rbac::EvaluateManyRequest{.user = "alice", .items = {}};
+  expectEqualsJson(req, R"({
+    "user": "alice",
+    "items": []
+  })");
+}
+
 TEST(RbacSerializationTest, ResponseItem) {
   auto item = rbac::Backend::ResponseItem{.effect = rbac::Backend::Effect::Deny,
                                           .message = "not authorized"};

--- a/tests/Auth/RbacServiceImplTest.cpp
+++ b/tests/Auth/RbacServiceImplTest.cpp
@@ -26,6 +26,7 @@
 #include "Auth/Rbac/ServiceImpl.h"
 
 #include <array>
+#include <variant>
 
 using namespace arangodb;
 
@@ -35,14 +36,14 @@ struct MockBackend : rbac::Backend {
   rbac::Backend::Effect nextEffect = rbac::Backend::Effect::Allow;
   std::string nextMessage;  // top-level message returned to the caller
   std::vector<rbac::Backend::RequestItem> lastItems;
-  std::string lastJwtToken;
+  rbac::Subject lastSubject;
   int calls = 0;
 
-  auto evaluateTokenManyImpl(rbac::JwtToken const& token,
-                             RequestItems const& items, transaction::MethodsApi)
+  auto evaluateManyImpl(rbac::Subject const& subject, RequestItems const& items,
+                        transaction::MethodsApi)
       -> futures::Future<ResultT<EvaluateResponseMany>> override {
     ++calls;
-    lastJwtToken = token.jwtToken;
+    lastSubject = subject;
     lastItems = items.items;
     EvaluateResponseMany resp{};
     resp.effect = nextEffect;
@@ -55,6 +56,10 @@ struct MockBackend : rbac::Backend {
 };
 
 auto constexpr testToken = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.test";
+
+// The subject used by the translation tests below; which of the two subject
+// kinds is used is irrelevant to them, that is covered separately at the end.
+auto testSubject() -> rbac::Subject { return rbac::JwtToken{testToken}; }
 
 // Helper: build a ServiceImpl over a fresh MockBackend, keeping a raw pointer
 // to the mock for inspection after the move.
@@ -81,12 +86,12 @@ TEST(RbacServiceImplCheckTest, translatesDatabaseRead) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  auto r = f.svc.check({testToken}, queries);
+  auto r = f.svc.check(testSubject(), queries);
   EXPECT_TRUE(r.ok());
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:Read");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:database:mydb");
-  EXPECT_EQ(f.mock->lastJwtToken, testToken);
+  EXPECT_EQ(std::get<rbac::JwtToken>(f.mock->lastSubject).jwtToken, testToken);
 }
 
 TEST(RbacServiceImplCheckTest, translatesCollectionCreate) {
@@ -94,7 +99,7 @@ TEST(RbacServiceImplCheckTest, translatesCollectionCreate) {
   std::array queries{rbac::ActionResource{
       rbac::Action::Create,
       rbac::resources::Collection{.db = "mydb", .name = "c"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:Create");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:collection:mydb:c");
@@ -104,7 +109,7 @@ TEST(RbacServiceImplCheckTest, translatesViewDrop) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{
       rbac::Action::Drop, rbac::resources::View{.db = "mydb", .name = "v"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:Drop");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:view:mydb:v");
@@ -115,7 +120,7 @@ TEST(RbacServiceImplCheckTest, translatesAnalyzerWriteMeta) {
   std::array queries{rbac::ActionResource{
       rbac::Action::WriteMeta,
       rbac::resources::Analyzer{.db = "mydb", .name = "a"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:WriteMeta");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:analyzer:mydb:a");
@@ -126,7 +131,7 @@ TEST(RbacServiceImplCheckTest, translatesCollectionWriteData) {
   std::array queries{rbac::ActionResource{
       rbac::Action::WriteData,
       rbac::resources::Collection{.db = "mydb", .name = "c"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:WriteData");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:collection:mydb:c");
@@ -136,7 +141,7 @@ TEST(RbacServiceImplCheckTest, translatesGraphRead) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::Graph{.db = "mydb", .name = "g"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:Read");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:graph:mydb:g");
@@ -146,7 +151,7 @@ TEST(RbacServiceImplCheckTest, translatesUserRead) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::User{.name = "alice"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:user:alice");
 }
@@ -155,7 +160,7 @@ TEST(RbacServiceImplCheckTest, translatesUseApiVersion) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{
       rbac::Action::UseApiVersion, rbac::resources::ApiVersion{.version = 1}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:UseApiVersion");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:apiversion:v1");
@@ -165,7 +170,7 @@ TEST(RbacServiceImplCheckTest, translatesUseApiVersionZero) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{
       rbac::Action::UseApiVersion, rbac::resources::ApiVersion{.version = 0}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:UseApiVersion");
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:apiversion:v0");
@@ -175,7 +180,7 @@ TEST(RbacServiceImplCheckTest, adminActionHasNoResource) {
   auto f = CheckFixture::make();
   std::array queries{rbac::ActionResource{rbac::Action::AdminQueryCache,
                                           rbac::resources::NoResource{}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   ASSERT_EQ(f.mock->lastItems.size(), 1u);
   EXPECT_EQ(f.mock->lastItems[0].action, "db:AdminQueryCache");
   EXPECT_EQ(f.mock->lastItems[0].resource, "");
@@ -192,7 +197,7 @@ TEST(RbacServiceImplCheckTest, sendsWholeBatchInOrder) {
       rbac::ActionResource{
           rbac::Action::Read,
           rbac::resources::Collection{.db = "mydb", .name = "c2"}}};
-  f.svc.check({testToken}, queries);
+  f.svc.check(testSubject(), queries);
   EXPECT_EQ(f.mock->calls, 1);  // one batch, one round-trip
   ASSERT_EQ(f.mock->lastItems.size(), 3u);
   EXPECT_EQ(f.mock->lastItems[0].resource, "db:graph:mydb:g");
@@ -205,7 +210,7 @@ TEST(RbacServiceImplCheckTest, allowReturnsOk) {
   f.mock->nextEffect = rbac::Backend::Effect::Allow;
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  EXPECT_TRUE(f.svc.check({testToken}, queries).ok());
+  EXPECT_TRUE(f.svc.check(testSubject(), queries).ok());
 }
 
 TEST(RbacServiceImplCheckTest, denyReturnsForbiddenWithMessage) {
@@ -214,15 +219,15 @@ TEST(RbacServiceImplCheckTest, denyReturnsForbiddenWithMessage) {
   f.mock->nextMessage = "role lacks db:Read";
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  auto r = f.svc.check({testToken}, queries);
+  auto r = f.svc.check(testSubject(), queries);
   EXPECT_EQ(r.errorNumber(), TRI_ERROR_FORBIDDEN);
   EXPECT_EQ(r.errorMessage(), "role lacks db:Read");
 }
 
 TEST(RbacServiceImplCheckTest, backendErrorIsPropagated) {
   struct ErrorBackend : rbac::Backend {
-    auto evaluateTokenManyImpl(rbac::JwtToken const&, RequestItems const&,
-                               transaction::MethodsApi)
+    auto evaluateManyImpl(rbac::Subject const&, RequestItems const&,
+                          transaction::MethodsApi)
         -> futures::Future<ResultT<EvaluateResponseMany>> override {
       co_return Result{TRI_ERROR_INTERNAL, "backend failure"};
     }
@@ -230,13 +235,37 @@ TEST(RbacServiceImplCheckTest, backendErrorIsPropagated) {
   rbac::ServiceImpl svc{std::make_unique<ErrorBackend>()};
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  auto r = svc.check({testToken}, queries);
+  auto r = svc.check(testSubject(), queries);
   EXPECT_EQ(r.errorNumber(), TRI_ERROR_INTERNAL);
+}
+
+// ---------------------------------------------------------------------------
+// check(): the subject is passed through to the backend untouched. It decides
+// which endpoint the backend talks to, so a Basic-authenticated caller must
+// arrive as a Username, not as an empty token.
+// ---------------------------------------------------------------------------
+
+TEST(RbacServiceImplCheckTest, forwardsJwtTokenSubject) {
+  auto f = CheckFixture::make();
+  std::array queries{rbac::ActionResource{
+      rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
+  f.svc.check(rbac::JwtToken{testToken}, queries);
+  ASSERT_TRUE(std::holds_alternative<rbac::JwtToken>(f.mock->lastSubject));
+  EXPECT_EQ(std::get<rbac::JwtToken>(f.mock->lastSubject).jwtToken, testToken);
+}
+
+TEST(RbacServiceImplCheckTest, forwardsUsernameSubject) {
+  auto f = CheckFixture::make();
+  std::array queries{rbac::ActionResource{
+      rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
+  f.svc.check(rbac::Username{"alice"}, queries);
+  ASSERT_TRUE(std::holds_alternative<rbac::Username>(f.mock->lastSubject));
+  EXPECT_EQ(std::get<rbac::Username>(f.mock->lastSubject).name, "alice");
 }
 
 TEST(RbacServiceImplCheckTest, emptyBatchIsOkWithoutBackendCall) {
   auto f = CheckFixture::make();
-  auto r = f.svc.check({testToken}, {});
+  auto r = f.svc.check(testSubject(), {});
   EXPECT_TRUE(r.ok());
   EXPECT_EQ(f.mock->calls, 0);  // no round-trip for an empty batch
 }


### PR DESCRIPTION
Use the username centric endpoint if no jwt is provided.