### PR TITLE
Finishing touches to address Claude findings [COR-933]

### DIFF
--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -1058,7 +1058,9 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
                     checkOne(adminAction(admin), rbac::resources::NoResource{});
                 r.fail()) {
               // This is for backwards compatibility with the classic case
-              return {TRI_ERROR_HTTP_FORBIDDEN, r.errorMessage()};
+              return _requestedApiVersion == 0
+                         ? Result{TRI_ERROR_HTTP_FORBIDDEN, r.errorMessage()}
+                         : r;
             }
             return {};
           },
@@ -1323,7 +1325,9 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
             if (auto r = checkOne(rbac::Action::Read,
                                   rbac::resources::User{user.name});
                 r.fail()) {
-              return {TRI_ERROR_HTTP_FORBIDDEN, r.errorMessage()};
+              return _requestedApiVersion == 0
+                         ? Result{TRI_ERROR_HTTP_FORBIDDEN, r.errorMessage()}
+                         : r;
             }
             return {};
           },

--- a/arangod/Auth/AuthMode.cpp
+++ b/arangod/Auth/AuthMode.cpp
@@ -1054,7 +1054,13 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
       overload{
           // -- Admin actions ---------------------------------------------
           [&](p::AnyAdmin auto const& admin) -> Result {
-            return checkOne(adminAction(admin), rbac::resources::NoResource{});
+            if (auto r =
+                    checkOne(adminAction(admin), rbac::resources::NoResource{});
+                r.fail()) {
+              // This is for backwards compatibility with the classic case
+              return {TRI_ERROR_HTTP_FORBIDDEN, r.errorMessage()};
+            }
+            return {};
           },
           // -- Databases -------------------------------------------------
           [&](p::UseDatabase const& database) -> Result {
@@ -1075,21 +1081,69 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
           },
           // -- Collections -----------------------------------------------
           [&](p::UseCollection const& collection) -> Result {
+            // _system._users: always NONE access (no user may touch it
+            // through normal APIs).
+            if (collection.db == StaticStrings::SystemDatabase &&
+                collection.name == StaticStrings::UsersCollection) {
+              return {
+                  TRI_ERROR_FORBIDDEN,
+                  failureMessage(collection,
+                                 std::format("Access to {} collection in {} "
+                                             "database is forbidden",
+                                             StaticStrings::UsersCollection,
+                                             StaticStrings::SystemDatabase))};
+            }
             return checkOne(
                 collectionAccessModeToAction(collection.level),
                 rbac::resources::Collection{collection.db, collection.name});
           },
           [&](p::SeeCollection const& collection) -> Result {
+            // _system._users: always NONE access (no user may touch it
+            // through normal APIs).
+            if (collection.db == StaticStrings::SystemDatabase &&
+                collection.name == StaticStrings::UsersCollection) {
+              return {
+                  TRI_ERROR_FORBIDDEN,
+                  failureMessage(collection,
+                                 std::format("Access to {} collection in {} "
+                                             "database is forbidden",
+                                             StaticStrings::UsersCollection,
+                                             StaticStrings::SystemDatabase))};
+            }
             return checkOne(
                 rbac::Action::Read,
                 rbac::resources::Collection{collection.db, collection.name});
           },
           [&](p::CreateCollection const& collection) -> Result {
+            // _system._users: always NONE access (no user may touch it
+            // through normal APIs).
+            if (collection.db == StaticStrings::SystemDatabase &&
+                collection.name == StaticStrings::UsersCollection) {
+              return {
+                  TRI_ERROR_FORBIDDEN,
+                  failureMessage(collection,
+                                 std::format("Access to {} collection in {} "
+                                             "database is forbidden",
+                                             StaticStrings::UsersCollection,
+                                             StaticStrings::SystemDatabase))};
+            }
             return checkOne(
                 rbac::Action::Create,
                 rbac::resources::Collection{collection.db, collection.name});
           },
           [&](p::DropCollection const& collection) -> Result {
+            // _system._users: always NONE access (no user may touch it
+            // through normal APIs).
+            if (collection.db == StaticStrings::SystemDatabase &&
+                collection.name == StaticStrings::UsersCollection) {
+              return {
+                  TRI_ERROR_FORBIDDEN,
+                  failureMessage(collection,
+                                 std::format("Access to {} collection in {} "
+                                             "database is forbidden",
+                                             StaticStrings::UsersCollection,
+                                             StaticStrings::SystemDatabase))};
+            }
             return checkOne(
                 rbac::Action::Drop,
                 rbac::resources::Collection{collection.db, collection.name});
@@ -1266,8 +1320,12 @@ auto AuthMode::Rbac::check(auth::Permission permission) const -> Result {
           // Each user operation maps to the identically-scoped action on the
           // db:user:<name> resource.
           [&](p::ReadUser const& user) -> Result {
-            return checkOne(rbac::Action::Read,
-                            rbac::resources::User{user.name});
+            if (auto r = checkOne(rbac::Action::Read,
+                                  rbac::resources::User{user.name});
+                r.fail()) {
+              return {TRI_ERROR_HTTP_FORBIDDEN, r.errorMessage()};
+            }
+            return {};
           },
           [&](p::CreateUser const& user) -> Result {
             return checkOne(rbac::Action::Create,

--- a/arangod/Auth/AuthMode.h
+++ b/arangod/Auth/AuthMode.h
@@ -115,11 +115,14 @@ struct AuthMode {
     rbac::Service& _rbacService;
     std::string const _username;
     std::string const _jwtToken;
+    uint32_t _requestedApiVersion;
 
-    Rbac(rbac::Service& rbacService, std::string username, std::string jwtToken)
+    Rbac(rbac::Service& rbacService, std::string username, std::string jwtToken,
+         uint32_t requestedApiVersion)
         : _rbacService(rbacService),
           _username(std::move(username)),
-          _jwtToken(std::move(jwtToken)) {}
+          _jwtToken(std::move(jwtToken)),
+          _requestedApiVersion(requestedApiVersion) {}
 
     [[nodiscard]] auto username() const noexcept -> std::string_view override;
 

--- a/arangod/RestHandler/RestUsersHandler.cpp
+++ b/arangod/RestHandler/RestUsersHandler.cpp
@@ -183,6 +183,10 @@ RestStatus RestUsersHandler::getRequest(auth::UserManager* um) {
     }
 
     if (suffixes[1] == "database") {
+      if (!(exec.isClassic() || exec.isSuperuserOrDisabled())) {
+        generateError(Result{TRI_ERROR_FORBIDDEN, "Not allowed in RBAC mode."});
+        return RestStatus::DONE;
+      }
       if (suffixes.size() == 2) {
         //_api/user/<user>/database?full=<true/false>
         bool full = false;

--- a/arangod/Utils/ExecContext.cpp
+++ b/arangod/Utils/ExecContext.cpp
@@ -107,7 +107,8 @@ ExecContext::ExecContext(ConstructorToken, AuthMode authMode,
     }
 
     if (auto* rbacService = rbacFeature.service(); rbacService != nullptr) {
-      return AuthMode::Rbac(*rbacService, req.user(), req.jwtToken());
+      return AuthMode::Rbac(*rbacService, req.user(), req.jwtToken(),
+                            req.requestedApiVersion());
     }
 
     ADB_PROD_ASSERT(userManager != nullptr);

--- a/tests/Auth/RbacAuthModeTest.cpp
+++ b/tests/Auth/RbacAuthModeTest.cpp
@@ -108,7 +108,7 @@ struct MockService : rbac::Service {
 // Fixture bundling a mock service and the Rbac auth mode under test.
 struct RbacAuthModeTest : ::testing::Test {
   MockService svc;
-  AuthMode::Rbac rbac{svc, "myuser", "mytoken"};
+  AuthMode::Rbac rbac{svc, "myuser", "mytoken", 0};
 
   // Discarding wrapper around rbac.check(). IAuth::check is [[nodiscard]], so
   // tests that only inspect the recorded queries would otherwise not compile


### PR DESCRIPTION
### Scope & Purpose

This is about this:

 - RBAC should treat _users with the same special case as classic
 - Every RBAC action Admin* except AdminQueryCache should return 403 and not 11
 - ReadUser RBAC should deny with ErrorNum 403 instead of 11
 - /_api/user/<user>/database reports classic grants while RBAC does the enforcing --> looks like a bug, investigate


- [*] :hankey: Bugfix

### Checklist

- [*] Tests
  - [*] **Regression tests**
  - [*] C++ **Unit tests**
  - [*] **integration tests**

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [*] GitHub issue / Jira ticket: https://arangodb.atlassian.net/browse/COR-933
