### PR TITLE
[COR-857] Feat: cost estimation for join orderings over index statistics

### DIFF
--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/CMakeLists.txt
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/CMakeLists.txt
@@ -1,3 +1,5 @@
 target_sources(arango_aql PRIVATE
+  IndexJoinStatistics.cpp
   JoinGraph.cpp
+  SystemRCostEstimator.cpp
 )

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/IndexJoinStatistics.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/IndexJoinStatistics.cpp
@@ -1,0 +1,310 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "IndexJoinStatistics.h"
+
+#include "Aql/Ast.h"
+#include "Aql/Collection.h"
+#include "Aql/ExecutionNode/EnumerateCollectionNode.h"
+#include "Aql/ExecutionPlan.h"
+#include "Aql/QueryContext.h"
+#include "Indexes/Index.h"
+#include "Transaction/Methods.h"
+
+#include <algorithm>
+#include <vector>
+
+namespace arangodb::aql {
+namespace {
+
+/// @brief only these index types carry a distinct-value estimate with the
+/// semantics this model needs. Inverted, geo, ttl, mdi and vector indexes
+/// report unrelated numbers.
+auto isAllowedType(IndexFacts const& facts) noexcept -> bool {
+  return facts.type == Index::TRI_IDX_TYPE_PRIMARY_INDEX ||
+         facts.type == Index::TRI_IDX_TYPE_EDGE_INDEX ||
+         facts.type == Index::TRI_IDX_TYPE_PERSISTENT_INDEX;
+}
+
+auto hasExpandedField(IndexFacts const& facts) noexcept -> bool {
+  for (auto const& field : facts.fields) {
+    for (auto const& component : field) {
+      if (component.shouldExpand) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/// @brief structural prerequisites shared by both rules. `sparse` is
+/// rejected because a sparse index's estimate is relative to the indexed
+/// documents only; expanded (array) fields have different selectivity
+/// semantics.
+auto isUsable(IndexFacts const& facts) noexcept -> bool {
+  return isAllowedType(facts) && !facts.hidden && !facts.inProgress &&
+         !facts.sparse && !hasExpandedField(facts);
+}
+
+auto fieldEquals(std::vector<basics::AttributeName> const& field,
+                 AttributePath const& path) -> bool {
+  if (field.size() != path.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < field.size(); ++i) {
+    if (field[i].shouldExpand || field[i].name != path[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// @brief are all of the candidate's fields present in `attributes`? A
+/// subset-covering index yields a lower bound on distinct(attributes), which
+/// is the conservative direction; a superset would over-estimate
+/// distinctness.
+auto fieldsAreSubsetOf(IndexFacts const& facts,
+                       std::span<AttributePath const> attributes) -> bool {
+  for (auto const& field : facts.fields) {
+    bool found = false;
+    for (auto const& path : attributes) {
+      if (fieldEquals(field, path)) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return false;
+    }
+  }
+  return true;
+}
+
+auto cacheKey(JoinGraph::Node const& node,
+              std::span<AttributePath const> attributes) -> std::string {
+  std::vector<std::string> parts;
+  parts.reserve(attributes.size());
+  for (auto const& path : attributes) {
+    std::string joined;
+    for (auto const& component : path) {
+      if (!joined.empty()) {
+        // Not '.': it can appear inside an attribute name, so ["a","b"] and
+        // ["a.b"] would collide in the cache. '\x1e' joins path components,
+        // '\x1f' joins whole paths below.
+        joined += '\x1e';
+      }
+      joined += component;
+    }
+    parts.emplace_back(std::move(joined));
+  }
+  std::sort(parts.begin(), parts.end());
+
+  std::string key = std::to_string(node.executionNode->id().id());
+  for (auto const& part : parts) {
+    key += '\x1f';
+    key += part;
+  }
+  return key;
+}
+
+/// @brief lift the properties this model needs out of a real Index. The
+auto toIndexFacts(Index const& index) -> IndexFacts {
+  IndexFacts facts;
+  facts.type = index.type();
+  facts.fields = index.fields();
+  facts.hidden = index.isHidden();
+  facts.inProgress = index.inProgress();
+  facts.sparse = index.sparse();
+  facts.hasSelectivityEstimate = index.hasSelectivityEstimate();
+  // The Index contract does not permit calling selectivityEstimate() when
+  // hasSelectivityEstimate() is false.
+  facts.selectivityEstimate =
+      facts.hasSelectivityEstimate ? index.selectivityEstimate() : 0.0;
+  return facts;
+}
+
+auto candidatesFor(JoinGraph::Node const& node) -> std::vector<IndexFacts> {
+  std::vector<IndexFacts> candidates;
+  for (auto const& index : node.executionNode->collection()->indexes()) {
+    if (index != nullptr) {
+      candidates.push_back(toIndexFacts(*index));
+    }
+  }
+  return candidates;
+}
+
+}  // namespace
+
+auto distinctFromIndexFacts(std::span<IndexFacts const> candidates,
+                            double count,
+                            std::span<AttributePath const> attributes)
+    -> DistinctEstimate {
+  if (attributes.empty()) {
+    // No restriction at all -- the empty-subset case of the rule below, not
+    // an exception to it, and it must not be reported as a guess.
+    return {1.0, false};
+  }
+
+  double best = 1.0;
+  bool found = false;
+
+  for (auto const& facts : candidates) {
+    if (!isUsable(facts)) {
+      continue;
+    }
+    if (!facts.hasSelectivityEstimate) {
+      continue;
+    }
+    if (!fieldsAreSubsetOf(facts, attributes)) {
+      continue;
+    }
+    // The Index contract does not promise that hasSelectivityEstimate()
+    // yields a usable number, and an out-of-range value divides by zero
+    // downstream.
+    double const selectivity = facts.selectivityEstimate;
+    if (!(selectivity > 0.0) || selectivity > 1.0) {
+      continue;
+    }
+    best = std::max(best, selectivity * count);
+    found = true;
+  }
+
+  if (!found) {
+    return {1.0, true};
+  }
+  return {std::clamp(best, 1.0, std::max(count, 1.0)), false};
+}
+
+auto coveringFromIndexFacts(std::span<IndexFacts const> candidates,
+                            std::span<AttributePath const> attributes) -> bool {
+  if (attributes.empty()) {
+    return false;
+  }
+
+  for (auto const& facts : candidates) {
+    if (!isUsable(facts)) {
+      continue;
+    }
+    // A probe needs the *leading* field: an index on (y,x) cannot serve a
+    // probe by x alone. No selectivity estimate is required, only
+    // existence.
+    if (facts.fields.empty()) {
+      continue;
+    }
+    auto const& leading = facts.fields.front();
+    for (auto const& path : attributes) {
+      if (fieldEquals(leading, path)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+IndexJoinStatistics::IndexJoinStatistics(ExecutionPlan const& plan)
+    : _plan(plan) {}
+
+/// @brief unlike distinctValues(), this has no `defaulted` channel: an
+/// out-of-transaction call silently reads back as 0.0 rather than reporting
+/// that it guessed. That is safe only by the combination of two properties,
+/// both worth re-checking before trusting this again:
+///   1. restrictedFor() clamps this to count = std::max(documentCount, 1.0),
+///      so a 0.0 here becomes count = 1 everywhere downstream, which makes
+///      probeCost == scanCost for every candidate order -- no order looks
+///      cheaper than any other, so this alone cannot steer the greedy.
+///   2. any real equijoin also calls distinctValues() with a non-empty
+///      attribute set, which *does* honestly report `defaulted = true` when
+///      the transaction is not RUNNING (see below) -- so the existing
+///      `defaulted` flag still reaches a caller through that second lookup,
+///      even though this one is silent.
+/// If either property stops holding -- e.g. a caller starts using
+/// documentCount for something other than a uniform "all counts are 1"
+/// clamp, or a code path reaches this with conditions/residuals empty and no
+/// accompanying distinctValues() call -- this reasoning breaks and
+/// documentCount needs its own `defaulted` channel.
+auto IndexJoinStatistics::documentCount(JoinGraph::Node const& node) const
+    -> double {
+  if (auto it = _counts.find(node.executionNode); it != _counts.end()) {
+    return it->second;
+  }
+
+  double count = 0.0;
+  auto& trx = _plan.getAst()->query().trxForOptimization();
+  if (trx.status() == transaction::Status::RUNNING) {
+    count = static_cast<double>(node.executionNode->collection()->count(
+        &trx, transaction::CountType::kTryCache));
+  }
+  _counts.emplace(node.executionNode, count);
+  return count;
+}
+
+auto IndexJoinStatistics::distinctValues(
+    JoinGraph::Node const& node,
+    std::span<AttributePath const> attributes) const -> DistinctEstimate {
+  if (attributes.empty()) {
+    // No restriction at all. This is the empty-subset case of the rule below,
+    // not an exception to it -- and it must not be reported as a guess.
+    return {1.0, false};
+  }
+
+  auto const key = cacheKey(node, attributes);
+  if (auto it = _distinct.find(key); it != _distinct.end()) {
+    return it->second;
+  }
+
+  // Defaults to "no confident estimate" and stays there unless the
+  // transaction is actually RUNNING. documentCount() has no defaulted
+  // channel of its own (it would silently read back as 0), and feeding that
+  // into the rule below for a qualifying index would look like a confident
+  // distinct count of 1 -- an unusable transaction must not masquerade as a
+  // confident estimate, so that case is rejected up front rather than being
+  // allowed to fall out of the arithmetic.
+  DistinctEstimate estimate{1.0, true};
+  auto& trx = _plan.getAst()->query().trxForOptimization();
+  if (trx.status() == transaction::Status::RUNNING) {
+    double const count = documentCount(node);
+    estimate = distinctFromIndexFacts(candidatesFor(node), count, attributes);
+  }
+
+  _distinct.emplace(key, estimate);
+  return estimate;
+}
+
+auto IndexJoinStatistics::hasIndexCovering(
+    JoinGraph::Node const& node,
+    std::span<AttributePath const> attributes) const -> bool {
+  if (attributes.empty()) {
+    return false;
+  }
+
+  auto const key = cacheKey(node, attributes);
+  if (auto it = _covering.find(key); it != _covering.end()) {
+    return it->second;
+  }
+
+  bool const covering = coveringFromIndexFacts(candidatesFor(node), attributes);
+
+  _covering.emplace(key, covering);
+  return covering;
+}
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/IndexJoinStatistics.h
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/IndexJoinStatistics.h
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinStatistics.h"
+#include "Basics/AttributeNameParser.h"
+#include "Indexes/Index.h"
+
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace arangodb::aql {
+class ExecutionPlan;
+
+/// @brief the index properties this model consults, lifted out of Index so
+/// the selection rules below can be exercised without a storage engine (no
+/// real collection, no registered indexes -- just scripted facts).
+struct IndexFacts {
+  Index::IndexType type = Index::TRI_IDX_TYPE_UNKNOWN;
+  std::vector<std::vector<basics::AttributeName>> fields;
+  bool hidden = false;
+  bool inProgress = false;
+  bool sparse = false;
+  bool hasSelectivityEstimate = false;
+  // Only meaningful when hasSelectivityEstimate is true; the Index contract
+  // forbids calling Index::selectivityEstimate() otherwise.
+  double selectivityEstimate = 0.0;
+};
+
+/// @brief |C_S| under the subset rule: consider only candidates whose fields
+/// are a subset of `attributes`, and take the maximum of
+/// selectivityEstimate() * count over them -- a subset-covering index yields
+/// a lower bound on distinct(attributes), which is the conservative
+/// direction; a superset would over-estimate distinctness and therefore
+/// under-estimate the join. Structural prerequisites (allowed type, not
+/// hidden, not in progress, not sparse, no expanded/array field, a usable
+/// selectivity estimate in (0, 1]) are enforced the same way regardless of
+/// where the facts came from. Falls back to {1.0, defaulted = true} -- the
+/// identity for both max() and the estimator's division -- when nothing
+/// qualifies, which includes the empty-attribute-set case (no real index
+/// has an empty field list, so nothing can ever look like a subset of it;
+/// that case is instead the trivial "exactly one empty tuple", handled here
+/// directly rather than left to fall out of the loop).
+auto distinctFromIndexFacts(std::span<IndexFacts const> candidates,
+                            double count,
+                            std::span<AttributePath const> attributes)
+    -> DistinctEstimate;
+
+/// @brief can any candidate serve a *probe* by these attributes, i.e. an
+/// index lookup rather than a full scan per outer row? This is a
+/// leading-field question, not a subset one: an index on (y,x) cannot serve
+/// a probe by x alone. No selectivity estimate is required, only existence.
+auto coveringFromIndexFacts(std::span<IndexFacts const> candidates,
+                            std::span<AttributePath const> attributes) -> bool;
+
+/// @brief statistics read from whatever indexes happen to exist on the
+/// collections. This runs before index selection, so it consults the
+/// collection's indexes directly rather than any IndexNode.
+///
+/// Depends only on the abstract Index interface: no concrete index class is
+/// named and no storage engine is assumed. The selection rules themselves
+/// live in distinctFromIndexFacts()/coveringFromIndexFacts() above, over the
+/// engine-independent IndexFacts; this class is just the thin adapter that
+/// reads real Index objects into that shape.
+class IndexJoinStatistics final : public JoinStatistics {
+ public:
+  explicit IndexJoinStatistics(ExecutionPlan const& plan);
+
+  auto documentCount(JoinGraph::Node const& node) const -> double override;
+
+  auto distinctValues(JoinGraph::Node const& node,
+                      std::span<AttributePath const> attributes) const
+      -> DistinctEstimate override;
+
+  auto hasIndexCovering(JoinGraph::Node const& node,
+                        std::span<AttributePath const> attributes) const
+      -> bool override;
+
+ private:
+  ExecutionPlan const& _plan;
+  // The greedy issues O(n^2) statistics queries and every uncached one walks
+  // the collection's index list, so both lookups are memoised. Keyed on the
+  // EnumerateCollectionNode -- not the JoinGraph::Node address -- because a
+  // JoinGraph is rebuilt per spine run while this object is expected to live
+  // for the whole plan, so a freed Node's address could otherwise be reused
+  // by an unrelated later graph's node (see SystemRCostEstimator's analogous
+  // cache for the same reasoning).
+  mutable std::unordered_map<EnumerateCollectionNode const*, double> _counts;
+  mutable std::unordered_map<std::string, DistinctEstimate> _distinct;
+  mutable std::unordered_map<std::string, bool> _covering;
+};
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinCostEstimator.h
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinCostEstimator.h
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.h"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <span>
+
+namespace arangodb::aql {
+class ExecutionPlan;
+
+/// @brief ceiling for cardinalities and costs. A long chain of defaulted
+/// statistics would otherwise reach infinity, and inf - inf is nan, which
+/// would break the ordering comparison. A large finite number keeps the
+/// comparison total.
+constexpr double kMaxEstimate = 1e18;
+
+inline auto clampEstimate(double value) noexcept -> double {
+  if (!std::isfinite(value) || value > kMaxEstimate) {
+    return kMaxEstimate;
+  }
+  return std::max(value, 0.0);
+}
+
+/// @brief cost of one index lookup per outer row. The descent traverses the
+/// whole index, so `collectionSize` is the *unrestricted* document count: a
+/// constant restriction on the inner side is an extra predicate and does not
+/// shrink the index. Floored at 1.0 per row so a one-document collection does
+/// not make a join free.
+///
+inline auto probeCost(double rows, double collectionSize) noexcept -> double {
+  double const perRow = std::max(std::log2(std::max(collectionSize, 1.0)), 1.0);
+  return clampEstimate(rows * perRow);
+}
+
+/// @brief cost of one full scan per outer row, i.e. no usable index.
+inline auto scanCost(double rows, double collectionSize) noexcept -> double {
+  return clampEstimate(rows * std::max(collectionSize, 1.0));
+}
+
+/// @brief the running estimate for one join prefix.
+struct JoinEstimate {
+  /// @brief n_i : estimated rows produced by the prefix.
+  double cardinality = 0.0;
+  /// @brief c_i : accumulated cost of the prefix.
+  double cost = 0.0;
+  /// @brief true when any statistic feeding this estimate was a fallback.
+  bool defaulted = false;
+};
+
+/// @brief costs the incremental growth of a join prefix.
+class JoinCostEstimator {
+ public:
+  virtual ~JoinCostEstimator() = default;
+
+  /// @brief the estimate for a prefix consisting of `start` alone.
+  virtual auto seed(JoinGraph::Node const& start) const -> JoinEstimate = 0;
+
+  /// @brief extend the prefix by `next`, joined via `connecting` -- *all* edges
+  /// between `next` and the prefix, because a cycle constrains the new vertex
+  /// with more than one predicate. An empty span means a cross product.
+  virtual auto extend(JoinEstimate const& prefix, JoinGraph::Node const& next,
+                      std::span<JoinGraph::Edge const* const> connecting) const
+      -> JoinEstimate = 0;
+};
+
+/// @brief the estimator used in production: System-R cardinality over
+/// index-backed statistics.
+auto makeDefaultJoinCostEstimator(ExecutionPlan const& plan)
+    -> std::unique_ptr<JoinCostEstimator>;
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.cpp
@@ -86,7 +86,28 @@ auto JoinGraph::addJoinCondition(Variable const* v, AttributePath vAttributes,
 }
 
 void JoinGraph::addResidual(AstNode const* node) {
-  residuals.emplace_back(node);
+  // A residual that constrains exactly one graph variable is a genuine
+  // restriction on that node's row count, so attach it there. Anything that
+  // touches none or several is kept graph-level and left unmodelled.
+  VarSet referenced;
+  Ast::getReferencedVariables(node, referenced);
+
+  Node* single = nullptr;
+  for (auto const* var : referenced) {
+    if (auto* candidate = nodeForVariable(var); candidate != nullptr) {
+      if (single != nullptr && single != candidate) {
+        single = nullptr;  // more than one graph variable
+        break;
+      }
+      single = candidate;
+    }
+  }
+
+  if (single != nullptr) {
+    single->residuals.emplace_back(node);
+  } else {
+    residuals.emplace_back(node);
+  }
 }
 
 auto JoinGraph::getEdgesForNode(Node* node) -> std::vector<Edge*> {
@@ -157,6 +178,8 @@ auto extractAttributeAccess(AstNode const* n, AttributePath& path)
   return nullptr;
 }
 
+}  // namespace
+
 auto extractAttributeAccess(AstNode const* n)
     -> std::optional<std::pair<Variable const*, AttributePath>> {
   AttributePath path;
@@ -166,6 +189,8 @@ auto extractAttributeAccess(AstNode const* n)
   }
   return std::nullopt;
 }
+
+namespace {
 
 // equijoins between two graph variables become edges, constant restrictions on
 // a single graph variable become node conditions, everything else is recorded

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.h
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.h
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <map>
+#include <optional>
+#include <utility>
 #include <string_view>
 #include <vector>
 
@@ -35,6 +37,12 @@ struct Variable;
 /// @brief a path of nested attribute accesses, e.g. `doc.a.b` -> {"a", "b"}.
 using AttributePath = std::vector<std::string_view>;
 
+/// @brief if `n` is a chain of attribute accesses rooted at a variable
+/// reference, return that variable and the path. A leading `_id` is rewritten
+/// to `_key` so it matches the primary index.
+auto extractAttributeAccess(AstNode const* n)
+    -> std::optional<std::pair<Variable const*, AttributePath>>;
+
 /// @brief The join graph describes a maximal run of adjacent collection
 /// enumerations (`FOR`-loops) that are connected via equijoin conditions.
 struct JoinGraph {
@@ -44,6 +52,11 @@ struct JoinGraph {
     /// @brief attribute paths that are constrained by a constant restriction
     /// on this node (e.g. the `x` of `doc.x == 'foo'`).
     std::vector<AttributePath> conditions;
+
+    /// @brief residual predicates that reference this node's variable and no
+    /// other graph variable. Priced with a default selectivity factor by the
+    /// cost estimator.
+    std::vector<AstNode const*> residuals;
 
     explicit Node(EnumerateCollectionNode* executionNode)
         : executionNode(executionNode) {}

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinStatistics.h
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/JoinStatistics.h
@@ -1,0 +1,69 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.h"
+
+#include <span>
+
+namespace arangodb::aql {
+
+/// @brief the result of a distinct-tuple lookup.
+struct DistinctEstimate {
+  /// @brief |C_S| : estimated number of distinct *tuples* over the attribute
+  /// set S. For S = {x,y} this is the count of distinct (x,y) combinations,
+  /// not distinct(x) * distinct(y) and not either one alone. A count, not a
+  /// ratio; `double` because it is an estimate that feeds into products.
+  double value = 1.0;
+  /// @brief true when no index could supply an estimate and `value` is the
+  /// fallback of 1.
+  bool defaulted = true;
+};
+
+/// @brief statistics about the data a join graph reads. Implementations must
+/// depend only on the abstract Index and Collection interfaces, never on a
+/// concrete index class or a particular storage engine.
+class JoinStatistics {
+ public:
+  virtual ~JoinStatistics() = default;
+
+  /// @brief |C_v| : documents in the node's collection.
+  virtual auto documentCount(JoinGraph::Node const& node) const -> double = 0;
+
+  /// @brief |C_S| : distinct tuples over the attribute set S. Note the two
+  /// levels of vector mean different things -- AttributePath is itself a
+  /// vector, so S = {["b","c"]} is the *single* attribute v.b.c and the tuple
+  /// arity is S.size(), not the length of any path within it.
+  virtual auto distinctValues(JoinGraph::Node const& node,
+                              std::span<AttributePath const> attributes) const
+      -> DistinctEstimate = 0;
+
+  /// @brief can an index serve a *probe* by these attributes, i.e. an index
+  /// lookup rather than a full scan per outer row? This is a leading-field
+  /// question, not a subset one, and needs no selectivity estimate.
+  virtual auto hasIndexCovering(JoinGraph::Node const& node,
+                                std::span<AttributePath const> attributes) const
+      -> bool = 0;
+};
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/SystemRCostEstimator.cpp
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/SystemRCostEstimator.cpp
@@ -1,0 +1,205 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "SystemRCostEstimator.h"
+
+#include "Aql/AstNode.h"
+#include "Aql/ExecutionNode/EnumerateCollectionNode.h"
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/IndexJoinStatistics.h"
+#include "Assertions/ProdAssert.h"
+
+#include <algorithm>
+#include <array>
+#include <utility>
+
+namespace arangodb::aql {
+namespace {
+
+/// @brief the same attribute path may be recorded twice, e.g. from
+/// `a.x == 'u' AND a.x == 'v'`. Dividing twice by its distinct count would
+/// double-count the restriction.
+auto dedupe(std::vector<AttributePath> const& paths)
+    -> std::vector<AttributePath> {
+  std::vector<AttributePath> result = paths;
+  std::sort(result.begin(), result.end());
+  result.erase(std::unique(result.begin(), result.end()), result.end());
+  return result;
+}
+
+}  // namespace
+
+auto residualSelectivityFactor(AstNode const* residual,
+                               JoinStatistics const& stats,
+                               JoinGraph::Node const& node) -> double {
+  switch (residual->type) {
+    case NODE_TYPE_OPERATOR_BINARY_LT:
+    case NODE_TYPE_OPERATOR_BINARY_LE:
+    case NODE_TYPE_OPERATOR_BINARY_GT:
+    case NODE_TYPE_OPERATOR_BINARY_GE:
+      return kRangeSelectivityFactor;
+
+    case NODE_TYPE_OPERATOR_BINARY_IN: {
+      if (residual->numMembers() != 2) {
+        return 1.0;
+      }
+      auto const* values = residual->getMemberUnchecked(1);
+      if (!values->isArray()) {
+        return 1.0;
+      }
+      auto access = extractAttributeAccess(residual->getMemberUnchecked(0));
+      if (!access.has_value() ||
+          access->first != node.executionNode->outVariable()) {
+        // Either not an attribute access, or an access on some other
+        // variable: a residual is attached to a node when it references
+        // exactly one *graph* variable, but it may also reference non-graph
+        // variables (e.g. `FILTER t.k IN [a.x, 1, 2]` attaches to `a`), so
+        // this cannot be assumed to be about `node`'s own attribute.
+        return 1.0;
+      }
+      std::array<AttributePath, 1> attributes{std::move(access->second)};
+      auto distinct = stats.distinctValues(node, attributes);
+      if (distinct.defaulted) {
+        return 1.0;
+      }
+      return std::min(1.0, static_cast<double>(values->numMembers()) /
+                               std::max(distinct.value, 1.0));
+    }
+
+    default:
+      // no principled constant for this shape; do not guess
+      return 1.0;
+  }
+}
+
+SystemRCostEstimator::SystemRCostEstimator(
+    std::unique_ptr<JoinStatistics> statistics)
+    : _statistics(std::move(statistics)) {
+  ADB_PROD_ASSERT(_statistics != nullptr);
+}
+
+auto SystemRCostEstimator::restrictedFor(JoinGraph::Node const& node) const
+    -> Restricted const& {
+  auto const* variable = node.executionNode->outVariable();
+  if (auto it = _restricted.find(variable); it != _restricted.end()) {
+    return it->second;
+  }
+
+  double const count = std::max(_statistics->documentCount(node), 1.0);
+  auto const conditions = dedupe(node.conditions);
+  auto const distinct = _statistics->distinctValues(node, conditions);
+
+  Restricted value;
+  value.defaulted = distinct.defaulted;
+  value.restricted =
+      std::clamp(count / std::max(distinct.value, 1.0), 1.0, count);
+
+  double base = value.restricted;
+  for (auto const* residual : node.residuals) {
+    base *= residualSelectivityFactor(residual, *_statistics, node);
+  }
+  value.base = std::clamp(base, 1.0, count);
+
+  return _restricted.emplace(variable, value).first->second;
+}
+
+auto SystemRCostEstimator::seed(JoinGraph::Node const& start) const
+    -> JoinEstimate {
+  auto const& restricted = restrictedFor(start);
+
+  JoinEstimate estimate;
+  estimate.cardinality = clampEstimate(restricted.base);
+  estimate.defaulted = restricted.defaulted;
+  // An index over the constant restrictions turns the initial scan into a
+  // lookup returning restricted(v) rows; otherwise the whole collection is
+  // read. Residuals never cheapen this -- they filter afterwards.
+  estimate.cost =
+      _statistics->hasIndexCovering(start, start.conditions)
+          ? clampEstimate(restricted.restricted)
+          : clampEstimate(std::max(_statistics->documentCount(start), 1.0));
+  return estimate;
+}
+
+auto SystemRCostEstimator::extend(
+    JoinEstimate const& prefix, JoinGraph::Node const& next,
+    std::span<JoinGraph::Edge const* const> connecting) const -> JoinEstimate {
+  auto const& nextRestricted = restrictedFor(next);
+
+  JoinEstimate estimate;
+  estimate.defaulted = prefix.defaulted || nextRestricted.defaulted;
+
+  double factor = 1.0;
+  bool probeable = false;
+
+  for (auto const* edge : connecting) {
+    if (edge->from == edge->to) {
+      // A self-loop is really a single-node filter, not a join predicate; it
+      // constrains nothing about this extension.
+      continue;
+    }
+    bool const nextIsTo = (edge->to == &next);
+    ADB_PROD_ASSERT(nextIsTo || edge->from == &next);
+
+    auto const& nextAttributes =
+        nextIsTo ? edge->toAttributes : edge->fromAttributes;
+    auto const& otherAttributes =
+        nextIsTo ? edge->fromAttributes : edge->toAttributes;
+    JoinGraph::Node const* other = nextIsTo ? edge->from : edge->to;
+
+    auto const& otherRestricted = restrictedFor(*other);
+    auto const otherDistinct =
+        _statistics->distinctValues(*other, otherAttributes);
+    auto const nextDistinct = _statistics->distinctValues(next, nextAttributes);
+    estimate.defaulted =
+        estimate.defaulted || otherDistinct.defaulted || nextDistinct.defaulted;
+
+    // A node cannot hold more distinct values than surviving rows.
+    double const dp = std::min(otherDistinct.value, otherRestricted.base);
+    double const dn = std::min(nextDistinct.value, nextRestricted.base);
+    factor /= std::max({dp, dn, 1.0});
+
+    probeable =
+        probeable || _statistics->hasIndexCovering(next, nextAttributes);
+  }
+
+  double const count = std::max(_statistics->documentCount(next), 1.0);
+  // Floored at 1.0: a join cannot meaningfully produce less than one row when
+  // its output is itself a multiplier feeding later extend() calls. Without
+  // this floor, two connecting edges plus a residual-shrunk base(next) can
+  // drive the product arbitrarily far below 1 (clampEstimate only floors at
+  // 0), which then charges near-zero cost for every subsequent step and
+  // erases the cost differences the search relies on to discriminate between
+  // orderings.
+  estimate.cardinality = std::max(
+      clampEstimate(prefix.cardinality * nextRestricted.base * factor), 1.0);
+  estimate.cost = clampEstimate(
+      prefix.cost + (probeable ? probeCost(prefix.cardinality, count)
+                               : scanCost(prefix.cardinality, count)));
+  return estimate;
+}
+
+auto makeDefaultJoinCostEstimator(ExecutionPlan const& plan)
+    -> std::unique_ptr<JoinCostEstimator> {
+  return std::make_unique<SystemRCostEstimator>(
+      std::make_unique<IndexJoinStatistics>(plan));
+}
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/SystemRCostEstimator.h
+++ b/arangod/Aql/Optimizer/Rule/OptimizeJoinOrder/SystemRCostEstimator.h
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinCostEstimator.h"
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinStatistics.h"
+
+#include <memory>
+#include <span>
+#include <unordered_map>
+
+namespace arangodb::aql {
+
+/// @brief System-R's default selectivity factor for a range comparison with
+/// unknown bounds: a third of the rows survive.
+constexpr double kRangeSelectivityFactor = 1.0 / 3.0;
+
+/// @brief the fraction of `node`'s rows that survive the residual predicate
+/// `residual`, in the surviving-fraction sense (1.0 filters nothing -- the
+/// opposite direction from Index::selectivityEstimate). Returns 1.0 for any
+/// predicate shape without a principled constant, so an unmodelled predicate
+/// leaves the estimate untouched rather than nudging it arbitrarily.
+auto residualSelectivityFactor(AstNode const* residual,
+                               JoinStatistics const& stats,
+                               JoinGraph::Node const& node) -> double;
+
+/// @brief System-R cardinality estimation over a pluggable statistics source.
+/// |a join b| = |a||b| / max(|a_x|, |b_y|), which is symmetric, paired with the
+/// engine-level probe/scan cost recurrence from JoinCostEstimator.h.
+class SystemRCostEstimator final : public JoinCostEstimator {
+ public:
+  explicit SystemRCostEstimator(std::unique_ptr<JoinStatistics> statistics);
+
+  auto seed(JoinGraph::Node const& start) const -> JoinEstimate override;
+
+  auto extend(JoinEstimate const& prefix, JoinGraph::Node const& next,
+              std::span<JoinGraph::Edge const* const> connecting) const
+      -> JoinEstimate override;
+
+ private:
+  /// @brief per-node row counts. `restricted` is after the equality
+  /// restrictions only and drives *costs*, because an index lookup returns
+  /// that many rows and the residuals filter them afterwards. `base` is after
+  /// the residuals too and drives *cardinalities*.
+  struct Restricted {
+    double restricted = 1.0;
+    double base = 1.0;
+    bool defaulted = false;
+  };
+
+  auto restrictedFor(JoinGraph::Node const& node) const -> Restricted const&;
+
+  std::unique_ptr<JoinStatistics> _statistics;
+  // Keyed on the node's out-variable, not the `JoinGraph::Node*` address: the
+  // rule builds and destroys one JoinGraph per spine run while this estimator
+  // is constructed once per plan, so a freed node's address can be reused by
+  // an unrelated later graph's node. Variables are owned by the Ast and stay
+  // alive and distinct for the whole plan, so they are a safe cache key.
+  mutable std::unordered_map<Variable const*, Restricted> _restricted;
+};
+
+}  // namespace arangodb::aql

--- a/arangod/Aql/Query.cpp
+++ b/arangod/Aql/Query.cpp
@@ -1931,6 +1931,20 @@ void Query::initTrxForTests() {
   auto res = _trx->begin();
   TRI_ASSERT(res.ok());
 }
+
+void Query::prepareOptimizedPlanForTests() {
+  // Mirrors the beginning of prepareQuery(): initialize, then hand off to
+  // preparePlan(), which parses, validates/optimizes the AST, opens the
+  // transaction, instantiates the plan and runs the optimizer. Unlike
+  // prepareQuery(), we stop right there instead of going on to physically
+  // instantiate the execution engine and enter EXECUTION -- preparePlan()
+  // itself never advances the state past PLAN_OPTIMIZATION.
+  init(/*createProfile*/ false);
+  enterState(QueryExecutionState::ValueType::PARSING);
+  auto plan = preparePlan();
+  TRI_ASSERT(plan != nullptr);
+  _plans.push_back(std::move(plan));
+}
 #endif
 
 /// @brief return the query's shared state

--- a/arangod/Aql/Query.h
+++ b/arangod/Aql/Query.h
@@ -256,6 +256,17 @@ class Query : public QueryContext, public std::enable_shared_from_this<Query> {
   }
   void initForTests();
   void initTrxForTests();
+
+  /// @brief runs the same parse/validate/instantiate/optimize pipeline that
+  /// prepareQuery() uses (via preparePlan()), but -- unlike prepareQuery() --
+  /// never proceeds to physically instantiate the execution engine or enter
+  /// EXECUTION state. The query is left in PLAN_OPTIMIZATION with its
+  /// transaction open, so optimization-time APIs such as
+  /// trxForOptimization() remain callable on the result afterwards, which
+  /// lets tests exercise an optimizer-adjacent component directly against a
+  /// real Query/transaction/plan instead of only through the optimizer rule
+  /// that would normally call it.
+  void prepareOptimizedPlanForTests();
 #endif
 
   AqlItemBlockManager& itemBlockManager() { return _itemBlockManager; }

--- a/tests/Aql/IndexJoinStatisticsTest.cpp
+++ b/tests/Aql/IndexJoinStatisticsTest.cpp
@@ -1,0 +1,361 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/IndexJoinStatistics.h"
+#include "JoinGraphTestHelper.h"
+// trx.abort() below needs the full transaction::Methods definition, which
+// none of the above only-forward-declaring headers provide.
+#include "Transaction/Methods.h"
+
+// createIndex() is called through a shared_ptr<LogicalCollection>, so the full
+// definition is required here -- JoinGraphTestHelper.h only forward-declares
+// it.
+#include "VocBase/LogicalCollection.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+using namespace arangodb::aql;
+
+namespace arangodb::tests::aql {
+namespace {
+
+// -----------------------------------------------------------------------------
+// IndexJoinStatistics itself, against a real MockAqlServer collection. This
+// exercises the adapter (real Ast/Query/transaction, real Collection) end to
+// end -- exactly what the IndexFacts-level tests below cannot do.
+//
+// PhysicalCollectionMock::createIndex implements only edge, hash, inverted
+// and arangosearch types, so a "persistent" index is never created and never
+// found here. Only the "no index found" paths are exercisable against this
+// fixture; which index qualifies belongs to the IndexFacts-level tests below.
+// -----------------------------------------------------------------------------
+
+class IndexJoinStatisticsTest : public testing::Test {
+ protected:
+  mocks::MockAqlServer server;
+
+  // Creates collection `name` with `count` documents where x = i, y = i % 10,
+  // z = i, then applies `indexes` (each a full index definition).
+  void makeCollection(std::string const& name, int count,
+                      std::vector<std::string> const& indexes = {}) {
+    auto& vocbase = server.getSystemDatabase();
+    auto json = velocypack::Parser::fromJson(R"({"name":")" + name + R"("})");
+    auto collection = vocbase.createCollection(json->slice());
+    for (auto const& definition : indexes) {
+      bool created = false;
+      collection
+          ->createIndex(velocypack::Parser::fromJson(definition)->slice(),
+                        created)
+          .waitAndGet();
+    }
+    executeQuery(vocbase, "FOR i IN 1.." + std::to_string(count) +
+                              " INSERT {x: i, y: i % 10, z: i} INTO " + name);
+  }
+
+  static AttributePath path(std::string_view name) {
+    return AttributePath{name};
+  }
+};
+
+}  // namespace
+
+TEST_F(IndexJoinStatisticsTest, document_count_matches_the_collection) {
+  makeCollection("s1", 100);
+  auto q = prepareJoinPlanForStatistics(server, "FOR a IN s1 RETURN a");
+  auto g = buildGraph(*q);
+  IndexJoinStatistics stats{*q->plan()};
+
+  EXPECT_DOUBLE_EQ(stats.documentCount(*nodeByName(g, "a")), 100.0);
+}
+
+TEST_F(IndexJoinStatisticsTest, empty_attribute_set_is_one_and_not_defaulted) {
+  makeCollection("s1", 100);
+  auto q = prepareJoinPlanForStatistics(server, "FOR a IN s1 RETURN a");
+  auto g = buildGraph(*q);
+  IndexJoinStatistics stats{*q->plan()};
+
+  auto est = stats.distinctValues(*nodeByName(g, "a"), {});
+  EXPECT_DOUBLE_EQ(est.value, 1.0);
+  EXPECT_FALSE(est.defaulted)
+      << "an unrestricted node must not be reported as a guess";
+}
+
+TEST_F(IndexJoinStatisticsTest, no_covering_index_defaults_to_one) {
+  makeCollection("s1", 100);
+  auto q = prepareJoinPlanForStatistics(server, "FOR a IN s1 RETURN a");
+  auto g = buildGraph(*q);
+  IndexJoinStatistics stats{*q->plan()};
+
+  std::array<AttributePath, 1> attributes{path("x")};
+  auto est = stats.distinctValues(*nodeByName(g, "a"), attributes);
+  EXPECT_DOUBLE_EQ(est.value, 1.0);
+  EXPECT_TRUE(est.defaulted);
+}
+
+TEST_F(IndexJoinStatisticsTest,
+       unusable_transaction_defaults_even_with_a_qualifying_index) {
+  // If the transaction cannot be consulted, documentCount() falls back to 0
+  // (its only fallback -- the interface has no defaulted channel of its
+  // own). Naively feeding that into `selectivity * count` for a qualifying
+  // index would produce a confident-looking {1.0, defaulted = false}: a
+  // fabricated statistic wearing a trustworthy flag. distinctValues() must
+  // reject this case outright rather than let it fall out of the
+  // arithmetic.
+  makeCollection("s1", 100,
+                 {R"({"type":"persistent","fields":["x"],"unique":true})"});
+  auto q = prepareJoinPlanForStatistics(server, "FOR a IN s1 RETURN a");
+  auto g = buildGraph(*q);
+  IndexJoinStatistics stats{*q->plan()};
+
+  auto& trx = q->trxForOptimization();
+  ASSERT_TRUE(trx.abort().ok());
+
+  std::array<AttributePath, 1> attributes{path("x")};
+  auto est = stats.distinctValues(*nodeByName(g, "a"), attributes);
+  EXPECT_DOUBLE_EQ(est.value, 1.0);
+  EXPECT_TRUE(est.defaulted);
+}
+
+// -----------------------------------------------------------------------------
+// The selection rules themselves, against scripted IndexFacts. No collection,
+// no server, no storage engine:
+// distinctFromIndexFacts()/coveringFromIndexFacts() are pure functions of the
+// facts and the attribute set, which is exactly what lets these be exact and
+// environment-independent.
+//
+// Every rejection case below is paired with a qualifying index (or, where a
+// companion index would be numerically invisible against a max(), a solo
+// index whose exclusion is instead observable through `defaulted`) so that an
+// implementation with the corresponding guard removed would fail the test,
+// not pass it vacuously.
+// -----------------------------------------------------------------------------
+
+namespace {
+
+auto singleField(std::string_view name, bool expand = false)
+    -> std::vector<basics::AttributeName> {
+  return {basics::AttributeName{name, expand}};
+}
+
+// A persistent index (the type this model trusts for a selectivity estimate)
+// covering exactly one field, with a controllable estimate.
+auto qualifyingIndex(std::string_view name, double selectivity) -> IndexFacts {
+  IndexFacts facts;
+  facts.type = Index::TRI_IDX_TYPE_PERSISTENT_INDEX;
+  facts.fields = {singleField(name)};
+  facts.hasSelectivityEstimate = true;
+  facts.selectivityEstimate = selectivity;
+  return facts;
+}
+
+}  // namespace
+
+TEST(IndexFactsRulesTest, subset_index_qualifies) {
+  // index on {x} is a subset of {x,y}: distinct(x) <= distinct(x,y), a valid
+  // lower bound, so it may be used.
+  std::array<IndexFacts, 1> candidates{qualifyingIndex("x", 1.0)};
+  std::array<AttributePath, 2> attributes{AttributePath{"x"},
+                                          AttributePath{"y"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 100.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     superset_index_is_rejected_even_with_a_qualifying_index) {
+  // index on {x,z} is a superset of {x}: distinct(x,z) >= distinct(x), so
+  // using it would over-estimate distinctness and under-estimate the join.
+  // The qualifying {x} index alone would report 10 (selectivity 0.1); if the
+  // superset were wrongly allowed too, its selectivity of 1.0 would push the
+  // answer to 100 instead.
+  auto superset = qualifyingIndex("x", 1.0);
+  superset.fields = {singleField("x"), singleField("z")};
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), superset};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     sparse_index_is_rejected_even_with_a_qualifying_index) {
+  // a sparse index's estimate is relative to the indexed documents only.
+  auto sparse = qualifyingIndex("x", 1.0);
+  sparse.sparse = true;
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), sparse};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     disallowed_type_is_rejected_even_with_a_qualifying_index) {
+  // Inverted, geo, ttl, mdi and vector indexes report unrelated numbers, so
+  // only primary/edge/persistent indexes are trusted.
+  auto disallowed = qualifyingIndex("x", 1.0);
+  disallowed.type = Index::TRI_IDX_TYPE_INVERTED_INDEX;
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), disallowed};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     hidden_index_is_rejected_even_with_a_qualifying_index) {
+  // Collection::indexes() already strips hidden indexes, so in production
+  // this guard is belt-and-braces; the rule is pure over IndexFacts and must
+  // not assume its caller filtered.
+  auto hidden = qualifyingIndex("x", 1.0);
+  hidden.hidden = true;
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), hidden};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     in_progress_index_is_rejected_even_with_a_qualifying_index) {
+  // An index still being built has no reliable estimate yet.
+  auto inProgress = qualifyingIndex("x", 1.0);
+  inProgress.inProgress = true;
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), inProgress};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     expanded_field_is_rejected_even_with_a_qualifying_index) {
+  // An index on x[*] has different selectivity semantics than a plain field.
+  auto expanded = qualifyingIndex("x", 1.0);
+  expanded.fields = {singleField("x", /*expand*/ true)};
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), expanded};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     missing_selectivity_estimate_is_rejected_even_with_a_qualifying_index) {
+  // hasSelectivityEstimate() == false must be honoured even when a stale
+  // value sits in the estimate field.
+  auto noEstimate = qualifyingIndex("x", 1.0);
+  noEstimate.hasSelectivityEstimate = false;
+  std::array<IndexFacts, 2> candidates{qualifyingIndex("x", 0.1), noEstimate};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 10.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest, zero_selectivity_is_rejected_despite_the_flag) {
+  // A selectivity of 0.0 divides badly downstream and is never a genuine
+  // "every row is distinct" reading, so it is rejected even though
+  // hasSelectivityEstimate() says true. Unlike the other rejections, a
+  // companion qualifying index would make this invisible: a 0-contribution
+  // never changes a max(). So this is a solo positive control instead --
+  // without the guard, this index alone would be accepted and report
+  // {1.0, defaulted = false} rather than the correct {1.0, defaulted = true}.
+  std::array<IndexFacts, 1> candidates{qualifyingIndex("x", 0.0)};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 1.0);
+  EXPECT_TRUE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     distinct_takes_the_max_over_several_qualifying_indexes) {
+  std::array<IndexFacts, 3> candidates{
+      qualifyingIndex("x", 0.1),
+      qualifyingIndex("x", 0.3),
+      qualifyingIndex("x", 0.05),
+  };
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, 100.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 30.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest,
+     distinct_is_floored_at_one_even_for_an_empty_collection) {
+  // selectivity is always <= 1, so selectivity * count can never exceed
+  // count -- the clamp's upper bound is never actually reached. Its lower
+  // bound is the interesting side: a qualifying index over an empty (or
+  // fully-restricted-to-nothing) collection must still report 1, not 0.
+  std::array<IndexFacts, 1> candidates{qualifyingIndex("x", 1.0)};
+  std::array<AttributePath, 1> attributes{AttributePath{"x"}};
+
+  auto est = distinctFromIndexFacts(candidates, /*count*/ 0.0, attributes);
+  EXPECT_DOUBLE_EQ(est.value, 1.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST(IndexFactsRulesTest, covering_needs_the_leading_field) {
+  // an index on (y,x) cannot serve a probe by x alone
+  IndexFacts compound;
+  compound.type = Index::TRI_IDX_TYPE_PERSISTENT_INDEX;
+  compound.fields = {singleField("y"), singleField("x")};
+  compound.hasSelectivityEstimate = true;
+  compound.selectivityEstimate = 1.0;
+  std::array<IndexFacts, 1> candidates{compound};
+
+  std::array<AttributePath, 1> byX{AttributePath{"x"}};
+  std::array<AttributePath, 1> byY{AttributePath{"y"}};
+  EXPECT_FALSE(coveringFromIndexFacts(candidates, byX));
+  EXPECT_TRUE(coveringFromIndexFacts(candidates, byY));
+}
+
+TEST(IndexFactsRulesTest, covering_succeeds_without_a_selectivity_estimate) {
+  // The index still exists and can still serve a probe even with no
+  // selectivity estimate at all -- that is a distinctValues() concern, not a
+  // hasIndexCovering() one.
+  IndexFacts noEstimate;
+  noEstimate.type = Index::TRI_IDX_TYPE_PERSISTENT_INDEX;
+  noEstimate.fields = {singleField("x")};
+  noEstimate.hasSelectivityEstimate = false;
+  std::array<IndexFacts, 1> candidates{noEstimate};
+  std::array<AttributePath, 1> byX{AttributePath{"x"}};
+
+  EXPECT_TRUE(coveringFromIndexFacts(candidates, byX));
+  EXPECT_TRUE(distinctFromIndexFacts(candidates, 100.0, byX).defaulted);
+}
+
+}  // namespace arangodb::tests::aql

--- a/tests/Aql/JoinCostEstimatorTest.cpp
+++ b/tests/Aql/JoinCostEstimatorTest.cpp
@@ -1,0 +1,510 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#include "gtest/gtest.h"
+
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinCostEstimator.h"
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/SystemRCostEstimator.h"
+
+#include "JoinGraphTestHelper.h"
+
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+
+using namespace arangodb::aql;
+
+namespace arangodb::tests::aql {
+
+TEST(JoinCostFunctionsTest, probe_cost_is_rows_times_log2_of_collection) {
+  EXPECT_DOUBLE_EQ(probeCost(100.0, 1000.0), 100.0 * std::log2(1000.0));
+  EXPECT_DOUBLE_EQ(probeCost(1000.0, 100.0), 1000.0 * std::log2(100.0));
+}
+
+TEST(JoinCostFunctionsTest, probe_cost_per_row_is_floored_at_one) {
+  // log2(1) == 0 would make a join into a one-document collection free.
+  EXPECT_DOUBLE_EQ(probeCost(50.0, 1.0), 50.0);
+  EXPECT_DOUBLE_EQ(probeCost(50.0, 0.0), 50.0);
+}
+
+TEST(JoinCostFunctionsTest, scan_cost_is_rows_times_collection) {
+  EXPECT_DOUBLE_EQ(scanCost(100.0, 1000.0), 100000.0);
+  // an empty collection still costs one touch per outer row
+  EXPECT_DOUBLE_EQ(scanCost(100.0, 0.0), 100.0);
+}
+
+TEST(JoinCostFunctionsTest, probing_beats_scanning_the_larger_side) {
+  // scan the small collection, probe the large one
+  double const scanSmallProbeLarge = 100.0 + probeCost(100.0, 1000.0);
+  double const scanLargeProbeSmall = 1000.0 + probeCost(1000.0, 100.0);
+  EXPECT_LT(scanSmallProbeLarge, scanLargeProbeSmall);
+}
+
+TEST(JoinCostFunctionsTest, estimates_clamp_to_a_finite_ceiling) {
+  EXPECT_DOUBLE_EQ(clampEstimate(std::numeric_limits<double>::infinity()),
+                   kMaxEstimate);
+  EXPECT_DOUBLE_EQ(clampEstimate(std::nan("")), kMaxEstimate);
+  EXPECT_DOUBLE_EQ(clampEstimate(1e300), kMaxEstimate);
+  EXPECT_DOUBLE_EQ(clampEstimate(-5.0), 0.0);
+  EXPECT_DOUBLE_EQ(clampEstimate(42.0), 42.0);
+  EXPECT_DOUBLE_EQ(scanCost(1e200, 1e200), kMaxEstimate);
+}
+
+TEST(JoinCostFunctionsTest, probe_cost_guards_log2_against_a_nonpositive_size) {
+  // The inner max(collectionSize, 1.0) keeps log2's argument >= 1. Without it a
+  // negative size yields log2(negative) == NaN, and std::max(NaN, 1.0) returns
+  // NaN rather than the floor, so the NaN would propagate into the cost.
+  // clampEstimate would catch it downstream, but the guard is what keeps the
+  // per-row cost meaningful in the first place.
+  EXPECT_DOUBLE_EQ(probeCost(10.0, -5.0), 10.0);
+  EXPECT_TRUE(std::isfinite(probeCost(10.0, -5.0)));
+}
+
+class SystemRCostEstimatorTest : public testing::Test {
+ protected:
+  mocks::MockAqlServer server;
+
+  SystemRCostEstimatorTest() {
+    auto& vocbase = server.getSystemDatabase();
+    for (auto const& name : {"c1", "c2", "c3"}) {
+      auto json = velocypack::Parser::fromJson(std::string{R"({"name":")"} +
+                                               name + "\"}");
+      vocbase.createCollection(json->slice());
+    }
+  }
+
+  std::shared_ptr<Query> prepare(std::string const& query) {
+    return prepareJoinPlan(server, query);
+  }
+
+  // The estimator takes ownership of the statistics, so hand back a raw
+  // pointer for the test to keep scripting through.
+  static std::pair<std::unique_ptr<SystemRCostEstimator>, FakeJoinStatistics*>
+  makeEstimator() {
+    auto stats = std::make_unique<FakeJoinStatistics>();
+    auto* raw = stats.get();
+    return {std::make_unique<SystemRCostEstimator>(std::move(stats)), raw};
+  }
+};
+
+// With unique indexes on both sides the
+// current estimator says 1000, System-R says 100.
+TEST_F(SystemRCostEstimatorTest, worked_example_from_the_design_note) {
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  ASSERT_EQ(g.edges.size(), 1u);
+
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["x"] = {1000.0, false};  // unique
+  stats->distinct["b"]["y"] = {100.0, false};   // unique
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  EXPECT_DOUBLE_EQ(est.cardinality, 100.0);
+  EXPECT_FALSE(est.defaulted);
+}
+
+TEST_F(SystemRCostEstimatorTest, cardinality_is_symmetric_but_cost_is_not) {
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["x"] = {1000.0, false};
+  stats->distinct["b"]["y"] = {100.0, false};
+  stats->indexed["a"] = {"x"};
+  stats->indexed["b"] = {"y"};
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  auto ab = estimator->extend(estimator->seed(*a), *b, connecting);
+  auto ba = estimator->extend(estimator->seed(*b), *a, connecting);
+
+  EXPECT_DOUBLE_EQ(ab.cardinality, ba.cardinality);
+  // scanning the 100-row side and probing the 1000-row side is cheaper
+  EXPECT_LT(ba.cost, ab.cost);
+  EXPECT_DOUBLE_EQ(ba.cost, 100.0 + probeCost(100.0, 1000.0));
+  EXPECT_DOUBLE_EQ(ab.cost, 1000.0 + probeCost(1000.0, 100.0));
+}
+
+TEST_F(SystemRCostEstimatorTest, unindexed_join_attribute_costs_a_scan) {
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["x"] = {1000.0, false};
+  stats->distinct["b"]["y"] = {100.0, false};
+  // no entry in stats->indexed, so hasIndexCovering is false
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  EXPECT_DOUBLE_EQ(est.cost, 1000.0 + scanCost(1000.0, 100.0));
+}
+
+TEST_F(SystemRCostEstimatorTest, empty_connecting_span_is_a_cross_product) {
+  auto q = prepare("FOR a IN c1 FOR b IN c2 RETURN [a, b]");
+  auto g = buildGraph(*q);
+  ASSERT_TRUE(g.edges.empty());
+
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  auto est = estimator->extend(estimator->seed(*a), *b, {});
+
+  EXPECT_DOUBLE_EQ(est.cardinality, 100000.0);  // no reduction
+  EXPECT_DOUBLE_EQ(est.cost, 1000.0 + scanCost(1000.0, 100.0));
+}
+
+TEST_F(SystemRCostEstimatorTest, missing_statistic_defaults_to_one_and_flags) {
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["b"]["y"] = {100.0, false};  // only b is known
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  // max(1, 100) defers to the known side: 1000 * 100 / 100
+  EXPECT_DOUBLE_EQ(est.cardinality, 1000.0);
+  EXPECT_TRUE(est.defaulted);
+}
+
+TEST_F(SystemRCostEstimatorTest, constant_restriction_shrinks_the_base) {
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.k == 'v' RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["k"] = {10.0, false};  // 10 distinct k values
+
+  auto* a = nodeByName(g, "a");
+  auto seeded = estimator->seed(*a);
+  EXPECT_DOUBLE_EQ(seeded.cardinality, 100.0);  // 1000 / 10
+  // no index covers k, so the seed still pays a full scan
+  EXPECT_DOUBLE_EQ(seeded.cost, 1000.0);
+}
+
+TEST_F(SystemRCostEstimatorTest,
+       indexed_constant_restriction_cheapens_the_seed) {
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.k == 'v' RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["k"] = {10.0, false};
+  stats->indexed["a"] = {"k"};
+
+  auto seeded = estimator->seed(*nodeByName(g, "a"));
+  EXPECT_DOUBLE_EQ(seeded.cardinality, 100.0);
+  EXPECT_DOUBLE_EQ(seeded.cost, 100.0);  // restricted(v), not |C_v|
+}
+
+TEST_F(SystemRCostEstimatorTest, range_residual_applies_a_third) {
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.p < 5 RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 900.0}, {"b", 100.0}};
+
+  auto seeded = estimator->seed(*nodeByName(g, "a"));
+  EXPECT_DOUBLE_EQ(seeded.cardinality, 300.0);  // 900 * 1/3
+  // the residual does not cheapen the scan: restricted(v) is unchanged
+  EXPECT_DOUBLE_EQ(seeded.cost, 900.0);
+}
+
+TEST_F(SystemRCostEstimatorTest, residual_factor_does_not_set_defaulted) {
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.p < 5 RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 900.0}, {"b", 100.0}};
+
+  // 'a' has no constant restrictions, so its condition lookup uses the empty
+  // set, which is not a defaulted lookup. The 1/3 range constant is a
+  // heuristic, not a missing statistic, so it must not raise the flag either.
+  EXPECT_FALSE(estimator->seed(*nodeByName(g, "a")).defaulted);
+}
+
+TEST_F(SystemRCostEstimatorTest, distinct_is_capped_by_the_restricted_base) {
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 10.0}, {"b", 10.0}};
+  // an absurd distinct estimate: more distinct values than rows
+  stats->distinct["a"]["x"] = {1e6, false};
+  stats->distinct["b"]["y"] = {5.0, false};
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  // dp is capped at base(a) = 10, so the factor is 1/max(10,5) = 1/10
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  EXPECT_DOUBLE_EQ(est.cardinality, 10.0);
+}
+
+TEST_F(SystemRCostEstimatorTest, multiple_edges_multiply_their_factors) {
+  // a cycle: a-b, b-c, a-c. Adding c to prefix {a,b} is constrained twice.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FOR c IN c3 "
+      "FILTER a.x == b.y FILTER b.z == c.w FILTER a.q == c.r "
+      "RETURN [a, b, c]");
+  auto g = buildGraph(*q);
+  ASSERT_EQ(g.edges.size(), 3u);
+
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 100.0}, {"b", 100.0}, {"c", 100.0}};
+  stats->distinct["b"]["z"] = {10.0, false};
+  stats->distinct["c"]["w"] = {10.0, false};
+  stats->distinct["a"]["q"] = {5.0, false};
+  stats->distinct["c"]["r"] = {5.0, false};
+
+  auto* c = nodeByName(g, "c");
+  std::vector<JoinGraph::Edge const*> connecting;
+  for (auto const& e : g.edges) {
+    if (e.from == c || e.to == c) {
+      connecting.emplace_back(&e);
+    }
+  }
+  ASSERT_EQ(connecting.size(), 2u);
+
+  JoinEstimate prefix{.cardinality = 1000.0, .cost = 0.0, .defaulted = false};
+  auto est = estimator->extend(prefix, *c, connecting);
+  // 1000 * 100 * (1/10) * (1/5)
+  EXPECT_DOUBLE_EQ(est.cardinality, 2000.0);
+}
+
+TEST_F(SystemRCostEstimatorTest, distinct_caps_pair_with_their_own_node) {
+  // Unlike the equal-base cap test above, base(a) and base(b) are clearly
+  // different here (100 vs. 1000), so a bug that caps otherDistinct against
+  // nextRestricted.base (or vice versa) changes the answer instead of
+  // silently agreeing with the correct pairing.
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 100.0}, {"b", 1000.0}};
+  stats->distinct["a"]["x"] = {1e6, false};  // capped by base(a) = 100
+  stats->distinct["b"]["y"] = {5.0, false};  // stays under base(b) = 1000
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  // correct: dp = min(1e6, 100) = 100, dn = min(5, 1000) = 5,
+  // factor = 1/max(100, 5) = 1/100; cardinality = 100 * 1000 / 100 = 1000.
+  // a swapped pairing gives dp = min(1e6, 1000) = 1000, dn = min(5, 100) = 5,
+  // factor = 1/1000, cardinality = 100.
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  EXPECT_DOUBLE_EQ(est.cardinality, 1000.0);
+}
+
+TEST_F(SystemRCostEstimatorTest, extend_costs_against_the_unrestricted_count) {
+  // Give `next` (b) a constant restriction that shrinks restricted(b) well
+  // below |C_b|, and check that extend()'s cost still uses the full
+  // documentCount(b), not restricted(b) -- an index descent traverses the
+  // whole index regardless of how selective the outer restriction is.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER b.k == 'v' RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 500.0}, {"b", 1000.0}};
+  stats->distinct["b"]["k"] = {100.0, false};  // restricted(b) = 1000/100 = 10
+  stats->indexed["b"] = {"y"};                 // extend() probes, not scans
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  // seed(a).cost == documentCount(a) == 500 (no index on a's empty
+  // conditions); the probe is against |C_b| = 1000, not restricted(b) = 10.
+  EXPECT_DOUBLE_EQ(est.cost, 500.0 + probeCost(500.0, 1000.0));
+}
+
+TEST_F(SystemRCostEstimatorTest, defaulted_propagates_from_the_prefix) {
+  // Every lookup this extend() touches is fully scripted (not defaulted);
+  // only the prefix itself carries the flag. The result must still be
+  // defaulted -- once a fallback statistic has fed the estimate, nothing
+  // downstream can un-flag it.
+  auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 100.0}, {"b", 100.0}};
+  stats->distinct["a"]["x"] = {10.0, false};
+  stats->distinct["b"]["y"] = {10.0, false};
+
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  JoinEstimate prefix{.cardinality = 100.0, .cost = 0.0, .defaulted = true};
+  auto est = estimator->extend(prefix, *b, connecting);
+  EXPECT_TRUE(est.defaulted);
+}
+
+TEST_F(SystemRCostEstimatorTest,
+       defaulted_propagates_from_next_s_own_condition_lookup) {
+  // `next` (b) carries a constant restriction whose distinct count is not
+  // scripted, so restrictedFor(b) is itself defaulted -- distinct from every
+  // edge-level lookup, which are all scripted here, and from the prefix,
+  // which starts clean.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER b.k == 'v' RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 100.0}, {"b", 100.0}};
+  stats->distinct["a"]["x"] = {10.0, false};
+  stats->distinct["b"]["y"] = {10.0, false};
+  // stats->distinct["b"]["k"] intentionally left unscripted
+
+  auto* a = nodeByName(g, "a");
+  auto* b = nodeByName(g, "b");
+  std::array<JoinGraph::Edge const*, 1> connecting{&g.edges.front()};
+
+  auto est = estimator->extend(estimator->seed(*a), *b, connecting);
+  EXPECT_TRUE(est.defaulted);
+}
+
+TEST_F(SystemRCostEstimatorTest, in_residual_uses_min_of_one_and_the_ratio) {
+  // The ratio must exceed 1 to exercise the min at all, and the node needs a
+  // separate constant restriction so restricted(a) < count(a): otherwise
+  // restricted == count and the [1, count] clamp on base() would mask a
+  // missing min() just as easily as a correct one. distinct(c) = 10 shrinks
+  // restricted(a) to 100; the IN array of 5 over distinct(k) = 2 gives a raw
+  // ratio of 2.5, so 100 * 2.5 = 250 sits well inside [1, 1000] and is
+  // genuinely visible if the min is dropped.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.c == 'v' "
+      "FILTER a.k IN ['p', 'q', 'r', 's', 't'] RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["c"] = {10.0, false};  // restricted(a) = 1000/10 = 100
+  stats->distinct["a"]["k"] = {2.0, false};   // ratio = 5/2 = 2.5
+
+  auto seeded = estimator->seed(*nodeByName(g, "a"));
+  // base(a) = 100 * min(1, 2.5) = 100. Without the min, base(a) = 250.
+  EXPECT_DOUBLE_EQ(seeded.cardinality, 100.0);
+}
+
+TEST_F(SystemRCostEstimatorTest,
+       in_residual_on_a_different_variable_is_neutral) {
+  // The residual is attached to `a` because it is the only *graph* variable
+  // it references, but the IN's own attribute access (t.k) belongs to a
+  // variable outside the graph entirely. distinct["a"]["k"] is scripted and
+  // non-defaulted on purpose: an unguarded lookup would not fall back to the
+  // masking defaulted-1.0 case, it would compute a visibly wrong factor
+  // (3 array members / 50 = 0.06) instead of the correct neutral 1.0.
+  auto q = prepare(
+      "LET t = NOOPT({k: 1}) FOR a IN c1 FOR b IN c2 "
+      "FILTER a.x == b.y FILTER t.k IN [a.q, 1, 2] RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto* a = nodeByName(g, "a");
+  ASSERT_NE(a, nullptr);
+  ASSERT_EQ(a->residuals.size(), 1u);
+
+  FakeJoinStatistics stats;
+  stats.distinct["a"]["k"] = {50.0, false};
+  EXPECT_DOUBLE_EQ(residualSelectivityFactor(a->residuals.front(), stats, *a),
+                   1.0);
+}
+
+TEST_F(SystemRCostEstimatorTest, unmodelled_residual_is_the_neutral_element) {
+  // a != comparison has no principled selectivity constant. Its factor must
+  // be exactly 1.0, so base(v) ends up equal to restricted(v) even though a
+  // residual is present.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.k == 'v' FILTER a.m != 5 RETURN [a, b]");
+  auto g = buildGraph(*q);
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 1000.0}, {"b", 100.0}};
+  stats->distinct["a"]["k"] = {10.0, false};
+
+  auto* a = nodeByName(g, "a");
+  ASSERT_EQ(a->residuals.size(), 1u);
+  EXPECT_DOUBLE_EQ(residualSelectivityFactor(a->residuals.front(), *stats, *a),
+                   1.0);
+
+  // restricted(a) = 1000 / 10 = 100; base(a) = 100 * 1.0 == restricted(a).
+  auto seeded = estimator->seed(*a);
+  EXPECT_DOUBLE_EQ(seeded.cardinality, 100.0);
+}
+
+TEST_F(SystemRCostEstimatorTest, extend_floors_cardinality_at_one) {
+  // Two connecting edges each divide by ~100, and c's own equality
+  // restriction is so over-selective that restricted(c)/base(c) clamp to
+  // their floor of 1. Unfloored, 100 * 1 * (1/100) * (1/100) == 0.01; a join
+  // cannot meaningfully produce a fraction of a row, and letting it through
+  // would make every later probeCost/scanCost on this prefix collapse
+  // towards zero.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FOR c IN c3 "
+      "FILTER a.x == b.y FILTER b.z == c.w FILTER a.q == c.r "
+      "FILTER c.k == 'v' RETURN [a, b, c]");
+  auto g = buildGraph(*q);
+  ASSERT_EQ(g.edges.size(), 3u);
+
+  auto [estimator, stats] = makeEstimator();
+  stats->counts = {{"a", 100.0}, {"b", 100.0}, {"c", 100.0}};
+  stats->distinct["b"]["z"] = {100.0, false};
+  stats->distinct["c"]["w"] = {100.0, false};
+  stats->distinct["a"]["q"] = {100.0, false};
+  stats->distinct["c"]["r"] = {100.0, false};
+  // 100 distinct k values over 100 documents in c: restricted(c) clamps to 1.
+  stats->distinct["c"]["k"] = {1000.0, false};
+
+  auto* c = nodeByName(g, "c");
+  std::vector<JoinGraph::Edge const*> connecting;
+  for (auto const& e : g.edges) {
+    if (e.from == c || e.to == c) {
+      connecting.emplace_back(&e);
+    }
+  }
+  ASSERT_EQ(connecting.size(), 2u);
+
+  JoinEstimate prefix{.cardinality = 100.0, .cost = 0.0, .defaulted = false};
+  auto est = estimator->extend(prefix, *c, connecting);
+  EXPECT_DOUBLE_EQ(est.cardinality, 1.0);
+}
+
+}  // namespace arangodb::tests::aql

--- a/tests/Aql/JoinGraphTest.cpp
+++ b/tests/Aql/JoinGraphTest.cpp
@@ -19,23 +19,12 @@
 /// Copyright holder is ArangoDB GmbH, Cologne, Germany
 ////////////////////////////////////////////////////////////////////////////////
 
-#include "gtest/gtest.h"
+#include "JoinGraphTestHelper.h"
 
-#include "Aql/ExecutionNode/ExecutionNode.h"
-#include "Aql/ExecutionPlan.h"
-#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.h"
-#include "Aql/Query.h"
-#include "Aql/QueryString.h"
-#include "Aql/Variable.h"
-#include "Transaction/StandaloneContext.h"
-
-#include "velocypack/Parser.h"
-
-#include "../IResearch/common.h"
-#include "../Mocks/Servers.h"
-#include "Async/async.h"
+#include "Aql/OptimizerRule.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -58,65 +47,8 @@ class JoinGraphTest : public testing::Test {
     }
   }
 
-  // Prepares a plan for `query` without any optional optimizer rules, so that
-  // the plain EnumerateCollection / Filter nodes survive (this mirrors what the
-  // optimize-join-order rule sees at its position in the pipeline).
-  std::shared_ptr<Query> prepare(std::string const& query) const {
-    auto ctx = std::make_shared<transaction::StandaloneContext>(
-        server.getSystemDatabase(), transaction::OperationOriginTestCase{});
-    auto options =
-        velocypack::Parser::fromJson(R"({"optimizer":{"rules":["-all"]}})");
-    auto q = Query::create(std::move(ctx), QueryString(query), nullptr,
-                           QueryOptions(options->slice()));
-    waitForAsync(q->prepareQuery());
-    return q;
-  }
-
-  // Walks from the singleton towards the root and returns the first
-  // EnumerateCollection node (i.e. the bottom-most enumeration).
-  static ExecutionNode* firstEnumeration(const ExecutionPlan* plan) {
-    for (ExecutionNode* n = plan->root()->getSingleton(); n != nullptr;
-         n = n->getFirstParent()) {
-      if (n->getType() == ExecutionNode::ENUMERATE_COLLECTION) {
-        return n;
-      }
-    }
-    return nullptr;
-  }
-
-  static JoinGraph build(const Query& q) {
-    auto* plan = q.plan();
-    auto* first = firstEnumeration(plan);
-    EXPECT_NE(first, nullptr);
-    ExecutionNode* next = nullptr;
-    return buildJoinGraph(plan, first, next);
-  }
-
-  // Builds one JoinGraph per maximal run of adjacent enumerations, mirroring
-  // the spine walk of the optimizeJoinOrder rule itself.
-  static std::vector<JoinGraph> buildAll(const Query& q) {
-    auto* plan = q.plan();
-    std::vector<JoinGraph> graphs;
-    for (ExecutionNode* n = plan->root()->getSingleton(); n != nullptr;) {
-      if (n->getType() == ExecutionNode::ENUMERATE_COLLECTION) {
-        ExecutionNode* next = nullptr;
-        graphs.emplace_back(buildJoinGraph(plan, n, next));
-        n = next;
-      } else {
-        n = n->getFirstParent();
-      }
-    }
-    return graphs;
-  }
-
-  static JoinGraph::Node const* nodeByName(JoinGraph const& g,
-                                           std::string_view name) {
-    for (auto const& [var, node] : g.nodes) {
-      if (var->name == name) {
-        return &node;
-      }
-    }
-    return nullptr;
+  std::shared_ptr<Query> prepare(std::string const& query) {
+    return prepareJoinPlan(server, query);
   }
 };
 }  // namespace
@@ -125,7 +57,7 @@ TEST_F(JoinGraphTest, linear_three_way_chain) {
   auto q = prepare(
       "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
       "FOR c IN c3 FILTER b.z == c.w RETURN [a, b, c]");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   EXPECT_EQ(g.nodes.size(), 3u);
   EXPECT_EQ(g.edges.size(), 2u);
@@ -136,7 +68,7 @@ TEST_F(JoinGraphTest, linear_three_way_chain) {
 
 TEST_F(JoinGraphTest, equijoin_edge_records_attribute_paths) {
   auto q = prepare("FOR a IN c1 FOR b IN c2 FILTER a.x == b.y RETURN [a, b]");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   ASSERT_EQ(g.edges.size(), 1u);
   auto const& e = g.edges.front();
@@ -156,7 +88,7 @@ TEST_F(JoinGraphTest, constant_restriction_becomes_node_condition) {
   auto q = prepare(
       "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
       "FILTER a.k == 'v' RETURN [a, b]");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   EXPECT_EQ(g.nodes.size(), 2u);
   EXPECT_EQ(g.edges.size(), 1u);
@@ -173,7 +105,7 @@ TEST_F(JoinGraphTest, non_equijoin_predicate_becomes_residual) {
   auto q = prepare(
       "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
       "FILTER a.p < b.q RETURN [a, b]");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   EXPECT_EQ(g.edges.size(), 1u);
   EXPECT_FALSE(g.residuals.empty());
@@ -182,7 +114,7 @@ TEST_F(JoinGraphTest, non_equijoin_predicate_becomes_residual) {
 TEST_F(JoinGraphTest, id_is_remapped_to_key) {
   auto q =
       prepare("FOR a IN c1 FOR b IN c2 FILTER a._id == b._id RETURN [a, b]");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   ASSERT_EQ(g.edges.size(), 1u);
   auto const& e = g.edges.front();
@@ -197,7 +129,7 @@ TEST_F(JoinGraphTest, disconnected_graph_has_two_components) {
   auto q = prepare(
       "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
       "FOR c IN c3 FOR d IN c1 FILTER c.x == d.y RETURN [a, b, c, d]");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   EXPECT_EQ(g.nodes.size(), 4u);
   EXPECT_EQ(g.edges.size(), 2u);
@@ -206,7 +138,7 @@ TEST_F(JoinGraphTest, disconnected_graph_has_two_components) {
 
 TEST_F(JoinGraphTest, single_enumeration_has_no_join) {
   auto q = prepare("FOR a IN c1 FILTER a.x == 1 RETURN a");
-  auto g = build(*q);
+  auto g = buildGraph(*q);
 
   EXPECT_EQ(g.nodes.size(), 1u);
   EXPECT_TRUE(g.edges.empty());
@@ -221,7 +153,7 @@ TEST_F(JoinGraphTest, separate_runs_produce_separate_graphs) {
       "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
       "SORT a.x "
       "FOR c IN c3 FOR d IN c1 FILTER c.x == d.y RETURN [a, b, c, d]");
-  auto graphs = buildAll(*q);
+  auto graphs = buildAllGraphs(*q);
 
   ASSERT_EQ(graphs.size(), 2u);
   for (auto const& g : graphs) {
@@ -230,6 +162,48 @@ TEST_F(JoinGraphTest, separate_runs_produce_separate_graphs) {
     EXPECT_TRUE(g.hasJoin());
     EXPECT_EQ(g.connectedComponents().size(), 1u);
   }
+}
+
+TEST_F(JoinGraphTest, single_variable_residual_attaches_to_node) {
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.p < 5 RETURN [a, b]");
+  auto g = buildGraph(*q);
+
+  EXPECT_TRUE(g.residuals.empty()) << "should have been attached to node a";
+  auto* a = nodeByName(g, "a");
+  ASSERT_NE(a, nullptr);
+  EXPECT_EQ(a->residuals.size(), 1u);
+  auto* b = nodeByName(g, "b");
+  ASSERT_NE(b, nullptr);
+  EXPECT_TRUE(b->residuals.empty());
+}
+
+TEST_F(JoinGraphTest, two_variable_residual_stays_graph_level) {
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER a.p < b.q RETURN [a, b]");
+  auto g = buildGraph(*q);
+
+  EXPECT_EQ(g.residuals.size(), 1u);
+  EXPECT_TRUE(nodeByName(g, "a")->residuals.empty());
+  EXPECT_TRUE(nodeByName(g, "b")->residuals.empty());
+}
+
+TEST_F(JoinGraphTest, residual_without_graph_variable_stays_graph_level) {
+  // NOOPT() is load-bearing: Ast::optimizeBinaryOperatorRelational
+  // constant-folds a comparison whose both sides are constant, so a literal `1
+  // < 2` collapses to `true` during AST optimization and never reaches
+  // addResidual at all. NOOPT keeps the left side non-constant so the predicate
+  // survives as a real residual that happens to reference no graph variable. Do
+  // not "simplify" this back to `1 < 2`.
+  auto q = prepare(
+      "FOR a IN c1 FOR b IN c2 FILTER a.x == b.y "
+      "FILTER NOOPT(1) < 2 RETURN [a, b]");
+  auto g = buildGraph(*q);
+
+  EXPECT_EQ(g.residuals.size(), 1u);
+  EXPECT_TRUE(nodeByName(g, "a")->residuals.empty());
 }
 
 }  // namespace arangodb::tests::aql

--- a/tests/Aql/JoinGraphTestHelper.h
+++ b/tests/Aql/JoinGraphTestHelper.h
@@ -1,0 +1,223 @@
+////////////////////////////////////////////////////////////////////////////////
+/// DISCLAIMER
+///
+/// Copyright 2014-2026 ArangoDB GmbH, Cologne, Germany
+/// Copyright 2004-2014 triAGENS GmbH, Cologne, Germany
+///
+/// Licensed under the Business Source License 1.1 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     https://github.com/arangodb/arangodb/blob/devel/LICENSE
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+/// Copyright holder is ArangoDB GmbH, Cologne, Germany
+///
+////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "gtest/gtest.h"
+
+#include "Aql/ExecutionNode/EnumerateCollectionNode.h"
+#include "Aql/ExecutionNode/ExecutionNode.h"
+#include "Aql/ExecutionPlan.h"
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinGraph.h"
+#include "Aql/Optimizer/Rule/OptimizeJoinOrder/JoinStatistics.h"
+#include "Aql/Query.h"
+#include "Aql/QueryString.h"
+#include "Aql/Variable.h"
+#include "Transaction/StandaloneContext.h"
+
+#include "velocypack/Parser.h"
+
+#include "../IResearch/common.h"
+#include "../Mocks/Servers.h"
+#include "Async/async.h"
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace arangodb::tests::aql {
+
+// Prepares a plan for `query` without any optional optimizer rules, so that
+// the plain EnumerateCollection / Filter nodes survive (this mirrors what the
+// optimize-join-order rule sees at its position in the pipeline).
+inline std::shared_ptr<arangodb::aql::Query> prepareJoinPlan(
+    mocks::MockAqlServer& server, std::string const& query) {
+  auto ctx = std::make_shared<transaction::StandaloneContext>(
+      server.getSystemDatabase(), transaction::OperationOriginTestCase{});
+  auto options =
+      velocypack::Parser::fromJson(R"({"optimizer":{"rules":["-all"]}})");
+  auto q = arangodb::aql::Query::create(
+      std::move(ctx), arangodb::aql::QueryString(query), nullptr,
+      arangodb::aql::QueryOptions(options->slice()));
+  waitForAsync(q->prepareQuery());
+  return q;
+}
+
+// Like prepareJoinPlan(), but leaves the query in PLAN_OPTIMIZATION instead
+// of EXECUTION. prepareJoinPlan()'s prepareQuery() call always finishes by
+// entering EXECUTION, which is fine for consumers that only walk the plan's
+// node structure -- but IndexJoinStatistics itself calls
+// Query::trxForOptimization(), an optimization-time API that asserts (under
+// maintainer mode) that the query has not started executing. Use this
+// instead of prepareJoinPlan() wherever an IndexJoinStatistics is
+// constructed directly over the resulting plan.
+inline std::shared_ptr<arangodb::aql::Query> prepareJoinPlanForStatistics(
+    mocks::MockAqlServer& server, std::string const& query) {
+  auto ctx = std::make_shared<transaction::StandaloneContext>(
+      server.getSystemDatabase(), transaction::OperationOriginTestCase{});
+  auto options =
+      velocypack::Parser::fromJson(R"({"optimizer":{"rules":["-all"]}})");
+  auto q = arangodb::aql::Query::create(
+      std::move(ctx), arangodb::aql::QueryString(query), nullptr,
+      arangodb::aql::QueryOptions(options->slice()));
+  q->prepareOptimizedPlanForTests();
+  return q;
+}
+
+// Walks from the singleton towards the root and returns the first
+// EnumerateCollection node (i.e. the bottom-most enumeration).
+inline arangodb::aql::ExecutionNode* firstEnumeration(
+    arangodb::aql::ExecutionPlan const* plan) {
+  for (auto* n = plan->root()->getSingleton(); n != nullptr;
+       n = n->getFirstParent()) {
+    if (n->getType() == arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION) {
+      return n;
+    }
+  }
+  return nullptr;
+}
+
+inline arangodb::aql::JoinGraph buildGraph(arangodb::aql::Query const& q) {
+  auto* plan = q.plan();
+  auto* first = firstEnumeration(plan);
+  EXPECT_NE(first, nullptr);
+  arangodb::aql::ExecutionNode* next = nullptr;
+  return arangodb::aql::buildJoinGraph(plan, first, next);
+}
+
+// Builds one JoinGraph per maximal run of adjacent enumerations, mirroring
+// the spine walk of the optimizeJoinOrder rule itself.
+inline std::vector<arangodb::aql::JoinGraph> buildAllGraphs(
+    arangodb::aql::Query const& q) {
+  auto* plan = q.plan();
+  std::vector<arangodb::aql::JoinGraph> graphs;
+  for (auto* n = plan->root()->getSingleton(); n != nullptr;) {
+    if (n->getType() == arangodb::aql::ExecutionNode::ENUMERATE_COLLECTION) {
+      arangodb::aql::ExecutionNode* next = nullptr;
+      graphs.emplace_back(arangodb::aql::buildJoinGraph(plan, n, next));
+      n = next;
+    } else {
+      n = n->getFirstParent();
+    }
+  }
+  return graphs;
+}
+
+inline arangodb::aql::JoinGraph::Node* nodeByName(arangodb::aql::JoinGraph& g,
+                                                  std::string_view name) {
+  for (auto& [var, node] : g.nodes) {
+    if (var->name == name) {
+      return &node;
+    }
+  }
+  return nullptr;
+}
+
+// Scripted statistics, keyed by out-variable name so tests read declaratively.
+// This is what makes the formula tests exact: real collections cannot produce
+// an exact non-unique distinct count.
+class FakeJoinStatistics final : public arangodb::aql::JoinStatistics {
+ public:
+  // variable name -> document count
+  std::map<std::string, double, std::less<>> counts;
+  // variable name -> "attr,attr" key -> distinct estimate
+  std::map<std::string, std::map<std::string, arangodb::aql::DistinctEstimate>,
+           std::less<>>
+      distinct;
+  // variable name -> attribute names that an index can probe by
+  std::map<std::string, std::set<std::string>, std::less<>> indexed;
+
+  // Joins an attribute set into a stable lookup key: {["a"],["b","c"]}
+  // becomes "a,b.c". Paths are sorted so callers need not match ordering.
+  static std::string keyFor(
+      std::span<arangodb::aql::AttributePath const> attributes) {
+    std::vector<std::string> parts;
+    parts.reserve(attributes.size());
+    for (auto const& path : attributes) {
+      std::string joined;
+      for (auto const& component : path) {
+        if (!joined.empty()) {
+          joined += '.';
+        }
+        joined += component;
+      }
+      parts.emplace_back(std::move(joined));
+    }
+    std::sort(parts.begin(), parts.end());
+    std::string key;
+    for (auto const& part : parts) {
+      if (!key.empty()) {
+        key += ',';
+      }
+      key += part;
+    }
+    return key;
+  }
+
+  static std::string nameOf(arangodb::aql::JoinGraph::Node const& node) {
+    return node.executionNode->outVariable()->name;
+  }
+
+  auto documentCount(arangodb::aql::JoinGraph::Node const& node) const
+      -> double override {
+    auto it = counts.find(nameOf(node));
+    return it == counts.end() ? 0.0 : it->second;
+  }
+
+  auto distinctValues(arangodb::aql::JoinGraph::Node const& node,
+                      std::span<arangodb::aql::AttributePath const> attributes)
+      const -> arangodb::aql::DistinctEstimate override {
+    if (attributes.empty()) {
+      return {1.0, false};
+    }
+    auto outer = distinct.find(nameOf(node));
+    if (outer != distinct.end()) {
+      auto inner = outer->second.find(keyFor(attributes));
+      if (inner != outer->second.end()) {
+        return inner->second;
+      }
+    }
+    return {1.0, true};
+  }
+
+  auto hasIndexCovering(
+      arangodb::aql::JoinGraph::Node const& node,
+      std::span<arangodb::aql::AttributePath const> attributes) const
+      -> bool override {
+    auto it = indexed.find(nameOf(node));
+    if (it == indexed.end()) {
+      return false;
+    }
+    for (auto const& path : attributes) {
+      if (!path.empty() && it->second.contains(std::string{path.front()})) {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+}  // namespace arangodb::tests::aql

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,7 +160,9 @@ set(ARANGODB_TESTS_SOURCES
   Aql/Function/NgramMatchFunctionTest.cpp
   Aql/Function/NgramPosSimilarityFunctionTest.cpp
   Aql/Function/NgramSimilarityFunctionTest.cpp
+  Aql/IndexJoinStatisticsTest.cpp
   Aql/InputRangeTest.cpp
+  Aql/JoinCostEstimatorTest.cpp
   Aql/JoinGraphTest.cpp
   Aql/JoinStrategy/GenericAndTwoNonUniqueJoinTest.cpp
   Aql/JoinStrategy/TwoIndicesUniqueJoinTest.cpp


### PR DESCRIPTION
> Second of three PRs split out of #23149. **Stacked on #23240**. Nothing calls this code yet; the code that
consumes it is the third PR in the stack.

Adds the two abstractions a cost-based join reordering search needs, and one
implementation of each.

**`JoinStatistics`** answers what the data looks like: document counts,
distinct value counts for an attribute set, and whether an index can serve a
lookup. **`IndexJoinStatistics`** implements it over whatever indexes a
collection happens to have, rejecting those whose selectivity estimates do not
supply what this model needs - meaning sparse indexes, expanded fields, and types that
report unrelated numbers.

**`JoinCostEstimator`** turns join stats into cost estimates for one join order: a seed for
the first collection, an extension for each subsequent one, yielding a
cardinality and an accumulated cost. **`SystemRCostEstimator`** implements it
with the System-R formula `|a⋈b| = |a||b| / max(distinct(a.x), distinct(b.y))`,
which is symmetric, unlike the naive form that divides by one side only.
Costs follow from whether an index can serve the lookup: a probe is
logarithmic in collection size, a scan is linear.

Two quantities are tracked deliberately. Equality restrictions shrink the rows
an index lookup returns and so drive **cost**; residual predicates filter
afterwards and so shrink only **cardinality**, never the cost of getting there.

### Notes for review

Both implementations are tested directly - the estimator against scripted
statistics, the statistics adaptor against scripted index facts - so the rules
about which index qualifies are exercised without needing a storage engine to
produce one. 50 tests pass across the five suites.

Added to the `JoinGraph`: per-node residuals (pricing
a residual requires knowing which collection it constrains) and visibility for
its attribute-access helper.

`Query::prepareOptimizedPlanForTests` is added inside the existing
`ARANGODB_USE_GOOGLE_TESTS` block. `IndexJoinStatistics` calls
`Query::trxForOptimization()`, which asserts under maintainer mode that the
query has not entered EXECUTION — and the ordinary `prepareQuery()` path always
ends there, so the tests need a way to stop after optimization.
