### PR TITLE
Filter Array Expression Traversal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 3.12.11-devel (XXXX-XX-XX)
 --------------------------
 
+* Filters on path expansions with an inline FILTER now run during the traversal,
+  so they prune earlier and no longer drop results with uniqueVertices: "global".
+
 * Updated ArangoDB Starter to v0.19.27.
 
 * Rebuilt included rclone v1.75.0 with go1.25.13 and non-vulnerable

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -2954,7 +2954,7 @@ bool Ast::getReferencedAttributesRecursive(
           // here we need to take special precautions that we normally
           // don't need
           if (expansionNode.getFilter()->type != NODE_TYPE_NOP ||
-              expansionNode.getOptions()->type != NODE_TYPE_NOP) {
+              expansionNode.getProjection()->type != NODE_TYPE_NOP) {
             // expansion has a filter or a projection set, e.g.
             // p.vertices[FILTER CURRENT.x == 1 RETURN CURRENT.y].
             // we currently cannot handle this.

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -114,30 +114,71 @@ AstNodeType buildSingleComparatorType(AstNode const* condition) {
   return type;
 }
 
+/// @brief the CURRENT variable an expansion binds for its elements
+Variable const* expansionIteratorVariable(AstNode const* expansion) {
+  TRI_ASSERT(expansion->type == NODE_TYPE_EXPANSION);
+  AstNode const* iterator = expansion->getMemberUnchecked(0);
+  TRI_ASSERT(iterator->type == NODE_TYPE_ITERATOR);
+  AstNode const* variable = iterator->getMemberUnchecked(0);
+  TRI_ASSERT(variable->type == NODE_TYPE_VARIABLE);
+  return static_cast<Variable const*>(variable->getData());
+}
+
+/// @brief replace all references to the expansion's CURRENT variable with the
+/// traversal's temporary variable, so that the expression can be evaluated for
+/// a single edge/vertex instead of the whole path
+AstNode* replaceIteratorReference(AstNode* node, Variable const* iteratorVar,
+                                  AstNode* tmpVar) {
+  auto func = [&](AstNode* n) -> AstNode* {
+    if (n->type == NODE_TYPE_REFERENCE || n->type == NODE_TYPE_VARIABLE) {
+      if (static_cast<Variable const*>(n->getData()) == iteratorVar) {
+        return tmpVar;
+      }
+    }
+    return n;
+  };
+  return Ast::traverseAndModify(node, func);
+}
+
 AstNode* buildExpansionReplacement(Ast* ast, AstNode const* condition,
                                    AstNode* tmpVar) {
   AstNodeType type = buildSingleComparatorType(condition);
 
-  auto replaceReference = [&tmpVar](AstNode* node) -> AstNode* {
-    if (node->type == NODE_TYPE_REFERENCE) {
-      return tmpVar;
-    }
-    return node;
-  };
-
-  // Now we need to traverse down and replace the reference
-  auto lhs = condition->getMemberUnchecked(0);
+  auto expansion = condition->getMemberUnchecked(0);
   auto rhs = condition->getMemberUnchecked(1);
   // We can only optimize if path.edges[*] is on the left hand side
-  TRI_ASSERT(lhs->type == NODE_TYPE_EXPANSION);
-  TRI_ASSERT(lhs->numMembers() >= 2);
-  // This is the part appended to each element in the expansion.
-  lhs = lhs->getMemberUnchecked(1);
+  TRI_ASSERT(expansion->type == NODE_TYPE_EXPANSION);
+  TRI_ASSERT(expansion->numMembers() == 5);
 
-  // We have to take the return-value if LHS already is the refence.
+  Variable const* iteratorVar = expansionIteratorVariable(expansion);
+
+  // This is the part appended to each element in the expansion.
+  // We have to take the return-value if LHS already is the reference,
   // otherwise the point will not be relocated.
-  lhs = Ast::traverseAndModify(lhs, replaceReference);
-  return ast->createNodeBinaryOperator(type, lhs, rhs);
+  AstNode* lhs = replaceIteratorReference(expansion->getMemberUnchecked(1),
+                                         iteratorVar, tmpVar);
+  AstNode* result = ast->createNodeBinaryOperator(type, lhs, rhs);
+
+  AstNode* filter = expansion->getMemberUnchecked(2);
+  if (filter->type != NODE_TYPE_NOP) {
+    // An inline FILTER restricts the quantifier to those elements that
+    // satisfy it:
+    //   p.edges[* FILTER B(CURRENT)].attr ALL op y
+    // means "for every edge with B(edge): edge.attr op y", which per edge is
+    //   !B(edge) || edge.attr op y
+    // For NONE the comparator has already been negated above, so the same
+    // implication holds.
+    TRI_ASSERT(filter->type == NODE_TYPE_ARRAY_FILTER);
+    AstNode* filterExpression = replaceIteratorReference(
+        filter->getMemberUnchecked(1)->clone(ast), iteratorVar, tmpVar);
+    result = ast->createNodeBinaryOperator(
+        NODE_TYPE_OPERATOR_BINARY_OR,
+        ast->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_NOT,
+                                     filterExpression),
+        result);
+  }
+
+  return result;
 }
 
 bool isSupportedNode(Ast const* ast, Variable const* pathVar,
@@ -266,6 +307,41 @@ bool isSupportedNode(Ast const* ast, Variable const* pathVar,
   }
 }
 
+/// @brief check whether the inline FILTER of an expansion (an ARRAY_FILTER
+/// node) can be pulled into the traversal
+bool isSupportedInlineFilter(Ast const* ast, Variable const* pathVar,
+                             AstNode const* filter) {
+  TRI_ASSERT(filter->type == NODE_TYPE_ARRAY_FILTER);
+  TRI_ASSERT(filter->numMembers() == 2);
+  // an ARRAY_FILTER carries (quantifier, filter expression). we only support
+  // the plain `[* FILTER ...]` form, i.e. without an own quantifier
+  if (filter->getMemberUnchecked(0)->type != NODE_TYPE_NOP) {
+    return false;
+  }
+  bool supported = true;
+  Ast::traverseReadOnly(
+      filter->getMemberUnchecked(1),
+      [&](AstNode const* n) -> bool {
+        if (!supported) {
+          return false;
+        }
+        if (!isSupportedNode(ast, pathVar, n)) {
+          supported = false;
+          return false;
+        }
+        // the filter is evaluated per edge/vertex, so it must not look at the
+        // path itself
+        if ((n->type == NODE_TYPE_REFERENCE || n->type == NODE_TYPE_VARIABLE) &&
+            static_cast<Variable const*>(n->getData()) == pathVar) {
+          supported = false;
+          return false;
+        }
+        return true;
+      },
+      [](AstNode const*) {});
+  return supported;
+}
+
 bool checkPathVariableAccessFeasible(Ast* ast, ExecutionPlan* plan,
                                      AstNode* parent, size_t testIndex,
                                      TraversalNode* tn, Variable const* pathVar,
@@ -304,6 +380,15 @@ bool checkPathVariableAccessFeasible(Ast* ast, ExecutionPlan* plan,
     }
     if (!isSupportedNode(ast, pathVar, n)) {
       notSupported = true;
+      return false;
+    }
+    if (n->type == NODE_TYPE_ARRAY_FILTER) {
+      // the inline FILTER of an expansion is validated as a whole here, and
+      // then skipped, so that the pattern matcher below cannot mistake an
+      // expansion nested inside it for the path access itself
+      if (!isSupportedInlineFilter(ast, pathVar, n)) {
+        notSupported = true;
+      }
       return false;
     }
     return true;
@@ -390,12 +475,14 @@ bool checkPathVariableAccessFeasible(Ast* ast, ExecutionPlan* plan,
           return node;
         }
         if (node->type == NODE_TYPE_EXPANSION) {
-          // Check that the expansion [*] contains no inline expression;
+          // Check that the expansion [*] contains no inline LIMIT or RETURN;
           // members 2, 3 and 4 correspond to FILTER, LIMIT and RETURN,
-          // respectively.
+          // respectively. An inline FILTER (member 2) is supported and turned
+          // into an implication per edge/vertex, see
+          // buildExpansionReplacement(). It has already been validated (and
+          // skipped) by the supportedGuard.
           TRI_ASSERT(node->numMembers() == 5);
-          if (node->getMemberUnchecked(2)->type != NODE_TYPE_NOP ||
-              node->getMemberUnchecked(3)->type != NODE_TYPE_NOP ||
+          if (node->getMemberUnchecked(3)->type != NODE_TYPE_NOP ||
               node->getMemberUnchecked(4)->type != NODE_TYPE_NOP) {
             notSupported = true;
             return node;
@@ -413,8 +500,10 @@ bool checkPathVariableAccessFeasible(Ast* ast, ExecutionPlan* plan,
         if (node->type == NODE_TYPE_QUANTIFIER) {
           // We are in array case. We need to wait for a quantifier
           // This means we have path.edges[*] on the right hand side
-          if (Quantifier::isAny(node)) {
-            // Nono optimize for ANY
+          if (Quantifier::isAny(node) || Quantifier::isAtLeast(node)) {
+            // No optimization for ANY and AT LEAST: both would need to count
+            // matches over the whole path, which a per-edge condition cannot
+            // express.
             notSupported = true;
             return node;
           }

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -156,7 +156,7 @@ AstNode* buildExpansionReplacement(Ast* ast, AstNode const* condition,
   // We have to take the return-value if LHS already is the reference,
   // otherwise the point will not be relocated.
   AstNode* lhs = replaceIteratorReference(expansion->getMemberUnchecked(1),
-                                         iteratorVar, tmpVar);
+                                          iteratorVar, tmpVar);
   AstNode* result = ast->createNodeBinaryOperator(type, lhs, rhs);
 
   AstNode* filter = expansion->getMemberUnchecked(2);

--- a/arangod/Aql/TraversalConditionFinder.cpp
+++ b/arangod/Aql/TraversalConditionFinder.cpp
@@ -32,6 +32,7 @@
 #include "Aql/Expression.h"
 #include "Aql/Function.h"
 #include "Aql/Quantifier.h"
+#include "Aql/TypedAstNodes.h"
 #include "Aql/Query.h"
 #include "Basics/StaticStrings.h"
 #include "Cluster/ServerState.h"
@@ -114,16 +115,6 @@ AstNodeType buildSingleComparatorType(AstNode const* condition) {
   return type;
 }
 
-/// @brief the CURRENT variable an expansion binds for its elements
-Variable const* expansionIteratorVariable(AstNode const* expansion) {
-  TRI_ASSERT(expansion->type == NODE_TYPE_EXPANSION);
-  AstNode const* iterator = expansion->getMemberUnchecked(0);
-  TRI_ASSERT(iterator->type == NODE_TYPE_ITERATOR);
-  AstNode const* variable = iterator->getMemberUnchecked(0);
-  TRI_ASSERT(variable->type == NODE_TYPE_VARIABLE);
-  return static_cast<Variable const*>(variable->getData());
-}
-
 /// @brief replace all references to the expansion's CURRENT variable with the
 /// traversal's temporary variable, so that the expression can be evaluated for
 /// a single edge/vertex instead of the whole path
@@ -144,22 +135,19 @@ AstNode* buildExpansionReplacement(Ast* ast, AstNode const* condition,
                                    AstNode* tmpVar) {
   AstNodeType type = buildSingleComparatorType(condition);
 
-  auto expansion = condition->getMemberUnchecked(0);
-  auto rhs = condition->getMemberUnchecked(1);
   // We can only optimize if path.edges[*] is on the left hand side
-  TRI_ASSERT(expansion->type == NODE_TYPE_EXPANSION);
-  TRI_ASSERT(expansion->numMembers() == 5);
+  ast::ExpansionNode expansion{condition->getMemberUnchecked(0)};
+  auto rhs = condition->getMemberUnchecked(1);
 
-  Variable const* iteratorVar = expansionIteratorVariable(expansion);
+  Variable const* iteratorVar = expansion.getIterator().getVariable();
 
-  // This is the part appended to each element in the expansion.
-  // We have to take the return-value if LHS already is the reference,
-  // otherwise the point will not be relocated.
-  AstNode* lhs = replaceIteratorReference(expansion->getMemberUnchecked(1),
+  // This is the part appended to each element in the expansion. We work on a
+  // copy, the expansion itself is left alone.
+  AstNode* lhs = replaceIteratorReference(expansion.getExpression()->clone(ast),
                                           iteratorVar, tmpVar);
   AstNode* result = ast->createNodeBinaryOperator(type, lhs, rhs);
 
-  AstNode* filter = expansion->getMemberUnchecked(2);
+  AstNode const* filter = expansion.getFilter();
   if (filter->type != NODE_TYPE_NOP) {
     // An inline FILTER restricts the quantifier to those elements that
     // satisfy it:
@@ -168,9 +156,9 @@ AstNode* buildExpansionReplacement(Ast* ast, AstNode const* condition,
     //   !B(edge) || edge.attr op y
     // For NONE the comparator has already been negated above, so the same
     // implication holds.
-    TRI_ASSERT(filter->type == NODE_TYPE_ARRAY_FILTER);
     AstNode* filterExpression = replaceIteratorReference(
-        filter->getMemberUnchecked(1)->clone(ast), iteratorVar, tmpVar);
+        ast::ArrayFilterNode{filter}.getFilter()->clone(ast), iteratorVar,
+        tmpVar);
     result = ast->createNodeBinaryOperator(
         NODE_TYPE_OPERATOR_BINARY_OR,
         ast->createNodeUnaryOperator(NODE_TYPE_OPERATOR_UNARY_NOT,
@@ -311,16 +299,15 @@ bool isSupportedNode(Ast const* ast, Variable const* pathVar,
 /// node) can be pulled into the traversal
 bool isSupportedInlineFilter(Ast const* ast, Variable const* pathVar,
                              AstNode const* filter) {
-  TRI_ASSERT(filter->type == NODE_TYPE_ARRAY_FILTER);
-  TRI_ASSERT(filter->numMembers() == 2);
+  ast::ArrayFilterNode arrayFilter{filter};
   // an ARRAY_FILTER carries (quantifier, filter expression). we only support
   // the plain `[* FILTER ...]` form, i.e. without an own quantifier
-  if (filter->getMemberUnchecked(0)->type != NODE_TYPE_NOP) {
+  if (arrayFilter.getQuantifier()->type != NODE_TYPE_NOP) {
     return false;
   }
   bool supported = true;
   Ast::traverseReadOnly(
-      filter->getMemberUnchecked(1),
+      arrayFilter.getFilter(),
       [&](AstNode const* n) -> bool {
         if (!supported) {
           return false;
@@ -481,9 +468,9 @@ bool checkPathVariableAccessFeasible(Ast* ast, ExecutionPlan* plan,
           // into an implication per edge/vertex, see
           // buildExpansionReplacement(). It has already been validated (and
           // skipped) by the supportedGuard.
-          TRI_ASSERT(node->numMembers() == 5);
-          if (node->getMemberUnchecked(3)->type != NODE_TYPE_NOP ||
-              node->getMemberUnchecked(4)->type != NODE_TYPE_NOP) {
+          ast::ExpansionNode expansion{node};
+          if (expansion.getLimit()->type != NODE_TYPE_NOP ||
+              expansion.getProjection()->type != NODE_TYPE_NOP) {
             notSupported = true;
             return node;
           }
@@ -500,7 +487,8 @@ bool checkPathVariableAccessFeasible(Ast* ast, ExecutionPlan* plan,
         if (node->type == NODE_TYPE_QUANTIFIER) {
           // We are in array case. We need to wait for a quantifier
           // This means we have path.edges[*] on the right hand side
-          if (Quantifier::isAny(node) || Quantifier::isAtLeast(node)) {
+          ast::QuantifierNode quantifier{node};
+          if (quantifier.isAny() || quantifier.isAtLeast()) {
             // No optimization for ANY and AT LEAST: both would need to count
             // matches over the whole path, which a per-edge condition cannot
             // express.

--- a/arangod/Aql/TypedAstNodes.h
+++ b/arangod/Aql/TypedAstNodes.h
@@ -693,9 +693,9 @@ struct ExpansionNode : TypedAstNode {
 
   AstNode const* getFilter() const { return _node->getMember(2); }
 
-  AstNode const* getProjection() const { return _node->getMember(3); }
+  AstNode const* getLimit() const { return _node->getMember(3); }
 
-  AstNode const* getOptions() const { return _node->getMember(4); }
+  AstNode const* getProjection() const { return _node->getMember(4); }
 };
 
 struct ValueNode : TypedAstNode {

--- a/tests/js/client/aql/aql-graph-traverser-complexFiltering.js
+++ b/tests/js/client/aql/aql-graph-traverser-complexFiltering.js
@@ -704,6 +704,39 @@ function complexFilteringSuite() {
       assertEqual(stats.filtered, 0);
     },
 
+    // An expansion with an inline FILTER is pushed into the traversal, so a
+    // vertex failing the condition is not expanded any further: D is dropped
+    // and its subtree is never walked. With optimize-traversals disabled the
+    // condition is a post filter and everything below D is visited first,
+    // which is what the index lookup comparison below measures.
+    // Note the inline FILTER matters here: B and D carry a `value`, A, C and F
+    // do not, so a plain ALL would reject every path.
+    testVertexInlineFilterPrunesSubtree: function () {
+      var query = `WITH ${vn}
+      FOR v, e, p IN 1..2 OUTBOUND @start @@eCol
+      FILTER p.vertices[* FILTER CURRENT.value != null].value ALL < 50
+      SORT v._key
+      RETURN v._key`;
+      var bindVars = {
+        '@eCol': en,
+        'start': vertex.A
+      };
+
+      var cursor = executeQuery(query, bindVars);
+      assertEqual(cursor.toArray(), ['B', 'C', 'F']);
+      var stats = cursor.getExtra().stats;
+      assertEqual(stats.scannedFull, 0);
+
+      // the same query with the pushdown disabled: same result, but the
+      // traversal has to walk everything below D and discard it afterwards
+      var noOpt = db._query(query, bindVars, {optimizer: {rules: ['-optimize-traversals']}});
+      var noOptStats = noOpt.getExtra().stats;
+      assertEqual(noOpt.toArray(), ['B', 'C', 'F']);
+      assertEqual(noOptStats.scannedFull, 0);
+      assertTrue(stats.scannedIndex < noOptStats.scannedIndex,
+        `expected fewer index lookups when the condition is pushed into the traversal, got ${stats.scannedIndex} vs ${noOptStats.scannedIndex}`);
+    },
+
     testVertexLevel0: function () {
       var query = `WITH ${vn}
       FOR v, e, p IN 1..2 OUTBOUND @start @@ecol

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -263,6 +263,17 @@ describe('Single Traversal Optimizer', function () {
                       RETURN v._key`, bindVars);
       });
 
+      it('with CURRENT bound again by a nested expansion', () => {
+        // the inner CURRENT is a `bar` element, the outer one an edge. Only
+        // references to the outer one may be rewritten to the edge: `edge < 3`
+        // would compare an object to a number and select nothing, which turns
+        // the implication into a tautology and lets every path through.
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER LENGTH(CURRENT.bar[* FILTER CURRENT < 3]) > 0].foo ALL > 3
+                      RETURN v._key`, bindVars);
+      });
+
       it('with a constant true inline FILTER', () => {
         pushedDown(`WITH @@vertices
                       FOR v, e, p IN 1..2 OUTBOUND @start @@edges

--- a/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
+++ b/tests/js/client/aql/aql-optimizer-rule-remove-filter-covered-by-traversal-spec.js
@@ -203,6 +203,128 @@ describe('Single Traversal Optimizer', function () {
         hasFilterNode(planWithoutOurRule);
       });
     });
+
+    // An expansion with an inline FILTER restricts the quantifier to a subset
+    // of the path, which per edge/vertex is an implication:
+    //   p.edges[* FILTER B(CURRENT)].attr ALL op y
+    //     <=>  for every edge:  !B(edge) || edge.attr op y
+    // optimize-traversals pushes that implication into the TraversalNode, so no
+    // FilterNode is left. Note the data set only has `bar` on the second level
+    // of edges, and no `foo` on the start vertex, so the inline filters below
+    // do exclude elements.
+    describe('expansion with an inline FILTER', () => {
+      const pushedDown = (query, bindVars) => {
+        let plan = db._createStatement({query: query, bindVars: bindVars, options: activateOptimizer}).explain();
+        hasNoFilterNode(plan);
+        validateResult(query, bindVars);
+      };
+
+      it('on p.edges[*] ALL', () => {
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER CURRENT.bar != null].foo ALL > 3
+                      RETURN v._key`, bindVars);
+      });
+
+      it('on p.edges[*] NONE', () => {
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER CURRENT.bar != null].foo NONE <= 3
+                      RETURN v._key`, bindVars);
+      });
+
+      it('on p.vertices[*] ALL, excluding the start vertex', () => {
+        // the start vertex has no `foo`, so a plain ALL would reject every path
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.vertices[* FILTER CURRENT.foo != null].foo ALL >= 5
+                      RETURN v._key`, bindVars);
+      });
+
+      it('with a conjunction in the inline FILTER', () => {
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER CURRENT.foo > 3 && CURRENT.foo < 8].foo ALL != 5
+                      RETURN v._key`, bindVars);
+      });
+
+      it('with a function call in the inline FILTER', () => {
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER HAS(CURRENT, 'bar')].foo ALL > 3
+                      RETURN v._key`, bindVars);
+      });
+
+      it('with a nested expansion in the inline FILTER', () => {
+        // the inner expansion must not be mistaken for the path access itself
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER CURRENT.bar[*] ANY == 2].foo ALL > 3
+                      RETURN v._key`, bindVars);
+      });
+
+      it('with a constant true inline FILTER', () => {
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER true].foo ALL > 3
+                      RETURN v._key`, bindVars);
+      });
+
+      it('with a constant false inline FILTER', () => {
+        // no element is left for the quantifier, so ALL is trivially true
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER false].foo ALL > 3
+                      RETURN v._key`, bindVars);
+      });
+
+      it('with an outer variable in the inline FILTER', () => {
+        pushedDown(`WITH @@vertices
+                      LET threshold = NOOPT(3)
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER CURRENT.foo > threshold].foo ALL < 9
+                      RETURN v._key`, bindVars);
+      });
+
+      it('next to a second path condition', () => {
+        pushedDown(`WITH @@vertices
+                      FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                      FILTER p.edges[* FILTER CURRENT.bar != null].foo ALL > 3
+                      FILTER p.vertices[*].foo NONE == 42
+                      RETURN v._key`, bindVars);
+      });
+    });
+  });
+
+  describe('should not remove an inline expansion it cannot push', () => {
+    const notPushedDown = (query, bindVars) => {
+      let plan = db._createStatement({query: query, bindVars: bindVars, options: activateOptimizer}).explain();
+      hasFilterNode(plan);
+      validateResult(query, bindVars);
+    };
+
+    it('on an expansion with an inline LIMIT', () => {
+      // a LIMIT needs the whole array, it cannot be evaluated per edge
+      notPushedDown(`WITH @@vertices
+                       FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                       FILTER p.edges[* FILTER CURRENT.bar != null LIMIT 1].foo ALL > 3
+                       RETURN v._key`, bindVars);
+    });
+
+    it('on an expansion with an inline RETURN', () => {
+      notPushedDown(`WITH @@vertices
+                       FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                       FILTER p.edges[* FILTER CURRENT.bar != null RETURN CURRENT.foo] ALL > 3
+                       RETURN v._key`, bindVars);
+    });
+
+    it('on an inline FILTER referencing the path variable', () => {
+      // the condition is evaluated per edge, where the path is not available
+      notPushedDown(`WITH @@vertices
+                       FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                       FILTER p.edges[* FILTER CURRENT.foo != LENGTH(p.vertices)].foo ALL > 3
+                       RETURN v._key`, bindVars);
+    });
   });
 
   describe('should not remove a filter when quantifiers differ', () => {
@@ -222,6 +344,128 @@ describe('Single Traversal Optimizer', function () {
       hasNoFilterNode(plan);
       validateResult(query, bindVars);
     });
+
+    // AT LEAST (n) cannot be turned into a per-edge condition, as that would
+    // apply it to every edge, i.e. it would be treated like ALL. The condition
+    // has to stay a post-filter.
+    it('on p.edges[*].foo AT LEAST (1) > 3', () => {
+      let query = `WITH @@vertices
+                     FOR v, e, p IN 1..2 OUTBOUND @start @@edges
+                     FILTER p.edges[*].foo AT LEAST (1) > 3
+                     RETURN v._key`;
+
+      let plan = db._createStatement({query: query, bindVars: bindVars, options: activateOptimizer}).explain();
+      hasFilterNode(plan);
+      validateResult(query, bindVars);
+    });
   });
 
+});
+
+// An inline FILTER has to be evaluated during the traversal, not on the paths
+// it produces, or it breaks vertex uniqueness: a vertex reached over an edge
+// the filter rejects still counts as visited, and with uniqueVertices:
+// "global" it is then unreachable over the path that the filter keeps.
+//
+// Graph, with `versionTo` marking the version at which an edge expired
+// (null / absent means still valid):
+//
+//   start -e1-> b -e2(50)-> x -e5-> y      x is reachable through an expired edge
+//   start -e3-> c -e4-----> x              ... and through a valid path
+//                 c -e9(150)-> w           still valid at version 100
+//   start -e6(50)-> d -e7-> z              expired already at depth 1
+//
+// The filter keeps a path if every edge that has a `versionTo` expired after
+// @version. Pushed into the traversal it stops e2 from being followed at all,
+// so x is first reached over the valid start->c->x, and both uniqueness modes
+// return the same paths.
+describe('Traversal vertex uniqueness with an inline FILTER', function () {
+  const vertexCollection = 'UnitTestsInlineFilterVertices';
+  const edgeCollection = 'UnitTestsInlineFilterEdges';
+  const startId = `${vertexCollection}/start`;
+
+  const bindVars = {
+    "@vertices": vertexCollection,
+    "@edges": edgeCollection,
+    start: startId,
+    version: 100
+  };
+
+  const dropCollections = () => {
+    db._drop(vertexCollection);
+    db._drop(edgeCollection);
+  };
+
+  const query = (uniqueVertices) => `WITH @@vertices
+        FOR v, e, p IN 1..4 OUTBOUND @start @@edges
+        OPTIONS {uniqueVertices: "${uniqueVertices}", uniqueEdges: "path", order: "bfs"}
+        FILTER p.edges[* FILTER CURRENT.versionTo != null].versionTo ALL > @version
+        RETURN CONCAT_SEPARATOR(">", p.edges[*]._key)`;
+
+  const run = (uniqueVertices, options) =>
+    db._query(query(uniqueVertices), bindVars, options).toArray().sort();
+
+  before(function () {
+    dropCollections();
+    let v = db._create(vertexCollection);
+    let e = db._createEdgeCollection(edgeCollection);
+    v.save([{_key: "start"}, {_key: "b"}, {_key: "c"}, {_key: "d"},
+            {_key: "w"}, {_key: "x"}, {_key: "y"}, {_key: "z"}]);
+    e.save([
+      {_key: "e1", _from: `${vertexCollection}/start`, _to: `${vertexCollection}/b`, versionTo: null},
+      {_key: "e2", _from: `${vertexCollection}/b`, _to: `${vertexCollection}/x`, versionTo: 50},
+      {_key: "e3", _from: `${vertexCollection}/start`, _to: `${vertexCollection}/c`, versionTo: null},
+      {_key: "e4", _from: `${vertexCollection}/c`, _to: `${vertexCollection}/x`, versionTo: null},
+      {_key: "e5", _from: `${vertexCollection}/x`, _to: `${vertexCollection}/y`, versionTo: null},
+      {_key: "e6", _from: `${vertexCollection}/start`, _to: `${vertexCollection}/d`, versionTo: 50},
+      {_key: "e7", _from: `${vertexCollection}/d`, _to: `${vertexCollection}/z`, versionTo: null},
+      {_key: "e9", _from: `${vertexCollection}/c`, _to: `${vertexCollection}/w`, versionTo: 150}
+    ]);
+  });
+
+  after(dropCollections);
+
+  it('pushes the condition into the traversal', () => {
+    let plan = db._createStatement({query: query("global"), bindVars: bindVars, options: activateOptimizer}).explain();
+    expect(findExecutionNodes(plan, "FilterNode").length).to.equal(0, "Plan should have no filter node");
+  });
+
+  it('returns the expected paths', () => {
+    expect(run("global", activateOptimizer)).to.deep.equal(["e1", "e3", "e3>e4", "e3>e4>e5", "e3>e9"]);
+  });
+
+  it('still uses an index for the edge lookup', () => {
+    // the pushed down condition is a disjunction (!B || cmp) and ends up in the
+    // edge index lookup condition, so make sure it does not degrade into a
+    // collection scan
+    let cursor = db._query(query("global"), bindVars, activateOptimizer);
+    cursor.toArray();
+    expect(cursor.getExtra().stats.scannedFull).to.equal(0);
+  });
+
+  it('is not treated as covered by a sparse index', () => {
+    // the pushed down condition is a disjunction (!B || cmp), which
+    // collectOverlappingMembersForTraversal must never consider covered by an
+    // index: a sparse index does not contain the edges without a versionTo,
+    // which are exactly the ones the inline FILTER lets through
+    const edges = db._collection(edgeCollection);
+    const index = edges.ensureIndex({type: 'persistent', fields: ['_from', 'versionTo'], sparse: true});
+    try {
+      expect(run("global", activateOptimizer)).to.deep.equal(["e1", "e3", "e3>e4", "e3>e4>e5", "e3>e9"]);
+    } finally {
+      edges.dropIndex(index);
+    }
+  });
+
+  it('returns the same paths for global as for path uniqueness', () => {
+    expect(run("global", activateOptimizer)).to.deep.equal(run("path", activateOptimizer));
+  });
+
+  it('agrees with the unoptimized plan', () => {
+    // uniqueVertices: "path" is the reference: it cannot lose a path to a
+    // vertex that was visited through a rejected path
+    const reference = run("path", { optimizer: { rules: [ "-optimize-traversals" ] } });
+    expect(run("path", activateOptimizer)).to.deep.equal(reference);
+    expect(run("global", activateOptimizer)).to.deep.equal(reference);
+  });
 });


### PR DESCRIPTION
Use filter array expressions in traversal conditions if applicable.

```
FILTER p.edges[* FILTER Condition(CURRENT)].attr ALL op value
```
is translated to an per edge filter
```
!Condition($e) || $e.attr op value
```

Also contains a bug-fix. At least was not treated like any, which can't be optimized into an per-edge check.