### PR TITLE
Remove `cacheCurrentKey` from IndexStreamInterface

### DIFF
--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.cpp
@@ -130,7 +130,7 @@ auto IndexAggregateScanExecutor::skipRowsRange(
   auto vpackOptions = &_infos.query->vpackOptions();
 
   while (clientCall.needSkipMore() && hasMore) {
-    _iterator->cacheCurrentKey(_currentGroupKeySlices);
+    _currentGroupKeyCache.update(_keySlices, _currentGroupKeySlices);
     LOG_AGG_SCAN << "[SCAN] Group keys "
                  << inspection::json(_currentGroupKeySlices);
 
@@ -200,7 +200,7 @@ auto IndexAggregateScanExecutor::produceRows(AqlItemBlockInputRange& inputRange,
       _variablesToProjectionsRelative};
 
   while (!output.isFull() && hasMore) {
-    _iterator->cacheCurrentKey(_currentGroupKeySlices);
+    _currentGroupKeyCache.update(_keySlices, _currentGroupKeySlices);
     LOG_AGG_SCAN << "[SCAN] Group keys "
                  << inspection::json(_currentGroupKeySlices);
 
@@ -272,9 +272,8 @@ IndexAggregateScanExecutor::IndexAggregateScanExecutor(Fetcher& fetcher,
 
   // fill projection slices
   _projectionSlices.resize(streamOptions.projectedFields.size());
-  bool hasMore = _iterator->reset(_currentGroupKeySlices, {});
-  LOG_AGG_SCAN << "[SCAN] after reset at "
-               << inspection::json(_currentGroupKeySlices)
+  bool hasMore = _iterator->reset(_keySlices, {});
+  LOG_AGG_SCAN << "[SCAN] after reset at " << inspection::json(_keySlices)
                << " hasMore= " << hasMore;
   _indexIncludesAnyData = hasMore;
 

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.h
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.h
@@ -23,6 +23,7 @@
 
 #include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/IndexStreamIterator.h"
+#include "Aql/IndexStreamKeyCache.h"
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/Stats.h"
 #include "Aql/QueryContext.h"
@@ -110,6 +111,7 @@ struct IndexAggregateScanExecutor {
 
   // needed as output of the iterator
   std::vector<VPackSlice> _currentGroupKeySlices;
+  IndexStreamKeyCache<VPackSlice> _currentGroupKeyCache;
   std::vector<VPackSlice> _keySlices;
   std::vector<VPackSlice> _projectionSlices;
 

--- a/arangod/Aql/Executor/IndexAggregateScanExecutor.h
+++ b/arangod/Aql/Executor/IndexAggregateScanExecutor.h
@@ -23,7 +23,7 @@
 
 #include "Aql/AqlFunctionsInternalCache.h"
 #include "Aql/IndexStreamIterator.h"
-#include "Aql/IndexStreamKeyCache.h"
+#include "Aql/IndexStreamKeyStore.h"
 #include "Aql/SingleRowFetcher.h"
 #include "Aql/Stats.h"
 #include "Aql/QueryContext.h"
@@ -111,7 +111,7 @@ struct IndexAggregateScanExecutor {
 
   // needed as output of the iterator
   std::vector<VPackSlice> _currentGroupKeySlices;
-  IndexStreamKeyCache<VPackSlice> _currentGroupKeyCache;
+  IndexStreamKeyStore<VPackSlice> _currentGroupKeyCache;
   std::vector<VPackSlice> _keySlices;
   std::vector<VPackSlice> _projectionSlices;
 

--- a/arangod/Aql/IndexJoin/GenericMerge.h
+++ b/arangod/Aql/IndexJoin/GenericMerge.h
@@ -26,7 +26,7 @@
 #include "Logger/LogMacros.h"
 #include "Aql/IndexStreamIterator.h"
 #include "Aql/IndexJoinStrategy.h"
-#include "Aql/IndexStreamKeyCache.h"
+#include "Aql/IndexStreamKeyStore.h"
 
 namespace arangodb::aql {
 
@@ -91,7 +91,7 @@ struct GenericMergeJoin : IndexJoinStrategy<SliceType, DocIdType> {
   std::vector<DocIdType> documentIds;
   std::vector<SliceType> sliceBuffer;
   std::vector<SliceType> currentKeySet;
-  IndexStreamKeyCache<SliceType> currentKeyCache;
+  IndexStreamKeyStore<SliceType> currentKeyStore;
   std::span<SliceType> projectionsSpan;
 
   IndexMinHeap minHeap;
@@ -377,7 +377,7 @@ void GenericMergeJoin<SliceType, DocIdType, KeyCompare>::fillInitialMatch() {
     auto& index = indexes[i];
     documentIds[i] = index._iter->load(index._projections);
   }
-  currentKeyCache.update(indexes.rbegin()->_position, currentKeySet);
+  currentKeyStore.update(indexes.rbegin()->_position, currentKeySet);
 }
 
 template<typename SliceType, typename DocIdType, typename KeyCompare>

--- a/arangod/Aql/IndexJoin/GenericMerge.h
+++ b/arangod/Aql/IndexJoin/GenericMerge.h
@@ -26,6 +26,7 @@
 #include "Logger/LogMacros.h"
 #include "Aql/IndexStreamIterator.h"
 #include "Aql/IndexJoinStrategy.h"
+#include "Aql/IndexStreamKeyCache.h"
 
 namespace arangodb::aql {
 
@@ -90,6 +91,7 @@ struct GenericMergeJoin : IndexJoinStrategy<SliceType, DocIdType> {
   std::vector<DocIdType> documentIds;
   std::vector<SliceType> sliceBuffer;
   std::vector<SliceType> currentKeySet;
+  IndexStreamKeyCache<SliceType> currentKeyCache;
   std::span<SliceType> projectionsSpan;
 
   IndexMinHeap minHeap;
@@ -375,7 +377,7 @@ void GenericMergeJoin<SliceType, DocIdType, KeyCompare>::fillInitialMatch() {
     auto& index = indexes[i];
     documentIds[i] = index._iter->load(index._projections);
   }
-  indexes.rbegin()->_iter->cacheCurrentKey(currentKeySet);
+  currentKeyCache.update(indexes.rbegin()->_position, currentKeySet);
 }
 
 template<typename SliceType, typename DocIdType, typename KeyCompare>

--- a/arangod/Aql/IndexJoin/TwoIndicesMergeJoin.h
+++ b/arangod/Aql/IndexJoin/TwoIndicesMergeJoin.h
@@ -26,7 +26,7 @@
 #include "Logger/LogMacros.h"
 #include "Aql/IndexStreamIterator.h"
 #include "Aql/IndexJoinStrategy.h"
-#include "Aql/IndexStreamKeyCache.h"
+#include "Aql/IndexStreamKeyStore.h"
 
 namespace arangodb::aql {
 
@@ -87,7 +87,7 @@ struct TwoIndicesMergeJoin : IndexJoinStrategy<SliceType, DocIdType> {
   std::array<DocIdType, 2> documentIds;
   std::vector<SliceType> sliceBuffer;
   std::vector<SliceType> currentKeySet;
-  IndexStreamKeyCache<SliceType> currentKeyCache;
+  IndexStreamKeyStore<SliceType> currentKeyStore;
   std::span<SliceType> projectionsSpan;
 
   // This iterator holds the current maximum position
@@ -380,7 +380,7 @@ void TwoIndicesMergeJoin<SliceType, DocIdType, KeyCompare>::fillInitialMatch() {
     auto& index = indexes[i];
     documentIds[i] = index._iter->load(index._projections);
   }
-  currentKeyCache.update(indexes.rbegin()->_position, currentKeySet);
+  currentKeyStore.update(indexes.rbegin()->_position, currentKeySet);
 }
 
 template<typename SliceType, typename DocIdType, typename KeyCompare>

--- a/arangod/Aql/IndexJoin/TwoIndicesMergeJoin.h
+++ b/arangod/Aql/IndexJoin/TwoIndicesMergeJoin.h
@@ -26,6 +26,7 @@
 #include "Logger/LogMacros.h"
 #include "Aql/IndexStreamIterator.h"
 #include "Aql/IndexJoinStrategy.h"
+#include "Aql/IndexStreamKeyCache.h"
 
 namespace arangodb::aql {
 
@@ -86,6 +87,7 @@ struct TwoIndicesMergeJoin : IndexJoinStrategy<SliceType, DocIdType> {
   std::array<DocIdType, 2> documentIds;
   std::vector<SliceType> sliceBuffer;
   std::vector<SliceType> currentKeySet;
+  IndexStreamKeyCache<SliceType> currentKeyCache;
   std::span<SliceType> projectionsSpan;
 
   // This iterator holds the current maximum position
@@ -378,7 +380,7 @@ void TwoIndicesMergeJoin<SliceType, DocIdType, KeyCompare>::fillInitialMatch() {
     auto& index = indexes[i];
     documentIds[i] = index._iter->load(index._projections);
   }
-  indexes.rbegin()->_iter->cacheCurrentKey(currentKeySet);
+  currentKeyCache.update(indexes.rbegin()->_position, currentKeySet);
 }
 
 template<typename SliceType, typename DocIdType, typename KeyCompare>

--- a/arangod/Aql/IndexStreamIterator.h
+++ b/arangod/Aql/IndexStreamIterator.h
@@ -61,10 +61,6 @@ struct IndexStreamIterator {
   virtual bool next(std::span<SliceType> keys, DocIdType&,
                     std::span<SliceType> projections) = 0;
 
-  // cache the current key. The span has to stay valid until this function
-  // is called again.
-  virtual void cacheCurrentKey(std::span<SliceType> keys) = 0;
-
   // called to reset the iterator to the initial position and loads that
   // positions keys into span. returns false if the iterator is exhausted.
   // Constants remain valid until the next reset call.

--- a/arangod/Aql/IndexStreamKeyCache.h
+++ b/arangod/Aql/IndexStreamKeyCache.h
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2024 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+#pragma once
+#include <algorithm>
+#include <span>
+#include <vector>
+
+#include <velocypack/Slice.h>
+#include <velocypack/String.h>
+
+namespace arangodb::aql {
+
+template<typename SliceType>
+struct IndexStreamKeyCache {
+  void update(std::span<SliceType const> src, std::span<SliceType> dst) {
+    std::copy(src.begin(), src.end(), dst.begin());
+  }
+};
+
+template<>
+struct IndexStreamKeyCache<velocypack::Slice> {
+  void update(std::span<velocypack::Slice const> src,
+              std::span<velocypack::Slice> dst) {
+    _owned.resize(src.size());
+    for (std::size_t i = 0; i < src.size(); ++i) {
+      _owned[i] = src[i];
+      dst[i] = _owned[i].slice();
+    }
+  }
+
+ private:
+  std::vector<velocypack::String> _owned;
+};
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/IndexStreamKeyStore.h
+++ b/arangod/Aql/IndexStreamKeyStore.h
@@ -30,14 +30,14 @@
 namespace arangodb::aql {
 
 template<typename SliceType>
-struct IndexStreamKeyCache {
+struct IndexStreamKeyStore {
   void update(std::span<SliceType const> src, std::span<SliceType> dst) {
     std::copy(src.begin(), src.end(), dst.begin());
   }
 };
 
 template<>
-struct IndexStreamKeyCache<velocypack::Slice> {
+struct IndexStreamKeyStore<velocypack::Slice> {
   void update(std::span<velocypack::Slice const> src,
               std::span<velocypack::Slice> dst) {
     _owned.resize(src.size());

--- a/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBPrimaryIndex.cpp
@@ -1280,7 +1280,6 @@ struct RocksDBPrimaryIndexStreamIterator final : AqlIndexStreamIterator {
   std::unique_ptr<rocksdb::Iterator> _iterator;
 
   VPackBuilder _builder;
-  VPackString _cache;
   RocksDBKeyBounds _bounds;
   rocksdb::Slice _end;
   RocksDBKey _rocksdbKey;
@@ -1358,11 +1357,6 @@ struct RocksDBPrimaryIndexStreamIterator final : AqlIndexStreamIterator {
     docId = load(projections);
 
     return true;
-  }
-
-  void cacheCurrentKey(std::span<VPackSlice> cache) override {
-    _cache = VPackString{_builder.slice()};
-    cache[0] = _cache;
   }
 
   bool reset(std::span<VPackSlice> span,

--- a/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
+++ b/arangod/RocksDBEngine/RocksDBVPackIndex.cpp
@@ -3016,7 +3016,6 @@ struct RocksDBVPackStreamIterator final : AqlIndexStreamIterator {
 
   RocksDBVPackStreamOptions _options;
   VPackBuilder _builder;
-  VPackString _cache;
   RocksDBKeyBounds _bounds;
   rocksdb::Slice _end;
   RocksDBKey _rocksdbKey;
@@ -3118,11 +3117,6 @@ struct RocksDBVPackStreamIterator final : AqlIndexStreamIterator {
     storeKey(key, RocksDBKey::indexedVPack(_iterator->key()));
     docId = load(projections);
     return true;
-  }
-
-  void cacheCurrentKey(std::span<VPackSlice> cache) override {
-    _cache = VPackString{RocksDBKey::indexedVPack(_iterator->key())};
-    storeKey(cache, _cache);
   }
 
   static void constructKey(VPackBuilder& builder,

--- a/tests/Aql/Executor/IndexAggregateScanExecutorTest.cpp
+++ b/tests/Aql/Executor/IndexAggregateScanExecutorTest.cpp
@@ -134,14 +134,6 @@ struct MyVectorIterator : public AqlIndexStreamIterator {
     return LocalDocumentId{};
   }
 
-  void cacheCurrentKey(std::span<velocypack::Slice> keys) override {
-    size_t count = 0;
-    for (auto const& keyField : _keyFields) {
-      keys[count] = (*_current)[keyField];
-      count++;
-    }
-  }
-
   bool reset(std::span<velocypack::Slice> keys,
              std::span<velocypack::Slice> constants) override {
     _current = _values.begin();

--- a/tests/Aql/JoinStrategy/GenericAndTwoNonUniqueJoinTest.cpp
+++ b/tests/Aql/JoinStrategy/GenericAndTwoNonUniqueJoinTest.cpp
@@ -69,10 +69,6 @@ struct MyVectorIterator : MyIndexStreamIterator {
     return *current;
   }
 
-  void cacheCurrentKey(std::span<MyKeyValue> cache) override {
-    cache[0] = *current;
-  }
-
   bool reset(std::span<MyKeyValue> span,
              std::span<MyKeyValue> constants) override {
     current = begin;

--- a/tests/Aql/JoinStrategy/TwoIndicesUniqueJoinTest.cpp
+++ b/tests/Aql/JoinStrategy/TwoIndicesUniqueJoinTest.cpp
@@ -66,10 +66,6 @@ struct MyVectorIterator : MyIndexStreamIterator {
     return *current;
   }
 
-  void cacheCurrentKey(std::span<MyKeyValue> cache) override {
-    cache[0] = *current;
-  }
-
   bool reset(std::span<MyKeyValue> span,
              std::span<MyKeyValue> constants) override {
     current = begin;


### PR DESCRIPTION
Remove `cacheCurrentKey` from the generic index stream interface and make the storage local to the join strategy.

This is a preparation PR for eventually implementing a hash join strategy.