### PR TITLE
Fix duplicate vector index hints handling

### DIFF
--- a/arangod/Aql/Optimizer/Rule/UseVectorIndex.cpp
+++ b/arangod/Aql/Optimizer/Rule/UseVectorIndex.cpp
@@ -223,13 +223,15 @@ std::vector<std::shared_ptr<Index>> getVectorIndexes(
     auto& idxNames = indexHint.candidateIndexes();
     auto currentIt = vectorIndexes.begin();
     for (auto const& idxName : idxNames) {
+      if (currentIt == vectorIndexes.end()) {
+        break;
+      }
       if (auto foundHintedIndexIt = std::ranges::find_if(
-              vectorIndexes,
+              currentIt, vectorIndexes.end(),
               [&idxName](const auto& elem) { return elem->name() == idxName; });
           foundHintedIndexIt != vectorIndexes.end()) {
-        auto oldIt = currentIt;
-        std::iter_swap(oldIt, foundHintedIndexIt);
-        currentIt++;
+        std::iter_swap(currentIt, foundHintedIndexIt);
+        ++currentIt;
       }
     }
   }

--- a/tests/js/client/aql/vector/aql-vector-index-hints.js
+++ b/tests/js/client/aql/vector/aql-vector-index-hints.js
@@ -216,6 +216,27 @@ function VectorIndexHintsSuite() {
         assertEqual("vector_l2_secondary", indexName);
     },
 
+    testVectorL2HintDuplicateIndexes: function () {
+        // Use one more matching hint than available vector indexes.
+        // Triggers bound checks and duplicate index handling in the optimizer.
+        const hintedIndex = "vector_l2_secondary";
+        const vectorIndexCount = collection.indexes().filter(
+          index => index.type === "vector"
+        ).length;
+        const duplicateHints = Array(vectorIndexCount + 1).fill(hintedIndex);
+
+        const query = `
+          FOR doc IN ${collName} OPTIONS { indexHint: ${JSON.stringify(duplicateHints)} }
+            SORT APPROX_NEAR_L2(doc.vector, @qp)
+            LIMIT 5
+            RETURN doc
+        `;
+        const bindVars = { qp: randomPoint };
+        const indexName = getVectorIndexName(query, bindVars);
+
+        assertEqual(hintedIndex, indexName);
+    },
+
     testVectorL2HintWithFilterNotForced: function () {
         const query = `
           FOR doc IN ${collName} OPTIONS { indexHint: "vector_l2_with_filter" }


### PR DESCRIPTION
### Scope & Purpose

The problem arises when a query repeats a valid vector index name more times than the collection has vector indexes. Only for vector-search queries that contain **non-forced** index hints.

### Repro
See `testVectorL2HintDuplicateIndexes` for an example query.
Without the patch, either the coordinator crashes or the assertion fails with:
```
assertEqual: (vector_l2) is not equal to (vector_l2_secondary)
```

### Context
1. `ExecutionPlan.cpp:1368-1371` builds an `IndexHint` from the `FOR ... OPTIONS` object and stores it in the execution node.
2. `UseVectorIndex.cpp:322-325` passes the stored hint to `getVectorIndexes()`.
3. `UseVectorIndex.cpp:221-235` scans the complete list for every hint. Each match advances `currentIt`. A duplicate can count the same real index several times.

For example, during the `testVectorL2HintDuplicateIndexes` test, `vectorIndexes` looks like this:
1. initial: `[vector_l2, vector_l2_secondary, vector_l2_with_filter]`
2. hint 1: `[vector_l2_secondary, vector_l2, vector_l2_with_filter]`
3. hint 2: `[vector_l2, vector_l2_secondary, vector_l2_with_filter]`
4. hint 3: `[vector_l2, vector_l2_with_filter, vector_l2_secondary]`
5. hint 4: `iter_swap(end(), vector_l2_secondary)`

### Fix
1. Stop when the end of the vector index list is reached.
2. Each matching hint moves one index to the front of the list. Later hints search only the remaining indexes, so duplicate hints cannot select the same index again.

- [x] :hankey: Bugfix

### Checklist

- [x] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [x] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
