### PR TITLE
[COR-958] Fix join node expression crash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,13 @@
 3.12.12 (XXXX-XX-XX)
 --------------------
 
+* COR-958: JoinNode aborts the server when a later index condition uses an 
+  expression over an earlier index's document.
+  Fixed an issue where certain AQL queries using index joins across multiple 
+  collections could cause the server to abort when a join condition referenced 
+  a calculated expression based on a document from an earlier collection.
+  Such queries are now handled safely without triggering an assertion failure or server crash.
+  
 * Rebuilt included rclone v1.75.0 with go1.25.13 and non-vulnerable
   dependencies.
 

--- a/arangod/Aql/Optimizer/Rule/JoinIndexNodes.cpp
+++ b/arangod/Aql/Optimizer/Rule/JoinIndexNodes.cpp
@@ -292,12 +292,11 @@ void optimizeJoinNode(ExecutionPlan& plan, JoinNode* jn) {
                           << node->toString() << ")";
 
   if (isVarAccessToOthersSideOutVariable) {
-    // Only constant if we're sure that both (lhs + rhs) are not used outVars
-    // of our first candidate.
+    // Simple attribute access to the first candidate's outVariable is a join
+    // key, not a constant expression evaluated by JoinExecutor.
     return false;
   }
 
-  // TODO:  Quickly explain this section
   VarSet result;
   Ast::getReferencedVariables(node, result);
 
@@ -305,16 +304,16 @@ void optimizeJoinNode(ExecutionPlan& plan, JoinNode* jn) {
     return true;
   }
 
-  // Print names of the known constant variables
+  // knownConstVariables is the JoinNode input-row set
+  // (firstCandidate->getFirstDependency()->getVarsValid()).
+  TRI_ASSERT(knownConstVariables != nullptr);
   LOG_JOIN_OPTIMIZER_RULE << "Known constant variables:";
-  if (knownConstVariables != nullptr) {
-    for (auto const& var : *knownConstVariables) {
-      LOG_JOIN_OPTIMIZER_RULE << "  - " << var->name;
-    }
-    for (auto const& var : result) {
-      if (!knownConstVariables->contains(var)) {
-        return false;
-      }
+  for (auto const& var : *knownConstVariables) {
+    LOG_JOIN_OPTIMIZER_RULE << "  - " << var->name;
+  }
+  for (auto const& var : result) {
+    if (!knownConstVariables->contains(var)) {
+      return false;
     }
   }
 
@@ -647,27 +646,27 @@ bool checkCandidateEligibleForAdvancedJoin(
 std::tuple<bool, IndicesOffsets> checkCandidatesEligible(
     ExecutionPlan& plan, std::span<IndexNode*> candidates) {
   IndicesOffsets indicesOffsets = {};
+  // Variables available on the JoinNode *input* row when JoinExecutor
+  // evaluates constantExpressions. JoinNode replaces the first candidate, so
+  // its input corresponds to that candidate's dependency (vars valid *before*
+  // the first index runs). Join keys such as `doc2.x == doc1.x` are handled
+  // separately via isVarAccessToOthersSideOutVariable / processJoinKeyFinding.
   VarSet const* knownConstVariables = nullptr;
 
   for (auto* candidate : candidates) {
     LOG_JOIN_OPTIMIZER_RULE << "==> Checking candidate: (" << candidate->id()
                             << ")";
     if (candidate == candidates.front()) {
+      TRI_ASSERT(candidate->hasDependency());
+      knownConstVariables = &candidate->getFirstDependency()->getVarsValid();
+      LOG_JOIN_OPTIMIZER_RULE << "Variables which are known as constants: ";
+      for (auto kVar : *knownConstVariables) {
+        LOG_JOIN_OPTIMIZER_RULE << " -> " << kVar->name;
+      }
+
       auto const* root = candidate->condition()->root();
 
       if (root != nullptr) {
-        // Build-up the known variables for the first index node.
-        // This operation is only needed for the first index node, because
-        // we're only interested in the variables which are known for the
-        // first index node including the outVariable of the first index node.
-        // Therefore, we call getVarsValid instead of getVariablesUsedHere.
-        knownConstVariables = &candidate->getVarsValid();
-        TRI_ASSERT(knownConstVariables != nullptr);
-        LOG_JOIN_OPTIMIZER_RULE << "Variables which are known: ";
-        for (auto kVar : *knownConstVariables) {
-          LOG_JOIN_OPTIMIZER_RULE << " -> " << kVar->name;
-        }
-
         LOG_JOIN_OPTIMIZER_RULE
             << "Calling CandidateEligible check for first candidate";
         bool eligible = checkCandidateEligibleForAdvancedJoin(

--- a/tests/js/client/aql/large/aql-index-join.js
+++ b/tests/js/client/aql/large/aql-index-join.js
@@ -1284,6 +1284,180 @@ const IndexJoinTestSuite = function () {
         const result = db._createStatement(query).execute().toArray();
         assertEqual(result.length, 0);
       }
+    },
+
+    // Regression: expressions that reference the first index's own outVariable
+    // (e.g. doc1.z + 1, CONCAT('s-', doc1.z)) must not be treated as JoinExecutor
+    // constantExpressions — those are evaluated against the JoinNode input row
+    // where doc1 is not available. Simple join keys (doc2.x == doc1.x) remain OK.
+    testRejectConstantExprUsingFirstOutVariable: function () {
+      const A = createCollection("A2", ["x"]);
+      A.ensureIndex({type: "persistent", fields: ["x"], storedValues: ["z"]});
+      fillCollection("A2", attributeGenerator(20, {
+        x: x => x,
+        z: x => x
+      }));
+      const B = createCollection("B2", ["x"]);
+      B.ensureIndex({type: "persistent", fields: ["x", "y"]});
+      fillCollection("B2", attributeGenerator(20, {
+        x: x => x + 1,
+        y: x => x
+      }));
+      const C = createCollection("C2", ["x"]);
+      C.ensureIndex({type: "persistent", fields: ["x"]});
+      fillCollection("C2", singleAttributeGenerator(20, "x", x => x));
+
+      const arithmeticQuery = `
+        FOR doc1 IN A2
+          SORT doc1.x
+          FOR doc2 IN B2
+            FILTER doc2.x == doc1.z + 1
+            FILTER doc2.y == doc1.x
+            RETURN [doc1.x, doc2.x, doc2.y]
+      `;
+      {
+        const plan = db._createStatement({
+          query: arithmeticQuery,
+          options: queryOptions
+        }).explain().plan;
+        const nodes = plan.nodes.map(n => n.type);
+        assertEqual(nodes.indexOf("JoinNode"), -1,
+          "join-index-nodes must not fire for doc2.x == doc1.z + 1");
+        const result = db._createStatement({
+          query: arithmeticQuery,
+          options: queryOptions
+        }).execute().toArray();
+        assertEqual(result.length, 20);
+        for (const [x1, x2, y2] of result) {
+          assertEqual(x2, x1 + 1);
+          assertEqual(y2, x1);
+        }
+      }
+
+      const B3 = createCollection("B3", ["x"]);
+      B3.ensureIndex({type: "persistent", fields: ["x"]});
+      fillCollection("B3", singleAttributeGenerator(20, "x", x => `s-${x}`));
+      const concatQuery = `
+        FOR doc1 IN A2
+          SORT doc1.x
+          FOR doc2 IN B3
+            FILTER doc2.x == CONCAT('s-', doc1.z)
+            RETURN [doc1.x, doc2.x]
+      `;
+      {
+        const plan = db._createStatement({
+          query: concatQuery,
+          options: queryOptions
+        }).explain().plan;
+        const nodes = plan.nodes.map(n => n.type);
+        assertEqual(nodes.indexOf("JoinNode"), -1,
+          "join-index-nodes must not fire for CONCAT('s-', doc1.z)");
+        const result = db._createStatement({
+          query: concatQuery,
+          options: queryOptions
+        }).execute().toArray();
+        assertEqual(result.length, 20);
+        for (const [x1, x2] of result) {
+          assertEqual(x2, `s-${x1}`);
+        }
+      }
+
+      // Control: plain join key must still produce a JoinNode.
+      const B4 = createCollection("B4", ["x"]);
+      B4.ensureIndex({type: "persistent", fields: ["x"]});
+      fillCollection("B4", singleAttributeGenerator(20, "x", x => x));
+      const joinKeyQuery = `
+        FOR doc1 IN A2
+          SORT doc1.x
+          FOR doc2 IN B4
+            FILTER doc2.x == doc1.x
+            RETURN [doc1.x, doc2.x]
+      `;
+      {
+        const plan = db._createStatement({
+          query: joinKeyQuery,
+          options: queryOptions
+        }).explain().plan;
+        const nodes = plan.nodes.map(n => n.type);
+        assertNotEqual(nodes.indexOf("JoinNode"), -1,
+          "join-index-nodes must still fire for doc2.x == doc1.x");
+        const result = db._createStatement({
+          query: joinKeyQuery,
+          options: queryOptions
+        }).execute().toArray();
+        assertEqual(result.length, 20);
+        for (const [x1, x2] of result) {
+          assertEqual(x1, x2);
+        }
+      }
+
+      // Full 3-collection reproduction of the COR-958 regression, which previously
+      // aborted in variableToRegisterId(doc1) while building the JoinNode and
+      // projections. With +join-index-nodes, the planner may still create a
+      // JoinNode for A2/C2 while keeping B2 as a separate IndexNode. On a cluster,
+      // this can miss cross-shard B2 matches. Therefore, the optimized plan is
+      // checked only for safe execution and valid JoinNode expressions, while the
+      // full result cardinality is verified using the non-optimized baseline.
+
+      const tripleQuery = `
+        FOR doc1 IN A2
+          SORT doc1.x
+          FOR doc2 IN B2
+            FOR doc3 IN C2
+              FILTER doc2.x == doc1.z + 1
+              FILTER doc2.y == doc1.x
+              FILTER doc3.x == doc1.x
+              RETURN [doc1.x, doc2.x, doc2.y, doc3.x]
+      `;
+      {
+        const plan = db._createStatement({
+          query: tripleQuery,
+          options: queryOptions
+        }).explain().plan;
+        // Optimized execution must no longer abort (COR-958).
+        db._createStatement({
+          query: tripleQuery,
+          options: queryOptions
+        }).execute().toArray();
+        // Ensure no JoinNode embeds doc1.z+1 (or similar) as a
+        // constantExpression referencing the first outVariable.
+        for (const node of plan.nodes) {
+          if (node.type !== "JoinNode") {
+            continue;
+          }
+          for (const info of node.indexInfos) {
+            if (!info.expressions || info.expressions.length === 0) {
+              continue;
+            }
+            const dump = JSON.stringify(info.expressions);
+            assertEqual(dump.indexOf("doc1"), -1,
+              "JoinNode must not carry constantExpressions referencing doc1: " +
+              dump);
+          }
+        }
+
+        // Full cardinality is only reliable when matches are not evaluated
+        // shard-locally. On cluster, A2/B2/C2 use distributeShardsLike with
+        // shardKeys ["x"], but B matches need doc2.x == doc1.x + 1 (other
+        // shard). That yields ~1/3 of rows regardless of join-index-nodes.
+        if (!isCluster) {
+          const baseline = db._createStatement({
+            query: tripleQuery,
+            options: {
+              optimizer: {
+                rules: ["-join-index-nodes", "-replace-equal-attribute-accesses"]
+              },
+              maxNumberOfPlans: 1
+            }
+          }).execute().toArray();
+          assertEqual(baseline.length, 20);
+          for (const [x1, x2, y2, x3] of baseline) {
+            assertEqual(x2, x1 + 1);
+            assertEqual(y2, x1);
+            assertEqual(x3, x1);
+          }
+        }
+      }
     }
 
   };


### PR DESCRIPTION
When the join-index-nodes rule fires and a later index's lookup condition compares its own attribute against an expression over an earlier index's document, running the query aborts the server:

assertion failed in arangod/Aql/RegisterPlan.tpp
  [RegisterPlanT<ExecutionNode>::variableToRegisterId]:
  it != varInfo.end() ; variable doc1 (0)
doc1 never received a register during register planning, but JoinNode::createBlock asks for one when it fills expressionVarsToRegs.

**Reproduction:**
---------------
```js
db._create("A2");
db._create("B2");
db._create("C2");

db._query(`FOR i IN 1..200
  INSERT {
    x: i,
    y: i,
    z: i,
    w: i
  } INTO A2
  `)

db._query(`FOR i IN 1..200
  INSERT {
    x: i + 1,
    y: i,
    z: i,
    w: i
  } INTO B2`) 

db._query(`FOR i IN 1..200
  INSERT {
    x: i,
    y: i,
    z: i,
    w: i
  } INTO C2`)
```
**Create the persistent indexes:**
```js
db.A2.ensureIndex({
  type: "persistent",
  fields: ["x", "y", "z", "w"]
});

db.B2.ensureIndex({
  type: "persistent",
  fields: ["x", "y", "z", "w"]
});

db.C2.ensureIndex({
  type: "persistent",
  fields: ["x", "y", "z", "w"]
});
```

**Before Fix:**
```
127.0.0.1:8529@_system> db._query(`FOR doc1 IN A2  SORT doc1.x  FOR doc2 IN B2    FOR doc3 IN C2      FILTER doc2.x == doc1.z + 1      FILTER doc2.y == doc1.x      FILTER doc3.x == doc1.x      RETURN [doc1.x, doc2.x, doc2.y, doc3.x] `)
JavaScript exception in file '/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arango-statement.js' at 167,50: ArangoError 2001: not connected
!  var requestResult = this._database._connection.POST(
!                                                 ^
stacktrace: ArangoError: not connected
    at ArangoStatement.execute (/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arango-statement.js:167:50)
    at ArangoDatabase._query (/home/pavani/project/arangodb_4.0/arangodb/js/client/modules/@arangodb/arango-database.js:1019:45)
    at <shell command>:1:4
```
**After Fix:**
```
127.0.0.1:8529@_system> db._query(`FOR doc1 IN A2  SORT doc1.x  FOR doc2 IN B2    FOR doc3 IN C2      FILTER doc2.x == doc1.z + 1      FILTER doc2.y == doc1.x      FILTER doc3.x == doc1.x      RETURN [doc1.x, doc2.x, doc2.y, doc3.x] `)
[object ArangoQueryCursor, count: 200, results cached: false, hasMore: true]

[ 
  [ 
    1, 
    2, 
    1, 
    1 
  ], 
  [ 
    2, 
    3, 
    2, 
    2 
  ], 
  [ 
    3, 
    4, 
    3, 
    3 
  ], 
  [ 
    4, 
    5, 
    4, 
    4 
  ], 
  [ 
    5, 
    6, 
    5, 
    5 
  ], 

type 'more' to show more documents
```
**Fix summary:**
Crash came from treating expressions like doc1.z + 1 as JoinExecutor “constants” while doc1 is not available on the JoinNode input row.
primary fix = reject in the rule (drop first outVariable from known consts)
secondary = don’t erase out vars used by other indexes’ expressions.
