### PR TITLE
[COR-932] avoid execcontext nullptr deref during startup

### DIFF
--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -808,9 +808,7 @@ async<void> RestHandler::handleAuthorizationChecks() {
   // This is a temporary band-aid so we answer with a 500 rather than crashing
   // in that situation. A proper fix will be implemented soon.
   if (request()->requestContext() == nullptr) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(
-        TRI_ERROR_INTERNAL,
-        "Missing ExecContext");
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "Missing ExecContext");
   }
 
   if (auto res = co_await checkApiVersionAccess(); res.fail()) {

--- a/arangod/GeneralServer/RestHandler.cpp
+++ b/arangod/GeneralServer/RestHandler.cpp
@@ -789,6 +789,30 @@ async<void> RestHandler::handleAuthorizationChecks() {
     co_return;
   }
 
+  // Authentication succeeded (AuthenticationGrant::GRANTED), so the request
+  // must carry an ExecContext for the authorization checks below. Any route
+  // that continues execution should have resolved a request context by now
+  // (see CommTask::prepareExecution). The allow-listed early paths served
+  // during STARTUP/MAINTENANCE do not, but their handlers return GRANTED_EARLY
+  // above and never reach this point.
+  //
+  // However, there's a race:
+  // When the CommTask checks the mode during request processing while it's
+  // STARTUP or MAINTENANCE, there's no vocbase nor ExecContext.
+  // If the mode changes to DEFAULT before checkUserAuthentication() is called
+  // (take, for example, `RestStatusHandler::checkUserAuthentication()`),
+  // it can return GRANTED rather than GRANTED_EARLY.
+  // But the following calls to `checkApiVersionAccess()` and
+  // `checkDatabaseAccess()` require an ExecContext.
+  //
+  // This is a temporary band-aid so we answer with a 500 rather than crashing
+  // in that situation. A proper fix will be implemented soon.
+  if (request()->requestContext() == nullptr) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        "Missing ExecContext");
+  }
+
   if (auto res = co_await checkApiVersionAccess(); res.fail()) {
     _state = HandlerState::FAILED;
     events::NotAuthorized(*_request);


### PR DESCRIPTION
### Scope & Purpose

With `--server.early-connections true`, there's a race when a request eligible for early connections is being processed during the server mode change from either STARTUP or MAINTENANCE to default, that can lead to a crash.

This PR turns that into a 500 instead. A proper fix avoiding the 500 will follow.

- [X] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
