### PR TITLE
Disable granting classic permissions when RBAC is switched on [COR-904]

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -1299,8 +1299,8 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
                             rbac::resources::User{user.name});
           },
           [&](p::GrantUserPermissions const& user) -> Result {
-            return checkOne(rbac::Action::WriteMeta,
-                            rbac::resources::User{user.name});
+            return {TRI_ERROR_FORBIDDEN,
+                    "Cannot modify classic user permissions in RBAC mode!"};
           },
           // -- API versions ----------------------------------------------
           [&](p::UseApiVersion const& apiVersion) -> Result {

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -395,7 +395,7 @@ TEST_F(RbacAuthModeTest, ModifyUserProfile) {
 
 TEST_F(RbacAuthModeTest, GrantUserPermissions) {
   check(p::GrantUserPermissions{.name = "alice"});
-  expectSingle(rbac::Action::WriteMeta, "user:alice");
+  ASSERT_TRUE(svc.queries.empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -394,7 +394,8 @@ TEST_F(RbacAuthModeTest, ModifyUserProfile) {
 }
 
 TEST_F(RbacAuthModeTest, GrantUserPermissions) {
-  check(p::GrantUserPermissions{.name = "alice"});
+  auto r = check(p::GrantUserPermissions{.name = "alice"});
+  ASSERT_EQ(r.errorNumber(), ErrorCode{11});
   ASSERT_TRUE(svc.queries.empty());
 }
 


### PR DESCRIPTION
### Scope & Purpose

As the title suggests: When RBAC is on, we disallow modifying classic
permissions.

- [*] :hankey: Bugfix
- [*] :hammer: Refactoring/simplification

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**

#### Related Information

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-916
- [ ] Design document: 
