### PR TITLE
[COR-931] Propagate communication errors as exceptions rather than result

### DIFF
--- a/arangod/Auth/Rbac/ServiceImpl.cpp
+++ b/arangod/Auth/Rbac/ServiceImpl.cpp
@@ -172,8 +172,9 @@ auto ServiceImpl::check(JwtToken const& token,
   auto result = _backend->evaluateTokenManySync(token, items);
 
   if (!result.ok()) {
-    // Transport or parsing error: propagate it verbatim.
-    return result.result();
+    // transport or parse errors must be exceptions, the Result
+    // return value must reflect allow or deny.
+    THROW_ARANGO_EXCEPTION(std::move(result).result());
   }
   auto const& response = result.get();
   if (response.effect == Backend::Effect::Allow) {

--- a/tests/Auth/RbacServiceImplTest.cpp
+++ b/tests/Auth/RbacServiceImplTest.cpp
@@ -219,7 +219,7 @@ TEST(RbacServiceImplCheckTest, denyReturnsForbiddenWithMessage) {
   EXPECT_EQ(r.errorMessage(), "role lacks db:Read");
 }
 
-TEST(RbacServiceImplCheckTest, backendErrorIsPropagated) {
+TEST(RbacServiceImplCheckTest, backendErrorIsThrown) {
   struct ErrorBackend : rbac::Backend {
     auto evaluateTokenManyImpl(rbac::JwtToken const&, RequestItems const&,
                                transaction::MethodsApi)
@@ -230,8 +230,7 @@ TEST(RbacServiceImplCheckTest, backendErrorIsPropagated) {
   rbac::ServiceImpl svc{std::make_unique<ErrorBackend>()};
   std::array queries{rbac::ActionResource{
       rbac::Action::Read, rbac::resources::Database{.name = "mydb"}}};
-  auto r = svc.check({testToken}, queries);
-  EXPECT_EQ(r.errorNumber(), TRI_ERROR_INTERNAL);
+  EXPECT_THROW((svc.check({testToken}, queries)), basics::Exception);
 }
 
 TEST(RbacServiceImplCheckTest, emptyBatchIsOkWithoutBackendCall) {


### PR DESCRIPTION
### Scope & Purpose

The ExecContext `can` API, and in turn `IAuth::check` and `rbac::Service::check`, should return an allow/deny decision in the Result (e.g. no error, forbidden, read-only), but not communication errors - these should be thrown as exceptions.

There is code that relies on this, e.g. https://github.com/arangodb/arangodb/blob/devel/arangod/StorageEngine/TransactionState.cpp#L719

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
