### PR TITLE
Another attempt at fixing the out of sync shards metric.

### DIFF
--- a/arangod/Cluster/FollowerInfo.cpp
+++ b/arangod/Cluster/FollowerInfo.cpp
@@ -116,13 +116,12 @@ VPackSlice planShardEntry(arangodb::LogicalCollection const& col,
        std::to_string(col.planId().id()), "shards", col.name()}));
 }
 
-bool checkWriteConcernCondition(
-    std::shared_ptr<std::vector<ServerID>> const& followers,
-    LogicalCollection* docColl) noexcept {
-  return followers->size() + 1 >= docColl->writeConcern();
-}
-
 }  // namespace
+
+bool FollowerInfo::checkWriteConcernCondition() const noexcept {
+  return !_theLeader.empty() ||
+         _followers->size() + 1 >= _docColl->writeConcern();
+}
 
 FollowerInfo::FollowerInfo(LogicalCollection* d)
     : _followers(std::make_shared<std::vector<ServerID>>()),
@@ -134,7 +133,7 @@ FollowerInfo::FollowerInfo(LogicalCollection* d)
           metrics::InstrumentedBool::Metrics{
               .false_counter =
                   d->vocbase().metrics().shards_read_only_by_write_concern},
-          checkWriteConcernCondition(_followers, _docColl)) {
+          _followers->size() + 1 >= d->writeConcern()) {
   // On replicationfactor 1 we do not have any failover servers to maintain.
   // This should also disable satellite tracking.
 }
@@ -184,7 +183,7 @@ Result FollowerInfo::add(ServerID const& sid) {
     v = std::make_shared<std::vector<ServerID>>(*_followers);
     v->push_back(sid);  // add a single entry
     _followers = v;     // will cast to std::vector<ServerID> const
-    _writeConcernReached = checkWriteConcernCondition(_followers, _docColl);
+    _writeConcernReached = checkWriteConcernCondition();
     {
       // insertIntoCandidates
       if (std::find(_failoverCandidates->begin(), _failoverCandidates->end(),
@@ -228,7 +227,7 @@ void FollowerInfo::setTheLeader(std::string const& who) {
   WRITE_LOCKER(writeLocker, _dataLock);
   _theLeader = who;
   _theLeaderTouched = true;
-  _writeConcernReached = true;
+  _writeConcernReached = checkWriteConcernCondition();
 }
 
 // conditionally change the leader, in case the current leader is still the
@@ -246,7 +245,7 @@ bool FollowerInfo::setTheLeaderConditional(std::string const& expected,
   // old leader was as expected. now change it and return success.
   _theLeader = actual;
   _theLeaderTouched = true;
-  _writeConcernReached = true;
+  _writeConcernReached = checkWriteConcernCondition();
   return true;
 }
 
@@ -279,7 +278,7 @@ FollowerInfo::WriteState FollowerInfo::allowedToWrite() {
           << " failover-candidates = " << *_failoverCandidates;
       // Our follower list only contains followers, numFollowers + leader
       // needs to be at least writeConcern.
-      TRI_ASSERT(checkWriteConcernCondition(_followers, _docColl))
+      TRI_ASSERT(checkWriteConcernCondition())
           << "followers.size() = " << _followers->size()
           << " write-concern = " << _docColl->writeConcern();
       TRI_ASSERT(_writeConcernReached);
@@ -322,7 +321,7 @@ void FollowerInfo::invalidateCanWrite() {
   WRITE_LOCKER(canWriteLocker, _canWriteLock);
   WRITE_LOCKER(dataLocker, _dataLock);
   _canWrite = false;
-  _writeConcernReached = checkWriteConcernCondition(_followers, _docColl);
+  _writeConcernReached = checkWriteConcernCondition();
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -401,7 +400,7 @@ Result FollowerInfo::remove(ServerID const& sid) {
   Result agencyRes =
       persistInAgency(/*isRemove*/ true, /*acquireDataLock*/ false);
   if (agencyRes.ok()) {
-    _writeConcernReached = checkWriteConcernCondition(_followers, _docColl);
+    _writeConcernReached = checkWriteConcernCondition();
     // +1 for the leader (me)
     if (_followers->size() + 1 < _docColl->writeConcern()) {
       _canWrite = false;
@@ -443,7 +442,7 @@ void FollowerInfo::clear() {
   _followers = std::make_shared<std::vector<ServerID>>();
   _failoverCandidates = std::make_shared<std::vector<ServerID>>();
   _canWrite = false;
-  _writeConcernReached = checkWriteConcernCondition(_followers, _docColl);
+  _writeConcernReached = checkWriteConcernCondition();
 }
 
 void FollowerInfo::clearWriteConcernMetric() {
@@ -533,10 +532,10 @@ void FollowerInfo::takeOverLeadership(
   }
 
   _canWrite = false;
-  _writeConcernReached = checkWriteConcernCondition(_followers, _docColl);
   // Take over leadership
   _theLeader.clear();
   _theLeaderTouched = true;
+  _writeConcernReached = checkWriteConcernCondition();
 }
 
 /// @brief Update the current information in the Agency. We update the failover-
@@ -558,7 +557,7 @@ bool FollowerInfo::updateFailoverCandidates() {
 #endif
     return _canWrite;
   }
-  TRI_ASSERT(checkWriteConcernCondition(_followers, _docColl));
+  TRI_ASSERT(checkWriteConcernCondition());
   // Update both lists (we use a copy here, as we are modifying them in other
   // places individually!)
   _failoverCandidates = std::make_shared<std::vector<ServerID>>(*_followers);
@@ -581,7 +580,7 @@ bool FollowerInfo::updateFailoverCandidates() {
     TRI_ASSERT(!_canWrite);
   } else {
     _canWrite = true;
-    _writeConcernReached = checkWriteConcernCondition(_followers, _docColl);
+    _writeConcernReached = checkWriteConcernCondition();
   }
   return _canWrite;
 }

--- a/arangod/Cluster/FollowerInfo.h
+++ b/arangod/Cluster/FollowerInfo.h
@@ -187,6 +187,7 @@ class FollowerInfo {
   /// @brief inject the information about "servers" and "failoverCandidates".
   /// must be called with _dataLock locked.
   void injectFollowerInfoInternal(velocypack::Builder& builder) const;
+  bool checkWriteConcernCondition() const noexcept;
 
   bool updateFailoverCandidates();
 

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -1053,13 +1053,6 @@ Result LogicalCollection::properties(velocypack::Slice slice) {
 
       writeConcern = writeConcernSlice.getNumber<size_t>();
 
-      // Invalidate the _canWrite flag in FollowerInfo since writeConcern
-      // has changed. This ensures the write condition
-      // will be re-evaluated on the next write attempt.
-      if (_followers != nullptr) {
-        _followers->invalidateCanWrite();
-      }
-
       if (ServerState::instance()->isCoordinator() &&
           writeConcern > replicationFactor) {
         return Result(TRI_ERROR_BAD_PARAMETER,
@@ -1098,8 +1091,17 @@ Result LogicalCollection::properties(velocypack::Slice slice) {
   TRI_ASSERT(!isSatellite() || replicationFactor == 0);
   _waitForSync = Helper::getBooleanValue(
       slice, StaticStrings::WaitForSyncString, _waitForSync);
+  bool const writeConcernChanged = writeConcern != this->writeConcern();
   _sharding->setWriteConcernAndReplicationFactor(writeConcern,
                                                  replicationFactor);
+
+  // Invalidate the _canWrite flag in FollowerInfo so that the write condition
+  // is re-evaluated on the next write attempt. This has to happen after the new
+  // writeConcern is stored, otherwise FollowerInfo re-evaluates against the old
+  // one.
+  if (writeConcernChanged && _followers != nullptr) {
+    _followers->invalidateCanWrite();
+  }
 
   if (ServerState::instance()->isDBServer()) {
     // This code is only allowed to be executed by the maintenance

--- a/tests/js/client/shell/shell-write-concern-read-only-metric-cluster.js
+++ b/tests/js/client/shell/shell-write-concern-read-only-metric-cluster.js
@@ -176,6 +176,45 @@ function WriteConcernReadOnlyMetricSuite() {
 
       eventuallyAssertMetric(leader, metricName, (v) => v === 0, `expected ${metricName} to be 0 after database drop`);
     },
+
+    testFollowerNotCountedAfterWriteConcernChange: function () {
+
+      const c = db._create("c", {numberOfShards: 1, replicationFactor: 3, writeConcern: 2});
+      const [shard, servers] = Object.entries(c.shards(true))[0];
+      const instances = servers.map((id) => IM.getInstanceByID(id));
+
+      c.insert({});
+      waitForShardsInSync(c.name());
+
+      const assertNoneCounted = function (context) {
+        instances.forEach((server, i) => {
+          eventuallyAssertMetric(server, metricName, (v) => v === 0,
+            `expected ${metricName} to be 0 on ${i === 0 ? "the leader" : "follower " + i} ${context}`);
+        });
+      };
+
+      assertNoneCounted("in a healthy state");
+
+      // Raising writeConcern makes the maintenance push the new properties to
+      // every replica. A follower does not maintain a follower list, so it must
+      // not be counted, and nothing on a follower would ever recompute it.
+      const setWriteConcern = function (value) {
+        c.properties({writeConcern: value});
+        let tries = 20;
+        while (c.properties().writeConcern !== value) {
+          if (--tries === 0) {
+            assertTrue(false, `writeConcern change to ${value} was not applied within 10 seconds`);
+          }
+          internal.wait(0.5);
+        }
+      };
+
+      setWriteConcern(3);
+      assertNoneCounted("after raising writeConcern to 3");
+
+      setWriteConcern(2);
+      assertNoneCounted("after lowering writeConcern to 2");
+    },
   };
 }
 


### PR DESCRIPTION
When changing the write concern, we first invalidated and then changed the actual value. This would mess up the metric and could cause drift as we see on customer sites. 