### PR TITLE
[COR-868] Add support for conditional field processing to inspector

### DIFF
--- a/lib/Inspection/include/Inspection/InspectorBase.h
+++ b/lib/Inspection/include/Inspection/InspectorBase.h
@@ -201,6 +201,37 @@ struct InspectorBase : detail::ContextContainer<Context> {
   }
 
   template<class T>
+  static decltype(auto) getConditionalField(T& field) noexcept {
+    using TT = std::remove_cvref_t<T>;
+    if constexpr (detail::IsConditionalField<TT>::value) {
+      return field;
+    } else if constexpr (!detail::IsRawField<TT>::value) {
+      return getConditionalField(field.inner);
+    }
+  }
+
+  /// Evaluates the field's condition for the direction this inspector runs in.
+  /// Fields without an applicable condition are always processed.
+  template<class T>
+  static FieldCondition evaluateCondition(T& field) {
+    using Conditional = decltype(getConditionalField(field));
+    if constexpr (std::is_void_v<Conditional>) {
+      return FieldCondition::Process;
+    } else {
+      constexpr auto scope = std::remove_cvref_t<Conditional>::scope;
+      constexpr bool applies =
+          scope == detail::ConditionScope::Always ||
+          (Derived::isLoading ? scope == detail::ConditionScope::Loading
+                              : scope == detail::ConditionScope::Saving);
+      if constexpr (applies) {
+        return std::invoke(getConditionalField(field).predicate);
+      } else {
+        return FieldCondition::Process;
+      }
+    }
+  }
+
+  template<class T>
   static decltype(auto) getTransformer(T& field) noexcept {
     using TT = std::remove_cvref_t<T>;
     if constexpr (detail::IsTransformField<TT>::value) {

--- a/lib/Inspection/include/Inspection/LoadInspectorBase.h
+++ b/lib/Inspection/include/Inspection/LoadInspectorBase.h
@@ -306,20 +306,44 @@ struct LoadInspectorBase : InspectorBase<Derived, Context> {
            | [&]() { return embeddedFields->checkInvariant(); };
   }
 
-  [[nodiscard]] Status::Success parseField(FieldsMap& fields,
-                                           typename Base::IgnoreField&& field) {
-    if (auto it = fields.find(field.name); it != fields.end()) {
+  static void markFieldProcessed(FieldsMap& fields, std::string_view name) {
+    if (auto it = fields.find(name); it != fields.end()) {
       assert(!it->second.second &&
              "field processed twice during inspection. Make sure field names "
              "are unique!");
-      it->second.second = true;  // mark the field as processed
+      it->second.second = true;
     }
+  }
+
+  [[nodiscard]] Status::Success parseField(FieldsMap& fields,
+                                           typename Base::IgnoreField&& field) {
+    markFieldProcessed(fields, field.name);
     return {};
   }
 
   template<class T>
   [[nodiscard]] Status parseField(FieldsMap& fields, T&& field) {
     auto name = Base::getFieldName(field);
+    if (auto condition = Base::evaluateCondition(field);
+        condition != FieldCondition::Process) {
+      // A rejected field stays unprocessed, so an attribute of that name is
+      // reported by the unexpected-attribute check in applyFields.
+      if (condition == FieldCondition::Ignore) {
+        markFieldProcessed(fields, name);
+      }
+      // The attribute is not read, so the fallback provides the value - just
+      // as it does for an attribute that is missing from the input.
+      if constexpr (!std::is_void_v<decltype(Base::getFallbackField(field))>) {
+        Base::getFallbackField(field).apply(Base::getFieldValue(field));
+      }
+      // The condition governs whether the attribute is read, not whether the
+      // member must be valid - the invariant is checked either way.
+      if (auto res = this->checkInvariant(field); !res.ok()) {
+        return {std::move(res), name, Status::AttributeTag{}};
+      }
+      return {};
+    }
+
     bool isPresent = false;
     auto getFieldData = [&]() -> ValueType {
       if (auto it = fields.find(name); it != fields.end()) {

--- a/lib/Inspection/include/Inspection/README.md
+++ b/lib/Inspection/include/Inspection/README.md
@@ -206,6 +206,95 @@ auto inspect(Inspector& f, LogTargetConfig& x) {
 }
 ```
 
+### Conditional fields
+
+Fallbacks let a field be _optional_, but sometimes a field should not take part
+in the inspection at all, based on the data itself. The typical case is schema
+evolution, where a version attribute decides which of the remaining attributes
+exist:
+```cpp
+using arangodb::inspection::FieldCondition;
+
+struct Config {
+  std::uint32_t version = 1;
+  std::size_t writeConcern = 1;
+  bool waitForSync = false;  // added in version 2
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, Config& x) {
+  return f.object(x).fields(
+      f.field("version", x.version),
+      f.field("writeConcern", x.writeConcern),
+      f.field("waitForSync", x.waitForSync).when([&x] {
+        return x.version >= 2 ? FieldCondition::Process : FieldCondition::Reject;
+      }));
+}
+```
+
+The predicate is called without arguments and returns a `FieldCondition`:
+
+  * `Process` - the field is loaded/saved as usual.
+  * `Reject` - the field is skipped. When loading, an attribute of that name
+    present in the input is reported as an unexpected attribute; when saving,
+    the field is omitted from the output.
+  * `Ignore` - the field is skipped. When loading, an attribute of that name
+    present in the input is silently ignored; when saving, the field is omitted
+    from the output.
+
+`Reject` and `Ignore` only differ while loading - both omit the field when
+saving. Use `Ignore` for attributes that may legitimately still be present in
+old data, and `Reject` to catch data that does not match its own version.
+
+Just like fallbacks, conditions are evaluated in the order the fields are
+specified, so a field whose condition inspects another field must be specified
+_after_ it - `version` above is already loaded when the condition of
+`waitForSync` is evaluated.
+
+A condition governs whether the _attribute_ is read and written, not whether
+the _member_ has to be valid. A skipped field therefore takes its value from
+its fallback (or fallback factory) if it declares one, and otherwise keeps the
+value it already had; its invariant is then checked against that value. For
+`Ignore` this holds whether or not the attribute is present, since an ignored
+attribute is never read as this field's data. Because invariants are checked
+either way, adding a condition to a field never silently reduces what is
+verified while loading.
+
+Conditions do not apply to the `ValidateInspector` at all. It reads no
+attributes, so there is nothing for a condition to govern - it validates every
+field unconditionally, including the inner invariants of fields whose type is
+itself an object. Note the consequence for two fields sharing an attribute name
+under complementary conditions: both are validated, so the inactive one has to
+hold a valid value as well.
+
+Note that this collapses "not part of the schema" and "part of the schema but
+omitted" onto the same value. Use `fallbackFactory` if the two need to differ -
+it can inspect fields that were specified before it:
+```cpp
+f.field("waitForSync", x.waitForSync)
+    .fallbackFactory([&x] { return x.version >= 2; })
+    .when([&x] {
+      return x.version >= 2 ? FieldCondition::Process : FieldCondition::Reject;
+    })
+```
+
+`when` applies in both directions. To control only one of them, use
+`whenLoading` or `whenSaving`; the field is unconditionally processed in the
+other direction. A field carries at most one condition - combining two of these
+calls on the same field is a compile error.
+
+If a field needs a _different_ condition per direction, note that the predicate
+is instantiated per Inspector, so a single `when` can still tell them apart:
+```cpp
+f.field("waitForSync", x.waitForSync).when([&x] {
+  if constexpr (Inspector::isLoading) {
+    return x.version >= 2 ? FieldCondition::Process : FieldCondition::Reject;
+  } else {
+    return x.version >= 3 ? FieldCondition::Process : FieldCondition::Reject;
+  }
+})
+```
+
 ### Embedded fields
 
 In some cases we may want to "reuse" the inspect function of some type, e.g.,

--- a/lib/Inspection/include/Inspection/SaveInspectorBase.h
+++ b/lib/Inspection/include/Inspection/SaveInspectorBase.h
@@ -191,6 +191,10 @@ struct SaveInspectorBase : InspectorBase<Derived, Context> {
     if constexpr (std::is_same_v<typename Base::IgnoreField, T>) {
       return Status::Success{};
     } else {
+      if (Base::evaluateCondition(field) != FieldCondition::Process) {
+        return Status{};
+      }
+
       auto name = Base::getFieldName(field);
       auto& value = Base::getFieldValue(field);
       constexpr bool hasFallback =

--- a/lib/Inspection/include/Inspection/Types.h
+++ b/lib/Inspection/include/Inspection/Types.h
@@ -26,6 +26,21 @@
 
 namespace arangodb::inspection {
 
+/// Result of a field condition, i.e., of the predicate passed to
+/// `field(...).when(...)` or one of its direction specific variants.
+enum class FieldCondition {
+  /// The field takes part in the inspection as usual.
+  Process,
+  /// The field is skipped. When loading, an attribute of that name present in
+  /// the input is reported as an unexpected attribute; when saving, the field
+  /// is omitted from the output.
+  Reject,
+  /// The field is skipped. When loading, an attribute of that name present in
+  /// the input is silently ignored; when saving, the field is omitted from the
+  /// output.
+  Ignore,
+};
+
 namespace detail {
 template<class T>
 struct AlternativeType {

--- a/lib/Inspection/include/Inspection/ValidateInspector.h
+++ b/lib/Inspection/include/Inspection/ValidateInspector.h
@@ -165,6 +165,9 @@ struct ValidateInspector : InspectorBase<ValidateInspector<Context>, Context> {
     auto name = Base::getFieldName(field);
     auto& value = Base::getFieldValue(field);
 
+    // Conditions govern whether an *attribute* is read or written. This
+    // inspector reads nothing, so they do not apply here: every field is
+    // validated, including the inner invariants of complex types.
     auto res = loadField(*this, name, true, value)         //
                | [&]() { return checkInvariant(field); };  //
 

--- a/lib/Inspection/include/Inspection/detail/Fields.h
+++ b/lib/Inspection/include/Inspection/detail/Fields.h
@@ -28,6 +28,7 @@
 #include <variant>
 
 #include "Inspection/Status.h"
+#include "Inspection/Types.h"
 
 namespace arangodb::inspection::detail {
 
@@ -49,6 +50,30 @@ struct FallbackFactoryField;
 
 template<class Inspector, class InnerField, class Invariant>
 struct InvariantField;
+
+/// Determines for which inspection direction a field condition is evaluated.
+/// In the direction it does not apply to, the field is always processed.
+enum class ConditionScope { Always, Loading, Saving };
+
+template<class Inspector, class InnerField, class Predicate,
+         ConditionScope Scope>
+struct ConditionalField;
+
+template<class T>
+struct IsConditionalField : std::false_type {};
+template<class Inspector, class T, class P, ConditionScope S>
+struct IsConditionalField<ConditionalField<Inspector, T, P, S>>
+    : std::true_type {};
+
+/// True if `Field` or any of the fields it wraps carries a condition.
+template<class Field, class = void>
+struct ContainsCondition : std::false_type {};
+
+template<class Field>
+struct ContainsCondition<Field, std::void_t<decltype(Field::inner)>>
+    : std::disjunction<
+          IsConditionalField<Field>,
+          ContainsCondition<std::remove_cvref_t<decltype(Field::inner)>>> {};
 
 template<class Inspector, class Field>
 struct InvariantMixin {
@@ -86,6 +111,46 @@ struct TransformMixin {
   [[nodiscard]] auto transformWith(T transformer) && {
     return TransformField<Inspector, Field, T>(
         std::move(static_cast<Field&>(*this)), std::move(transformer));
+  }
+};
+
+/// Attaches a condition to a field. A field carries at most one condition, so
+/// `ConditionalField` deliberately does not inherit this mixin - chaining two
+/// conditions is a compile error instead of one of them being dropped.
+template<class Inspector, class Field>
+struct ConditionMixin {
+  /// Evaluates `predicate` both when loading and when saving.
+  template<class Predicate>
+  [[nodiscard]] auto when(Predicate predicate) && {
+    return makeConditional<ConditionScope::Always>(std::move(predicate));
+  }
+
+  /// Evaluates `predicate` when loading; the field is always saved.
+  template<class Predicate>
+  [[nodiscard]] auto whenLoading(Predicate predicate) && {
+    return makeConditional<ConditionScope::Loading>(std::move(predicate));
+  }
+
+  /// Evaluates `predicate` when saving; the field is always loaded.
+  template<class Predicate>
+  [[nodiscard]] auto whenSaving(Predicate predicate) && {
+    return makeConditional<ConditionScope::Saving>(std::move(predicate));
+  }
+
+ private:
+  template<ConditionScope Scope, class Predicate>
+  auto makeConditional(Predicate&& predicate) {
+    static_assert(
+        std::is_invocable_r_v<FieldCondition, Predicate> &&
+            std::is_same_v<std::invoke_result_t<Predicate>, FieldCondition>,
+        "Field conditions must be invocable without arguments and return "
+        "inspection::FieldCondition");
+    static_assert(!ContainsCondition<Field>::value,
+                  "A field must not carry more than one condition");
+
+    return ConditionalField<Inspector, Field, Predicate, Scope>(
+        std::move(static_cast<Field&>(*this)),
+        std::forward<Predicate>(predicate));
   }
 };
 
@@ -139,7 +204,8 @@ using WithTransform =
 template<class Inspector, typename DerivedField>
 struct BasicField : InvariantMixin<Inspector, DerivedField>,
                     FallbackMixin<Inspector, DerivedField>,
-                    TransformMixin<Inspector, DerivedField> {
+                    TransformMixin<Inspector, DerivedField>,
+                    ConditionMixin<Inspector, DerivedField> {
   explicit BasicField(std::string_view name) : name(name) {}
   std::string_view name;
 };
@@ -164,7 +230,9 @@ struct FallbackField
       WithInvariant<Inspector,
                     FallbackField<Inspector, InnerField, FallbackValue>>,
       WithTransform<Inspector,
-                    FallbackField<Inspector, InnerField, FallbackValue>> {
+                    FallbackField<Inspector, InnerField, FallbackValue>>,
+      ConditionMixin<Inspector,
+                     FallbackField<Inspector, InnerField, FallbackValue>> {
   FallbackField(InnerField inner, FallbackValue&& val)
       : Inspector::template FallbackContainer<FallbackValue>(std::move(val)),
         inner(std::move(inner)) {}
@@ -178,7 +246,9 @@ struct FallbackFactoryField
       WithInvariant<Inspector, FallbackFactoryField<Inspector, InnerField,
                                                     FallbackFactory>>,
       WithTransform<Inspector, FallbackFactoryField<Inspector, InnerField,
-                                                    FallbackFactory>> {
+                                                    FallbackFactory>>,
+      ConditionMixin<Inspector, FallbackFactoryField<Inspector, InnerField,
+                                                     FallbackFactory>> {
   FallbackFactoryField(InnerField inner, FallbackFactory&& fn)
       : Inspector::template FallbackFactoryContainer<FallbackFactory>(
             std::move(fn)),
@@ -192,7 +262,9 @@ struct InvariantField
     : Inspector::template InvariantContainer<Invariant>,
       WithFallback<Inspector, InvariantField<Inspector, InnerField, Invariant>>,
       WithTransform<Inspector,
-                    InvariantField<Inspector, InnerField, Invariant>> {
+                    InvariantField<Inspector, InnerField, Invariant>>,
+      ConditionMixin<Inspector,
+                     InvariantField<Inspector, InnerField, Invariant>> {
   InvariantField(InnerField inner, Invariant&& invariant)
       : Inspector::template InvariantContainer<Invariant>(std::move(invariant)),
         inner(std::move(inner)) {}
@@ -205,12 +277,31 @@ struct TransformField
     : WithInvariant<Inspector,
                     TransformField<Inspector, InnerField, Transformer>>,
       WithFallback<Inspector,
-                   TransformField<Inspector, InnerField, Transformer>> {
+                   TransformField<Inspector, InnerField, Transformer>>,
+      ConditionMixin<Inspector,
+                     TransformField<Inspector, InnerField, Transformer>> {
   TransformField(InnerField inner, Transformer&& transformer)
       : inner(std::move(inner)), transformer(std::move(transformer)) {}
   using value_type = typename InnerField::value_type;
   InnerField inner;
   Transformer transformer;
+};
+
+template<class Inspector, class InnerField, class Predicate,
+         ConditionScope Scope>
+struct ConditionalField
+    : WithInvariant<Inspector,
+                    ConditionalField<Inspector, InnerField, Predicate, Scope>>,
+      WithFallback<Inspector,
+                   ConditionalField<Inspector, InnerField, Predicate, Scope>>,
+      WithTransform<Inspector,
+                    ConditionalField<Inspector, InnerField, Predicate, Scope>> {
+  ConditionalField(InnerField inner, Predicate&& predicate)
+      : inner(std::move(inner)), predicate(std::move(predicate)) {}
+  using value_type = typename InnerField::value_type;
+  static constexpr ConditionScope scope = Scope;
+  InnerField inner;
+  Predicate predicate;
 };
 
 template<class T>

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -1046,6 +1046,254 @@ TEST_F(VPackLoadInspectorTest, load_object_with_invariant_and_fallback) {
   EXPECT_EQ("foobar", i.s);
 }
 
+TEST_F(VPackLoadInspectorTest, load_conditional_field_when_condition_is_met) {
+  builder.openObject();
+  builder.add("version", VPackValue(2));
+  builder.add("newField", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalReject c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_rejecting_condition_leaves_value_untouched) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalReject c{.version = 0, .newField = 7};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(7, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_rejecting_condition_rejects_present_field) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.add("newField", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalReject c;
+  auto result = inspector.apply(c);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Found unexpected attribute 'newField'", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_rejecting_condition_tolerates_present_field_when_ignoring_unknown) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.add("newField", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder, {.ignoreUnknownFields = true}};
+
+  ConditionalReject c{.version = 0, .newField = 7};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(7, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_ignoring_condition_tolerates_present_field) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.add("newField", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalIgnore c{.version = 0, .newField = 7};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(7, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_applies_load_scoped_condition) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalLoadOnly c{.version = 0, .newField = 7};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(7, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_ignores_save_scoped_condition) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.add("newField", VPackValue(42));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalSaveOnly c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_skipped_field_applies_fallback) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalWithFallback c{.version = 0, .newField = 7};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_processed_field_still_applies_fallback) {
+  builder.openObject();
+  builder.add("version", VPackValue(2));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalWithFallback c{.version = 0, .newField = 7};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_skipped_field_checks_invariant_on_fallback) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  // The member starts out violating the invariant; only the fallback, applied
+  // before the check, makes it valid.
+  ConditionalFallbackAndInvariant c{.version = 0, .newField = 0};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_selects_first_alternative_field) {
+  builder.openObject();
+  builder.add("useId", VPackValue(true));
+  builder.add("target", VPackValue(7));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  AlternativeFields a{.useId = false, .id = 0, .name = "untouched"};
+  auto result = inspector.apply(a);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(7u, a.id);
+  EXPECT_EQ("untouched", a.name);
+}
+
+TEST_F(VPackLoadInspectorTest, load_selects_second_alternative_field) {
+  builder.openObject();
+  builder.add("useId", VPackValue(false));
+  builder.add("target", VPackValue("foo"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  AlternativeFields a{.useId = true, .id = 42, .name = ""};
+  auto result = inspector.apply(a);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42u, a.id);
+  EXPECT_EQ("foo", a.name);
+}
+
+TEST_F(VPackLoadInspectorTest, load_alternative_field_resolves_fallback_through_condition) {
+  builder.openObject();
+  builder.add("useId", VPackValue(false));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  AlternativeFields a{.useId = true, .id = 0, .name = "untouched"};
+  auto result = inspector.apply(a);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ("untouched", a.name);
+}
+
+TEST_F(VPackLoadInspectorTest,
+       load_alternative_field_stays_required_without_fallback) {
+  builder.openObject();
+  builder.add("useId", VPackValue(true));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  AlternativeFields a;
+  auto result = inspector.apply(a);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Missing required attribute 'target'", result.error());
+}
+
+TEST_F(VPackLoadInspectorTest, load_skipped_field_still_checks_invariant) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.close();
+
+  {  // the member has no fallback, so its own value is what gets checked
+    VPackLoadInspector inspector{builder};
+    ConditionalWithInvariant c{.version = 0, .newField = 0};
+    auto result = inspector.apply(c);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("newField", result.path());
+  }
+  {
+    VPackLoadInspector inspector{builder};
+    ConditionalWithInvariant c{.version = 0, .newField = 5};
+    auto result = inspector.apply(c);
+    ASSERT_TRUE(result.ok()) << result.error();
+    EXPECT_EQ(5, c.newField);
+  }
+}
+
+TEST_F(VPackLoadInspectorTest, load_processed_field_still_checks_invariant) {
+  builder.openObject();
+  builder.add("version", VPackValue(2));
+  builder.add("newField", VPackValue(0));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalWithInvariant c;
+  auto result = inspector.apply(c);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Field invariant failed", result.error());
+  EXPECT_EQ("newField", result.path());
+}
+
+TEST_F(VPackLoadInspectorTest, load_conditional_transformed_field) {
+  builder.openObject();
+  builder.add("version", VPackValue(2));
+  builder.add("newField", VPackValue("42"));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalWithTransform c;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, c.newField);
+}
+
+TEST_F(VPackLoadInspectorTest, load_conditional_embedded_field) {
+  builder.openObject();
+  builder.add("version", VPackValue(1));
+  builder.add("innerVersion", VPackValue(1));
+  builder.close();
+  VPackLoadInspector inspector{builder};
+
+  ConditionalEmbedded c;
+  c.inner.innerVersion = 0;
+  c.inner.newField = 7;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(7, c.inner.newField);
+}
+
 TEST_F(VPackLoadInspectorTest, load_object_with_object_invariant) {
   builder.openObject();
   builder.add("i", VPackValue(42));

--- a/tests/Inspection/VPackLoadTest.cpp
+++ b/tests/Inspection/VPackLoadTest.cpp
@@ -1205,7 +1205,8 @@ TEST_F(VPackLoadInspectorTest, load_selects_second_alternative_field) {
   EXPECT_EQ("foo", a.name);
 }
 
-TEST_F(VPackLoadInspectorTest, load_alternative_field_resolves_fallback_through_condition) {
+TEST_F(VPackLoadInspectorTest,
+       load_alternative_field_resolves_fallback_through_condition) {
   builder.openObject();
   builder.add("useId", VPackValue(false));
   builder.close();

--- a/tests/Inspection/VPackSaveTest.cpp
+++ b/tests/Inspection/VPackSaveTest.cpp
@@ -439,6 +439,94 @@ TEST_F(VPackSaveInspectorTest, store_object_with_invariant_and_fallback) {
       sizeof(inspector.field("i", i.i).fallback(42).invariant(invariant)));
 }
 
+TEST_F(VPackSaveInspectorTest, conditions_are_detected_anywhere_in_the_chain) {
+  // A field carries at most one condition; the detection that enforces this
+  // must see through the other decorators.
+  int i = 0;
+  auto condition = [] { return inspection::FieldCondition::Process; };
+  auto plain = inspector.field("i", i);
+  auto conditional = inspector.field("i", i).when(condition).fallback(42);
+
+  static_assert(!inspection::detail::ContainsCondition<decltype(plain)>::value);
+  static_assert(
+      inspection::detail::ContainsCondition<decltype(conditional)>::value);
+}
+
+TEST_F(VPackSaveInspectorTest, store_writes_only_the_active_alternative_field) {
+  AlternativeFields a{.useId = false, .id = 7, .name = "foo"};
+  auto result = inspector.apply(a);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(2u, builder.slice().length());
+  EXPECT_EQ("foo", builder.slice()["target"].copyString());
+}
+
+TEST_F(VPackSaveInspectorTest, store_uses_the_saving_branch_of_a_condition) {
+  {
+    // the loading branch would already include the field at version 2
+    AsymmetricCondition c{.version = 2, .newField = 42};
+    auto result = inspector.apply(c);
+    ASSERT_TRUE(result.ok()) << result.error();
+    EXPECT_TRUE(builder.slice()["newField"].isNone());
+  }
+  {
+    velocypack::Builder b;
+    VPackSaveInspector i{b};
+    AsymmetricCondition c{.version = 3, .newField = 42};
+    auto result = i.apply(c);
+    ASSERT_TRUE(result.ok()) << result.error();
+    EXPECT_EQ(42, b.slice()["newField"].getInt());
+  }
+}
+
+TEST_F(VPackSaveInspectorTest, store_conditional_field_when_condition_is_met) {
+  ConditionalReject c{.version = 2, .newField = 42};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(2, builder.slice()["version"].getInt());
+  EXPECT_EQ(42, builder.slice()["newField"].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_omits_field_for_any_skipping_condition) {
+  {  // Reject and Ignore are indistinguishable when saving
+    ConditionalReject c{.version = 1, .newField = 42};
+    auto result = inspector.apply(c);
+    ASSERT_TRUE(result.ok()) << result.error();
+    EXPECT_EQ(1, builder.slice()["version"].getInt());
+    EXPECT_TRUE(builder.slice()["newField"].isNone());
+  }
+  {
+    velocypack::Builder b;
+    VPackSaveInspector i{b};
+    ConditionalIgnore c{.version = 1, .newField = 42};
+    auto result = i.apply(c);
+    ASSERT_TRUE(result.ok()) << result.error();
+    EXPECT_TRUE(b.slice()["newField"].isNone());
+  }
+}
+
+TEST_F(VPackSaveInspectorTest, store_applies_save_scoped_condition) {
+  ConditionalSaveOnly c{.version = 1, .newField = 42};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_TRUE(builder.slice()["newField"].isNone());
+}
+
+TEST_F(VPackSaveInspectorTest, store_ignores_load_scoped_condition) {
+  ConditionalLoadOnly c{.version = 1, .newField = 42};
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(42, builder.slice()["newField"].getInt());
+}
+
+TEST_F(VPackSaveInspectorTest, store_omits_conditional_embedded_field) {
+  ConditionalEmbedded c;
+  c.inner.newField = 42;
+  auto result = inspector.apply(c);
+  ASSERT_TRUE(result.ok()) << result.error();
+  EXPECT_EQ(1, builder.slice()["innerVersion"].getInt());
+  EXPECT_TRUE(builder.slice()["newField"].isNone());
+}
+
 TEST_F(VPackSaveInspectorTest, store_object_with_field_transform) {
   FieldTransform f{.x = 42};
   auto result = inspector.apply(f);

--- a/tests/Inspection/ValidateTest.cpp
+++ b/tests/Inspection/ValidateTest.cpp
@@ -75,6 +75,57 @@ TEST_F(ValidateInspectorTest,
   }
 }
 
+TEST_F(ValidateInspectorTest, validate_checks_invariant_regardless_of_condition) {
+  {  // skipped field, invariant violated
+    ConditionalWithInvariant c{.version = 1, .newField = 0};
+    auto result = inspector.apply(c);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("newField", result.path());
+  }
+  {  // skipped field, the member's own value satisfies the invariant
+    ConditionalWithInvariant c{.version = 1, .newField = 5};
+    auto result = inspector.apply(c);
+    ASSERT_TRUE(result.ok()) << result.error();
+  }
+  {  // processed field, invariant violated
+    ConditionalWithInvariant c{.version = 2, .newField = 0};
+    auto result = inspector.apply(c);
+    ASSERT_FALSE(result.ok());
+    EXPECT_EQ("Field invariant failed", result.error());
+    EXPECT_EQ("newField", result.path());
+  }
+}
+
+TEST_F(ValidateInspectorTest, validate_checks_inner_invariants_of_skipped_field) {
+  ConditionalNested c{.version = 1, .inner = {.i = 0, .s = "x"}};
+  auto result = inspector.apply(c);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Field invariant failed", result.error());
+  EXPECT_EQ("inner.i", result.path());
+}
+
+TEST_F(ValidateInspectorTest, validate_also_checks_the_inactive_alternative) {
+  // Conditions do not apply here, so both alternatives sharing an attribute
+  // name are validated - the inactive one must hold a valid value too.
+  AlternativeFields a{.useId = true, .id = 7, .name = ""};
+  auto result = inspector.apply(a);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Field invariant failed", result.error());
+  EXPECT_EQ("target", result.path());
+}
+
+TEST_F(ValidateInspectorTest, validate_does_not_apply_fallback_to_skipped_field) {
+  // Loading applies the fallback before checking the invariant, so the same
+  // object loads fine. Validation must not modify the object to "fix" it.
+  ConditionalFallbackAndInvariant c{.version = 1, .newField = 0};
+  auto result = inspector.apply(c);
+  ASSERT_FALSE(result.ok());
+  EXPECT_EQ("Field invariant failed", result.error());
+  EXPECT_EQ("newField", result.path());
+  EXPECT_EQ(0, c.newField);
+}
+
 TEST_F(ValidateInspectorTest, validate_object_with_object_invariant) {
   ObjectInvariant o{.i = 42, .s = ""};
   auto result = inspector.apply(o);

--- a/tests/Inspection/ValidateTest.cpp
+++ b/tests/Inspection/ValidateTest.cpp
@@ -75,7 +75,8 @@ TEST_F(ValidateInspectorTest,
   }
 }
 
-TEST_F(ValidateInspectorTest, validate_checks_invariant_regardless_of_condition) {
+TEST_F(ValidateInspectorTest,
+       validate_checks_invariant_regardless_of_condition) {
   {  // skipped field, invariant violated
     ConditionalWithInvariant c{.version = 1, .newField = 0};
     auto result = inspector.apply(c);
@@ -97,7 +98,8 @@ TEST_F(ValidateInspectorTest, validate_checks_invariant_regardless_of_condition)
   }
 }
 
-TEST_F(ValidateInspectorTest, validate_checks_inner_invariants_of_skipped_field) {
+TEST_F(ValidateInspectorTest,
+       validate_checks_inner_invariants_of_skipped_field) {
   ConditionalNested c{.version = 1, .inner = {.i = 0, .s = "x"}};
   auto result = inspector.apply(c);
   ASSERT_FALSE(result.ok());
@@ -115,7 +117,8 @@ TEST_F(ValidateInspectorTest, validate_also_checks_the_inactive_alternative) {
   EXPECT_EQ("target", result.path());
 }
 
-TEST_F(ValidateInspectorTest, validate_does_not_apply_fallback_to_skipped_field) {
+TEST_F(ValidateInspectorTest,
+       validate_does_not_apply_fallback_to_skipped_field) {
   // Loading applies the fallback before checking the invariant, so the same
   // object loads fine. Validation must not modify the object to "fix" it.
   ConditionalFallbackAndInvariant c{.version = 1, .newField = 0};

--- a/tests/Inspection/include/Inspection/InspectionTestHelper.h
+++ b/tests/Inspection/include/Inspection/InspectionTestHelper.h
@@ -703,6 +703,216 @@ auto inspect(Inspector& f, NestedEmbeddingWithObjectInvariant& v) {
       f.embedFields(static_cast<EmbeddedObjectInvariant&>(v)));
 }
 
+// Conditions are evaluated in field declaration order while loading, so a
+// field whose condition inspects `version` must be declared after it.
+inline auto processFromV2(int const& version) {
+  return [&version] {
+    return version >= 2 ? arangodb::inspection::FieldCondition::Process
+                        : arangodb::inspection::FieldCondition::Reject;
+  };
+}
+
+inline auto ignoreBeforeV2(int const& version) {
+  return [&version] {
+    return version >= 2 ? arangodb::inspection::FieldCondition::Process
+                        : arangodb::inspection::FieldCondition::Ignore;
+  };
+}
+
+struct ConditionalReject {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalReject& x) {
+  return f.object(x).fields(
+      f.field("version", x.version),
+      f.field("newField", x.newField).when(processFromV2(x.version)));
+}
+
+struct ConditionalIgnore {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalIgnore& x) {
+  return f.object(x).fields(
+      f.field("version", x.version),
+      f.field("newField", x.newField).when(ignoreBeforeV2(x.version)));
+}
+
+struct ConditionalLoadOnly {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalLoadOnly& x) {
+  return f.object(x).fields(
+      f.field("version", x.version),
+      f.field("newField", x.newField).whenLoading(processFromV2(x.version)));
+}
+
+struct ConditionalSaveOnly {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalSaveOnly& x) {
+  return f.object(x).fields(
+      f.field("version", x.version),
+      f.field("newField", x.newField).whenSaving(processFromV2(x.version)));
+}
+
+// A single `when` can still distinguish the directions, because the predicate
+// body is instantiated per Inspector.
+struct AsymmetricCondition {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, AsymmetricCondition& x) {
+  return f.object(x).fields(f.field("version", x.version),
+                            f.field("newField", x.newField).when([&x] {
+                              using arangodb::inspection::FieldCondition;
+                              if constexpr (Inspector::isLoading) {
+                                return x.version >= 2 ? FieldCondition::Process
+                                                      : FieldCondition::Reject;
+                              } else {
+                                return x.version >= 3 ? FieldCondition::Process
+                                                      : FieldCondition::Reject;
+                              }
+                            }));
+}
+
+// The only chain where a decorator follows `when`, i.e. where ConditionalField
+// is *not* outermost and evaluateCondition has to find the condition by
+// recursing through another wrapper. Every other conditional struct ends in
+// `when`, so this is the sole coverage of that traversal.
+struct ConditionalWithFallback {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalWithFallback& x) {
+  return f.object(x).fields(f.field("version", x.version),
+                            f.field("newField", x.newField)
+                                .when(processFromV2(x.version))
+                                .fallback(42));
+}
+
+// The fallback has to be applied before the invariant is checked.
+struct ConditionalFallbackAndInvariant {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalFallbackAndInvariant& x) {
+  return f.object(x).fields(f.field("version", x.version),
+                            f.field("newField", x.newField)
+                                .fallback(42)
+                                .invariant([](int v) { return v != 0; })
+                                .when(processFromV2(x.version)));
+}
+
+struct ConditionalWithInvariant {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalWithInvariant& x) {
+  return f.object(x).fields(f.field("version", x.version),
+                            f.field("newField", x.newField)
+                                .invariant([](int v) { return v != 0; })
+                                .when(processFromV2(x.version)));
+}
+
+// A skipped field of a complex type. The field itself declares no invariant -
+// the meaningful checks all live inside `Invariant`.
+struct ConditionalNested {
+  int version = 1;
+  Invariant inner;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalNested& x) {
+  return f.object(x).fields(
+      f.field("version", x.version),
+      f.field("inner", x.inner).when(processFromV2(x.version)));
+}
+
+struct ConditionalWithTransform {
+  int version = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalWithTransform& x) {
+  return f.object(x).fields(f.field("version", x.version),
+                            f.field("newField", x.newField)
+                                .transformWith(MyTransformer{})
+                                .when(processFromV2(x.version)));
+}
+
+// Two alternative definitions of the same attribute, kept apart by
+// complementary conditions. Exactly one of them may be processed.
+struct AlternativeFields {
+  bool useId = false;
+  std::uint64_t id = 0;
+  std::string name;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, AlternativeFields& x) {
+  auto ifUsingId = [&x] {
+    return x.useId ? arangodb::inspection::FieldCondition::Process
+                   : arangodb::inspection::FieldCondition::Reject;
+  };
+  auto ifUsingName = [&x] {
+    return x.useId ? arangodb::inspection::FieldCondition::Reject
+                   : arangodb::inspection::FieldCondition::Process;
+  };
+  return f.object(x).fields(
+      f.field("useId", x.useId),
+      f.field("target", x.id)
+          .invariant([](std::uint64_t v) { return v != 99; })
+          .when(ifUsingId),
+      f.field("target", x.name)
+          .fallback(f.keep())
+          .invariant([](std::string const& v) { return !v.empty(); })
+          .when(ifUsingName));
+}
+
+struct ConditionalEmbeddable {
+  int innerVersion = 1;
+  int newField = 0;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalEmbeddable& x) {
+  return f.object(x).fields(
+      f.field("innerVersion", x.innerVersion),
+      f.field("newField", x.newField).when(processFromV2(x.innerVersion)));
+}
+
+struct ConditionalEmbedded {
+  int version = 1;
+  ConditionalEmbeddable inner;
+};
+
+template<class Inspector>
+auto inspect(Inspector& f, ConditionalEmbedded& x) {
+  return f.object(x).fields(f.field("version", x.version),
+                            f.embedFields(x.inner));
+}
+
 struct WithContext {
   int i;
   std::string s;


### PR DESCRIPTION
### Scope & Purpose

Sometimes a field should not take part in the inspection at all, based on the data itself. The typical case is schema
evolution, where a version attribute decides which of the remaining attributes exist:
```cpp
using arangodb::inspection::FieldCondition;

struct Config {
  std::uint32_t version = 1;
  std::size_t writeConcern = 1;
  bool waitForSync = false;  // added in version 2
};

template<class Inspector>
auto inspect(Inspector& f, Config& x) {
  return f.object(x).fields(
      f.field("version", x.version),
      f.field("writeConcern", x.writeConcern),
      f.field("waitForSync", x.waitForSync).when([&x] {
        return x.version >= 2 ? FieldCondition::Process : FieldCondition::Reject;
      }));
}
```

The predicate is called without arguments and returns a `FieldCondition`:

  * `Process` - the field is loaded/saved as usual.
  * `Reject` - the field is skipped. When loading, an attribute of that name present in the input is reported as an unexpected attribute; when saving, the field is omitted from the output.
  * `Ignore` - the field is skipped. When loading, an attribute of that name present in the input is silently ignored; when saving, the field is omitted from the output.

`Reject` and `Ignore` only differ while loading - both omit the field when saving. Use `Ignore` for attributes that may legitimately still be present in old data, and `Reject` to catch data that does not match its own version.

Just like fallbacks, conditions are evaluated in the order the fields are specified, so a field whose condition inspects another field must be specified _after_ it - `version` above is already loaded when the condition of `waitForSync` is evaluated.

- [x] :pizza: New feature
### Checklist

- [x] Tests
  - [x] C++ **Unit tests**