### PR TITLE
Add new mode for AqlValue for query-static memory.

### DIFF
--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -46,6 +46,9 @@
 namespace arangodb::aql {
 
 void AqlValue::setPointer(uint8_t const* pointer) noexcept {
+  // the pointer layouts leave bytes 1-7 unused, but isBorrowed() reads byte 1,
+  // so it must be defined rather than whatever was on the stack
+  _data.words[0] = 0;
   setType(AqlValueType::VPACK_SLICE_POINTER);
   _data.slicePointerMeta.pointer = pointer;
 }
@@ -1035,6 +1038,7 @@ AqlValue::AqlValue(DocumentData& data) noexcept {
   if (size < sizeof(AqlValue)) {
     initFromSlice(slice, size);
   } else {
+    _data.words[0] = 0;
     setType(AqlValueType::VPACK_MANAGED_STRING);
     _data.managedStringMeta.pointer = data.release();
   }
@@ -1049,6 +1053,7 @@ AqlValue::AqlValue(uint8_t const* pointer) noexcept {
 AqlValue::AqlValue(AqlValue const& other, void const* data) noexcept {
   TRI_ASSERT(data != nullptr);
   auto t = other.type();
+  _data.words[0] = 0;
   setType(t);
   switch (t) {
     case VPACK_MANAGED_SLICE:
@@ -1194,6 +1199,7 @@ AqlValue::AqlValue(VPackSlice slice, velocypack::ValueLength length) {
 }
 
 AqlValue::AqlValue(int64_t low, int64_t high) {
+  _data.words[0] = 0;
   _data.rangeMeta.range = new Range(low, high);
   setType(AqlValueType::RANGE);
 }
@@ -1218,16 +1224,45 @@ AqlValue AqlValue::fromOwnedMallocSlice(uint8_t* data, size_t length) {
 }
 
 bool AqlValue::requiresDestruction() const noexcept {
-  auto t = type();
-  switch (t) {
-    case VPACK_SLICE_POINTER:
-    case VPACK_INLINE:
-    case VPACK_INLINE_INT64:
-    case VPACK_INLINE_UINT64:
-    case VPACK_INLINE_DOUBLE:
-      return false;
-    default:
+  switch (type()) {
+    case VPACK_MANAGED_SLICE:
+    case VPACK_MANAGED_STRING:
+    case RANGE:
       return true;
+    default:
+      // inline values are self-contained and VPACK_SLICE_POINTER never owns
+      return false;
+  }
+}
+
+bool AqlValue::isStaticSlice() const noexcept {
+  return type() == VPACK_SLICE_POINTER &&
+         (_data.bytes[1] & kStaticSliceFlag) != 0;
+}
+
+bool AqlValue::isShortLivedSlice() const noexcept {
+  return type() == VPACK_SLICE_POINTER &&
+         (_data.bytes[1] & kStaticSliceFlag) == 0;
+}
+
+AqlValue AqlValue::staticSlice(uint8_t const* pointer) noexcept {
+  AqlValue result{pointer};
+  result._data.bytes[1] |= kStaticSliceFlag;
+  return result;
+}
+
+AqlValue AqlValue::borrow() const {
+  switch (type()) {
+    case VPACK_MANAGED_SLICE:
+      return AqlValue{_data.managedSliceMeta.pointer};
+    case VPACK_MANAGED_STRING:
+      return AqlValue{_data.managedStringMeta.toSlice().begin()};
+    case RANGE:
+      // a range has no pointer form, so it is treated as a value
+      return clone();
+    default:
+      // inline values and slice pointers already own nothing
+      return AqlValue{*this};
   }
 }
 

--- a/arangod/Aql/AqlValue.cpp
+++ b/arangod/Aql/AqlValue.cpp
@@ -843,9 +843,18 @@ AqlValue AqlValue::clone() const {
                       _data.managedStringMeta.getLength()};
     case RANGE:
       return AqlValue{range()->_low, range()->_high};
+    case VPACK_SLICE_POINTER:
+      if (isStaticSlice()) {
+        // the payload outlives every AqlItemBlock, so sharing it is safe and
+        // keeps plan constants from being copied per row
+        return AqlValue{*this};
+      }
+      // the payload belongs to something shorter-lived, so detach from it
+      return AqlValue{slice()};
     default:
       break;
   }
+  // inline values carry their payload in the 16 bytes themselves
   return AqlValue{*this};
 }
 

--- a/arangod/Aql/AqlValue.h
+++ b/arangod/Aql/AqlValue.h
@@ -177,6 +177,7 @@ struct AqlValue final {
  private:
   union {
     uint8_t aqlValueType;
+    uint8_t bytes[16];  // byte-addressable view; bytes[0] is aqlValueType
     uint64_t words[2];  // keep this for fast zeroing AqlValue
 
     // RANGE
@@ -269,6 +270,17 @@ struct AqlValue final {
     Malloc = 1,  // memory allocated by malloc
   };
 
+  /// @brief marks a VPACK_SLICE_POINTER whose payload outlives every
+  /// AqlItemBlock: query plan memory, AST constants, the const value block.
+  /// stored in the high bit of byte 1, which that layout leaves unused. the
+  /// inline layouts keep payload bytes in byte 1, so the flag is only ever
+  /// read after the type byte has been checked.
+  ///
+  /// the default is the opposite, a short-lived pointer, so that forgetting to
+  /// mark a static producer costs a copy rather than leaving a dangling
+  /// pointer in a block cell.
+  static constexpr uint8_t kStaticSliceFlag = 0x80;
+
  public:
   // construct an empty AqlValue
   // note: this is the default constructor and should be as cheap as possible
@@ -339,6 +351,28 @@ struct AqlValue final {
 
   /// @brief whether or not the value must be destroyed
   bool requiresDestruction() const noexcept;
+
+  /// @brief whether this is a slice pointer into memory that outlives every
+  /// AqlItemBlock. only such a pointer may be stored in a block cell without
+  /// being copied first.
+  bool isStaticSlice() const noexcept;
+
+  /// @brief whether this is a slice pointer that is only valid while whatever
+  /// it points into stays alive.
+  bool isShortLivedSlice() const noexcept;
+
+  /// @brief a value that does not own its payload, for reading only.
+  /// managed slices and strings become a short-lived slice pointer in constant
+  /// time. inline values and slice pointers are returned unchanged. a RANGE is
+  /// copied, because it has no pointer form and is treated as a value.
+  /// the caller should destroy() the result either way; that is a no-op for
+  /// everything except the range copy.
+  AqlValue borrow() const;
+
+  /// @brief a slice pointer into memory that outlives every AqlItemBlock.
+  /// only for query plan memory: Expression::_data, AstNode::_computedValue,
+  /// and the const value block.
+  static AqlValue staticSlice(uint8_t const* pointer) noexcept;
 
   /// @brief whether or not the value is empty / none
   bool isEmpty() const noexcept;

--- a/arangod/Aql/Expression.cpp
+++ b/arangod/Aql/Expression.cpp
@@ -122,7 +122,7 @@ AqlValue Expression::execute(ExpressionContext* ctx, bool& mustDestroy) {
     case ExpressionType::kJson: {
       mustDestroy = false;
       TRI_ASSERT(_data != nullptr);
-      return AqlValue(_data);
+      return AqlValue::staticSlice(_data);
     }
 
     case ExpressionType::kSimple: {
@@ -683,10 +683,10 @@ AqlValue Expression::executeSimpleExpressionArray(ExpressionContext& ctx,
     // this will not create a copy
     uint8_t const* cv = node->computedValue();
     if (cv != nullptr) {
-      return AqlValue(cv);
+      return AqlValue::staticSlice(cv);
     }
     auto builder = ThreadLocalBuilderLeaser::lease();
-    return AqlValue(node->computeValue(builder.get()).begin());
+    return AqlValue::staticSlice(node->computeValue(builder.get()).begin());
   }
 
   size_t const n = node->numMembers();
@@ -766,11 +766,11 @@ AqlValue Expression::executeSimpleExpressionObject(ExpressionContext& ctx,
     uint8_t const* cv = node->computedValue();
     if (cv != nullptr) {
       // no copy
-      return AqlValue(cv);
+      return AqlValue::staticSlice(cv);
     }
 
     auto builder = ThreadLocalBuilderLeaser::lease();
-    return AqlValue(node->computeValue(builder.get()).begin());
+    return AqlValue::staticSlice(node->computeValue(builder.get()).begin());
   }
 
   size_t const n = node->numMembers();
@@ -937,10 +937,10 @@ AqlValue Expression::executeSimpleExpressionValue(ExpressionContext& ctx,
   mustDestroy = false;
   uint8_t const* cv = node->computedValue();
   if (cv != nullptr) {
-    return AqlValue(cv);
+    return AqlValue::staticSlice(cv);
   }
   auto builder = ThreadLocalBuilderLeaser::lease();
-  return AqlValue(node->computeValue(builder.get()).begin());
+  return AqlValue::staticSlice(node->computeValue(builder.get()).begin());
 }
 
 // execute an expression of type ExpressionType::kSimple with REFERENCE

--- a/arangod/Aql/Variable.cpp
+++ b/arangod/Aql/Variable.cpp
@@ -179,7 +179,9 @@ AqlValue Variable::extractOwnedConstantValue() {
 
 void Variable::setConstantBlockReference(velocypack::Slice slice) {
   TRI_ASSERT(!slice.isNone());
-  _constantValue = AqlValue(AqlValueHintSliceNoCopy{slice});
+  // points into AqlItemBlockManager's const value block, which lives as long
+  // as the query
+  _constantValue = AqlValue::staticSlice(slice.begin());
 }
 
 std::string_view Variable::bindParameterName() const noexcept {

--- a/tests/Aql/AqlValueBorrowTest.cpp
+++ b/tests/Aql/AqlValueBorrowTest.cpp
@@ -1,0 +1,219 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Aql/AqlValue.h"
+#include "Aql/Range.h"
+
+#include <velocypack/Builder.h>
+#include <velocypack/Parser.h>
+#include <velocypack/Slice.h>
+
+#include <string>
+
+using namespace arangodb::aql;
+
+namespace {
+
+// larger than the 15 byte inline budget, so it becomes VPACK_MANAGED_SLICE
+std::shared_ptr<arangodb::velocypack::Builder> largeObject() {
+  return arangodb::velocypack::Parser::fromJson(
+      "{\"someLongAttributeName\":\"someLongAttributeValue\"}");
+}
+
+}  // namespace
+
+// Ownership is a pure function of the type byte. borrow() hands out something
+// that owns nothing, so destroying it must never touch the owner's payload.
+// These run under ASAN in CI, so a double free or use after free fails loudly.
+
+TEST(AqlValueBorrowTest, ownership_follows_the_type_byte) {
+  auto builder = largeObject();
+  AqlValue managed{builder->slice()};
+  AqlValue range{int64_t{1}, int64_t{10}};
+  AqlValue pointer{AqlValueHintSliceNoCopy{builder->slice()}};
+  AqlValue inlineValue{AqlValueHintInt{42}};
+
+  EXPECT_TRUE(managed.requiresDestruction());
+  EXPECT_TRUE(range.requiresDestruction());
+  EXPECT_FALSE(pointer.requiresDestruction());
+  EXPECT_FALSE(inlineValue.requiresDestruction());
+
+  managed.destroy();
+  range.destroy();
+}
+
+TEST(AqlValueBorrowTest, managed_slice_borrow_becomes_a_short_lived_pointer) {
+  auto builder = largeObject();
+  AqlValue owner{builder->slice()};
+  ASSERT_EQ(owner.type(), AqlValue::VPACK_MANAGED_SLICE);
+
+  {
+    AqlValue borrowed = owner.borrow();
+    EXPECT_EQ(borrowed.type(), AqlValue::VPACK_SLICE_POINTER);
+    EXPECT_TRUE(borrowed.isShortLivedSlice());
+    EXPECT_FALSE(borrowed.isStaticSlice());
+    EXPECT_FALSE(borrowed.requiresDestruction());
+    EXPECT_EQ(borrowed.slice().begin(), owner.slice().begin());
+    // must be a no-op, the owner still needs the payload afterwards
+    borrowed.destroy();
+  }
+
+  EXPECT_EQ(owner.slice().get("someLongAttributeName").stringView(),
+            "someLongAttributeValue");
+  owner.destroy();
+}
+
+TEST(AqlValueBorrowTest, managed_string_borrow_points_at_the_vpack) {
+  AqlValue owner{std::string_view{
+      "a string well beyond the inline budget of fifteen bytes"}};
+  ASSERT_TRUE(owner.requiresDestruction());
+
+  AqlValue borrowed = owner.borrow();
+  EXPECT_EQ(borrowed.type(), AqlValue::VPACK_SLICE_POINTER);
+  EXPECT_FALSE(borrowed.requiresDestruction());
+  EXPECT_EQ(borrowed.slice().begin(), owner.slice().begin());
+  EXPECT_TRUE(borrowed.slice().isString());
+  borrowed.destroy();
+
+  EXPECT_TRUE(owner.slice().isString());
+  owner.destroy();
+}
+
+TEST(AqlValueBorrowTest, range_borrow_copies) {
+  AqlValue owner{int64_t{1}, int64_t{10}};
+  ASSERT_EQ(owner.type(), AqlValue::RANGE);
+
+  AqlValue copy = owner.borrow();
+  // a range has no pointer form, so it is treated as a value
+  EXPECT_EQ(copy.type(), AqlValue::RANGE);
+  EXPECT_TRUE(copy.requiresDestruction());
+  EXPECT_NE(copy.range(), owner.range());
+  EXPECT_EQ(copy.range()->_low, owner.range()->_low);
+  EXPECT_EQ(copy.range()->_high, owner.range()->_high);
+
+  copy.destroy();
+  EXPECT_EQ(owner.range()->_low, 1);
+  EXPECT_EQ(owner.range()->_high, 10);
+  owner.destroy();
+}
+
+TEST(AqlValueBorrowTest, inline_borrow_is_a_plain_copy) {
+  AqlValue const values[] = {
+      AqlValue{AqlValueHintInt{42}}, AqlValue{AqlValueHintUInt{42}},
+      AqlValue{AqlValueHintDouble{4.2}}, AqlValue{AqlValueHintBool{true}},
+      AqlValue{AqlValueHintNull{}}};
+
+  for (auto const& v : values) {
+    AqlValue b = v.borrow();
+    EXPECT_EQ(b.type(), v.type());
+    EXPECT_FALSE(b.requiresDestruction());
+    // an inline value points at nothing, so it is neither static nor
+    // short-lived
+    EXPECT_FALSE(b.isStaticSlice());
+    EXPECT_FALSE(b.isShortLivedSlice());
+  }
+}
+
+TEST(AqlValueBorrowTest, slice_pointers_default_to_short_lived) {
+  auto builder = largeObject();
+  AqlValue v{AqlValueHintSliceNoCopy{builder->slice()}};
+  ASSERT_EQ(v.type(), AqlValue::VPACK_SLICE_POINTER);
+  EXPECT_TRUE(v.isShortLivedSlice());
+  EXPECT_FALSE(v.isStaticSlice());
+}
+
+TEST(AqlValueBorrowTest, static_slices_are_marked) {
+  auto builder = largeObject();
+  AqlValue v = AqlValue::staticSlice(builder->slice().begin());
+  ASSERT_EQ(v.type(), AqlValue::VPACK_SLICE_POINTER);
+  EXPECT_TRUE(v.isStaticSlice());
+  EXPECT_FALSE(v.isShortLivedSlice());
+  EXPECT_FALSE(v.requiresDestruction());
+  EXPECT_EQ(v.slice().begin(), builder->slice().begin());
+  EXPECT_TRUE(v.slice().isObject());
+
+  // the marker must survive being handed around
+  AqlValue again = v.borrow();
+  EXPECT_TRUE(again.isStaticSlice());
+}
+
+TEST(AqlValueBorrowTest, erase_clears_the_static_marker) {
+  auto builder = largeObject();
+  AqlValue v = AqlValue::staticSlice(builder->slice().begin());
+  ASSERT_TRUE(v.isStaticSlice());
+
+  v.erase();
+  EXPECT_TRUE(v.isEmpty());
+  EXPECT_FALSE(v.isStaticSlice());
+  EXPECT_FALSE(v.isShortLivedSlice());
+}
+
+// clone() is not yet uniform: it deep-copies the managed types but bit-copies a
+// slice pointer, via the `default: break` in AqlValue::clone(). So cloning a
+// borrow currently hands back another pointer to the owner's payload rather
+// than an independent value. Pinned here so the gap is visible; making clone()
+// uniform is the next step, and needs a check that every query-static producer
+// is marked first, or constants start being copied per row.
+TEST(AqlValueBorrowTest, clone_of_a_borrow_does_not_yet_detach) {
+  auto builder = largeObject();
+  AqlValue owner{builder->slice()};
+  AqlValue borrowed = owner.borrow();
+
+  AqlValue copy = borrowed.clone();
+  EXPECT_FALSE(copy.requiresDestruction());
+  EXPECT_EQ(copy.slice().begin(), owner.slice().begin());
+
+  owner.destroy();
+}
+
+// the target behaviour, enable together with the clone() change
+TEST(AqlValueBorrowTest, DISABLED_clone_of_a_borrow_owns_its_copy) {
+  auto builder = largeObject();
+  AqlValue owner{builder->slice()};
+  AqlValue borrowed = owner.borrow();
+
+  AqlValue copy = borrowed.clone();
+  EXPECT_TRUE(copy.requiresDestruction());
+  EXPECT_NE(copy.slice().begin(), owner.slice().begin());
+  EXPECT_GT(copy.memoryUsage(), 0);
+
+  owner.destroy();
+  // the clone must survive the owner
+  EXPECT_EQ(copy.slice().get("someLongAttributeName").stringView(),
+            "someLongAttributeValue");
+  copy.destroy();
+}
+
+TEST(AqlValueBorrowTest, memory_origin_is_unaffected) {
+  // byte 1 carries MemoryOriginType for a managed slice and the static marker
+  // for a slice pointer. the two layouts must not interfere.
+  auto builder = largeObject();
+  AqlValue owner{builder->slice()};
+  AqlValue borrowed = owner.borrow();
+  EXPECT_FALSE(borrowed.requiresDestruction());
+  EXPECT_GT(owner.memoryUsage(), 0);
+  // destroying the owner must still pick the right deallocation path
+  owner.destroy();
+  EXPECT_TRUE(owner.isEmpty());
+}

--- a/tests/Aql/AqlValueBorrowTest.cpp
+++ b/tests/Aql/AqlValueBorrowTest.cpp
@@ -169,26 +169,7 @@ TEST(AqlValueBorrowTest, erase_clears_the_static_marker) {
   EXPECT_FALSE(v.isShortLivedSlice());
 }
 
-// clone() is not yet uniform: it deep-copies the managed types but bit-copies a
-// slice pointer, via the `default: break` in AqlValue::clone(). So cloning a
-// borrow currently hands back another pointer to the owner's payload rather
-// than an independent value. Pinned here so the gap is visible; making clone()
-// uniform is the next step, and needs a check that every query-static producer
-// is marked first, or constants start being copied per row.
-TEST(AqlValueBorrowTest, clone_of_a_borrow_does_not_yet_detach) {
-  auto builder = largeObject();
-  AqlValue owner{builder->slice()};
-  AqlValue borrowed = owner.borrow();
-
-  AqlValue copy = borrowed.clone();
-  EXPECT_FALSE(copy.requiresDestruction());
-  EXPECT_EQ(copy.slice().begin(), owner.slice().begin());
-
-  owner.destroy();
-}
-
-// the target behaviour, enable together with the clone() change
-TEST(AqlValueBorrowTest, DISABLED_clone_of_a_borrow_owns_its_copy) {
+TEST(AqlValueBorrowTest, clone_of_a_borrow_owns_its_copy) {
   auto builder = largeObject();
   AqlValue owner{builder->slice()};
   AqlValue borrowed = owner.borrow();
@@ -203,6 +184,17 @@ TEST(AqlValueBorrowTest, DISABLED_clone_of_a_borrow_owns_its_copy) {
   EXPECT_EQ(copy.slice().get("someLongAttributeName").stringView(),
             "someLongAttributeValue");
   copy.destroy();
+}
+
+TEST(AqlValueBorrowTest, clone_of_a_static_slice_shares_the_payload) {
+  auto builder = largeObject();
+  AqlValue v = AqlValue::staticSlice(builder->slice().begin());
+
+  AqlValue copy = v.clone();
+  // query-static memory outlives every block, so cloning must not allocate
+  EXPECT_FALSE(copy.requiresDestruction());
+  EXPECT_TRUE(copy.isStaticSlice());
+  EXPECT_EQ(copy.slice().begin(), v.slice().begin());
 }
 
 TEST(AqlValueBorrowTest, memory_origin_is_unaffected) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,7 @@ set(ARANGODB_TESTS_SOURCES
   Aql/AqlItemRowTest.cpp
   Aql/AqlMergeTest.cpp
   Aql/AqlShadowRowTest.cpp
+  Aql/AqlValueBorrowTest.cpp
   Aql/AqlValueCompare.cpp
   Aql/AqlValueMemoryLayoutTest.cpp
   Aql/AstNodeTest.cpp


### PR DESCRIPTION
### Scope & Purpose
For cleaning up the `mustDestroy` and `doCopy` flags, the `AqlValue` has to be updated with the concept of query-static data. This is for example plain json in the query, constant-registers, any value or slice that has a lifetime bound to the query.

The difference in behavior is subtle but important: calling `clone` on  static data will not create a copy but simply alias. 