### PR TITLE
Multi-Parameter Aggregators

### DIFF
--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -33,6 +33,7 @@
 #include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
+#include <functional>
 #include <set>
 
 using namespace arangodb;
@@ -78,6 +79,29 @@ struct AggregatorInfo {
   /// needs to be converted to SUM to sum up the partial lengths from the DB
   /// servers
   std::string_view runOnCoordinatorAs;
+
+  /// @brief number of arguments the aggregator expects in a user query, e.g.
+  /// MIN(x) takes one. only relevant for aggregators that require input at
+  /// all.
+  std::size_t numArguments = 1;
+};
+
+/// @brief adapts an aggregator that consumes exactly one value per row to the
+/// span-based Aggregator interface.
+///
+/// `Derived` must provide `void reduceValue(AqlValue const&)`. That call is
+/// resolved statically, so a subclass which changes the single-value behaviour
+/// cannot rely on a base that already applied this adapter: it has to apply
+/// the adapter itself, passing the shared state as `Base` and itself as
+/// `Derived`. Forgetting to do so silently keeps the base's behaviour.
+template<typename Derived, typename Base = Aggregator>
+struct SingleValueAggregator : Base {
+  using Base::Base;
+
+  void reduce(std::span<AqlValue const> values) override {
+    TRI_ASSERT(values.size() == 1);
+    static_cast<Derived*>(this)->reduceValue(values[0]);
+  }
 };
 
 /// @brief helper class for block-wise memory allocations
@@ -153,7 +177,9 @@ struct AggregatorLength final : public Aggregator {
 
   void reset() override { count = 0; }
 
-  void reduce(AqlValue const&) override { ++count; }
+  /// @brief COUNT/LENGTH have their input optimized away, so the span is
+  /// empty. Take it directly rather than through SingleValueAggregator.
+  void reduce(std::span<AqlValue const>) override { ++count; }
 
   AqlValue get() const override {
     uint64_t value = count;
@@ -163,10 +189,10 @@ struct AggregatorLength final : public Aggregator {
   uint64_t count;
 };
 
-struct AggregatorMin final : public Aggregator {
+struct AggregatorMin final : public SingleValueAggregator<AggregatorMin> {
   explicit AggregatorMin(velocypack::Options const* opts,
                          ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor), value() {}
+      : SingleValueAggregator(opts, resourceMonitor), value() {}
 
   ~AggregatorMin() { value.destroy(); }
 
@@ -179,7 +205,7 @@ struct AggregatorMin final : public Aggregator {
     }
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!cmpValue.isNull(true) &&
         (value.isEmpty() ||
          AqlValue::Compare(_vpackOptions, value, cmpValue, true) > 0)) {
@@ -208,10 +234,10 @@ struct AggregatorMin final : public Aggregator {
   AqlValue value;
 };
 
-struct AggregatorMax final : public Aggregator {
+struct AggregatorMax final : public SingleValueAggregator<AggregatorMax> {
   explicit AggregatorMax(velocypack::Options const* opts,
                          ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor), value() {}
+      : SingleValueAggregator(opts, resourceMonitor), value() {}
 
   ~AggregatorMax() { value.destroy(); }
 
@@ -224,7 +250,7 @@ struct AggregatorMax final : public Aggregator {
     }
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (value.isEmpty() ||
         AqlValue::Compare(_vpackOptions, value, cmpValue, true) < 0) {
       auto memoryUsage = value.memoryUsage();
@@ -250,10 +276,10 @@ struct AggregatorMax final : public Aggregator {
   AqlValue value;
 };
 
-struct AggregatorSum final : public Aggregator {
+struct AggregatorSum final : public SingleValueAggregator<AggregatorSum> {
   explicit AggregatorSum(velocypack::Options const* opts,
                          ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         sum(0.0),
         invalid(false),
         invoked(false) {}
@@ -264,7 +290,7 @@ struct AggregatorSum final : public Aggregator {
     invoked = false;
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!invalid) {
       invoked = true;
       if (cmpValue.isNull(true)) {
@@ -298,10 +324,13 @@ struct AggregatorSum final : public Aggregator {
 };
 
 /// @brief the single-server variant of AVERAGE
-struct AggregatorAverage : public Aggregator {
+struct AggregatorAverage : public SingleValueAggregator<AggregatorAverage> {
   explicit AggregatorAverage(velocypack::Options const* opts,
                              ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor), count(0), sum(0.0), invalid(false) {}
+      : SingleValueAggregator(opts, resourceMonitor),
+        count(0),
+        sum(0.0),
+        invalid(false) {}
 
   void reset() override final {
     count = 0;
@@ -309,7 +338,7 @@ struct AggregatorAverage : public Aggregator {
     invalid = false;
   }
 
-  virtual void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!invalid) {
       if (cmpValue.isNull(true)) {
         // ignore `null` values here
@@ -374,12 +403,13 @@ struct AggregatorAverageStep1 final : public AggregatorAverage {
 
 /// @brief the coordinator variant of AVERAGE, aggregating partial sums and
 /// counts
-struct AggregatorAverageStep2 final : public AggregatorAverage {
+struct AggregatorAverageStep2 final
+    : public SingleValueAggregator<AggregatorAverageStep2, AggregatorAverage> {
   explicit AggregatorAverageStep2(velocypack::Options const* opts,
                                   ResourceMonitor& resourceMonitor)
-      : AggregatorAverage(opts, resourceMonitor) {}
+      : SingleValueAggregator(opts, resourceMonitor) {}
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!cmpValue.isArray()) {
       invalid = true;
       return;
@@ -406,10 +436,11 @@ struct AggregatorAverageStep2 final : public AggregatorAverage {
 };
 
 /// @brief base functionality for VARIANCE
-struct AggregatorVarianceBase : public Aggregator {
+struct AggregatorVarianceBase
+    : public SingleValueAggregator<AggregatorVarianceBase> {
   AggregatorVarianceBase(velocypack::Options const* opts, bool population,
                          ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         count(0),
         sum(0.0),
         mean(0.0),
@@ -423,7 +454,7 @@ struct AggregatorVarianceBase : public Aggregator {
     invalid = false;
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!invalid) {
       if (cmpValue.isNull(true)) {
         // ignore `null` values here
@@ -508,10 +539,12 @@ struct AggregatorVarianceBaseStep1 final : public AggregatorVarianceBase {
 };
 
 /// @brief the coordinator variant of VARIANCE
-struct AggregatorVarianceBaseStep2 : public AggregatorVarianceBase {
+struct AggregatorVarianceBaseStep2
+    : public SingleValueAggregator<AggregatorVarianceBaseStep2,
+                                   AggregatorVarianceBase> {
   AggregatorVarianceBaseStep2(velocypack::Options const* opts, bool population,
                               ResourceMonitor& resourceMonitor)
-      : AggregatorVarianceBase(opts, population, resourceMonitor) {}
+      : SingleValueAggregator(opts, population, resourceMonitor) {}
 
   void reset() override {
     AggregatorVarianceBase::reset();
@@ -520,7 +553,7 @@ struct AggregatorVarianceBaseStep2 : public AggregatorVarianceBase {
         .revert();  // revert after it actually clears the values
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!cmpValue.isArray()) {
       invalid = true;
       return;
@@ -645,10 +678,10 @@ struct AggregatorStddevBaseStep2 final : public AggregatorVarianceBaseStep2 {
 };
 
 /// @brief the single-server and DB server variant of UNIQUE
-struct AggregatorUnique : public Aggregator {
+struct AggregatorUnique : public SingleValueAggregator<AggregatorUnique> {
   explicit AggregatorUnique(velocypack::Options const* opts,
                             ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         allocator(1024),
         seen(512, basics::VelocyPackHelper::VPackHash(),
              basics::VelocyPackHelper::VPackEqual(_vpackOptions)),
@@ -666,7 +699,7 @@ struct AggregatorUnique : public Aggregator {
     allocator.clear();
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
 
     VPackSlice s = materializer.slice(cmpValue);
@@ -705,12 +738,13 @@ struct AggregatorUnique : public Aggregator {
 };
 
 /// @brief the coordinator variant of UNIQUE
-struct AggregatorUniqueStep2 final : public AggregatorUnique {
+struct AggregatorUniqueStep2 final
+    : public SingleValueAggregator<AggregatorUniqueStep2, AggregatorUnique> {
   explicit AggregatorUniqueStep2(velocypack::Options const* opts,
                                  ResourceMonitor& resourceMonitor)
-      : AggregatorUnique(opts, resourceMonitor) {}
+      : SingleValueAggregator(opts, resourceMonitor) {}
 
-  void reduce(AqlValue const& cmpValue) override final {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
 
     VPackSlice s = materializer.slice(cmpValue);
@@ -739,10 +773,11 @@ struct AggregatorUniqueStep2 final : public AggregatorUnique {
 };
 
 /// @brief the single-server and DB server variant of SORTED_UNIQUE
-struct AggregatorSortedUnique : public Aggregator {
+struct AggregatorSortedUnique
+    : public SingleValueAggregator<AggregatorSortedUnique> {
   explicit AggregatorSortedUnique(velocypack::Options const* opts,
                                   ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         allocator(1024),
         seen(_vpackOptions),
         builder(
@@ -759,7 +794,7 @@ struct AggregatorSortedUnique : public Aggregator {
     builder.clear();
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
 
     VPackSlice s = materializer.slice(cmpValue);
@@ -788,12 +823,14 @@ struct AggregatorSortedUnique : public Aggregator {
 };
 
 /// @brief the coordinator variant of SORTED_UNIQUE
-struct AggregatorSortedUniqueStep2 final : public AggregatorSortedUnique {
+struct AggregatorSortedUniqueStep2 final
+    : public SingleValueAggregator<AggregatorSortedUniqueStep2,
+                                   AggregatorSortedUnique> {
   explicit AggregatorSortedUniqueStep2(velocypack::Options const* opts,
                                        ResourceMonitor& resourceMonitor)
-      : AggregatorSortedUnique(opts, resourceMonitor) {}
+      : SingleValueAggregator(opts, resourceMonitor) {}
 
-  void reduce(AqlValue const& cmpValue) override final {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
 
     VPackSlice s = materializer.slice(cmpValue);
@@ -816,10 +853,11 @@ struct AggregatorSortedUniqueStep2 final : public AggregatorSortedUnique {
   }
 };
 
-struct AggregatorCountDistinct : public Aggregator {
+struct AggregatorCountDistinct
+    : public SingleValueAggregator<AggregatorCountDistinct> {
   explicit AggregatorCountDistinct(velocypack::Options const* opts,
                                    ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         allocator(1024),
         seen(512, basics::VelocyPackHelper::VPackHash(),
              basics::VelocyPackHelper::VPackEqual(_vpackOptions)) {}
@@ -833,7 +871,7 @@ struct AggregatorCountDistinct : public Aggregator {
     allocator.clear();
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
 
     VPackSlice s = materializer.slice(cmpValue);
@@ -892,12 +930,14 @@ struct GenericVarianceFactory : Aggregator::Factory {
 };
 
 /// @brief the coordinator variant of COUNT_DISTINCT
-struct AggregatorCountDistinctStep2 final : public AggregatorCountDistinct {
+struct AggregatorCountDistinctStep2 final
+    : public SingleValueAggregator<AggregatorCountDistinctStep2,
+                                   AggregatorCountDistinct> {
   explicit AggregatorCountDistinctStep2(velocypack::Options const* opts,
                                         ResourceMonitor& resourceMonitor)
-      : AggregatorCountDistinct(opts, resourceMonitor) {}
+      : SingleValueAggregator(opts, resourceMonitor) {}
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
 
     VPackSlice s = materializer.slice(cmpValue);
@@ -938,10 +978,13 @@ struct BitFunctionXOr {
 };
 
 template<typename BitFunction>
-struct AggregatorBitFunction : public Aggregator, BitFunction {
+struct AggregatorBitFunction
+    : public SingleValueAggregator<AggregatorBitFunction<BitFunction>>,
+      BitFunction {
   explicit AggregatorBitFunction(velocypack::Options const* opts,
                                  ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator<AggregatorBitFunction<BitFunction>>(
+            opts, resourceMonitor),
         result(0),
         invalid(false),
         invoked(false) {}
@@ -952,7 +995,7 @@ struct AggregatorBitFunction : public Aggregator, BitFunction {
     invoked = false;
   }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     if (!invalid) {
       if (cmpValue.isNull(true)) {
         // ignore `null` values here
@@ -996,25 +1039,26 @@ struct AggregatorBitFunction : public Aggregator, BitFunction {
 struct AggregatorBitAnd : public AggregatorBitFunction<BitFunctionAnd> {
   explicit AggregatorBitAnd(velocypack::Options const* opts,
                             ResourceMonitor& resourceMonitor)
-      : AggregatorBitFunction(opts, resourceMonitor) {}
+      : AggregatorBitFunction<BitFunctionAnd>(opts, resourceMonitor) {}
 };
 
 struct AggregatorBitOr : public AggregatorBitFunction<BitFunctionOr> {
   explicit AggregatorBitOr(velocypack::Options const* opts,
                            ResourceMonitor& resourceMonitor)
-      : AggregatorBitFunction(opts, resourceMonitor) {}
+      : AggregatorBitFunction<BitFunctionOr>(opts, resourceMonitor) {}
 };
 
 struct AggregatorBitXOr : public AggregatorBitFunction<BitFunctionXOr> {
   explicit AggregatorBitXOr(velocypack::Options const* opts,
                             ResourceMonitor& resourceMonitor)
-      : AggregatorBitFunction(opts, resourceMonitor) {}
+      : AggregatorBitFunction<BitFunctionXOr>(opts, resourceMonitor) {}
 };
 
-struct AggregatorMergeLists : public Aggregator {
+struct AggregatorMergeLists
+    : public SingleValueAggregator<AggregatorMergeLists> {
   explicit AggregatorMergeLists(velocypack::Options const* opts,
                                 ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         builder(
             std::make_shared<velocypack::SupervisedBuffer>(resourceMonitor)) {}
 
@@ -1023,7 +1067,7 @@ struct AggregatorMergeLists : public Aggregator {
   // cppcheck-suppress virtualCallInConstructor
   void reset() override final { builder.clear(); }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
     VPackSlice s = materializer.slice(cmpValue);
     if (!builder.isOpenArray()) {
@@ -1043,10 +1087,10 @@ struct AggregatorMergeLists : public Aggregator {
   mutable arangodb::velocypack::Builder builder;
 };
 
-struct AggregatorList : public Aggregator {
+struct AggregatorList : public SingleValueAggregator<AggregatorList> {
   explicit AggregatorList(velocypack::Options const* opts,
                           ResourceMonitor& resourceMonitor)
-      : Aggregator(opts, resourceMonitor),
+      : SingleValueAggregator(opts, resourceMonitor),
         builder(
             std::make_shared<velocypack::SupervisedBuffer>(resourceMonitor)) {}
 
@@ -1055,7 +1099,7 @@ struct AggregatorList : public Aggregator {
   // cppcheck-suppress virtualCallInConstructor
   void reset() override final { builder.clear(); }
 
-  void reduce(AqlValue const& cmpValue) override {
+  void reduceValue(AqlValue const& cmpValue) {
     AqlValueMaterializer materializer(_vpackOptions);
     VPackSlice s = materializer.slice(cmpValue);
     if (!builder.isOpenArray()) {
@@ -1254,6 +1298,15 @@ bool Aggregator::isValid(std::string_view type) {
   }
   // check if the aggregator is part of the public API or internal
   return (*it).second.isOfficialAggregator;
+}
+
+std::size_t Aggregator::numArguments(std::string_view type) {
+  auto it = ::aggregators.find(translateAlias(type));
+
+  if (it != ::aggregators.end()) {
+    return (*it).second.numArguments;
+  }
+  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid aggregator type");
 }
 
 bool Aggregator::requiresInput(std::string_view type) {

--- a/arangod/Aql/Aggregator.cpp
+++ b/arangod/Aql/Aggregator.cpp
@@ -42,9 +42,6 @@ using namespace arangodb::basics;
 
 namespace {
 
-constexpr bool doesRequireInput = true;
-constexpr bool doesNotRequireInput = false;
-
 constexpr bool official = true;
 constexpr bool internalOnly = false;
 
@@ -54,11 +51,6 @@ struct AggregatorInfo {
   /// Note: this is a shared_ptr because a unique_ptr cannot be initialized via
   /// initializer list
   std::shared_ptr<Aggregator::Factory> factory;
-
-  /// @brief whether or not the aggregator needs input
-  /// note: currently this is false only for LENGTH/COUNT, for which the input
-  /// is optimized away
-  bool requiresInput;
 
   /// @brief whether or not the aggregator is part of the public API (i.e.
   /// callable from a user AQL query)
@@ -80,9 +72,10 @@ struct AggregatorInfo {
   /// servers
   std::string_view runOnCoordinatorAs;
 
-  /// @brief number of arguments the aggregator expects in a user query, e.g.
-  /// MIN(x) takes one. only relevant for aggregators that require input at
-  /// all.
+  /// @brief number of input values the aggregator consumes per row, which is
+  /// also the size of the span handed to reduce(). MIN(x) consumes one.
+  /// LENGTH/COUNT consume none: a query may still pass them an argument, as
+  /// in LENGTH(value), but the aggregator never reads it.
   std::size_t numArguments = 1;
 };
 
@@ -1127,107 +1120,102 @@ struct AggregatorList : public SingleValueAggregator<AggregatorList> {
 /// @brief all available aggregators with their meta data
 std::unordered_map<std::string_view, AggregatorInfo> const aggregators = {
     {"LENGTH",
-     {std::make_shared<GenericFactory<AggregatorLength>>(), doesNotRequireInput,
-      official, "LENGTH",
-      "SUM"}},  // we need to sum up the lengths from the DB servers
+     {std::make_shared<GenericFactory<AggregatorLength>>(), official, "LENGTH",
+      "SUM", /*numArguments*/ 0}},  // sum up the lengths from the DB servers
     {"MIN",
-     {std::make_shared<GenericFactory<AggregatorMin>>(), doesRequireInput,
-      official, "MIN", "MIN"}},  // min is commutative
+     {std::make_shared<GenericFactory<AggregatorMin>>(), official, "MIN",
+      "MIN"}},  // min is commutative
     {"MAX",
-     {std::make_shared<GenericFactory<AggregatorMax>>(), doesRequireInput,
-      official, "MAX", "MAX"}},  // max is commutative
+     {std::make_shared<GenericFactory<AggregatorMax>>(), official, "MAX",
+      "MAX"}},  // max is commutative
     {"SUM",
-     {std::make_shared<GenericFactory<AggregatorSum>>(), doesRequireInput,
-      official, "SUM", "SUM"}},  // sum is commutative
+     {std::make_shared<GenericFactory<AggregatorSum>>(), official, "SUM",
+      "SUM"}},  // sum is commutative
     {"AVERAGE",
-     {std::make_shared<GenericFactory<AggregatorAverage>>(), doesRequireInput,
-      official, "AVERAGE_STEP1", "AVERAGE_STEP2"}},
+     {std::make_shared<GenericFactory<AggregatorAverage>>(), official,
+      "AVERAGE_STEP1", "AVERAGE_STEP2"}},
     {"AVERAGE_STEP1",
-     {std::make_shared<GenericFactory<AggregatorAverageStep1>>(),
-      doesRequireInput, internalOnly, "", "AVERAGE_STEP1"}},
+     {std::make_shared<GenericFactory<AggregatorAverageStep1>>(), internalOnly,
+      "", "AVERAGE_STEP1"}},
     {"AVERAGE_STEP2",
-     {std::make_shared<GenericFactory<AggregatorAverageStep2>>(),
-      doesRequireInput, internalOnly, "", "AVERAGE_STEP2"}},
+     {std::make_shared<GenericFactory<AggregatorAverageStep2>>(), internalOnly,
+      "", "AVERAGE_STEP2"}},
     {"VARIANCE_POPULATION",
      {std::make_shared<GenericVarianceFactory<AggregatorVariance>>(true),
-      doesRequireInput, official, "VARIANCE_POPULATION_STEP1",
-      "VARIANCE_POPULATION_STEP2"}},
+      official, "VARIANCE_POPULATION_STEP1", "VARIANCE_POPULATION_STEP2"}},
     {"VARIANCE_POPULATION_STEP1",
      {std::make_shared<GenericVarianceFactory<AggregatorVarianceBaseStep1>>(
           true),
-      doesRequireInput, internalOnly, "", "VARIANCE_POPULATION_STEP1"}},
+      internalOnly, "", "VARIANCE_POPULATION_STEP1"}},
     {"VARIANCE_POPULATION_STEP2",
      {std::make_shared<GenericVarianceFactory<AggregatorVarianceBaseStep2>>(
           true),
-      doesRequireInput, internalOnly, "", "VARIANCE_POPULATION_STEP2"}},
+      internalOnly, "", "VARIANCE_POPULATION_STEP2"}},
     {"VARIANCE_SAMPLE",
      {std::make_shared<GenericVarianceFactory<AggregatorVariance>>(false),
-      doesRequireInput, official, "VARIANCE_SAMPLE_STEP1",
-      "VARIANCE_SAMPLE_STEP2"}},
+      official, "VARIANCE_SAMPLE_STEP1", "VARIANCE_SAMPLE_STEP2"}},
     {"VARIANCE_SAMPLE_STEP1",
      {std::make_shared<GenericVarianceFactory<AggregatorVarianceBaseStep1>>(
           false),
-      doesRequireInput, internalOnly, "", "VARIANCE_SAMPLE_STEP1"}},
+      internalOnly, "", "VARIANCE_SAMPLE_STEP1"}},
     {"VARIANCE_SAMPLE_STEP2",
      {std::make_shared<GenericVarianceFactory<AggregatorVarianceBaseStep2>>(
           false),
-      doesRequireInput, internalOnly, "", "VARIANCE_SAMPLE_STEP2"}},
+      internalOnly, "", "VARIANCE_SAMPLE_STEP2"}},
     {"STDDEV_POPULATION",
      {std::make_shared<GenericVarianceFactory<AggregatorStddev>>(true),
-      doesRequireInput, official, "STDDEV_POPULATION_STEP1",
-      "STDDEV_POPULATION_STEP2"}},
+      official, "STDDEV_POPULATION_STEP1", "STDDEV_POPULATION_STEP2"}},
     {"STDDEV_POPULATION_STEP1",
      {std::make_shared<GenericVarianceFactory<AggregatorVarianceBaseStep1>>(
           true),
-      doesRequireInput, internalOnly, "", "STDDEV_POPULATION_STEP1"}},
+      internalOnly, "", "STDDEV_POPULATION_STEP1"}},
     {"STDDEV_POPULATION_STEP2",
      {std::make_shared<GenericVarianceFactory<AggregatorStddevBaseStep2>>(true),
-      doesRequireInput, internalOnly, "", "STDDEV_POPULATION_STEP2"}},
+      internalOnly, "", "STDDEV_POPULATION_STEP2"}},
     {"STDDEV_SAMPLE",
      {std::make_shared<GenericVarianceFactory<AggregatorStddev>>(false),
-      doesRequireInput, official, "STDDEV_SAMPLE_STEP1",
-      "STDDEV_SAMPLE_STEP2"}},
+      official, "STDDEV_SAMPLE_STEP1", "STDDEV_SAMPLE_STEP2"}},
     {"STDDEV_SAMPLE_STEP1",
      {std::make_shared<GenericVarianceFactory<AggregatorVarianceBaseStep1>>(
           false),
-      doesRequireInput, internalOnly, "", "STDDEV_SAMPLE_STEP1"}},
+      internalOnly, "", "STDDEV_SAMPLE_STEP1"}},
     {"STDDEV_SAMPLE_STEP2",
      {std::make_shared<GenericVarianceFactory<AggregatorStddevBaseStep2>>(
           false),
-      doesRequireInput, internalOnly, "", "STDDEV_SAMPLE_STEP2"}},
+      internalOnly, "", "STDDEV_SAMPLE_STEP2"}},
     {"UNIQUE",
-     {std::make_shared<GenericFactory<AggregatorUnique>>(), doesRequireInput,
-      official, "UNIQUE", "UNIQUE_STEP2"}},
+     {std::make_shared<GenericFactory<AggregatorUnique>>(), official, "UNIQUE",
+      "UNIQUE_STEP2"}},
     {"UNIQUE_STEP2",
-     {std::make_shared<GenericFactory<AggregatorUniqueStep2>>(),
-      doesRequireInput, internalOnly, "", "UNIQUE_STEP2"}},
+     {std::make_shared<GenericFactory<AggregatorUniqueStep2>>(), internalOnly,
+      "", "UNIQUE_STEP2"}},
     {"SORTED_UNIQUE",
-     {std::make_shared<GenericFactory<AggregatorSortedUnique>>(),
-      doesRequireInput, official, "SORTED_UNIQUE", "SORTED_UNIQUE_STEP2"}},
+     {std::make_shared<GenericFactory<AggregatorSortedUnique>>(), official,
+      "SORTED_UNIQUE", "SORTED_UNIQUE_STEP2"}},
     {"SORTED_UNIQUE_STEP2",
      {std::make_shared<GenericFactory<AggregatorSortedUniqueStep2>>(),
-      doesRequireInput, internalOnly, "", "SORTED_UNIQUE_STEP2"}},
+      internalOnly, "", "SORTED_UNIQUE_STEP2"}},
     {"COUNT_DISTINCT",
-     {std::make_shared<GenericFactory<AggregatorCountDistinct>>(),
-      doesRequireInput, official, "UNIQUE", "COUNT_DISTINCT_STEP2"}},
+     {std::make_shared<GenericFactory<AggregatorCountDistinct>>(), official,
+      "UNIQUE", "COUNT_DISTINCT_STEP2"}},
     {"COUNT_DISTINCT_STEP2",
      {std::make_shared<GenericFactory<AggregatorCountDistinctStep2>>(),
-      doesRequireInput, internalOnly, "", "COUNT_DISTINCT_STEP2"}},
+      internalOnly, "", "COUNT_DISTINCT_STEP2"}},
     {"BIT_AND",
-     {std::make_shared<GenericFactory<AggregatorBitAnd>>(), doesRequireInput,
-      official, "BIT_AND", "BIT_AND"}},
+     {std::make_shared<GenericFactory<AggregatorBitAnd>>(), official, "BIT_AND",
+      "BIT_AND"}},
     {"BIT_OR",
-     {std::make_shared<GenericFactory<AggregatorBitOr>>(), doesRequireInput,
-      official, "BIT_OR", "BIT_OR"}},
+     {std::make_shared<GenericFactory<AggregatorBitOr>>(), official, "BIT_OR",
+      "BIT_OR"}},
     {"BIT_XOR",
-     {std::make_shared<GenericFactory<AggregatorBitXOr>>(), doesRequireInput,
-      official, "BIT_XOR", "BIT_XOR"}},
+     {std::make_shared<GenericFactory<AggregatorBitXOr>>(), official, "BIT_XOR",
+      "BIT_XOR"}},
     {"MERGE_LISTS",
-     {std::make_shared<GenericFactory<AggregatorMergeLists>>(),
-      doesRequireInput, internalOnly, "", "MERGE_LISTS"}},
+     {std::make_shared<GenericFactory<AggregatorMergeLists>>(), internalOnly,
+      "", "MERGE_LISTS"}},
     {"PUSH",
-     {std::make_shared<GenericFactory<AggregatorList>>(), doesRequireInput,
-      official, "PUSH", "MERGE_LISTS"}},
+     {std::make_shared<GenericFactory<AggregatorList>>(), official, "PUSH",
+      "MERGE_LISTS"}},
 };
 
 /// @brief aliases (user-visible) for aggregation functions
@@ -1310,10 +1298,5 @@ std::size_t Aggregator::numArguments(std::string_view type) {
 }
 
 bool Aggregator::requiresInput(std::string_view type) {
-  auto it = ::aggregators.find(translateAlias(type));
-
-  if (it != ::aggregators.end()) {
-    return (*it).second.requiresInput;
-  }
-  THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_INTERNAL, "invalid aggregator type");
+  return numArguments(type) > 0;
 }

--- a/arangod/Aql/Aggregator.h
+++ b/arangod/Aql/Aggregator.h
@@ -62,10 +62,10 @@ struct Aggregator {
 
   virtual ~Aggregator() = default;
   virtual void reset() = 0;
-  /// @brief consume one input row. The span holds one value per argument of
-  /// the aggregate call, so a single-argument aggregator such as MIN(x) gets
-  /// one value. Aggregators that need no input at all (COUNT/LENGTH) get an
-  /// empty span. The values are only valid for the duration of the call.
+  /// @brief consume one input row. The span always holds exactly
+  /// numArguments() values, so a single-argument aggregator such as MIN(x)
+  /// gets one and COUNT/LENGTH get an empty span. The values are only valid
+  /// for the duration of the call.
   virtual void reduce(std::span<AqlValue const>) = 0;
   virtual AqlValue get() const = 0;
   AqlValue stealValue() {
@@ -108,13 +108,13 @@ struct Aggregator {
   /// public API. all internal-only aggregators count as not supported here
   static bool isValid(std::string_view type);
 
-  /// @brief whether or not the aggregator requires any input or if the input
-  /// can be optimized away (note current: COUNT/LENGTH don't, all others do)
+  /// @brief whether the aggregator reads any input at all. Derived from
+  /// numArguments(); currently only COUNT/LENGTH do not.
   static bool requiresInput(std::string_view type);
 
-  /// @brief number of arguments the aggregator expects when called from a user
-  /// query, e.g. 1 for MIN(x). only meaningful for aggregators that require
-  /// input.
+  /// @brief number of input values the aggregator consumes per row, which is
+  /// also the size of the span handed to reduce(). MIN(x) consumes one,
+  /// COUNT/LENGTH consume none.
   static std::size_t numArguments(std::string_view type);
 
   /// @brief called when we need to increase/decrease memory usage for

--- a/arangod/Aql/Aggregator.h
+++ b/arangod/Aql/Aggregator.h
@@ -26,8 +26,10 @@
 #include "Basics/ResourceUsage.h"
 #include "Basics/SupervisedBuffer.h"
 
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <span>
 #include <string>
 #include <string_view>
 
@@ -60,7 +62,11 @@ struct Aggregator {
 
   virtual ~Aggregator() = default;
   virtual void reset() = 0;
-  virtual void reduce(AqlValue const&) = 0;
+  /// @brief consume one input row. The span holds one value per argument of
+  /// the aggregate call, so a single-argument aggregator such as MIN(x) gets
+  /// one value. Aggregators that need no input at all (COUNT/LENGTH) get an
+  /// empty span. The values are only valid for the duration of the call.
+  virtual void reduce(std::span<AqlValue const>) = 0;
   virtual AqlValue get() const = 0;
   AqlValue stealValue() {
     AqlValue r = this->get();
@@ -105,6 +111,11 @@ struct Aggregator {
   /// @brief whether or not the aggregator requires any input or if the input
   /// can be optimized away (note current: COUNT/LENGTH don't, all others do)
   static bool requiresInput(std::string_view type);
+
+  /// @brief number of arguments the aggregator expects when called from a user
+  /// query, e.g. 1 for MIN(x). only meaningful for aggregators that require
+  /// input.
+  static std::size_t numArguments(std::string_view type);
 
   /// @brief called when we need to increase/decrease memory usage for
   /// computations of AGGREGATE; for AqlValue and VPackSlice values.

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1899,15 +1899,16 @@ AstNode* Ast::createNodeAggregateFunctionCall(std::string_view functionName,
   TRI_ASSERT(arguments != nullptr);
   TRI_ASSERT(arguments->type == NODE_TYPE_ARRAY);
 
-  if (Aggregator::requiresInput(normalized)) {
-    size_t const numExpectedArguments = Aggregator::numArguments(normalized);
-    if (arguments->numMembers() != numExpectedArguments) {
-      std::string temp(functionName);
-      int const expected = static_cast<int>(numExpectedArguments);
-      THROW_ARANGO_EXCEPTION_PARAMS(
-          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, temp.c_str(),
-          expected, expected);
-    }
+  // COUNT/LENGTH consume no input and accept whatever the query passes them,
+  // so only the aggregators that read their input are checked.
+  if (size_t const numExpectedArguments = Aggregator::numArguments(normalized);
+      numExpectedArguments > 0 &&
+      arguments->numMembers() != numExpectedArguments) {
+    std::string temp(functionName);
+    int const expected = static_cast<int>(numExpectedArguments);
+    THROW_ARANGO_EXCEPTION_PARAMS(
+        TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, temp.c_str(),
+        expected, expected);
   }
 
   // TODO - we should consider to introduce a NODE_TYPE_AGGREATE_FCALL type

--- a/arangod/Aql/Ast.cpp
+++ b/arangod/Aql/Ast.cpp
@@ -1900,14 +1900,13 @@ AstNode* Ast::createNodeAggregateFunctionCall(std::string_view functionName,
   TRI_ASSERT(arguments->type == NODE_TYPE_ARRAY);
 
   if (Aggregator::requiresInput(normalized)) {
-    // validate number of function call arguments
-    size_t numExpectedArguments =
-        1;  // at the moment all aggregators take only a single argument
+    size_t const numExpectedArguments = Aggregator::numArguments(normalized);
     if (arguments->numMembers() != numExpectedArguments) {
       std::string temp(functionName);
+      int const expected = static_cast<int>(numExpectedArguments);
       THROW_ARANGO_EXCEPTION_PARAMS(
-          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, temp.c_str(), 1,
-          1);
+          TRI_ERROR_QUERY_FUNCTION_ARGUMENT_NUMBER_MISMATCH, temp.c_str(),
+          expected, expected);
     }
   }
 

--- a/arangod/Aql/CollectOptions.cpp
+++ b/arangod/Aql/CollectOptions.cpp
@@ -21,13 +21,54 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include "CollectOptions.h"
+#include "Aql/Ast.h"
+#include "Aql/Variable.h"
+#include "Aql/VariableGenerator.h"
 #include "Basics/Exceptions.h"
 #include "Basics/StaticStrings.h"
 
 #include <velocypack/Builder.h>
+#include <velocypack/Iterator.h>
 #include <velocypack/Slice.h>
 
 namespace arangodb::aql {
+
+std::vector<AggregateVarInfo> AggregateVarInfo::fromVelocyPack(
+    Ast* ast, velocypack::Slice aggregates) {
+  if (!aggregates.isArray()) {
+    THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
+                                   "invalid \"aggregates\" definition");
+  }
+
+  std::vector<AggregateVarInfo> result;
+  result.reserve(aggregates.length());
+
+  for (velocypack::Slice it : velocypack::ArrayIterator(aggregates)) {
+    Variable* outVar = Variable::varFromVPack(ast, it, "outVariable");
+
+    std::vector<Variable const*> inVars;
+    if (velocypack::Slice inVarsSlice = it.get("inVariables");
+        inVarsSlice.isArray()) {
+      inVars.reserve(inVarsSlice.length());
+      for (velocypack::Slice inVarSlice :
+           velocypack::ArrayIterator(inVarsSlice)) {
+        inVars.emplace_back(ast->variables()->createVariable(inVarSlice));
+      }
+    } else if (Variable* inVar = Variable::varFromVPack(ast, it, "inVariable",
+                                                        /*optional*/ true);
+               inVar != nullptr) {
+      // A coordinator from before multi-argument aggregates writes a single
+      // "inVariable". Coordinators are upgraded after DB servers, so during a
+      // rolling upgrade this is the shape a DB server receives.
+      inVars.emplace_back(inVar);
+    }
+
+    result.emplace_back(AggregateVarInfo{outVar, std::move(inVars),
+                                         it.get("type").copyString()});
+  }
+
+  return result;
+}
 
 CollectOptions::CollectOptions() noexcept
     : method(CollectMethod::kUndefined), fixed(false) {}

--- a/arangod/Aql/CollectOptions.h
+++ b/arangod/Aql/CollectOptions.h
@@ -103,10 +103,6 @@ struct AggregateVarInfo final {
   std::vector<Variable const*> inVars;
   std::string type;
 
-  /// @brief read the "aggregates" array of a serialized CollectNode or
-  /// WindowNode. Accepts both the current "inVariables" array and the single
-  /// "inVariable" that coordinators wrote before multi-argument aggregates
-  /// existed.
   static std::vector<AggregateVarInfo> fromVelocyPack(
       Ast* ast, velocypack::Slice aggregates);
 };

--- a/arangod/Aql/CollectOptions.h
+++ b/arangod/Aql/CollectOptions.h
@@ -22,8 +22,11 @@
 
 #pragma once
 
+#include "Aql/RegisterId.h"
+
 #include <string>
 #include <string_view>
+#include <vector>
 
 namespace arangodb {
 namespace velocypack {
@@ -31,6 +34,7 @@ class Builder;
 class Slice;
 }  // namespace velocypack
 namespace aql {
+class Ast;
 struct Variable;
 
 /// @brief CollectOptions
@@ -94,8 +98,24 @@ struct GroupVarInfo final {
 
 struct AggregateVarInfo final {
   Variable const* outVar;
-  Variable const* inVar;
+  /// @brief one entry per argument of the aggregate call, so MIN(x) has one.
+  /// Empty for aggregators whose input is optimized away (COUNT/LENGTH).
+  std::vector<Variable const*> inVars;
   std::string type;
+
+  /// @brief read the "aggregates" array of a serialized CollectNode or
+  /// WindowNode. Accepts both the current "inVariables" array and the single
+  /// "inVariable" that coordinators wrote before multi-argument aggregates
+  /// existed.
+  static std::vector<AggregateVarInfo> fromVelocyPack(
+      Ast* ast, velocypack::Slice aggregates);
+};
+
+/// @brief output register of an aggregate plus the input registers feeding it,
+/// one per argument. `inRegs` is empty for COUNT/LENGTH.
+struct AggregateRegisters final {
+  RegisterId outReg;
+  std::vector<RegisterId> inRegs;
 };
 
 }  // namespace aql

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -110,11 +110,6 @@ void CollectNode::doToVelocyPack(VPackBuilder& nodes,
           inVar->toVelocyPack(nodes);
         }
       }
-      if (aggregateVariable.inVars.size() == 1) {
-        // keep the shape that explain() had before multi-argument aggregates
-        nodes.add(VPackValue("inVariable"));
-        aggregateVariable.inVars[0]->toVelocyPack(nodes);
-      }
       nodes.add("type", VPackValue(aggregateVariable.type));
     }
   }

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -218,13 +218,16 @@ void CollectNode::calcAggregateRegisters(
     RegisterId outReg = itOut->second.registerId;
     TRI_ASSERT(outReg.isValid());
 
+    // The aggregator reads exactly numArguments values per row. A query may
+    // pass an argument to one that reads none, as in LENGTH(value): that
+    // argument is planned like any other, and simply not read here.
+    size_t const numArguments = Aggregator::numArguments(p.type);
+    TRI_ASSERT(p.inVars.size() >= numArguments);
+
     std::vector<RegisterId> inRegs;
-    // aggregators whose input is optimized away (COUNT/LENGTH) have no input
-    // variables, and therefore no input registers
-    TRI_ASSERT(Aggregator::requiresInput(p.type) || p.inVars.empty());
-    inRegs.reserve(p.inVars.size());
-    for (auto const* inVar : p.inVars) {
-      auto itIn = getRegisterPlan()->varInfo.find(inVar->id);
+    inRegs.reserve(numArguments);
+    for (size_t i = 0; i < numArguments; ++i) {
+      auto itIn = getRegisterPlan()->varInfo.find(p.inVars[i]->id);
       TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
       RegisterId inReg = itIn->second.registerId;
       TRI_ASSERT(inReg.isValid());

--- a/arangod/Aql/ExecutionNode/CollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/CollectNode.cpp
@@ -103,9 +103,17 @@ void CollectNode::doToVelocyPack(VPackBuilder& nodes,
       VPackObjectBuilder obj(&nodes);
       nodes.add(VPackValue("outVariable"));
       aggregateVariable.outVar->toVelocyPack(nodes);
-      if (aggregateVariable.inVar) {
+      nodes.add(VPackValue("inVariables"));
+      {
+        VPackArrayBuilder inVarsGuard(&nodes);
+        for (auto const* inVar : aggregateVariable.inVars) {
+          inVar->toVelocyPack(nodes);
+        }
+      }
+      if (aggregateVariable.inVars.size() == 1) {
+        // keep the shape that explain() had before multi-argument aggregates
         nodes.add(VPackValue("inVariable"));
-        aggregateVariable.inVar->toVelocyPack(nodes);
+        aggregateVariable.inVars[0]->toVelocyPack(nodes);
       }
       nodes.add("type", VPackValue(aggregateVariable.type));
     }
@@ -199,7 +207,7 @@ void CollectNode::calcGroupRegisters(
 }
 
 void CollectNode::calcAggregateRegisters(
-    std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,
+    std::vector<AggregateRegisters>& aggregateRegisters,
     RegIdSet& readableInputRegisters,
     RegIdSet& writeableOutputRegisters) const {
   for (auto const& p : _aggregateVariables) {
@@ -210,17 +218,22 @@ void CollectNode::calcAggregateRegisters(
     RegisterId outReg = itOut->second.registerId;
     TRI_ASSERT(outReg.isValid());
 
-    RegisterId inReg{RegisterId::maxRegisterId};
-    if (Aggregator::requiresInput(p.type)) {
-      auto itIn = getRegisterPlan()->varInfo.find(p.inVar->id);
+    std::vector<RegisterId> inRegs;
+    // aggregators whose input is optimized away (COUNT/LENGTH) have no input
+    // variables, and therefore no input registers
+    TRI_ASSERT(Aggregator::requiresInput(p.type) || p.inVars.empty());
+    inRegs.reserve(p.inVars.size());
+    for (auto const* inVar : p.inVars) {
+      auto itIn = getRegisterPlan()->varInfo.find(inVar->id);
       TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
-      inReg = itIn->second.registerId;
+      RegisterId inReg = itIn->second.registerId;
       TRI_ASSERT(inReg.isValid());
       readableInputRegisters.insert(inReg);
+      inRegs.emplace_back(inReg);
     }
-    // else: no input variable required
 
-    aggregateRegisters.emplace_back(std::make_pair(outReg, inReg));
+    aggregateRegisters.emplace_back(
+        AggregateRegisters{outReg, std::move(inRegs)});
     writeableOutputRegisters.insert((outReg));
   }
   TRI_ASSERT(aggregateRegisters.size() == _aggregateVariables.size());
@@ -280,7 +293,7 @@ std::unique_ptr<ExecutionBlock> CollectNode::createBlock(
                          writeableOutputRegisters);
 
       // calculate the aggregate registers
-      std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+      std::vector<AggregateRegisters> aggregateRegisters;
       calcAggregateRegisters(aggregateRegisters, readableInputRegisters,
                              writeableOutputRegisters);
 
@@ -329,7 +342,7 @@ std::unique_ptr<ExecutionBlock> CollectNode::createBlock(
                          writeableOutputRegisters);
 
       // calculate the aggregate registers
-      std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+      std::vector<AggregateRegisters> aggregateRegisters;
       calcAggregateRegisters(aggregateRegisters, readableInputRegisters,
                              writeableOutputRegisters);
 
@@ -657,7 +670,9 @@ void CollectNode::replaceVariables(
     variable.first = Variable::replace(old, replacements);
   }
   for (auto& variable : _aggregateVariables) {
-    variable.inVar = Variable::replace(variable.inVar, replacements);
+    for (auto& inVar : variable.inVars) {
+      inVar = Variable::replace(inVar, replacements);
+    }
   }
   if (_expressionVariable != nullptr) {
     _expressionVariable = Variable::replace(_expressionVariable, replacements);
@@ -673,8 +688,8 @@ void CollectNode::getVariablesUsedHere(VarSet& vars) const {
     vars.emplace(p.inVar);
   }
   for (auto const& p : _aggregateVariables) {
-    if (p.inVar) {
-      vars.emplace(p.inVar);
+    for (auto const* inVar : p.inVars) {
+      vars.emplace(inVar);
     }
   }
 
@@ -773,9 +788,9 @@ void CollectNode::clearAggregates(
       it = _aggregateVariables.erase(it);
     } else {
       if (!Aggregator::requiresInput(it->type)) {
-        // aggregator has an input variable attached, but doesn't need it.
+        // aggregator has input variables attached, but doesn't need them.
         // remove the dependency, e.g.  COUNT(1) => COUNT()
-        it->inVar = nullptr;
+        it->inVars.clear();
       }
       ++it;
     }
@@ -852,8 +867,8 @@ std::vector<Variable const*> CollectNode::getVariablesSetHere() const {
 }
 
 void CollectNode::setMergeListsAggregation(Variable const* outVariable) {
-  _aggregateVariables.emplace_back(
-      AggregateVarInfo{_outVariable, outVariable, "MERGE_LISTS"});
+  _aggregateVariables.emplace_back(AggregateVarInfo{
+      _outVariable, std::vector<Variable const*>{outVariable}, "MERGE_LISTS"});
 
   // clear out variable and expression variable
   _outVariable = _expressionVariable = nullptr;

--- a/arangod/Aql/ExecutionNode/CollectNode.h
+++ b/arangod/Aql/ExecutionNode/CollectNode.h
@@ -100,7 +100,7 @@ class CollectNode : public ExecutionNode {
 
   /// @brief calculate the aggregate registers
   void calcAggregateRegisters(
-      std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,
+      std::vector<AggregateRegisters>& aggregateRegisters,
       RegIdSet& readableInputRegisters,
       RegIdSet& writeableOutputRegisters) const;
 

--- a/arangod/Aql/ExecutionNode/ExecutionNode.cpp
+++ b/arangod/Aql/ExecutionNode/ExecutionNode.cpp
@@ -350,25 +350,9 @@ ExecutionNode* ExecutionNode::fromVPackFactory(ExecutionPlan* plan,
       }
 
       // aggregates
-      VPackSlice aggregatesSlice = slice.get("aggregates");
-      if (!aggregatesSlice.isArray()) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
-                                       "invalid \"aggregates\" definition");
-      }
-
-      std::vector<AggregateVarInfo> aggregateVariables;
-      {
-        aggregateVariables.reserve(aggregatesSlice.length());
-        for (VPackSlice it : VPackArrayIterator(aggregatesSlice)) {
-          Variable* outVar =
-              Variable::varFromVPack(plan->getAst(), it, "outVariable");
-          Variable* inVar =
-              Variable::varFromVPack(plan->getAst(), it, "inVariable", true);
-
-          aggregateVariables.emplace_back(
-              AggregateVarInfo{outVar, inVar, it.get("type").copyString()});
-        }
-      }
+      std::vector<AggregateVarInfo> aggregateVariables =
+          AggregateVarInfo::fromVelocyPack(plan->getAst(),
+                                           slice.get("aggregates"));
 
       return new CollectNode(plan, slice, expressionVariable, outVariable,
                              keepVariables,
@@ -446,25 +430,9 @@ ExecutionNode* ExecutionNode::fromVPackFactory(ExecutionPlan* plan,
           plan->getAst(), slice, "rangeVariable", /*optional*/ true);
 
       // aggregates
-      VPackSlice aggregatesSlice = slice.get("aggregates");
-      if (!aggregatesSlice.isArray()) {
-        THROW_ARANGO_EXCEPTION_MESSAGE(TRI_ERROR_NOT_IMPLEMENTED,
-                                       "invalid \"aggregates\" definition");
-      }
-
-      std::vector<AggregateVarInfo> aggregateVariables;
-      {
-        aggregateVariables.reserve(aggregatesSlice.length());
-        for (VPackSlice it : VPackArrayIterator(aggregatesSlice)) {
-          Variable* outVar =
-              Variable::varFromVPack(plan->getAst(), it, "outVariable");
-          Variable* inVar =
-              Variable::varFromVPack(plan->getAst(), it, "inVariable", true);
-
-          aggregateVariables.emplace_back(
-              AggregateVarInfo{outVar, inVar, it.get("type").copyString()});
-        }
-      }
+      std::vector<AggregateVarInfo> aggregateVariables =
+          AggregateVarInfo::fromVelocyPack(plan->getAst(),
+                                           slice.get("aggregates"));
 
       auto type = rangeVar != nullptr ? WindowBounds::Type::Range
                                       : WindowBounds::Type::Row;

--- a/arangod/Aql/ExecutionNode/IndexCollectNode.cpp
+++ b/arangod/Aql/ExecutionNode/IndexCollectNode.cpp
@@ -39,8 +39,13 @@ ExecutionNode* IndexCollectNode::clone(ExecutionPlan* plan,
   IndexCollectAggregations aggregations;
   aggregations.reserve(_aggregations.size());
   for (auto const& agg : _aggregations) {
-    aggregations.emplace_back(IndexCollectAggregation{
-        agg.type, agg.outVariable, agg.expression->clone(plan->getAst())});
+    std::vector<std::unique_ptr<Expression>> expressions;
+    expressions.reserve(agg.expressions.size());
+    for (auto const& expression : agg.expressions) {
+      expressions.emplace_back(expression->clone(plan->getAst()));
+    }
+    aggregations.emplace_back(IndexCollectAggregation{agg.type, agg.outVariable,
+                                                      std::move(expressions)});
   }
 
   auto c = std::make_unique<IndexCollectNode>(
@@ -120,14 +125,20 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockAggregationScan(
     auto& a = infos.aggregations.emplace_back();
     a.type = agg.type;
     a.outputRegister = getRegisterPlan()->variableToRegisterId(agg.outVariable);
-    a.expression = agg.expression->clone(infos.query->ast());
     writableOutputRegisters.emplace(a.outputRegister);
 
-    // find attributes used in expression
+    a.expressions.reserve(agg.expressions.size());
+    for (auto const& source : agg.expressions) {
+      a.expressions.emplace_back(source->clone(infos.query->ast()));
+    }
+
+    // find attributes used in the expressions
     containers::FlatHashSet<aql::AttributeNamePath> attributes;
-    Ast::getReferencedAttributesRecursive(a.expression->node(),
-                                          _oldIndexVariable, "", attributes,
-                                          infos.query->resourceMonitor());
+    for (auto const& expression : a.expressions) {
+      Ast::getReferencedAttributesRecursive(expression->node(),
+                                            _oldIndexVariable, "", attributes,
+                                            infos.query->resourceMonitor());
+    }
     // get what index fields cover these attributes
     for (auto const& attr : attributes) {
       auto iter = std::find_if(
@@ -149,8 +160,10 @@ std::unique_ptr<ExecutionBlock> IndexCollectNode::createBlockAggregationScan(
       std::copy(attr.get().begin(), attr.get().end(),
                 std::back_inserter(attribView));
 
-      a.expression->replaceAttributeAccess(_oldIndexVariable, attribView,
+      for (auto& expression : a.expressions) {
+        expression->replaceAttributeAccess(_oldIndexVariable, attribView,
                                            it->second);
+      }
     }
   }
 
@@ -191,7 +204,18 @@ IndexCollectNode::IndexCollectNode(ExecutionPlan* plan,
     auto& agg = _aggregations.emplace_back();
     agg.outVariable = Variable::varFromVPack(plan->getAst(), as, "outVariable");
     agg.type = as.get("type").copyString();
-    agg.expression = std::make_unique<Expression>(plan->getAst(), as);
+    if (VPackSlice expressions = as.get("expressions"); expressions.isArray()) {
+      for (auto es : VPackArrayIterator(expressions)) {
+        agg.expressions.emplace_back(std::make_unique<Expression>(
+            plan->getAst(), plan->getAst()->createNode(es)));
+      }
+    } else {
+      // A coordinator from before multi-argument aggregates writes a single
+      // "expression". Coordinators are upgraded after DB servers, so during a
+      // rolling upgrade this is the shape a DB server receives.
+      agg.expressions.emplace_back(
+          std::make_unique<Expression>(plan->getAst(), as));
+    }
   }
 }
 
@@ -211,10 +235,12 @@ IndexCollectNode::IndexCollectNode(ExecutionPlan* plan, ExecutionNodeId id,
       _collectOptions(collectOptions) {
 #if ARANGODB_ENABLE_MAINTAINER_MODE
   for (auto const& agg : _aggregations) {
-    VarSet usedVariables;
-    agg.expression->variables(usedVariables);
-    TRI_ASSERT(usedVariables.size() == 1);
-    TRI_ASSERT(usedVariables.contains(_oldIndexVariable));
+    for (auto const& expression : agg.expressions) {
+      VarSet usedVariables;
+      expression->variables(usedVariables);
+      TRI_ASSERT(usedVariables.size() == 1);
+      TRI_ASSERT(usedVariables.contains(_oldIndexVariable));
+    }
   }
 #endif
 }
@@ -251,8 +277,15 @@ void IndexCollectNode::doToVelocyPack(velocypack::Builder& builder,
       builder.add("type", agg.type);
       builder.add(VPackValue("outVariable"));
       agg.outVariable->toVelocyPack(builder);
-      builder.add(VPackValue("expression"));
-      agg.expression->toVelocyPack(builder, true);
+      builder.add(VPackValue("expressions"));
+      {
+        VPackArrayBuilder exprGuard(&builder);
+        for (auto const& expression : agg.expressions) {
+          // Expression::toVelocyPack emits the bare node, so the array holds
+          // nodes rather than {"expression": ...} objects
+          expression->toVelocyPack(builder, true);
+        }
+      }
     }
   }
 

--- a/arangod/Aql/ExecutionNode/IndexCollectNode.h
+++ b/arangod/Aql/ExecutionNode/IndexCollectNode.h
@@ -39,9 +39,10 @@ struct IndexCollectAggregation {
   std::string type;
   // output variable
   Variable const* outVariable;
-  // aggregation expression. It must only contain attribute accesses to the old
-  // document variable that are covered by the index.
-  std::unique_ptr<Expression> expression;
+  // one aggregation expression per argument of the aggregate call. Each must
+  // only contain attribute accesses to the old document variable that are
+  // covered by the index.
+  std::vector<std::unique_ptr<Expression>> expressions;
 };
 
 using IndexCollectGroups = std::vector<IndexCollectGroup>;

--- a/arangod/Aql/ExecutionNode/WindowNode.cpp
+++ b/arangod/Aql/ExecutionNode/WindowNode.cpp
@@ -360,11 +360,6 @@ void WindowNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
           inVar->toVelocyPack(nodes);
         }
       }
-      if (aggregateVariable.inVars.size() == 1) {
-        // keep the shape that explain() had before multi-argument aggregates
-        nodes.add(VPackValue("inVariable"));
-        aggregateVariable.inVars[0]->toVelocyPack(nodes);
-      }
       nodes.add("type", VPackValue(aggregateVariable.type));
     }
   }

--- a/arangod/Aql/ExecutionNode/WindowNode.cpp
+++ b/arangod/Aql/ExecutionNode/WindowNode.cpp
@@ -353,9 +353,17 @@ void WindowNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
       VPackObjectBuilder obj(&nodes);
       nodes.add(VPackValue("outVariable"));
       aggregateVariable.outVar->toVelocyPack(nodes);
-      if (aggregateVariable.inVar) {
+      nodes.add(VPackValue("inVariables"));
+      {
+        VPackArrayBuilder inVarsGuard(&nodes);
+        for (auto const* inVar : aggregateVariable.inVars) {
+          inVar->toVelocyPack(nodes);
+        }
+      }
+      if (aggregateVariable.inVars.size() == 1) {
+        // keep the shape that explain() had before multi-argument aggregates
         nodes.add(VPackValue("inVariable"));
-        aggregateVariable.inVar->toVelocyPack(nodes);
+        aggregateVariable.inVars[0]->toVelocyPack(nodes);
       }
       nodes.add("type", VPackValue(aggregateVariable.type));
     }
@@ -365,7 +373,7 @@ void WindowNode::doToVelocyPack(VPackBuilder& nodes, unsigned flags) const {
 }
 
 void WindowNode::calcAggregateRegisters(
-    std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,
+    std::vector<AggregateRegisters>& aggregateRegisters,
     RegIdSet& readableInputRegisters,
     RegIdSet& writeableOutputRegisters) const {
   for (auto const& p : _aggregateVariables) {
@@ -376,17 +384,22 @@ void WindowNode::calcAggregateRegisters(
     RegisterId outReg = itOut->second.registerId;
     TRI_ASSERT(outReg.isValid());
 
-    RegisterId inReg = RegisterPlan::MaxRegisterId;
-    if (Aggregator::requiresInput(p.type)) {
-      auto itIn = getRegisterPlan()->varInfo.find(p.inVar->id);
+    std::vector<RegisterId> inRegs;
+    // aggregators whose input is optimized away (COUNT/LENGTH) have no input
+    // variables, and therefore no input registers
+    TRI_ASSERT(Aggregator::requiresInput(p.type) || p.inVars.empty());
+    inRegs.reserve(p.inVars.size());
+    for (auto const* inVar : p.inVars) {
+      auto itIn = getRegisterPlan()->varInfo.find(inVar->id);
       TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
-      inReg = itIn->second.registerId;
+      RegisterId inReg = itIn->second.registerId;
       TRI_ASSERT(inReg.isValid());
       readableInputRegisters.insert(inReg);
+      inRegs.emplace_back(inReg);
     }
-    // else: no input variable required
 
-    aggregateRegisters.emplace_back(std::make_pair(outReg, inReg));
+    aggregateRegisters.emplace_back(
+        AggregateRegisters{outReg, std::move(inRegs)});
     writeableOutputRegisters.insert((outReg));
   }
   TRI_ASSERT(aggregateRegisters.size() == _aggregateVariables.size());
@@ -411,7 +424,7 @@ std::unique_ptr<ExecutionBlock> WindowNode::createBlock(
   }
 
   // calculate the aggregate registers
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+  std::vector<AggregateRegisters> aggregateRegisters;
   calcAggregateRegisters(aggregateRegisters, readableInputRegisters,
                          writeableOutputRegisters);
 
@@ -455,7 +468,9 @@ void WindowNode::replaceVariables(
     std::unordered_map<VariableId, Variable const*> const& replacements) {
   _rangeVariable = Variable::replace(_rangeVariable, replacements);
   for (auto& variable : _aggregateVariables) {
-    variable.inVar = Variable::replace(variable.inVar, replacements);
+    for (auto& inVar : variable.inVars) {
+      inVar = Variable::replace(inVar, replacements);
+    }
   }
 }
 
@@ -465,8 +480,8 @@ void WindowNode::getVariablesUsedHere(VarSet& vars) const {
     vars.emplace(_rangeVariable);
   }
   for (auto const& p : _aggregateVariables) {
-    if (p.inVar) {
-      vars.emplace(p.inVar);
+    for (auto const* inVar : p.inVars) {
+      vars.emplace(inVar);
     }
   }
 }

--- a/arangod/Aql/ExecutionNode/WindowNode.cpp
+++ b/arangod/Aql/ExecutionNode/WindowNode.cpp
@@ -384,13 +384,16 @@ void WindowNode::calcAggregateRegisters(
     RegisterId outReg = itOut->second.registerId;
     TRI_ASSERT(outReg.isValid());
 
+    // The aggregator reads exactly numArguments values per row. A query may
+    // pass an argument to one that reads none, as in LENGTH(value): that
+    // argument is planned like any other, and simply not read here.
+    size_t const numArguments = Aggregator::numArguments(p.type);
+    TRI_ASSERT(p.inVars.size() >= numArguments);
+
     std::vector<RegisterId> inRegs;
-    // aggregators whose input is optimized away (COUNT/LENGTH) have no input
-    // variables, and therefore no input registers
-    TRI_ASSERT(Aggregator::requiresInput(p.type) || p.inVars.empty());
-    inRegs.reserve(p.inVars.size());
-    for (auto const* inVar : p.inVars) {
-      auto itIn = getRegisterPlan()->varInfo.find(inVar->id);
+    inRegs.reserve(numArguments);
+    for (size_t i = 0; i < numArguments; ++i) {
+      auto itIn = getRegisterPlan()->varInfo.find(p.inVars[i]->id);
       TRI_ASSERT(itIn != getRegisterPlan()->varInfo.end());
       RegisterId inReg = itIn->second.registerId;
       TRI_ASSERT(inReg.isValid());

--- a/arangod/Aql/ExecutionNode/WindowNode.h
+++ b/arangod/Aql/ExecutionNode/WindowNode.h
@@ -114,7 +114,7 @@ class WindowNode : public ExecutionNode {
 
   /// @brief calculate the aggregate registers
   void calcAggregateRegisters(
-      std::vector<std::pair<RegisterId, RegisterId>>& aggregateRegisters,
+      std::vector<AggregateRegisters>& aggregateRegisters,
       RegIdSet& readableInputRegisters,
       RegIdSet& writeableOutputRegisters) const;
 

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -3004,26 +3004,25 @@ std::vector<AggregateVarInfo> ExecutionPlan::prepareAggregateVars(
     auto func = funcCall.getFunction();
     TRI_ASSERT(func != nullptr);
 
-    // function should have one argument (an array with the parameters)
+    // one input variable per argument of the aggregate call
     auto args = funcCall.getArguments().getElements();
     std::string_view functionName = Aggregator::translateAlias(func->name);
-    Variable const* variable = nullptr;
-    if (args.size() == 1) {
-      auto arg = args[0];
+    std::vector<Variable const*> inVars;
+    TRI_ASSERT(!args.empty() || !Aggregator::requiresInput(func->name));
+    inVars.reserve(args.size());
+    for (auto const* arg : args) {
       if (arg->type == NODE_TYPE_REFERENCE) {
         // operand is a variable
         ast::ReferenceNode refNode(arg);
-        variable = refNode.getVariable();
+        inVars.emplace_back(refNode.getVariable());
       } else {
         auto calc = createTemporaryCalculation(arg, *previous);
         *previous = calc;
-        variable = getOutVariable(calc);
+        inVars.emplace_back(getOutVariable(calc));
       }
-    } else {
-      TRI_ASSERT(!Aggregator::requiresInput(func->name));
     }
     aggregateVariables.emplace_back(
-        AggregateVarInfo{outVar, variable, std::string(functionName)});
+        AggregateVarInfo{outVar, std::move(inVars), std::string(functionName)});
   }
 
   return aggregateVariables;

--- a/arangod/Aql/ExecutionPlan.cpp
+++ b/arangod/Aql/ExecutionPlan.cpp
@@ -3004,7 +3004,6 @@ std::vector<AggregateVarInfo> ExecutionPlan::prepareAggregateVars(
     auto func = funcCall.getFunction();
     TRI_ASSERT(func != nullptr);
 
-    // one input variable per argument of the aggregate call
     auto args = funcCall.getArguments().getElements();
     std::string_view functionName = Aggregator::translateAlias(func->name);
     std::vector<Variable const*> inVars;

--- a/arangod/Aql/Executor/HashedCollectExecutor.cpp
+++ b/arangod/Aql/Executor/HashedCollectExecutor.cpp
@@ -41,14 +41,12 @@
 
 namespace arangodb::aql {
 
-static const AqlValue EmptyValue;
-
 HashedCollectExecutorInfos::HashedCollectExecutorInfos(
     std::vector<std::pair<RegisterId, RegisterId>>&& groupRegisters,
     RegisterId collectRegister, RegisterId expressionRegister,
     Variable const* expressionVariable, std::vector<std::string> aggregateTypes,
     std::vector<std::pair<std::string, RegisterId>>&& inputVariables,
-    std::vector<std::pair<RegisterId, RegisterId>>&& aggregateRegisters,
+    std::vector<AggregateRegisters>&& aggregateRegisters,
     velocypack::Options const* opts, arangodb::ResourceMonitor& resourceMonitor)
     : _aggregateTypes(aggregateTypes),
       _aggregateRegisters(aggregateRegisters),
@@ -67,7 +65,7 @@ HashedCollectExecutorInfos::getGroupRegisters() const {
   return _groupRegisters;
 }
 
-std::vector<std::pair<RegisterId, RegisterId>> const&
+std::vector<AggregateRegisters> const&
 HashedCollectExecutorInfos::getAggregatedRegisters() const {
   return _aggregateRegisters;
 }
@@ -156,11 +154,11 @@ void HashedCollectExecutor::consumeInputRow(InputAqlItemRow& input) {
                    _infos.getAggregatedRegisters().size());
     size_t j = 0;
     for (auto const& r : _infos.getAggregatedRegisters()) {
-      if (r.second.value() == RegisterId::maxRegisterId) {
-        (*aggregateValues)[j].reduce(EmptyValue);
-      } else {
-        (*aggregateValues)[j].reduce(input.getValue(r.second));
+      _inputValues.clear();
+      for (auto const& reg : r.inRegs) {
+        _inputValues.emplace_back(input.getValue(reg));
       }
+      (*aggregateValues)[j].reduce(_inputValues);
       ++j;
     }
   }
@@ -192,7 +190,7 @@ void HashedCollectExecutor::writeCurrentGroupToOutput(
          ++aggregatorIdx) {
       AqlValue r = aggregators[aggregatorIdx].stealValue();
       AqlValueGuard guard{r, true};
-      output.moveValueInto(_infos.getAggregatedRegisters()[j++].first,
+      output.moveValueInto(_infos.getAggregatedRegisters()[j++].outReg,
                            _lastInitializedInputRow, &guard);
     }
   }

--- a/arangod/Aql/Executor/HashedCollectExecutor.h
+++ b/arangod/Aql/Executor/HashedCollectExecutor.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Aql/Aggregator.h"
+#include "Aql/CollectOptions.h"
 #include "Aql/AqlValueGroup.h"
 #include "Aql/ExecutionState.h"
 #include "Aql/InputAqlItemRow.h"
@@ -76,7 +77,7 @@ class HashedCollectExecutorInfos {
       Variable const* expressionVariable,
       std::vector<std::string> aggregateTypes,
       std::vector<std::pair<std::string, RegisterId>>&& inputVariables,
-      std::vector<std::pair<RegisterId, RegisterId>>&& aggregateRegisters,
+      std::vector<AggregateRegisters>&& aggregateRegisters,
       velocypack::Options const* vpackOptions,
       arangodb::ResourceMonitor& resourceMonitor);
 
@@ -88,8 +89,7 @@ class HashedCollectExecutorInfos {
  public:
   std::vector<std::pair<RegisterId, RegisterId>> const& getGroupRegisters()
       const;
-  std::vector<std::pair<RegisterId, RegisterId>> const& getAggregatedRegisters()
-      const;
+  std::vector<AggregateRegisters> const& getAggregatedRegisters() const;
   std::vector<std::string> const& getAggregateTypes() const;
   velocypack::Options const* getVPackOptions() const;
   RegisterId getCollectRegister() const noexcept;
@@ -107,8 +107,8 @@ class HashedCollectExecutorInfos {
   /// @brief aggregate types
   std::vector<std::string> _aggregateTypes;
 
-  /// @brief pairs, consisting of out register and in register
-  std::vector<std::pair<RegisterId, RegisterId>> _aggregateRegisters;
+  /// @brief out register plus the in registers feeding each aggregate
+  std::vector<AggregateRegisters> _aggregateRegisters;
 
   /// @brief pairs, consisting of out register and in register
   std::vector<std::pair<RegisterId, RegisterId>> _groupRegisters;
@@ -187,6 +187,11 @@ class HashedCollectExecutor {
       -> size_t;
 
  private:
+  /// @brief scratch buffer holding one aggregate's input values for the
+  /// current row. Reused so that a multi-argument aggregate does not allocate
+  /// per row.
+  std::vector<AqlValue> _inputValues;
+
   struct ValueAggregators {
     ValueAggregators(std::vector<Aggregator::Factory const*> factories,
                      velocypack::Options const* opts,

--- a/arangod/Aql/Executor/HashedCollectExecutor.h
+++ b/arangod/Aql/Executor/HashedCollectExecutor.h
@@ -107,7 +107,6 @@ class HashedCollectExecutorInfos {
   /// @brief aggregate types
   std::vector<std::string> _aggregateTypes;
 
-  /// @brief out register plus the in registers feeding each aggregate
   std::vector<AggregateRegisters> _aggregateRegisters;
 
   /// @brief pairs, consisting of out register and in register

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
@@ -26,7 +26,9 @@
 #include "Aql/ExecutionBlockImpl.h"
 #include "Aql/ExecutionBlockImpl.tpp"
 #include "Aql/Aggregator.h"
+#include "Basics/ScopeGuard.h"
 #include "Basics/VelocyPackHelper.h"
+#include "Containers/SmallVector.h"
 
 #define LOG_AGG_SCAN LOG_DEVEL_IF(false)
 
@@ -97,12 +99,29 @@ void aggregate(
     std::vector<IndexAggregateScanInfos::Aggregation> const& aggregations,
     SliceSpanExpressionContext& context) {
   for (size_t k = 0; k < aggregations.size(); k++) {
-    bool mustDestroy;
-    AqlValue result =
-        aggregations[k].expression->execute(&context, mustDestroy);
-    AqlValueGuard guard(result, mustDestroy);
-    LOG_AGG_SCAN << "[SCAN] Agg " << k << " reduce with value ";
-    aggregators[k]->reduce(result);
+    auto const& expressions = aggregations[k].expressions;
+    // one value per argument of the aggregate call. AqlValueGuard is not
+    // movable, so it cannot be kept per value in a container; release them
+    // together once the aggregator has consumed the span.
+    containers::SmallVector<AqlValue, 4> values;
+    containers::SmallVector<bool, 4> mustDestroy;
+    values.reserve(expressions.size());
+    mustDestroy.reserve(expressions.size());
+    auto releaseValues = scopeGuard([&]() noexcept {
+      for (size_t i = 0; i < values.size(); ++i) {
+        if (mustDestroy[i]) {
+          values[i].destroy();
+        }
+      }
+    });
+    for (auto const& expression : expressions) {
+      bool destroy = false;
+      values.emplace_back(expression->execute(&context, destroy));
+      mustDestroy.emplace_back(destroy);
+    }
+    LOG_AGG_SCAN << "[SCAN] Agg " << k << " reduce with " << values.size()
+                 << " value(s)";
+    aggregators[k]->reduce(values);
   }
 }
 

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.h
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.h
@@ -50,7 +50,7 @@ struct IndexAggregateScanInfos {
   struct Aggregation {
     std::string type;
     RegisterId outputRegister;
-    std::unique_ptr<Expression> expression;
+    std::vector<std::unique_ptr<Expression>> expressions;
   };
   std::vector<Aggregation> aggregations;
 

--- a/arangod/Aql/Executor/SortedCollectExecutor.cpp
+++ b/arangod/Aql/Executor/SortedCollectExecutor.cpp
@@ -39,7 +39,6 @@
 #define INTERNAL_LOG_SC LOG_DEVEL_IF(false)
 
 namespace arangodb::aql {
-static const AqlValue EmptyValue;  // TODO
 
 SortedCollectExecutor::CollectGroup::CollectGroup(Infos& infos)
     : groupLength(0),
@@ -121,7 +120,7 @@ SortedCollectExecutorInfos::SortedCollectExecutorInfos(
     RegisterId collectRegister, RegisterId expressionRegister,
     Variable const* expressionVariable, std::vector<std::string> aggregateTypes,
     std::vector<std::pair<std::string, RegisterId>>&& inputVariables,
-    std::vector<std::pair<RegisterId, RegisterId>>&& aggregateRegisters,
+    std::vector<AggregateRegisters>&& aggregateRegisters,
     velocypack::Options const* opts, ResourceMonitor& resourceMonitor)
     : _aggregateTypes(std::move(aggregateTypes)),
       _aggregateRegisters(std::move(aggregateRegisters)),
@@ -154,12 +153,11 @@ void SortedCollectExecutor::CollectGroup::addLine(
   for (auto& it : this->aggregators) {
     TRI_ASSERT(!this->aggregators.empty());
     TRI_ASSERT(infos.getAggregatedRegisters().size() > j);
-    RegisterId const reg = infos.getAggregatedRegisters()[j].second;
-    if (reg.value() != RegisterId::maxRegisterId) {
-      it->reduce(input.getValue(reg));
-    } else {
-      it->reduce(EmptyValue);
+    _inputValues.clear();
+    for (auto const& reg : infos.getAggregatedRegisters()[j].inRegs) {
+      _inputValues.emplace_back(input.getValue(reg));
     }
+    it->reduce(_inputValues);
     ++j;
   }
   TRI_IF_FAILURE("SortedCollectBlock::getOrSkipSome") {
@@ -262,8 +260,8 @@ void SortedCollectExecutor::CollectGroup::writeToOutput(
   for (auto& it : this->aggregators) {
     AqlValue val = it->stealValue();
     AqlValueGuard guard{val, true};
-    output.moveValueInto(infos.getAggregatedRegisters()[j].first, _lastInputRow,
-                         &guard);
+    output.moveValueInto(infos.getAggregatedRegisters()[j].outReg,
+                         _lastInputRow, &guard);
     ++j;
   }
 

--- a/arangod/Aql/Executor/SortedCollectExecutor.h
+++ b/arangod/Aql/Executor/SortedCollectExecutor.h
@@ -95,7 +95,6 @@ class SortedCollectExecutorInfos {
   /// @brief aggregate types
   std::vector<std::string> _aggregateTypes;
 
-  /// @brief out register plus the in registers feeding each aggregate
   std::vector<AggregateRegisters> _aggregateRegisters;
 
   /// @brief pairs, consisting of out register and in register

--- a/arangod/Aql/Executor/SortedCollectExecutor.h
+++ b/arangod/Aql/Executor/SortedCollectExecutor.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Aql/Aggregator.h"
+#include "Aql/CollectOptions.h"
 #include "Aql/AqlValueGroup.h"
 #include "Aql/ExecutionBlock.h"
 #include "Aql/ExecutionBlockImpl.h"
@@ -55,7 +56,7 @@ class SortedCollectExecutorInfos {
       Variable const* expressionVariable,
       std::vector<std::string> aggregateTypes,
       std::vector<std::pair<std::string, RegisterId>>&& inputVariables,
-      std::vector<std::pair<RegisterId, RegisterId>>&& aggregateRegisters,
+      std::vector<AggregateRegisters>&& aggregateRegisters,
       velocypack::Options const*, ResourceMonitor& resourceMonitor);
 
   SortedCollectExecutorInfos() = delete;
@@ -68,8 +69,7 @@ class SortedCollectExecutorInfos {
       const {
     return _groupRegisters;
   }
-  std::vector<std::pair<RegisterId, RegisterId>> const& getAggregatedRegisters()
-      const {
+  std::vector<AggregateRegisters> const& getAggregatedRegisters() const {
     return _aggregateRegisters;
   }
   std::vector<std::string> const& getAggregateTypes() const {
@@ -95,8 +95,8 @@ class SortedCollectExecutorInfos {
   /// @brief aggregate types
   std::vector<std::string> _aggregateTypes;
 
-  /// @brief pairs, consisting of out register and in register
-  std::vector<std::pair<RegisterId, RegisterId>> _aggregateRegisters;
+  /// @brief out register plus the in registers feeding each aggregate
+  std::vector<AggregateRegisters> _aggregateRegisters;
 
   /// @brief pairs, consisting of out register and in register
   std::vector<std::pair<RegisterId, RegisterId>> _groupRegisters;
@@ -147,6 +147,11 @@ class SortedCollectExecutor {
     InputAqlItemRow _lastInputRow;
     arangodb::velocypack::SupervisedBuffer _buffer;
     arangodb::velocypack::Builder _builder;  // Supervised builder
+
+    /// @brief scratch buffer holding one aggregate's input values for the
+    /// current row. Reused so that a multi-argument aggregate does not
+    /// allocate per row.
+    std::vector<AqlValue> _inputValues;
 
     CollectGroup() = delete;
     CollectGroup(CollectGroup&&) = default;

--- a/arangod/Aql/Executor/WindowExecutor.cpp
+++ b/arangod/Aql/Executor/WindowExecutor.cpp
@@ -110,7 +110,6 @@ void BaseWindowExecutor::applyAggregators(InputAqlItemRow& input) {
   TRI_ASSERT(_aggregators.size() == _infos.getAggregatedRegisters().size());
   size_t j = 0;
   for (auto const& r : _infos.getAggregatedRegisters()) {
-    // stays empty for aggregators without input, e.g. LENGTH / COUNT
     _inputValues.clear();
     for (auto const& reg : r.inRegs) {
       _inputValues.emplace_back(input.getValue(reg));

--- a/arangod/Aql/Executor/WindowExecutor.cpp
+++ b/arangod/Aql/Executor/WindowExecutor.cpp
@@ -39,16 +39,13 @@
 
 namespace arangodb::aql {
 
-namespace {
-static const AqlValue EmptyValue;
-}
+namespace {}
 
 WindowExecutorInfos::WindowExecutorInfos(
     WindowBounds const& bounds, RegisterId rangeRegister,
     std::vector<std::string> aggregateTypes,
-    std::vector<std::pair<RegisterId, RegisterId>>&& aggregateRegisters,
-    QueryWarnings& w, velocypack::Options const* opts,
-    ResourceMonitor& resourceMonitor)
+    std::vector<AggregateRegisters>&& aggregateRegisters, QueryWarnings& w,
+    velocypack::Options const* opts, ResourceMonitor& resourceMonitor)
     : _bounds(bounds),
       _rangeRegister(rangeRegister),
       _aggregateTypes(std::move(aggregateTypes)),
@@ -63,8 +60,8 @@ WindowBounds const& WindowExecutorInfos::bounds() const { return _bounds; }
 
 RegisterId WindowExecutorInfos::rangeRegister() const { return _rangeRegister; }
 
-std::vector<std::pair<RegisterId, RegisterId>>
-WindowExecutorInfos::getAggregatedRegisters() const {
+std::vector<AggregateRegisters> WindowExecutorInfos::getAggregatedRegisters()
+    const {
   return _aggregateRegisters;
 }
 
@@ -113,11 +110,12 @@ void BaseWindowExecutor::applyAggregators(InputAqlItemRow& input) {
   TRI_ASSERT(_aggregators.size() == _infos.getAggregatedRegisters().size());
   size_t j = 0;
   for (auto const& r : _infos.getAggregatedRegisters()) {
-    if (r.second.value() == RegisterId::maxRegisterId) {  // e.g. LENGTH / COUNT
-      _aggregators[j]->reduce(::EmptyValue);
-    } else {
-      _aggregators[j]->reduce(input.getValue(/*inRegister*/ r.second));
+    // stays empty for aggregators without input, e.g. LENGTH / COUNT
+    _inputValues.clear();
+    for (auto const& reg : r.inRegs) {
+      _inputValues.emplace_back(input.getValue(reg));
     }
+    _aggregators[j]->reduce(_inputValues);
     ++j;
   }
 }
@@ -137,7 +135,7 @@ void BaseWindowExecutor::produceOutputRow(InputAqlItemRow& input,
   for (std::unique_ptr<Aggregator> const& agg : _aggregators) {
     AqlValue r = agg->get();
     AqlValueGuard guard{r, /*destroy*/ true};
-    output.moveValueInto(/*outRegister*/ registers[j++].first, input, &guard);
+    output.moveValueInto(/*outRegister*/ registers[j++].outReg, input, &guard);
     if (reset) {
       agg->reset();
     }
@@ -149,7 +147,7 @@ void BaseWindowExecutor::produceInvalidOutputRow(InputAqlItemRow& input,
                                                  OutputAqlItemRow& output) {
   VPackSlice nullSlice = VPackSlice::nullSlice();
   for (auto const& regId : _infos.getAggregatedRegisters()) {
-    output.moveValueInto(/*outRegister*/ regId.first, input, nullSlice);
+    output.moveValueInto(/*outRegister*/ regId.outReg, input, nullSlice);
   }
   output.advanceRow();
 }

--- a/arangod/Aql/Executor/WindowExecutor.h
+++ b/arangod/Aql/Executor/WindowExecutor.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "Aql/Aggregator.h"
+#include "Aql/CollectOptions.h"
 #include "Aql/AqlValueGroup.h"
 #include "Aql/ExecutionNode/WindowNode.h"
 #include "Aql/ExecutionState.h"
@@ -54,12 +55,12 @@ class WindowExecutorInfos {
    * @param aggregateRegisters Input and output Register for Aggregation
    * @param options The AQL transaction, as it might be needed for aggregates
    */
-  WindowExecutorInfos(
-      WindowBounds const& b, RegisterId rangeRegister,
-      std::vector<std::string> aggregateTypes,
-      std::vector<std::pair<RegisterId, RegisterId>>&& aggregateRegisters,
-      QueryWarnings& warnings, velocypack::Options const* options,
-      ResourceMonitor& resourceMonitor);
+  WindowExecutorInfos(WindowBounds const& b, RegisterId rangeRegister,
+                      std::vector<std::string> aggregateTypes,
+                      std::vector<AggregateRegisters>&& aggregateRegisters,
+                      QueryWarnings& warnings,
+                      velocypack::Options const* options,
+                      ResourceMonitor& resourceMonitor);
 
   WindowExecutorInfos() = delete;
   WindowExecutorInfos(WindowExecutorInfos&&) = default;
@@ -69,7 +70,7 @@ class WindowExecutorInfos {
  public:
   WindowBounds const& bounds() const;
   RegisterId rangeRegister() const;
-  std::vector<std::pair<RegisterId, RegisterId>> getAggregatedRegisters() const;
+  std::vector<AggregateRegisters> getAggregatedRegisters() const;
   std::vector<std::string> const& getAggregateTypes() const;
   QueryWarnings& warnings() const;
   velocypack::Options const* getVPackOptions() const;
@@ -83,8 +84,8 @@ class WindowExecutorInfos {
   /// @brief aggregate types
   std::vector<std::string> _aggregateTypes;
 
-  /// @brief pairs, consisting of out register and in register
-  std::vector<std::pair<RegisterId, RegisterId>> _aggregateRegisters;
+  /// @brief out register plus the in registers feeding each aggregate
+  std::vector<AggregateRegisters> _aggregateRegisters;
 
   QueryWarnings& _warnings;
 
@@ -111,6 +112,11 @@ class BaseWindowExecutor {
 
   static AggregatorList createAggregators(
       BaseWindowExecutor::Infos const& infos);
+
+  /// @brief scratch buffer holding one aggregate's input values for the
+  /// current row. Reused so that a multi-argument aggregate does not allocate
+  /// per row.
+  std::vector<AqlValue> _inputValues;
 
   void applyAggregators(InputAqlItemRow& input);
   void resetAggregators();

--- a/arangod/Aql/Executor/WindowExecutor.h
+++ b/arangod/Aql/Executor/WindowExecutor.h
@@ -84,7 +84,6 @@ class WindowExecutorInfos {
   /// @brief aggregate types
   std::vector<std::string> _aggregateTypes;
 
-  /// @brief out register plus the in registers feeding each aggregate
   std::vector<AggregateRegisters> _aggregateRegisters;
 
   QueryWarnings& _warnings;

--- a/arangod/Aql/Optimizer/Rule/CollectInCluster.cpp
+++ b/arangod/Aql/Optimizer/Rule/CollectInCluster.cpp
@@ -240,7 +240,7 @@ void collectInClusterRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
                 plan->getAst()->variables()->createTemporaryVariable();
             std::vector<AggregateVarInfo> aggregateVariables;
             aggregateVariables.emplace_back(AggregateVarInfo{
-                outVariable, collectNode->aggregateVariables()[0].inVar,
+                outVariable, collectNode->aggregateVariables()[0].inVars,
                 "LENGTH"});
             auto dbCollectNode = plan->createNode<CollectNode>(
                 plan.get(), plan->nextId(), collectNode->getOptions(),
@@ -256,7 +256,7 @@ void collectInClusterRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
             // re-use the existing CollectNode on the coordinator to aggregate
             // the counts of the DB servers
             collectNode->aggregateVariables()[0].type = "SUM";
-            collectNode->aggregateVariables()[0].inVar = outVariable;
+            collectNode->aggregateVariables()[0].inVars = {outVariable};
             collectNode->aggregationMethod(
                 CollectOptions::CollectMethod::kSorted);
 
@@ -314,7 +314,7 @@ void collectInClusterRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
               auto outVariable =
                   plan->getAst()->variables()->createTemporaryVariable();
               dbServerAggVars.emplace_back(
-                  AggregateVarInfo{outVariable, it.inVar, std::string(func)});
+                  AggregateVarInfo{outVariable, it.inVars, std::string(func)});
             }
 
             if (!eligible) {
@@ -371,7 +371,9 @@ void collectInClusterRule(Optimizer* opt, std::unique_ptr<ExecutionPlan> plan,
 
             size_t j = 0;
             for (AggregateVarInfo& it : collectNode->aggregateVariables()) {
-              it.inVar = dbServerAggVars[j].outVar;
+              // the DB server's partial result is a single value, whatever the
+              // arity of the original aggregate call was
+              it.inVars = {dbServerAggVars[j].outVar};
               it.type = Aggregator::runOnCoordinatorAs(it.type);
               ++j;
             }

--- a/arangod/Aql/Optimizer/Rule/UseIndexForCollect.cpp
+++ b/arangod/Aql/Optimizer/Rule/UseIndexForCollect.cpp
@@ -323,7 +323,6 @@ getEligibleAggregates(ExecutionPlan const& plan, CollectNode const& cn,
   auto const& coveredFields = idx.getSingleIndex()->coveredFields();
 
   for (auto const& agg : cn.aggregateVariables()) {
-    // one expression per argument of the aggregate call
     std::vector<std::unique_ptr<Expression>> expressions;
     expressions.reserve(agg.inVars.size());
 

--- a/arangod/Aql/Optimizer/Rule/UseIndexForCollect.cpp
+++ b/arangod/Aql/Optimizer/Rule/UseIndexForCollect.cpp
@@ -66,7 +66,7 @@ bool isCollectNodeEligible(CollectNode const& cn) {
   for (auto const& agg : cn.aggregateVariables()) {
     // TODO this happens with COUNT INTO or AGGREGATE var = COUNT().
     //   Maybe support this later on.
-    if (agg.inVar == nullptr) {
+    if (agg.inVars.empty()) {
       LOG_RULE << "Collect " << cn.id()
                << " not eligible - aggregation of type " << agg.type
                << " into variable " << agg.outVar->name
@@ -323,48 +323,56 @@ getEligibleAggregates(ExecutionPlan const& plan, CollectNode const& cn,
   auto const& coveredFields = idx.getSingleIndex()->coveredFields();
 
   for (auto const& agg : cn.aggregateVariables()) {
-    // get the producing node for the in variable, it should be a calculation
-    auto producer = plan.getVarSetBy(agg.inVar->id);
-    if (producer != nullptr && producer->getType() != EN::CALCULATION) {
-      return std::nullopt;
-    }
-    auto calculation = EN::castTo<CalculationNode*>(producer);
+    // one expression per argument of the aggregate call
+    std::vector<std::unique_ptr<Expression>> expressions;
+    expressions.reserve(agg.inVars.size());
 
-    // check if it is just an attribute access for the out variable of the
-    // index node.
-    VarSet variablesUsed;
-    calculation->expression()->variables(variablesUsed);
-    if (variablesUsed != VarSet{idx.outVariable()}) {
-      LOG_RULE << "Calculation " << calculation->id()
-               << " not eligible - expression uses other variables than index ("
-               << idx.id() << ") out variable " << idx.outVariable()->name;
-      return std::nullopt;
-    }
-
-    // check if all attributes in aggregate expression are covered fields
-    containers::FlatHashSet<aql::AttributeNamePath> attributes;
-    Ast::getReferencedAttributesRecursive(
-        calculation->expression()->node(), idx.outVariable(), "", attributes,
-        plan.getAst()->query().resourceMonitor());
-    for (auto const& attr : attributes) {
-      auto iter = std::find_if(
-          coveredFields.begin(), coveredFields.end(),
-          [&](auto const& field) { return attributeMatches(attr, field); });
-      if (iter == coveredFields.end()) {
-        LOG_RULE << "Calculation " << calculation->id()
-                 << " not eligible - accessed attribute " << attr
-                 << " which is not covered by the index";
+    for (auto const* inVar : agg.inVars) {
+      // get the producing node for the in variable, it should be a calculation
+      auto producer = plan.getVarSetBy(inVar->id);
+      if (producer != nullptr && producer->getType() != EN::CALCULATION) {
         return std::nullopt;
       }
-      std::size_t fieldIndex = std::distance(coveredFields.begin(), iter);
-      aggregationFields.emplace_back(fieldIndex);
+      auto calculation = EN::castTo<CalculationNode*>(producer);
+
+      // check if it is just an attribute access for the out variable of the
+      // index node.
+      VarSet variablesUsed;
+      calculation->expression()->variables(variablesUsed);
+      if (variablesUsed != VarSet{idx.outVariable()}) {
+        LOG_RULE << "Calculation " << calculation->id()
+                 << " not eligible - expression uses other variables than "
+                    "index ("
+                 << idx.id() << ") out variable " << idx.outVariable()->name;
+        return std::nullopt;
+      }
+
+      // check if all attributes in aggregate expression are covered fields
+      containers::FlatHashSet<aql::AttributeNamePath> attributes;
+      Ast::getReferencedAttributesRecursive(
+          calculation->expression()->node(), idx.outVariable(), "", attributes,
+          plan.getAst()->query().resourceMonitor());
+      for (auto const& attr : attributes) {
+        auto iter = std::find_if(
+            coveredFields.begin(), coveredFields.end(),
+            [&](auto const& field) { return attributeMatches(attr, field); });
+        if (iter == coveredFields.end()) {
+          LOG_RULE << "Calculation " << calculation->id()
+                   << " not eligible - accessed attribute " << attr
+                   << " which is not covered by the index";
+          return std::nullopt;
+        }
+        std::size_t fieldIndex = std::distance(coveredFields.begin(), iter);
+        aggregationFields.emplace_back(fieldIndex);
+      }
+
+      expressions.emplace_back(calculation->expression()->clone(plan.getAst()));
     }
 
-    // put the calculation expression inside the aggregation
-    aggregations.emplace_back(IndexCollectAggregation{
-        .type = agg.type,
-        .outVariable = agg.outVar,
-        .expression = calculation->expression()->clone(plan.getAst())});
+    aggregations.emplace_back(
+        IndexCollectAggregation{.type = agg.type,
+                                .outVariable = agg.outVar,
+                                .expressions = std::move(expressions)});
   }
 
   return std::make_tuple(std::move(aggregations), std::move(aggregationFields));

--- a/arangod/Aql/RegisterId.h
+++ b/arangod/Aql/RegisterId.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <functional>
 #include <limits>
 #include <stdint.h>
 #include <type_traits>

--- a/js/common/modules/@arangodb/aql/explainer.js
+++ b/js/common/modules/@arangodb/aql/explainer.js
@@ -972,6 +972,15 @@ function processQuery(query, explain, planIndex) {
     return variable(node.name);
   };
 
+  // an aggregate has one input variable per argument of its call. Servers from
+  // before multi-argument aggregates emit a single "inVariable" instead.
+  const aggregateArguments = function (node) {
+    if (node.inVariables) {
+      return node.inVariables.map(function (variable) { return variableName(variable); }).join(', ');
+    }
+    return node.inVariable ? variableName(node.inVariable) : '';
+  };
+
   const lateVariableCallback = function () {
     return (node) => variableName(node);
   };
@@ -1871,14 +1880,6 @@ function processQuery(query, explain, planIndex) {
         return keyword('LET') + ' ' + variableName(node.outVariable) + ' = ' + buildExpression(node.expression) + '   ' + annotation('/* ' + node.expressionType + ' expression */') + variablesUsed() + constNess();
       case 'FilterNode':
         return keyword('FILTER') + ' ' + variableName(node.inVariable);
-      case 'AggregateNode': /* old-style COLLECT node */
-        return keyword('COLLECT') + ' ' + node.aggregates.map(function (node) {
-          return variableName(node.outVariable) + ' = ' + variableName(node.inVariable);
-        }).join(', ') +
-          (node.count ? ' ' + keyword('WITH COUNT') : '') +
-          (node.outVariable ? ' ' + keyword('INTO') + ' ' + variableName(node.outVariable) : '') +
-          (node.keepVariables ? ' ' + keyword('KEEP') + ' ' + node.keepVariables.map(function (variable) { return variableName(variable); }).join(', ') : '') +
-          '   ' + annotation('/* ' + node.aggregationOptions.method + ' */');
       case 'CollectNode':
         var collect = keyword('COLLECT') + ' ' +
           node.groups.map(function (node) {
@@ -1891,7 +1892,7 @@ function processQuery(query, explain, planIndex) {
           }
           collect += keyword('AGGREGATE') + ' ' +
             node.aggregates.map(function (node) {
-              return variableName(node.outVariable) + ' = ' + func(node.type) + '(' + (node.inVariable ? variableName(node.inVariable) : '') + ')';
+              return variableName(node.outVariable) + ' = ' + func(node.type) + '(' + aggregateArguments(node) + ')';
             }).join(', ');
         }
         collect +=
@@ -2186,12 +2187,7 @@ function processQuery(query, explain, planIndex) {
         if (node.hasOwnProperty('aggregates') && node.aggregates.length > 0) {
           window += keyword('AGGREGATE') + ' ' +
             node.aggregates.map(function (node) {
-              let aggregateString = variableName(node.outVariable) + ' = ' + func(node.type) + '(';
-              if (node.inVariable !== undefined) {
-                aggregateString += variableName(node.inVariable);
-              }
-              aggregateString += ')';
-              return aggregateString;
+              return variableName(node.outVariable) + ' = ' + func(node.type) + '(' + aggregateArguments(node) + ')';
             }).join(', ');
         }
         return window;

--- a/tests/Aql/AggregateVarInfoTest.cpp
+++ b/tests/Aql/AggregateVarInfoTest.cpp
@@ -1,0 +1,145 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Aql/Ast.h"
+#include "Aql/CollectOptions.h"
+#include "Aql/Query.h"
+#include "Aql/Variable.h"
+#include "Aql/VariableGenerator.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
+
+#include "../Mocks/Servers.h"
+
+using namespace arangodb::aql;
+
+namespace arangodb::tests::aql {
+
+class AggregateVarInfoTest : public ::testing::Test {
+ protected:
+  mocks::MockAqlServer server;
+  std::shared_ptr<arangodb::aql::Query> fakedQuery;
+  Ast ast;
+
+ public:
+  AggregateVarInfoTest()
+      : fakedQuery(server.createFakeQuery()), ast(*fakedQuery.get()) {}
+
+  std::vector<AggregateVarInfo> parse(std::string_view json) {
+    auto builder = velocypack::Parser::fromJson(json.data(), json.size());
+    return AggregateVarInfo::fromVelocyPack(&ast, builder->slice());
+  }
+};
+
+// The deserializer does not look at the aggregator type, so a placeholder is
+// enough to cover an aggregate call with more than one argument.
+TEST_F(AggregateVarInfoTest, reads_multiple_in_variables) {
+  auto result = parse(R"([{
+    "outVariable": {"id": 1, "name": "hi"},
+    "inVariables": [{"id": 2, "name": "2"}, {"id": 3, "name": "3"}],
+    "type": "MULTI_ARG"
+  }])");
+
+  ASSERT_EQ(1, result.size());
+  EXPECT_EQ("MULTI_ARG", result[0].type);
+  EXPECT_EQ(1, result[0].outVar->id);
+  ASSERT_EQ(2, result[0].inVars.size());
+  EXPECT_EQ(2, result[0].inVars[0]->id);
+  EXPECT_EQ(3, result[0].inVars[1]->id);
+}
+
+TEST_F(AggregateVarInfoTest, reads_single_in_variable) {
+  auto result = parse(R"([{
+    "outVariable": {"id": 1, "name": "mn"},
+    "inVariables": [{"id": 2, "name": "2"}],
+    "type": "MIN"
+  }])");
+
+  ASSERT_EQ(1, result.size());
+  ASSERT_EQ(1, result[0].inVars.size());
+  EXPECT_EQ(2, result[0].inVars[0]->id);
+}
+
+// Coordinators are upgraded after DB servers, so a new DB server must still
+// understand the single "inVariable" that an old coordinator writes.
+TEST_F(AggregateVarInfoTest, reads_legacy_single_in_variable) {
+  auto result = parse(R"([{
+    "outVariable": {"id": 1, "name": "mn"},
+    "inVariable": {"id": 2, "name": "2"},
+    "type": "MIN"
+  }])");
+
+  ASSERT_EQ(1, result.size());
+  EXPECT_EQ("MIN", result[0].type);
+  EXPECT_EQ(1, result[0].outVar->id);
+  ASSERT_EQ(1, result[0].inVars.size());
+  EXPECT_EQ(2, result[0].inVars[0]->id);
+}
+
+// COUNT/LENGTH have their input optimized away, so an old coordinator writes
+// no "inVariable" at all
+TEST_F(AggregateVarInfoTest, reads_legacy_without_in_variable) {
+  auto result = parse(R"([{
+    "outVariable": {"id": 1, "name": "n"},
+    "type": "LENGTH"
+  }])");
+
+  ASSERT_EQ(1, result.size());
+  EXPECT_EQ("LENGTH", result[0].type);
+  EXPECT_TRUE(result[0].inVars.empty());
+}
+
+TEST_F(AggregateVarInfoTest, reads_empty_in_variables) {
+  auto result = parse(R"([{
+    "outVariable": {"id": 1, "name": "n"},
+    "inVariables": [],
+    "type": "LENGTH"
+  }])");
+
+  ASSERT_EQ(1, result.size());
+  EXPECT_TRUE(result[0].inVars.empty());
+}
+
+TEST_F(AggregateVarInfoTest, reads_several_aggregates) {
+  auto result = parse(R"([
+    {"outVariable": {"id": 1, "name": "n"}, "type": "LENGTH"},
+    {"outVariable": {"id": 2, "name": "mn"},
+     "inVariable": {"id": 3, "name": "3"}, "type": "MIN"},
+    {"outVariable": {"id": 4, "name": "hi"},
+     "inVariables": [{"id": 5, "name": "5"}, {"id": 6, "name": "6"}],
+     "type": "MULTI_ARG"}
+  ])");
+
+  ASSERT_EQ(3, result.size());
+  EXPECT_TRUE(result[0].inVars.empty());
+  EXPECT_EQ(1, result[1].inVars.size());
+  EXPECT_EQ(2, result[2].inVars.size());
+}
+
+TEST_F(AggregateVarInfoTest, rejects_non_array) {
+  EXPECT_ANY_THROW(parse(R"({"outVariable": {"id": 1, "name": "n"}})"));
+}
+
+}  // namespace arangodb::tests::aql

--- a/tests/Aql/Executor/HashedCollectExecutorTest.cpp
+++ b/tests/Aql/Executor/HashedCollectExecutorTest.cpp
@@ -47,6 +47,18 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
+namespace {
+/// @brief build the register info for a single aggregate. MaxRegisterId means
+/// the aggregator takes no arguments at all, as COUNT/LENGTH do.
+AggregateRegisters aggRegs(RegisterId out, RegisterId in) {
+  std::vector<RegisterId> inRegs;
+  if (in != RegisterPlan::MaxRegisterId) {
+    inRegs.emplace_back(in);
+  }
+  return AggregateRegisters{out, std::move(inRegs)};
+}
+}  // namespace
+
 using HashedCollectInputParam = std::tuple<SplitType, bool>;
 
 class HashedCollectExecutorTest
@@ -66,7 +78,7 @@ class HashedCollectExecutorTest
       RegisterCount nrInputRegisters, RegisterCount nrOutputRegisters,
       std::vector<std::pair<RegisterId, RegisterId>> groupRegisters,
       RegisterId collectRegister = RegisterPlan::MaxRegisterId,
-      std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters = {})
+      std::vector<AggregateRegisters> aggregateRegisters = {})
       -> RegisterInfos {
     RegIdSet registersToClear{};
     RegIdSetStack registersToKeep{{}};
@@ -86,11 +98,11 @@ class HashedCollectExecutorTest
     if (collectRegister != RegisterPlan::MaxRegisterId) {
       writeableOutputRegisters.emplace(collectRegister);
     }
-    for (auto const& [out, in] : aggregateRegisters) {
-      if (in != RegisterPlan::MaxRegisterId) {
+    for (auto const& agg : aggregateRegisters) {
+      for (auto const& in : agg.inRegs) {
         readableInputRegisters.emplace(in);
       }
-      writeableOutputRegisters.emplace(out);
+      writeableOutputRegisters.emplace(agg.outReg);
     }
 
     return RegisterInfos{std::move(readableInputRegisters),
@@ -106,7 +118,7 @@ class HashedCollectExecutorTest
       std::vector<std::pair<RegisterId, RegisterId>> groupRegisters,
       RegisterId collectRegister = RegisterPlan::MaxRegisterId,
       std::vector<std::string> aggregateTypes = {},
-      std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters = {})
+      std::vector<AggregateRegisters> aggregateRegisters = {})
       -> HashedCollectExecutorInfos {
     return HashedCollectExecutorInfos{std::move(groupRegisters),
                                       RegisterPlan::MaxRegisterId,
@@ -424,12 +436,12 @@ TEST_P(HashedCollectExecutorTest, collect_only_multiple_values) {
 
 // Collect with multiple aggregators
 TEST_P(HashedCollectExecutorTest, many_aggregators) {
-  auto registerInfos =
-      buildRegisterInfos(2, 5, {{2, 0}}, RegisterPlan::MaxRegisterId,
-                         {{3, RegisterPlan::MaxRegisterId}, {4, 1}});
+  auto registerInfos = buildRegisterInfos(
+      2, 5, {{2, 0}}, RegisterPlan::MaxRegisterId,
+      {aggRegs(3, RegisterPlan::MaxRegisterId), aggRegs(4, 1)});
   auto executorInfos = buildExecutorInfos(
       2, 5, {{2, 0}}, RegisterPlan::MaxRegisterId, {"LENGTH", "SUM"},
-      {{3, RegisterPlan::MaxRegisterId}, {4, 1}});
+      {aggRegs(3, RegisterPlan::MaxRegisterId), aggRegs(4, 1)});
   AqlCall call{};          // unlimited produce
   ExecutionStats stats{};  // No stats here
   makeExecutorTestHelper<2, 3>()
@@ -567,8 +579,7 @@ class HashedCollectExecutorTestAggregate
     }
 
     auto agg = getAggregator();
-    std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters{
-        {3, agg.inReg}};
+    std::vector<AggregateRegisters> aggregateRegisters{aggRegs(3, agg.inReg)};
     if (agg.inReg != RegisterPlan::MaxRegisterId) {
       readableInputRegisters.emplace(agg.inReg);
     }
@@ -590,8 +601,7 @@ class HashedCollectExecutorTestAggregate
 
     auto agg = getAggregator();
     std::vector<std::string> aggregateTypes{agg.name};
-    std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters{
-        {3, agg.inReg}};
+    std::vector<AggregateRegisters> aggregateRegisters{aggRegs(3, agg.inReg)};
 
     auto infos = HashedCollectExecutorInfos(
         std::move(groupRegisters), collectRegister, RegisterPlan::MaxRegisterId,

--- a/tests/Aql/Executor/IndexAggregateScanExecutorTest.cpp
+++ b/tests/Aql/Executor/IndexAggregateScanExecutorTest.cpp
@@ -308,10 +308,10 @@ TEST_F(IndexAggregateScanExecutorTest,
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()
@@ -342,10 +342,10 @@ TEST_F(IndexAggregateScanExecutorTest,
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t groupIndexField = 0;
   size_t aggregateIndexField = groupIndexField;
@@ -388,10 +388,10 @@ TEST_F(IndexAggregateScanExecutorTest,
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t groupIndexField = 0;
   size_t aggregateIndexField = 1;
@@ -434,10 +434,10 @@ TEST_F(IndexAggregateScanExecutorTest, groups_by_several_index_fields) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t groupIndexField_0 = 0;
   size_t groupIndexField_1 = 1;
@@ -490,15 +490,15 @@ TEST_F(IndexAggregateScanExecutorTest, aggregates_different_columns) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId_0,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression_0.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId_0});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression_0.slice()));
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId_1,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression_1.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId_1});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression_1.slice()));
 
   size_t groupIndexField = 0;
   size_t aggregateIndexField_0 = 1;
@@ -546,15 +546,15 @@ TEST_F(IndexAggregateScanExecutorTest,
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId_0,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId_0});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "MAX",
-      .outputRegister = aggregationRegisterId_1,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "MAX", .outputRegister = aggregationRegisterId_1});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t groupIndexField = 0;
   size_t aggregateIndexField = 1;
@@ -608,10 +608,10 @@ TEST_F(IndexAggregateScanExecutorTest,
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t groupIndexField = 0;
   size_t aggregateIndexField_0 = 1;
@@ -658,10 +658,10 @@ TEST_F(IndexAggregateScanExecutorTest, skip) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()
@@ -691,10 +691,10 @@ TEST_F(IndexAggregateScanExecutorTest, hard_limit) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()
@@ -724,10 +724,10 @@ TEST_F(IndexAggregateScanExecutorTest, soft_limit) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()
@@ -757,10 +757,10 @@ TEST_F(IndexAggregateScanExecutorTest, fullcount) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()
@@ -790,10 +790,10 @@ TEST_F(IndexAggregateScanExecutorTest, skip_produce_fullcount) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()
@@ -823,10 +823,10 @@ TEST_F(IndexAggregateScanExecutorTest, skip_too_much) {
 
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
-      .type = "SUM",
-      .outputRegister = aggregationRegisterId,
-      .expression =
-          std::make_unique<Expression>(&ast, aggregationExpression.slice())});
+      .type = "SUM", .outputRegister = aggregationRegisterId});
+  // a braced initializer would copy the unique_ptr, so append instead
+  aggregations.back().expressions.emplace_back(
+      std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
   size_t indexField = 0;
   makeExecutorTestHelper<0, 1>()

--- a/tests/Aql/Executor/IndexAggregateScanExecutorTest.cpp
+++ b/tests/Aql/Executor/IndexAggregateScanExecutorTest.cpp
@@ -309,7 +309,6 @@ TEST_F(IndexAggregateScanExecutorTest,
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -343,7 +342,6 @@ TEST_F(IndexAggregateScanExecutorTest,
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -389,7 +387,6 @@ TEST_F(IndexAggregateScanExecutorTest,
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -435,7 +432,6 @@ TEST_F(IndexAggregateScanExecutorTest, groups_by_several_index_fields) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -491,12 +487,10 @@ TEST_F(IndexAggregateScanExecutorTest, aggregates_different_columns) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId_0});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression_0.slice()));
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId_1});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression_1.slice()));
 
@@ -547,12 +541,10 @@ TEST_F(IndexAggregateScanExecutorTest,
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId_0});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "MAX", .outputRegister = aggregationRegisterId_1});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -609,7 +601,6 @@ TEST_F(IndexAggregateScanExecutorTest,
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -659,7 +650,6 @@ TEST_F(IndexAggregateScanExecutorTest, skip) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -692,7 +682,6 @@ TEST_F(IndexAggregateScanExecutorTest, hard_limit) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -725,7 +714,6 @@ TEST_F(IndexAggregateScanExecutorTest, soft_limit) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -758,7 +746,6 @@ TEST_F(IndexAggregateScanExecutorTest, fullcount) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -791,7 +778,6 @@ TEST_F(IndexAggregateScanExecutorTest, skip_produce_fullcount) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 
@@ -824,7 +810,6 @@ TEST_F(IndexAggregateScanExecutorTest, skip_too_much) {
   std::vector<IndexAggregateScanInfos::Aggregation> aggregations;
   aggregations.emplace_back(IndexAggregateScanInfos::Aggregation{
       .type = "SUM", .outputRegister = aggregationRegisterId});
-  // a braced initializer would copy the unique_ptr, so append instead
   aggregations.back().expressions.emplace_back(
       std::make_unique<Expression>(&ast, aggregationExpression.slice()));
 

--- a/tests/Aql/Executor/SortedCollectExecutorTest.cpp
+++ b/tests/Aql/Executor/SortedCollectExecutorTest.cpp
@@ -61,7 +61,7 @@ class SortedCollectExecutorTestNoRowsUpstream : public ::testing::Test {
 
   std::vector<std::string> aggregateTypes;
 
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+  std::vector<AggregateRegisters> aggregateRegisters;
 
   // if count = true, then we need to set a countRegister
   RegisterId collectRegister;
@@ -149,7 +149,7 @@ class SortedCollectExecutorTestRowsUpstream : public ::testing::Test {
 
   RegisterCount nrOutputRegister;
 
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+  std::vector<AggregateRegisters> aggregateRegisters;
   std::vector<std::string> aggregateTypes;
 
   // if count = true, then we need to set a valid countRegister
@@ -405,8 +405,8 @@ TEST(SortedCollectExecutorTestRowsUpstreamCount, test) {
   auto writeableOutputRegisters = RegIdSet{1, 2};
   RegisterCount nrOutputRegister = 3;
 
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
-  aggregateRegisters.emplace_back(std::make_pair<RegisterId, RegisterId>(2, 0));
+  std::vector<AggregateRegisters> aggregateRegisters;
+  aggregateRegisters.emplace_back(AggregateRegisters{2, {0}});
 
   std::vector<std::string> aggregateTypes = {"SUM"};
 
@@ -499,8 +499,8 @@ TEST(SortedCollectExecutorTestRowsUpstreamCountStrings, test) {
 
   RegisterCount nrOutputRegister = 3;
 
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
-  aggregateRegisters.emplace_back(std::make_pair<RegisterId, RegisterId>(2, 0));
+  std::vector<AggregateRegisters> aggregateRegisters;
+  aggregateRegisters.emplace_back(AggregateRegisters{2, {0}});
 
   std::vector<std::string> aggregateTypes;
   aggregateTypes.emplace_back("LENGTH");
@@ -606,7 +606,7 @@ class SortedCollectExecutorTestSkip : public ::testing::Test {
 
   RegisterCount nrOutputRegister;
 
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+  std::vector<AggregateRegisters> aggregateRegisters;
   std::vector<std::string> aggregateTypes;
 
   // if count = true, then we need to set a valid countRegister
@@ -948,7 +948,7 @@ class SortedCollectExecutorTestSplit
   RegisterId collectRegister;
   RegisterCount nrOutputRegister;
 
-  std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters;
+  std::vector<AggregateRegisters> aggregateRegisters;
   std::vector<std::string> aggregateTypes;
 
   // if count = true, then we need to set a valid countRegister

--- a/tests/Aql/Executor/WindowExecutorTest.cpp
+++ b/tests/Aql/Executor/WindowExecutorTest.cpp
@@ -50,6 +50,18 @@ namespace arangodb {
 namespace tests {
 namespace aql {
 
+namespace {
+/// @brief build the register info for a single aggregate. MaxRegisterId means
+/// the aggregator takes no arguments at all, as COUNT/LENGTH do.
+AggregateRegisters aggRegs(RegisterId out, RegisterId in) {
+  std::vector<RegisterId> inRegs;
+  if (in != RegisterPlan::MaxRegisterId) {
+    inRegs.emplace_back(in);
+  }
+  return AggregateRegisters{out, std::move(inRegs)};
+}
+}  // namespace
+
 struct WindowInput {
   WindowBounds bounds;
   RegisterId rangeReg;
@@ -123,8 +135,7 @@ class WindowExecutorTest
   auto buildExecutorInfos() -> WindowExecutorInfos {
     WindowInput const& input = getWindowParams();
     std::vector<std::string> aggregateTypes{input.name};
-    std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters{
-        {2, input.inReg}};
+    std::vector<AggregateRegisters> aggregateRegisters{aggRegs(2, input.inReg)};
 
     return WindowExecutorInfos(
         input.bounds, input.rangeReg, std::move(aggregateTypes),
@@ -441,7 +452,7 @@ class WindowExecutorInSubqueryTest : public AqlExecutorTestCase<false> {
 
   auto buildExecutorInfos() -> WindowExecutorInfos {
     std::vector<std::string> aggregateTypes{"SUM"};
-    std::vector<std::pair<RegisterId, RegisterId>> aggregateRegisters{{1, 0}};
+    std::vector<AggregateRegisters> aggregateRegisters{aggRegs(1, 0)};
 
     return WindowExecutorInfos(_preOnePostOne, 0, std::move(aggregateTypes),
                                std::move(aggregateRegisters),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,7 @@ set(ARANGODB_TESTS_SOURCES
   Aql/EngineInfoContainerCoordinatorTest.cpp
   Aql/ExecutionBlockImplTest.cpp
   Aql/ExecutionNode/EnumeratePathsNodeTest.cpp
+  Aql/AggregateVarInfoTest.cpp
   Aql/ExecutionNode/ExecutionNodeTest.cpp
   Aql/ExecutionNode/IndexNodeTest.cpp
   Aql/ExecutionNode/LocalGraphNodeCompatibilityTest.cpp

--- a/tests/js/client/aql/aql-collect-output-aggregation-optimization-cluster.js
+++ b/tests/js/client/aql/aql-collect-output-aggregation-optimization-cluster.js
@@ -41,7 +41,8 @@ const checkOptimization = function (plan) {
 
   const [aggregate] = collect.aggregates;
   assertEqual(aggregate.type, "MERGE_LISTS");
-  assertEqual(aggregate.inVariable.id, dbCollect.outVariable.id);
+  assertEqual(aggregate.inVariables.length, 1);
+  assertEqual(aggregate.inVariables[0].id, dbCollect.outVariable.id);
 };
 
 const checkNotOptimized = function (plan) {


### PR DESCRIPTION
Aggregator::reduce now receives a span of input values rather than a single one, with single-value aggregators adapted through a SingleValueAggregator CRTP.

The goal is to add `ARG_MIN` and `ARG_MAX` aggregators or other aggregators that support more than one argument.