### PR TITLE
cor-890 Introduced MATCH Semantic-Normalization layer

### DIFF
--- a/arangod/Aql/CMakeLists.txt
+++ b/arangod/Aql/CMakeLists.txt
@@ -63,6 +63,8 @@ add_library(arango_aql STATIC
   LateMaterializedExpressionContext.cpp
   LimitStats.cpp
   MatchBuilder.cpp
+  MatchPatternNormalizer.cpp
+  MatchPatternTypes.cpp
   ModificationExecutorFlags.h
   ModificationOptions.cpp
   MultiAqlItemBlockInputRange.cpp

--- a/arangod/Aql/MatchBuilder.cpp
+++ b/arangod/Aql/MatchBuilder.cpp
@@ -32,20 +32,65 @@
 #include "Aql/ExecutionPlan.h"
 #include "Aql/Expression.h"
 #include "Aql/IndexHint.h"
-#include "Aql/Variable.h"
+#include "Aql/MatchPatternNormalizer.h"
 #include "Aql/QueryContext.h"
+#include "Aql/Variable.h"
 #include "Basics/Exceptions.h"
 #include "Graph/TraverserOptions.h"
+#include "VocBase/AccessMode.h"
 
 #include <absl/strings/str_cat.h>
 
 #include <algorithm>
-#include <functional>
+#include <limits>
 #include <memory>
 #include <unordered_set>
 #include <utility>
 
 namespace arangodb::aql {
+namespace {
+
+std::string requireCollectionName(MatchDataSource const& ds) {
+  if (ds.kind() != MatchDataSource::Kind::kCollection) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL,
+        "MATCH planning requires resolved collection names; unresolved "
+        "collection bind parameters are not supported at plan time");
+  }
+  return std::string(ds.name());
+}
+
+int directionFilterBits(MatchEdgeDirection direction) {
+  switch (direction) {
+    case MatchEdgeDirection::kInbound:
+      return 1;
+    case MatchEdgeDirection::kOutbound:
+      return 2;
+    case MatchEdgeDirection::kAny:
+      return 3;
+  }
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                 "invalid direction for match expression");
+}
+
+void applyPathRange(MatchPathRange const& range,
+                    traverser::TraverserOptions& options) {
+  if (range.isDefaultFixedOne()) {
+    options.minDepth = 1;
+    options.maxDepth = 1;
+    return;
+  }
+
+  options.minDepth = range.minDepth();
+  if (range.hasMaxDepth()) {
+    options.maxDepth = range.maxDepth();
+  } else {
+    // kUnboundedMin: no finite upper bound in the normalized representation.
+    options.maxDepth = std::numeric_limits<uint64_t>::max();
+  }
+}
+
+}  // namespace
 
 MatchBuilder::MatchBuilder(ExecutionPlan& plan, Ast* ast)
     : _plan(plan), _ast(ast) {}
@@ -56,45 +101,38 @@ AstNode* MatchBuilder::createPropertyAccess(Variable const* variable,
                                          property);
 }
 
-size_t MatchBuilder::patternEdgeCollectionCount(
-    AstNode const* edgeLabelMember) {
-  TRI_ASSERT(edgeLabelMember != nullptr &&
-             edgeLabelMember->type == NODE_TYPE_ARRAY);
-  return edgeLabelMember->numMembers();
-}
-
-AstNode const* MatchBuilder::getPatternEdgeCollection(
-    AstNode const* edgeLabelMember, size_t index) {
-  TRI_ASSERT(edgeLabelMember->type == NODE_TYPE_ARRAY);
-  return edgeLabelMember->getMember(index);
-}
-
-AstNode* MatchBuilder::buildPatternEdgeCollectionList(
-    AstNode const* edgeLabelMember) {
+AstNode* MatchBuilder::buildEdgeCollectionList(NormalizedEdge const& edge) {
   auto* edgeCollectionList = _ast->createNodeArray();
-  size_t const n = patternEdgeCollectionCount(edgeLabelMember);
-  for (size_t i = 0; i < n; ++i) {
-    edgeCollectionList->addMember(getPatternEdgeCollection(edgeLabelMember, i));
+  if (!edge.collectionAstNodes.empty()) {
+    for (AstNode const* collectionNode : edge.collectionAstNodes) {
+      edgeCollectionList->addMember(collectionNode);
+    }
+    return edgeCollectionList;
+  }
+
+  for (auto const& ds : edge.collections) {
+    auto name = requireCollectionName(ds);
+    edgeCollectionList->addMember(_ast->createNodeCollection(
+        _ast->query().resolver(), name, AccessMode::Type::READ));
   }
   return edgeCollectionList;
 }
 
 std::tuple<CalculationNode*, FilterNode*> MatchBuilder::createPropertiesFilter(
-    Variable const* variable, AstNode* properties,
-    AstNode* additionalExpression) {
-  AstNode* root = additionalExpression->type == NODE_TYPE_NOP
-                      ? nullptr
-                      : additionalExpression;
-  ADB_PROD_ASSERT(properties->type == NODE_TYPE_OBJECT ||
-                  properties->type == NODE_TYPE_NOP);
+    Variable const* variable,
+    std::vector<MatchPropertyConstraint> const& properties,
+    std::optional<MatchExpressionRef> const& additionalFilter,
+    std::unordered_map<VariableId, Variable const*> const& subst) {
+  AstNode* root = nullptr;
+  if (additionalFilter.has_value()) {
+    root = Ast::replaceVariables(const_cast<AstNode*>(additionalFilter->node),
+                                 subst);
+  }
 
-  for (auto member : properties->getMemberList()) {
-    ADB_PROD_ASSERT(member->type == NODE_TYPE_OBJECT_ELEMENT);
-
-    auto key = member->getStringView();
-    auto value = member->getMember(0);
-
-    auto access = createPropertyAccess(variable, key);
+  for (auto const& property : properties) {
+    auto access = createPropertyAccess(variable, property.key);
+    auto value =
+        Ast::replaceVariables(const_cast<AstNode*>(property.value.node), subst);
     auto operatorEq = _ast->createNodeBinaryOperator(
         NODE_TYPE_OPERATOR_BINARY_EQ, access, value);
     if (root) {
@@ -121,9 +159,9 @@ std::tuple<CalculationNode*, FilterNode*> MatchBuilder::createPropertiesFilter(
 
 std::tuple<ExecutionNode*, ExecutionNode*, Variable const*>
 MatchBuilder::createCollectionAccess(
-    AstNode const* member, Variable const* fullDocumentVariable,
+    NormalizedVertex const& vertex, Variable const* fullDocumentVariable,
     std::unordered_map<VariableId, Variable const*> const& subst) {
-  auto collectionName = member->getMember(1)->getString();
+  auto collectionName = requireCollectionName(vertex.collection);
   auto& collections = _ast->query().collections();
   auto collection = collections.get(collectionName);
   if (collection == nullptr) {
@@ -136,210 +174,161 @@ MatchBuilder::createCollectionAccess(
       &_plan, _plan.nextId(), collection, fullDocumentVariable, false,
       std::move(hint));
 
-  auto additionalFilter = Ast::replaceVariables(member->getMember(3), subst);
-
   auto [firstNode, lastNode] = createPropertiesFilter(
-      fullDocumentVariable, member->getMember(2), additionalFilter);
+      fullDocumentVariable, vertex.properties, vertex.filter, subst);
   firstNode->addDependency(enumCollection);
   return std::make_tuple(enumCollection, lastNode, fullDocumentVariable);
 }
 
 ExecutionNode* MatchBuilder::createPatternProjection(
-    AstNode const* member, Variable const* fullDocumentVar,
+    Variable const* destinationVariable, Variable const* fullDocumentVar,
+    std::optional<MatchProjection> const& projectionOpt, bool isEdge,
     std::unordered_map<VariableId, Variable const*> const& subst) {
-  auto variable = static_cast<Variable const*>(member->getMember(0)->getData());
-
-  // Vertices store projections at member 4 and edges store them at member 6
-  // (appended after direction/range by createPatternEdge).
-  AstNode const* projections = nullptr;
-  bool const isEdge = member->type == NODE_TYPE_PATTERN_EDGE;
-  if (isEdge) {
-    ADB_PROD_ASSERT(member->numMembers() > 6)
-        << "pattern edge missing projection member";
-    projections = member->getMember(6);
-  } else {
-    projections = member->getMember(4);
+  if (!projectionOpt.has_value()) {
+    auto* root = _ast->createNodeReference(fullDocumentVar);
+    return _plan.createNode<CalculationNode>(
+        &_plan, _plan.nextId(), std::make_unique<Expression>(_ast, root),
+        destinationVariable);
   }
 
-  if (projections->type != NODE_TYPE_NOP) {
-    auto* root = _ast->createNodeObject();
+  auto const& projection = *projectionOpt;
+  auto* root = _ast->createNodeObject();
+  auto* ref = _ast->createNodeReference(fullDocumentVar);
 
-    auto* ref = _ast->createNodeReference(fullDocumentVar);
+  auto isSystemAttribute = [&](std::string_view name) {
+    return name == "_id" || (isEdge && (name == "_from" || name == "_to"));
+  };
 
-    auto isSystemAttribute = [&](std::string_view name) {
-      return name == "_id" || (isEdge && (name == "_from" || name == "_to"));
-    };
+  auto registerKey = [&](std::string_view key) -> std::string_view {
+    char const* p = _ast->resources().registerString(key);
+    return {p, key.size()};
+  };
 
-    // createNodeObjectElement stores the raw pointer from string_view. keys
-    // must outlive the AST (register into Ast resources).
-    auto registerKey = [&](std::string_view key) -> std::string_view {
-      char const* p = _ast->resources().registerString(key);
-      return {p, key.size()};
-    };
-
-    // Find an existing nested OBJECT member named `key`, or create one.
-    auto findOrCreateNestedObject = [&](AstNode* object,
-                                        std::string_view key) -> AstNode* {
-      for (size_t i = 0; i < object->numMembers(); ++i) {
-        AstNode* elt = object->getMemberUnchecked(i);
-        if (elt->type == NODE_TYPE_OBJECT_ELEMENT &&
-            elt->getStringView() == key &&
-            elt->getMember(0)->type == NODE_TYPE_OBJECT) {
-          return elt->getMember(0);
-        }
-      }
-      auto* nested = _ast->createNodeObject();
-      object->addMember(
-          _ast->createNodeObjectElement(registerKey(key), nested));
-      return nested;
-    };
-
-    // Insert valueExpr at path segments under object, rebuilding hierarchy
-    // (e.g. ["profile","name"] → { profile: { name: valueExpr } }).
-    auto insertNestedPath = [&](AstNode* object,
-                                std::vector<std::string> const& path,
-                                AstNode* valueExpr) {
-      TRI_ASSERT(!path.empty());
-      AstNode* cursor = object;
-      for (size_t i = 0; i + 1 < path.size(); ++i) {
-        cursor = findOrCreateNestedObject(cursor, path[i]);
-      }
-      cursor->addMember(
-          _ast->createNodeObjectElement(registerKey(path.back()), valueExpr));
-    };
-
-    auto addProjectedAttribute = [&](std::vector<std::string> const& path) {
-      TRI_ASSERT(!path.empty());
-      auto* attrAccess = _ast->createNodeAttributeAccess(ref, path);
-      insertNestedPath(root, path, attrAccess);
-    };
-
-    // Implicit system attributes required for graph topology.
-    addProjectedAttribute({"_id"});
-    if (isEdge) {
-      addProjectedAttribute({"_from"});
-      addProjectedAttribute({"_to"});
-    }
-
-    // Collect bare keep paths and alias items, bare keeps use PATH arrays
-    // (unquoted dotted) or VALUE strings (quoted literal keys).
-    std::vector<std::vector<std::string>> keepPaths;
-    struct AliasItem {
-      std::string_view name;
-      AstNode* expr;
-    };
-    std::vector<AliasItem> aliases;
-
-    auto extractPath = [](AstNode const* item) -> std::vector<std::string> {
-      std::vector<std::string> path;
-      if (item->type == NODE_TYPE_ARRAY) {
-        path.reserve(item->numMembers());
-        for (size_t j = 0; j < item->numMembers(); ++j) {
-          AstNode const* part = item->getMemberUnchecked(j);
-          TRI_ASSERT(part->isStringValue());
-          path.emplace_back(part->getString());
-        }
-      } else {
-        // Quoted literal keep: single top-level key (dots not hierarchy).
-        TRI_ASSERT(item->isStringValue());
-        path.emplace_back(item->getString());
-      }
-      return path;
-    };
-
-    for (auto i = size_t{0}; i < projections->numMembers(); ++i) {
-      AstNode* item = projections->getMemberUnchecked(i);
-      if (item->type == NODE_TYPE_OBJECT_ELEMENT) {
-        aliases.push_back(AliasItem{item->getStringView(), item->getMember(0)});
-      } else {
-        auto path = extractPath(item);
-        // Skip any RETURN whose first segment is an implicit system attribute
-        // (bare `_id` and nested `_id.foo` / `_from.x`), so we never
-        // overwrite the scalar system attrs with a nested object of the same
-        // key.
-        if (!path.empty() && isSystemAttribute(path[0])) {
-          continue;
-        }
-        keepPaths.push_back(std::move(path));
+  auto findOrCreateNestedObject = [&](AstNode* object,
+                                      std::string_view key) -> AstNode* {
+    for (size_t i = 0; i < object->numMembers(); ++i) {
+      AstNode* elt = object->getMemberUnchecked(i);
+      if (elt->type == NODE_TYPE_OBJECT_ELEMENT &&
+          elt->getStringView() == key &&
+          elt->getMember(0)->type == NODE_TYPE_OBJECT) {
+        return elt->getMember(0);
       }
     }
+    auto* nested = _ast->createNodeObject();
+    object->addMember(_ast->createNodeObjectElement(registerKey(key), nested));
+    return nested;
+  };
 
-    // Drop paths that are duplicates or have a shorter kept prefix
-    // (same policy as Projections::handleSharedPrefixes).
-    {
-      std::sort(keepPaths.begin(), keepPaths.end());
-      keepPaths.erase(std::unique(keepPaths.begin(), keepPaths.end()),
-                      keepPaths.end());
-      std::vector<std::vector<std::string>> filtered;
-      filtered.reserve(keepPaths.size());
-      for (auto const& path : keepPaths) {
-        bool covered = false;
-        for (auto const& kept : filtered) {
-          if (kept.size() <= path.size() &&
-              std::equal(kept.begin(), kept.end(), path.begin())) {
-            covered = true;
-            break;
-          }
-        }
-        if (!covered) {
-          filtered.push_back(path);
-        }
-      }
-      keepPaths = std::move(filtered);
+  auto insertNestedPath = [&](AstNode* object,
+                              std::vector<std::string> const& path,
+                              AstNode* valueExpr) {
+    TRI_ASSERT(!path.empty());
+    AstNode* cursor = object;
+    for (size_t i = 0; i + 1 < path.size(); ++i) {
+      cursor = findOrCreateNestedObject(cursor, path[i]);
     }
+    cursor->addMember(
+        _ast->createNodeObjectElement(registerKey(path.back()), valueExpr));
+  };
 
-    // Top-level keys already claimed by bare keeps (and implicit system
-    // attrs). Alias names must not collide with these, or with each other.
-    std::unordered_set<std::string_view> usedTopLevelKeys;
-    usedTopLevelKeys.emplace("_id");
-    if (isEdge) {
-      usedTopLevelKeys.emplace("_from");
-      usedTopLevelKeys.emplace("_to");
-    }
-    for (auto const& path : keepPaths) {
-      TRI_ASSERT(!path.empty());
-      usedTopLevelKeys.emplace(path[0]);
-    }
+  auto addProjectedAttribute = [&](std::vector<std::string> const& path) {
+    TRI_ASSERT(!path.empty());
+    auto* attrAccess = _ast->createNodeAttributeAccess(ref, path);
+    insertNestedPath(root, path, attrAccess);
+  };
 
-    for (auto const& path : keepPaths) {
-      addProjectedAttribute(path);
-    }
+  addProjectedAttribute({"_id"});
+  if (isEdge) {
+    addProjectedAttribute({"_from"});
+    addProjectedAttribute({"_to"});
+  }
 
-    for (auto const& alias : aliases) {
-      if (isSystemAttribute(alias.name)) {
+  std::vector<std::vector<std::string>> keepPaths;
+  struct AliasItem {
+    std::string_view name;
+    AstNode* expr;
+  };
+  std::vector<AliasItem> aliases;
+
+  for (auto const& item : projection.items) {
+    if (item.kind == MatchProjectionItem::Kind::kAlias) {
+      aliases.push_back(
+          AliasItem{item.name, const_cast<AstNode*>(item.expression.node)});
+    } else {
+      TRI_ASSERT(!item.path.empty());
+      if (isSystemAttribute(item.path[0])) {
         continue;
       }
-      if (!usedTopLevelKeys.emplace(alias.name).second) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(
-            TRI_ERROR_QUERY_PARSE,
-            absl::StrCat("duplicate projection attribute name '", alias.name,
-                         "'"));
+      keepPaths.push_back(item.path);
+    }
+  }
+
+  // Drop paths that are duplicates or have a shorter kept prefix
+  {
+    std::sort(keepPaths.begin(), keepPaths.end());
+    keepPaths.erase(std::unique(keepPaths.begin(), keepPaths.end()),
+                    keepPaths.end());
+    std::vector<std::vector<std::string>> filtered;
+    filtered.reserve(keepPaths.size());
+    for (auto const& path : keepPaths) {
+      bool covered = false;
+      for (auto const& kept : filtered) {
+        if (kept.size() <= path.size() &&
+            std::equal(kept.begin(), kept.end(), path.begin())) {
+          covered = true;
+          break;
+        }
       }
-      // alias = expression: evaluate in normal query scope (explicit
-      // variable references required, e.g. v.profile.first_name).
-      AstNode* expr = Ast::replaceVariables(alias.expr, subst);
-      root->addMember(_ast->createNodeObjectElement(alias.name, expr));
+      if (!covered) {
+        filtered.push_back(path);
+      }
+    }
+    keepPaths = std::move(filtered);
+  }
+
+  std::unordered_set<std::string_view> usedTopLevelKeys;
+  usedTopLevelKeys.emplace("_id");
+  if (isEdge) {
+    usedTopLevelKeys.emplace("_from");
+    usedTopLevelKeys.emplace("_to");
+  }
+  for (auto const& path : keepPaths) {
+    TRI_ASSERT(!path.empty());
+    usedTopLevelKeys.emplace(path[0]);
+  }
+
+  for (auto const& path : keepPaths) {
+    addProjectedAttribute(path);
+  }
+
+  for (auto const& alias : aliases) {
+    if (isSystemAttribute(alias.name)) {
+      continue;
+    }
+    if (!usedTopLevelKeys.emplace(alias.name).second) {
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_QUERY_PARSE,
+          absl::StrCat("duplicate projection attribute name '", alias.name,
+                       "'"));
     }
 
-    auto* calc = _plan.createNode<CalculationNode>(
-        &_plan, _plan.nextId(), std::make_unique<Expression>(_ast, root),
-        variable);
-    return calc;
-  } else {
-    auto* root = _ast->createNodeReference(fullDocumentVar);
-    auto* calc = _plan.createNode<CalculationNode>(
-        &_plan, _plan.nextId(), std::make_unique<Expression>(_ast, root),
-        variable);
-    return calc;
+    // alias = expression: evaluate in normal query scope (explicit
+    // variable references required, e.g. v.profile.first_name).
+    AstNode* expr = Ast::replaceVariables(alias.expr, subst);
+    root->addMember(_ast->createNodeObjectElement(alias.name, expr));
   }
+
+  return _plan.createNode<CalculationNode>(
+      &_plan, _plan.nextId(), std::make_unique<Expression>(_ast, root),
+      destinationVariable);
 }
 
 std::tuple<ExecutionNode*, ExecutionNode*, Variable const*>
 MatchBuilder::createPatternEdgeEnumerateAccess(
-    AstNode const* edge, Variable const* outputVariable,
+    NormalizedEdge const& edge, Variable const* outputVariable,
     std::unordered_map<VariableId, Variable const*> const& subst) {
-  auto const* collectionNode = getPatternEdgeCollection(edge->getMember(1), 0);
-  auto collectionName = collectionNode->getString();
+  ADB_PROD_ASSERT(!edge.collections.empty());
+  auto collectionName = requireCollectionName(edge.collections.front());
   auto& collections = _ast->query().collections();
   auto collection = collections.get(collectionName);
   if (collection == nullptr) {
@@ -351,20 +340,19 @@ MatchBuilder::createPatternEdgeEnumerateAccess(
   auto enumCollection = _plan.createNode<EnumerateCollectionNode>(
       &_plan, _plan.nextId(), collection, outputVariable, false,
       std::move(hint));
-  auto additionalFilter = Ast::replaceVariables(edge->getMember(3), subst);
   auto [firstNode, lastNode] = createPropertiesFilter(
-      outputVariable, edge->getMember(2), additionalFilter);
+      outputVariable, edge.properties, edge.filter, subst);
   firstNode->addDependency(enumCollection);
   return std::make_tuple(enumCollection, lastNode, outputVariable);
 }
 
 std::tuple<CalculationNode*, FilterNode*> MatchBuilder::createVertexEdgeFilter(
     Variable const* leftVertex, Variable const* edge,
-    Variable const* rightVertex, int direction) {
-  AstNode* root =
-      nullptr;  //_ast->createNodeNaryOperator(NODE_TYPE_OPERATOR_NARY_OR);
+    Variable const* rightVertex, MatchEdgeDirection direction) {
+  AstNode* root = nullptr;
+  int const bits = directionFilterBits(direction);
 
-  if (direction & 2) {
+  if (bits & 2) {
     auto leftVertexId = createPropertyAccess(leftVertex, "_id");
     auto rightVertexId = createPropertyAccess(rightVertex, "_id");
     auto edgeFrom = createPropertyAccess(edge, "_from");
@@ -376,7 +364,7 @@ std::tuple<CalculationNode*, FilterNode*> MatchBuilder::createVertexEdgeFilter(
     root = _ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_AND, first,
                                           second);
   }
-  if (direction & 1) {
+  if (bits & 1) {
     auto leftVertexId = createPropertyAccess(leftVertex, "_id");
     auto rightVertexId = createPropertyAccess(rightVertex, "_id");
     auto edgeFrom = createPropertyAccess(edge, "_from");
@@ -388,9 +376,8 @@ std::tuple<CalculationNode*, FilterNode*> MatchBuilder::createVertexEdgeFilter(
     auto andNode = _ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_AND,
                                                   first, second);
     if (root) {
-      auto orNode = _ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_OR,
-                                                   root, andNode);
-      root = orNode;
+      root = _ast->createNodeBinaryOperator(NODE_TYPE_OPERATOR_BINARY_OR, root,
+                                            andNode);
     } else {
       root = andNode;
     }
@@ -407,92 +394,54 @@ std::tuple<CalculationNode*, FilterNode*> MatchBuilder::createVertexEdgeFilter(
 }
 
 std::tuple<ExecutionNode*, ExecutionNode*, Variable const*>
-MatchBuilder::createTraversalForPattern(Variable const* startNodeVar,  //
-                                        AstNode const* edge,
-                                        /* edge part of the pattern */  //
-                                        AstNode const* node) {
-  auto const* patternEdgeOutputVariable =
-      static_cast<Variable const*>(edge->getMember(0)->getData());
-  auto const* patternEdgeCollections = edge->getMember(1);
+MatchBuilder::createTraversalForPattern(Variable const* startNodeVar,
+                                        NormalizedEdge const& edge,
+                                        MatchPatternElement const& target) {
+  auto const* patternEdgeOutputVariable = edge.variable;
 
   aql::QueryContext& query = _ast->query();
   auto options = std::make_unique<traverser::TraverserOptions>(query);
-  auto range = edge->getMember(5);
-  if (range->type == NODE_TYPE_NOP) {
-    options->minDepth = 1;
-    options->maxDepth = 1;
-  } else {
-    options->minDepth = range->getMember(0)->getIntValue();
-    options->maxDepth = range->getMember(1)->getIntValue();
-  }
+  applyPathRange(edge.range, *options);
 
   auto dirNode = _ast->createNodeValueInt(std::invoke(
-      [](int64_t d) {
+      [](MatchEdgeDirection d) {
         switch (d) {
-          case 1:
+          case MatchEdgeDirection::kInbound:
             return 1;
-          case 2:
+          case MatchEdgeDirection::kOutbound:
             return 2;
-          case 3:
+          case MatchEdgeDirection::kAny:
             return 0;
-          default:
-            THROW_ARANGO_EXCEPTION_MESSAGE(
-                TRI_ERROR_INTERNAL, "invalid direction for match expression");
         }
+        THROW_ARANGO_EXCEPTION_MESSAGE(
+            TRI_ERROR_INTERNAL, "invalid direction for match expression");
       },
-      edge->getMember(4)->getIntValue()));
+      edge.direction));
 
   auto* startNode = _ast->createNodeReference(startNodeVar);
-
-  auto* edgeCollectionList =
-      buildPatternEdgeCollectionList(patternEdgeCollections);
+  auto* edgeCollectionList = buildEdgeCollectionList(edge);
   auto* graphNode = _ast->createNodeCollectionList(edgeCollectionList,
                                                    _ast->query().resolver());
 
   auto* traversal = _plan.createNode<TraversalNode>(
-      &_plan /* plan */,                       //
-      _plan.nextId() /* id */,                 //
-      &_ast->query().vocbase() /* vocbase */,  //
-      dirNode /* direction */,                 //
-      startNode, /* start */                   //
-      graphNode, /* graph */                   //
-      nullptr, /* prune expression */          //
-      std::move(options));
+      &_plan, _plan.nextId(), &_ast->query().vocbase(), dirNode, startNode,
+      graphNode, nullptr, std::move(options));
 
-  bool const fixedDepth = range->type == NODE_TYPE_NOP;
+  bool const fixedDepth = edge.range.isDefaultFixedOne();
   if (fixedDepth) {
-    // fixed-depth multi-edge patterns use a 1..1 traversal over all listed
-    // edge collections and expose the edge document in the pattern variable
     traversal->setEdgeOutput(patternEdgeOutputVariable);
   } else {
-    traversal->setPathOutput(
-        patternEdgeOutputVariable); /* note that it is intentional to
-                                    output the path segment that is
-                                    output by the traversal into the
-                                    edge variable in the pattern; see
-                                    transformations below */
+    traversal->setPathOutput(patternEdgeOutputVariable);
     auto traversalEdgeOutputVar = _ast->variables()->createTemporaryVariable();
     traversal->setEdgeOutput(traversalEdgeOutputVar);
   }
 
-  switch (node->type) {
-    case NODE_TYPE_REFERENCE: {
-      /*
-        FOR w IN ovc
-          MATCH (v:vc) -[ e:ec * 2..3 ]-> (w)
-            RETURN [v, e, w]
-
-        FOR w IN ovc
-          FOR v IN vc
-            FOR #3,_,e IN 2..3 OUTBOUND v ec
-              FILTER #3._id == w._id
-              RETURN [v, e, w]
-       */
-
+  switch (target.kind) {
+    case MatchPatternElement::Kind::kVariableReference: {
       auto const* traversalVertexOutputVar =
           _ast->variables()->createTemporaryVariable();
       traversal->setVertexOutput(traversalVertexOutputVar);
-      auto rightVertexVar = static_cast<Variable*>(node->getData());
+      auto rightVertexVar = target.variableReference;
 
       auto traversalOutputVertexId =
           createPropertyAccess(traversalVertexOutputVar, "_id");
@@ -509,27 +458,17 @@ MatchBuilder::createTraversalForPattern(Variable const* startNodeVar,  //
       filter->addDependency(calc);
 
       return std::make_tuple(traversal, filter, rightVertexVar);
+    }
+    case MatchPatternElement::Kind::kVertex: {
+      ADB_PROD_ASSERT(target.vertex.has_value());
+      auto const& vertex = *target.vertex;
 
-    } break;
-    case NODE_TYPE_PATTERN_NODE_PATTERN: {
-      /*
-         MATCH (v:vc) -[ e:ec * 2..3 ]-> (w:ovc)
-          RETURN [v, e, w]
-
-        FOR v IN vc
-          FOR w,_,e IN 2..3 OUTBOUND v ec
-            FILTER IS_SAME_COLLECTION(w._id, "ovc")
-            RETURN [v, e, w]
-      */
-
-      auto traversalVertexOutputVar =
-          static_cast<Variable const*>(node->getMember(0)->getData());
+      auto traversalVertexOutputVar = vertex.variable;
       traversal->setVertexOutput(traversalVertexOutputVar);
 
       auto traversalVertexOutputId =
           createPropertyAccess(traversalVertexOutputVar, "_id");
-      auto vertexCollection = node->getMember(1);
-      auto vertexCollectionName = vertexCollection->getStringView();
+      auto vertexCollectionName = requireCollectionName(vertex.collection);
 
       auto args = _ast->createNodeArray();
       args->addMember(traversalVertexOutputId);
@@ -548,14 +487,12 @@ MatchBuilder::createTraversalForPattern(Variable const* startNodeVar,  //
       filter->addDependency(calc);
 
       return std::make_tuple(traversal, filter, traversalVertexOutputVar);
-    } break;
-    default: {
-      // Throw
-      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                     "unexpected match expression member");
-      return std::make_tuple(nullptr, nullptr, nullptr);
     }
   }
+
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                 "unexpected match expression member");
+  return std::make_tuple(nullptr, nullptr, nullptr);
 }
 
 AstNode* MatchBuilder::constructArray(std::vector<AstNode const*> const& vars) {
@@ -576,233 +513,185 @@ CalculationNode* MatchBuilder::constructPathObject(
   root->addMember(
       _ast->createNodeObjectElement("vertices", constructArray(vertices)));
 
-  CalculationNode* calc = _plan.createNode<CalculationNode>(
+  return _plan.createNode<CalculationNode>(
       &_plan, _plan.nextId(), std::make_unique<Expression>(_ast, root),
       outVariable);
-
-  return calc;
 }
 
 ExecutionNode* MatchBuilder::build(ExecutionNode* previous,
                                    AstNode const* matchNode) {
+  MatchPatternNormalizer normalizer(*_ast);
+  NormalizedMatchStatement const statement = normalizer.normalize(*matchNode);
+
   auto en = previous;
-  auto nMembers = matchNode->numMembers();
 
-  for (size_t i = 0; i < nMembers; ++i) {
-    auto matchExpr = matchNode->getMemberUnchecked(i);
-
+  for (auto const& pattern : statement.patterns) {
     Variable const* prevVar = nullptr;
-    Variable const* pathVariable = nullptr;
+    Variable const* pathVariable = pattern.pathVariable;
     std::vector<AstNode const*> pathVertices;
     std::vector<AstNode const*> pathEdges;
     std::vector<ExecutionNode*> projections;
 
     std::unordered_map<VariableId, Variable const*> variableSubstitutions;
 
-    ADB_PROD_ASSERT(matchExpr->type == NODE_TYPE_PATTERN_MATCH_EXPRESSION);
+    auto const handleStartVertex = [&](NormalizedVertex const& vertex) {
+      auto destinationVariable = vertex.variable;
+      bool const hasProjection = vertex.projection.has_value();
+      Variable const* enumOutputVariable =
+          hasProjection ? _ast->variables()->createTemporaryVariable()
+                        : destinationVariable;
+      if (hasProjection) {
+        variableSubstitutions.emplace(destinationVariable->id,
+                                      enumOutputVariable);
+      }
 
-    for (size_t j = 0; j < matchExpr->numMembers(); ++j) {
-      auto member = matchExpr->getMemberUnchecked(j);
+      ExecutionNode* lastNode;
+      std::tie(en, lastNode, prevVar) = createCollectionAccess(
+          vertex, enumOutputVariable, variableSubstitutions);
+      en->addDependency(previous);
+      previous = en = lastNode;
 
-      if (member->type == NODE_TYPE_PATTERN_NODE_PATTERN) {
-        // generate code like
-        // FOR <outvariable> IN <collection>
-        //  FILTER <outvariable>.property1 == xxx && ....
-        ExecutionNode* lastNode;
-        auto destinationVariable =
-            static_cast<Variable const*>(member->getMember(0)->getData());
+      pathVertices.push_back(_ast->createNodeReference(destinationVariable));
 
-        // Without an inline projection we enumerate directly into the
-        // user-facing variable (as the non-projection lowering does), so that
-        // downstream rules and outputs observe the expected variable. With a
-        // projection we enumerate into a temporary full-document variable and
-        // copy the projected attributes into the user variable.
-        bool const hasProjection = member->getMember(4)->type != NODE_TYPE_NOP;
-        Variable const* enumOutputVariable =
-            hasProjection ? _ast->variables()->createTemporaryVariable()
-                          : destinationVariable;
-        if (hasProjection) {
-          variableSubstitutions.emplace(destinationVariable->id,
-                                        enumOutputVariable);
-        }
+      if (hasProjection) {
+        projections.push_back(createPatternProjection(
+            destinationVariable, prevVar, vertex.projection, false,
+            variableSubstitutions));
+      }
+    };
 
-        std::tie(en, lastNode, prevVar) = createCollectionAccess(
-            member, enumOutputVariable, variableSubstitutions);
-        en->addDependency(previous);
+    if (pattern.start.kind == MatchPatternElement::Kind::kVertex) {
+      ADB_PROD_ASSERT(pattern.start.vertex.has_value());
+      handleStartVertex(*pattern.start.vertex);
+    } else {
+      ADB_PROD_ASSERT(pattern.start.kind ==
+                      MatchPatternElement::Kind::kVariableReference);
+      prevVar = pattern.start.variableReference;
+      if (auto it = variableSubstitutions.find(prevVar->id);
+          it != std::end(variableSubstitutions)) {
+        prevVar = it->second;
+      }
+      pathVertices.push_back(_ast->createNodeReference(prevVar));
+    }
+
+    for (auto const& segment : pattern.segments) {
+      auto const& edge = segment.edge;
+      auto const& target = segment.target;
+      ADB_PROD_ASSERT(prevVar != nullptr);
+
+      if (edge.range.isDefaultFixedOne() && edge.collections.size() > 1) {
+        auto [firstNode, lastNode, rightVertexVar] =
+            createTraversalForPattern(prevVar, edge, target);
+
+        firstNode->addDependency(previous);
         previous = en = lastNode;
 
-        pathVertices.push_back(_ast->createNodeReference(destinationVariable));
+        auto const* edgeVar = edge.variable;
+        if (!edge.properties.empty() || edge.filter.has_value()) {
+          auto [propCalc, propFilter] = createPropertiesFilter(
+              edgeVar, edge.properties, edge.filter, variableSubstitutions);
+          propCalc->addDependency(previous);
+          previous = en = propFilter;
+        }
 
-        if (hasProjection) {
-          auto projection =
-              createPatternProjection(member, prevVar, variableSubstitutions);
-          projections.push_back(projection);
-        }
-      } else if (member->type == NODE_TYPE_PATTERN_PATH_VARIABLE) {
-        pathVariable = static_cast<Variable const*>(member->getData());
-      } else if (member->type == NODE_TYPE_REFERENCE) {
-        prevVar = static_cast<Variable*>(member->getData());
-        if (auto it = variableSubstitutions.find(prevVar->id);
-            it != std::end(variableSubstitutions)) {
-          prevVar = it->second;
-        }
+        prevVar = rightVertexVar;
+        pathEdges.push_back(_ast->createNodeReference(edgeVar));
         pathVertices.push_back(_ast->createNodeReference(prevVar));
-      } else if (member->type == NODE_TYPE_PATTERN_SEGMENT) {
-        // generate code like
-        //  FOR <outvar> IN <edge>
-        //    FILTER <outvar>._from == <prevVar>._id
-        auto edge = member->getMember(0);
-        auto node = member->getMember(1);
-        ADB_PROD_ASSERT(prevVar != nullptr);
+      } else if (edge.range.isDefaultFixedOne()) {
+        ExecutionNode* lastNodeFilter;
+        Variable const* edgeVar;
 
-        if (edge->getMember(5)->type == NODE_TYPE_NOP &&
-            patternEdgeCollectionCount(edge->getMember(1)) > 1) {
-          auto [firstNode, lastNode, rightVertexVar] =
-              createTraversalForPattern(prevVar, edge, node);
-
-          firstNode->addDependency(previous);
-          previous = en = lastNode;
-
-          auto const* edgeVar =
-              static_cast<Variable const*>(edge->getMember(0)->getData());
-          if (edge->getMember(2)->type != NODE_TYPE_NOP ||
-              edge->getMember(3)->type != NODE_TYPE_NOP) {
-            auto [propCalc, propFilter] = createPropertiesFilter(
-                edgeVar, edge->getMember(2), edge->getMember(3));
-            propCalc->addDependency(previous);
-            previous = en = propFilter;
-          }
-
-          prevVar = rightVertexVar;
-
-          pathEdges.push_back(_ast->createNodeReference(edgeVar));
-          pathVertices.push_back(_ast->createNodeReference(prevVar));
-        } else if (edge->getMember(5)->type == NODE_TYPE_NOP) {
-          ExecutionNode* lastNodeFilter;
-          Variable const* edgeVar;
-
-          auto edgeDestinationVariable =
-              static_cast<Variable const*>(edge->getMember(0)->getData());
-
-          // Same reasoning as for vertices: only introduce a temporary
-          // full-document variable plus a projection copy when an inline
-          // projection is actually requested. Otherwise enumerate straight
-          // into the user-facing edge variable.
-          bool const edgeHasProjection =
-              edge->getMember(6)->type != NODE_TYPE_NOP;
-          Variable const* edgeEnumOutputVariable =
-              edgeHasProjection ? _ast->variables()->createTemporaryVariable()
-                                : edgeDestinationVariable;
-          if (edgeHasProjection) {
-            variableSubstitutions.emplace(edgeDestinationVariable->id,
-                                          edgeEnumOutputVariable);
-          }
-
-          std::tie(en, lastNodeFilter, edgeVar) =
-              createPatternEdgeEnumerateAccess(edge, edgeEnumOutputVariable,
-                                               variableSubstitutions);
-          en->addDependency(previous);
-          previous = en = lastNodeFilter;
-
-          if (edgeHasProjection) {
-            auto edgeProjection = createPatternProjection(
-                edge, edgeEnumOutputVariable, variableSubstitutions);
-            projections.push_back(edgeProjection);
-          }
-
-          Variable const* rightVertexVar;
-          Variable const* vertexDestinationVariable = nullptr;
-
-          if (node->type == NODE_TYPE_REFERENCE) {
-            // todo: possibly replace?
-            rightVertexVar = static_cast<Variable*>(node->getData());
-            vertexDestinationVariable = rightVertexVar;
-          } else {
-            ADB_PROD_ASSERT(node->type == NODE_TYPE_PATTERN_NODE_PATTERN)
-                << member->type;
-
-            vertexDestinationVariable =
-                static_cast<Variable const*>(node->getMember(0)->getData());
-
-            bool const vertexHasProjection =
-                node->getMember(4)->type != NODE_TYPE_NOP;
-            Variable const* vertexEnumOutputVariable =
-                vertexHasProjection
-                    ? _ast->variables()->createTemporaryVariable()
-                    : vertexDestinationVariable;
-            if (vertexHasProjection) {
-              variableSubstitutions.emplace(vertexDestinationVariable->id,
-                                            vertexEnumOutputVariable);
-            }
-
-            std::tie(en, lastNodeFilter, rightVertexVar) =
-                createCollectionAccess(node, vertexEnumOutputVariable,
-                                       variableSubstitutions);
-            en->addDependency(previous);
-
-            if (vertexHasProjection) {
-              auto projection = createPatternProjection(node, rightVertexVar,
-                                                        variableSubstitutions);
-              projections.push_back(projection);
-            }
-
-            previous = en = lastNodeFilter;
-          }
-
-          auto [firstNode, lastNode] =
-              createVertexEdgeFilter(prevVar, edgeVar, rightVertexVar,
-                                     edge->getMember(4)->getIntValue());
-          firstNode->addDependency(previous);
-          previous = en = lastNode;
-          prevVar = rightVertexVar;
-
-          pathEdges.push_back(
-              _ast->createNodeReference(edgeDestinationVariable));
-
-          pathVertices.push_back(
-              _ast->createNodeReference(vertexDestinationVariable));
-        } else {
-          auto [firstNode, lastNode, rightVertexVar] =
-              createTraversalForPattern(prevVar,  // start node
-                                        edge,     // edge part of the pattern
-                                        node      // node part of the pattern
-              );
-
-          firstNode->addDependency(previous);
-          previous = en = lastNode;
-          prevVar = rightVertexVar;
-
-          pathEdges.push_back(
-              _ast->createNodeArraySplice(_ast->createNodeAttributeAccess(
-                  _ast->createNodeReference(static_cast<Variable const*>(
-                      edge->getMember(0)->getData())),
-                  "edges")));
-
-          // The path output of the traversal contains the start vertex.
-          pathVertices.pop_back();
-          pathVertices.push_back(
-              _ast->createNodeArraySplice(_ast->createNodeAttributeAccess(
-                  _ast->createNodeReference(static_cast<Variable const*>(
-                      edge->getMember(0)->getData())),
-                  "vertices")));
+        auto edgeDestinationVariable = edge.variable;
+        bool const edgeHasProjection = edge.projection.has_value();
+        Variable const* edgeEnumOutputVariable =
+            edgeHasProjection ? _ast->variables()->createTemporaryVariable()
+                              : edgeDestinationVariable;
+        if (edgeHasProjection) {
+          variableSubstitutions.emplace(edgeDestinationVariable->id,
+                                        edgeEnumOutputVariable);
         }
 
+        std::tie(en, lastNodeFilter, edgeVar) =
+            createPatternEdgeEnumerateAccess(edge, edgeEnumOutputVariable,
+                                             variableSubstitutions);
+        en->addDependency(previous);
+        previous = en = lastNodeFilter;
+
+        if (edgeHasProjection) {
+          projections.push_back(createPatternProjection(
+              edgeDestinationVariable, edgeEnumOutputVariable, edge.projection,
+              true, variableSubstitutions));
+        }
+
+        Variable const* rightVertexVar;
+        Variable const* vertexDestinationVariable = nullptr;
+
+        if (target.kind == MatchPatternElement::Kind::kVariableReference) {
+          rightVertexVar = target.variableReference;
+          vertexDestinationVariable = rightVertexVar;
+        } else {
+          ADB_PROD_ASSERT(target.kind == MatchPatternElement::Kind::kVertex);
+          ADB_PROD_ASSERT(target.vertex.has_value());
+
+          vertexDestinationVariable = target.vertex->variable;
+          bool const vertexHasProjection =
+              target.vertex->projection.has_value();
+          Variable const* vertexEnumOutputVariable =
+              vertexHasProjection ? _ast->variables()->createTemporaryVariable()
+                                  : vertexDestinationVariable;
+          if (vertexHasProjection) {
+            variableSubstitutions.emplace(vertexDestinationVariable->id,
+                                          vertexEnumOutputVariable);
+          }
+
+          std::tie(en, lastNodeFilter, rightVertexVar) = createCollectionAccess(
+              *target.vertex, vertexEnumOutputVariable, variableSubstitutions);
+          en->addDependency(previous);
+
+          if (vertexHasProjection) {
+            projections.push_back(createPatternProjection(
+                vertexDestinationVariable, rightVertexVar,
+                target.vertex->projection, false, variableSubstitutions));
+          }
+
+          previous = en = lastNodeFilter;
+        }
+
+        auto [firstNode, lastNode] = createVertexEdgeFilter(
+            prevVar, edgeVar, rightVertexVar, edge.direction);
+        firstNode->addDependency(previous);
+        previous = en = lastNode;
+        prevVar = rightVertexVar;
+
+        pathEdges.push_back(_ast->createNodeReference(edgeDestinationVariable));
+        pathVertices.push_back(
+            _ast->createNodeReference(vertexDestinationVariable));
       } else {
-        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
-                                       "unexpected match expression member");
+        auto [firstNode, lastNode, rightVertexVar] =
+            createTraversalForPattern(prevVar, edge, target);
+
+        firstNode->addDependency(previous);
+        previous = en = lastNode;
+        prevVar = rightVertexVar;
+
+        pathEdges.push_back(
+            _ast->createNodeArraySplice(_ast->createNodeAttributeAccess(
+                _ast->createNodeReference(edge.variable), "edges")));
+
+        pathVertices.pop_back();
+        pathVertices.push_back(
+            _ast->createNodeArraySplice(_ast->createNodeAttributeAccess(
+                _ast->createNodeReference(edge.variable), "vertices")));
       }
     }
 
-    // insert projections
-    for (auto&& p : projections) {
-      // TODO don't insert into projections if nullptr?
+    for (auto* p : projections) {
       if (p != nullptr) {
         p->addDependency(previous);
         previous = en = p;
       }
     }
 
-    // produce path variable if requested
     if (pathVariable != nullptr) {
       auto calcNode =
           constructPathObject(pathVariable, pathVertices, pathEdges);

--- a/arangod/Aql/MatchBuilder.cpp
+++ b/arangod/Aql/MatchBuilder.cpp
@@ -97,8 +97,10 @@ MatchBuilder::MatchBuilder(ExecutionPlan& plan, Ast* ast)
 
 AstNode* MatchBuilder::createPropertyAccess(Variable const* variable,
                                             std::string_view property) {
-  return _ast->createNodeAttributeAccess(_ast->createNodeReference(variable),
-                                         property);
+  char const* registered = _ast->resources().registerString(property);
+  return _ast->createNodeAttributeAccess(
+      _ast->createNodeReference(variable),
+      std::string_view(registered, property.size()));
 }
 
 AstNode* MatchBuilder::buildEdgeCollectionList(NormalizedEdge const& edge) {
@@ -315,7 +317,8 @@ ExecutionNode* MatchBuilder::createPatternProjection(
     // alias = expression: evaluate in normal query scope (explicit
     // variable references required, e.g. v.profile.first_name).
     AstNode* expr = Ast::replaceVariables(alias.expr, subst);
-    root->addMember(_ast->createNodeObjectElement(alias.name, expr));
+    root->addMember(
+        _ast->createNodeObjectElement(registerKey(alias.name), expr));
   }
 
   return _plan.createNode<CalculationNode>(
@@ -469,11 +472,13 @@ MatchBuilder::createTraversalForPattern(Variable const* startNodeVar,
       auto traversalVertexOutputId =
           createPropertyAccess(traversalVertexOutputVar, "_id");
       auto vertexCollectionName = requireCollectionName(vertex.collection);
+      char const* registeredCollectionName =
+          _ast->resources().registerString(vertexCollectionName);
 
       auto args = _ast->createNodeArray();
       args->addMember(traversalVertexOutputId);
       args->addMember(_ast->createNodeValueString(
-          vertexCollectionName.data(), vertexCollectionName.length()));
+          registeredCollectionName, vertexCollectionName.length()));
 
       auto root =
           _ast->createNodeFunctionCall("IS_SAME_COLLECTION", args, true);

--- a/arangod/Aql/MatchBuilder.h
+++ b/arangod/Aql/MatchBuilder.h
@@ -22,9 +22,11 @@
 
 #pragma once
 
+#include "Aql/MatchPatternTypes.h"
 #include "Aql/types.h"
 
 #include <cstddef>
+#include <optional>
 #include <string_view>
 #include <tuple>
 #include <unordered_map>
@@ -40,9 +42,9 @@ class ExecutionPlan;
 class FilterNode;
 struct Variable;
 
-/// @brief Lowers AQL MATCH pattern AST nodes into ExecutionPlan fragments.
-/// Extracted from ExecutionPlan::fromNodeMatch so capturing lambdas become
-/// named methods without changing lowering semantics or call order.
+/// @brief Lowers normalized MATCH patterns into ExecutionPlan fragments.
+/// Parser AST semantics are normalized by MatchPatternNormalizer before
+/// planning; this class owns only execution-plan construction.
 class MatchBuilder {
  public:
   MatchBuilder(ExecutionPlan& plan, Ast* ast);
@@ -54,36 +56,37 @@ class MatchBuilder {
   AstNode* createPropertyAccess(Variable const* variable,
                                 std::string_view property);
 
-  static size_t patternEdgeCollectionCount(AstNode const* edgeLabelMember);
-  static AstNode const* getPatternEdgeCollection(AstNode const* edgeLabelMember,
-                                                 size_t index);
-  AstNode* buildPatternEdgeCollectionList(AstNode const* edgeLabelMember);
+  AstNode* buildEdgeCollectionList(NormalizedEdge const& edge);
 
   std::tuple<CalculationNode*, FilterNode*> createPropertiesFilter(
-      Variable const* variable, AstNode* properties,
-      AstNode* additionalExpression);
+      Variable const* variable,
+      std::vector<MatchPropertyConstraint> const& properties,
+      std::optional<MatchExpressionRef> const& additionalFilter,
+      std::unordered_map<VariableId, Variable const*> const& subst);
 
   std::tuple<ExecutionNode*, ExecutionNode*, Variable const*>
   createCollectionAccess(
-      AstNode const* member, Variable const* fullDocumentVariable,
+      NormalizedVertex const& vertex, Variable const* fullDocumentVariable,
       std::unordered_map<VariableId, Variable const*> const& subst);
 
   ExecutionNode* createPatternProjection(
-      AstNode const* member, Variable const* fullDocumentVar,
+      Variable const* destinationVariable, Variable const* fullDocumentVar,
+      std::optional<MatchProjection> const& projection, bool isEdge,
       std::unordered_map<VariableId, Variable const*> const& subst);
 
   std::tuple<ExecutionNode*, ExecutionNode*, Variable const*>
   createPatternEdgeEnumerateAccess(
-      AstNode const* edge, Variable const* outputVariable,
+      NormalizedEdge const& edge, Variable const* outputVariable,
       std::unordered_map<VariableId, Variable const*> const& subst);
 
   std::tuple<CalculationNode*, FilterNode*> createVertexEdgeFilter(
       Variable const* leftVertex, Variable const* edge,
-      Variable const* rightVertex, int direction);
+      Variable const* rightVertex, MatchEdgeDirection direction);
 
   std::tuple<ExecutionNode*, ExecutionNode*, Variable const*>
-  createTraversalForPattern(Variable const* startNodeVar, AstNode const* edge,
-                            AstNode const* node);
+  createTraversalForPattern(Variable const* startNodeVar,
+                            NormalizedEdge const& edge,
+                            MatchPatternElement const& target);
 
   AstNode* constructArray(std::vector<AstNode const*> const& vars);
 

--- a/arangod/Aql/MatchPatternNormalizer.cpp
+++ b/arangod/Aql/MatchPatternNormalizer.cpp
@@ -263,11 +263,11 @@ std::optional<MatchProjection> MatchPatternNormalizer::normalizeProjection(
   for (size_t i = 0; i < node->numMembers(); ++i) {
     AstNode const* item = node->getMemberUnchecked(i);
     if (item->type == NODE_TYPE_OBJECT_ELEMENT) {
-      projection.items.push_back(MatchProjectionItem{
-          MatchProjectionItem::Kind::kAlias,
-          std::string(item->getStringView()),
-          {},
-          {item->getMember(0)}});
+      projection.items.push_back(
+          MatchProjectionItem{MatchProjectionItem::Kind::kAlias,
+                              std::string(item->getStringView()),
+                              {},
+                              {item->getMember(0)}});
     } else if (item->type == NODE_TYPE_ARRAY) {
       // Unquoted keep path: ARRAY of path segments (nested when size > 1).
       std::vector<std::string> path;
@@ -279,16 +279,20 @@ std::optional<MatchProjection> MatchPatternNormalizer::normalizeProjection(
       }
       TRI_ASSERT(!path.empty());
       std::string name = path.size() == 1 ? path.front() : std::string{};
-      projection.items.push_back(MatchProjectionItem{
-          MatchProjectionItem::Kind::kKeepAttribute, std::move(name),
-          std::move(path), {}});
+      projection.items.push_back(
+          MatchProjectionItem{MatchProjectionItem::Kind::kKeepAttribute,
+                              std::move(name),
+                              std::move(path),
+                              {}});
     } else if (item->type == NODE_TYPE_VALUE && item->isStringValue()) {
       // Quoted literal keep: single top-level key (dots are not hierarchy).
       std::string name{item->getStringView()};
       std::vector<std::string> path{name};
-      projection.items.push_back(MatchProjectionItem{
-          MatchProjectionItem::Kind::kKeepAttribute, std::move(name),
-          std::move(path), {}});
+      projection.items.push_back(
+          MatchProjectionItem{MatchProjectionItem::Kind::kKeepAttribute,
+                              std::move(name),
+                              std::move(path),
+                              {}});
     } else {
       THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
                                      "unexpected match projection item");

--- a/arangod/Aql/MatchPatternNormalizer.cpp
+++ b/arangod/Aql/MatchPatternNormalizer.cpp
@@ -1,0 +1,353 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "MatchPatternNormalizer.h"
+
+#include "Aql/Ast.h"
+#include "Aql/AstNode.h"
+#include "Aql/Variable.h"
+#include "Basics/Exceptions.h"
+
+#include <cmath>
+#include <cstdint>
+
+namespace arangodb::aql {
+namespace {
+
+uint64_t checkDepthValue(AstNode const* node) {
+  if (node == nullptr || !node->isNumericValue()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
+                                   "invalid traversal depth");
+  }
+  double const v = node->getDoubleValue();
+  if (v > static_cast<double>(INT64_MAX)) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
+                                   "invalid traversal depth");
+  }
+
+  double intpart;
+  if (std::modf(v, &intpart) != 0.0 || v < 0.0) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
+                                   "invalid traversal depth");
+  }
+  return static_cast<uint64_t>(v);
+}
+
+}  // namespace
+
+MatchPatternNormalizer::MatchPatternNormalizer(Ast& ast) noexcept : _ast{ast} {}
+
+NormalizedMatchStatement MatchPatternNormalizer::normalize(
+    AstNode const& matchNode) const {
+  TRI_ASSERT(matchNode.type == NODE_TYPE_MATCH);
+
+  NormalizedMatchStatement statement;
+  statement.patterns.reserve(matchNode.numMembers());
+
+  for (size_t i = 0; i < matchNode.numMembers(); ++i) {
+    statement.patterns.push_back(
+        normalizePattern(*matchNode.getMemberUnchecked(i)));
+  }
+
+  return statement;
+}
+
+NormalizedMatchPattern MatchPatternNormalizer::normalizePattern(
+    AstNode const& matchExpr) const {
+  TRI_ASSERT(matchExpr.type == NODE_TYPE_PATTERN_MATCH_EXPRESSION);
+
+  NormalizedMatchPattern pattern;
+  pattern.pathVariable = nullptr;
+  bool hasStart = false;
+
+  for (size_t i = 0; i < matchExpr.numMembers(); ++i) {
+    AstNode const* member = matchExpr.getMemberUnchecked(i);
+
+    switch (member->type) {
+      case NODE_TYPE_PATTERN_PATH_VARIABLE:
+        if (pattern.pathVariable != nullptr) {
+          THROW_ARANGO_EXCEPTION_MESSAGE(
+              TRI_ERROR_INTERNAL,
+              "multiple path variables in match expression");
+        }
+        pattern.pathVariable = static_cast<Variable const*>(member->getData());
+        break;
+
+      case NODE_TYPE_PATTERN_NODE_PATTERN:
+      case NODE_TYPE_REFERENCE:
+        if (hasStart) {
+          THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                         "multiple start nodes in match "
+                                         "expression");
+        }
+        pattern.start = normalizeStartElement(*member);
+        hasStart = true;
+        break;
+
+      case NODE_TYPE_PATTERN_SEGMENT:
+        pattern.segments.push_back(normalizeSegment(*member));
+        break;
+
+      default:
+        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                       "unexpected match expression member");
+    }
+  }
+
+  if (!hasStart) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "match expression without start node");
+  }
+
+  return pattern;
+}
+
+MatchPatternElement MatchPatternNormalizer::normalizeStartElement(
+    AstNode const& node) const {
+  if (node.type == NODE_TYPE_REFERENCE) {
+    MatchPatternElement element;
+    element.kind = MatchPatternElement::Kind::kVariableReference;
+    element.variableReference = static_cast<Variable const*>(node.getData());
+    return element;
+  }
+
+  TRI_ASSERT(node.type == NODE_TYPE_PATTERN_NODE_PATTERN);
+  MatchPatternElement element;
+  element.kind = MatchPatternElement::Kind::kVertex;
+  element.vertex = normalizeVertex(node);
+  return element;
+}
+
+NormalizedMatchSegment MatchPatternNormalizer::normalizeSegment(
+    AstNode const& segment) const {
+  TRI_ASSERT(segment.type == NODE_TYPE_PATTERN_SEGMENT);
+  TRI_ASSERT(segment.numMembers() == 2);
+
+  NormalizedMatchSegment result;
+  result.edge = normalizeEdge(*segment.getMember(0));
+  result.target = normalizeStartElement(*segment.getMember(1));
+  return result;
+}
+
+NormalizedVertex MatchPatternNormalizer::normalizeVertex(
+    AstNode const& nodePattern) const {
+  TRI_ASSERT(nodePattern.type == NODE_TYPE_PATTERN_NODE_PATTERN);
+  TRI_ASSERT(nodePattern.numMembers() >= 5);
+
+  NormalizedVertex vertex;
+  vertex.variable = normalizeOutputVariable(nodePattern.getMember(0));
+
+  AstNode const* label = nodePattern.getMember(1);
+  if (label == nullptr || label->type == NODE_TYPE_VALUE) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "match vertex without collection label");
+  }
+  vertex.collection = normalizeDataSource(*label);
+  vertex.properties = normalizeProperties(nodePattern.getMember(2));
+  vertex.filter = normalizeFilter(nodePattern.getMember(3));
+  vertex.projection = normalizeProjection(nodePattern.getMember(4));
+  return vertex;
+}
+
+NormalizedEdge MatchPatternNormalizer::normalizeEdge(
+    AstNode const& edge) const {
+  TRI_ASSERT(edge.type == NODE_TYPE_PATTERN_EDGE);
+  TRI_ASSERT(edge.numMembers() >= 7);
+
+  NormalizedEdge result;
+  result.variable = normalizeOutputVariable(edge.getMember(0));
+  AstNode const* collectionsNode = edge.getMember(1);
+  result.collections = normalizeDataSourceList(collectionsNode);
+  if (collectionsNode != nullptr && collectionsNode->type == NODE_TYPE_ARRAY) {
+    result.collectionAstNodes.reserve(collectionsNode->numMembers());
+    for (size_t i = 0; i < collectionsNode->numMembers(); ++i) {
+      result.collectionAstNodes.push_back(collectionsNode->getMember(i));
+    }
+  }
+  if (result.collections.empty()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "match edge without collection label");
+  }
+  result.properties = normalizeProperties(edge.getMember(2));
+  result.filter = normalizeFilter(edge.getMember(3));
+  result.direction = normalizeDirection(edge.getMember(4));
+  result.range = normalizeRange(edge.getMember(5));
+  result.projection = normalizeProjection(edge.getMember(6));
+  return result;
+}
+
+MatchDataSource MatchPatternNormalizer::normalizeDataSource(
+    AstNode const& node) const {
+  switch (node.type) {
+    case NODE_TYPE_COLLECTION:
+      return MatchDataSource::collection(std::string(node.getStringView()));
+    case NODE_TYPE_PARAMETER_DATASOURCE:
+      return MatchDataSource::bindParameter(std::string(node.getStringView()));
+    default:
+      THROW_ARANGO_EXCEPTION_MESSAGE(
+          TRI_ERROR_INTERNAL,
+          "unexpected data source node in match pattern normalization");
+  }
+}
+
+std::vector<MatchDataSource> MatchPatternNormalizer::normalizeDataSourceList(
+    AstNode const* node) const {
+  std::vector<MatchDataSource> collections;
+  if (node == nullptr || node->type == NODE_TYPE_VALUE) {
+    return collections;
+  }
+
+  TRI_ASSERT(node->type == NODE_TYPE_ARRAY);
+  collections.reserve(node->numMembers());
+  for (size_t i = 0; i < node->numMembers(); ++i) {
+    collections.push_back(normalizeDataSource(*node->getMember(i)));
+  }
+  return collections;
+}
+
+std::vector<MatchPropertyConstraint>
+MatchPatternNormalizer::normalizeProperties(AstNode const* node) const {
+  std::vector<MatchPropertyConstraint> properties;
+  if (node == nullptr || node->type == NODE_TYPE_NOP) {
+    return properties;
+  }
+
+  TRI_ASSERT(node->type == NODE_TYPE_OBJECT);
+  properties.reserve(node->numMembers());
+  for (size_t i = 0; i < node->numMembers(); ++i) {
+    AstNode const* member = node->getMember(i);
+    TRI_ASSERT(member->type == NODE_TYPE_OBJECT_ELEMENT);
+    properties.push_back(MatchPropertyConstraint{
+        std::string(member->getStringView()), {member->getMember(0)}});
+  }
+  return properties;
+}
+
+std::optional<MatchExpressionRef> MatchPatternNormalizer::normalizeFilter(
+    AstNode const* node) const {
+  if (node == nullptr || node->type == NODE_TYPE_NOP) {
+    return std::nullopt;
+  }
+  return MatchExpressionRef{node};
+}
+
+std::optional<MatchProjection> MatchPatternNormalizer::normalizeProjection(
+    AstNode const* node) const {
+  if (node == nullptr || node->type == NODE_TYPE_NOP) {
+    return std::nullopt;
+  }
+
+  TRI_ASSERT(node->type == NODE_TYPE_ARRAY);
+  MatchProjection projection;
+  projection.items.reserve(node->numMembers());
+
+  for (size_t i = 0; i < node->numMembers(); ++i) {
+    AstNode const* item = node->getMemberUnchecked(i);
+    if (item->type == NODE_TYPE_OBJECT_ELEMENT) {
+      projection.items.push_back(MatchProjectionItem{
+          MatchProjectionItem::Kind::kAlias,
+          std::string(item->getStringView()),
+          {},
+          {item->getMember(0)}});
+    } else if (item->type == NODE_TYPE_ARRAY) {
+      // Unquoted keep path: ARRAY of path segments (nested when size > 1).
+      std::vector<std::string> path;
+      path.reserve(item->numMembers());
+      for (size_t j = 0; j < item->numMembers(); ++j) {
+        AstNode const* part = item->getMemberUnchecked(j);
+        TRI_ASSERT(part->isStringValue());
+        path.emplace_back(part->getString());
+      }
+      TRI_ASSERT(!path.empty());
+      std::string name = path.size() == 1 ? path.front() : std::string{};
+      projection.items.push_back(MatchProjectionItem{
+          MatchProjectionItem::Kind::kKeepAttribute, std::move(name),
+          std::move(path), {}});
+    } else if (item->type == NODE_TYPE_VALUE && item->isStringValue()) {
+      // Quoted literal keep: single top-level key (dots are not hierarchy).
+      std::string name{item->getStringView()};
+      std::vector<std::string> path{name};
+      projection.items.push_back(MatchProjectionItem{
+          MatchProjectionItem::Kind::kKeepAttribute, std::move(name),
+          std::move(path), {}});
+    } else {
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "unexpected match projection item");
+    }
+  }
+
+  return projection;
+}
+
+MatchEdgeDirection MatchPatternNormalizer::normalizeDirection(
+    AstNode const* node) const {
+  TRI_ASSERT(node != nullptr);
+  TRI_ASSERT(node->type == NODE_TYPE_VALUE);
+
+  switch (node->getIntValue()) {
+    case 1:
+      return MatchEdgeDirection::kInbound;
+    case 2:
+      return MatchEdgeDirection::kOutbound;
+    case 3:
+      return MatchEdgeDirection::kAny;
+    default:
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "invalid direction for match expression");
+  }
+}
+
+MatchPathRange MatchPatternNormalizer::normalizeRange(
+    AstNode const* node) const {
+  if (node == nullptr || node->type == NODE_TYPE_NOP) {
+    return MatchPathRange::defaultFixedOne();
+  }
+
+  TRI_ASSERT(node->type == NODE_TYPE_RANGE);
+  TRI_ASSERT(node->numMembers() == 2);
+
+  uint64_t const minDepth = checkDepthValue(node->getMember(0));
+  uint64_t const maxDepth = checkDepthValue(node->getMember(1));
+  if (maxDepth < minDepth) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_QUERY_PARSE,
+                                   "invalid traversal depth");
+  }
+  return MatchPathRange::bounded(minDepth, maxDepth);
+}
+
+Variable const* MatchPatternNormalizer::normalizeOutputVariable(
+    AstNode const* node) const {
+  if (node == nullptr || node->type == NODE_TYPE_VALUE) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                   "match pattern without output variable");
+  }
+
+  if (node->type == NODE_TYPE_REFERENCE || node->type == NODE_TYPE_VARIABLE) {
+    return static_cast<Variable const*>(node->getData());
+  }
+
+  THROW_ARANGO_EXCEPTION_MESSAGE(
+      TRI_ERROR_INTERNAL,
+      "unexpected output variable node in match pattern normalization");
+}
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/MatchPatternNormalizer.h
+++ b/arangod/Aql/MatchPatternNormalizer.h
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/MatchPatternTypes.h"
+
+namespace arangodb::aql {
+
+class Ast;
+struct AstNode;
+
+/// @brief converts MATCH parser AST into a semantic representation
+class MatchPatternNormalizer {
+ public:
+  explicit MatchPatternNormalizer(Ast& ast) noexcept;
+
+  [[nodiscard]] NormalizedMatchStatement normalize(
+      AstNode const& matchNode) const;
+
+ private:
+  [[nodiscard]] NormalizedMatchPattern normalizePattern(
+      AstNode const& matchExpr) const;
+  [[nodiscard]] MatchPatternElement normalizeStartElement(
+      AstNode const& node) const;
+  [[nodiscard]] NormalizedMatchSegment normalizeSegment(
+      AstNode const& segment) const;
+  [[nodiscard]] NormalizedVertex normalizeVertex(
+      AstNode const& nodePattern) const;
+  [[nodiscard]] NormalizedEdge normalizeEdge(AstNode const& edge) const;
+
+  [[nodiscard]] MatchDataSource normalizeDataSource(AstNode const& node) const;
+  [[nodiscard]] std::vector<MatchDataSource> normalizeDataSourceList(
+      AstNode const* node) const;
+  [[nodiscard]] std::vector<MatchPropertyConstraint> normalizeProperties(
+      AstNode const* node) const;
+  [[nodiscard]] std::optional<MatchExpressionRef> normalizeFilter(
+      AstNode const* node) const;
+  [[nodiscard]] std::optional<MatchProjection> normalizeProjection(
+      AstNode const* node) const;
+  [[nodiscard]] MatchEdgeDirection normalizeDirection(
+      AstNode const* node) const;
+  [[nodiscard]] MatchPathRange normalizeRange(AstNode const* node) const;
+  [[nodiscard]] Variable const* normalizeOutputVariable(
+      AstNode const* node) const;
+
+  Ast& _ast;
+};
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/MatchPatternTypes.cpp
+++ b/arangod/Aql/MatchPatternTypes.cpp
@@ -1,0 +1,73 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "MatchPatternTypes.h"
+
+#include "Aql/Variable.h"
+#include "Basics/debugging.h"
+
+namespace arangodb::aql {
+
+MatchDataSource MatchDataSource::collection(std::string name) {
+  return MatchDataSource{Kind::kCollection, std::move(name)};
+}
+
+MatchDataSource MatchDataSource::bindParameter(std::string name) {
+  return MatchDataSource{Kind::kBindParameter, std::move(name)};
+}
+
+MatchDataSource::MatchDataSource(Kind kind, std::string name)
+    : _kind{kind}, _name{std::move(name)} {}
+
+MatchPathRange MatchPathRange::defaultFixedOne() {
+  return MatchPathRange{Kind::kDefaultFixedOne, 1, 1};
+}
+
+MatchPathRange MatchPathRange::bounded(uint64_t minDepth, uint64_t maxDepth) {
+  return MatchPathRange{Kind::kBounded, minDepth, maxDepth};
+}
+
+MatchPathRange MatchPathRange::unboundedMin(uint64_t minDepth) {
+  return MatchPathRange{Kind::kUnboundedMin, minDepth, std::nullopt};
+}
+
+MatchPathRange::MatchPathRange(Kind kind, uint64_t minDepth,
+                               std::optional<uint64_t> maxDepth)
+    : _kind{kind}, _minDepth{minDepth}, _maxDepth{maxDepth} {}
+
+bool MatchPathRange::isFixedOne() const noexcept {
+  return _minDepth == 1 && _maxDepth == 1;
+}
+
+bool MatchPathRange::isFixed() const noexcept {
+  return _maxDepth.has_value() && _minDepth == *_maxDepth;
+}
+
+Variable const* MatchPatternElement::outputVariable() const noexcept {
+  if (kind == Kind::kVariableReference) {
+    return variableReference;
+  }
+  TRI_ASSERT(vertex.has_value());
+  return vertex->variable;
+}
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/MatchPatternTypes.h
+++ b/arangod/Aql/MatchPatternTypes.h
@@ -1,0 +1,167 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace arangodb::aql {
+
+struct AstNode;
+struct Variable;
+
+/// @brief references an expression subtree owned by the query Ast
+/// valid for the lifetime of the associated Ast object
+struct MatchExpressionRef {
+  AstNode const* node;
+};
+
+/// @brief a collection name or an unresolved collection bind parameter
+struct MatchDataSource {
+  enum class Kind : uint8_t { kCollection, kBindParameter };
+
+  MatchDataSource() noexcept = default;
+
+  static MatchDataSource collection(std::string name);
+  static MatchDataSource bindParameter(std::string name);
+
+  Kind kind() const noexcept { return _kind; }
+  std::string_view name() const noexcept { return _name; }
+
+ private:
+  MatchDataSource(Kind kind, std::string name);
+
+  Kind _kind{Kind::kCollection};
+  std::string _name;
+};
+
+enum class MatchEdgeDirection : uint8_t { kOutbound, kInbound, kAny };
+
+/// @brief path depth for a MATCH edge pattern.
+/// Distinguishes the default single-hop form (no `*`) from an explicit
+/// `* min..max` range, including `* 1..1`, because planning treats them
+/// differently (enumerate vs path-producing traversal).
+struct MatchPathRange {
+  enum class Kind : uint8_t { kDefaultFixedOne, kBounded, kUnboundedMin };
+
+  MatchPathRange() noexcept = default;
+
+  /// @brief omitted range (no `*`): plan as fixed one-hop edge access
+  static MatchPathRange defaultFixedOne();
+  static MatchPathRange bounded(uint64_t minDepth, uint64_t maxDepth);
+  static MatchPathRange unboundedMin(uint64_t minDepth);
+
+  Kind kind() const noexcept { return _kind; }
+  /// @brief true when the pattern had no `*` (default one-hop)
+  bool isDefaultFixedOne() const noexcept {
+    return _kind == Kind::kDefaultFixedOne;
+  }
+  uint64_t minDepth() const noexcept { return _minDepth; }
+  bool hasMaxDepth() const noexcept { return _maxDepth.has_value(); }
+  uint64_t maxDepth() const noexcept { return *_maxDepth; }
+  bool isFixedOne() const noexcept;
+  bool isFixed() const noexcept;
+
+ private:
+  MatchPathRange(Kind kind, uint64_t minDepth,
+                 std::optional<uint64_t> maxDepth);
+
+  Kind _kind{Kind::kDefaultFixedOne};
+  uint64_t _minDepth{1};
+  std::optional<uint64_t> _maxDepth{1};
+};
+
+struct MatchPropertyConstraint {
+  std::string key;
+  MatchExpressionRef value;
+};
+
+struct MatchProjectionItem {
+  enum class Kind : uint8_t { kKeepAttribute, kAlias };
+
+  Kind kind;
+  /// @brief alias name for kAlias; for single-segment keeps equals path[0]
+  std::string name;
+  /// @brief keep attribute path segments (COR-741 nested keeps). Empty for
+  /// aliases. Quoted literal keeps are a single-element path whose value may
+  /// contain dots that are NOT hierarchy.
+  std::vector<std::string> path;
+  /// @brief only set for alias items
+  MatchExpressionRef expression;
+};
+
+struct MatchProjection {
+  std::vector<MatchProjectionItem> items;
+};
+
+struct NormalizedVertex {
+  Variable const* variable{nullptr};
+  MatchDataSource collection;
+  std::vector<MatchPropertyConstraint> properties;
+  std::optional<MatchExpressionRef> filter;
+  std::optional<MatchProjection> projection;
+};
+
+struct NormalizedEdge {
+  Variable const* variable{nullptr};
+  std::vector<MatchDataSource> collections;
+  /// @brief parser-owned collection datasource nodes (member 1 of PATTERN_EDGE).
+  /// Used by MatchBuilder when constructing traversal collection lists so
+  /// collection nodes match parser registration/lifetime semantics.
+  std::vector<AstNode const*> collectionAstNodes;
+  std::vector<MatchPropertyConstraint> properties;
+  std::optional<MatchExpressionRef> filter;
+  MatchEdgeDirection direction{MatchEdgeDirection::kOutbound};
+  MatchPathRange range{MatchPathRange::defaultFixedOne()};
+  std::optional<MatchProjection> projection;
+};
+
+struct MatchPatternElement {
+  enum class Kind : uint8_t { kVertex, kVariableReference };
+
+  Kind kind{Kind::kVariableReference};
+  std::optional<NormalizedVertex> vertex;
+  Variable const* variableReference{nullptr};
+
+  Variable const* outputVariable() const noexcept;
+};
+
+struct NormalizedMatchSegment {
+  NormalizedEdge edge;
+  MatchPatternElement target;
+};
+
+struct NormalizedMatchPattern {
+  Variable const* pathVariable{nullptr};
+  MatchPatternElement start;
+  std::vector<NormalizedMatchSegment> segments;
+};
+
+struct NormalizedMatchStatement {
+  std::vector<NormalizedMatchPattern> patterns;
+};
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/MatchPatternTypes.h
+++ b/arangod/Aql/MatchPatternTypes.h
@@ -128,9 +128,9 @@ struct NormalizedVertex {
 struct NormalizedEdge {
   Variable const* variable{nullptr};
   std::vector<MatchDataSource> collections;
-  /// @brief parser-owned collection datasource nodes (member 1 of PATTERN_EDGE).
-  /// Used by MatchBuilder when constructing traversal collection lists so
-  /// collection nodes match parser registration/lifetime semantics.
+  /// @brief parser-owned collection datasource nodes (member 1 of
+  /// PATTERN_EDGE). Used by MatchBuilder when constructing traversal collection
+  /// lists so collection nodes match parser registration/lifetime semantics.
   std::vector<AstNode const*> collectionAstNodes;
   std::vector<MatchPropertyConstraint> properties;
   std::optional<MatchExpressionRef> filter;

--- a/tests/Aql/MatchPatternNormalizerTest.cpp
+++ b/tests/Aql/MatchPatternNormalizerTest.cpp
@@ -506,6 +506,27 @@ TEST_F(MatchPatternNormalizerTest, vertexPropertiesAndWhereFilter) {
   ASSERT_TRUE(edge.filter.has_value());
 }
 
+TEST_F(MatchPatternNormalizerTest, vertexPropertiesAfterOptimize) {
+  auto parsed = parseMatch("MATCH (v :vc {j: 0}) RETURN v");
+  optimizeAst(parsed);
+
+  AstNode const* vertexPattern = parsed.matchNode->getMember(0)->getMember(0);
+  ASSERT_EQ(NODE_TYPE_PATTERN_NODE_PATTERN, vertexPattern->type);
+  AstNode const* propsNode = vertexPattern->getMember(2);
+  ASSERT_NE(nullptr, propsNode);
+  ASSERT_EQ(NODE_TYPE_OBJECT, propsNode->type) << propsNode->getTypeString();
+  ASSERT_EQ(1U, propsNode->numMembers());
+  AstNode const* propMember = propsNode->getMember(0);
+  ASSERT_EQ(NODE_TYPE_OBJECT_ELEMENT, propMember->type);
+  EXPECT_EQ("j", propMember->getStringView());
+
+  auto statement = normalize(parsed);
+  auto const& vertex = statement.patterns.front().start.vertex;
+  ASSERT_TRUE(vertex.has_value());
+  ASSERT_EQ(1U, vertex->properties.size());
+  EXPECT_EQ("j", vertex->properties.front().key);
+}
+
 TEST_F(MatchPatternNormalizerTest, combinedPattern) {
   auto parsed = parseMatch(
       "MATCH p = (v :@@vc RETURN i) "

--- a/tests/Aql/MatchPatternNormalizerTest.cpp
+++ b/tests/Aql/MatchPatternNormalizerTest.cpp
@@ -1,0 +1,859 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+#include "Mocks/Servers.h"
+
+#include "Aql/Ast.h"
+#include "Aql/AstNode.h"
+#include "Aql/BindParameters.h"
+#include "Aql/ExecutionPlan.h"
+#include "Aql/MatchPatternNormalizer.h"
+#include "Aql/Parser/Parser.h"
+#include "Aql/QueryContext.h"
+#include "Aql/QueryString.h"
+#include "Aql/StandaloneCalculation.h"
+#include "Aql/TypedAstNodes.h"
+#include "Aql/Variable.h"
+#include "Basics/Exceptions.h"
+#include "Transaction/OperationOrigin.h"
+#include "VocBase/voc-types.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+using namespace arangodb;
+using namespace arangodb::aql;
+using namespace arangodb::tests;
+
+namespace {
+
+class MatchPatternNormalizerTest : public ::testing::Test {
+ protected:
+  static void createDocumentCollection(std::string_view name) {
+    auto& vocbase = server->getSystemDatabase();
+    velocypack::Builder builder;
+    builder.openObject();
+    builder.add("name", velocypack::Value(name));
+    builder.close();
+    vocbase.createCollection(builder.slice());
+  }
+
+  static void createEdgeCollection(std::string_view name) {
+    auto& vocbase = server->getSystemDatabase();
+    velocypack::Builder builder;
+    builder.openObject();
+    builder.add("name", velocypack::Value(name));
+    builder.add("type", velocypack::Value(static_cast<int>(TRI_COL_TYPE_EDGE)));
+    builder.close();
+    vocbase.createCollection(builder.slice());
+  }
+
+  static void SetUpTestCase() {
+    server = std::make_unique<mocks::MockRestAqlServer>();
+    createDocumentCollection("vc");
+    createEdgeCollection("ec");
+    createEdgeCollection("ec2");
+    createDocumentCollection("resolved_vc");
+    createDocumentCollection("resolved_ec");
+    createDocumentCollection("mvc");
+    createDocumentCollection("mec1");
+    createDocumentCollection("mec2");
+  }
+
+  static void TearDownTestCase() { server.reset(); }
+
+  struct ParsedMatch {
+    std::unique_ptr<QueryContext> queryContext;
+    std::unique_ptr<Ast> ast;
+    AstNode const* matchNode;
+  };
+
+  static BindParameters makeBindParameters(
+      ResourceMonitor& resourceMonitor,
+      std::initializer_list<std::pair<char const*, char const*>> params) {
+    auto builder = std::make_shared<velocypack::Builder>();
+    builder->openObject();
+    for (auto const& [key, value] : params) {
+      builder->add(key, velocypack::Value(value));
+    }
+    builder->close();
+    return BindParameters(resourceMonitor, builder);
+  }
+
+  ParsedMatch parseMatch(
+      std::string_view query, bool injectBindParameters = false,
+      std::initializer_list<std::pair<char const*, char const*>> bindParams =
+          {}) {
+    auto& vocbase = server->getSystemDatabase();
+    auto queryContext = StandaloneCalculation::buildQueryContext(
+        vocbase, transaction::OperationOriginTestCase{});
+    queryContext->queryOptions().enableMatchStatement = "experimental";
+
+    auto ast = std::make_unique<Ast>(*queryContext);
+    auto queryString = QueryString(query);
+    Parser parser(*queryContext, *ast, queryString);
+    parser.parse();
+
+    if (injectBindParameters) {
+      auto parameters =
+          makeBindParameters(queryContext->resourceMonitor(), bindParams);
+      ast->injectBindParametersFirstStage(parameters, queryContext->resolver());
+      ast->injectBindParametersSecondStage(parameters);
+    }
+
+    AstNode const* matchNode = nullptr;
+    for (size_t i = 0; i < ast->root()->numMembers(); ++i) {
+      AstNode const* op = ast->root()->getMember(i);
+      if (op->type == NODE_TYPE_MATCH) {
+        matchNode = op;
+        break;
+      }
+    }
+    EXPECT_NE(nullptr, matchNode);
+
+    return ParsedMatch{std::move(queryContext), std::move(ast), matchNode};
+  }
+
+  static NormalizedMatchStatement normalize(ParsedMatch const& parsed) {
+    MatchPatternNormalizer normalizer(*parsed.ast);
+    return normalizer.normalize(*parsed.matchNode);
+  }
+
+  static std::unique_ptr<ExecutionPlan> instantiatePlan(ParsedMatch const& parsed) {
+    return ExecutionPlan::instantiateFromAst(parsed.ast.get(), false);
+  }
+
+  /// @brief run AST validation/optimization so expression trees match what
+  /// MatchBuilder / MatchPatternNormalizer observe after Query::prepare.
+  static void optimizeAst(ParsedMatch& parsed) {
+    parsed.ast->validateAndOptimize(parsed.queryContext->trxForOptimization(),
+                                    Ast::ValidateAndOptimizeOptions{});
+  }
+
+  /// @brief walk a NODE_TYPE_ATTRIBUTE_ACCESS chain into (variable, attrs).
+  /// attrs[0] is the outermost attribute (closest to the reference).
+  static void expectNestedAttributeAccess(
+      AstNode const* node, std::string_view expectedVariable,
+      std::vector<std::string_view> const& expectedAttributes) {
+    ASSERT_NE(nullptr, node);
+    ASSERT_FALSE(expectedAttributes.empty());
+
+    std::vector<std::string> attrs;
+    AstNode const* cur = node;
+    while (cur->type == NODE_TYPE_ATTRIBUTE_ACCESS) {
+      ast::AttributeAccessNode access(cur);
+      attrs.emplace_back(access.getAttributeName());
+      cur = access.getObject();
+    }
+    std::reverse(attrs.begin(), attrs.end());
+
+    ASSERT_EQ(NODE_TYPE_REFERENCE, cur->type) << cur->getTypeString();
+    ast::ReferenceNode ref(cur);
+    ASSERT_NE(nullptr, ref.getVariable());
+    EXPECT_EQ(expectedVariable, ref.getVariable()->name);
+
+    ASSERT_EQ(expectedAttributes.size(), attrs.size());
+    for (size_t i = 0; i < expectedAttributes.size(); ++i) {
+      EXPECT_EQ(expectedAttributes[i], attrs[i]) << "attribute index " << i;
+    }
+
+    // Nested dotted access must not collapse into a single dotted name.
+    if (expectedAttributes.size() > 1) {
+      std::string collapsed;
+      for (size_t i = 0; i < expectedAttributes.size(); ++i) {
+        if (i != 0) {
+          collapsed.push_back('.');
+        }
+        collapsed.append(expectedAttributes[i]);
+      }
+      EXPECT_FALSE(attrs.size() == 1 && attrs.front() == collapsed);
+    }
+  }
+
+  /// @brief e["Data.Weight"] after parse (INDEXED_ACCESS) or after optimize
+  /// (ATTRIBUTE_ACCESS with a single attribute name containing a dot).
+  static void expectSingleDottedAttributeAccess(
+      AstNode const* node, std::string_view expectedVariable,
+      std::string_view expectedAttribute) {
+    ASSERT_NE(nullptr, node);
+
+    if (node->type == NODE_TYPE_INDEXED_ACCESS) {
+      ast::IndexedAccessNode indexed(node);
+      AstNode const* object = indexed.getObject();
+      AstNode const* index = indexed.getIndex();
+
+      ASSERT_EQ(NODE_TYPE_REFERENCE, object->type) << object->getTypeString();
+      ast::ReferenceNode ref(object);
+      ASSERT_NE(nullptr, ref.getVariable());
+      EXPECT_EQ(expectedVariable, ref.getVariable()->name);
+
+      ASSERT_EQ(NODE_TYPE_VALUE, index->type) << index->getTypeString();
+      ASSERT_TRUE(index->isStringValue());
+      EXPECT_EQ(expectedAttribute, index->getStringView());
+      return;
+    }
+
+    ASSERT_EQ(NODE_TYPE_ATTRIBUTE_ACCESS, node->type) << node->getTypeString();
+    expectNestedAttributeAccess(node, expectedVariable, {expectedAttribute});
+  }
+
+  static AstNode const* equalityLhs(AstNode const* eqNode) {
+    EXPECT_NE(nullptr, eqNode);
+    if (eqNode == nullptr) {
+      return nullptr;
+    }
+    EXPECT_EQ(NODE_TYPE_OPERATOR_BINARY_EQ, eqNode->type)
+        << eqNode->getTypeString();
+    if (eqNode->type != NODE_TYPE_OPERATOR_BINARY_EQ) {
+      return nullptr;
+    }
+    ast::RelationalOperatorNode rel(eqNode);
+    return rel.getLeft();
+  }
+
+  static inline std::unique_ptr<mocks::MockRestAqlServer> server;
+};
+
+TEST_F(MatchPatternNormalizerTest, simpleVertex) {
+  auto parsed = parseMatch("MATCH (v :vc) RETURN v");
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(1U, statement.patterns.size());
+  auto const& pattern = statement.patterns.front();
+  ASSERT_EQ(MatchPatternElement::Kind::kVertex, pattern.start.kind);
+  ASSERT_TRUE(pattern.start.vertex.has_value());
+  EXPECT_EQ("v", pattern.start.vertex->variable->name);
+  EXPECT_EQ(MatchDataSource::Kind::kCollection,
+            pattern.start.vertex->collection.kind());
+  EXPECT_EQ("vc", pattern.start.vertex->collection.name());
+  EXPECT_TRUE(pattern.start.vertex->properties.empty());
+  EXPECT_FALSE(pattern.start.vertex->filter.has_value());
+  EXPECT_FALSE(pattern.start.vertex->projection.has_value());
+  EXPECT_TRUE(pattern.segments.empty());
+}
+
+TEST_F(MatchPatternNormalizerTest, outboundEdgeSingleCollection) {
+  auto parsed = parseMatch("MATCH (v :vc) -[ e :ec ]-> (w :vc) RETURN [v,e,w]");
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(1U, statement.patterns.size());
+  auto const& pattern = statement.patterns.front();
+  ASSERT_EQ(1U, pattern.segments.size());
+
+  auto const& edge = pattern.segments.front().edge;
+  EXPECT_EQ("e", edge.variable->name);
+  ASSERT_EQ(1U, edge.collections.size());
+  EXPECT_EQ("ec", edge.collections.front().name());
+  EXPECT_EQ(MatchEdgeDirection::kOutbound, edge.direction);
+  EXPECT_TRUE(edge.range.isDefaultFixedOne());
+  EXPECT_TRUE(edge.range.isFixedOne());
+  EXPECT_TRUE(edge.properties.empty());
+  EXPECT_FALSE(edge.filter.has_value());
+  EXPECT_FALSE(edge.projection.has_value());
+
+  auto const& target = pattern.segments.front().target;
+  ASSERT_EQ(MatchPatternElement::Kind::kVertex, target.kind);
+  EXPECT_EQ("w", target.vertex->variable->name);
+  EXPECT_EQ("vc", target.vertex->collection.name());
+}
+
+TEST_F(MatchPatternNormalizerTest, inboundEdge) {
+  auto parsed = parseMatch("MATCH (v :vc) <-[ e :ec ]- (w :vc) RETURN [v,e,w]");
+  auto statement = normalize(parsed);
+  EXPECT_EQ(MatchEdgeDirection::kInbound,
+            statement.patterns.front().segments.front().edge.direction);
+}
+
+TEST_F(MatchPatternNormalizerTest, anyDirectionEdge) {
+  auto parsed = parseMatch("MATCH (v :vc) -[ e :ec ]- (w :vc) RETURN [v,e,w]");
+  auto statement = normalize(parsed);
+  EXPECT_EQ(MatchEdgeDirection::kAny,
+            statement.patterns.front().segments.front().edge.direction);
+}
+
+TEST_F(MatchPatternNormalizerTest, multipleEdgeCollections) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec|ec2 ]-> (w :vc) RETURN [v,e,w]");
+  auto statement = normalize(parsed);
+
+  auto const& collections =
+      statement.patterns.front().segments.front().edge.collections;
+  ASSERT_EQ(2U, collections.size());
+  EXPECT_EQ("ec", collections[0].name());
+  EXPECT_EQ("ec2", collections[1].name());
+}
+
+TEST_F(MatchPatternNormalizerTest, literalCollectionVertexAndEdge) {
+  auto parsed = parseMatch("MATCH (v :vc1) -[ e :ec1 ]-> (w :vc2) RETURN 1");
+  auto statement = normalize(parsed);
+
+  EXPECT_EQ("vc1", statement.patterns.front().start.vertex->collection.name());
+  EXPECT_EQ("vc2", statement.patterns.front()
+                       .segments.front()
+                       .target.vertex->collection.name());
+  EXPECT_EQ("ec1", statement.patterns.front()
+                       .segments.front()
+                       .edge.collections.front()
+                       .name());
+}
+
+TEST_F(MatchPatternNormalizerTest, collectionBindParameter) {
+  auto parsed = parseMatch("MATCH (v :@@vc) -[ e :@@ec ]-> (w :@@vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  EXPECT_EQ(MatchDataSource::Kind::kBindParameter,
+            statement.patterns.front().start.vertex->collection.kind());
+  EXPECT_EQ("@vc", statement.patterns.front().start.vertex->collection.name());
+
+  auto const& edgeCollection =
+      statement.patterns.front().segments.front().edge.collections.front();
+  EXPECT_EQ(MatchDataSource::Kind::kBindParameter, edgeCollection.kind());
+  EXPECT_EQ("@ec", edgeCollection.name());
+}
+
+TEST_F(MatchPatternNormalizerTest, resolvedCollectionBindParameter) {
+  auto parsed =
+      parseMatch("MATCH (v :@@vc) -[ e :@@ec ]-> (w :@@vc) RETURN 1", true,
+                 {{"@vc", "resolved_vc"}, {"@ec", "resolved_ec"}});
+  auto statement = normalize(parsed);
+
+  EXPECT_EQ(MatchDataSource::Kind::kCollection,
+            statement.patterns.front().start.vertex->collection.kind());
+  EXPECT_EQ("resolved_vc",
+            statement.patterns.front().start.vertex->collection.name());
+  EXPECT_EQ("resolved_ec", statement.patterns.front()
+                               .segments.front()
+                               .edge.collections.front()
+                               .name());
+}
+
+TEST_F(MatchPatternNormalizerTest, fixedRange) {
+  auto parsed = parseMatch("MATCH (v :vc) -[ e :ec ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+  auto const& range = statement.patterns.front().segments.front().edge.range;
+  EXPECT_TRUE(range.isDefaultFixedOne());
+  EXPECT_TRUE(range.isFixedOne());
+  EXPECT_EQ(1U, range.minDepth());
+  EXPECT_TRUE(range.hasMaxDepth());
+  EXPECT_EQ(1U, range.maxDepth());
+}
+
+TEST_F(MatchPatternNormalizerTest, fixedRangeThree) {
+  auto parsed = parseMatch("MATCH (v :vc) -[ e :ec *3..3 ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+  auto const& range = statement.patterns.front().segments.front().edge.range;
+
+  EXPECT_TRUE(range.isFixed());
+  EXPECT_FALSE(range.isDefaultFixedOne());
+  EXPECT_FALSE(range.isFixedOne());
+  EXPECT_EQ(3U, range.minDepth());
+  EXPECT_TRUE(range.hasMaxDepth());
+  EXPECT_EQ(3U, range.maxDepth());
+}
+
+TEST_F(MatchPatternNormalizerTest, boundedRange) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec * 2..5 ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+  auto const& range = statement.patterns.front().segments.front().edge.range;
+  EXPECT_FALSE(range.isDefaultFixedOne());
+  EXPECT_FALSE(range.isFixedOne());
+  EXPECT_EQ(2U, range.minDepth());
+  EXPECT_TRUE(range.hasMaxDepth());
+  EXPECT_EQ(5U, range.maxDepth());
+}
+
+TEST_F(MatchPatternNormalizerTest, explicitFixedRangeIsNotDefault) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec * 1..1 ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+  auto const& range = statement.patterns.front().segments.front().edge.range;
+  EXPECT_FALSE(range.isDefaultFixedOne());
+  EXPECT_TRUE(range.isFixedOne());
+  EXPECT_EQ(MatchPathRange::Kind::kBounded, range.kind());
+}
+
+TEST_F(MatchPatternNormalizerTest, unboundedRangeSemanticType) {
+  auto range = MatchPathRange::unboundedMin(3);
+  EXPECT_EQ(3U, range.minDepth());
+  EXPECT_FALSE(range.hasMaxDepth());
+  EXPECT_FALSE(range.isFixedOne());
+  EXPECT_FALSE(range.isDefaultFixedOne());
+}
+
+TEST_F(MatchPatternNormalizerTest, projectionKeepPath) {
+  auto parsed =
+      parseMatch("MATCH (v :vc RETURN i) -[ e :ec ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& projection = statement.patterns.front().start.vertex->projection;
+  ASSERT_TRUE(projection.has_value());
+  ASSERT_EQ(1U, projection->items.size());
+  EXPECT_EQ(MatchProjectionItem::Kind::kKeepAttribute,
+            projection->items.front().kind);
+  EXPECT_EQ("i", projection->items.front().name);
+  ASSERT_EQ((std::vector<std::string>{"i"}), projection->items.front().path);
+}
+
+TEST_F(MatchPatternNormalizerTest, projectionAliasAndNestedPath) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc RETURN idx = v.profile.first_name, status) "
+      "-[ e :ec RETURN edgeI = e.i ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& vertexProjection =
+      statement.patterns.front().start.vertex->projection;
+  ASSERT_TRUE(vertexProjection.has_value());
+  ASSERT_EQ(2U, vertexProjection->items.size());
+
+  EXPECT_EQ(MatchProjectionItem::Kind::kAlias, vertexProjection->items[0].kind);
+  EXPECT_EQ("idx", vertexProjection->items[0].name);
+  ASSERT_NE(nullptr, vertexProjection->items[0].expression.node);
+
+  EXPECT_EQ(MatchProjectionItem::Kind::kKeepAttribute,
+            vertexProjection->items[1].kind);
+  EXPECT_EQ("status", vertexProjection->items[1].name);
+  ASSERT_EQ((std::vector<std::string>{"status"}),
+            vertexProjection->items[1].path);
+
+  auto const& edgeProjection =
+      statement.patterns.front().segments.front().edge.projection;
+  ASSERT_TRUE(edgeProjection.has_value());
+  ASSERT_EQ(1U, edgeProjection->items.size());
+  EXPECT_EQ(MatchProjectionItem::Kind::kAlias, edgeProjection->items[0].kind);
+  EXPECT_EQ("edgeI", edgeProjection->items[0].name);
+}
+
+TEST_F(MatchPatternNormalizerTest, projectionNestedKeepPath) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc RETURN profile.name) -[ e :ec ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& projection = statement.patterns.front().start.vertex->projection;
+  ASSERT_TRUE(projection.has_value());
+  ASSERT_EQ(1U, projection->items.size());
+  EXPECT_EQ(MatchProjectionItem::Kind::kKeepAttribute,
+            projection->items.front().kind);
+  EXPECT_TRUE(projection->items.front().name.empty());
+  ASSERT_EQ((std::vector<std::string>{"profile", "name"}),
+            projection->items.front().path);
+}
+
+TEST_F(MatchPatternNormalizerTest, variableReferenceTarget) {
+  auto parsed = parseMatch(
+      "FOR w IN 1..1 LET start = \"vc/v0\" "
+      "MATCH (v :vc) -[ e :ec ]-> (w) RETURN [v,e,w]");
+  auto statement = normalize(parsed);
+
+  auto const& target = statement.patterns.front().segments.front().target;
+  ASSERT_EQ(MatchPatternElement::Kind::kVariableReference, target.kind);
+  EXPECT_EQ("w", target.variableReference->name);
+}
+
+TEST_F(MatchPatternNormalizerTest, pathVariable) {
+  auto parsed =
+      parseMatch("MATCH p = (v :vc) -[ e :ec * 1..2 ]-> (w :vc) RETURN p");
+  auto statement = normalize(parsed);
+
+  ASSERT_NE(nullptr, statement.patterns.front().pathVariable);
+  EXPECT_EQ("p", statement.patterns.front().pathVariable->name);
+}
+
+TEST_F(MatchPatternNormalizerTest, vertexPropertiesAndWhereFilter) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc {j: 0, k: 1} WHERE v.i > 0) -[ e :ec {j: 2} WHERE e.i > 1 "
+      "]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& vertex = statement.patterns.front().start.vertex;
+  ASSERT_TRUE(vertex.has_value());
+  ASSERT_EQ(2U, vertex->properties.size());
+  EXPECT_EQ("j", vertex->properties[0].key);
+  EXPECT_EQ("k", vertex->properties[1].key);
+  ASSERT_TRUE(vertex->filter.has_value());
+  ASSERT_NE(nullptr, vertex->filter->node);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_EQ(1U, edge.properties.size());
+  EXPECT_EQ("j", edge.properties.front().key);
+  ASSERT_TRUE(edge.filter.has_value());
+}
+
+TEST_F(MatchPatternNormalizerTest, combinedPattern) {
+  auto parsed = parseMatch(
+      "MATCH p = (v :@@vc RETURN i) "
+      "-[ e :@@ec1|@@ec2 * 2..4 ]-> (w :@@vc RETURN wId = w._key) "
+      "RETURN p",
+      true, {{"@vc", "mvc"}, {"@ec1", "mec1"}, {"@ec2", "mec2"}});
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(1U, statement.patterns.size());
+  auto const& pattern = statement.patterns.front();
+  EXPECT_EQ("p", pattern.pathVariable->name);
+  EXPECT_EQ("v", pattern.start.vertex->variable->name);
+  EXPECT_EQ("mvc", pattern.start.vertex->collection.name());
+  ASSERT_TRUE(pattern.start.vertex->projection.has_value());
+
+  ASSERT_EQ(1U, pattern.segments.size());
+  auto const& segment = pattern.segments.front();
+  ASSERT_EQ(2U, segment.edge.collections.size());
+  EXPECT_EQ("mec1", segment.edge.collections[0].name());
+  EXPECT_EQ("mec2", segment.edge.collections[1].name());
+  EXPECT_EQ(MatchEdgeDirection::kOutbound, segment.edge.direction);
+  EXPECT_EQ(2U, segment.edge.range.minDepth());
+  EXPECT_EQ(4U, segment.edge.range.maxDepth());
+  EXPECT_FALSE(segment.edge.projection.has_value());
+  EXPECT_EQ("w", segment.target.vertex->variable->name);
+  EXPECT_EQ("mvc", segment.target.vertex->collection.name());
+  ASSERT_TRUE(segment.target.vertex->projection.has_value());
+}
+
+TEST_F(MatchPatternNormalizerTest, multiplePatternsInOneMatch) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec ]-> (w :vc), (a :vc2) -[ b :ec2 ]-> (c :vc2) "
+      "RETURN 1");
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(2U, statement.patterns.size());
+  EXPECT_EQ("v", statement.patterns[0].start.vertex->variable->name);
+  EXPECT_EQ("a", statement.patterns[1].start.vertex->variable->name);
+}
+
+TEST_F(MatchPatternNormalizerTest, rejectsInvalidDirectionValue) {
+  auto parsed = parseMatch("MATCH (v :vc) -[ e :ec ]-> (w :vc) RETURN 1");
+
+  AstNode* matchNode = const_cast<AstNode*>(parsed.matchNode);
+  AstNode* edge = matchNode->getMember(0)->getMember(1)->getMember(0);
+  edge->getMember(4)->setIntValue(99);
+
+  MatchPatternNormalizer normalizer(*parsed.ast);
+  EXPECT_THROW(
+      { (void)normalizer.normalize(*parsed.matchNode); }, basics::Exception);
+}
+
+TEST_F(MatchPatternNormalizerTest, rejectsInvalidRange) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec * 5..2 ]-> (w :vc) RETURN 1");
+  MatchPatternNormalizer normalizer(*parsed.ast);
+  EXPECT_THROW(
+      { (void)normalizer.normalize(*parsed.matchNode); }, basics::Exception);
+}
+
+TEST_F(MatchPatternNormalizerTest, whereNestedDottedAttributeAccess) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec WHERE e.Data.Weight == 1 ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_TRUE(edge.filter.has_value());
+  AstNode const* lhs = equalityLhs(edge.filter->node);
+  expectNestedAttributeAccess(lhs, "e", {"Data", "Weight"});
+}
+
+TEST_F(MatchPatternNormalizerTest, whereBracketDottedAttributeName) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec WHERE e[\"Data.Weight\"] == 2 ]-> (w :vc) "
+      "RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_TRUE(edge.filter.has_value());
+  AstNode const* lhs = equalityLhs(edge.filter->node);
+  // Pre-optimize: INDEXED_ACCESS with literal index "Data.Weight".
+  expectSingleDottedAttributeAccess(lhs, "e", "Data.Weight");
+  EXPECT_EQ(NODE_TYPE_INDEXED_ACCESS, lhs->type);
+}
+
+TEST_F(MatchPatternNormalizerTest, whereNestedAndBracketRemainDistinct) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec WHERE e.Data.Weight == 1 AND "
+      "e[\"Data.Weight\"] == 2 ]-> (w :vc) RETURN 1");
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_TRUE(edge.filter.has_value());
+  ASSERT_EQ(NODE_TYPE_OPERATOR_BINARY_AND, edge.filter->node->type);
+
+  ast::LogicalOperatorNode andNode(edge.filter->node);
+  AstNode const* nestedLhs = equalityLhs(andNode.getLeft());
+  AstNode const* dottedLhs = equalityLhs(andNode.getRight());
+
+  expectNestedAttributeAccess(nestedLhs, "e", {"Data", "Weight"});
+  expectSingleDottedAttributeAccess(dottedLhs, "e", "Data.Weight");
+
+  // Distinct representations: nested ATTRIBUTE_ACCESS chain vs single
+  // INDEXED_ACCESS / single ATTRIBUTE_ACCESS with a dotted name.
+  EXPECT_NE(nestedLhs->type, dottedLhs->type);
+  EXPECT_EQ(NODE_TYPE_ATTRIBUTE_ACCESS, nestedLhs->type);
+  EXPECT_EQ(NODE_TYPE_INDEXED_ACCESS, dottedLhs->type);
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       whereNestedAndBracketRemainDistinctAfterOptimize) {
+  // Mirrors Query prepare order: parse → validateAndOptimize → normalize
+  // (as invoked from ExecutionPlan::fromNodeMatch).
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec WHERE e.Data.Weight == 1 AND "
+      "e[\"Data.Weight\"] == 2 ]-> (w :vc) RETURN 1");
+  optimizeAst(parsed);
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_TRUE(edge.filter.has_value());
+  ASSERT_EQ(NODE_TYPE_OPERATOR_BINARY_AND, edge.filter->node->type);
+
+  ast::LogicalOperatorNode andNode(edge.filter->node);
+  AstNode const* nestedLhs = equalityLhs(andNode.getLeft());
+  AstNode const* dottedLhs = equalityLhs(andNode.getRight());
+
+  // After optimizeIndexedAccess, e["Data.Weight"] becomes a single
+  // ATTRIBUTE_ACCESS whose attribute name is the literal "Data.Weight".
+  expectNestedAttributeAccess(nestedLhs, "e", {"Data", "Weight"});
+  expectSingleDottedAttributeAccess(dottedLhs, "e", "Data.Weight");
+
+  ASSERT_EQ(NODE_TYPE_ATTRIBUTE_ACCESS, nestedLhs->type);
+  ASSERT_EQ(NODE_TYPE_ATTRIBUTE_ACCESS, dottedLhs->type);
+
+  ast::AttributeAccessNode nestedLeaf(nestedLhs);
+  ast::AttributeAccessNode dottedLeaf(dottedLhs);
+  EXPECT_EQ("Weight", nestedLeaf.getAttributeName());
+  EXPECT_EQ("Data.Weight", dottedLeaf.getAttributeName());
+  EXPECT_NE(nestedLeaf.getAttributeName(), dottedLeaf.getAttributeName());
+
+  // Nested form has Reference under Data; dotted form has Reference under
+  // the single "Data.Weight" attribute.
+  EXPECT_EQ(NODE_TYPE_ATTRIBUTE_ACCESS, nestedLeaf.getObject()->type);
+  EXPECT_EQ(NODE_TYPE_REFERENCE, dottedLeaf.getObject()->type);
+}
+
+TEST_F(MatchPatternNormalizerTest, nestedAttributeEquivalentForms) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec WHERE e.Data.Weight == 1 AND "
+      "e[\"Data\"][\"Weight\"] == 1 AND e.Data[\"Weight\"] == 1 ]-> "
+      "(w :vc) RETURN 1");
+  optimizeAst(parsed);
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_TRUE(edge.filter.has_value());
+
+  // ((a AND b) AND c) after left-associative parsing.
+  ASSERT_EQ(NODE_TYPE_OPERATOR_BINARY_AND, edge.filter->node->type);
+  ast::LogicalOperatorNode outer(edge.filter->node);
+  ASSERT_EQ(NODE_TYPE_OPERATOR_BINARY_AND, outer.getLeft()->type);
+  ast::LogicalOperatorNode inner(outer.getLeft());
+
+  AstNode const* formDot = equalityLhs(inner.getLeft());
+  AstNode const* formBrackets = equalityLhs(inner.getRight());
+  AstNode const* formMixed = equalityLhs(outer.getRight());
+
+  expectNestedAttributeAccess(formDot, "e", {"Data", "Weight"});
+  expectNestedAttributeAccess(formBrackets, "e", {"Data", "Weight"});
+  expectNestedAttributeAccess(formMixed, "e", {"Data", "Weight"});
+}
+
+TEST_F(MatchPatternNormalizerTest, edgePropertyDottedNameVsNestedAttribute) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec {nested: e.Data.Weight, dotted: "
+      "e[\"Data.Weight\"]} ]-> "
+      "(w :vc) RETURN 1");
+  optimizeAst(parsed);
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_EQ(2U, edge.properties.size());
+
+  EXPECT_EQ("nested", edge.properties[0].key);
+  ASSERT_NE(nullptr, edge.properties[0].value.node);
+  expectNestedAttributeAccess(edge.properties[0].value.node, "e",
+                              {"Data", "Weight"});
+
+  EXPECT_EQ("dotted", edge.properties[1].key);
+  ASSERT_NE(nullptr, edge.properties[1].value.node);
+  expectSingleDottedAttributeAccess(edge.properties[1].value.node, "e",
+                                    "Data.Weight");
+}
+
+TEST_F(MatchPatternNormalizerTest, matchBuilderConsumesNormalizedSimpleVertex) {
+  auto parsed = parseMatch("MATCH (v :vc) RETURN v");
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(1U, statement.patterns.size());
+  ASSERT_TRUE(statement.patterns.front().start.vertex.has_value());
+  EXPECT_EQ("vc", statement.patterns.front().start.vertex->collection.name());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest, matchBuilderConsumesNormalizedEdgeMatch) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec ]-> (w :vc) RETURN [v, e, w]");
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(1U, statement.patterns.front().segments.size());
+  EXPECT_EQ("ec", statement.patterns.front()
+                      .segments.front()
+                      .edge.collections.front()
+                      .name());
+  EXPECT_TRUE(statement.patterns.front()
+                  .segments.front()
+                  .edge.range.isDefaultFixedOne());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       matchBuilderConsumesNormalizedMultipleEdgeCollections) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec|ec2 ]-> (w :vc) RETURN [v, e, w]");
+  auto statement = normalize(parsed);
+
+  ASSERT_EQ(2U, statement.patterns.front()
+                    .segments.front()
+                    .edge.collections.size());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest, matchBuilderConsumesNormalizedFixedPathRange) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec * 2..2 ]-> (w :vc) RETURN [v, e, w]");
+  auto statement = normalize(parsed);
+  auto const& range = statement.patterns.front().segments.front().edge.range;
+
+  EXPECT_FALSE(range.isDefaultFixedOne());
+  EXPECT_TRUE(range.isFixed());
+  EXPECT_EQ(2U, range.minDepth());
+  EXPECT_EQ(2U, range.maxDepth());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       matchBuilderConsumesNormalizedBoundedPathRange) {
+  auto parsed =
+      parseMatch("MATCH (v :vc) -[ e :ec * 1..3 ]-> (w :vc) RETURN [v, e, w]");
+  auto statement = normalize(parsed);
+  auto const& range = statement.patterns.front().segments.front().edge.range;
+
+  EXPECT_EQ(1U, range.minDepth());
+  EXPECT_TRUE(range.hasMaxDepth());
+  EXPECT_EQ(3U, range.maxDepth());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       matchBuilderConsumesNormalizedPropertyAccessForms) {
+  auto parsed = parseMatch(
+      "MATCH (v :vc) -[ e :ec WHERE e.Data.Weight == 1 AND "
+      "e[\"Data.Weight\"] == 2 ]-> (w :vc) RETURN e");
+  optimizeAst(parsed);
+  auto statement = normalize(parsed);
+
+  auto const& edge = statement.patterns.front().segments.front().edge;
+  ASSERT_TRUE(edge.filter.has_value());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       matchBuilderConsumesResolvedCollectionBindParameter) {
+  auto parsed = parseMatch("MATCH (v :@@vc) -[ e :@@ec ]-> (w :@@vc) RETURN v",
+                           true, {{"@vc", "vc"}, {"@ec", "ec"}});
+  auto statement = normalize(parsed);
+
+  EXPECT_EQ(MatchDataSource::Kind::kCollection,
+            statement.patterns.front().start.vertex->collection.kind());
+  EXPECT_EQ("vc", statement.patterns.front().start.vertex->collection.name());
+
+  auto plan = instantiatePlan(parsed);
+  ASSERT_NE(nullptr, plan);
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       fromNodeMatchRejectsUnresolvedCollectionBindParameter) {
+  // Normalization intentionally preserves unresolved collection bind
+  // parameters as MatchDataSource::Kind::kBindParameter. MatchBuilder then
+  // rejects them via requireCollectionName (TRI_ERROR_INTERNAL).
+
+  auto parsed = parseMatch("MATCH (v :@@vc) -[ e :ec ]-> (w :vc) RETURN 1");
+
+  auto statement = normalize(parsed);
+  ASSERT_EQ(1U, statement.patterns.size());
+  ASSERT_TRUE(statement.patterns.front().start.vertex.has_value());
+  EXPECT_EQ(MatchDataSource::Kind::kBindParameter,
+            statement.patterns.front().start.vertex->collection.kind());
+
+  try {
+    // trackMemoryUsage=false: safer under gtest (see ExecutionPlan.h).
+    auto plan = ExecutionPlan::instantiateFromAst(parsed.ast.get(), false);
+    FAIL() << "expected unresolved collection bind parameter to throw during "
+              "plan construction, but instantiateFromAst succeeded";
+    (void)plan;
+  } catch (basics::Exception const& ex) {
+    EXPECT_EQ(TRI_ERROR_INTERNAL, ex.code());
+  } catch (...) {
+    FAIL() << "expected basics::Exception with TRI_ERROR_INTERNAL";
+  }
+}
+
+TEST_F(MatchPatternNormalizerTest,
+       fromNodeMatchRejectsUnresolvedEdgeCollectionBindParameter) {
+  // Start/target use an existing collection so plan construction reaches
+  // requireCollectionName on the unresolved edge bind parameter.
+  auto parsed = parseMatch("MATCH (v :mvc) -[ e :@@ec ]-> (w :mvc) RETURN 1");
+
+  auto statement = normalize(parsed);
+  ASSERT_EQ(1U, statement.patterns.size());
+  ASSERT_EQ(1U, statement.patterns.front().segments.size());
+  EXPECT_EQ(MatchDataSource::Kind::kBindParameter, statement.patterns.front()
+                                                       .segments.front()
+                                                       .edge.collections.front()
+                                                       .kind());
+
+  try {
+    auto plan = ExecutionPlan::instantiateFromAst(parsed.ast.get(), false);
+    FAIL() << "expected unresolved edge collection bind parameter to throw "
+              "during plan construction, but instantiateFromAst succeeded";
+    (void)plan;
+  } catch (basics::Exception const& ex) {
+    EXPECT_EQ(TRI_ERROR_INTERNAL, ex.code());
+  } catch (...) {
+    FAIL() << "expected basics::Exception with TRI_ERROR_INTERNAL";
+  }
+}
+
+}  // namespace

--- a/tests/Aql/MatchPatternNormalizerTest.cpp
+++ b/tests/Aql/MatchPatternNormalizerTest.cpp
@@ -145,7 +145,8 @@ class MatchPatternNormalizerTest : public ::testing::Test {
     return normalizer.normalize(*parsed.matchNode);
   }
 
-  static std::unique_ptr<ExecutionPlan> instantiatePlan(ParsedMatch const& parsed) {
+  static std::unique_ptr<ExecutionPlan> instantiatePlan(
+      ParsedMatch const& parsed) {
     return ExecutionPlan::instantiateFromAst(parsed.ast.get(), false);
   }
 
@@ -553,16 +554,16 @@ TEST_F(MatchPatternNormalizerTest, rejectsInvalidDirectionValue) {
   edge->getMember(4)->setIntValue(99);
 
   MatchPatternNormalizer normalizer(*parsed.ast);
-  EXPECT_THROW(
-      { (void)normalizer.normalize(*parsed.matchNode); }, basics::Exception);
+  EXPECT_THROW({ (void)normalizer.normalize(*parsed.matchNode); },
+               basics::Exception);
 }
 
 TEST_F(MatchPatternNormalizerTest, rejectsInvalidRange) {
   auto parsed =
       parseMatch("MATCH (v :vc) -[ e :ec * 5..2 ]-> (w :vc) RETURN 1");
   MatchPatternNormalizer normalizer(*parsed.ast);
-  EXPECT_THROW(
-      { (void)normalizer.normalize(*parsed.matchNode); }, basics::Exception);
+  EXPECT_THROW({ (void)normalizer.normalize(*parsed.matchNode); },
+               basics::Exception);
 }
 
 TEST_F(MatchPatternNormalizerTest, whereNestedDottedAttributeAccess) {
@@ -736,15 +737,15 @@ TEST_F(MatchPatternNormalizerTest,
       parseMatch("MATCH (v :vc) -[ e :ec|ec2 ]-> (w :vc) RETURN [v, e, w]");
   auto statement = normalize(parsed);
 
-  ASSERT_EQ(2U, statement.patterns.front()
-                    .segments.front()
-                    .edge.collections.size());
+  ASSERT_EQ(
+      2U, statement.patterns.front().segments.front().edge.collections.size());
 
   auto plan = instantiatePlan(parsed);
   ASSERT_NE(nullptr, plan);
 }
 
-TEST_F(MatchPatternNormalizerTest, matchBuilderConsumesNormalizedFixedPathRange) {
+TEST_F(MatchPatternNormalizerTest,
+       matchBuilderConsumesNormalizedFixedPathRange) {
   auto parsed =
       parseMatch("MATCH (v :vc) -[ e :ec * 2..2 ]-> (w :vc) RETURN [v, e, w]");
   auto statement = normalize(parsed);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,7 +100,8 @@ set(ARANGODB_TESTS_SOURCES
   Aql/AqlValueMemoryLayoutTest.cpp
   Aql/AstNodeTest.cpp
   Aql/AstResourcesTest.cpp
-  Aql/AttributeNamePathTest.cpp
+  Aql/MatchPatternNormalizerTest.cpp
+  Aql/AttributeNamePathTest.cpp  
   Aql/BlockCollector.cpp
   Aql/ConditionRemoveForIndexTest.cpp
   Aql/ConditionRemoveForTraversalTest.cpp


### PR DESCRIPTION
A transformation that reads the parser-specific MATCH AST once, resolves its syntactic variations and semantic details into a stable, typed NormalizedMatch representation, and allows MatchBuilder to construct the execution plan without depending on the raw AST layout.

**Before Normalization Layer:**
AQL query --> Parser --> Raw AST --> ExecutionPlan


**After Normalization Layer:**
AQL query --> Parser --> Raw AST --> MatchPatternNormalizer --> NormalizedMatchStatement --> MatchBuilder --> ExecutionPlan / traversal nodes