### PR TITLE
Adds clang-tidy to the build-image.

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -25,7 +25,7 @@ parameters:
     default: ""
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-98e896176"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
     description: "Docker image to use for building ArangoDB - only relevant when trying new build images"
   test-docker-image:
     type: string

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -206,7 +206,7 @@ parameters:
     description: "Nightly date (YYYYMMDD), pinned once by the setup config so all jobs derive the same version even when the workflow runs across midnight. Cannot be set at trigger time (the setup config does not declare it)."
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-98e896176"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
     description: "Ubuntu build image (compiler toolchain + packaging/scan tools) the compile, packaging, scan, and sign jobs run in. The tag is bumped automatically by the infrastructure pipeline's build-image rebuild; override only to try a new build image."
   build-debian-packages:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ parameters:
     description: "Docker image to use for testing ArangoDB - only relevant when trying new test images"
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-98e896176"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
     description: "Docker image to use for building ArangoDB - only relevant when trying new build images"
   # Rarely used options
   replication-two:

--- a/.circleci/nightly_packages.yml
+++ b/.circleci/nightly_packages.yml
@@ -36,7 +36,7 @@ parameters:
     description: "Enterprise repo branch to use. Defaults to the same branch as arangodb, falling back to devel."
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-98e896176"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
     description: "Ubuntu build image (compiler toolchain + packaging/scan tools) the compile, packaging, scan, and sign jobs run in. The tag is bumped automatically by the infrastructure pipeline's build-image rebuild; override only to try a new build image."
   build-debian-packages:
     type: boolean

--- a/scripts/docker/build/linux/Dockerfile.x86-64
+++ b/scripts/docker/build/linux/Dockerfile.x86-64
@@ -65,11 +65,15 @@ RUN apt-get update --fix-missing && \
   apt-get build-dep -y llvm-${CLANG_VERSION}-dev && \
   apt-get update --fix-missing && \
   apt-get install -y clang-${CLANG_VERSION} clang++-${CLANG_VERSION} && \
+  apt-get install -y clang-tidy-${CLANG_VERSION} && \
   rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 COPY patches/diff_llvm.patch .
 
 RUN ln -s $(echo llvm-toolchain-${CLANG_VERSION}-*) /llvm-toolchain-${CLANG_VERSION}
+
+RUN ln -s $(which clang-tidy-${CLANG_VERSION}) /usr/local/bin/clang-tidy
+RUN ln -s $(which run-clang-tidy-${CLANG_VERSION}.py) /usr/local/bin/run-clang-tidy.py
 
 WORKDIR /llvm-toolchain-${CLANG_VERSION}
 

--- a/scripts/docker/build/linux/amd64-build-tag.txt
+++ b/scripts/docker/build/linux/amd64-build-tag.txt
@@ -1,1 +1,1 @@
-public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-98e896176
+public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc


### PR DESCRIPTION
### Scope & Purpose

we want to make clang-tidy part of the CI-pipeline, we need it in the build-image. For now we start with x86 only. 

- [x] :pizza: New feature

