### PR TITLE
AqlValue bugs and others

### DIFF
--- a/arangod/Aql/AqlItemBlock.cpp
+++ b/arangod/Aql/AqlItemBlock.cpp
@@ -45,9 +45,16 @@
 namespace arangodb::aql {
 namespace {
 
-inline void copyValueOver(arangodb::containers::HashSet<void const*>& cache,
-                          AqlValue const& a, size_t rowNumber,
-                          RegisterId::value_t col, SharedAqlItemBlockPtr& res) {
+// maps a payload pointer in the source block to the corresponding payload
+// pointer in the target block, so that values appearing in more than one cell
+// are copied over once and then aliased. keyed on the source pointer, because
+// that is what the lookups below have in hand.
+using ValueCopyCache =
+    arangodb::containers::FlatHashMap<void const*, void const*>;
+
+inline void copyValueOver(ValueCopyCache& cache, AqlValue const& a,
+                          size_t rowNumber, RegisterId::value_t col,
+                          SharedAqlItemBlockPtr& res) {
   if (a.requiresDestruction()) {
     auto it = cache.find(a.data());
 
@@ -59,9 +66,9 @@ inline void copyValueOver(arangodb::containers::HashSet<void const*>& cache,
         b.destroy();
         throw;
       }
-      cache.emplace(b.data());
+      cache.emplace(a.data(), b.data());
     } else {
-      res->setValue(rowNumber, col, AqlValue(a, (*it)));
+      res->setValue(rowNumber, col, AqlValue(a, (*it).second));
     }
   } else {
     res->setValue(rowNumber, col, a);
@@ -493,8 +500,7 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
 
   auto const numModifiedRows = _maxModifiedRowIndex;
 
-  auto copyRows = [&](arangodb::containers::HashSet<void const*>& cache,
-                      auto type) {
+  auto copyRows = [&](ValueCopyCache& cache, auto type) {
     constexpr bool checkShadowRows =
         std::is_same_v<decltype(type), WithShadowRows>;
     cache.reserve(_valueCount.size());
@@ -506,8 +512,10 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
           AqlValue a = stealAndEraseValue(row, col);
           if (a.requiresDestruction()) {
             AqlValueGuard guard{a, true};
-            auto [it, inserted] = cache.emplace(a.data());
-            res->setValue(row, col, AqlValue(a, (*it)));
+            // the stolen value moves into `res` as-is, so the target payload
+            // is the source payload
+            auto [it, inserted] = cache.emplace(a.data(), a.data());
+            res->setValue(row, col, AqlValue(a, (*it).second));
             if (inserted) {
               // otherwise, destroy this; we used a cached value.
               guard.steal();
@@ -528,7 +536,7 @@ SharedAqlItemBlockPtr AqlItemBlock::cloneDataAndMoveShadow() {
     }
   };
 
-  arangodb::containers::HashSet<void const*> cache;
+  ValueCopyCache cache;
 
   if (hasShadowRows()) {
     // at least one shadow row exists. this is the slow path
@@ -585,7 +593,7 @@ auto AqlItemBlock::slice(std::span<std::pair<size_t, size_t> const> ranges)
     numRows += to - from;
   }
 
-  arangodb::containers::HashSet<void const*> cache;
+  ValueCopyCache cache;
   cache.reserve(numRows * _numRegisters / 4 + 1);
 
   SharedAqlItemBlockPtr res{_manager.requestBlock(numRows, _numRegisters)};
@@ -612,7 +620,7 @@ SharedAqlItemBlockPtr AqlItemBlock::slice(
     RegisterCount newNumRegisters) const {
   TRI_ASSERT(_numRegisters <= newNumRegisters);
 
-  arangodb::containers::HashSet<void const*> cache;
+  ValueCopyCache cache;
   SharedAqlItemBlockPtr res{_manager.requestBlock(1, newNumRegisters)};
   for (auto const& col : registers) {
     TRI_ASSERT(col.isRegularRegister() && col < _numRegisters);
@@ -630,7 +638,7 @@ SharedAqlItemBlockPtr AqlItemBlock::slice(std::vector<size_t> const& chosen,
                                           size_t from, size_t to) const {
   TRI_ASSERT(from < to && to <= chosen.size());
 
-  arangodb::containers::HashSet<void const*> cache;
+  ValueCopyCache cache;
   cache.reserve((to - from) * _numRegisters / 4 + 1);
 
   SharedAqlItemBlockPtr res{_manager.requestBlock(to - from, _numRegisters)};

--- a/arangod/Aql/AqlValueMaterializer.cpp
+++ b/arangod/Aql/AqlValueMaterializer.cpp
@@ -53,8 +53,14 @@ AqlValueMaterializer& AqlValueMaterializer::operator=(
       materialized.destroy();
       hasCopied = false;
     }
-    // copy other's slice
-    materialized = other.materialized.clone();
+    // only clone when the other side actually owns its value. cloning a
+    // borrowed value would allocate and then record the result as non-owning,
+    // leaking it.
+    if (other.hasCopied) {
+      materialized = other.materialized.clone();
+    } else {
+      materialized = other.materialized;
+    }
     hasCopied = other.hasCopied;
   }
   return *this;

--- a/arangod/Aql/FixedVarExpressionContext.cpp
+++ b/arangod/Aql/FixedVarExpressionContext.cpp
@@ -44,6 +44,7 @@ AqlValue FixedVarExpressionContext::getVariableValue(Variable const* variable,
         auto it = _vars.find(variable);
         if (it == _vars.end()) {
           TRI_ASSERT(false);
+          mustDestroy = false;
           return AqlValue(AqlValueHintNull());
         }
         mustDestroy = doCopy;
@@ -88,7 +89,8 @@ NoVarExpressionContext::NoVarExpressionContext(transaction::Methods& trx,
 
 AqlValue NoVarExpressionContext::getVariableValue(Variable const* /*variable*/,
                                                   bool /*doCopy*/,
-                                                  bool& /*mustDestroy*/) const {
+                                                  bool& mustDestroy) const {
+  mustDestroy = false;
   return AqlValue(AqlValueHintNull());
 }
 

--- a/arangod/IResearch/AqlHelper.h
+++ b/arangod/IResearch/AqlHelper.h
@@ -264,6 +264,7 @@ class ScopedAqlValue : private irs::util::noncopyable {
       : _value(rhs._value),
         _node(rhs._node),
         _type(rhs._type),
+        _destroy(rhs._destroy),
         _executed(rhs._executed) {
     rhs._node = &INVALID_NODE;
     rhs._type = SCOPED_VALUE_TYPE_INVALID;

--- a/arangod/IResearch/IResearchAqlAnalyzer.cpp
+++ b/arangod/IResearch/IResearchAqlAnalyzer.cpp
@@ -342,6 +342,8 @@ AqlAnalyzer::AqlAnalyzer(Options const& options)
           .ok());
 }
 
+AqlAnalyzer::~AqlAnalyzer() { _valueBuffer.destroy(); }
+
 bool AqlAnalyzer::next() {
   do {
     if (_queryResults != nullptr) {

--- a/arangod/IResearch/IResearchAqlAnalyzer.cpp
+++ b/arangod/IResearch/IResearchAqlAnalyzer.cpp
@@ -360,8 +360,8 @@ bool AqlAnalyzer::next() {
                 aql::NoVarExpressionContext ctx(_query->trxForOptimization(),
                                                 *_query,
                                                 _aqlFunctionsInternalCache);
-                _valueBuffer = aql::functions::ToString(
-                    &ctx, *_query->ast()->root(), params);
+                resetValueBuffer(aql::functions::ToString(
+                    &ctx, *_query->ast()->root(), params));
                 TRI_ASSERT(_valueBuffer.isString());
                 std::get<2>(_attrs).value = irs::ViewCast<irs::byte_type>(
                     _valueBuffer.slice().stringView());
@@ -376,8 +376,8 @@ bool AqlAnalyzer::next() {
                 aql::NoVarExpressionContext ctx(_query->trxForOptimization(),
                                                 *_query,
                                                 _aqlFunctionsInternalCache);
-                _valueBuffer = aql::functions::ToNumber(
-                    &ctx, *_query->ast()->root(), params);
+                resetValueBuffer(aql::functions::ToNumber(
+                    &ctx, *_query->ast()->root(), params));
                 TRI_ASSERT(_valueBuffer.isNumber());
                 std::get<3>(_attrs).value = _valueBuffer.slice();
               }
@@ -391,8 +391,8 @@ bool AqlAnalyzer::next() {
                 aql::NoVarExpressionContext ctx(_query->trxForOptimization(),
                                                 *_query,
                                                 _aqlFunctionsInternalCache);
-                _valueBuffer = aql::functions::ToBool(
-                    &ctx, *_query->ast()->root(), params);
+                resetValueBuffer(aql::functions::ToBool(
+                    &ctx, *_query->ast()->root(), params));
                 TRI_ASSERT(_valueBuffer.isBoolean());
                 std::get<3>(_attrs).value = _valueBuffer.slice();
               }
@@ -405,7 +405,7 @@ bool AqlAnalyzer::next() {
                   << static_cast<std::underlying_type_t<AnalyzerValueType>>(
                          _options.returnType);
               std::get<2>(_attrs).value = irs::kEmptyStringView<irs::byte_type>;
-              _valueBuffer = AqlValue();
+              resetValueBuffer(AqlValue());
               std::get<3>(_attrs).value = _valueBuffer.slice();
           }
           std::get<0>(_attrs).value = _nextIncVal;

--- a/arangod/IResearch/IResearchAqlAnalyzer.h
+++ b/arangod/IResearch/IResearchAqlAnalyzer.h
@@ -105,6 +105,8 @@ class AqlAnalyzer final : public irs::analysis::analyzer {
 
   explicit AqlAnalyzer(Options const& options);
 
+  ~AqlAnalyzer() final { _valueBuffer.destroy(); }
+
   irs::type_info::type_id type() const noexcept final {
     return irs::type<AqlAnalyzer>::id();
   }
@@ -117,6 +119,14 @@ class AqlAnalyzer final : public irs::analysis::analyzer {
   bool reset(std::string_view field) noexcept final;
 
  private:
+  // takes ownership of `value` and releases whatever _valueBuffer held before.
+  // the argument is evaluated before the old payload is freed, so the two may
+  // safely alias.
+  void resetValueBuffer(aql::AqlValue value) noexcept {
+    _valueBuffer.destroy();
+    _valueBuffer = value;
+  }
+
   using ResetImplFunctor = void (*)(AqlAnalyzer* analyzer);
 
   friend bool tryOptimize(AqlAnalyzer* analyzer);

--- a/arangod/IResearch/IResearchAqlAnalyzer.h
+++ b/arangod/IResearch/IResearchAqlAnalyzer.h
@@ -105,7 +105,7 @@ class AqlAnalyzer final : public irs::analysis::analyzer {
 
   explicit AqlAnalyzer(Options const& options);
 
-  ~AqlAnalyzer() final { _valueBuffer.destroy(); }
+  ~AqlAnalyzer() final;
 
   irs::type_info::type_id type() const noexcept final {
     return irs::type<AqlAnalyzer>::id();

--- a/arangod/IResearch/IResearchInvertedIndex.cpp
+++ b/arangod/IResearch/IResearchInvertedIndex.cpp
@@ -284,8 +284,9 @@ class InvertedIndexExpressionContext final : public aql::ExpressionContext {
 
  private:
   aql::AqlValue getVariableValue(aql::Variable const*, bool,
-                                 bool&) const final {
+                                 bool& mustDestroy) const final {
     TRI_ASSERT(false);
+    mustDestroy = false;
     return {};
   }
 

--- a/arangod/VocBase/ComputedValues.cpp
+++ b/arangod/VocBase/ComputedValues.cpp
@@ -138,11 +138,16 @@ ValidatorBase* ComputedValuesExpressionContext::buildValidator(
 
 aql::AqlValue ComputedValuesExpressionContext::getVariableValue(
     aql::Variable const* variable, bool doCopy, bool& mustDestroy) const {
+  mustDestroy = false;
   auto it = _variables.find(variable);
   if (it == _variables.end()) {
     return aql::AqlValue(aql::AqlValueHintNull());
   }
   if (doCopy) {
+    // AqlValueHintSliceCopy allocates only for slices that do not fit inline.
+    // Report ownership in both cases, because destroy() is a no-op on an
+    // inline value.
+    mustDestroy = true;
     return aql::AqlValue(aql::AqlValueHintSliceCopy(it->second));
   }
   return aql::AqlValue(aql::AqlValueHintSliceNoCopy(it->second));


### PR DESCRIPTION
Fixing multiple bugs where mustDestroy was uninitialized. Also `AqlValueMaterialized` can leak memory when copied.