### PR TITLE
[COR-936] Fix dump-options and dump-dependencies

### DIFF
--- a/lib/ApplicationFeatures/ApplicationServer.cpp
+++ b/lib/ApplicationFeatures/ApplicationServer.cpp
@@ -186,6 +186,8 @@ void ApplicationServer::run(int argc, char* argv[]) {
 
   processOptions();
 
+  maybeDumpOptions();
+
   // validate options of all features
   _state.store(State::IN_VALIDATE_OPTIONS, std::memory_order_release);
   reportServerProgress(State::IN_VALIDATE_OPTIONS);
@@ -201,6 +203,8 @@ void ApplicationServer::run(int argc, char* argv[]) {
   // turn off all features that depend on other features that have been
   // turned off
   disableDependentFeatures();
+
+  maybeDumpDependencies();
 
   // allows process control
   daemonize();
@@ -246,6 +250,36 @@ void ApplicationServer::run(int argc, char* argv[]) {
   // stopped
   _state.store(State::STOPPED, std::memory_order_release);
   reportServerProgress(State::STOPPED);
+}
+
+void ApplicationServer::maybeDumpOptions() {
+  if (_dumpOptions) {
+    auto builder = _options->toVelocyPack(
+        false, true, [](std::string const&) { return true; });
+    arangodb::velocypack::Options options;
+    options.prettyPrint = true;
+    std::cout << builder.slice().toJson(&options) << std::endl;
+    exit(EXIT_SUCCESS);
+  }
+}
+
+void ApplicationServer::maybeDumpDependencies() {
+  if (_dumpDependencies) {
+    std::cout << "digraph dependencies\n"
+              << "{\n"
+              << "  overlap = false;\n";
+    for (auto& [_id, feature] : _features) {
+      for (auto& before : feature->startsAfter()) {
+        std::string_view depName;
+        if (hasFeature(before)) {
+          depName = getFeature(before).name();
+        }
+        std::cout << "  " << feature->name() << " -> " << depName << ";\n";
+      }
+    }
+    std::cout << "}\n";
+    exit(EXIT_SUCCESS);
+  }
 }
 
 // signal the server to initiate a soft shutdown
@@ -415,32 +449,6 @@ void ApplicationServer::parseOptions(int argc, char* argv[]) {
   // handle `--version` command
   if (_printVersion) {
     rest::Version::print(std::cout);
-    exit(EXIT_SUCCESS);
-  }
-
-  if (_dumpDependencies) {
-    std::cout << "digraph dependencies\n"
-              << "{\n"
-              << "  overlap = false;\n";
-    for (auto& [_id, feature] : _features) {
-      for (auto& before : feature->startsAfter()) {
-        std::string_view depName;
-        if (hasFeature(before)) {
-          depName = getFeature(before).name();
-        }
-        std::cout << "  " << feature->name() << " -> " << depName << ";\n";
-      }
-    }
-    std::cout << "}\n";
-    exit(EXIT_SUCCESS);
-  }
-
-  if (_dumpOptions) {
-    auto builder = _options->toVelocyPack(
-        false, true, [](std::string const&) { return true; });
-    arangodb::velocypack::Options options;
-    options.prettyPrint = true;
-    std::cout << builder.slice().toJson(&options) << std::endl;
     exit(EXIT_SUCCESS);
   }
 }

--- a/lib/ApplicationFeatures/ApplicationServer.h
+++ b/lib/ApplicationFeatures/ApplicationServer.h
@@ -382,6 +382,9 @@ class ApplicationServer {
       _features;
 
  private:
+  void maybeDumpOptions();
+  void maybeDumpDependencies();
+
   // the current state
   std::atomic<State> _state;
 


### PR DESCRIPTION
### Scope & Purpose

`--dump-options` now prints the options _after_ running `processOptions` on all options providers, which also implies that the config file has been processed. However, some providers still modify some options in validateOptions, so the values reported by `--dump-options` are still not the full truth, but the behavior is now essentially the same as for previous releases.

Since option processing has been separated from feature creation, the option validation phase now happens _before_ we create the features. Consequently, `--dump-dependencies` can only run _after_ validation, which means one has to provide a valid set of options (e.g., specify a database directory) in order to print the dependencies. This is a change to the old behavior.

- [x] :hankey: Bugfix