### PR TITLE
Link LLVM OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1099,67 +1099,42 @@ if(STATIC_EXECUTABLES)
   if(ARCH_AMD64)
     set(LAPACK_LIBRARIES "/usr/lib/x86_64-linux-gnu/lapack/liblapack.a" CACHE PATH "LAPACK static library path")
     set(BLAS_LIBRARIES "/usr/lib/x86_64-linux-gnu/libblas.a" CACHE PATH "BLAS static library path")
-    set(OpenMP_gomp_LIBRARY "/usr/lib/gcc/x86_64-linux-gnu/13/libgomp.a")
   else()
     set(LAPACK_LIBRARIES "/usr/lib/aarch64-linux-gnu/lapack/liblapack.a" CACHE PATH "LAPACK static library path")
     set(BLAS_LIBRARIES "/usr/lib/aarch64-linux-gnu/libblas.a" CACHE PATH "BLAS static library path")
-    set(OpenMP_gomp_LIBRARY "/usr/lib/gcc/aarch64-linux-gnu/13/libgomp.a")
   endif()
   message(STATUS "LAPACK: ${LAPACK_LIBRARIES}")
   message(STATUS "BLAS: ${BLAS_LIBRARIES}")
 
-  # Setting this is necessary because we want to bind to gcc static library
-  # since the LLVM OpenMP implementation fails in our CI
-  # This is related to this issue (https://github.com/llvm/llvm-project/issues/137136)
-  set(OpenMP_C_FLAGS "-fopenmp=libgomp")
-  set(OpenMP_CXX_FLAGS "-fopenmp=libgomp")
-  set(OpenMP_C_LIB_NAMES "gomp;pthread")
-  set(OpenMP_CXX_LIB_NAMES "gomp;pthread")
+  # faiss must be built with LLVM's libomp: clang generates no OpenMP code for
+  # libgomp
+  # The build image provides a static libomp in /opt/omp
+  find_library(LIBOMP omp PATHS /opt/omp NO_DEFAULT_PATH)
+  if(NOT LIBOMP)
+    message(FATAL_ERROR "libomp.a not found in /opt/omp")
+  endif()
+  message(STATUS "Using static libomp: ${LIBOMP}")
+
+  set(OpenMP_C_FLAGS "-fopenmp=libomp")
+  set(OpenMP_CXX_FLAGS "-fopenmp=libomp")
+  set(OpenMP_C_LIB_NAMES "omp;pthread")
+  set(OpenMP_CXX_LIB_NAMES "omp;pthread")
+  set(OpenMP_omp_LIBRARY "${LIBOMP}")
   set(OpenMP_pthread_LIBRARY "pthread")
 
-  set(FAISS_EXE_LINKER_FLAGS "-fopenmp=libgomp -llapack -lgfortran")
-  message(STATUS "OpenMP version: " ${OpenMP_CXX_VERSION})
+  set(FAISS_EXE_LINKER_FLAGS "-fopenmp=libomp -L/opt/omp -llapack -lgfortran")
 else()
   set(BLA_STATIC Off)
   set(BLA_VENDOR OpenBLAS)
 
-  # Setting this is necessary because we want to bind to gcc library
-  # since the LLVM OpenMP implementation fails in our CI
-  # This is related to this issue (https://github.com/llvm/llvm-project/issues/137136)
-  # Dynamically find libgomp.so without hardcoding version
-  # First, try to get GCC's library directory
-  execute_process(
-    COMMAND gcc -print-file-name=libgomp.so
-    OUTPUT_VARIABLE LIBGOMP_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
-  if(EXISTS "${LIBGOMP_PATH}")
-    message(STATUS "Found libgomp: ${LIBGOMP_PATH}")
-    set(OpenMP_gomp_LIBRARY "${LIBGOMP_PATH}")
-  else()
-    # Fallback to find_library if gcc command didn't work
-    find_library(LIBGOMP_LIBRARY NAMES gomp REQUIRED)
-    message(STATUS "Found libgomp via find_library: ${LIBGOMP_LIBRARY}")
-    set(OpenMP_gomp_LIBRARY "${LIBGOMP_LIBRARY}")
-  endif()
-
-  set(OpenMP_C_FLAGS "-fopenmp=libgomp")
-  set(OpenMP_CXX_FLAGS "-fopenmp=libgomp")
-  set(OpenMP_C_LIB_NAMES "gomp;pthread")
-  set(OpenMP_CXX_LIB_NAMES "gomp;pthread")
-  set(OpenMP_pthread_LIBRARY "pthread")
-
+  # clang generates OpenMP code only for libomp, so let FindOpenMP pick the
   find_package(OpenMP REQUIRED)
 
   message(STATUS "OpenMP_CXX_VERSION: ${OpenMP_CXX_VERSION}")
   message(STATUS "OpenMP_CXX_FLAGS: ${OpenMP_CXX_FLAGS}")
   message(STATUS "OpenMP_CXX_LIB_NAMES: ${OpenMP_CXX_LIB_NAMES}")
-  message(STATUS "OpenMP_gomp_LIBRARY: ${OpenMP_gomp_LIBRARY}")
   message(STATUS "OpenMP_omp_LIBRARY: ${OpenMP_omp_LIBRARY}")
-  message(STATUS "OpenMP_pthread_LIBRARY: ${OpenMP_pthread_LIBRARY}")
   message(STATUS "OpenMP_CXX_LIBRARIES: ${OpenMP_CXX_LIBRARIES}")
-
 
   find_package(LAPACK)
   find_package(BLAS)
@@ -1169,8 +1144,6 @@ else()
     message(STATUS "Using LAPACK library: ${lapack_lib}")
     set(FAISS_EXE_LINKER_FLAGS "${FAISS_EXE_LINKER_FLAGS} ${lapack_lib}")
   endforeach()
-
-  set(FAISS_EXE_LINKER_FLAGS "${FAISS_EXE_LINKER_FLAGS}")
 endif()
 
 # It could be so easy if add_subdirectory allowed to pass variables

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -278,7 +278,7 @@
         "BUILD_REPO_INFO": "nightly",
         "CMAKE_C_FLAGS": "-fno-stack-protector",
         "CMAKE_CXX_FLAGS": "-fno-stack-protector",
-        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--build-id=sha1 -fno-stack-protector -fuse-ld=lld -fopenmp=libgomp -llapack -lgfortran",
+        "CMAKE_EXE_LINKER_FLAGS": "-Wl,--build-id=sha1 -fno-stack-protector -fuse-ld=lld -fopenmp=libomp -L/opt/omp -llapack -lgfortran",
         "CMAKE_SHARED_LINKER_FLAGS": "-fuse-ld=lld"
       }
     },

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -135,6 +135,12 @@ int main(int argc, char* argv[]) {
 
   auto workdir = std::filesystem::current_path();
 
+  // libomp (used by faiss) asserts during CPU topology detection on ARM hosts
+  // under cgroup v2 (llvm/llvm-project#137136). The flat method derives the
+  // topology from the affinity mask itself, so the two cannot disagree. Must be
+  // set before the first OpenMP call; an explicit user setting wins.
+  setenv("KMP_TOPOLOGY_METHOD", "flat", /*overwrite*/ 0);
+
   ArangoGlobalContext context(argc, argv, SBIN_DIRECTORY);
 
   arangodb::restartAction = nullptr;

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -135,12 +135,6 @@ int main(int argc, char* argv[]) {
 
   auto workdir = std::filesystem::current_path();
 
-  // libomp (used by faiss) asserts during CPU topology detection on ARM hosts
-  // under cgroup v2 (llvm/llvm-project#137136). The flat method derives the
-  // topology from the affinity mask itself, so the two cannot disagree. Must be
-  // set before the first OpenMP call; an explicit user setting wins.
-  // setenv("KMP_TOPOLOGY_METHOD", "flat", [>overwrite<] 0);
-
   ArangoGlobalContext context(argc, argv, SBIN_DIRECTORY);
 
   arangodb::restartAction = nullptr;

--- a/arangod/RestServer/arangod.cpp
+++ b/arangod/RestServer/arangod.cpp
@@ -139,7 +139,7 @@ int main(int argc, char* argv[]) {
   // under cgroup v2 (llvm/llvm-project#137136). The flat method derives the
   // topology from the affinity mask itself, so the two cannot disagree. Must be
   // set before the first OpenMP call; an explicit user setting wins.
-  setenv("KMP_TOPOLOGY_METHOD", "flat", /*overwrite*/ 0);
+  // setenv("KMP_TOPOLOGY_METHOD", "flat", [>overwrite<] 0);
 
   ArangoGlobalContext context(argc, argv, SBIN_DIRECTORY);
 

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -85,3 +85,6 @@ race:v8::*
 
 # Suppress tsan races from OpenBLAS used by faiss
 race:libopenblas
+
+# Since archer does not manage to ignore all races from libomp this is needed
+race:libomp


### PR DESCRIPTION
### Scope & Purpose

This bug was caught during benchmarking of the vector index with ann-benchmark using the sweep nProbe 256 . And it seems that after upgrading faiss to v1.14, we introduced an issue where merging the results from multiple nLists can somehow produce multiple identical results in the search output in the faiss internals. We never relied on OpenMP during search since we have disabled the parallel mode, but in the PR https://github.com/facebookresearch/faiss/pull/5000 they do that regardless of the parallel mode when some conditions are met.
That makes the benchmarking fail since ann-benchmark aborts in those cases. The reason why this happens for us but not on faiss might be related to how we build OpenMP. I see that using libgomp is not the smartest, since I think all the pragmas `omp_num_max_threads` are not working properly and we are using the OpenMP interface. I confirmed that the issue does not happen once I set `OMP_NUM_THREADS=1`.


- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
