### PR TITLE
[COR-650] Allow inserting documents with _created attribute into time travel collection

### DIFF
--- a/arangod/RocksDBEngine/Methods/RocksDBReadOnlyMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBReadOnlyMethods.cpp
@@ -55,7 +55,7 @@ rocksdb::Status RocksDBReadOnlyMethods::Get(rocksdb::ColumnFamilyHandle* cf,
                                             ReadOwnWrites) {
   TRI_ASSERT(cf != nullptr);
   TRI_ASSERT(_readOptions.snapshot != nullptr);
-  return _db->Get(_readOptions, cf, key, val);
+  return _db->Get(withUdtReadTimestamp(_readOptions, cf), cf, key, val);
 }
 
 std::unique_ptr<rocksdb::Iterator> RocksDBReadOnlyMethods::NewIterator(

--- a/arangod/RocksDBEngine/Methods/RocksDBSingleOperationReadOnlyMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBSingleOperationReadOnlyMethods.cpp
@@ -46,7 +46,7 @@ rocksdb::Status RocksDBSingleOperationReadOnlyMethods::Get(
     rocksdb::ColumnFamilyHandle* cf, rocksdb::Slice const& key,
     rocksdb::PinnableSlice* val, ReadOwnWrites) {
   TRI_ASSERT(cf != nullptr);
-  return _db->Get(_readOptions, cf, key, val);
+  return _db->Get(withUdtReadTimestamp(_readOptions, cf), cf, key, val);
 }
 
 std::unique_ptr<rocksdb::Iterator>

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.cpp
@@ -31,6 +31,8 @@
 
 #include <absl/cleanup/cleanup.h>
 #include <absl/strings/str_cat.h>
+#include <rocksdb/comparator.h>
+#include <rocksdb/db.h>
 #include <rocksdb/utilities/write_batch_with_index.h>
 
 using namespace arangodb;
@@ -187,12 +189,26 @@ Result RocksDBTrxBaseMethods::addOperation(
   return {};
 }
 
+Result RocksDBTrxBaseMethods::setCommitTimestamp(uint64_t ts) {
+  // A rocksdb transaction stamps all its UDT column families with one commit
+  // timestamp, so every time-travel write in this transaction must agree on it.
+  // (Per-document timestamps would need the WriteBatch per-key timestamp API,
+  // which WBWI does not support - out of scope for the PoC.)
+  if (_commitTimestamp.has_value() && _commitTimestamp.value() != ts) {
+    return {TRI_ERROR_BAD_PARAMETER,
+            "all documents written in a single time-travel transaction must "
+            "use the same _created timestamp"};
+  }
+  _commitTimestamp = ts;
+  return {};
+}
+
 rocksdb::Status RocksDBTrxBaseMethods::Get(rocksdb::ColumnFamilyHandle* cf,
                                            rocksdb::Slice const& key,
                                            rocksdb::PinnableSlice* val,
                                            ReadOwnWrites readOwnWrites) {
   TRI_ASSERT(cf != nullptr);
-  rocksdb::ReadOptions const& ro = _readOptions;
+  rocksdb::ReadOptions ro = withUdtReadTimestamp(_readOptions, cf);
   TRI_ASSERT(ro.snapshot != nullptr || _state->options().avoidSnapshot);
   if (readOwnWrites == ReadOwnWrites::yes) {
     return _rocksTransaction->Get(ro, cf, key, val);
@@ -205,9 +221,30 @@ rocksdb::Status RocksDBTrxBaseMethods::GetForUpdate(
     rocksdb::PinnableSlice* val) {
   TRI_ASSERT(cf != nullptr);
   TRI_ASSERT(_rocksTransaction);
-  rocksdb::ReadOptions const& ro = _readOptions;
-  TRI_ASSERT(ro.snapshot != nullptr || _state->options().avoidSnapshot);
-  rocksdb::Status s = _rocksTransaction->GetForUpdate(ro, cf, key, val);
+  TRI_ASSERT(_readOptions.snapshot != nullptr ||
+             _state->options().avoidSnapshot);
+  // GetForUpdate locks the document key - which, on a UDT (time-travel) column
+  // family, covers every version of that key - and reads the latest version to
+  // check existence. It carries no read timestamp on purpose: the lock always
+  // targets the latest version, which is what serializes writes on a key.
+  //
+  // Under UDT, RocksDB validates write-write conflicts by timestamp rather than
+  // by snapshot, and a validated GetForUpdate would require a validation read
+  // timestamp strictly below the commit timestamp (coupling it to _created).
+  // We don't want that, so validation is disabled; RocksDB in turn forbids a
+  // snapshot on a non-validating GetForUpdate, so it is dropped here. The
+  // exclusive lock alone provides the write-write conflict protection we need.
+  // TODO(COR-951) - fix validation to ensure we have no lost updates
+  bool const udt = cf->GetComparator()->timestamp_size() > 0;
+  rocksdb::Status s;
+  if (udt) {
+    rocksdb::ReadOptions ro = _readOptions;
+    ro.snapshot = nullptr;
+    s = _rocksTransaction->GetForUpdate(ro, cf, key, val, /*exclusive*/ true,
+                                        /*do_validate*/ false);
+  } else {
+    s = _rocksTransaction->GetForUpdate(_readOptions, cf, key, val);
+  }
   if (s.ok()) {
     _memoryTracker.increaseMemoryUsage(
         lockOverhead(!_state->isOnlyExclusiveTransaction(), key.size()));
@@ -513,6 +550,16 @@ Result RocksDBTrxBaseMethods::doCommitImpl() {
                     _rocksTransaction->GetNumDeletes() +
                     _rocksTransaction->GetNumMerges();
 
+  // Time travel: stamp the commit timestamp onto every User-Defined Timestamp
+  // column family this transaction wrote to (the write timestamp = the
+  // document's _created). Non-UDT families are left untouched by RocksDB.
+  if (_commitTimestamp.has_value()) {
+    rocksdb::Status ts =
+        _rocksTransaction->SetCommitTimestamp(*_commitTimestamp);
+    if (!ts.ok()) {
+      return rocksutils::convertStatus(ts);
+    }
+  }
   rocksdb::Status s = _rocksTransaction->Commit();
   if (!s.ok()) {  // cleanup performed by scope-guard
     return rocksutils::convertStatus(s);

--- a/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.h
+++ b/arangod/RocksDBEngine/Methods/RocksDBTrxBaseMethods.h
@@ -22,12 +22,11 @@
 
 #pragma once
 
-#include "Aql/QueryContext.h"
-#include "Containers/SmallVector.h"
 #include "RocksDBEngine/RocksDBMethodsMemoryTracker.h"
 #include "RocksDBEngine/RocksDBTransactionMethods.h"
 
 #include <cstdint>
+#include <optional>
 
 namespace arangodb {
 struct ResourceMonitor;
@@ -119,6 +118,8 @@ class RocksDBTrxBaseMethods : public RocksDBTransactionMethods {
                                RocksDBKey const&) final override;
   void PutLogData(rocksdb::Slice const&) final override;
 
+  Result setCommitTimestamp(uint64_t ts) final override;
+
   void SetSavePoint() final override;
   rocksdb::Status RollbackToSavePoint() final override;
   rocksdb::Status RollbackToWriteBatchSavePoint() final override;
@@ -171,6 +172,12 @@ class RocksDBTrxBaseMethods : public RocksDBTransactionMethods {
 
   /// @brief object used for tracking memory usage
   RocksDBMethodsMemoryTracker _memoryTracker;
+
+  /// @brief commit timestamp for User-Defined Timestamp column families (time
+  /// travel). Set from a document's _created on time-travel writes and applied
+  /// via SetCommitTimestamp just before Commit(). Unset for ordinary
+  /// transactions, which leaves non-UDT commits untouched.
+  std::optional<uint64_t> _commitTimestamp;
 
   bool _indexingDisabled{false};
 };

--- a/arangod/RocksDBEngine/RocksDBCollection.cpp
+++ b/arangod/RocksDBEngine/RocksDBCollection.cpp
@@ -418,6 +418,8 @@ Result RocksDBCollection::updateProperties(velocypack::Slice slice) {
   }
 
   // nothing else to do
+  // Changes to immutable properties are simply ignored here. This could be
+  // unexpected - we should consider returning an error instead.
   return {};
 }
 
@@ -1496,7 +1498,21 @@ Result RocksDBCollection::insertDocument(transaction::Methods* trx,
   Result res;
 
   RocksDBTransactionState* state = RocksDBTransactionState::toState(trx);
-  RocksDBMethods* mthds = state->rocksdbMethods(_logicalCollection.id());
+  auto* mthds = state->rocksdbMethods(_logicalCollection.id());
+
+  // Time travel: the write timestamp is the document's _created attribute
+  // (materialized into the body by newObjectForInsert, so it is present here).
+  // It becomes the commit timestamp for the UDT primary-index write. All
+  // documents in one transaction must share it (single commit timestamp per
+  // rocksdb transaction), which setCommitTimestamp enforces.
+  if (timeTravelEnabled()) {
+    VPackSlice created = doc.get(StaticStrings::Created);
+    TRI_ASSERT(created.isNumber());
+    res = mthds->setCommitTimestamp(created.getNumber<uint64_t>());
+    if (res.fail()) {
+      return res;
+    }
+  }
 
   auto const& indexes = indexesSnapshot.getIndexes();
 

--- a/arangod/RocksDBEngine/RocksDBCollection.h
+++ b/arangod/RocksDBEngine/RocksDBCollection.h
@@ -158,7 +158,9 @@ class RocksDBCollection final : public RocksDBMetaCollection {
 
   // Whether this collection stores time-travel history
   // Immutable, set at creation.
-  bool timeTravelEnabled() const noexcept { return _timeTravelEnabled; }
+  bool timeTravelEnabled() const noexcept override {
+    return _timeTravelEnabled;
+  }
 
   bool hasDocuments() override;
 

--- a/arangod/RocksDBEngine/RocksDBTransactionMethods.cpp
+++ b/arangod/RocksDBEngine/RocksDBTransactionMethods.cpp
@@ -23,7 +23,26 @@
 #include "RocksDBTransactionMethods.h"
 #include "RocksDBEngine/RocksDBTransactionState.h"
 
+#include <rocksdb/comparator.h>
+#include <rocksdb/db.h>
+
 using namespace arangodb;
+
+rocksdb::ReadOptions RocksDBTransactionMethods::withUdtReadTimestamp(
+    rocksdb::ReadOptions const& base, rocksdb::ColumnFamilyHandle* cf) {
+  TRI_ASSERT(cf != nullptr);
+  if (cf->GetComparator()->timestamp_size() == 0) {
+    // Not a User-Defined Timestamp column family: a timestamp would be
+    // rejected, so read as-is.
+    return base;
+  }
+  // Read the current state. MaxU64Ts() is a Slice over static storage, so it is
+  // safe to keep the Slice object in a static as well.
+  static const rocksdb::Slice kCurrentStateTimestamp = rocksdb::MaxU64Ts();
+  rocksdb::ReadOptions ro = base;
+  ro.timestamp = &kCurrentStateTimestamp;
+  return ro;
+}
 
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
 std::size_t RocksDBTransactionMethods::countInBounds(

--- a/arangod/RocksDBEngine/RocksDBTransactionMethods.h
+++ b/arangod/RocksDBEngine/RocksDBTransactionMethods.h
@@ -108,12 +108,28 @@ class RocksDBTransactionMethods : public RocksDBMethods {
   virtual rocksdb::Status RollbackToWriteBatchSavePoint() = 0;
   virtual void PopSavePoint() = 0;
 
+  /// @brief record the commit timestamp applied to User-Defined Timestamp
+  /// column families (time travel) when this transaction commits. A rocksdb
+  /// transaction commits its UDT families with a single timestamp, so every
+  /// time-travel write in the same transaction must agree on it; a conflicting
+  /// timestamp is rejected. No-op for methods that do not commit a rocksdb
+  /// transaction. See RocksDBTrxBaseMethods.
+  virtual Result setCommitTimestamp(uint64_t /*ts*/) { return {}; }
+
 #ifdef ARANGODB_ENABLE_MAINTAINER_MODE
   std::size_t countInBounds(RocksDBKeyBounds const& bounds,
                             bool isElementInRange = false);
 #endif
 
  protected:
+  /// @brief User-Defined Timestamp column families (time travel) require a read
+  /// timestamp on every read, while non-UDT families reject one, so it must be
+  /// applied per column family. For a UDT `cf` this returns a copy of `base`
+  /// reading the current state (kMax timestamp); for any other `cf` it returns
+  /// `base` unchanged.
+  static rocksdb::ReadOptions withUdtReadTimestamp(
+      rocksdb::ReadOptions const& base, rocksdb::ColumnFamilyHandle* cf);
+
   RocksDBTransactionState* _state;
 };
 

--- a/arangod/StorageEngine/PhysicalCollection.h
+++ b/arangod/StorageEngine/PhysicalCollection.h
@@ -268,6 +268,10 @@ class PhysicalCollection {
 
   virtual bool cacheEnabled() const noexcept = 0;
 
+  // Whether this collection stores time-travel history. Only the RocksDB
+  // engine supports it; the default is "off" for every other implementation.
+  virtual bool timeTravelEnabled() const noexcept { return false; }
+
  protected:
   explicit PhysicalCollection(LogicalCollection& collection);
 

--- a/arangod/Transaction/Helpers.cpp
+++ b/arangod/Transaction/Helpers.cpp
@@ -720,17 +720,38 @@ Result newObjectForInsert(Methods& trx, LogicalCollection& collection,
     b->add(StaticStrings::RevString, revisionId.toValuePair(ridBuffer));
   }
 
+  // _created / _expired: time-travel collections stamp every version with the
+  // user-supplied creation timestamp and a null expiry. The user must provide
+  // _created explicitly (the PoC does not auto-generate it); a missing or
+  // non-numeric value is rejected. Any user-supplied _expired on insert is
+  // ignored - a freshly inserted version is always live.
+  bool const timeTravel = collection.timeTravelEnabled();
+  if (timeTravel) {
+    VPackSlice created = value.get(StaticStrings::Created);
+    if (!created.isNumber()) {
+      return Result(TRI_ERROR_BAD_PARAMETER,
+                    "time-travel collections require a numeric '_created' "
+                    "timestamp on insert");
+    }
+    b->add(StaticStrings::Created, created);
+    b->add(StaticStrings::Expired, VPackSlice::nullSlice());
+  }
+
   containers::FlatHashSet<std::string_view> keysWritten;
 
   // add other attributes after the system attributes
   VPackObjectIterator it(value, true);
   while (it.valid()) {
     auto key = it.key().stringView();
-    // _id, _key, _rev, _from, _to. minimum size here is 3
+    // _id, _key, _rev, _from, _to. minimum size here is 3. for time-travel
+    // collections _created/_expired are system attributes too (added above),
+    // so they must not be copied again from the user input.
     if (key.size() < 3 || key[0] != '_' ||
         (key != StaticStrings::KeyString && key != StaticStrings::IdString &&
          key != StaticStrings::RevString && key != StaticStrings::FromString &&
-         key != StaticStrings::ToString)) {
+         key != StaticStrings::ToString &&
+         !(timeTravel &&
+           (key == StaticStrings::Created || key == StaticStrings::Expired)))) {
       b->add(key, it.value());
       if (batchOptions.computedValues != nullptr) {
         // track which attributes we have produced so that they are not

--- a/arangod/VocBase/LogicalCollection.cpp
+++ b/arangod/VocBase/LogicalCollection.cpp
@@ -340,6 +340,10 @@ bool LogicalCollection::cacheEnabled() const noexcept {
   return _physical->cacheEnabled();
 }
 
+bool LogicalCollection::timeTravelEnabled() const noexcept {
+  return _physical->timeTravelEnabled();
+}
+
 bool LogicalCollection::supportsRBAC() const noexcept {
   return _supportsRBAC.load();
 }

--- a/arangod/VocBase/LogicalCollection.h
+++ b/arangod/VocBase/LogicalCollection.h
@@ -165,6 +165,7 @@ class LogicalCollection : public LogicalDataSource {
   RevisionId revision(transaction::Methods*) const;
   bool waitForSync() const noexcept;
   bool cacheEnabled() const noexcept;
+  bool timeTravelEnabled() const noexcept;
   bool supportsRBAC() const noexcept;
 #ifdef USE_ENTERPRISE
   bool isDisjoint() const noexcept { return _isDisjoint; }

--- a/lib/Basics/StaticStrings.cpp
+++ b/lib/Basics/StaticStrings.cpp
@@ -47,6 +47,8 @@ std::string const StaticStrings::PostfixOfKeyString(":_key");
 std::string const StaticStrings::RevString("_rev");
 std::string const StaticStrings::FromString("_from");
 std::string const StaticStrings::ToString("_to");
+std::string const StaticStrings::Created("_created");
+std::string const StaticStrings::Expired("_expired");
 
 // URL parameter names
 std::string const StaticStrings::IgnoreRevsString("ignoreRevs");

--- a/lib/Basics/StaticStrings.h
+++ b/lib/Basics/StaticStrings.h
@@ -53,6 +53,8 @@ class StaticStrings {
   static std::string const RevString;
   static std::string const FromString;
   static std::string const ToString;
+  static std::string const Created;  // time-travel version validity start
+  static std::string const Expired;  // time-travel version validity end
 
   // URL parameter names
   static std::string const IgnoreRevsString;

--- a/tests/RocksDBEngine/StorageEngineDocumentTest.h
+++ b/tests/RocksDBEngine/StorageEngineDocumentTest.h
@@ -52,14 +52,21 @@ namespace arangodb::tests {
 // posting to one. Most tests use the committed-single-op helpers (insertR /
 // updateR / read): each write commits in its own transaction and is verified by
 // reading it back in a separate one, so the default pattern exercises persisted
-// visibility. Tests that need multi-op or read-own-writes behaviour instead
+// visibility. Tests that need multi-op or read-own-writes behavior instead
 // drive a SingleCollectionTransaction directly (see the transaction-lifecycle
 // group in DocumentTest.cpp).
-class StorageEngineDocumentTest : public StorageEngineDataTest {
+//
+// Parameterized on the base data-test fixture, which selects plain vs.
+// time-travel engine and carries the matching `timeTravelEnabled` flag, so the
+// same helpers serve both worlds and the collection can never disagree with the
+// engine it runs on.
+template<class BaseDataTest>
+class BasicStorageEngineDocumentTest : public BaseDataTest {
  protected:
   void SetUp() override {
-    _database = makeDatabase("testDatabase", 42);
-    _collection = makeCollection(*_database, "testCollection");
+    _database = this->makeDatabase("testDatabase", 42);
+    _collection = this->makeCollection(*_database, "testCollection",
+                                       BaseDataTest::timeTravelEnabled);
   }
 
   void TearDown() override {
@@ -220,5 +227,11 @@ class StorageEngineDocumentTest : public StorageEngineDataTest {
   std::unique_ptr<Database> _database;
   std::shared_ptr<LogicalCollection> _collection;
 };
+
+using StorageEngineDocumentTest =
+    BasicStorageEngineDocumentTest<StorageEngineDataTest>;
+
+using TimeTravelStorageEngineDocumentTest =
+    BasicStorageEngineDocumentTest<TimeTravelStorageEngineDataTest>;
 
 }  // namespace arangodb::tests

--- a/tests/RocksDBEngine/TimeTravelTest.cpp
+++ b/tests/RocksDBEngine/TimeTravelTest.cpp
@@ -30,8 +30,11 @@
 #include "Basics/StaticStrings.h"
 #include "RocksDBEngine/RocksDBCollection.h"
 #include "RocksDBEngine/RocksDBColumnFamilyManager.h"
+#include "RocksDBEngine/RocksDBEngine.h"
+#include "RocksDBEngine/RocksDBKey.h"
 #include "RocksDBEngine/RocksDBPrimaryIndex.h"
 #include "RocksDBEngine/StorageEngineDataTest.h"
+#include "RocksDBEngine/StorageEngineDocumentTest.h"
 #include "RocksDBEngine/StorageEngineFixture.h"
 #include "VocBase/LogicalCollection.h"
 
@@ -52,11 +55,8 @@ TEST_F(TimeTravelStorageEngineFixture, PrimaryIndexTtColumnFamilyIsUdt) {
   rocksdb::ColumnFamilyHandle* ttCf = RocksDBColumnFamilyManager::get(
       RocksDBColumnFamilyManager::Family::PrimaryIndex_TT);
   ASSERT_NE(ttCf, nullptr);
-  // ts_sz = 8: the comparator carries an 8-byte timestamp.
   EXPECT_EQ(ttCf->GetComparator()->timestamp_size(), 8u);
 
-  // The non-UDT primary index remains a plain comparator (no timestamp),
-  // confirming the UDT comparator is scoped to the TT family only.
   rocksdb::ColumnFamilyHandle* primaryCf = RocksDBColumnFamilyManager::get(
       RocksDBColumnFamilyManager::Family::PrimaryIndex);
   ASSERT_NE(primaryCf, nullptr);
@@ -127,4 +127,171 @@ TEST_F(TimeTravelStorageEngineDataTest, TimeTravelFlagIsImmutable) {
 
   EXPECT_TRUE(
       toRocksDBCollection(collection->getPhysical())->timeTravelEnabled());
+}
+
+TEST_F(TimeTravelStorageEngineDataTest,
+       RegularCollectionCannotEnableTimeTravel) {
+  auto database = makeDatabase("testDatabase", 42);
+  auto collection =
+      makeCollection(*database, "plainCollection", /*timeTravel*/ false);
+
+  VPackBuilder update;
+  update.openObject();
+  update.add(StaticStrings::EnableTimeTravel, VPackValue(true));
+  update.close();
+
+  auto res = collection->getPhysical()->updateProperties(update.slice());
+  EXPECT_TRUE(res.ok()) << res.errorMessage();
+
+  EXPECT_FALSE(
+      toRocksDBCollection(collection->getPhysical())->timeTravelEnabled());
+}
+
+// ================ insert with custom _created ================
+
+namespace {
+
+VPackString createdDoc(std::string_view key, int value, uint64_t created) {
+  VPackBuilder b;
+  b.openObject();
+  b.add(StaticStrings::KeyString, VPackValue(key));
+  b.add("value", VPackValue(value));
+  b.add(StaticStrings::Created, VPackValue(created));
+  b.close();
+  return VPackString{b.slice()};
+}
+
+}  // namespace
+
+TEST_F(TimeTravelStorageEngineDocumentTest, InsertStampsCreatedAndNullExpired) {
+  auto doc = createdDoc("k1", 42, /*created*/ 1000);
+  auto ins = insertR(doc.slice());
+  ASSERT_TRUE(ins.ok()) << ins.errorMessage();
+
+  auto res = read("k1");
+  ASSERT_TRUE(res.ok()) << res.errorMessage();
+  auto slice = res.slice();
+  ASSERT_TRUE(slice.get(StaticStrings::Created).isNumber()) << slice.toJson();
+  EXPECT_EQ(slice.get(StaticStrings::Created).getNumber<uint64_t>(), 1000u);
+  EXPECT_TRUE(slice.get(StaticStrings::Expired).isNull()) << slice.toJson();
+  EXPECT_EQ(slice.get("value").getNumber<int>(), 42);
+}
+
+TEST_F(TimeTravelStorageEngineDocumentTest, InsertWithoutCreatedIsRejected) {
+  VPackBuilder b;
+  b.openObject();
+  b.add(StaticStrings::KeyString, VPackValue("k1"));
+  b.add("value", VPackValue(42));
+  b.close();
+
+  auto ins = insertR(b.slice());
+  ASSERT_TRUE(ins.fail());
+  EXPECT_EQ(ins.errorNumber(), TRI_ERROR_BAD_PARAMETER) << ins.errorMessage();
+
+  EXPECT_TRUE(read("k1").fail());
+}
+
+TEST_F(TimeTravelStorageEngineDocumentTest,
+       InsertWithNonNumericCreatedIsRejected) {
+  VPackBuilder b;
+  b.openObject();
+  b.add(StaticStrings::KeyString, VPackValue("k1"));
+  b.add("value", VPackValue(42));
+  b.add(StaticStrings::Created, VPackValue("not-a-number"));
+  b.close();
+
+  auto ins = insertR(b.slice());
+  ASSERT_TRUE(ins.fail());
+  EXPECT_EQ(ins.errorNumber(), TRI_ERROR_BAD_PARAMETER) << ins.errorMessage();
+  EXPECT_TRUE(read("k1").fail());
+}
+
+TEST_F(StorageEngineDocumentTest,
+       NonTimeTravelInsertDoesNotMaterializeExpired) {
+  auto doc = createdDoc("k1", 42, /*created*/ 1000);
+  auto ins = insertR(doc.slice());
+  ASSERT_TRUE(ins.ok()) << ins.errorMessage();
+
+  auto res = read("k1");
+  ASSERT_TRUE(res.ok()) << res.errorMessage();
+  auto slice = res.slice();
+  EXPECT_TRUE(slice.get(StaticStrings::Expired).isNone()) << slice.toJson();
+  // _created was carried through verbatim as a plain attribute.
+  EXPECT_EQ(slice.get(StaticStrings::Created).getNumber<uint64_t>(), 1000u);
+}
+
+// Proves the primary-index entry was actually written at the UDT timestamp T1
+// (not merely "some timestamp"): a raw Get on the PrimaryIndex_TT family finds
+// the entry at and after T1 but not strictly before it. Point-in-time reads
+// through the engine arrive with COR-652.
+TEST_F(TimeTravelStorageEngineDocumentTest,
+       PrimaryIndexEntryLivesAtCreatedTimestamp) {
+  constexpr uint64_t T1 = 1000;
+  ASSERT_TRUE(insertR(createdDoc("k1", 42, T1).slice()).ok());
+
+  auto* index = toRocksDBCollection(_collection->getPhysical())->primaryIndex();
+  RocksDBKey key;
+  key.constructPrimaryIndexValue(index->objectId(), "k1");
+
+  rocksdb::ColumnFamilyHandle* cf = RocksDBColumnFamilyManager::get(
+      RocksDBColumnFamilyManager::Family::PrimaryIndex_TT);
+
+  auto getAt = [&](uint64_t ts) {
+    std::string tsBuf;
+    rocksdb::Slice tsSlice = rocksdb::EncodeU64Ts(ts, &tsBuf);
+    rocksdb::ReadOptions ro;
+    ro.timestamp = &tsSlice;
+    rocksdb::PinnableSlice val;
+    return engine().db()->Get(ro, cf, key.string(), &val);
+  };
+
+  EXPECT_TRUE(getAt(T1).ok());
+  EXPECT_TRUE(getAt(T1 + 1000).ok());
+  EXPECT_TRUE(getAt(T1 - 1).IsNotFound());
+}
+
+// A rocksdb transaction commits its UDT families with a single timestamp, so
+// two documents written in one transaction with different _created values
+// cannot both be honored - the second write is rejected.
+TEST_F(TimeTravelStorageEngineDocumentTest,
+       MixedCreatedTimestampsInOneTransactionRejected) {
+  SingleCollectionTransaction trx{context(), *_collection,
+                                  AccessMode::Type::WRITE};
+  ASSERT_TRUE(trx.begin().ok());
+  OperationOptions options;
+
+  auto r1 = trx.insert(_collection->name(), createdDoc("k1", 1, 1000).slice(),
+                       options);
+  ASSERT_TRUE(r1.ok()) << r1.errorMessage();
+
+  auto r2 = trx.insert(_collection->name(), createdDoc("k2", 2, 2000).slice(),
+                       options);
+  EXPECT_TRUE(r2.fail());
+  EXPECT_EQ(r2.errorNumber(), TRI_ERROR_BAD_PARAMETER) << r2.errorMessage();
+
+  std::ignore = trx.finish(r2.result);
+}
+
+TEST_F(TimeTravelStorageEngineDocumentTest,
+       SharedCreatedTimestampInOneTransactionCommits) {
+  {
+    SingleCollectionTransaction trx{context(), *_collection,
+                                    AccessMode::Type::WRITE};
+    ASSERT_TRUE(trx.begin().ok());
+    OperationOptions options;
+    ASSERT_TRUE(trx.insert(_collection->name(),
+                           createdDoc("k1", 1, 1000).slice(), options)
+                    .ok());
+    ASSERT_TRUE(trx.insert(_collection->name(),
+                           createdDoc("k2", 2, 1000).slice(), options)
+                    .ok());
+    ASSERT_TRUE(trx.finish(Result{}).ok());
+  }
+
+  auto a = read("k1");
+  ASSERT_TRUE(a.ok()) << a.errorMessage();
+  EXPECT_EQ(a.slice().get(StaticStrings::Created).getNumber<uint64_t>(), 1000u);
+  auto b = read("k2");
+  ASSERT_TRUE(b.ok()) << b.errorMessage();
+  EXPECT_EQ(b.slice().get(StaticStrings::Created).getNumber<uint64_t>(), 1000u);
 }


### PR DESCRIPTION
### Scope & Purpose

ATM we still have some limitations:
  - only inserts (no updates or removes)
  - all documents inserted in the same transaction must have identical timestamps

- [x] :pizza: New feature

### Checklist

- [x] Tests
  - [x] C++ **Unit tests**