### PR TITLE
Catch exceptions in handleAuthorizationChecks [COR-905]

### DIFF
--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -435,7 +435,17 @@ auto RestHandler::runHandlerStateMachine() -> futures::Future<futures::Unit> {
     shutdownExecute(false);
   };
 
-  co_await handleAuthorizationChecks();
+  try {
+    co_await handleAuthorizationChecks();
+  } catch (std::exception const& exc) {
+    generateError(
+        ResponseCode::SERVER_ERROR, TRI_ERROR_INTERNAL,
+        absl::StrCat("Caught exception in `handleAuthorizationChecks`: ",
+                     exc.what()));
+    _sendResponseCallback(this);
+    co_return;
+  }
+
   if (_state == HandlerState::FAILED) {
     co_return fail();
   }


### PR DESCRIPTION
### Scope & Purpose

This fixes an oversight in the RBAC implementation:

We now catch exceptions in the call to `handleAuthorizationChecks`
and return an internal server error when this happens.

- [*] :hankey: Bugfix

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-905
- [ ] Design document: 
