### PR TITLE
[COR-927] /_api/version should always include the version field

### DIFF
--- a/arangod/RestHandler/RestAccessTokenHandler.cpp
+++ b/arangod/RestHandler/RestAccessTokenHandler.cpp
@@ -43,7 +43,7 @@ using namespace arangodb::rest;
 RestAccessTokenHandler::RestAccessTokenHandler(
     application_features::ApplicationServer& server, GeneralRequest* request,
     GeneralResponse* response)
-    : RestVocbaseBaseHandler(server, request, response) {}
+    : RestBaseHandler(server, request, response) {}
 
 // Mounted at /_api/token (prefix)
 RestStatus RestAccessTokenHandler::execute() {

--- a/arangod/RestHandler/RestAccessTokenHandler.h
+++ b/arangod/RestHandler/RestAccessTokenHandler.h
@@ -28,7 +28,7 @@ namespace auth {
 class UserManager;
 }
 
-class RestAccessTokenHandler : public RestVocbaseBaseHandler {
+class RestAccessTokenHandler : public RestBaseHandler {
  public:
   RestAccessTokenHandler(application_features::ApplicationServer&,
                          GeneralRequest*, GeneralResponse*);

--- a/arangod/RestHandler/RestVersionHandler.cpp
+++ b/arangod/RestHandler/RestVersionHandler.cpp
@@ -139,12 +139,14 @@ void RestVersionHandler::getVersion(
   result.add("license", VPackValue("community"));
 #endif
 
-  if (allowInfo) {
+  // "version" can be added unconditionally in 4.0
+  if (allowInfo || !ExecContext::current().isClassic() ||
+      requestedApiVersion > 0) {
     result.add("version", VPackValue(ARANGODB_VERSION));
+  }
 
-    if (includeDetails) {
-      addVersionDetails(server, result);
-    }
+  if (allowInfo && includeDetails) {
+    addVersionDetails(server, result);
   }
 
   // Add API version information (both in short and long form)


### PR DESCRIPTION
### Scope & Purpose

`--server.harden=true` hid the arangod version from `/_api/version` for non-admin users; and with RBAC, that was true for everyone without the _AdminMonitoringInternal_ action.

In addition to a lot of tools relying on the version field, the version is a necessity for drivers to work with the versioned API. So we decided to include it unconditionally, with one exception:

With API v0 and Classic authentication, we leave it as-is to keep backwards compatibility.

One unrelated minor cleanup: `RestAccessTokenHandler` doesn't need a Vocbase.

- [ ] :hankey: Bugfix
- [X] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
