### PR TITLE
Docs: Fix version remark for `arangodb_rbac_request_duration metric`

### DIFF
--- a/Documentation/Metrics/arangodb_rbac_request_duration.yaml
+++ b/Documentation/Metrics/arangodb_rbac_request_duration.yaml
@@ -1,5 +1,5 @@
 name: arangodb_rbac_request_duration
-introducedIn: "3.12.10"
+introducedIn: "3.12.11"
 help: |
   Duration of requests to the external RBAC authorization service in microseconds.
 unit: microseconds


### PR DESCRIPTION
https://github.com/arangodb/arangodb/pull/23012 was apparently be merged after the v3.12.10 release and the `introducedIn` field wasn't updated.