### PR TITLE
Add input/output Register Lookup

### DIFF
--- a/arangod/Aql/ExecutionEngine.cpp
+++ b/arangod/Aql/ExecutionEngine.cpp
@@ -916,8 +916,8 @@ void ExecutionEngine::initializeConstValueBlock(
         [&, regPlan = plan.root()->getRegisterPlan(),
          block = mgr.getConstValueBlock()](Variable* var) {
           if (var->type() == Variable::Type::Const) {
-            RegisterId reg = regPlan->variableToOptionalRegisterId(var->id);
-            if (reg.value() != RegisterId::maxRegisterId) {
+            RegisterId reg = regPlan->constVariableToRegisterId(var->id);
+            if (reg.isValid()) {
               TRI_ASSERT(reg.isConstRegister());
               AqlValue owned = var->extractOwnedConstantValue();
               block->emplaceValue(0, reg.value(), std::move(owned));
@@ -925,8 +925,8 @@ void ExecutionEngine::initializeConstValueBlock(
                   block->getValueReference(0, reg.value()).slice());
             }
           } else if (var->type() == Variable::Type::BindParameter) {
-            RegisterId reg = regPlan->variableToOptionalRegisterId(var->id);
-            if (reg.value() != RegisterId::maxRegisterId) {
+            RegisterId reg = regPlan->constVariableToRegisterId(var->id);
+            if (reg.isValid()) {
               auto [slice, node] = bindParameters.get(var->bindParameterName());
               if (slice.isNone()) {
                 THROW_ARANGO_EXCEPTION(TRI_ERROR_QUERY_BIND_PARAMETER_MISSING);

--- a/arangod/Aql/ExecutionNode/CalculationNode.cpp
+++ b/arangod/Aql/ExecutionNode/CalculationNode.cpp
@@ -130,9 +130,9 @@ std::unique_ptr<ExecutionBlock> CalculationNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId outputRegister = variableToRegisterId(_outVariable);
+  RegisterId outReg = outputRegister(_outVariable);
   TRI_ASSERT((_outVariable->type() == Variable::Type::Const) ==
-             outputRegister.isConstRegister());
+             outReg.isConstRegister());
 
   VarSet inVars;
   _expression->variables(inVars);
@@ -144,7 +144,7 @@ std::unique_ptr<ExecutionBlock> CalculationNode::createBlock(
 
   for (auto const& var : inVars) {
     TRI_ASSERT(var != nullptr);
-    auto regId = variableToRegisterId(var);
+    auto regId = inputRegister(var);
     expInVarsToRegs.emplace_back(var->id, regId);
     inputRegisters.emplace(regId);
   }
@@ -157,21 +157,21 @@ std::unique_ptr<ExecutionBlock> CalculationNode::createBlock(
   TRI_ASSERT(expression() != nullptr);
 
   auto registerInfos = createRegisterInfos(std::move(inputRegisters),
-                                           outputRegister.isRegularRegister()
-                                               ? RegIdSet{outputRegister}
+                                           outReg.isRegularRegister()
+                                               ? RegIdSet{outReg}
                                                : RegIdSet{});
 
   if (_outVariable->type() == Variable::Type::Const) {
     // we have a const variable, so we can simply use an IdExector to forward
     // the rows.
-    auto executorInfos = IdExecutorInfos(false, outputRegister);
+    auto executorInfos = IdExecutorInfos(false, outReg);
     return std::make_unique<ExecutionBlockImpl<
         IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>>>(
         &engine, this, std::move(registerInfos), std::move(executorInfos));
   }
 
   auto executorInfos = CalculationExecutorInfos(
-      outputRegister,
+      outReg,
       engine.getQuery() /* used for v8 contexts and in expression */,
       *expression(),
       std::move(expInVarsToRegs)); /* required by expression.execute */

--- a/arangod/Aql/ExecutionNode/CalculationNode.cpp
+++ b/arangod/Aql/ExecutionNode/CalculationNode.cpp
@@ -156,10 +156,9 @@ std::unique_ptr<ExecutionBlock> CalculationNode::createBlock(
 
   TRI_ASSERT(expression() != nullptr);
 
-  auto registerInfos = createRegisterInfos(std::move(inputRegisters),
-                                           outReg.isRegularRegister()
-                                               ? RegIdSet{outReg}
-                                               : RegIdSet{});
+  auto registerInfos = createRegisterInfos(
+      std::move(inputRegisters),
+      outReg.isRegularRegister() ? RegIdSet{outReg} : RegIdSet{});
 
   if (_outVariable->type() == Variable::Type::Const) {
     // we have a const variable, so we can simply use an IdExector to forward
@@ -171,8 +170,7 @@ std::unique_ptr<ExecutionBlock> CalculationNode::createBlock(
   }
 
   auto executorInfos = CalculationExecutorInfos(
-      outReg,
-      engine.getQuery() /* used for v8 contexts and in expression */,
+      outReg, engine.getQuery() /* used for v8 contexts and in expression */,
       *expression(),
       std::move(expInVarsToRegs)); /* required by expression.execute */
 

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -155,10 +155,8 @@ void CollectNode::calcExpressionRegister(
     arangodb::aql::RegisterId& expressionRegister,
     RegIdSet& readableInputRegisters) const {
   if (_expressionVariable != nullptr) {
-    auto it = getRegisterPlan()->varInfo.find(_expressionVariable->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-    expressionRegister = (*it).second.registerId;
-    readableInputRegisters.insert((*it).second.registerId);
+    expressionRegister = inputRegister(_expressionVariable);
+    readableInputRegisters.insert(expressionRegister);
   }
 }
 
@@ -166,11 +164,9 @@ void CollectNode::calcCollectRegister(
     arangodb::aql::RegisterId& collectRegister,
     RegIdSet& writeableOutputRegisters) const {
   if (_outVariable != nullptr) {
-    auto it = getRegisterPlan()->varInfo.find(_outVariable->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-    collectRegister = (*it).second.registerId;
+    collectRegister = outputRegister(_outVariable);
     TRI_ASSERT(collectRegister.isValid());
-    writeableOutputRegisters.insert((*it).second.registerId);
+    writeableOutputRegisters.insert(collectRegister);
   }
 }
 
@@ -182,14 +178,8 @@ void CollectNode::calcGroupRegisters(
   for (auto const& p : _groupVariables) {
     // We know that planRegisters() has been run, so
     // getPlanNode()->_registerPlan is set up
-    auto itOut = getRegisterPlan()->varInfo.find(p.outVar->id);
-    TRI_ASSERT(itOut != getRegisterPlan()->varInfo.end());
-
-    auto itIn = getRegisterPlan()->varInfo.find(p.inVar->id);
-    TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
-
-    RegisterId inReg = itIn->second.registerId;
-    RegisterId outReg = itOut->second.registerId;
+    RegisterId inReg = inputRegister(p.inVar);
+    RegisterId outReg = outputRegister(p.outVar);
     TRI_ASSERT(inReg.isValid());
     TRI_ASSERT(outReg.isValid());
     groupRegisters.emplace_back(outReg, inReg);
@@ -205,16 +195,12 @@ void CollectNode::calcAggregateRegisters(
   for (auto const& p : _aggregateVariables) {
     // We know that planRegisters() has been run, so
     // getPlanNode()->_registerPlan is set up
-    auto itOut = getRegisterPlan()->varInfo.find(p.outVar->id);
-    TRI_ASSERT(itOut != getRegisterPlan()->varInfo.end());
-    RegisterId outReg = itOut->second.registerId;
+    RegisterId outReg = outputRegister(p.outVar);
     TRI_ASSERT(outReg.isValid());
 
-    RegisterId inReg{RegisterId::maxRegisterId};
+    RegisterId inReg = RegisterId::makeInvalid();
     if (Aggregator::requiresInput(p.type)) {
-      auto itIn = getRegisterPlan()->varInfo.find(p.inVar->id);
-      TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
-      inReg = itIn->second.registerId;
+      inReg = inputRegister(p.inVar);
       TRI_ASSERT(inReg.isValid());
       readableInputRegisters.insert(inReg);
     }
@@ -240,16 +226,13 @@ CollectNode::calcInputVariableNames() const {
   std::vector<std::pair<std::string, RegisterId>> variableNames;
 
   if (_outVariable != nullptr) {
-    auto const& varInfo = getRegisterPlan()->varInfo;
-    TRI_ASSERT(varInfo.find(_outVariable->id) != varInfo.end());
+    TRI_ASSERT(outputRegister(_outVariable).isValid());
 
-    // iterate over all our variables
+    // the KEEP variables are carried over from the input rows
     for (auto const& x : _keepVariables) {
-      auto const it = varInfo.find(x.first->id);
-
-      if (it != varInfo.end()) {
-        variableNames.emplace_back(
-            std::make_pair(x.second, (*it).second.registerId));
+      auto const reg = inputRegisterOptional(x.first);
+      if (reg.isValid()) {
+        variableNames.emplace_back(std::make_pair(x.second, reg));
       }
     }
   }
@@ -369,10 +352,8 @@ std::unique_ptr<ExecutionBlock> CollectNode::createBlock(
       ExecutionNode const* previousNode = getFirstDependency();
       TRI_ASSERT(previousNode != nullptr);
 
-      auto it =
-          getRegisterPlan()->varInfo.find(aggregateVariables()[0].outVar->id);
-      TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-      RegisterId collectRegister = (*it).second.registerId;
+      RegisterId collectRegister =
+          outputRegister(aggregateVariables()[0].outVar);
 
       auto registerInfos = createRegisterInfos({}, RegIdSet{collectRegister});
 

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -230,7 +230,7 @@ CollectNode::calcInputVariableNames() const {
 
     // the KEEP variables are carried over from the input rows
     for (auto const& x : _keepVariables) {
-      auto const reg = inputRegisterOptional(x.first);
+      auto const reg = inputRegisterOrInvalid(x.first);
       if (reg.isValid()) {
         variableNames.emplace_back(std::make_pair(x.second, reg));
       }

--- a/arangod/Aql/ExecutionNode/DistributeNode.cpp
+++ b/arangod/Aql/ExecutionNode/DistributeNode.cpp
@@ -105,13 +105,9 @@ std::unique_ptr<ExecutionBlock> DistributeNode::createBlock(
 
   // get the variable to inspect . . .
   TRI_ASSERT(_variable != nullptr);
-  VariableId varId = _variable->id;
 
   // get the register id of the variable to inspect . . .
-  auto it = getRegisterPlan()->varInfo.find(varId);
-  TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-  RegisterId regId = (*it).second.registerId;
-
+  RegisterId regId = inputRegister(_variable);
   TRI_ASSERT(regId.isValid());
 
   auto inRegs = RegIdSet{regId};

--- a/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
 
     for (auto& var : inVars) {
       TRI_ASSERT(var != nullptr);
-      auto regId = registerFor(var);
+      auto regId = inputOrOutputRegister(var);
       filterVarsToRegs.emplace_back(var->id, regId);
     }
   }

--- a/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
@@ -94,12 +94,12 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
 
     for (auto& var : inVars) {
       TRI_ASSERT(var != nullptr);
-      auto regId = variableToRegisterId(var);
+      auto regId = registerFor(var);
       filterVarsToRegs.emplace_back(var->id, regId);
     }
   }
 
-  RegisterId outputRegister = variableToRegisterId(_outVariable);
+  RegisterId outReg = outputRegister(_outVariable);
 
   auto outputRegisters = RegIdSet{};
 
@@ -115,7 +115,7 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
         continue;
       }
       TRI_ASSERT(var != nullptr);
-      auto regId = variableToRegisterId(var);
+      auto regId = outputRegister(var);
       filterVarsToRegs.emplace_back(var->id, regId);
       outputRegisters.emplace(regId);
     }
@@ -129,13 +129,13 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
     // this will be handled below by adding the main output register.
   }
   if (outputRegisters.empty() && isProduceResult()) {
-    outputRegisters.emplace(outputRegister);
+    outputRegisters.emplace(outReg);
   }
   TRI_ASSERT(!outputRegisters.empty() || !isProduceResult());
 
   auto registerInfos = createRegisterInfos({}, std::move(outputRegisters));
   auto executorInfos = EnumerateCollectionExecutorInfos(
-      outputRegister, engine.getQuery(), collection(), _outVariable,
+      outReg, engine.getQuery(), collection(), _outVariable,
       isProduceResult(), filter(), projections(), std::move(filterVarsToRegs),
       _random, doCount(), canReadOwnWrites());
   return std::make_unique<ExecutionBlockImpl<EnumerateCollectionExecutor>>(

--- a/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
@@ -94,7 +94,10 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
 
     for (auto& var : inVars) {
       TRI_ASSERT(var != nullptr);
-      auto regId = inputOrOutputRegister(var);
+      if (var == _outVariable) {
+        continue;
+      }
+      auto regId = inputRegister(var);
       filterVarsToRegs.emplace_back(var->id, regId);
     }
   }

--- a/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateCollectionNode.cpp
@@ -135,9 +135,9 @@ std::unique_ptr<ExecutionBlock> EnumerateCollectionNode::createBlock(
 
   auto registerInfos = createRegisterInfos({}, std::move(outputRegisters));
   auto executorInfos = EnumerateCollectionExecutorInfos(
-      outReg, engine.getQuery(), collection(), _outVariable,
-      isProduceResult(), filter(), projections(), std::move(filterVarsToRegs),
-      _random, doCount(), canReadOwnWrites());
+      outReg, engine.getQuery(), collection(), _outVariable, isProduceResult(),
+      filter(), projections(), std::move(filterVarsToRegs), _random, doCount(),
+      canReadOwnWrites());
   return std::make_unique<ExecutionBlockImpl<EnumerateCollectionExecutor>>(
       &engine, this, std::move(registerInfos), std::move(executorInfos));
 }

--- a/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
 
     for (auto const& var : inVars) {
       if (var->id != _outVariable->id) {
-        auto regId = registerFor(var);
+        auto regId = inputOrOutputRegister(var);
         varsToRegs.emplace_back(var->id, regId);
       }
     }

--- a/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
@@ -110,22 +110,22 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
     ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
-  RegisterId inputRegister = variableToRegisterId(_inVariable);
+  RegisterId inReg = inputRegister(_inVariable);
   std::vector<RegisterId> outRegisters;
 
   RegIdSet outRegisterSet;
   if (_mode == kEnumerateArray) {
     outRegisters.resize(1);
-    outRegisters[0] = variableToRegisterId(_outVariable);
+    outRegisters[0] = outputRegister(_outVariable);
     outRegisterSet = RegIdSet{outRegisters[0]};
   } else {
     outRegisters.resize(2);
-    outRegisters[0] = variableToRegisterId(_keyValuePairOutVars[0]);
-    outRegisters[1] = variableToRegisterId(_keyValuePairOutVars[1]);
+    outRegisters[0] = outputRegister(_keyValuePairOutVars[0]);
+    outRegisters[1] = outputRegister(_keyValuePairOutVars[1]);
     outRegisterSet = RegIdSet{outRegisters[0], outRegisters[1]};
   }
   auto registerInfos =
-      createRegisterInfos(RegIdSet{inputRegister}, outRegisterSet);
+      createRegisterInfos(RegIdSet{inReg}, outRegisterSet);
 
   std::vector<std::pair<VariableId, RegisterId>> varsToRegs;
   if (hasFilter()) {
@@ -134,13 +134,13 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
 
     for (auto const& var : inVars) {
       if (var->id != _outVariable->id) {
-        auto regId = variableToRegisterId(var);
+        auto regId = registerFor(var);
         varsToRegs.emplace_back(var->id, regId);
       }
     }
   }
   auto executorInfos = EnumerateListExecutorInfos(
-      inputRegister, std::move(outRegisters), engine.getQuery(), filter(),
+      inReg, std::move(outRegisters), engine.getQuery(), filter(),
       this->getVariablesSetHere(), std::move(varsToRegs), _mode);
 
   if (_mode == EnumerateListNode::kEnumerateArray) {

--- a/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
@@ -124,8 +124,7 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
     outRegisters[1] = outputRegister(_keyValuePairOutVars[1]);
     outRegisterSet = RegIdSet{outRegisters[0], outRegisters[1]};
   }
-  auto registerInfos =
-      createRegisterInfos(RegIdSet{inReg}, outRegisterSet);
+  auto registerInfos = createRegisterInfos(RegIdSet{inReg}, outRegisterSet);
 
   std::vector<std::pair<VariableId, RegisterId>> varsToRegs;
   if (hasFilter()) {

--- a/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
@@ -29,6 +29,8 @@
 #include "Aql/Executor/EnumerateListExecutor.h"
 #include "Aql/Expression.h"
 #include "Aql/RegisterPlan.h"
+
+#include <algorithm>
 #include "Aql/Variable.h"
 #include "Basics/StaticStrings.h"
 
@@ -131,11 +133,12 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
     VarSet inVars;
     _filter->variables(inVars);
 
+    auto const produced = getVariablesSetHere();
     for (auto const& var : inVars) {
-      if (var->id != _outVariable->id) {
-        auto regId = inputOrOutputRegister(var);
-        varsToRegs.emplace_back(var->id, regId);
+      if (std::find(produced.begin(), produced.end(), var) != produced.end()) {
+        continue;
       }
+      varsToRegs.emplace_back(var->id, inputRegister(var));
     }
   }
   auto executorInfos = EnumerateListExecutorInfos(

--- a/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateListNode.cpp
@@ -133,9 +133,13 @@ std::unique_ptr<ExecutionBlock> EnumerateListNode::createBlock(
     VarSet inVars;
     _filter->variables(inVars);
 
+    // getVariablesSetHere() omits _outVariable in kEnumerateObject mode, where
+    // the key/value pair is produced instead. Skip it unconditionally, as it
+    // has no register in that mode.
     auto const produced = getVariablesSetHere();
     for (auto const& var : inVars) {
-      if (std::find(produced.begin(), produced.end(), var) != produced.end()) {
+      if (var == _outVariable ||
+          std::find(produced.begin(), produced.end(), var) != produced.end()) {
         continue;
       }
       varsToRegs.emplace_back(var->id, inputRegister(var));

--- a/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
@@ -97,10 +97,14 @@ EnumerateNearVectorNode::extractFilterVarsToRegs() const {
   std::vector<std::pair<VariableId, RegisterId>> filterVarsToRegs;
   filterVarsToRegs.reserve(inVars.size());
 
+  // getVariablesSetHere() omits _outVariable in kCovered mode, where the
+  // document is not produced, but the filter may still reference it and it has
+  // no register either way. Skip it unconditionally.
   auto const produced = getVariablesSetHere();
   for (auto const& var : inVars) {
     TRI_ASSERT(var != nullptr);
-    if (std::find(produced.begin(), produced.end(), var) != produced.end()) {
+    if (var == _outVariable ||
+        std::find(produced.begin(), produced.end(), var) != produced.end()) {
       continue;
     }
     filterVarsToRegs.emplace_back(var->id, inputRegister(var));

--- a/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
@@ -97,12 +97,13 @@ EnumerateNearVectorNode::extractFilterVarsToRegs() const {
   std::vector<std::pair<VariableId, RegisterId>> filterVarsToRegs;
   filterVarsToRegs.reserve(inVars.size());
 
+  auto const produced = getVariablesSetHere();
   for (auto const& var : inVars) {
     TRI_ASSERT(var != nullptr);
-    if (var->id == _outVariable->id) {
+    if (std::find(produced.begin(), produced.end(), var) != produced.end()) {
       continue;
     }
-    filterVarsToRegs.emplace_back(var->id, inputOrOutputRegister(var));
+    filterVarsToRegs.emplace_back(var->id, inputRegister(var));
   }
 
   return filterVarsToRegs;

--- a/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
@@ -102,7 +102,7 @@ EnumerateNearVectorNode::extractFilterVarsToRegs() const {
     if (var->id == _outVariable->id) {
       continue;
     }
-    filterVarsToRegs.emplace_back(var->id, registerFor(var));
+    filterVarsToRegs.emplace_back(var->id, inputOrOutputRegister(var));
   }
 
   return filterVarsToRegs;

--- a/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumerateNearVectorNode.cpp
@@ -102,7 +102,7 @@ EnumerateNearVectorNode::extractFilterVarsToRegs() const {
     if (var->id == _outVariable->id) {
       continue;
     }
-    filterVarsToRegs.emplace_back(var->id, variableToRegisterId(var));
+    filterVarsToRegs.emplace_back(var->id, registerFor(var));
   }
 
   return filterVarsToRegs;
@@ -114,24 +114,24 @@ std::unique_ptr<ExecutionBlock> EnumerateNearVectorNode::createBlock(
   // The doc-variable register is written for everything except kCovered.
   RegisterId outDocumentRegId = RegisterId::maxRegisterId;
   if (_projectionMode != vector::ProjectionMode::kCovered) {
-    outDocumentRegId = variableToRegisterId(_outVariable);
+    outDocumentRegId = outputRegister(_outVariable);
     writableOutputRegisters.emplace(outDocumentRegId);
   }
 
-  RegisterId outDistanceRegId = variableToRegisterId(_distanceOutVariable);
+  RegisterId outDistanceRegId = outputRegister(_distanceOutVariable);
   writableOutputRegisters.emplace(outDistanceRegId);
   // per-projection output registers (set by the projections rule)
   containers::FlatHashMap<VariableId, RegisterId> projectionVarsToRegs;
   for (size_t i = 0; i < _projections.size(); ++i) {
     auto const* var = _projections[i].variable;
     if (var != nullptr) {
-      RegisterId regId = variableToRegisterId(var);
+      RegisterId regId = outputRegister(var);
       writableOutputRegisters.emplace(regId);
       projectionVarsToRegs.try_emplace(var->id, regId);
     }
   }
 
-  RegisterId inNmDocIdRegId = variableToRegisterId(_inVariable);
+  RegisterId inNmDocIdRegId = inputRegister(_inVariable);
   RegIdSet readableInputRegisters;
   readableInputRegisters.emplace(inNmDocIdRegId);
 

--- a/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
@@ -88,19 +88,13 @@ static GraphNode::InputVertex prepareVertexInput(EnumeratePathsNode const* node,
   using InputVertex = GraphNode::InputVertex;
   if (isTarget) {
     if (node->usesTargetInVariable()) {
-      auto it =
-          node->getRegisterPlan()->varInfo.find(node->targetInVariable().id);
-      TRI_ASSERT(it != node->getRegisterPlan()->varInfo.end());
-      return InputVertex{it->second.registerId};
+      return InputVertex{node->inputRegister(&node->targetInVariable())};
     } else {
       return InputVertex{node->getTargetVertex()};
     }
   } else {
     if (node->usesStartInVariable()) {
-      auto it =
-          node->getRegisterPlan()->varInfo.find(node->startInVariable().id);
-      TRI_ASSERT(it != node->getRegisterPlan()->varInfo.end());
-      return InputVertex{it->second.registerId};
+      return InputVertex{node->inputRegister(&node->startInVariable())};
     } else {
       return InputVertex{node->getStartVertex()};
     }
@@ -406,15 +400,15 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
   TRI_ASSERT(previousNode != nullptr);
   RegIdSet inputRegisters;
   if (usesStartInVariable()) {
-    inputRegisters.emplace(variableToRegisterId(&startInVariable()));
+    inputRegisters.emplace(inputRegister(&startInVariable()));
   }
   if (usesTargetInVariable()) {
-    inputRegisters.emplace(variableToRegisterId(&targetInVariable()));
+    inputRegisters.emplace(inputRegister(&targetInVariable()));
   }
 
   TRI_ASSERT(usesPathOutVariable());  // This node always produces the path!
-  auto outputRegister = variableToRegisterId(&pathOutVariable());
-  auto outputRegisters = RegIdSet{outputRegister};
+  auto outReg = outputRegister(&pathOutVariable());
+  auto outputRegisters = RegIdSet{outReg};
 
   auto registerInfos = createRegisterInfos(std::move(inputRegisters),
                                            std::move(outputRegisters));
@@ -488,7 +482,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                                        SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
-            validatorOptions, outputRegister, engine, sourceInput, targetInput,
+            validatorOptions, outReg, engine, sourceInput, targetInput,
             registerInfos);
       case arangodb::graph::PathType::Type::AllShortestPaths:
         return _makeExecutionBlockImpl<AllShortestPathsEnumerator<Provider>,
@@ -496,7 +490,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                                        SingleServerBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
-            validatorOptions, outputRegister, engine, sourceInput, targetInput,
+            validatorOptions, outReg, engine, sourceInput, targetInput,
             registerInfos);
       case arangodb::graph::PathType::Type::KShortestPaths:
         enumeratorOptions.setMinDepth(0);
@@ -509,7 +503,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                                          SingleServerBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outputRegister, engine, sourceInput,
+              validatorOptions, outReg, engine, sourceInput,
               targetInput, registerInfos);
         } else {
           // Weighted Variant
@@ -543,7 +537,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
               SingleServerBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outputRegister, engine, sourceInput,
+              validatorOptions, outReg, engine, sourceInput,
               targetInput, registerInfos);
         }
 
@@ -580,7 +574,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                                        ClusterBaseProviderOptions>(
             opts, std::move(forwardProviderOptions),
             std::move(backwardProviderOptions), enumeratorOptions,
-            validatorOptions, outputRegister, engine, sourceInput, targetInput,
+            validatorOptions, outReg, engine, sourceInput, targetInput,
             registerInfos);
       case arangodb::graph::PathType::Type::AllShortestPaths:
         return _makeExecutionBlockImpl<
@@ -588,7 +582,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
             ClusterBaseProviderOptions>(opts, std::move(forwardProviderOptions),
                                         std::move(backwardProviderOptions),
                                         enumeratorOptions, validatorOptions,
-                                        outputRegister, engine, sourceInput,
+                                        outReg, engine, sourceInput,
                                         targetInput, registerInfos);
       case arangodb::graph::PathType::Type::KShortestPaths:
         // TODO: deduplicate with SingleServer && SingleServer non-traced
@@ -603,7 +597,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
               ClusterBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outputRegister, engine, sourceInput,
+              validatorOptions, outReg, engine, sourceInput,
               targetInput, registerInfos);
         } else {
           // Weighted Variant
@@ -637,7 +631,7 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
               ClusterProvider, ClusterBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outputRegister, engine, sourceInput,
+              validatorOptions, outReg, engine, sourceInput,
               targetInput, registerInfos);
         }
       default:

--- a/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
+++ b/arangod/Aql/ExecutionNode/EnumeratePathsNode.cpp
@@ -503,8 +503,8 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
                                          SingleServerBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outReg, engine, sourceInput,
-              targetInput, registerInfos);
+              validatorOptions, outReg, engine, sourceInput, targetInput,
+              registerInfos);
         } else {
           // Weighted Variant
           double defaultWeight = opts->getDefaultWeight();
@@ -537,8 +537,8 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
               SingleServerBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outReg, engine, sourceInput,
-              targetInput, registerInfos);
+              validatorOptions, outReg, engine, sourceInput, targetInput,
+              registerInfos);
         }
 
       default:
@@ -597,8 +597,8 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
               ClusterBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outReg, engine, sourceInput,
-              targetInput, registerInfos);
+              validatorOptions, outReg, engine, sourceInput, targetInput,
+              registerInfos);
         } else {
           // Weighted Variant
           double defaultWeight = opts->getDefaultWeight();
@@ -631,8 +631,8 @@ std::unique_ptr<ExecutionBlock> EnumeratePathsNode::createBlock(
               ClusterProvider, ClusterBaseProviderOptions>(
               opts, std::move(forwardProviderOptions),
               std::move(backwardProviderOptions), enumeratorOptions,
-              validatorOptions, outReg, engine, sourceInput,
-              targetInput, registerInfos);
+              validatorOptions, outReg, engine, sourceInput, targetInput,
+              registerInfos);
         }
       default:
         ADB_PROD_ASSERT(false)

--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -1180,13 +1180,11 @@ struct RegisterPlanningDebugger final : public WalkerWorker<ExecutionNode, Walke
     VarSet variablesUsedHere;
     ep->getVariablesUsedHere(variablesUsedHere);
     for (auto const& v : variablesUsedHere) {
-      std::cout << ep->getRegisterPlan()->varInfo.find(v->id)->second.registerId
-                << " ";
+      std::cout << ep->inputRegister(v) << " ";
     }
     std::cout << "regsSetHere: ";
     for (auto const& v : ep->getVariablesSetHere()) {
-      std::cout << ep->getRegisterPlan()->varInfo.find(v->id)->second.registerId
-                << " ";
+      std::cout << ep->outputRegister(v) << " ";
     }
     std::cout << "regsToClear: ";
     for (auto const& r : ep->getRegsToClear()) {
@@ -1325,8 +1323,55 @@ void ExecutionNode::removeDependencies() {
   _dependencies.clear();
 }
 
-RegisterId ExecutionNode::variableToRegisterId(Variable const* variable) const {
-  return getRegisterPlan()->variableToRegisterId(variable);
+unsigned int ExecutionNode::inputDepth() const noexcept {
+  auto const* dependency = getFirstDependency();
+  // the SingletonNode has no input rows at all; report our own depth so that
+  // callers do not have to special-case it
+  TRI_ASSERT(dependency != nullptr || getType() == ExecutionNode::SINGLETON);
+  return dependency == nullptr ? _depth : dependency->_depth;
+}
+
+RegisterId ExecutionNode::outputRegister(Variable const* variable) const {
+  return getRegisterPlan()->variableToRegisterId(variable, _depth);
+}
+
+RegisterId ExecutionNode::inputRegister(Variable const* variable) const {
+  return getRegisterPlan()->variableToRegisterId(variable, inputDepth());
+}
+
+RegisterId ExecutionNode::inputRegisterOptional(Variable const* variable) const {
+  if (variable == nullptr) {
+    return RegisterId::makeInvalid();
+  }
+  return getRegisterPlan()->variableToOptionalRegisterId(variable->id,
+                                                         inputDepth());
+}
+
+RegisterId ExecutionNode::outputRegisterOptional(
+    Variable const* variable) const {
+  if (variable == nullptr) {
+    return RegisterId::makeInvalid();
+  }
+  return getRegisterPlan()->variableToOptionalRegisterId(variable->id, _depth);
+}
+
+bool ExecutionNode::setsVariable(Variable const* variable) const {
+  TRI_ASSERT(variable != nullptr);
+  auto const setHere = getVariablesSetHere();
+  return std::find(setHere.begin(), setHere.end(), variable) != setHere.end();
+}
+
+RegisterId ExecutionNode::registerFor(Variable const* variable) const {
+  return setsVariable(variable) ? outputRegister(variable)
+                                : inputRegister(variable);
+}
+
+RegisterResolver ExecutionNode::inputRegisterResolver() const {
+  return getRegisterPlan()->resolverForDepth(inputDepth());
+}
+
+RegisterResolver ExecutionNode::outputRegisterResolver() const {
+  return getRegisterPlan()->resolverForDepth(_depth);
 }
 
 // This is the general case and will not work if e.g. there is no predecessor.
@@ -1647,14 +1692,6 @@ void ExecutionNode::setRegsToClear(RegIdSet toClear) {
 
 void ExecutionNode::setRegsToKeep(RegIdSetStack toKeep) {
   _regsToKeepStack = std::move(toKeep);
-}
-
-RegisterId ExecutionNode::variableToRegisterOptionalId(
-    Variable const* var) const {
-  if (var) {
-    return variableToRegisterId(var);
-  }
-  return RegisterId{RegisterId::maxRegisterId};
 }
 
 bool ExecutionNode::isIncreaseDepth() const {

--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -1331,11 +1331,13 @@ unsigned int ExecutionNode::inputDepth() const noexcept {
   return dependency == nullptr ? _depth : dependency->_depth;
 }
 
-RegisterId ExecutionNode::outputRegister(Variable const* variable) const noexcept {
+RegisterId ExecutionNode::outputRegister(
+    Variable const* variable) const noexcept {
   return getRegisterPlan()->variableToRegisterId(variable, _depth);
 }
 
-RegisterId ExecutionNode::inputRegister(Variable const* variable) const noexcept {
+RegisterId ExecutionNode::inputRegister(
+    Variable const* variable) const noexcept {
   return getRegisterPlan()->variableToRegisterId(variable, inputDepth());
 }
 

--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -1331,17 +1331,15 @@ unsigned int ExecutionNode::inputDepth() const noexcept {
   return dependency == nullptr ? _depth : dependency->_depth;
 }
 
-RegisterId ExecutionNode::outputRegister(
-    Variable const* variable) const noexcept {
+RegisterId ExecutionNode::outputRegister(Variable const* variable) const {
   return getRegisterPlan()->variableToRegisterId(variable, _depth);
 }
 
-RegisterId ExecutionNode::inputRegister(
-    Variable const* variable) const noexcept {
+RegisterId ExecutionNode::inputRegister(Variable const* variable) const {
   return getRegisterPlan()->variableToRegisterId(variable, inputDepth());
 }
 
-RegisterId ExecutionNode::inputRegisterOptional(
+RegisterId ExecutionNode::inputRegisterOrInvalid(
     Variable const* variable) const noexcept {
   if (variable == nullptr) {
     return RegisterId::makeInvalid();
@@ -1350,24 +1348,12 @@ RegisterId ExecutionNode::inputRegisterOptional(
                                                          inputDepth());
 }
 
-RegisterId ExecutionNode::outputRegisterOptional(
+RegisterId ExecutionNode::outputRegisterOrInvalid(
     Variable const* variable) const noexcept {
   if (variable == nullptr) {
     return RegisterId::makeInvalid();
   }
   return getRegisterPlan()->variableToOptionalRegisterId(variable->id, _depth);
-}
-
-bool ExecutionNode::setsVariable(Variable const* variable) const {
-  TRI_ASSERT(variable != nullptr);
-  auto const setHere = getVariablesSetHere();
-  return std::find(setHere.begin(), setHere.end(), variable) != setHere.end();
-}
-
-RegisterId ExecutionNode::inputOrOutputRegister(
-    Variable const* variable) const {
-  return setsVariable(variable) ? outputRegister(variable)
-                                : inputRegister(variable);
 }
 
 RegisterResolver ExecutionNode::inputRegisterResolver() const noexcept {

--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -1331,15 +1331,16 @@ unsigned int ExecutionNode::inputDepth() const noexcept {
   return dependency == nullptr ? _depth : dependency->_depth;
 }
 
-RegisterId ExecutionNode::outputRegister(Variable const* variable) const {
+RegisterId ExecutionNode::outputRegister(Variable const* variable) const noexcept {
   return getRegisterPlan()->variableToRegisterId(variable, _depth);
 }
 
-RegisterId ExecutionNode::inputRegister(Variable const* variable) const {
+RegisterId ExecutionNode::inputRegister(Variable const* variable) const noexcept {
   return getRegisterPlan()->variableToRegisterId(variable, inputDepth());
 }
 
-RegisterId ExecutionNode::inputRegisterOptional(Variable const* variable) const {
+RegisterId ExecutionNode::inputRegisterOptional(
+    Variable const* variable) const noexcept {
   if (variable == nullptr) {
     return RegisterId::makeInvalid();
   }
@@ -1348,7 +1349,7 @@ RegisterId ExecutionNode::inputRegisterOptional(Variable const* variable) const 
 }
 
 RegisterId ExecutionNode::outputRegisterOptional(
-    Variable const* variable) const {
+    Variable const* variable) const noexcept {
   if (variable == nullptr) {
     return RegisterId::makeInvalid();
   }
@@ -1361,16 +1362,17 @@ bool ExecutionNode::setsVariable(Variable const* variable) const {
   return std::find(setHere.begin(), setHere.end(), variable) != setHere.end();
 }
 
-RegisterId ExecutionNode::inputOrOutputRegister(Variable const* variable) const {
+RegisterId ExecutionNode::inputOrOutputRegister(
+    Variable const* variable) const {
   return setsVariable(variable) ? outputRegister(variable)
                                 : inputRegister(variable);
 }
 
-RegisterResolver ExecutionNode::inputRegisterResolver() const {
+RegisterResolver ExecutionNode::inputRegisterResolver() const noexcept {
   return getRegisterPlan()->resolverForDepth(inputDepth());
 }
 
-RegisterResolver ExecutionNode::outputRegisterResolver() const {
+RegisterResolver ExecutionNode::outputRegisterResolver() const noexcept {
   return getRegisterPlan()->resolverForDepth(_depth);
 }
 

--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -1361,7 +1361,7 @@ bool ExecutionNode::setsVariable(Variable const* variable) const {
   return std::find(setHere.begin(), setHere.end(), variable) != setHere.end();
 }
 
-RegisterId ExecutionNode::registerFor(Variable const* variable) const {
+RegisterId ExecutionNode::inputOrOutputRegister(Variable const* variable) const {
   return setsVariable(variable) ? outputRegister(variable)
                                 : inputRegister(variable);
 }

--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -557,19 +557,19 @@ class ExecutionNode {
   /// @brief Register holding `variable` in the rows this node WRITES.
   /// Use this for the variables in getVariablesSetHere(), i.e. for everything
   /// the executor writes to an OutputAqlItemRow.
-  RegisterId outputRegister(Variable const* variable) const;
+  RegisterId outputRegister(Variable const* variable) const noexcept;
 
   /// @brief Register holding `variable` in the rows this node READS.
   /// Use this for everything the executor reads off an InputAqlItemRow.
-  RegisterId inputRegister(Variable const* variable) const;
+  RegisterId inputRegister(Variable const* variable) const noexcept;
 
   /// @brief Like inputRegister(), but returns an invalid RegisterId instead of
   /// asserting when `variable` is a nullptr or has no register.
-  RegisterId inputRegisterOptional(Variable const* variable) const;
+  RegisterId inputRegisterOptional(Variable const* variable) const noexcept;
 
   /// @brief Like outputRegister(), but returns an invalid RegisterId instead
   /// of asserting when `variable` is a nullptr or has no register.
-  RegisterId outputRegisterOptional(Variable const* variable) const;
+  RegisterId outputRegisterOptional(Variable const* variable) const noexcept;
 
   /// @brief Single-variable overload of setsVariable(): whether this node
   /// writes `variable`, i.e. whether it appears in getVariablesSetHere().
@@ -578,18 +578,13 @@ class ExecutionNode {
   /// @brief Register holding `variable` for this node, on whichever of the two
   /// rows it lives: the output register if this node writes the variable, the
   /// input register otherwise.
-  /// Only for collections of variables with mixed provenance -- most notably
-  /// the variables of a filter pushed down into an enumeration, which may
-  /// reference both this node's own outputs and variables read from the input
-  /// row. Prefer inputRegister()/outputRegister() when the provenance is known,
-  /// which is nearly everywhere.
   RegisterId inputOrOutputRegister(Variable const* variable) const;
 
   /// @brief Resolvers bound to the input/output row shape of this node, for
-  /// code that resolves variables later than createBlock() -- e.g. during
+  /// code that resolves variables later than createBlock() e.g. during
   /// execution. Prefer resolving here and passing RegisterIds down.
-  RegisterResolver inputRegisterResolver() const;
-  RegisterResolver outputRegisterResolver() const;
+  RegisterResolver inputRegisterResolver() const noexcept;
+  RegisterResolver outputRegisterResolver() const noexcept;
 
  protected:
   /// @brief serialize this ExecutionNode to VelocyPack.

--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -604,7 +604,6 @@ class ExecutionNode {
   static void getSortElements(SortElementVector& elements, ExecutionPlan* plan,
                               velocypack::Slice slice, std::string_view which);
 
-
   RegisterInfos createRegisterInfos(RegIdSet readableInputRegisters,
                                     RegIdSet writableOutputRegisters) const;
 

--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -557,28 +557,19 @@ class ExecutionNode {
   /// @brief Register holding `variable` in the rows this node WRITES.
   /// Use this for the variables in getVariablesSetHere(), i.e. for everything
   /// the executor writes to an OutputAqlItemRow.
-  RegisterId outputRegister(Variable const* variable) const noexcept;
+  RegisterId outputRegister(Variable const* variable) const;
 
   /// @brief Register holding `variable` in the rows this node READS.
   /// Use this for everything the executor reads off an InputAqlItemRow.
-  RegisterId inputRegister(Variable const* variable) const noexcept;
+  RegisterId inputRegister(Variable const* variable) const;
 
   /// @brief Like inputRegister(), but returns an invalid RegisterId instead of
   /// asserting when `variable` is a nullptr or has no register.
-  RegisterId inputRegisterOptional(Variable const* variable) const noexcept;
+  RegisterId inputRegisterOrInvalid(Variable const* variable) const noexcept;
 
   /// @brief Like outputRegister(), but returns an invalid RegisterId instead
   /// of asserting when `variable` is a nullptr or has no register.
-  RegisterId outputRegisterOptional(Variable const* variable) const noexcept;
-
-  /// @brief Single-variable overload of setsVariable(): whether this node
-  /// writes `variable`, i.e. whether it appears in getVariablesSetHere().
-  bool setsVariable(Variable const* variable) const;
-
-  /// @brief Register holding `variable` for this node, on whichever of the two
-  /// rows it lives: the output register if this node writes the variable, the
-  /// input register otherwise.
-  RegisterId inputOrOutputRegister(Variable const* variable) const;
+  RegisterId outputRegisterOrInvalid(Variable const* variable) const noexcept;
 
   /// @brief Resolvers bound to the input/output row shape of this node, for
   /// code that resolves variables later than createBlock() e.g. during

--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -64,6 +64,7 @@
 #include "Aql/IndexHint.h"
 #include "Aql/RegisterInfos.h"
 #include "Aql/SortElement.h"
+#include "Aql/VarInfoMap.h"
 #include "Aql/WalkerWorker.h"
 #include "Aql/types.h"
 #include "Basics/TypeTraits.h"
@@ -548,6 +549,46 @@ class ExecutionNode {
   /// An existing annotation with the same name is overwritten.
   void setAnnotatedFlag(std::string name, bool value);
 
+  /// @brief The depth of the rows this node reads, i.e. the depth of its
+  /// first dependency. Equal to getDepth() unless this node begins a new
+  /// block shape (isIncreaseDepth()).
+  unsigned int inputDepth() const noexcept;
+
+  /// @brief Register holding `variable` in the rows this node WRITES.
+  /// Use this for the variables in getVariablesSetHere(), i.e. for everything
+  /// the executor writes to an OutputAqlItemRow.
+  RegisterId outputRegister(Variable const* variable) const;
+
+  /// @brief Register holding `variable` in the rows this node READS.
+  /// Use this for everything the executor reads off an InputAqlItemRow.
+  RegisterId inputRegister(Variable const* variable) const;
+
+  /// @brief Like inputRegister(), but returns an invalid RegisterId instead of
+  /// asserting when `variable` is a nullptr or has no register.
+  RegisterId inputRegisterOptional(Variable const* variable) const;
+
+  /// @brief Like outputRegister(), but returns an invalid RegisterId instead
+  /// of asserting when `variable` is a nullptr or has no register.
+  RegisterId outputRegisterOptional(Variable const* variable) const;
+
+  /// @brief Single-variable overload of setsVariable(): whether this node
+  /// writes `variable`, i.e. whether it appears in getVariablesSetHere().
+  bool setsVariable(Variable const* variable) const;
+
+  /// @brief Register holding `variable` for this node: its output register if
+  /// this node writes the variable, its input register otherwise.
+  /// Only for collections of variables with mixed provenance -- most notably
+  /// the variables of a filter pushed down into an enumeration, which may
+  /// reference both this node's own outputs and variables read from the input
+  /// row. Prefer inputRegister()/outputRegister() when the provenance is known.
+  RegisterId registerFor(Variable const* variable) const;
+
+  /// @brief Resolvers bound to the input/output row shape of this node, for
+  /// code that resolves variables later than createBlock() -- e.g. during
+  /// execution. Prefer resolving here and passing RegisterIds down.
+  RegisterResolver inputRegisterResolver() const;
+  RegisterResolver outputRegisterResolver() const;
+
  protected:
   /// @brief serialize this ExecutionNode to VelocyPack.
   /// This function is called as part of `toVelocyPack` and must be overriden in
@@ -566,9 +607,6 @@ class ExecutionNode {
   static void getSortElements(SortElementVector& elements, ExecutionPlan* plan,
                               velocypack::Slice slice, std::string_view which);
 
-  RegisterId variableToRegisterId(Variable const*) const;
-
-  RegisterId variableToRegisterOptionalId(Variable const* var) const;
 
   RegisterInfos createRegisterInfos(RegIdSet readableInputRegisters,
                                     RegIdSet writableOutputRegisters) const;

--- a/arangod/Aql/ExecutionNode/ExecutionNode.h
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.h
@@ -575,13 +575,15 @@ class ExecutionNode {
   /// writes `variable`, i.e. whether it appears in getVariablesSetHere().
   bool setsVariable(Variable const* variable) const;
 
-  /// @brief Register holding `variable` for this node: its output register if
-  /// this node writes the variable, its input register otherwise.
+  /// @brief Register holding `variable` for this node, on whichever of the two
+  /// rows it lives: the output register if this node writes the variable, the
+  /// input register otherwise.
   /// Only for collections of variables with mixed provenance -- most notably
   /// the variables of a filter pushed down into an enumeration, which may
   /// reference both this node's own outputs and variables read from the input
-  /// row. Prefer inputRegister()/outputRegister() when the provenance is known.
-  RegisterId registerFor(Variable const* variable) const;
+  /// row. Prefer inputRegister()/outputRegister() when the provenance is known,
+  /// which is nearly everywhere.
+  RegisterId inputOrOutputRegister(Variable const* variable) const;
 
   /// @brief Resolvers bound to the input/output row shape of this node, for
   /// code that resolves variables later than createBlock() -- e.g. during

--- a/arangod/Aql/ExecutionNode/FilterNode.cpp
+++ b/arangod/Aql/ExecutionNode/FilterNode.cpp
@@ -50,10 +50,10 @@ std::unique_ptr<ExecutionBlock> FilterNode::createBlock(
     ExecutionEngine& engine) const {
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
-  RegisterId inputRegister = variableToRegisterId(_inVariable);
+  RegisterId inReg = inputRegister(_inVariable);
 
-  auto registerInfos = createRegisterInfos(RegIdSet{inputRegister}, {});
-  auto executorInfos = FilterExecutorInfos(inputRegister);
+  auto registerInfos = createRegisterInfos(RegIdSet{inReg}, {});
+  auto executorInfos = FilterExecutorInfos(inReg);
   return std::make_unique<ExecutionBlockImpl<FilterExecutor>>(
       &engine, this, std::move(registerInfos), std::move(executorInfos));
 }

--- a/arangod/Aql/ExecutionNode/GatherNode.cpp
+++ b/arangod/Aql/ExecutionNode/GatherNode.cpp
@@ -278,7 +278,8 @@ std::unique_ptr<ExecutionBlock> GatherNode::createBlock(
   }
 
   std::vector<SortRegister> sortRegister;
-  SortRegister::fill(*plan(), *getRegisterPlan(), _elements, sortRegister);
+  SortRegister::fill(*plan(), inputRegisterResolver(), _elements,
+                     sortRegister);
 
   auto executorInfos = SortingGatherExecutorInfos(
       std::move(sortRegister), _plan->getAst()->query(), sortMode(),

--- a/arangod/Aql/ExecutionNode/GatherNode.cpp
+++ b/arangod/Aql/ExecutionNode/GatherNode.cpp
@@ -278,8 +278,7 @@ std::unique_ptr<ExecutionBlock> GatherNode::createBlock(
   }
 
   std::vector<SortRegister> sortRegister;
-  SortRegister::fill(*plan(), inputRegisterResolver(), _elements,
-                     sortRegister);
+  SortRegister::fill(*plan(), inputRegisterResolver(), _elements, sortRegister);
 
   auto executorInfos = SortingGatherExecutorInfos(
       std::move(sortRegister), _plan->getAst()->query(), sortMode(),

--- a/arangod/Aql/ExecutionNode/GraphNode.cpp
+++ b/arangod/Aql/ExecutionNode/GraphNode.cpp
@@ -1100,8 +1100,10 @@ graph::Graph const* GraphNode::graph() const noexcept { return _graphObj; }
 void GraphNode::initializeIndexConditions() const {
   // We need to prepare the variable accesses before we ask the index nodes.
   // Those are located on the options, and need to be partially executed.
+  // the non-constant parts of the index conditions are evaluated against this
+  // node's input rows
   options()->initializeIndexConditions(
-      plan()->getAst(), getRegisterPlan()->varInfo, getTemporaryVariable());
+      plan()->getAst(), inputRegisterResolver(), getTemporaryVariable());
 }
 
 void GraphNode::setVertexProjections(Projections projections) {

--- a/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
+++ b/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
@@ -1946,7 +1946,7 @@ aql::RegIdSet IResearchViewNode::calcInputRegs() const {
     }
 
     for (auto const& it : vars) {
-      aql::RegisterId reg = registerFor(it);
+      aql::RegisterId reg = inputOrOutputRegister(it);
       // The filter condition may refer to registers that are written here
       if (reg.isConstRegister() || reg < getNrInputRegisters()) {
         inputRegs.emplace(reg);

--- a/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
+++ b/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
@@ -1946,7 +1946,7 @@ aql::RegIdSet IResearchViewNode::calcInputRegs() const {
     }
 
     for (auto const& it : vars) {
-      aql::RegisterId reg = variableToRegisterId(it);
+      aql::RegisterId reg = registerFor(it);
       // The filter condition may refer to registers that are written here
       if (reg.isConstRegister() || reg < getNrInputRegisters()) {
         inputRegs.emplace(reg);
@@ -2066,20 +2066,20 @@ std::unique_ptr<aql::ExecutionBlock> IResearchViewNode::createBlock(
 
     aql::RegisterId searchDocRegId{aql::RegisterId::makeInvalid()};
     if (_outSearchDocId != nullptr) {
-      searchDocRegId = variableToRegisterId(_outSearchDocId);
+      searchDocRegId = outputRegister(_outSearchDocId);
       writableOutputRegisters.emplace(searchDocRegId);
     }
 
     auto const outRegister = std::invoke([&]() -> aql::RegisterId {
       if (isLateMaterialized()) {
         aql::RegisterId documentRegId =
-            variableToRegisterId(_outNonMaterializedDocId);
+            outputRegister(_outNonMaterializedDocId);
         writableOutputRegisters.emplace(documentRegId);
         return documentRegId;
       } else if (isNoMaterialization()) {
         return aql::RegisterId::makeInvalid();
       } else {
-        auto outReg = variableToRegisterId(_outVariable);
+        auto outReg = outputRegister(_outVariable);
         writableOutputRegisters.emplace(outReg);
         return outReg;
       }
@@ -2088,23 +2088,17 @@ std::unique_ptr<aql::ExecutionBlock> IResearchViewNode::createBlock(
     std::vector<aql::RegisterId> scoreRegisters;
     scoreRegisters.reserve(numScoreRegisters);
     std::for_each(_scorers.begin(), _scorers.end(), [&](auto const& scorer) {
-      auto registerId = variableToRegisterId(scorer.var);
+      auto registerId = outputRegister(scorer.var);
       writableOutputRegisters.emplace(registerId);
       scoreRegisters.emplace_back(registerId);
     });
-
-    // TODO remove if not needed
-    auto const& varInfos = getRegisterPlan()->varInfo;
 
     ViewValuesRegisters outNonMaterializedViewRegs;
 
     for (auto const& columnFieldsVars : _outNonMaterializedViewVars) {
       for (auto const& fieldsVars : columnFieldsVars.second) {
         auto& fields = outNonMaterializedViewRegs[columnFieldsVars.first];
-        auto const it = varInfos.find(fieldsVars.var->id);
-
-        TRI_ASSERT(it != varInfos.cend());
-        auto const regId = it->second.registerId;
+        auto const regId = outputRegister(fieldsVars.var);
         writableOutputRegisters.emplace(regId);
         fields.emplace(fieldsVars.fieldNum, regId);
       }
@@ -2132,8 +2126,11 @@ std::unique_ptr<aql::ExecutionBlock> IResearchViewNode::createBlock(
         filterCondition(),
         volatility(),
         _immutableParts,
-        getRegisterPlan()->varInfo,  // ??? do we need this?
-        getDepth(),
+        // TODO ViewExpressionContext resolves these against InputAqlItemRows,
+        // so this arguably wants inputRegisterResolver(). Switching it changes
+        // when "variable is used before being assigned" is reported, so it
+        // needs its own change; kept at the node's own depth for now.
+        outputRegisterResolver(),
         std::move(outNonMaterializedViewRegs),
         _options.countApproximate,
         filterOptimization(),

--- a/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
+++ b/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
@@ -2110,34 +2110,20 @@ std::unique_ptr<aql::ExecutionBlock> IResearchViewNode::createBlock(
         calcInputRegs(), std::move(writableOutputRegisters));
     TRI_ASSERT(_view || _meta);
     auto executorInfos = aql::IResearchViewExecutorInfos{
-        std::move(reader),
-        outRegister,
-        searchDocRegId,
-        std::move(scoreRegisters),
-        engine.getQuery(),
+        std::move(reader), outRegister, searchDocRegId,
+        std::move(scoreRegisters), engine.getQuery(),
 #ifdef USE_ENTERPRISE
         optimizeTopK(_meta, _view),
 #endif
-        scorers(),
-        sort(),
-        iresearch::getStoredValues(_meta, _view),
-        *plan(),
-        outVariable(),
-        filterCondition(),
-        volatility(),
-        _immutableParts,
+        scorers(), sort(), iresearch::getStoredValues(_meta, _view), *plan(),
+        outVariable(), filterCondition(), volatility(), _immutableParts,
         // TODO ViewExpressionContext resolves these against InputAqlItemRows,
         // so this arguably wants inputRegisterResolver(). Switching it changes
         // when "variable is used before being assigned" is reported, so it
         // needs its own change; kept at the node's own depth for now.
-        outputRegisterResolver(),
-        std::move(outNonMaterializedViewRegs),
-        _options.countApproximate,
-        filterOptimization(),
-        _heapSort,
-        _heapSortLimit,
-        _meta.get(),
-        _options.parallelism,
+        outputRegisterResolver(), std::move(outNonMaterializedViewRegs),
+        _options.countApproximate, filterOptimization(), _heapSort,
+        _heapSortLimit, _meta.get(), _options.parallelism,
         _vocbase.server().getFeature<IResearchFeature>().getSearchPool()};
     return std::make_tuple(materializeType, std::move(executorInfos),
                            std::move(registerInfos));

--- a/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
+++ b/arangod/Aql/ExecutionNode/IResearchViewNode.cpp
@@ -1945,9 +1945,17 @@ aql::RegIdSet IResearchViewNode::calcInputRegs() const {
       vars.erase(_outVariable);
     }
 
+    // The filter condition may refer to variables that this node writes
+    // itself, and to variables that only become available further downstream:
+    // under late materialization the document variable is produced by the
+    // MaterializeNode, at a greater depth than this node's input rows. Neither
+    // is an input register, so probe instead of resolving.
+    auto const registers = inputRegisterResolver();
     for (auto const& it : vars) {
-      aql::RegisterId reg = inputOrOutputRegister(it);
-      // The filter condition may refer to registers that are written here
+      auto const [reg, status] = registers.lookup(it->id);
+      if (status != aql::RegisterResolver::Status::Ok) {
+        continue;
+      }
       if (reg.isConstRegister() || reg < getNrInputRegisters()) {
         inputRegs.emplace(reg);
       }

--- a/arangod/Aql/ExecutionNode/IndexCollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexCollectNode.cpp
@@ -61,8 +61,8 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockDistinctScan(
 
   RegIdSet writableOutputRegisters;
   for (auto const& group : _groups) {
-    auto reg = infos.groupRegisters.emplace_back(
-        outputRegister(group.outVariable));
+    auto reg =
+        infos.groupRegisters.emplace_back(outputRegister(group.outVariable));
     infos.scanOptions.distinctFields.emplace_back(group.indexField);
     writableOutputRegisters.emplace(reg);
   }
@@ -104,8 +104,7 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockAggregationScan(
   RegIdSet writableOutputRegisters;
   for (auto const& group : _groups) {
     auto& g = infos.groups.emplace_back();
-    g.outputRegister =
-        outputRegister(group.outVariable);
+    g.outputRegister = outputRegister(group.outVariable);
     g.indexField = group.indexField;
     writableOutputRegisters.emplace(g.outputRegister);
   }

--- a/arangod/Aql/ExecutionNode/IndexCollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexCollectNode.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockDistinctScan(
   RegIdSet writableOutputRegisters;
   for (auto const& group : _groups) {
     auto reg = infos.groupRegisters.emplace_back(
-        getRegisterPlan()->variableToRegisterId(group.outVariable));
+        outputRegister(group.outVariable));
     infos.scanOptions.distinctFields.emplace_back(group.indexField);
     writableOutputRegisters.emplace(reg);
   }
@@ -105,7 +105,7 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockAggregationScan(
   for (auto const& group : _groups) {
     auto& g = infos.groups.emplace_back();
     g.outputRegister =
-        getRegisterPlan()->variableToRegisterId(group.outVariable);
+        outputRegister(group.outVariable);
     g.indexField = group.indexField;
     writableOutputRegisters.emplace(g.outputRegister);
   }
@@ -119,7 +119,7 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockAggregationScan(
   for (auto const& agg : _aggregations) {
     auto& a = infos.aggregations.emplace_back();
     a.type = agg.type;
-    a.outputRegister = getRegisterPlan()->variableToRegisterId(agg.outVariable);
+    a.outputRegister = outputRegister(agg.outVariable);
     a.expression = agg.expression->clone(infos.query->ast());
     writableOutputRegisters.emplace(a.outputRegister);
 

--- a/arangod/Aql/ExecutionNode/IndexNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexNode.cpp
@@ -445,7 +445,7 @@ std::unique_ptr<ExecutionBlock> IndexNode::createBlock(
         // an error during register planning.
         continue;
       }
-      auto regId = registerFor(var);
+      auto regId = inputOrOutputRegister(var);
       filterVarsToRegs.emplace_back(var->id, regId);
     }
 

--- a/arangod/Aql/ExecutionNode/IndexNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexNode.cpp
@@ -438,15 +438,18 @@ std::unique_ptr<ExecutionBlock> IndexNode::createBlock(
 
     for (auto const& var : inVars) {
       TRI_ASSERT(var != nullptr);
-      if (var->id == outVariable()->id &&
-          filterProjections().usesCoveringIndex()) {
-        // if the index covers the filter projections, then don't add the
-        // document variable to the filter vars. It is not used and will cause
-        // an error during register planning.
+      if (var->id == outVariable()->id) {
+        if (filterProjections().usesCoveringIndex()) {
+          // the index covers the filter projections, so the filter does not
+          // read the document at all. Adding it would cause an error during
+          // register planning.
+          continue;
+        }
+        // not covered: the filter reads the document this node produces
+        filterVarsToRegs.emplace_back(var->id, outputRegister(var));
         continue;
       }
-      auto regId = inputOrOutputRegister(var);
-      filterVarsToRegs.emplace_back(var->id, regId);
+      filterVarsToRegs.emplace_back(var->id, inputRegister(var));
     }
 
     if (filterProjections().usesCoveringIndex()) {

--- a/arangod/Aql/ExecutionNode/IndexNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexNode.cpp
@@ -319,7 +319,7 @@ NonConstExpressionContainer IndexNode::buildNonConstExpressions() const {
     }
 
     return utils::extractNonConstPartsOfIndexCondition(
-        _plan->getAst(), getRegisterPlan()->varInfo, options().evaluateFCalls,
+        _plan->getAst(), inputRegisterResolver(), options().evaluateFCalls,
         idx.get(), _condition->root(), _outVariable);
   }
   return {};
@@ -445,7 +445,7 @@ std::unique_ptr<ExecutionBlock> IndexNode::createBlock(
         // an error during register planning.
         continue;
       }
-      auto regId = variableToRegisterId(var);
+      auto regId = registerFor(var);
       filterVarsToRegs.emplace_back(var->id, regId);
     }
 
@@ -471,7 +471,7 @@ std::unique_ptr<ExecutionBlock> IndexNode::createBlock(
 
   auto const outVariable =
       isLateMaterialized() ? _outNonMaterializedDocId : _outVariable;
-  auto const outRegister = variableToRegisterId(outVariable);
+  auto const outRegister = outputRegister(outVariable);
 
   // if late materialized
   // We have one additional output register for each index variable which is
@@ -491,7 +491,7 @@ std::unique_ptr<ExecutionBlock> IndexNode::createBlock(
         continue;
       }
       TRI_ASSERT(var != nullptr);
-      auto regId = variableToRegisterId(var);
+      auto regId = outputRegister(var);
       filterVarsToRegs.emplace_back(var->id, regId);
       writableOutputRegisters.emplace(regId);
       if (hasFilter()) {

--- a/arangod/Aql/ExecutionNode/InsertNode.cpp
+++ b/arangod/Aql/ExecutionNode/InsertNode.cpp
@@ -64,8 +64,8 @@ std::unique_ptr<ExecutionBlock> InsertNode::createBlock(
 
   RegisterId inReg = inputRegister(_inVariable);
 
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/InsertNode.cpp
+++ b/arangod/Aql/ExecutionNode/InsertNode.cpp
@@ -82,11 +82,10 @@ std::unique_ptr<ExecutionBlock> InsertNode::createBlock(
                                            std::move(writableOutputRegisters));
 
   ModificationExecutorInfos infos(
-      &engine, inReg, RegisterPlan::MaxRegisterId,
-      RegisterPlan::MaxRegisterId, outputNew, outputOld,
-      RegisterPlan::MaxRegisterId /*output*/, _plan->getAst()->query(),
-      std::move(options), collection(), ExecutionBlock::DefaultBatchSize,
-      ProducesResults(producesResults()),
+      &engine, inReg, RegisterPlan::MaxRegisterId, RegisterPlan::MaxRegisterId,
+      outputNew, outputOld, RegisterPlan::MaxRegisterId /*output*/,
+      _plan->getAst()->query(), std::move(options), collection(),
+      ExecutionBlock::DefaultBatchSize, ProducesResults(producesResults()),
       ConsultAqlWriteFilter(_options.consultAqlWriteFilter),
       IgnoreErrors(_options.ignoreErrors), DoCount(countStats()),
       IsReplace(false) /*(needed by upsert)*/,

--- a/arangod/Aql/ExecutionNode/InsertNode.cpp
+++ b/arangod/Aql/ExecutionNode/InsertNode.cpp
@@ -62,15 +62,15 @@ std::unique_ptr<ExecutionBlock> InsertNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inputRegister = variableToRegisterId(_inVariable);
+  RegisterId inReg = inputRegister(_inVariable);
 
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);
 
-  auto readableInputRegisters = RegIdSet{inputRegister};
+  auto readableInputRegisters = RegIdSet{inReg};
   auto writableOutputRegisters = RegIdSet{};
   if (outputNew.isValid()) {
     writableOutputRegisters.emplace(outputNew);
@@ -82,7 +82,7 @@ std::unique_ptr<ExecutionBlock> InsertNode::createBlock(
                                            std::move(writableOutputRegisters));
 
   ModificationExecutorInfos infos(
-      &engine, inputRegister, RegisterPlan::MaxRegisterId,
+      &engine, inReg, RegisterPlan::MaxRegisterId,
       RegisterPlan::MaxRegisterId, outputNew, outputOld,
       RegisterPlan::MaxRegisterId /*output*/, _plan->getAst()->query(),
       std::move(options), collection(), ExecutionBlock::DefaultBatchSize,

--- a/arangod/Aql/ExecutionNode/JoinNode.cpp
+++ b/arangod/Aql/ExecutionNode/JoinNode.cpp
@@ -343,7 +343,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
         continue;
       }
       TRI_ASSERT(var != nullptr);
-      auto regId = variableToRegisterId(var);
+      auto regId = outputRegister(var);
       varsToRegs.emplace(var->id, regId);
       if (idx.producesOutput) {
         writableOutputRegisters.emplace(regId);
@@ -353,7 +353,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
     RegisterId documentOutputRegister = RegisterId::maxRegisterId;
     if (!p.hasOutputRegisters()) {
       if (idx.producesOutput && !idx.isLateMaterialized) {
-        documentOutputRegister = variableToRegisterId(idx.outVariable);
+        documentOutputRegister = outputRegister(idx.outVariable);
         writableOutputRegisters.emplace(documentOutputRegister);
       }
     }
@@ -368,7 +368,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
     data.isLateMaterialized = idx.isLateMaterialized;
     data.isUniqueStream = idx.isUniqueStream;
     if (data.isLateMaterialized) {
-      data.docIdOutputRegister = variableToRegisterId(idx.outDocIdVariable);
+      data.docIdOutputRegister = outputRegister(idx.outDocIdVariable);
       writableOutputRegisters.emplace(data.docIdOutputRegister);
     }
 
@@ -386,7 +386,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
       }
 
       for (auto const& var : varsUsed) {
-        auto regId = variableToRegisterId(var);
+        auto regId = registerFor(var);
         data.expressionVarsToRegs.emplace_back(var->id, regId);
       }
     } else {
@@ -414,7 +414,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
           // an error during register planning.
           continue;
         }
-        auto regId = variableToRegisterId(var);
+        auto regId = registerFor(var);
         filter.filterVarsToRegs.emplace_back(var->id, regId);
       }
       if (filter.projections.usesCoveringIndex()) {

--- a/arangod/Aql/ExecutionNode/JoinNode.cpp
+++ b/arangod/Aql/ExecutionNode/JoinNode.cpp
@@ -385,9 +385,18 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
         data.constantFields = idx.constantFields;
       }
 
+      // These are constant for the whole lookup, so they come from the input
+      // row.
+      //
+      // TODO (COR-958) The join rule also admits expressions over an earlier
+      // index's document, such as `FILTER doc2.x == doc1.z + 1`. That shape
+      // cannot work: JoinExecutor evaluates these expressions once per input
+      // row, where that document does not exist, and the variable is never
+      // assigned a register. Such a query now fails with "no register
+      // assigned" instead of aborting the server. The fix belongs in the
+      // rule, not here.
       for (auto const& var : varsUsed) {
-        auto regId = inputOrOutputRegister(var);
-        data.expressionVarsToRegs.emplace_back(var->id, regId);
+        data.expressionVarsToRegs.emplace_back(var->id, inputRegister(var));
       }
     } else {
       data.usedKeyFields = {0};
@@ -407,15 +416,19 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
 
       for (auto const& var : inVars) {
         TRI_ASSERT(var != nullptr);
-        if (var->id == idx.outVariable->id &&
-            idx.filterProjections.usesCoveringIndex()) {
-          // if the index covers the filter projections, then don't add the
-          // document variable to the filter vars. It is not used and will cause
-          // an error during register planning.
+        if (var->id == idx.outVariable->id) {
+          if (idx.filterProjections.usesCoveringIndex()) {
+            // the index covers the filter projections, so the filter does not
+            // read the document at all. Adding it would cause an error during
+            // register planning.
+            continue;
+          }
+          // not covered: the filter reads the document this node produces.
+          // getVariablesSetHere() reports it because idx.filter is set.
+          filter.filterVarsToRegs.emplace_back(var->id, outputRegister(var));
           continue;
         }
-        auto regId = inputOrOutputRegister(var);
-        filter.filterVarsToRegs.emplace_back(var->id, regId);
+        filter.filterVarsToRegs.emplace_back(var->id, inputRegister(var));
       }
       if (filter.projections.usesCoveringIndex()) {
         for (auto const& p : filter.projections.projections()) {

--- a/arangod/Aql/ExecutionNode/JoinNode.cpp
+++ b/arangod/Aql/ExecutionNode/JoinNode.cpp
@@ -386,7 +386,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
       }
 
       for (auto const& var : varsUsed) {
-        auto regId = registerFor(var);
+        auto regId = inputOrOutputRegister(var);
         data.expressionVarsToRegs.emplace_back(var->id, regId);
       }
     } else {
@@ -414,7 +414,7 @@ std::unique_ptr<ExecutionBlock> JoinNode::createBlock(
           // an error during register planning.
           continue;
         }
-        auto regId = registerFor(var);
+        auto regId = inputOrOutputRegister(var);
         filter.filterVarsToRegs.emplace_back(var->id, regId);
       }
       if (filter.projections.usesCoveringIndex()) {

--- a/arangod/Aql/ExecutionNode/MaterializeRocksDBNode.cpp
+++ b/arangod/Aql/ExecutionNode/MaterializeRocksDBNode.cpp
@@ -101,24 +101,16 @@ std::unique_ptr<ExecutionBlock> MaterializeRocksDBNode::createBlock(
 
   RegisterId outDocumentRegId;
   if (projections().empty() || !projections().hasOutputRegisters()) {
-    auto it = getRegisterPlan()->varInfo.find(_outVariable->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end())
-        << "variable not found = " << _outVariable->id;
-    outDocumentRegId = it->second.registerId;
+    outDocumentRegId = outputRegister(_outVariable);
     writableOutputRegisters.emplace(outDocumentRegId);
   } else {
     for (auto const& p : projections().projections()) {
-      auto reg = getRegisterPlan()->variableToRegisterId(p.variable);
+      auto reg = outputRegister(p.variable);
       varsToRegs.emplace(p.variable->id, reg);
       writableOutputRegisters.emplace(reg);
     }
   }
-  RegisterId inNmDocIdRegId;
-  {
-    auto it = getRegisterPlan()->varInfo.find(_inNonMaterializedDocId->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-    inNmDocIdRegId = it->second.registerId;
-  }
+  RegisterId inNmDocIdRegId = inputRegister(_inNonMaterializedDocId);
   RegIdSet readableInputRegisters;
   if (inNmDocIdRegId.isValid()) {
     readableInputRegisters.emplace(inNmDocIdRegId);

--- a/arangod/Aql/ExecutionNode/MaterializeSearchNode.cpp
+++ b/arangod/Aql/ExecutionNode/MaterializeSearchNode.cpp
@@ -46,18 +46,8 @@ std::unique_ptr<ExecutionBlock> MaterializeSearchNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inNmDocIdRegId;
-  {
-    auto it = getRegisterPlan()->varInfo.find(_inNonMaterializedDocId->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-    inNmDocIdRegId = it->second.registerId;
-  }
-  RegisterId outDocumentRegId;
-  {
-    auto it = getRegisterPlan()->varInfo.find(_outVariable->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-    outDocumentRegId = it->second.registerId;
-  }
+  RegisterId inNmDocIdRegId = inputRegister(_inNonMaterializedDocId);
+  RegisterId outDocumentRegId = outputRegister(_outVariable);
 
   RegIdSet readableInputRegisters{inNmDocIdRegId};
   auto writableOutputRegisters = RegIdSet{outDocumentRegId};

--- a/arangod/Aql/ExecutionNode/MultipleRemoteModificationNode.cpp
+++ b/arangod/Aql/ExecutionNode/MultipleRemoteModificationNode.cpp
@@ -71,10 +71,10 @@ std::unique_ptr<ExecutionBlock> MultipleRemoteModificationNode::createBlock(
 
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId in = inputRegisterOptional(_inVariable);
-  RegisterId out = outputRegisterOptional(_outVariable);
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId in = inputRegisterOrInvalid(_inVariable);
+  RegisterId out = outputRegisterOrInvalid(_outVariable);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/MultipleRemoteModificationNode.cpp
+++ b/arangod/Aql/ExecutionNode/MultipleRemoteModificationNode.cpp
@@ -71,10 +71,10 @@ std::unique_ptr<ExecutionBlock> MultipleRemoteModificationNode::createBlock(
 
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId in = variableToRegisterOptionalId(_inVariable);
-  RegisterId out = variableToRegisterOptionalId(_outVariable);
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId in = inputRegisterOptional(_inVariable);
+  RegisterId out = outputRegisterOptional(_outVariable);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/RemoveNode.cpp
+++ b/arangod/Aql/ExecutionNode/RemoveNode.cpp
@@ -58,9 +58,9 @@ std::unique_ptr<ExecutionBlock> RemoveNode::createBlock(
 
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inDocRegister = variableToRegisterId(_inVariable);
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId inDocRegister = inputRegister(_inVariable);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/RemoveNode.cpp
+++ b/arangod/Aql/ExecutionNode/RemoveNode.cpp
@@ -59,8 +59,8 @@ std::unique_ptr<ExecutionBlock> RemoveNode::createBlock(
   TRI_ASSERT(previousNode != nullptr);
 
   RegisterId inDocRegister = inputRegister(_inVariable);
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/ReplaceNode.cpp
+++ b/arangod/Aql/ExecutionNode/ReplaceNode.cpp
@@ -53,11 +53,11 @@ std::unique_ptr<ExecutionBlock> ReplaceNode::createBlock(
 
   RegisterId inDocRegister = inputRegister(_inDocVariable);
 
-  RegisterId inKeyRegister = inputRegisterOptional(_inKeyVariable);
+  RegisterId inKeyRegister = inputRegisterOrInvalid(_inKeyVariable);
 
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
 
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   auto readableInputRegisters = RegIdSet{inDocRegister};
   if (inKeyRegister.isValid()) {

--- a/arangod/Aql/ExecutionNode/ReplaceNode.cpp
+++ b/arangod/Aql/ExecutionNode/ReplaceNode.cpp
@@ -51,13 +51,13 @@ std::unique_ptr<ExecutionBlock> ReplaceNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inDocRegister = variableToRegisterId(_inDocVariable);
+  RegisterId inDocRegister = inputRegister(_inDocVariable);
 
-  RegisterId inKeyRegister = variableToRegisterOptionalId(_inKeyVariable);
+  RegisterId inKeyRegister = inputRegisterOptional(_inKeyVariable);
 
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
 
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   auto readableInputRegisters = RegIdSet{inDocRegister};
   if (inKeyRegister.isValid()) {

--- a/arangod/Aql/ExecutionNode/ReturnNode.cpp
+++ b/arangod/Aql/ExecutionNode/ReturnNode.cpp
@@ -54,7 +54,7 @@ std::unique_ptr<ExecutionBlock> ReturnNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inputRegister = variableToRegisterId(_inVariable);
+  RegisterId inReg = inputRegister(_inVariable);
 
   // This is an important performance improvement:
   // If we have inherited results, we do move the block through
@@ -62,7 +62,7 @@ std::unique_ptr<ExecutionBlock> ReturnNode::createBlock(
   // In the other case it is important to shrink the matrix to exactly
   // one register that is stored within the DOCVEC.
   if (returnInheritedResults()) {
-    auto executorInfos = IdExecutorInfos(_count, inputRegister);
+    auto executorInfos = IdExecutorInfos(_count, inReg);
     auto registerInfos = createRegisterInfos({}, {});
     return std::make_unique<ExecutionBlockImpl<
         IdExecutor<SingleRowFetcher<BlockPassthrough::Enable>>>>(
@@ -75,8 +75,8 @@ std::unique_ptr<ExecutionBlock> ReturnNode::createBlock(
     constexpr auto outputRegister = RegisterId{0};
 
     auto registerInfos =
-        createRegisterInfos(RegIdSet{inputRegister}, RegIdSet{outputRegister});
-    auto executorInfos = ReturnExecutorInfos(inputRegister, _count);
+        createRegisterInfos(RegIdSet{inReg}, RegIdSet{outputRegister});
+    auto executorInfos = ReturnExecutorInfos(inReg, _count);
 
     return std::make_unique<ExecutionBlockImpl<ReturnExecutor>>(
         &engine, this, std::move(registerInfos), std::move(executorInfos));

--- a/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
+++ b/arangod/Aql/ExecutionNode/ShortestPathNode.cpp
@@ -78,19 +78,13 @@ static GraphNode::InputVertex prepareVertexInput(ShortestPathNode const* node,
   using InputVertex = GraphNode::InputVertex;
   if (isTarget) {
     if (node->usesTargetInVariable()) {
-      auto it =
-          node->getRegisterPlan()->varInfo.find(node->targetInVariable()->id);
-      TRI_ASSERT(it != node->getRegisterPlan()->varInfo.end());
-      return InputVertex{it->second.registerId};
+      return InputVertex{node->inputRegister(node->targetInVariable())};
     } else {
       return InputVertex{node->getTargetVertex()};
     }
   } else {
     if (node->usesStartInVariable()) {
-      auto it =
-          node->getRegisterPlan()->varInfo.find(node->startInVariable()->id);
-      TRI_ASSERT(it != node->getRegisterPlan()->varInfo.end());
-      return InputVertex{it->second.registerId};
+      return InputVertex{node->inputRegister(node->startInVariable())};
     } else {
       return InputVertex{node->getStartVertex()};
     }
@@ -286,42 +280,34 @@ std::pair<RegIdSet, typename ShortestPathExecutorInfos<
                         ShortestPathEnumeratorType>::RegisterMapping>
 ShortestPathNode::_buildOutputRegisters() const {
   auto outputRegisters = RegIdSet{};
-  auto& varInfo = getRegisterPlan()->varInfo;
 
   typename ShortestPathExecutorInfos<
       ShortestPathEnumeratorType>::RegisterMapping outputRegisterMapping;
   if (isVertexOutVariableUsedLater()) {
-    auto it = varInfo.find(vertexOutVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
+    auto const reg = outputRegister(vertexOutVariable());
     outputRegisterMapping.try_emplace(
         ShortestPathExecutorInfos<
             ShortestPathEnumeratorType>::OutputName::VERTEX,
-        it->second.registerId);
-    outputRegisters.emplace(it->second.registerId);
+        reg);
+    outputRegisters.emplace(reg);
   }
   if (isEdgeOutVariableUsedLater()) {
-    auto it = varInfo.find(edgeOutVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
+    auto const reg = outputRegister(edgeOutVariable());
     outputRegisterMapping.try_emplace(
         ShortestPathExecutorInfos<ShortestPathEnumeratorType>::OutputName::EDGE,
-        it->second.registerId);
-    outputRegisters.emplace(it->second.registerId);
+        reg);
+    outputRegisters.emplace(reg);
   }
   return std::make_pair(outputRegisters, outputRegisterMapping);
 };
 
 RegIdSet ShortestPathNode::buildVariableInformation() const {
   auto inputRegisters = RegIdSet();
-  auto& varInfo = getRegisterPlan()->varInfo;
   if (usesStartInVariable()) {
-    auto it = varInfo.find(startInVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
-    inputRegisters.emplace(it->second.registerId);
+    inputRegisters.emplace(inputRegister(startInVariable()));
   }
   if (usesTargetInVariable()) {
-    auto it = varInfo.find(targetInVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
-    inputRegisters.emplace(it->second.registerId);
+    inputRegisters.emplace(inputRegister(targetInVariable()));
   }
   return inputRegisters;
 }

--- a/arangod/Aql/ExecutionNode/SingleRemoteOperationNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingleRemoteOperationNode.cpp
@@ -92,10 +92,10 @@ std::unique_ptr<ExecutionBlock> SingleRemoteOperationNode::createBlock(
 
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId in = variableToRegisterOptionalId(_inVariable);
-  RegisterId out = variableToRegisterOptionalId(_outVariable);
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId in = inputRegisterOptional(_inVariable);
+  RegisterId out = outputRegisterOptional(_outVariable);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/SingleRemoteOperationNode.cpp
+++ b/arangod/Aql/ExecutionNode/SingleRemoteOperationNode.cpp
@@ -92,10 +92,10 @@ std::unique_ptr<ExecutionBlock> SingleRemoteOperationNode::createBlock(
 
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId in = inputRegisterOptional(_inVariable);
-  RegisterId out = outputRegisterOptional(_outVariable);
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId in = inputRegisterOrInvalid(_inVariable);
+  RegisterId out = outputRegisterOrInvalid(_outVariable);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   OperationOptions options = ModificationExecutorHelpers::convertOptions(
       _options, _outVariableNew, _outVariableOld);

--- a/arangod/Aql/ExecutionNode/SortNode.cpp
+++ b/arangod/Aql/ExecutionNode/SortNode.cpp
@@ -178,9 +178,7 @@ std::unique_ptr<ExecutionBlock> SortNode::createBlock(
   std::vector<SortRegister> sortRegs;
   auto inputRegs = RegIdSet{};
   for (auto const& element : _elements) {
-    auto it = getRegisterPlan()->varInfo.find(element.var->id);
-    TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-    RegisterId id = it->second.registerId;
+    RegisterId id = inputRegister(element.var);
     sortRegs.emplace_back(id, element);
     inputRegs.emplace(id);
   }
@@ -207,10 +205,7 @@ std::unique_ptr<ExecutionBlock> SortNode::createBlock(
       size_t count = 0;
       for (auto const& element : _elements) {
         if (count < _numberOfTopGroupedElements) {
-          auto it = getRegisterPlan()->varInfo.find(element.var->id);
-          TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-          RegisterId id = it->second.registerId;
-          groupedRegisters.emplace_back(id);
+          groupedRegisters.emplace_back(inputRegister(element.var));
         }
         count++;
       }

--- a/arangod/Aql/ExecutionNode/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/SubqueryEndExecutionNode.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<ExecutionBlock> SubqueryEndNode::createBlock(
   auto inputRegisters = RegIdSet{};
   auto outputRegisters = RegIdSet{};
 
-  auto inReg = inputRegisterOptional(_inVariable);
+  auto inReg = inputRegisterOrInvalid(_inVariable);
   if (inReg.value() != RegisterId::maxRegisterId) {
     inputRegisters.emplace(inReg);
   }

--- a/arangod/Aql/ExecutionNode/SubqueryEndExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/SubqueryEndExecutionNode.cpp
@@ -85,11 +85,11 @@ std::unique_ptr<ExecutionBlock> SubqueryEndNode::createBlock(
   auto inputRegisters = RegIdSet{};
   auto outputRegisters = RegIdSet{};
 
-  auto inReg = variableToRegisterOptionalId(_inVariable);
+  auto inReg = inputRegisterOptional(_inVariable);
   if (inReg.value() != RegisterId::maxRegisterId) {
     inputRegisters.emplace(inReg);
   }
-  auto outReg = variableToRegisterId(_outVariable);
+  auto outReg = outputRegister(_outVariable);
   outputRegisters.emplace(outReg);
 
   auto registerInfos = createRegisterInfos(std::move(inputRegisters),

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -1142,8 +1142,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     if (isSmart() && !isDisjoint()) {
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
-                         outputRegisterMapping, inReg,
-                         std::move(registerInfos), engines(), true /*isSmart*/);
+                         outputRegisterMapping, inReg, std::move(registerInfos),
+                         engines(), true /*isSmart*/);
 
     } else {
 #endif
@@ -1152,8 +1152,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
        */
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
-                         outputRegisterMapping, inReg,
-                         std::move(registerInfos), engines());
+                         outputRegisterMapping, inReg, std::move(registerInfos),
+                         engines());
 
 #ifdef USE_ENTERPRISE
     }
@@ -1173,8 +1173,8 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
 
   return createBlock(engine, std::move(filterConditionVariables),
                      checkPruneAvailability, checkPostFilterAvailability,
-                     outputRegisterMapping, inReg,
-                     std::move(registerInfos), nullptr);
+                     outputRegisterMapping, inReg, std::move(registerInfos),
+                     nullptr);
 }
 
 /// @brief clone ExecutionNode recursively

--- a/arangod/Aql/ExecutionNode/TraversalNode.cpp
+++ b/arangod/Aql/ExecutionNode/TraversalNode.cpp
@@ -813,7 +813,7 @@ std::vector<IndexAccessor> TraversalNode::buildIndexAccessor(
         generateExpression(remainderCondition, indexCondition);
 
     auto container = aql::utils::extractNonConstPartsOfIndexCondition(
-        ast, getRegisterPlan()->varInfo, false, nullptr, indexCondition,
+        ast, inputRegisterResolver(), false, nullptr, indexCondition,
         options()->tmpVar());
     indexAccessors.emplace_back(std::move(indexToUse), indexCondition,
                                 memberToUpdate, std::move(expression),
@@ -991,13 +991,10 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
   auto inputRegisters = RegIdSet{};
-  auto& varInfo = getRegisterPlan()->varInfo;
-  RegisterId inputRegister{RegisterId::maxRegisterId};
+  RegisterId inReg = RegisterId::makeInvalid();
   if (usesInVariable()) {
-    auto it = varInfo.find(inVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
-    inputRegisters.emplace(it->second.registerId);
-    inputRegister = it->second.registerId;
+    inReg = inputRegister(inVariable());
+    inputRegisters.emplace(inReg);
     TRI_ASSERT(getStartVertex().empty());
   }
   auto outputRegisters = RegIdSet{};
@@ -1006,29 +1003,22 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
       outputRegisterMapping;
 
   if (isVertexOutVariableUsedLater()) {
-    auto it = varInfo.find(vertexOutVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
-    TRI_ASSERT(it->second.registerId.isValid());
-    outputRegisters.emplace(it->second.registerId);
+    auto const reg = outputRegister(vertexOutVariable());
+    outputRegisters.emplace(reg);
     outputRegisterMapping.try_emplace(
-        TraversalExecutorInfosHelper::OutputName::VERTEX,
-        it->second.registerId);
+        TraversalExecutorInfosHelper::OutputName::VERTEX, reg);
   }
   if (isEdgeOutVariableUsedLater()) {
-    auto it = varInfo.find(edgeOutVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
-    TRI_ASSERT(it->second.registerId.isValid());
-    outputRegisters.emplace(it->second.registerId);
+    auto const reg = outputRegister(edgeOutVariable());
+    outputRegisters.emplace(reg);
     outputRegisterMapping.try_emplace(
-        TraversalExecutorInfosHelper::OutputName::EDGE, it->second.registerId);
+        TraversalExecutorInfosHelper::OutputName::EDGE, reg);
   }
   if (isPathOutVariableUsedLater()) {
-    auto it = varInfo.find(pathOutVariable()->id);
-    TRI_ASSERT(it != varInfo.end());
-    TRI_ASSERT(it->second.registerId.isValid());
-    outputRegisters.emplace(it->second.registerId);
+    auto const reg = outputRegister(pathOutVariable());
+    outputRegisters.emplace(reg);
     outputRegisterMapping.try_emplace(
-        TraversalExecutorInfosHelper::OutputName::PATH, it->second.registerId);
+        TraversalExecutorInfosHelper::OutputName::PATH, reg);
   }
   TraverserOptions* opts = this->options();
 
@@ -1056,9 +1046,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
             pathRegIdx = pruneRegs.size();
             pruneRegs.emplace_back(RegisterPlan::MaxRegisterId);
           } else {
-            auto it = varInfo.find(v->id);
-            TRI_ASSERT(it != varInfo.end());
-            pruneRegs.emplace_back(it->second.registerId);
+            pruneRegs.emplace_back(inputRegister(v));
           }
         }
 
@@ -1087,9 +1075,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
           } else if (v == pathOutVariable()) {
             TRI_ASSERT(false);
           } else {
-            auto it = varInfo.find(v->id);
-            TRI_ASSERT(it != varInfo.end());
-            postFilterRegs.emplace_back(it->second.registerId);
+            postFilterRegs.emplace_back(inputRegister(v));
           }
         }
 
@@ -1118,9 +1104,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
         // We can never optimize the path variable here. We can just do a normal
         // post filtering then. This should only avoid building path to aql.
         TRI_ASSERT(v != pathOutVariable());
-        auto it = varInfo.find(v->id);
-        TRI_ASSERT(it != varInfo.end());
-        postFilterRegs.emplace_back(it->second.registerId);
+        postFilterRegs.emplace_back(inputRegister(v));
       }
     }
     // We need to select at least one of vertex or edge for this filter.
@@ -1142,11 +1126,9 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
   for (const auto* variable : conditionVars) {
     if (variable == _tmpObjVariable) continue;
 
-    auto itVarInfo = varInfo.find(variable->id);
-    TRI_ASSERT(itVarInfo != varInfo.end());
-    filterConditionVariables.emplace_back(
-        std::make_pair(variable, itVarInfo->second.registerId));
-    inputRegisters.emplace(itVarInfo->second.registerId);
+    auto const reg = inputRegister(variable);
+    filterConditionVariables.emplace_back(std::make_pair(variable, reg));
+    inputRegisters.emplace(reg);
   }
 
   auto registerInfos = createRegisterInfos(std::move(inputRegisters),
@@ -1160,7 +1142,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
     if (isSmart() && !isDisjoint()) {
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
-                         outputRegisterMapping, inputRegister,
+                         outputRegisterMapping, inReg,
                          std::move(registerInfos), engines(), true /*isSmart*/);
 
     } else {
@@ -1170,7 +1152,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
        */
       return createBlock(engine, std::move(filterConditionVariables),
                          checkPruneAvailability, checkPostFilterAvailability,
-                         outputRegisterMapping, inputRegister,
+                         outputRegisterMapping, inReg,
                          std::move(registerInfos), engines());
 
 #ifdef USE_ENTERPRISE
@@ -1191,7 +1173,7 @@ std::unique_ptr<ExecutionBlock> TraversalNode::createBlock(
 
   return createBlock(engine, std::move(filterConditionVariables),
                      checkPruneAvailability, checkPostFilterAvailability,
-                     outputRegisterMapping, inputRegister,
+                     outputRegisterMapping, inReg,
                      std::move(registerInfos), nullptr);
 }
 

--- a/arangod/Aql/ExecutionNode/UpdateNode.cpp
+++ b/arangod/Aql/ExecutionNode/UpdateNode.cpp
@@ -55,9 +55,9 @@ std::unique_ptr<ExecutionBlock> UpdateNode::createBlock(
 
   RegisterId inDocRegister = inputRegister(_inDocVariable);
 
-  RegisterId inKeyRegister = inputRegisterOptional(_inKeyVariable);
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId inKeyRegister = inputRegisterOrInvalid(_inKeyVariable);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   auto readableInputRegisters = RegIdSet{inDocRegister};
   if (inKeyRegister.isValid()) {

--- a/arangod/Aql/ExecutionNode/UpdateNode.cpp
+++ b/arangod/Aql/ExecutionNode/UpdateNode.cpp
@@ -53,11 +53,11 @@ std::unique_ptr<ExecutionBlock> UpdateNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inDocRegister = variableToRegisterId(_inDocVariable);
+  RegisterId inDocRegister = inputRegister(_inDocVariable);
 
-  RegisterId inKeyRegister = variableToRegisterOptionalId(_inKeyVariable);
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId inKeyRegister = inputRegisterOptional(_inKeyVariable);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   auto readableInputRegisters = RegIdSet{inDocRegister};
   if (inKeyRegister.isValid()) {

--- a/arangod/Aql/ExecutionNode/UpsertNode.cpp
+++ b/arangod/Aql/ExecutionNode/UpsertNode.cpp
@@ -105,9 +105,9 @@ std::unique_ptr<ExecutionBlock> UpsertNode::createBlock(
   RegisterId insert = inputRegister(_insertVariable);
   RegisterId update = inputRegister(_updateVariable);
 
-  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
+  RegisterId outputNew = outputRegisterOrInvalid(_outVariableNew);
 
-  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
+  RegisterId outputOld = outputRegisterOrInvalid(_outVariableOld);
 
   auto readableInputRegisters = RegIdSet{inDoc, insert, update};
   auto writableOutputRegisters = RegIdSet{};

--- a/arangod/Aql/ExecutionNode/UpsertNode.cpp
+++ b/arangod/Aql/ExecutionNode/UpsertNode.cpp
@@ -101,13 +101,13 @@ std::unique_ptr<ExecutionBlock> UpsertNode::createBlock(
   ExecutionNode const* previousNode = getFirstDependency();
   TRI_ASSERT(previousNode != nullptr);
 
-  RegisterId inDoc = variableToRegisterId(_inDocVariable);
-  RegisterId insert = variableToRegisterId(_insertVariable);
-  RegisterId update = variableToRegisterId(_updateVariable);
+  RegisterId inDoc = inputRegister(_inDocVariable);
+  RegisterId insert = inputRegister(_insertVariable);
+  RegisterId update = inputRegister(_updateVariable);
 
-  RegisterId outputNew = variableToRegisterOptionalId(_outVariableNew);
+  RegisterId outputNew = outputRegisterOptional(_outVariableNew);
 
-  RegisterId outputOld = variableToRegisterOptionalId(_outVariableOld);
+  RegisterId outputOld = outputRegisterOptional(_outVariableOld);
 
   auto readableInputRegisters = RegIdSet{inDoc, insert, update};
   auto writableOutputRegisters = RegIdSet{};

--- a/arangod/Aql/ExecutionNode/WindowNode.cpp
+++ b/arangod/Aql/ExecutionNode/WindowNode.cpp
@@ -371,16 +371,12 @@ void WindowNode::calcAggregateRegisters(
   for (auto const& p : _aggregateVariables) {
     // We know that planRegisters() has been run, so
     // getPlanNode()->_registerPlan is set up
-    auto itOut = getRegisterPlan()->varInfo.find(p.outVar->id);
-    TRI_ASSERT(itOut != getRegisterPlan()->varInfo.end());
-    RegisterId outReg = itOut->second.registerId;
+    RegisterId outReg = outputRegister(p.outVar);
     TRI_ASSERT(outReg.isValid());
 
     RegisterId inReg = RegisterPlan::MaxRegisterId;
     if (Aggregator::requiresInput(p.type)) {
-      auto itIn = getRegisterPlan()->varInfo.find(p.inVar->id);
-      TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
-      inReg = itIn->second.registerId;
+      inReg = inputRegister(p.inVar);
       TRI_ASSERT(inReg.isValid());
       readableInputRegisters.insert(inReg);
     }
@@ -403,9 +399,7 @@ std::unique_ptr<ExecutionBlock> WindowNode::createBlock(
 
   RegisterId rangeRegister = RegisterPlan::MaxRegisterId;
   if (_rangeVariable != nullptr) {
-    auto itIn = getRegisterPlan()->varInfo.find(_rangeVariable->id);
-    TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
-    rangeRegister = itIn->second.registerId;
+    rangeRegister = inputRegister(_rangeVariable);
     TRI_ASSERT(rangeRegister.isValid());
     readableInputRegisters.insert(rangeRegister);
   }

--- a/arangod/Aql/Executor/IResearchViewExecutorBase.cpp
+++ b/arangod/Aql/Executor/IResearchViewExecutorBase.cpp
@@ -130,7 +130,7 @@ IResearchViewExecutorInfos::IResearchViewExecutorInfos(
     iresearch::IResearchViewStoredValues const& storedValues,
     ExecutionPlan const& plan, Variable const& outVariable,
     AstNode const& filterCondition, std::pair<bool, bool> volatility,
-    uint32_t immutableParts, VarInfoMap const& varInfoMap, int depth,
+    uint32_t immutableParts, RegisterResolver registers,
     iresearch::IResearchViewNode::ViewValuesRegisters&&
         outNonMaterializedViewRegs,
     iresearch::CountApproximate countApproximate,
@@ -153,7 +153,7 @@ IResearchViewExecutorInfos::IResearchViewExecutorInfos(
       _plan{plan},
       _outVariable{outVariable},
       _filterCondition{filterCondition},
-      _varInfoMap{varInfoMap},
+      _registers{registers},
       _outNonMaterializedViewRegs{std::move(outNonMaterializedViewRegs)},
       _countApproximate{countApproximate},
       _filterOptimization{filterOptimization},
@@ -162,7 +162,6 @@ IResearchViewExecutorInfos::IResearchViewExecutorInfos(
       _parallelism{parallelism},
       _meta{meta},
       _parallelExecutionPool{parallelExecutionPool},
-      _depth{depth},
       _immutableParts{immutableParts},
       _filterConditionIsEmpty{
           iresearch::isFilterConditionEmpty(&_filterCondition) &&

--- a/arangod/Aql/Executor/IResearchViewExecutorBase.h
+++ b/arangod/Aql/Executor/IResearchViewExecutorBase.h
@@ -443,7 +443,7 @@ class IResearchViewExecutorInfos {
       iresearch::IResearchViewStoredValues const& storedValues,
       ExecutionPlan const& plan, Variable const& outVariable,
       AstNode const& filterCondition, std::pair<bool, bool> volatility,
-      uint32_t immutableParts, VarInfoMap const& varInfoMap, int depth,
+      uint32_t immutableParts, RegisterResolver registers,
       iresearch::IResearchViewNode::ViewValuesRegisters&&
           outNonMaterializedViewRegs,
       iresearch::CountApproximate, iresearch::FilterOptimization,
@@ -478,9 +478,8 @@ class IResearchViewExecutorInfos {
     return _filterConditionIsEmpty;
   }
 
-  auto const& varInfoMap() const noexcept { return _varInfoMap; }
-
-  int getDepth() const noexcept { return _depth; }
+  /// @brief resolver for the rows the view expressions are evaluated against
+  auto const& registers() const noexcept { return _registers; }
 
   uint32_t immutableParts() const noexcept { return _immutableParts; }
 
@@ -532,7 +531,7 @@ class IResearchViewExecutorInfos {
   ExecutionPlan const& _plan;
   Variable const& _outVariable;
   AstNode const& _filterCondition;
-  VarInfoMap const& _varInfoMap;
+  RegisterResolver _registers;
   iresearch::IResearchViewNode::ViewValuesRegisters _outNonMaterializedViewRegs;
   iresearch::CountApproximate _countApproximate;
   iresearch::FilterOptimization _filterOptimization;
@@ -541,7 +540,6 @@ class IResearchViewExecutorInfos {
   size_t _parallelism;
   iresearch::SearchMeta const* _meta;
   iresearch::IResearchExecutionPool& _parallelExecutionPool;
-  int const _depth;
   uint32_t _immutableParts;
   bool _filterConditionIsEmpty;
   bool const _volatileSort;

--- a/arangod/Aql/Executor/IResearchViewExecutorBase.tpp
+++ b/arangod/Aql/Executor/IResearchViewExecutorBase.tpp
@@ -451,7 +451,7 @@ IResearchViewExecutorBase<Impl, ExecutionTraits>::IResearchViewExecutorBase(
       _indexReadBuffer(_infos.getScoreRegisters().size(),
                        _infos.getQuery().resourceMonitor()),
       _ctx(_trx, infos.getQuery(), _aqlFunctionsInternalCache,
-           infos.outVariable(), infos.varInfoMap(), infos.getDepth()),
+           infos.outVariable(), infos.registers()),
       _filterCtx(_ctx),
       _reader(infos.getReader()),
       _filter(irs::filter::prepared::empty()) {

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -574,7 +574,7 @@ void captureNonConstExpression(Ast* ast, RegisterResolver const& registers,
   for (auto const& v : innerVars) {
     // these expressions are evaluated against the input rows of the node that
     // owns the index condition, so `registers` must be bound to that depth
-    result._varToRegisterMapping.emplace_back(v->id, registers.registerFor(*v));
+    result._varToRegisterMapping.emplace_back(v->id, registers.resolve(*v));
   }
 
   TRI_IF_FAILURE("IndexBlock::initializeExpressions") {

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -552,7 +552,7 @@ bool accessesNonRegisterVariable(AstNode const* node) {
  * later execution. Extracts all required variables and retains their registers,
  * s.t. all necessary pieces are stored in the container.
  */
-void captureNonConstExpression(Ast* ast, VarInfoMap const& varInfo,
+void captureNonConstExpression(Ast* ast, RegisterResolver const& registers,
                                AstNode* expression,
                                std::vector<size_t> selectedMembersFromRoot,
                                NonConstExpressionContainer& result) {
@@ -572,10 +572,9 @@ void captureNonConstExpression(Ast* ast, VarInfoMap const& varInfo,
       std::move(e), std::move(selectedMembersFromRoot)));
 
   for (auto const& v : innerVars) {
-    auto it = varInfo.find(v->id);
-    TRI_ASSERT(it != varInfo.cend());
-    TRI_ASSERT(it->second.registerId.isValid());
-    result._varToRegisterMapping.emplace_back(v->id, it->second.registerId);
+    // these expressions are evaluated against the input rows of the node that
+    // owns the index condition, so `registers` must be bound to that depth
+    result._varToRegisterMapping.emplace_back(v->id, registers.registerFor(*v));
   }
 
   TRI_IF_FAILURE("IndexBlock::initializeExpressions") {
@@ -584,7 +583,7 @@ void captureNonConstExpression(Ast* ast, VarInfoMap const& varInfo,
 }
 
 void captureFCallArgumentExpressions(
-    Ast* ast, VarInfoMap const& varInfo, AstNode const* fCallExpression,
+    Ast* ast, RegisterResolver const& registers, AstNode const* fCallExpression,
     std::vector<size_t> selectedMembersFromRoot, Variable const* indexVariable,
     NonConstExpressionContainer& result) {
   TRI_ASSERT(fCallExpression->type == NODE_TYPE_FCALL);
@@ -600,13 +599,13 @@ void captureFCallArgumentExpressions(
         !accessesNonRegisterVariable(child)) {
       std::vector<size_t> idx = selectedMembersFromRoot;
       idx.emplace_back(k);
-      captureNonConstExpression(ast, varInfo, child, std::move(idx), result);
+      captureNonConstExpression(ast, registers, child, std::move(idx), result);
     }
   }
 }
 
 void captureArrayFilterArgumentExpressions(
-    Ast* ast, VarInfoMap const& varInfo, AstNode const* filter,
+    Ast* ast, RegisterResolver const& registers, AstNode const* filter,
     std::vector<size_t> const& selectedMembersFromRoot, bool evaluateFCalls,
     Variable const* indexVariable, NonConstExpressionContainer& result) {
   for (size_t i = 0, size = filter->numMembers(); i != size; ++i) {
@@ -621,10 +620,10 @@ void captureArrayFilterArgumentExpressions(
         // We will capture only Min and Max members as we do not want
         // entire array to be evaluated (like if someone writes
         // query 1..1234567890)
-        captureNonConstExpression(ast, varInfo, member->getMemberUnchecked(0),
+        captureNonConstExpression(ast, registers, member->getMemberUnchecked(0),
                                   std::move(path1), result);
         path.emplace_back(1);
-        captureNonConstExpression(ast, varInfo, member->getMemberUnchecked(1),
+        captureNonConstExpression(ast, registers, member->getMemberUnchecked(1),
                                   std::move(path), result);
       } else if (member->type == NODE_TYPE_QUANTIFIER) {
         auto quantifierType =
@@ -634,12 +633,12 @@ void captureArrayFilterArgumentExpressions(
           auto atLeastNodeValue = member->getMemberUnchecked(0);
           if (!atLeastNodeValue->isConstant()) {
             path.emplace_back(0);
-            captureNonConstExpression(ast, varInfo, atLeastNodeValue,
+            captureNonConstExpression(ast, registers, atLeastNodeValue,
                                       std::move(path), result);
           }
         }
       } else {
-        auto preVisitor = [&path, ast, &varInfo, &result, indexVariable,
+        auto preVisitor = [&path, ast, &registers, &result, indexVariable,
                            evaluateFCalls](AstNode const* node) -> bool {
           auto sg = ScopeGuard([&path]() noexcept { ++path.back(); });
           if (node->isConstant()) {
@@ -651,7 +650,7 @@ void captureArrayFilterArgumentExpressions(
             TRI_ASSERT(acessedVar);
             if (acessedVar->needsRegister() && acessedVar != indexVariable) {
               captureNonConstExpression(
-                  ast, varInfo, const_cast<AstNode*>(node), path, result);
+                  ast, registers, const_cast<AstNode*>(node), path, result);
             }
             // never dive into attribute access
             return false;
@@ -667,11 +666,11 @@ void captureArrayFilterArgumentExpressions(
             // it we need here to have index type and check supported
             // functions accordingly
             if (!evaluateFCalls || iresearch::isFilter(*fn)) {
-              captureFCallArgumentExpressions(ast, varInfo, node, path,
+              captureFCallArgumentExpressions(ast, registers, node, path,
                                               indexVariable, result);
             } else {
               captureNonConstExpression(
-                  ast, varInfo, const_cast<AstNode*>(node), path, result);
+                  ast, registers, const_cast<AstNode*>(node), path, result);
             }
             return false;
           } else if (node->type == NODE_TYPE_REFERENCE) {
@@ -679,7 +678,7 @@ void captureArrayFilterArgumentExpressions(
             TRI_ASSERT(acessedVar);
             if (acessedVar->needsRegister() && acessedVar != indexVariable) {
               captureNonConstExpression(
-                  ast, varInfo, const_cast<AstNode*>(node), path, result);
+                  ast, registers, const_cast<AstNode*>(node), path, result);
             }
             return false;
           }
@@ -722,13 +721,13 @@ AstNode* wrapInUniqueCall(Ast* ast, AstNode* node, bool sorted) {
 }
 
 void extractNonConstPartsOfJunctionCondition(
-    Ast* ast, VarInfoMap const& varInfo, bool evaluateFCalls, Index* index,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
     AstNode const* condition, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result);
 
 void extractNonConstPartsOfLeafNode(
-    Ast* ast, VarInfoMap const& varInfo, bool evaluateFCalls, Index* index,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
     AstNode* leaf, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
@@ -740,7 +739,7 @@ void extractNonConstPartsOfLeafNode(
     case NODE_TYPE_FCALL:
       // FCALL at this level is most likely a geo index
       captureFCallArgumentExpressions(
-          ast, varInfo, leaf, selectedMembersFromRoot, indexVariable, result);
+          ast, registers, leaf, selectedMembersFromRoot, indexVariable, result);
       return;
     case NODE_TYPE_EXPANSION:
       if (leaf->numMembers() > 2 &&
@@ -751,7 +750,7 @@ void extractNonConstPartsOfLeafNode(
         if (ADB_LIKELY(filter->type == NODE_TYPE_ARRAY_FILTER)) {
           auto path = selectedMembersFromRoot;
           path.emplace_back(2);
-          captureArrayFilterArgumentExpressions(ast, varInfo, filter,
+          captureArrayFilterArgumentExpressions(ast, registers, filter,
                                                 std::move(path), evaluateFCalls,
                                                 indexVariable, result);
         }
@@ -767,7 +766,7 @@ void extractNonConstPartsOfLeafNode(
       }
       auto path = selectedMembersFromRoot;
       path.emplace_back(0);
-      extractNonConstPartsOfLeafNode(ast, varInfo, evaluateFCalls, index,
+      extractNonConstPartsOfLeafNode(ast, registers, evaluateFCalls, index,
                                      negatedNode, indexVariable,
                                      std::move(path), result);
       return;
@@ -786,14 +785,14 @@ void extractNonConstPartsOfLeafNode(
       if (!valueNode->isConstant()) {
         auto path = selectedMembersFromRoot;
         path.emplace_back(0);
-        captureNonConstExpression(ast, varInfo, valueNode, std::move(path),
+        captureNonConstExpression(ast, registers, valueNode, std::move(path),
                                   result);
       }
       return;
     }
     case NODE_TYPE_OPERATOR_NARY_OR:
     case NODE_TYPE_OPERATOR_NARY_AND:
-      extractNonConstPartsOfJunctionCondition(ast, varInfo, evaluateFCalls,
+      extractNonConstPartsOfJunctionCondition(ast, registers, evaluateFCalls,
                                               index, leaf, indexVariable,
                                               selectedMembersFromRoot, result);
       return;
@@ -821,7 +820,7 @@ void extractNonConstPartsOfLeafNode(
       }
       auto path = selectedMembersFromRoot;
       path.emplace_back(1);
-      captureNonConstExpression(ast, varInfo, rhs, std::move(path), result);
+      captureNonConstExpression(ast, registers, rhs, std::move(path), result);
     }
   } else {
     auto path = selectedMembersFromRoot;
@@ -842,16 +841,16 @@ void extractNonConstPartsOfLeafNode(
     if (lhs->type == NODE_TYPE_FCALL &&
         (!evaluateFCalls || isInvertedIndexFunc())) {
       // most likely a geo index condition
-      captureFCallArgumentExpressions(ast, varInfo, lhs, std::move(path),
+      captureFCallArgumentExpressions(ast, registers, lhs, std::move(path),
                                       indexVariable, result);
     } else if (!lhs->isConstant()) {
-      captureNonConstExpression(ast, varInfo, lhs, std::move(path), result);
+      captureNonConstExpression(ast, registers, lhs, std::move(path), result);
     }
   }
 }
 
 void extractNonConstPartsOfAndPart(
-    Ast* ast, VarInfoMap const& varInfo, bool evaluateFCalls, Index* index,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
     AstNode const* andNode, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
@@ -863,14 +862,14 @@ void extractNonConstPartsOfAndPart(
     if (!leaf->isConstant()) {
       auto path = selectedMembersFromRoot;
       path.emplace_back(j);
-      extractNonConstPartsOfLeafNode(ast, varInfo, evaluateFCalls, index, leaf,
+      extractNonConstPartsOfLeafNode(ast, registers, evaluateFCalls, index, leaf,
                                      indexVariable, path, result);
     }
   }
 }
 
 void extractNonConstPartsOfJunctionCondition(
-    Ast* ast, VarInfoMap const& varInfo, bool evaluateFCalls, Index* index,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
     AstNode const* condition, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
@@ -888,12 +887,12 @@ void extractNonConstPartsOfJunctionCondition(
       }
       auto path = selectedMembersFromRoot;
       path.emplace_back(i);
-      extractNonConstPartsOfAndPart(ast, varInfo, evaluateFCalls, index,
+      extractNonConstPartsOfAndPart(ast, registers, evaluateFCalls, index,
                                     andNode, indexVariable, std::move(path),
                                     result);
     }
   } else {
-    extractNonConstPartsOfAndPart(ast, varInfo, evaluateFCalls, index,
+    extractNonConstPartsOfAndPart(ast, registers, evaluateFCalls, index,
                                   condition, indexVariable,
                                   selectedMembersFromRoot, result);
   }
@@ -1443,7 +1442,7 @@ bool getIndexForSortCondition(Collection const& coll,
 }
 
 NonConstExpressionContainer extractNonConstPartsOfIndexCondition(
-    Ast* ast, VarInfoMap const& varInfo, bool evaluateFCalls, Index* index,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
     AstNode const* condition, Variable const* indexVariable) {
   // conditions can be of the form (a [<|<=|>|=>] b) && ...
   TRI_ASSERT(condition != nullptr);
@@ -1452,7 +1451,7 @@ NonConstExpressionContainer extractNonConstPartsOfIndexCondition(
   TRI_ASSERT(indexVariable != nullptr);
 
   NonConstExpressionContainer result;
-  extractNonConstPartsOfJunctionCondition(ast, varInfo, evaluateFCalls, index,
+  extractNonConstPartsOfJunctionCondition(ast, registers, evaluateFCalls, index,
                                           condition, indexVariable, {}, result);
   return result;
 }

--- a/arangod/Aql/OptimizerUtils.cpp
+++ b/arangod/Aql/OptimizerUtils.cpp
@@ -721,14 +721,14 @@ AstNode* wrapInUniqueCall(Ast* ast, AstNode* node, bool sorted) {
 }
 
 void extractNonConstPartsOfJunctionCondition(
-    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
-    AstNode const* condition, Variable const* indexVariable,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls,
+    Index* index, AstNode const* condition, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result);
 
 void extractNonConstPartsOfLeafNode(
-    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
-    AstNode* leaf, Variable const* indexVariable,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls,
+    Index* index, AstNode* leaf, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
   if (leaf->isConstant()) {
@@ -850,8 +850,8 @@ void extractNonConstPartsOfLeafNode(
 }
 
 void extractNonConstPartsOfAndPart(
-    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
-    AstNode const* andNode, Variable const* indexVariable,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls,
+    Index* index, AstNode const* andNode, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
   // in case of a geo spatial index a might take the form
@@ -862,15 +862,15 @@ void extractNonConstPartsOfAndPart(
     if (!leaf->isConstant()) {
       auto path = selectedMembersFromRoot;
       path.emplace_back(j);
-      extractNonConstPartsOfLeafNode(ast, registers, evaluateFCalls, index, leaf,
-                                     indexVariable, path, result);
+      extractNonConstPartsOfLeafNode(ast, registers, evaluateFCalls, index,
+                                     leaf, indexVariable, path, result);
     }
   }
 }
 
 void extractNonConstPartsOfJunctionCondition(
-    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
-    AstNode const* condition, Variable const* indexVariable,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls,
+    Index* index, AstNode const* condition, Variable const* indexVariable,
     std::vector<size_t> const& selectedMembersFromRoot,
     NonConstExpressionContainer& result) {
   // conditions can be of the form (a [<|<=|>|=>] b) && ...
@@ -1442,8 +1442,8 @@ bool getIndexForSortCondition(Collection const& coll,
 }
 
 NonConstExpressionContainer extractNonConstPartsOfIndexCondition(
-    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
-    AstNode const* condition, Variable const* indexVariable) {
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls,
+    Index* index, AstNode const* condition, Variable const* indexVariable) {
   // conditions can be of the form (a [<|<=|>|=>] b) && ...
   TRI_ASSERT(condition != nullptr);
   TRI_ASSERT(condition->type == NODE_TYPE_OPERATOR_NARY_AND ||

--- a/arangod/Aql/OptimizerUtils.h
+++ b/arangod/Aql/OptimizerUtils.h
@@ -117,8 +117,8 @@ bool getIndexForSortCondition(aql::Collection const& coll,
                               size_t& coveredAttributes);
 
 NonConstExpressionContainer extractNonConstPartsOfIndexCondition(
-    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
-    AstNode const* condition, Variable const* indexVariable);
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls,
+    Index* index, AstNode const* condition, Variable const* indexVariable);
 
 arangodb::aql::Collection const* getCollection(
     arangodb::aql::ExecutionNode const* node);

--- a/arangod/Aql/OptimizerUtils.h
+++ b/arangod/Aql/OptimizerUtils.h
@@ -117,7 +117,7 @@ bool getIndexForSortCondition(aql::Collection const& coll,
                               size_t& coveredAttributes);
 
 NonConstExpressionContainer extractNonConstPartsOfIndexCondition(
-    Ast* ast, VarInfoMap const& varInfo, bool evaluateFCalls, Index* index,
+    Ast* ast, RegisterResolver const& registers, bool evaluateFCalls, Index* index,
     AstNode const* condition, Variable const* indexVariable);
 
 arangodb::aql::Collection const* getCollection(

--- a/arangod/Aql/QuerySnippet.cpp
+++ b/arangod/Aql/QuerySnippet.cpp
@@ -542,7 +542,7 @@ void QuerySnippet::serializeIntoBuilder(
         // lifetime needs to be extended.
         auto const var = dist->getVariable();
         if (!dist->getVarsUsedLater().contains(var)) {
-          auto reg = dist->getRegisterPlan()->variableToRegisterId(var);
+          auto reg = dist->inputRegister(var);
           auto globalRegsToClear = dist->getRegsToClear();
           auto globalRegsToKeepStack = dist->getRegsToKeepStack();
           for (auto& regSet : globalRegsToKeepStack) {

--- a/arangod/Aql/RegisterId.h
+++ b/arangod/Aql/RegisterId.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <functional>
 #include <limits>
 #include <stdint.h>
 #include <type_traits>

--- a/arangod/Aql/RegisterInfos.h
+++ b/arangod/Aql/RegisterInfos.h
@@ -53,10 +53,9 @@ class RegisterInfos {
    *                        TODO Update this comment, it's a stack now.
    *
    * Note that the output registers can be found in the ExecutionNode via
-   * getVariablesSetHere() and translated as follows:
-   *   auto it = getRegisterPlan()->varInfo.find(varSetHere->id);
-   *   TRI_ASSERT(it != getRegisterPlan()->varInfo.end());
-   *   RegisterId register = it->second.registerId;
+   * getVariablesSetHere() and translated with
+   * ExecutionNode::outputRegister(varSetHere). Registers the executor reads
+   * off its input rows are translated with ExecutionNode::inputRegister().
    */
 
   RegisterInfos(RegIdSet readableInputRegisters,

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -66,7 +66,9 @@ auto RegisterResolver::lookup(VariableId id) const noexcept
   if (it == _varInfo->end()) {
     return {RegisterId::makeInvalid(), Status::UnknownVariable};
   }
-  if (it->second.depth > _depth) {
+  // const registers live in one query-global block rather than in the
+  // per-depth item blocks, so they are available at every depth
+  if (!it->second.registerId.isConstRegister() && it->second.depth > _depth) {
     return {RegisterId::makeInvalid(), Status::NotYetAssigned};
   }
   return {it->second.registerId, Status::Ok};

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -40,7 +40,7 @@ VarInfo::VarInfo(unsigned int depth, RegisterId registerId)
   }
 }
 
-RegisterId RegisterResolver::resolve(Variable const& variable) const {
+RegisterId RegisterResolver::resolve(Variable const& variable) const noexcept {
   auto [reg, status] = lookup(variable.id);
   TRI_ASSERT(status == Status::Ok)
       << "variable " << variable.name << " (" << variable.id << ") "
@@ -51,7 +51,7 @@ RegisterId RegisterResolver::resolve(Variable const& variable) const {
   return reg;
 }
 
-RegisterId RegisterResolver::resolve(Variable const* variable) const {
+RegisterId RegisterResolver::resolve(Variable const* variable) const noexcept {
   TRI_ASSERT(variable != nullptr);
   return resolve(*variable);
 }

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -24,6 +24,8 @@
 
 #include "RegisterPlan.tpp"
 
+#include "Aql/Variable.h"
+
 using namespace arangodb;
 using namespace arangodb::aql;
 
@@ -36,6 +38,38 @@ VarInfo::VarInfo(unsigned int depth, RegisterId registerId)
         std::format("too many registers ({}) needed for AQL query",
                     registerId.value()));
   }
+}
+
+RegisterId RegisterResolver::registerFor(Variable const& variable) const {
+  auto [reg, status] = lookup(variable.id);
+  TRI_ASSERT(status == Status::Ok)
+      << "variable " << variable.name << " (" << variable.id << ") "
+      << (status == Status::UnknownVariable ? "has no register assigned"
+                                            : "is not available here")
+      << ", resolved for depth " << _depth;
+  TRI_ASSERT(reg.isValid());
+  return reg;
+}
+
+RegisterId RegisterResolver::registerFor(Variable const* variable) const {
+  TRI_ASSERT(variable != nullptr);
+  return registerFor(*variable);
+}
+
+RegisterId RegisterResolver::tryRegisterFor(VariableId id) const noexcept {
+  return lookup(id).first;
+}
+
+auto RegisterResolver::lookup(VariableId id) const noexcept
+    -> std::pair<RegisterId, Status> {
+  auto it = _varInfo->find(id);
+  if (it == _varInfo->end()) {
+    return {RegisterId::makeInvalid(), Status::UnknownVariable};
+  }
+  if (it->second.depth > _depth) {
+    return {RegisterId::makeInvalid(), Status::NotYetAssigned};
+  }
+  return {it->second.registerId, Status::Ok};
 }
 
 MissingVariablesException::MissingVariablesException(

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -26,6 +26,8 @@
 
 #include "Aql/Variable.h"
 
+#include <format>
+
 using namespace arangodb;
 using namespace arangodb::aql;
 
@@ -40,18 +42,23 @@ VarInfo::VarInfo(unsigned int depth, RegisterId registerId)
   }
 }
 
-RegisterId RegisterResolver::resolve(Variable const& variable) const noexcept {
+RegisterId RegisterResolver::resolve(Variable const& variable) const {
   auto [reg, status] = lookup(variable.id);
-  TRI_ASSERT(status == Status::Ok)
-      << "variable " << variable.name << " (" << variable.id << ") "
-      << (status == Status::UnknownVariable ? "has no register assigned"
-                                            : "is not available here")
-      << ", resolved for depth " << _depth;
+  if (status != Status::Ok) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL_AQL,
+        std::format("variable {} #{} {}, resolved for depth {}", variable.name,
+                    variable.id,
+                    status == Status::UnknownVariable
+                        ? "has no register assigned"
+                        : "is not available at that depth",
+                    _depth));
+  }
   TRI_ASSERT(reg.isValid());
   return reg;
 }
 
-RegisterId RegisterResolver::resolve(Variable const* variable) const noexcept {
+RegisterId RegisterResolver::resolve(Variable const* variable) const {
   TRI_ASSERT(variable != nullptr);
   return resolve(*variable);
 }

--- a/arangod/Aql/RegisterPlan.cpp
+++ b/arangod/Aql/RegisterPlan.cpp
@@ -40,7 +40,7 @@ VarInfo::VarInfo(unsigned int depth, RegisterId registerId)
   }
 }
 
-RegisterId RegisterResolver::registerFor(Variable const& variable) const {
+RegisterId RegisterResolver::resolve(Variable const& variable) const {
   auto [reg, status] = lookup(variable.id);
   TRI_ASSERT(status == Status::Ok)
       << "variable " << variable.name << " (" << variable.id << ") "
@@ -51,12 +51,12 @@ RegisterId RegisterResolver::registerFor(Variable const& variable) const {
   return reg;
 }
 
-RegisterId RegisterResolver::registerFor(Variable const* variable) const {
+RegisterId RegisterResolver::resolve(Variable const* variable) const {
   TRI_ASSERT(variable != nullptr);
-  return registerFor(*variable);
+  return resolve(*variable);
 }
 
-RegisterId RegisterResolver::tryRegisterFor(VariableId id) const noexcept {
+RegisterId RegisterResolver::tryResolve(VariableId id) const noexcept {
   return lookup(id).first;
 }
 

--- a/arangod/Aql/RegisterPlan.h
+++ b/arangod/Aql/RegisterPlan.h
@@ -52,15 +52,6 @@ namespace arangodb::aql {
 class ExecutionNode;
 struct Variable;
 
-/// @brief static analysis, walker class and information collector
-struct VarInfo {
-  unsigned int depth{0};
-  RegisterId registerId;
-
-  VarInfo() = default;
-  VarInfo(unsigned int depth, RegisterId registerId);
-};
-
 template<typename T>
 struct RegisterPlanT;
 
@@ -155,8 +146,23 @@ struct RegisterPlanT final
   void toVelocyPack(arangodb::velocypack::Builder& builder) const;
   static void toVelocyPackEmpty(arangodb::velocypack::Builder& builder);
 
-  auto variableToRegisterId(Variable const* variable) const -> RegisterId;
-  auto variableToOptionalRegisterId(VariableId varId) const -> RegisterId;
+  /// @brief register holding `variable` in rows of the given depth.
+  /// Prefer ExecutionNode::inputRegister()/outputRegister(), which pass the
+  /// depth of the row the caller actually means.
+  auto variableToRegisterId(Variable const* variable, unsigned int depth) const
+      -> RegisterId;
+  auto variableToOptionalRegisterId(VariableId varId, unsigned int depth) const
+      -> RegisterId;
+
+  /// @brief a resolver bound to one depth, for code that has to resolve
+  /// variables later than register planning (e.g. during execution).
+  auto resolverForDepth(unsigned int depth) const -> RegisterResolver;
+
+  /// @brief Register of a constant or bind-parameter variable. Const registers
+  /// live in one query-global block rather than in the per-depth item blocks,
+  /// so this lookup is deliberately depth-independent. Returns an invalid
+  /// RegisterId when the variable was never assigned a register.
+  auto constVariableToRegisterId(VariableId varId) const -> RegisterId;
 
   auto calcRegsToKeep(VarSetStack const& varsUsedLaterStack,
                       VarSetStack const& varsValidStack,
@@ -164,6 +170,12 @@ struct RegisterPlanT final
       -> RegIdSetStack;
 
  private:
+  /// @brief depth-agnostic lookups, for register planning itself: while the
+  /// plan is being built there is only one numbering to resolve against.
+  /// Everything downstream must go through the depth-aware overloads.
+  auto variableToRegisterId(Variable const* variable) const -> RegisterId;
+  auto variableToOptionalRegisterId(VariableId varId) const -> RegisterId;
+
   unsigned int depth;
 };
 

--- a/arangod/Aql/RegisterPlan.tpp
+++ b/arangod/Aql/RegisterPlan.tpp
@@ -588,17 +588,28 @@ auto RegisterPlanT<T>::variableToRegisterId(Variable const* variable,
     -> RegisterId {
   TRI_ASSERT(variable != nullptr);
   auto it = varInfo.find(variable->id);
-  TRI_ASSERT(it != varInfo.end())
-      << "variable " << variable->name << " (" << variable->id << ")";
-  // a variable can only be read from a row at or below the depth at which it
+  if (it == varInfo.end()) {
+    // An inconsistent plan, not a broken invariant of this class: the node
+    // asked for a variable that register planning never assigned a register
+    // to. Fail the query rather than the process.
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL_AQL,
+        std::format("no register assigned for variable {} #{} while creating "
+                    "the execution block",
+                    variable->name, variable->id));
+  }
+  // A variable can only be read from a row at or below the depth at which it
   // was assigned its register. Asking for a lower depth means the caller
-  // reached for the wrong row -- typically an output variable resolved against
-  // the input row of a depth-increasing node.
-  TRI_ASSERT(it->second.registerId.isConstRegister() ||
-             it->second.depth <= depth)
-      << "variable " << variable->name << " (" << variable->id
-      << ") is assigned at depth " << it->second.depth
-      << ", resolved for depth " << depth;
+  // reached for the wrong row, typically an output variable resolved against
+  // the input row of a depth-increasing node. Const registers live in one
+  // query-global block and are available at every depth.
+  if (!it->second.registerId.isConstRegister() && it->second.depth > depth) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(
+        TRI_ERROR_INTERNAL_AQL,
+        std::format("variable {} #{} is assigned at depth {} but was resolved "
+                    "for depth {} while creating the execution block",
+                    variable->name, variable->id, it->second.depth, depth));
+  }
   RegisterId rv = it->second.registerId;
   TRI_ASSERT(rv.isValid());
   return rv;

--- a/arangod/Aql/RegisterPlan.tpp
+++ b/arangod/Aql/RegisterPlan.tpp
@@ -607,7 +607,7 @@ template<typename T>
 auto RegisterPlanT<T>::variableToOptionalRegisterId(VariableId varId,
                                                     unsigned int depth) const
     -> RegisterId {
-  return resolverForDepth(depth).tryRegisterFor(varId);
+  return resolverForDepth(depth).tryResolve(varId);
 }
 
 template<typename T>

--- a/arangod/Aql/RegisterPlan.tpp
+++ b/arangod/Aql/RegisterPlan.tpp
@@ -594,7 +594,8 @@ auto RegisterPlanT<T>::variableToRegisterId(Variable const* variable,
   // was assigned its register. Asking for a lower depth means the caller
   // reached for the wrong row -- typically an output variable resolved against
   // the input row of a depth-increasing node.
-  TRI_ASSERT(it->second.depth <= depth)
+  TRI_ASSERT(it->second.registerId.isConstRegister() ||
+             it->second.depth <= depth)
       << "variable " << variable->name << " (" << variable->id
       << ") is assigned at depth " << it->second.depth
       << ", resolved for depth " << depth;

--- a/arangod/Aql/RegisterPlan.tpp
+++ b/arangod/Aql/RegisterPlan.tpp
@@ -579,7 +579,52 @@ auto RegisterPlanT<T>::variableToOptionalRegisterId(VariableId varId) const
   if (it != varInfo.end()) {
     return it->second.registerId;
   }
-  return RegisterId{RegisterId::maxRegisterId};
+  return RegisterId::makeInvalid();
+}
+
+template<typename T>
+auto RegisterPlanT<T>::variableToRegisterId(Variable const* variable,
+                                            unsigned int depth) const
+    -> RegisterId {
+  TRI_ASSERT(variable != nullptr);
+  auto it = varInfo.find(variable->id);
+  TRI_ASSERT(it != varInfo.end())
+      << "variable " << variable->name << " (" << variable->id << ")";
+  // a variable can only be read from a row at or below the depth at which it
+  // was assigned its register. Asking for a lower depth means the caller
+  // reached for the wrong row -- typically an output variable resolved against
+  // the input row of a depth-increasing node.
+  TRI_ASSERT(it->second.depth <= depth)
+      << "variable " << variable->name << " (" << variable->id
+      << ") is assigned at depth " << it->second.depth
+      << ", resolved for depth " << depth;
+  RegisterId rv = it->second.registerId;
+  TRI_ASSERT(rv.isValid());
+  return rv;
+}
+
+template<typename T>
+auto RegisterPlanT<T>::variableToOptionalRegisterId(VariableId varId,
+                                                    unsigned int depth) const
+    -> RegisterId {
+  return resolverForDepth(depth).tryRegisterFor(varId);
+}
+
+template<typename T>
+auto RegisterPlanT<T>::resolverForDepth(unsigned int depth) const
+    -> RegisterResolver {
+  return RegisterResolver{varInfo, depth};
+}
+
+template<typename T>
+auto RegisterPlanT<T>::constVariableToRegisterId(VariableId varId) const
+    -> RegisterId {
+  auto it = varInfo.find(varId);
+  if (it == varInfo.end()) {
+    return RegisterId::makeInvalid();
+  }
+  TRI_ASSERT(it->second.registerId.isConstRegister());
+  return it->second.registerId;
 }
 
 template<typename T>

--- a/arangod/Aql/SortRegister.cpp
+++ b/arangod/Aql/SortRegister.cpp
@@ -32,18 +32,13 @@ SortRegister::SortRegister(RegisterId reg, SortElement const& element) noexcept
     : attributePath(element.attributePath), reg(reg), asc(element.ascending) {}
 
 void SortRegister::fill(ExecutionPlan const& /*execPlan*/,
-                        RegisterPlan const& regPlan,
+                        RegisterResolver const& registers,
                         std::vector<SortElement> const& elements,
                         std::vector<SortRegister>& sortRegisters) {
   sortRegisters.reserve(elements.size());
-  auto const& vars = regPlan.varInfo;
 
   for (auto const& p : elements) {
-    auto const varId = p.var->id;
-    auto const it = vars.find(varId);
-    TRI_ASSERT(it != vars.end());
-    TRI_ASSERT(it->second.registerId.isValid());
-    sortRegisters.emplace_back(it->second.registerId, p);
+    sortRegisters.emplace_back(registers.registerFor(*p.var), p);
   }
 }
 

--- a/arangod/Aql/SortRegister.cpp
+++ b/arangod/Aql/SortRegister.cpp
@@ -38,7 +38,7 @@ void SortRegister::fill(ExecutionPlan const& /*execPlan*/,
   sortRegisters.reserve(elements.size());
 
   for (auto const& p : elements) {
-    sortRegisters.emplace_back(registers.registerFor(*p.var), p);
+    sortRegisters.emplace_back(registers.resolve(*p.var), p);
   }
 }
 

--- a/arangod/Aql/SortRegister.h
+++ b/arangod/Aql/SortRegister.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include "Aql/VarInfoMap.h"
 #include "Aql/types.h"
 
 #include <string>
@@ -48,8 +49,10 @@ struct SortRegister {
 
   SortRegister(RegisterId reg, SortElement const& element) noexcept;
 
+  /// @brief `registers` must be bound to the depth of the rows the sort
+  /// criteria are read from, i.e. the consuming node's input rows.
   static void fill(ExecutionPlan const& /*execPlan*/,
-                   RegisterPlan const& regPlan,
+                   RegisterResolver const& registers,
                    std::vector<SortElement> const& elements,
                    std::vector<SortRegister>& sortRegisters);
 };  // SortRegister

--- a/arangod/Aql/VarInfoMap.h
+++ b/arangod/Aql/VarInfoMap.h
@@ -56,8 +56,8 @@ class RegisterResolver {
 
   /// @brief register holding `variable` in rows of this depth. The variable
   /// must have a register and must be available here.
-  RegisterId resolve(Variable const& variable) const noexcept;
-  RegisterId resolve(Variable const* variable) const noexcept;
+  RegisterId resolve(Variable const& variable) const;
+  RegisterId resolve(Variable const* variable) const;
 
   /// @brief register holding the variable, or an invalid RegisterId if it has
   /// no register or is not available at this depth.

--- a/arangod/Aql/VarInfoMap.h
+++ b/arangod/Aql/VarInfoMap.h
@@ -75,12 +75,12 @@ class RegisterResolver {
 
   /// @brief register holding `variable` in rows of this depth. The variable
   /// must have a register and must be available here.
-  RegisterId registerFor(Variable const& variable) const;
-  RegisterId registerFor(Variable const* variable) const;
+  RegisterId resolve(Variable const& variable) const;
+  RegisterId resolve(Variable const* variable) const;
 
   /// @brief register holding the variable, or an invalid RegisterId if it has
   /// no register or is not available at this depth.
-  RegisterId tryRegisterFor(VariableId id) const noexcept;
+  RegisterId tryResolve(VariableId id) const noexcept;
 
   /// @brief full lookup result, for callers that need to tell the two failure
   /// modes apart.

--- a/arangod/Aql/VarInfoMap.h
+++ b/arangod/Aql/VarInfoMap.h
@@ -25,18 +25,13 @@
 #include "Aql/RegisterId.h"
 #include "Aql/types.h"
 
-#include <unordered_map>
 #include <utility>
-// TODO(MBkkt) Try to use FlatHashMap to achieve better
-//  lookup performance on query execution
-// #include "Containers/FlatHashMap.h"
+#include "Containers/FlatHashMap.h"
 
 namespace arangodb::aql {
 
 struct Variable;
 
-/// @brief where a variable lives: the depth at which it is assigned a
-/// register, and that register.
 struct VarInfo {
   unsigned int depth{0};
   RegisterId registerId;
@@ -45,28 +40,14 @@ struct VarInfo {
   VarInfo(unsigned int depth, RegisterId registerId);
 };
 
-using VarInfoMap = std::unordered_map<VariableId, VarInfo>;
+using VarInfoMap = containers::FlatHashMap<VariableId, VarInfo>;
 
 /// @brief Resolves variables to registers for rows of one specific depth.
-///
-/// "Depth" here is the register-planning notion: a run of adjacent execution
-/// nodes that share one block width and one register numbering. Every register
-/// lookup is really a question about a specific row, and a row always belongs
-/// to exactly one depth -- the rows a node reads sit at the depth of its
-/// dependency, the rows it writes sit at its own depth.
-///
-/// Hand this around instead of a bare VarInfoMap so that the depth travels
-/// with the map and a caller cannot resolve against the wrong numbering.
-/// Obtain one from ExecutionNode::inputRegisterResolver() /
-/// outputRegisterResolver().
 class RegisterResolver {
  public:
   enum class Status {
     Ok,
-    /// @brief the variable was never assigned a register
     UnknownVariable,
-    /// @brief the variable is assigned a register, but only becomes available
-    /// at a greater depth than the one being resolved for
     NotYetAssigned,
   };
 
@@ -75,8 +56,8 @@ class RegisterResolver {
 
   /// @brief register holding `variable` in rows of this depth. The variable
   /// must have a register and must be available here.
-  RegisterId resolve(Variable const& variable) const;
-  RegisterId resolve(Variable const* variable) const;
+  RegisterId resolve(Variable const& variable) const noexcept;
+  RegisterId resolve(Variable const* variable) const noexcept;
 
   /// @brief register holding the variable, or an invalid RegisterId if it has
   /// no register or is not available at this depth.

--- a/arangod/Aql/VarInfoMap.h
+++ b/arangod/Aql/VarInfoMap.h
@@ -22,17 +22,77 @@
 
 #pragma once
 
+#include "Aql/RegisterId.h"
 #include "Aql/types.h"
 
 #include <unordered_map>
+#include <utility>
 // TODO(MBkkt) Try to use FlatHashMap to achieve better
 //  lookup performance on query execution
 // #include "Containers/FlatHashMap.h"
 
 namespace arangodb::aql {
 
-struct VarInfo;
+struct Variable;
+
+/// @brief where a variable lives: the depth at which it is assigned a
+/// register, and that register.
+struct VarInfo {
+  unsigned int depth{0};
+  RegisterId registerId;
+
+  VarInfo() = default;
+  VarInfo(unsigned int depth, RegisterId registerId);
+};
 
 using VarInfoMap = std::unordered_map<VariableId, VarInfo>;
+
+/// @brief Resolves variables to registers for rows of one specific depth.
+///
+/// "Depth" here is the register-planning notion: a run of adjacent execution
+/// nodes that share one block width and one register numbering. Every register
+/// lookup is really a question about a specific row, and a row always belongs
+/// to exactly one depth -- the rows a node reads sit at the depth of its
+/// dependency, the rows it writes sit at its own depth.
+///
+/// Hand this around instead of a bare VarInfoMap so that the depth travels
+/// with the map and a caller cannot resolve against the wrong numbering.
+/// Obtain one from ExecutionNode::inputRegisterResolver() /
+/// outputRegisterResolver().
+class RegisterResolver {
+ public:
+  enum class Status {
+    Ok,
+    /// @brief the variable was never assigned a register
+    UnknownVariable,
+    /// @brief the variable is assigned a register, but only becomes available
+    /// at a greater depth than the one being resolved for
+    NotYetAssigned,
+  };
+
+  RegisterResolver(VarInfoMap const& varInfo, unsigned int depth) noexcept
+      : _varInfo(&varInfo), _depth(depth) {}
+
+  /// @brief register holding `variable` in rows of this depth. The variable
+  /// must have a register and must be available here.
+  RegisterId registerFor(Variable const& variable) const;
+  RegisterId registerFor(Variable const* variable) const;
+
+  /// @brief register holding the variable, or an invalid RegisterId if it has
+  /// no register or is not available at this depth.
+  RegisterId tryRegisterFor(VariableId id) const noexcept;
+
+  /// @brief full lookup result, for callers that need to tell the two failure
+  /// modes apart.
+  std::pair<RegisterId, Status> lookup(VariableId id) const noexcept;
+
+  unsigned int depth() const noexcept { return _depth; }
+
+  VarInfoMap const& varInfo() const noexcept { return *_varInfo; }
+
+ private:
+  VarInfoMap const* _varInfo;
+  unsigned int _depth;
+};
 
 }  // namespace arangodb::aql

--- a/arangod/Graph/BaseOptions.cpp
+++ b/arangod/Graph/BaseOptions.cpp
@@ -211,10 +211,10 @@ double BaseOptions::LookupInfo::estimateCost(size_t& nrItems) const {
 }
 
 void BaseOptions::LookupInfo::initializeNonConstExpressions(
-    aql::Ast* ast, aql::VarInfoMap const& varInfo,
+    aql::Ast* ast, aql::RegisterResolver const& registers,
     aql::Variable const* indexVariable) {
   _nonConstContainer = aql::utils::extractNonConstPartsOfIndexCondition(
-      ast, varInfo, false, nullptr, indexCondition, indexVariable);
+      ast, registers, false, nullptr, indexCondition, indexVariable);
   // We cannot optimize V8 expressions
   TRI_ASSERT(!_nonConstContainer._hasV8Expression);
 }
@@ -563,10 +563,10 @@ bool BaseOptions::evaluateExpression(arangodb::aql::Expression* expression,
 }
 
 void BaseOptions::initializeIndexConditions(
-    aql::Ast* ast, aql::VarInfoMap const& varInfo,
+    aql::Ast* ast, aql::RegisterResolver const& registers,
     aql::Variable const* indexVariable) {
   for (auto& it : _baseLookupInfos) {
-    it.initializeNonConstExpressions(ast, varInfo, indexVariable);
+    it.initializeNonConstExpressions(ast, registers, indexVariable);
   }
 }
 

--- a/arangod/Graph/BaseOptions.h
+++ b/arangod/Graph/BaseOptions.h
@@ -102,7 +102,7 @@ struct BaseOptions {
                arangodb::velocypack::Slice shards);
 
     void initializeNonConstExpressions(aql::Ast* ast,
-                                       aql::VarInfoMap const& varInfo,
+                                       aql::RegisterResolver const& registers,
                                        aql::Variable const* indexVariable);
 
     /// @brief Build a velocypack containing all relevant information
@@ -227,7 +227,7 @@ struct BaseOptions {
   arangodb::aql::FixedVarExpressionContext const& getExpressionCtx() const;
 
   virtual void initializeIndexConditions(aql::Ast* ast,
-                                         aql::VarInfoMap const& varInfo,
+                                         aql::RegisterResolver const& registers,
                                          aql::Variable const* indexVariable);
 
   virtual void calculateIndexExpressions(aql::Ast* ast);

--- a/arangod/Graph/TraverserOptions.cpp
+++ b/arangod/Graph/TraverserOptions.cpp
@@ -718,12 +718,12 @@ auto TraverserOptions::isSatelliteLeader() const -> bool {
 #endif
 
 void TraverserOptions::initializeIndexConditions(
-    aql::Ast* ast, aql::VarInfoMap const& varInfo,
+    aql::Ast* ast, aql::RegisterResolver const& registers,
     aql::Variable const* indexVariable) {
-  BaseOptions::initializeIndexConditions(ast, varInfo, indexVariable);
+  BaseOptions::initializeIndexConditions(ast, registers, indexVariable);
   for (auto& [unused, infos] : _depthLookupInfo) {
     for (auto& info : infos) {
-      info.initializeNonConstExpressions(ast, varInfo, indexVariable);
+      info.initializeNonConstExpressions(ast, registers, indexVariable);
     }
   }
 }

--- a/arangod/Graph/TraverserOptions.h
+++ b/arangod/Graph/TraverserOptions.h
@@ -202,7 +202,8 @@ struct TraverserOptions : public graph::BaseOptions {
 
   auto isSatelliteLeader() const -> bool;
 
-  void initializeIndexConditions(aql::Ast* ast, aql::RegisterResolver const& registers,
+  void initializeIndexConditions(aql::Ast* ast,
+                                 aql::RegisterResolver const& registers,
                                  aql::Variable const* indexVariable) override;
 
   void calculateIndexExpressions(aql::Ast* ast) override;

--- a/arangod/Graph/TraverserOptions.h
+++ b/arangod/Graph/TraverserOptions.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Aql/FixedVarExpressionContext.h"
+#include "Aql/VarInfoMap.h"
 #include "Graph/BaseOptions.h"
 #include "StorageEngine/TransactionState.h"
 
@@ -201,7 +202,7 @@ struct TraverserOptions : public graph::BaseOptions {
 
   auto isSatelliteLeader() const -> bool;
 
-  void initializeIndexConditions(aql::Ast* ast, aql::VarInfoMap const& varInfo,
+  void initializeIndexConditions(aql::Ast* ast, aql::RegisterResolver const& registers,
                                  aql::Variable const* indexVariable) override;
 
   void calculateIndexExpressions(aql::Ast* ast) override;

--- a/arangod/IResearch/IResearchExpressionContext.cpp
+++ b/arangod/IResearch/IResearchExpressionContext.cpp
@@ -130,23 +130,22 @@ AqlValue ViewExpressionContext::getVariableValue(Variable const* var,
 
   mustDestroy = false;
 
-  auto const& vars = varInfoMap();
-  auto const it = vars.find(var->id);
+  auto const [reg, status] = registers().lookup(var->id);
 
-  if (vars.end() == it) {
-    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "cannot find variable");
-  }
-
-  auto const& varInfo = it->second;
-
-  if (varInfo.depth > decltype(varInfo.depth)(nodeDepth())) {
-    THROW_ARANGO_EXCEPTION_FORMAT(TRI_ERROR_BAD_PARAMETER,
-                                  "Variable '%s' is used before being assigned",
-                                  var->name.c_str());
+  switch (status) {
+    case aql::RegisterResolver::Status::UnknownVariable:
+      THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL,
+                                     "cannot find variable");
+    case aql::RegisterResolver::Status::NotYetAssigned:
+      THROW_ARANGO_EXCEPTION_FORMAT(
+          TRI_ERROR_BAD_PARAMETER,
+          "Variable '%s' is used before being assigned", var->name.c_str());
+    case aql::RegisterResolver::Status::Ok:
+      break;
   }
 
   TRI_ASSERT(_inputRow.isInitialized());
-  AqlValue const& value = _inputRow.getValue(varInfo.registerId);
+  AqlValue const& value = _inputRow.getValue(reg);
 
   if (doCopy) {
     mustDestroy = true;

--- a/arangod/IResearch/IResearchExpressionContext.h
+++ b/arangod/IResearch/IResearchExpressionContext.h
@@ -26,6 +26,7 @@
 #include "Aql/ExpressionContext.h"
 #include "Aql/InputAqlItemRow.h"
 #include "Aql/RegisterPlan.h"
+#include "Aql/VarInfoMap.h"
 #include "Containers/FlatHashMap.h"
 
 #include <velocypack/Slice.h>
@@ -96,11 +97,10 @@ struct ViewExpressionContext final : public ViewExpressionContextBase {
                         aql::QueryContext& query,
                         aql::AqlFunctionsInternalCache& cache,
                         aql::Variable const& outVar,
-                        aql::VarInfoMap const& varInfoMap, int nodeDepth)
+                        aql::RegisterResolver registers)
       : ViewExpressionContextBase(&trx, &query, &cache),
         _outVar(outVar),
-        _varInfoMap(varInfoMap),
-        _nodeDepth(nodeDepth) {}
+        _registers(registers) {}
 
   // register a temporary variable in the ExpressionContext. the
   // slice used here is not owned by the QueryExpressionContext!
@@ -116,13 +116,11 @@ struct ViewExpressionContext final : public ViewExpressionContextBase {
                                  bool& mustDestroy) const override;
 
   inline auto const& outVariable() const noexcept { return _outVar; }
-  inline auto const& varInfoMap() const noexcept { return _varInfoMap; }
-  inline int nodeDepth() const noexcept { return _nodeDepth; }
+  inline auto const& registers() const noexcept { return _registers; }
 
   aql::InputAqlItemRow _inputRow{aql::CreateInvalidInputRowHint{}};
   aql::Variable const& _outVar;
-  aql::VarInfoMap const& _varInfoMap;
-  int const _nodeDepth;
+  aql::RegisterResolver _registers;
 
   // variables only temporarily valid during execution
   // variables only temporarily valid during execution. Slices stored

--- a/tests/IResearch/IResearchViewCountApproximateTest.cpp
+++ b/tests/IResearch/IResearchViewCountApproximateTest.cpp
@@ -565,7 +565,7 @@ TEST_F(IResearchViewCountApproximateTest, directSkipAllForMergeExecutorExact) {
 #endif
       emptyScorers, {&sort, 1U}, _view->storedValues(), *plan,
       viewNode.outVariable(), viewNode.filterCondition(), {false, false}, 0,
-      viewNode.getRegisterPlan()->varInfo, 0,
+      viewNode.getRegisterPlan()->resolverForDepth(0),
       arangodb::iresearch::IResearchViewNode::ViewValuesRegisters{},
       arangodb::iresearch::CountApproximate::Exact,
       arangodb::iresearch::FilterOptimization::MAX, emptyScorersSort, 0,
@@ -647,7 +647,7 @@ TEST_F(IResearchViewCountApproximateTest,
 #endif
       emptyScorers, {&sort, 1U}, _view->storedValues(), *plan,
       viewNode.outVariable(), viewNode.filterCondition(), {false, false}, 0,
-      viewNode.getRegisterPlan()->varInfo, 0,
+      viewNode.getRegisterPlan()->resolverForDepth(0),
       arangodb::iresearch::IResearchViewNode::ViewValuesRegisters{},
       arangodb::iresearch::CountApproximate::Exact,
       arangodb::iresearch::FilterOptimization::MAX, emptyScorersSort, 0,
@@ -731,7 +731,7 @@ TEST_F(IResearchViewCountApproximateTest, directSkipAllForMergeExecutorCost) {
 #endif
       emptyScorers, {&sort, 1U}, _view->storedValues(), *plan,
       viewNode.outVariable(), viewNode.filterCondition(), {false, false}, 0,
-      viewNode.getRegisterPlan()->varInfo, 0,
+      viewNode.getRegisterPlan()->resolverForDepth(0),
       arangodb::iresearch::IResearchViewNode::ViewValuesRegisters{},
       arangodb::iresearch::CountApproximate::Cost,
       arangodb::iresearch::FilterOptimization::MAX, emptyScorersSort, 0,


### PR DESCRIPTION
Explicit say if you want to have a register for input or output. The lookup did not take into account the depth (which should rather be called segment) of the variable. Each block that `alwaysCopiesRows` creates a new segment. We are working towards a better register planning. In that version a variable can be assigned to different registers and blocks that `alwaysCopiesRows` will remap those values to new registers. This allows for smaller AQL blocks.

To implement that, we need to make sure, that all nodes the right register for input or for output. It might not be the same.

Also we introduce a indirection for translating vars to registers that are depth aware using a RegisterResolver during some execution paths. Like filter evaluation. This is done instead of passing on the var infos directly. Later we have to look up the variables with the correct depth information. The RegisterResolver tracks the depth as well.

Enterprise PR: https://github.com/arangodb/enterprise/pull/1704