### PR TITLE
CI: authenticate GitHub clones through the arango-ci-checkout App

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -303,14 +303,12 @@ commands:
       driver-git-branch:
         type: string
     steps:
-      - github-auth
       - run:
           name: Clone driver repository
           command: |
             cd ..
             export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
             git clone --single-branch --branch << parameters.driver-git-branch >> << parameters.driver-git-repo >>
-      - github-auth-clear
 
   fetch-aux-binaries:
     parameters:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -202,6 +202,7 @@ commands:
     # unauthenticated downloads (CI outage 2026-09-02/03). The arango-ci-checkout
     # GitHub App (contents:read, public repos only) supplies a 1h token; without
     # credentials or on any failure the job clones anonymously, as before.
+    # Always paired with github-auth-clear after the clone.
     steps:
       - run:
           name: Authenticate git against GitHub
@@ -237,6 +238,15 @@ commands:
               "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')"
             echo "git authenticated against github.com as GitHub App installation $INST (token valid 1h)"
 
+  github-auth-clear:
+    # Drop the token header again once the clones it was set for are done, so a
+    # job running past the token's hour never fails on an expired header where
+    # an anonymous request would have worked.
+    steps:
+      - run:
+          name: Forget GitHub token
+          command: git config --global --unset-all http.https://github.com/.extraheader || true
+
   checkout-arangodb:
     parameters:
       destination:
@@ -265,6 +275,7 @@ commands:
                   cd << parameters.destination >>
                   git submodule init
                   git submodule update --recursive --depth 1 --jobs 8
+      - github-auth-clear
 
   checkout-enterprise:
     description: "Checkout enterprise code"
@@ -299,6 +310,7 @@ commands:
             cd ..
             export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
             git clone --single-branch --branch << parameters.driver-git-branch >> << parameters.driver-git-repo >>
+      - github-auth-clear
 
   fetch-aux-binaries:
     parameters:

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -197,6 +197,46 @@ commands:
               "s3://${AWS_S3_WORKSPACE_BUCKET}/workspaces/${CIRCLE_WORKFLOW_WORKSPACE_ID}/${ARCHIVE}" \
               - | tar -xzf -
 
+  github-auth:
+    # Anonymous clones from the runners' shared egress IP trip GitHub's limit on
+    # unauthenticated downloads (CI outage 2026-09-02/03). The arango-ci-checkout
+    # GitHub App (contents:read, public repos only) supplies a 1h token; without
+    # credentials or on any failure the job clones anonymously, as before.
+    steps:
+      - run:
+          name: Authenticate git against GitHub
+          command: |
+            set +x
+            if git config --global --get http.https://github.com/.extraheader >/dev/null 2>&1; then
+              exit 0
+            fi
+            if [ -z "${GITHUB_APP_ID:-}" ] || [ -z "${GITHUB_APP_PRIVATE_KEY_B64:-}" ]; then
+              echo "WARNING: GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY_B64 not set, cloning anonymously" >&2
+              exit 0
+            fi
+            KEY="$(mktemp)"
+            trap 'rm -f "$KEY"' EXIT
+            printf '%s' "$GITHUB_APP_PRIVATE_KEY_B64" | base64 -d > "$KEY"
+            b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+            NOW=$(date +%s)
+            JWT="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url).$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW-60))" "$((NOW+540))" "$GITHUB_APP_ID" | b64url)"
+            JWT="$JWT.$(printf '%s' "$JWT" | openssl dgst -sha256 -sign "$KEY" -binary | b64url)" || JWT=""
+            INST=""
+            TOKEN=""
+            if [ -n "$JWT" ]; then
+              INST=$(curl -sSf -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                        https://api.github.com/orgs/arangodb/installation | jq -r '.id // empty') || INST=""
+            fi
+            if [ -n "$INST" ]; then
+              TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                         "https://api.github.com/app/installations/$INST/access_tokens" | jq -r '.token // empty') || TOKEN=""
+            fi
+            if [ -z "$TOKEN" ]; then
+              echo "WARNING: no GitHub App token obtained, cloning anonymously" >&2
+              exit 0
+            fi
+            git config --global http.https://github.com/.extraheader \
+              "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')"
+            echo "git authenticated against github.com as GitHub App installation $INST (token valid 1h)"
+
   checkout-arangodb:
     parameters:
       destination:
@@ -204,6 +244,7 @@ commands:
       with-submodules:
         type: boolean
     steps:
+      - github-auth
       - run:
           name: Checkout ArangoDB
           command: |
@@ -251,6 +292,7 @@ commands:
       driver-git-branch:
         type: string
     steps:
+      - github-auth
       - run:
           name: Clone driver repository
           command: |

--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -225,10 +225,12 @@ commands:
             INST=""
             TOKEN=""
             if [ -n "$JWT" ]; then
-              INST=$(curl -sSf -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                        https://api.github.com/orgs/arangodb/installation | jq -r '.id // empty') || INST=""
+              INST=$(curl -sSf -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json" \
+                       https://api.github.com/orgs/arangodb/installation | jq -r '.id // empty') || INST=""
             fi
             if [ -n "$INST" ]; then
-              TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                         "https://api.github.com/app/installations/$INST/access_tokens" | jq -r '.token // empty') || TOKEN=""
+              TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json" \
+                        "https://api.github.com/app/installations/$INST/access_tokens" | jq -r '.token // empty') || TOKEN=""
             fi
             if [ -z "$TOKEN" ]; then
               echo "WARNING: no GitHub App token obtained, cloning anonymously" >&2

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -260,6 +260,7 @@ commands:
     # unauthenticated downloads (CI outage 2026-09-02/03). The arango-ci-checkout
     # GitHub App (contents:read, public repos only) supplies a 1h token; without
     # credentials or on any failure the job clones anonymously, as before.
+    # Always paired with github-auth-clear after the clone.
     steps:
       - run:
           name: Authenticate git against GitHub
@@ -294,6 +295,15 @@ commands:
             git config --global http.https://github.com/.extraheader \
               "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')"
             echo "git authenticated against github.com as GitHub App installation $INST (token valid 1h)"
+
+  github-auth-clear:
+    # Drop the token header again once the clones it was set for are done, so a
+    # job running past the token's hour never fails on an expired header where
+    # an anonymous request would have worked.
+    steps:
+      - run:
+          name: Forget GitHub token
+          command: git config --global --unset-all http.https://github.com/.extraheader || true
 
   checkout-arangodb:
     # Only compile-nightly needs the real source tree (sparse: false). All
@@ -336,6 +346,7 @@ commands:
                   cd << parameters.destination >>
                   git submodule init
                   git submodule update --recursive --depth 1 --jobs 8
+      - github-auth-clear
 
   checkout-enterprise:
     # The exact commit was resolved ONCE by the setup job and is passed in

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -283,10 +283,12 @@ commands:
             INST=""
             TOKEN=""
             if [ -n "$JWT" ]; then
-              INST=$(curl -sSf -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                        https://api.github.com/orgs/arangodb/installation | jq -r '.id // empty') || INST=""
+              INST=$(curl -sSf -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json" \
+                       https://api.github.com/orgs/arangodb/installation | jq -r '.id // empty') || INST=""
             fi
             if [ -n "$INST" ]; then
-              TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                         "https://api.github.com/app/installations/$INST/access_tokens" | jq -r '.token // empty') || TOKEN=""
+              TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json" \
+                        "https://api.github.com/app/installations/$INST/access_tokens" | jq -r '.token // empty') || TOKEN=""
             fi
             if [ -z "$TOKEN" ]; then
               echo "WARNING: no GitHub App token obtained, cloning anonymously" >&2

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -134,6 +134,12 @@ version: 2.1
 #   <TAG>-deb manifests, e.g. 3.12-nightly-deb. Alpine stays suffix-less.
 #
 # Required environment (contexts / project settings):
+#   project env settings:           GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY_B64
+#                                   (arango-ci-checkout GitHub App, contents:read
+#                                   on public repos only; github-auth turns them
+#                                   into a 1h token so clones are not subject to
+#                                   GitHub's unauthenticated download limits;
+#                                   absent = anonymous clones as before)
 #   clamav-aws-bucket context:      AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
 #                                   (same values as the sccache bucket's) and
 #                                   CLAMAV_BUCKET (S3 bucket caching the
@@ -249,6 +255,46 @@ parameters:
     description: "TEST run for a GitHub PR — NOT a real nightly. The generator renames the workflow to nightly-packages-pr; every selected job runs, but publish-nightly degrades to a dry run: packages are staged to GCS and the staging tree is verified, then discarded instead of promoted; Docker images are loaded and tagged but never pushed; no manifests, no live Docker/ reports, no index upload. The reports are still produced and stored as job artifacts."
 
 commands:
+  github-auth:
+    # Anonymous clones from the runners' shared egress IP trip GitHub's limit on
+    # unauthenticated downloads (CI outage 2026-09-02/03). The arango-ci-checkout
+    # GitHub App (contents:read, public repos only) supplies a 1h token; without
+    # credentials or on any failure the job clones anonymously, as before.
+    steps:
+      - run:
+          name: Authenticate git against GitHub
+          command: |
+            set +x
+            if git config --global --get http.https://github.com/.extraheader >/dev/null 2>&1; then
+              exit 0
+            fi
+            if [ -z "${GITHUB_APP_ID:-}" ] || [ -z "${GITHUB_APP_PRIVATE_KEY_B64:-}" ]; then
+              echo "WARNING: GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY_B64 not set, cloning anonymously" >&2
+              exit 0
+            fi
+            KEY="$(mktemp)"
+            trap 'rm -f "$KEY"' EXIT
+            printf '%s' "$GITHUB_APP_PRIVATE_KEY_B64" | base64 -d > "$KEY"
+            b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+            NOW=$(date +%s)
+            JWT="$(printf '{"alg":"RS256","typ":"JWT"}' | b64url).$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW-60))" "$((NOW+540))" "$GITHUB_APP_ID" | b64url)"
+            JWT="$JWT.$(printf '%s' "$JWT" | openssl dgst -sha256 -sign "$KEY" -binary | b64url)" || JWT=""
+            INST=""
+            TOKEN=""
+            if [ -n "$JWT" ]; then
+              INST=$(curl -sSf -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                        https://api.github.com/orgs/arangodb/installation | jq -r '.id // empty') || INST=""
+            fi
+            if [ -n "$INST" ]; then
+              TOKEN=$(curl -sSf -X POST -H "Authorization: Bearer $JWT" -H "Accept: application/vnd.github+json"                         "https://api.github.com/app/installations/$INST/access_tokens" | jq -r '.token // empty') || TOKEN=""
+            fi
+            if [ -z "$TOKEN" ]; then
+              echo "WARNING: no GitHub App token obtained, cloning anonymously" >&2
+              exit 0
+            fi
+            git config --global http.https://github.com/.extraheader \
+              "AUTHORIZATION: basic $(printf 'x-access-token:%s' "$TOKEN" | base64 | tr -d '\n')"
+            echo "git authenticated against github.com as GitHub App installation $INST (token valid 1h)"
+
   checkout-arangodb:
     # Only compile-nightly needs the real source tree (sparse: false). All
     # other jobs work on the install tree / workspace and need just the
@@ -266,6 +312,7 @@ commands:
         type: boolean
         default: false
     steps:
+      - github-auth
       - run:
           name: Checkout ArangoDB
           command: |


### PR DESCRIPTION
### What

- New `github-auth` command in `base_config.yml` and `base_nightly_packages.yml`. It turns `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY_B64` (CircleCI project settings) into a 1-hour GitHub App installation token and sets `http.https://github.com/.extraheader` for the clones that follow. `github-auth-clear` removes the header again right after them, so nothing later in the job changes and a job running past the token's hour cannot fail on an expired header. Without the settings, or if the token request fails, `github-auth` prints a warning and the job clones anonymously as today.
- `github-auth` is the first and `github-auth-clear` the last step of `checkout-arangodb` (main repo and submodules) in the testing and nightly configs. Driver repositories are cloned over SSH, so `clone-driver-repo` is untouched.
- Enterprise and RTA are untouched and stay on the SSH deploy key. No change to `infrastructure.yml`, which already clones over SSH.

### Why

- On 2026-09-02/03 GitHub limited unauthenticated downloads from the runners' shared egress IP ("GitHub is temporarily limiting some unauthenticated downloads to protect the stability of the platform. Please retry later or authenticate."). 28 jobs failed, including the devel and 4.0 nightlies. GitHub announced this limiting for anonymous HTTPS clones in May 2025. Authenticated traffic is not subject to it.
- The identity is the `arango-ci-checkout` GitHub App: `contents: read`, installed on the arangodb org with only the public `arangodb/arangodb` repository selected. It can read public repositories and nothing else. No personal token, nothing to rotate.

### Notes

- Supersedes #23228. Same goal, without URL rewriting or credentials in URLs, and SSH clones are left alone.
- Verified locally and in a bare Ubuntu 24.04 container with only curl, jq, git and ca-certificates: authenticated rate limit 15000/h vs 60/h anonymous, idempotent on repeat, missing or invalid credentials fall back to anonymous with exit 0.
- `circleci config validate` passes for both files. The project settings are populated. Pipeline 56324 on this branch already logged `git authenticated against github.com as GitHub App installation 159014877 (token valid 1h)` in minimal-checkout (#4674046) and build-x64-frontend (#4674053) with Checkout ArangoDB and Checkout submodules green; it was started through the legacy pipeline definition and has been cancelled. The final revision ran through the `testing` definition as pipeline 56330 (https://app.circleci.com/pipelines/github/arangodb/arangodb/56330): setup, lint, aarch64-pr and x64-pr green. x64-pr needed a rerun of three test jobs (server_parameters, cluster-UI, single-UI) that failed on known-flaky tests after a successful checkout; the same tests failed in the devel nightlies 55872 and 56045. The nightly continuation config generated from the patched base validates as well.





