### PR TITLE
[COR-865] add async registry pretty printer test to ci

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -123,11 +123,25 @@ parameters:
 
 
 commands:
+  write_paths_to_file:
+    parameters:
+      paths:
+        type: string
+      file:
+        type: string
+    steps:
+      - run:
+          name: Write << parameters.file >> path list
+          command: |
+            cat > "<< parameters.file >>" <<'EOF'
+            << parameters.paths >>
+            EOF
+
   persist_workspace_to_s3:
     parameters:
       root:
         type: string
-      paths:
+      paths-file:
         type: string
       archive:
         type: string
@@ -140,7 +154,7 @@ commands:
             set -x
 
             ROOT="<< parameters.root >>"
-            PATHS="<< parameters.paths >>"
+            PATHS_FILE="<< parameters.paths-file >>"
             ARCHIVE="<< parameters.archive >>"
 
             if [ -z "${AWS_S3_WORKSPACE_BUCKET:-}" ]; then
@@ -153,7 +167,7 @@ commands:
 
             cd "$ROOT"
 
-            tar -czf "$TAR" $PATHS
+            tar -czf "$TAR" -T "$PATHS_FILE"
             du -sh "$TAR"
             aws configure set profile.anon.s3.multipart_threshold 5GB
             aws s3 cp --no-sign-request --profile anon \
@@ -713,10 +727,13 @@ jobs:
       - persist_to_workspace:
           root: .
           paths: js/apps/system/_admin/aardvark/APP/react/build
+      - write_paths_to_file:
+          paths: js/apps/system/_admin/aardvark/APP/react/build
+          file: /tmp/frontend-paths.txt
       - persist_workspace_to_s3:
           root: .
-          paths: js/apps/system/_admin/aardvark/APP/react/build
           archive: frontend.tar.gz
+          paths-file: /tmp/frontend-paths.txt
 
   compile-linux:
     parameters:
@@ -877,15 +894,24 @@ jobs:
                   - tsan_arangodb_suppressions.txt
                   - ubsan_arangodb_suppressions.txt
                   - lsan_arangodb_suppressions.txt
+            - write_paths_to_file:
+                paths: |
+                  build/compile_commands.json
+                file: /tmp/cppcheck-paths.txt
             - persist_workspace_to_s3:
                 root: .
                 archive: cppcheck.tar.gz
-                paths: |
-                  build/compile_commands.json
+                paths-file: /tmp/cppcheck-paths.txt
+            - run:
+                name: Compute ctest metadata file list
+                command: |
+                  pip3 install pyyaml --break-system-packages
+                  python3 .circleci/collect_ctest_metadata.py build tests/ctest.yml /tmp/ctest-metadata-paths.txt
             - persist_workspace_to_s3:
-                # not there? install.tar.gz
                 root: .
-                archive: binaries.tar.gz
+                archive: ctest-metadata.tar.gz
+                paths-file: /tmp/ctest-metadata-paths.txt
+            - write_paths_to_file:
                 paths: |
                   VERSIONS
                   ARANGO-VERSION
@@ -903,6 +929,12 @@ jobs:
                   tsan_arangodb_suppressions.txt
                   ubsan_arangodb_suppressions.txt
                   lsan_arangodb_suppressions.txt
+                file: /tmp/binaries-paths.txt
+            - persist_workspace_to_s3:
+                # not there? install.tar.gz
+                root: .
+                archive: binaries.tar.gz
+                paths-file: /tmp/binaries-paths.txt
 
   # Builds one architecture's Alpine-based image locally and saves it to a
   # workspace tarball. No registry auth here - pushing (and the ECR login)
@@ -1033,6 +1065,30 @@ jobs:
           timeLimit: << parameters.timeLimit >>
           sanitizer: << parameters.sanitizer >>
           extraArgs: << parameters.extraArgs >>
+
+  run-ctest-tests:
+    parameters:
+      <<: *shared-test-job-parameters
+    docker:
+      - image: << parameters.docker_image >>
+    resource_class: << parameters.size >>
+    steps:
+      - checkout-arangodb:
+          with-submodules: false
+          destination: "/root/project"
+      - attach_workspace_from_s3:
+          at: .
+          archive: binaries.tar.gz
+      - attach_workspace_from_s3:
+          at: .
+          archive: ctest-metadata.tar.gz
+      - run:
+          name: Run << parameters.suiteName >> tests
+          command: |
+            set -eo pipefail
+            IFS=',' read -ra TEST_NAMES <<< "<< parameters.suites >>"
+            TESTS_REGEX="^($(IFS='|'; echo "${TEST_NAMES[*]}"))$"
+            ctest --test-dir build -R "$TESTS_REGEX" --output-on-failure
 
   run-driver-tests:
     parameters:

--- a/.circleci/collect_ctest_metadata.py
+++ b/.circleci/collect_ctest_metadata.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""
+Collects the CTestTestfile.cmake files needed to run the given ctests listed
+in <ctest-yml-file>.
+
+CTestTestfile.cmake exists in every directory CMake processed via
+add_subdirectory(), even ones with no tests of their own (a few hundred
+files project-wide) - ctest still needs each one that lies on the path down
+to a test it's asked to run, but tolerates missing sibling subdirs it never
+has to traverse. This script lists only the files required to execute the
+given ctests.
+
+Writes the resulting paths (relative to <build-dir>'s parent, one per line)
+to <output-file-list>.
+
+Usage: collect_ctest_metadata.py <build-dir> <ctest-yml-file> <output-file-list>
+"""
+from itertools import accumulate
+from pathlib import Path
+import sys
+
+import yaml
+
+
+def test_names(ctest_yml_path):
+    with open(ctest_yml_path) as f:
+        return [
+            name
+            for entry in yaml.safe_load(f)
+            for name in next(iter(entry.values())).get("suites", [])
+        ]
+
+
+def find_defining_files(build_dir, name):
+    """All CTestTestfile.cmake files under build_dir that define a test named `name`.
+
+    Exits with an error if none define it.
+
+    [=[<name>]=] is cmake's declaration pattern for a test
+    """
+    matches = [
+        path
+        for path in build_dir.rglob("CTestTestfile.cmake")
+        if f"[=[{name}]=]" in path.read_text(errors="ignore")
+    ]
+    if not matches:
+        sys.exit(
+            f"ERROR: no CTestTestfile.cmake in {build_dir} defines a test named '{name}'"
+        )
+    return matches
+
+
+def ancestor_chain(build_dir, file_path):
+    """The CTestTestfile.cmake files from build_dir down to file_path's directory.
+
+    This is the chain ctest needs on disk to reach file_path's test.
+    """
+    return [
+        path / "CTestTestfile.cmake"
+        for path in accumulate(
+            file_path.relative_to(build_dir).parent.parts,
+            lambda ancestor, part: ancestor / part,
+            initial=build_dir,
+        )
+    ]
+
+
+def main():
+    build_dir = Path(sys.argv[1])
+
+    needed = {
+        path
+        for name in test_names(sys.argv[2])
+        for match in find_defining_files(build_dir, name)
+        for path in ancestor_chain(build_dir, match)
+    }
+
+    with open(sys.argv[3], "w") as f:
+        f.writelines(f"{path}\n" for path in sorted(needed))
+
+
+if __name__ == "__main__":
+    main()

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,9 @@ parameters:
     description: "Build arangod without serverside JS (also excludes frontend)"
   config-definitions:
     type: string
-    default: tests.yml ui.yml
+    default: tests.yml ui.yml ctest.yml
     description: Space separated list of YAML files with test definitions. Available files
-      arangojs.yml java.yml spark-ds.yml ui.yml go.yml kafka.yml spring-data.yml tinkerpop.yml py-async.yml py.yml tests.yml
+      arangojs.yml java.yml spark-ds.yml ui.yml go.yml kafka.yml spring-data.yml tinkerpop.yml py-async.yml py.yml tests.yml ctest.yml
   config-definitions-branches:
     type: string
     default: ""

--- a/.circleci/tests_unit/test_collect_ctest_metadata.py
+++ b/.circleci/tests_unit/test_collect_ctest_metadata.py
@@ -1,0 +1,117 @@
+"""
+Unit tests for collect_ctest_metadata.py.
+"""
+
+import pytest
+import sys
+from pathlib import Path
+
+import collect_ctest_metadata as ccm
+
+
+def write_ctest_file(path, *test_names):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = "".join(f'add_test([=[{name}]=] "cmd")\n' for name in test_names)
+    path.write_text(lines or "# no tests\n")
+
+
+class TestTestNames:
+    def test_flattens_suites_across_entries(self, tmp_path):
+        ctest_yml = tmp_path / "ctest.yml"
+        ctest_yml.write_text(
+            "- group_one:\n"
+            "    suites:\n"
+            "      - test_a\n"
+            "      - test_b\n"
+            "- group_two:\n"
+            "    suites:\n"
+            "      - test_c\n"
+        )
+
+        assert ccm.test_names(ctest_yml) == ["test_a", "test_b", "test_c"]
+
+    def test_entry_without_suites_contributes_nothing(self, tmp_path):
+        ctest_yml = tmp_path / "ctest.yml"
+        ctest_yml.write_text("- group_one:\n    job: run-ctest-tests\n")
+
+        assert ccm.test_names(ctest_yml) == []
+
+
+class TestFindDefiningFiles:
+    def test_finds_file_defining_the_named_test(self, tmp_path):
+        write_ctest_file(tmp_path / "a" / "CTestTestfile.cmake", "my_test")
+        write_ctest_file(tmp_path / "b" / "CTestTestfile.cmake", "other_test")
+
+        matches = ccm.find_defining_files(tmp_path, "my_test")
+
+        assert matches == [tmp_path / "a" / "CTestTestfile.cmake"]
+
+    def test_matches_multiple_files_defining_the_same_test(self, tmp_path):
+        write_ctest_file(tmp_path / "a" / "CTestTestfile.cmake", "shared_test")
+        write_ctest_file(tmp_path / "b" / "CTestTestfile.cmake", "shared_test")
+
+        matches = ccm.find_defining_files(tmp_path, "shared_test")
+
+        assert sorted(matches) == sorted(
+            [
+                tmp_path / "a" / "CTestTestfile.cmake",
+                tmp_path / "b" / "CTestTestfile.cmake",
+            ]
+        )
+
+    def test_exits_when_no_file_defines_the_test(self, tmp_path):
+        write_ctest_file(tmp_path / "a" / "CTestTestfile.cmake", "my_test")
+
+        with pytest.raises(SystemExit):
+            ccm.find_defining_files(tmp_path, "missing_test")
+
+    def test_does_not_match_a_name_that_is_only_a_prefix(self, tmp_path):
+        write_ctest_file(tmp_path / "a" / "CTestTestfile.cmake", "my_test_extended")
+
+        with pytest.raises(SystemExit):
+            ccm.find_defining_files(tmp_path, "my_test")
+
+
+class TestAncestorChain:
+    def test_lists_every_directory_from_build_dir_down_to_the_file(self, tmp_path):
+        file_path = tmp_path / "a" / "b" / "CTestTestfile.cmake"
+
+        assert ccm.ancestor_chain(tmp_path, file_path) == [
+            tmp_path / "CTestTestfile.cmake",
+            tmp_path / "a" / "CTestTestfile.cmake",
+            tmp_path / "a" / "b" / "CTestTestfile.cmake",
+        ]
+
+    def test_file_directly_in_build_dir_yields_a_single_entry(self, tmp_path):
+        file_path = tmp_path / "CTestTestfile.cmake"
+
+        assert ccm.ancestor_chain(tmp_path, file_path) == [
+            tmp_path / "CTestTestfile.cmake"
+        ]
+
+
+class TestMain:
+    def test_writes_the_minimal_ancestor_chain_for_the_requested_tests(
+        self, tmp_path, monkeypatch
+    ):
+        build_dir = tmp_path / "build"
+        write_ctest_file(build_dir / "CTestTestfile.cmake")
+        write_ctest_file(build_dir / "wanted" / "CTestTestfile.cmake", "wanted_test")
+        write_ctest_file(
+            build_dir / "unrelated" / "CTestTestfile.cmake", "other_test"
+        )
+        ctest_yml = tmp_path / "ctest.yml"
+        ctest_yml.write_text("- group:\n    suites:\n      - wanted_test\n")
+        output_file = tmp_path / "out.txt"
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["collect_ctest_metadata.py", str(build_dir), str(ctest_yml), str(output_file)],
+        )
+        ccm.main()
+
+        assert output_file.read_text().splitlines() == [
+            str(build_dir / "CTestTestfile.cmake"),
+            str(build_dir / "wanted" / "CTestTestfile.cmake"),
+        ]

--- a/.circleci/tests_unit/test_parsing_integration.py
+++ b/.circleci/tests_unit/test_parsing_integration.py
@@ -12,6 +12,7 @@ from src.config_lib import TestDefinitionFile, DeploymentType
 
 TESTS_DIR = Path(__file__).parent.parent.parent / "tests"
 MAIN_TEST_DEFINITIONS = "tests.yml"
+CTEST_TEST_DEFINITIONS = "ctests.yml"
 
 
 class TestParsingIntegration:
@@ -63,13 +64,23 @@ class TestParsingIntegration:
             if job.options.buckets == "auto":
                 assert job.get_bucket_count() == len(job.suites)
 
+    def test_ctest_tests_have_ctest_job(self):
+        yaml_file = TESTS_DIR / CTEST_TEST_DEFINITIONS
+
+        test_def = TestDefinitionFile.from_yaml_file(str(yaml_file))
+
+        for job in test_def.jobs.values():
+            assert (
+                    job.job == run-ctest-tests
+                ), f"Ctest job in {yaml_file.name} should use ctest job run-ctest-tests"
+
     def test_driver_tests_have_repository_config(self):
         """Verify driver test files correctly set repository configuration."""
         yaml_files = sorted(TESTS_DIR.glob("*.yml"))
 
         for yaml_file in yaml_files:
             # Skip main test definitions - it contains regular tests, not driver tests
-            if yaml_file.name == MAIN_TEST_DEFINITIONS:
+            if yaml_file.name == MAIN_TEST_DEFINITIONS || yaml_file.name == CTEST_TEST_DEFINITIONS:
                 continue
 
             test_def = TestDefinitionFile.from_yaml_file(str(yaml_file))

--- a/scripts/docker/test/Dockerfile
+++ b/scripts/docker/test/Dockerfile
@@ -17,7 +17,7 @@ RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python3 \
-    7zip gdb tzdata curl jq binutils gcc \
+    7zip gdb cmake tzdata curl jq binutils gcc \
     llvm-${CLANG_VERSION} libatomic1 net-tools \
     libc6 libstdc++6 \
     libomp-${CLANG_VERSION}-dev liblapack-dev libopenblas-dev gfortran wget sed \

--- a/tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration/CMakeLists.txt
+++ b/tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(async_registry_gdb_pretty_printer EXCLUDE_FROM_ALL
+add_executable(async_registry_gdb_pretty_printer
   async_registry_gdb_pretty_printer_test.cpp)
 target_link_libraries(async_registry_gdb_pretty_printer
   PRIVATE

--- a/tests/ctest.yml
+++ b/tests/ctest.yml
@@ -1,0 +1,9 @@
+---
+# ctest-registered tests. `suites` here are exact ctest test names.
+- ctest-arangodb:
+    job: run-ctest-tests
+    options:
+      type: single
+    suites:
+      - async_registry_python_pretty_printer_test
+      - async_registry_gdb_pretty_printer_test


### PR DESCRIPTION
This adds the two ctests for the async-registry pretty printer to our CI:
- (1) async_registry_gdb_pretty_printer_test (defined in `tests/SystemMonitor/AsyncRegistry/PrettyPrinter/gdb_integration`)
- (2) async_registry_python_pretty_printer_test (defined in `tests/SystemMonitor/AsyncRegistry/PrettyPrinter/unittests`)
to make sure that the pretty printers stay correct when changing something in the async-registry structure.

We don't have any ctests running in our pipeline yet, therefore this PR does several changes. Basically:

1. it adds a `tests/ctest.yml` file that defines all ctest names that should run in the CI as a job
2. the `compile-linux` job now additionally loads all relevant ctest-files into a new archive
3. the ctest-job checks out arangodb, uses the binaries- and the new ctest-archive and executes ctest - for this we now additionally need `cmake` in our test docker container

## Some more details:
to 1. 
- currently the `ctest.yml` file only includes one job-item (`ctest-arangodb`), which will result in one additional test in the CI with name "test-single-ctest-arangodb-x64" (or -aarch64 at the end).

### to 2. 
- the `ctest-metadata.tar.gz` archive is created in the `compile-linux` job defined in `.circleci/base_config.yml`. It executes the python script `.circleci/collect_ctest_metadata.py` to find all relevant ctest files and adds all these files into the archive.
- This script `.circleci/collect_ctest_metadata.py` finds all ctest files for the ctests we want to execute: it reads in `tests/ctest.yml` what ctests we want to execute, finds the relevant ctest files (called `CTestTestfile.cmake`) were these tests are defined additionally all ctest files that lie on the path to these ctest files (because ctest requires all these files).

### to 3. 
- the ctest-job `run-ctest-tests` is defined in `.circleci/base_config.yml`. This job does an arangodb-checkout (needed e.g. for the tests in (2)), attaches the `binaries.tar.gz` archive (for the executable required in (1)), attaches the `ctest-metadata.tar.gz archive (that includes all ctest files that were generated in the build-step) and executes the ctest suites.
- Our tests run in a separate docker-container. When we want to run ctests in there, we need `cmake` in this container, therefore this is added in `scropts/docker/test/Dockerfile`

## Refactoring
- In `.circleci/base_config.yml` I adapted the `persist_workspace_to_s3` command such that it gets a `paths-file` instead of `paths`. This way, we can use the same command for our dynamically generated ctest-files to create `ctest-metadata.tar.gz`. All jobs with a static file-list need to call the new command `write_paths_to_file` now before executing `persist_workspace_to_s3`.

## Side note for executing the CI run
This change will not work in the CI until the Docker image (with the added `cmake` program) is rebuild (via triggering `infrastructure.yml`'s `rebuild-images=test` pipeline after this Dockerfile change lands, which will build/publish the new image and auto-bump the tag reference in `base_config.yml`.