### PR TITLE
COR-967 | Make UI usable in RBAC mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 3.12.12 (XXXX-XX-XX)
 --------------------
 
+* COR-967: Fixed the web UI in RBAC mode, where the classic permission API is
+  rejected.
+
 * COR-837 & COR-838 Fix a bug where deactivated users where still able to renew their token.
 
 * Vector index `factory` strings are now validated on index creation instead

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
@@ -1160,6 +1160,24 @@
       });
     },
 
+    // RBAC mode rejects the classic access-level probes. Grants there are per
+    // action and resource name, so nothing is disabled upfront; the server
+    // answers each write.
+    isRbacRejection: function (xhr) {
+      if (xhr.status !== 403) {
+        return false;
+      }
+      var body = xhr.responseJSON;
+      if (!body) {
+        try {
+          body = JSON.parse(xhr.responseText);
+        } catch (e) {
+          body = {};
+        }
+      }
+      return body.errorMessage === 'Not allowed in RBAC mode.';
+    },
+
     checkCollectionPermissions: function (collectionID, roCallback) {
       var url = arangoHelper.databaseUrl('/_api/user/' +
         encodeURIComponent(window.App.userCollection.activeUser || "root") +
@@ -1177,6 +1195,9 @@
           }
         },
         error: function (data) {
+          if (arangoHelper.isRbacRejection(data)) {
+            return;
+          }
           arangoHelper.arangoError('User', 'Could not fetch collection permissions.');
         }
       });
@@ -1215,7 +1236,13 @@
           }
         },
         error: function (data) {
-          arangoHelper.arangoError('User', 'Could not fetch collection permissions.');
+          if (arangoHelper.isRbacRejection(data)) {
+            if (rwCallback) {
+              rwCallback(false);
+            }
+            return;
+          }
+          arangoHelper.arangoError('User', 'Could not fetch database permissions.');
           if (errorCallback) {
             errorCallback(data);
           }

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/arango/arango.js
@@ -1160,10 +1160,14 @@
       });
     },
 
-    // RBAC mode rejects the classic access-level probes. Grants there are per
-    // action and resource name, so nothing is disabled upfront; the server
-    // answers each write.
-    isRbacRejection: function (xhr) {
+    // arangod's generic forbidden error number.
+    ERROR_FORBIDDEN: 11,
+
+    // The access-level probes ask about the current user, which classic mode
+    // always allows. A forbidden answer therefore only happens in RBAC mode,
+    // where grants are per action and resource name and cannot be known
+    // upfront; callers show everything and let the server answer each write.
+    isOwnAccessLevelForbidden: function (xhr) {
       if (xhr.status !== 403) {
         return false;
       }
@@ -1175,7 +1179,7 @@
           body = {};
         }
       }
-      return body.errorMessage === 'Not allowed in RBAC mode.';
+      return body.errorNum === arangoHelper.ERROR_FORBIDDEN;
     },
 
     checkCollectionPermissions: function (collectionID, roCallback) {
@@ -1195,7 +1199,7 @@
           }
         },
         error: function (data) {
-          if (arangoHelper.isRbacRejection(data)) {
+          if (arangoHelper.isOwnAccessLevelForbidden(data)) {
             return;
           }
           arangoHelper.arangoError('User', 'Could not fetch collection permissions.');
@@ -1236,7 +1240,7 @@
           }
         },
         error: function (data) {
-          if (arangoHelper.isRbacRejection(data)) {
+          if (arangoHelper.isOwnAccessLevelForbidden(data)) {
             if (rwCallback) {
               rwCallback(false);
             }

--- a/js/apps/system/_admin/aardvark/APP/frontend/js/views/loginView.js
+++ b/js/apps/system/_admin/aardvark/APP/frontend/js/views/loginView.js
@@ -65,17 +65,12 @@
 
         $.ajax({
           type: "GET",
-          url: user
-            ? arangoHelper.databaseUrl(`/_api/user/${encodeURIComponent(user)}/database`, '_system')
-            : arangoHelper.databaseUrl('/_api/database/user'),
+          // /_api/user/<user>/database is rejected in RBAC mode;
+          // /_api/database/user lists the caller's databases in both modes.
+          url: arangoHelper.databaseUrl('/_api/database/user'),
           success: (permissions) => {
-            let dbs = permissions.result;
-            if (user) {
-              // key, value tuples of database name and permission
-              dbs = Object.keys(dbs);
-            }
             // enable db select and login button
-            this.renderDatabasesDropdown(dbs);
+            this.renderDatabasesDropdown(permissions.result);
             this.renderDBS();
             $('.bodyWrapper').show();
           },
@@ -86,16 +81,6 @@
       }
 
       return this;
-    },
-
-    sortDatabases: function (obj) {
-      if (frontendConfig.authenticationEnabled) {
-        // key, value tuples of database name and permission
-        obj = Object.keys(obj);
-      } else {
-        // array contained only the database names
-      }
-      return _.sortBy(obj, (value) => value.toLowerCase());
     },
 
     clear: function () {
@@ -153,20 +138,13 @@
       // get list of allowed dbs
       $.ajax({
         type: "GET",
-        url: frontendConfig.authenticationEnabled
-          ? arangoHelper.databaseUrl(`/_api/user/${encodeURIComponent(username)}/database`, '_system')
-          : arangoHelper.databaseUrl('/_api/database/user'),
+        url: arangoHelper.databaseUrl('/_api/database/user'),
         success: (permissions) => {
           $('#loginForm').hide();
           $('.login-window #databases').show();
 
           // enable db select and login button
-          let dbs = permissions.result;
-          if (frontendConfig.authenticationEnabled) {
-            // key, value tuples of database name and permission
-            dbs = Object.keys(dbs);
-          }
-          this.renderDatabasesDropdown(dbs);
+          this.renderDatabasesDropdown(permissions.result);
           this.renderDBS();
         },
         error: () => {

--- a/js/apps/system/_admin/aardvark/APP/react/src/utils/arangoClient.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/utils/arangoClient.ts
@@ -29,9 +29,13 @@ export const getApiRouteForCurrentDB = () =>
 export const getAdminRouteForCurrentDB = () =>
   getRouteForDB(window.frontendConfig.db, "_admin");
 
-// The classic user-permission API answers this in RBAC mode, where grants
-// live in roles instead. Callers treat it as "unknown, show everything".
-export const isRbacRejection = (error: unknown) => {
-  const e = error as { code?: number; message?: string } | undefined;
-  return e?.code === 403 && e?.message === "Not allowed in RBAC mode.";
+// arangod's generic forbidden error number.
+const ERROR_FORBIDDEN = 11;
+
+// Classic mode always lets a user read their own access level, so a forbidden
+// answer to that probe only happens in RBAC mode, where grants live in roles.
+// Callers treat it as "unknown, show everything".
+export const isOwnAccessLevelForbidden = (error: unknown) => {
+  const e = error as { code?: number; errorNum?: number } | undefined;
+  return e?.code === 403 && e?.errorNum === ERROR_FORBIDDEN;
 };

--- a/js/apps/system/_admin/aardvark/APP/react/src/utils/arangoClient.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/utils/arangoClient.ts
@@ -28,3 +28,10 @@ export const getApiRouteForCurrentDB = () =>
   getRouteForDB(window.frontendConfig.db, "_api");
 export const getAdminRouteForCurrentDB = () =>
   getRouteForDB(window.frontendConfig.db, "_admin");
+
+// The classic user-permission API answers this in RBAC mode, where grants
+// live in roles instead. Callers treat it as "unknown, show everything".
+export const isRbacRejection = (error: unknown) => {
+  const e = error as { code?: number; message?: string } | undefined;
+  return e?.code === 403 && e?.message === "Not allowed in RBAC mode.";
+};

--- a/js/apps/system/_admin/aardvark/APP/react/src/utils/usePermissions.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/utils/usePermissions.ts
@@ -1,8 +1,8 @@
 import useSWR from "swr";
-import { getCurrentDB, isRbacRejection } from "./arangoClient";
+import { getCurrentDB, isOwnAccessLevelForbidden } from "./arangoClient";
 
-const usePermissions = () => {
-  const { data, error } = useSWR(
+const useOwnAccessLevel = () =>
+  useSWR(
     `/user/${window.arangoHelper.getCurrentJwtUsername()}/database/${
       window.frontendConfig.db
     }`,
@@ -12,7 +12,14 @@ const usePermissions = () => {
         { database: window.frontendConfig.db }
       )
   );
-  if (isRbacRejection(error)) {
+
+// Inferred from the probe above; the server exposes no RBAC flag.
+export const useInferredRbacMode = () =>
+  isOwnAccessLevelForbidden(useOwnAccessLevel().error);
+
+const usePermissions = () => {
+  const { data, error } = useOwnAccessLevel();
+  if (isOwnAccessLevelForbidden(error)) {
     return "rw";
   }
   return data || "none";

--- a/js/apps/system/_admin/aardvark/APP/react/src/utils/usePermissions.ts
+++ b/js/apps/system/_admin/aardvark/APP/react/src/utils/usePermissions.ts
@@ -1,8 +1,8 @@
 import useSWR from "swr";
-import { getCurrentDB } from "./arangoClient";
+import { getCurrentDB, isRbacRejection } from "./arangoClient";
 
 const usePermissions = () => {
-  const { data } = useSWR(
+  const { data, error } = useSWR(
     `/user/${window.arangoHelper.getCurrentJwtUsername()}/database/${
       window.frontendConfig.db
     }`,
@@ -12,6 +12,9 @@ const usePermissions = () => {
         { database: window.frontendConfig.db }
       )
   );
+  if (isRbacRejection(error)) {
+    return "rw";
+  }
   return data || "none";
 };
 

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/UserPermissionsTable.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/UserPermissionsTable.tsx
@@ -6,11 +6,8 @@ import {
   DatabaseTableType
 } from "./CollectionsPermissionsTable";
 import { SystemDatabaseWarningModal } from "./SystemDatabaseWarningModal";
-import {
-  useFetchDatabasePermissions,
-  useUsername
-} from "./useFetchDatabasePermissions";
-import { isRbacRejection } from "../../../utils/arangoClient";
+import { useUsername } from "./useFetchDatabasePermissions";
+import { useInferredRbacMode } from "../../../utils/usePermissions";
 import {
   UserPermissionsContextProvider,
   useUserPermissionsContext
@@ -32,9 +29,9 @@ const UserPermissionsTableInner = () => {
   }, [username]);
 
   const { isManagedUser, isRootUser } = tableInstance.options.meta as any;
-  const { error } = useFetchDatabasePermissions();
+  const inferredRbacMode = useInferredRbacMode();
 
-  if (isRbacRejection(error)) {
+  if (inferredRbacMode) {
     return (
       <Stack padding="4">
         <Alert status="info">

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/UserPermissionsTable.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/UserPermissionsTable.tsx
@@ -6,7 +6,11 @@ import {
   DatabaseTableType
 } from "./CollectionsPermissionsTable";
 import { SystemDatabaseWarningModal } from "./SystemDatabaseWarningModal";
-import { useUsername } from "./useFetchDatabasePermissions";
+import {
+  useFetchDatabasePermissions,
+  useUsername
+} from "./useFetchDatabasePermissions";
+import { isRbacRejection } from "../../../utils/arangoClient";
 import {
   UserPermissionsContextProvider,
   useUserPermissionsContext
@@ -28,6 +32,21 @@ const UserPermissionsTableInner = () => {
   }, [username]);
 
   const { isManagedUser, isRootUser } = tableInstance.options.meta as any;
+  const { error } = useFetchDatabasePermissions();
+
+  if (isRbacRejection(error)) {
+    return (
+      <Stack padding="4">
+        <Alert status="info">
+          <AlertIcon />
+          <AlertDescription>
+            Classic database permissions are not available in RBAC mode. Access
+            is granted through roles instead.
+          </AlertDescription>
+        </Alert>
+      </Stack>
+    );
+  }
 
   return (
     <Stack padding="4">

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/useFetchDatabasePermissions.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/useFetchDatabasePermissions.tsx
@@ -17,14 +17,19 @@ type FullDatabasePermissionsType = {
 
 export const useFetchDatabasePermissions = () => {
   const { username } = useUsername();
-  const { data, refetch } = useQuery({
+  const { data, refetch, error } = useQuery({
     queryKey: [username, "permissions"],
     queryFn: async () => {
       const url = `/_api/user/${username}/database`;
       const route = getRouteForCurrentDB(url);
       const data = await route.get({ full: "true" });
       return data.parsedBody.result as FullDatabasePermissionsType;
-    }
+    },
+    retry: false
   });
-  return { databasePermissions: data, refetchDatabasePermissions: refetch };
+  return {
+    databasePermissions: data,
+    refetchDatabasePermissions: refetch,
+    error
+  };
 };

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/useFetchDatabasePermissions.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/useFetchDatabasePermissions.tsx
@@ -1,5 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { getRouteForCurrentDB } from "../../../utils/arangoClient";
+import {
+  getRouteForCurrentDB,
+  isRbacRejection
+} from "../../../utils/arangoClient";
 
 export type PermissionType = "rw" | "ro" | "none" | "undefined";
 export const useUsername = () => {
@@ -25,7 +28,8 @@ export const useFetchDatabasePermissions = () => {
       const data = await route.get({ full: "true" });
       return data.parsedBody.result as FullDatabasePermissionsType;
     },
-    retry: false
+    // The RBAC rejection is final; retrying only delays the notice.
+    retry: (_count, error) => !isRbacRejection(error)
   });
   return {
     databasePermissions: data,

--- a/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/useFetchDatabasePermissions.tsx
+++ b/js/apps/system/_admin/aardvark/APP/react/src/views/users/viewUser/useFetchDatabasePermissions.tsx
@@ -1,8 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
-import {
-  getRouteForCurrentDB,
-  isRbacRejection
-} from "../../../utils/arangoClient";
+import { getRouteForCurrentDB } from "../../../utils/arangoClient";
+import { useInferredRbacMode } from "../../../utils/usePermissions";
 
 export type PermissionType = "rw" | "ro" | "none" | "undefined";
 export const useUsername = () => {
@@ -20,20 +18,17 @@ type FullDatabasePermissionsType = {
 
 export const useFetchDatabasePermissions = () => {
   const { username } = useUsername();
-  const { data, refetch, error } = useQuery({
+  const inferredRbacMode = useInferredRbacMode();
+  const { data, refetch } = useQuery({
     queryKey: [username, "permissions"],
+    // Classic grants have no data source in RBAC mode.
+    enabled: !inferredRbacMode,
     queryFn: async () => {
       const url = `/_api/user/${username}/database`;
       const route = getRouteForCurrentDB(url);
       const data = await route.get({ full: "true" });
       return data.parsedBody.result as FullDatabasePermissionsType;
-    },
-    // The RBAC rejection is final; retrying only delays the notice.
-    retry: (_count, error) => !isRbacRejection(error)
+    }
   });
-  return {
-    databasePermissions: data,
-    refetchDatabasePermissions: refetch,
-    error
-  };
+  return { databasePermissions: data, refetchDatabasePermissions: refetch };
 };


### PR DESCRIPTION
### Scope & Purpose

- [X] :hankey: Bugfix

In RBAC mode the classic user-permission API answers `403 Not allowed in RBAC mode.`, which broke UI/aardvark for every user:

1. **Login database list**: now uses `/_api/database/user`, which works in both modes. Dead `sortDatabases` helper removed.
2. **Access-level probes** (`checkDatabasePermissions`, `checkCollectionPermissions`, `usePermissions`): on that 403 the navigation never rendered. As agreed on COR-967, RBAC grants cannot be pre-discovered, so the UI now treats the rejection as read-write and lets the server answer each write. On servers without RBAC the probe still returns `ro`/`rw` and the read-only UI is unchanged.
3. **Users > Permissions tab**: shows a notice on that 403 instead of an empty classic grants table.

Also applies without RBAC: the login endpoint switch, and the database-probe error toast now says "database" instead of "collection".

### Checklist

- [X] Tests
  - [X] manually tested against an RBAC-enabled cluster (3.12.11) as root and as a super-admin test user: sidebar, documents, indices, view editor, users, permissions tab
- [x] :book: CHANGELOG entry made

#### Related Information

- [X] GitHub issue / Jira ticket: [COR-967](https://arangodb.atlassian.net/browse/COR-967), [AIS-2082](https://arangodb.atlassian.net/browse/AIS-2082)


[COR-967]: https://arangodb.atlassian.net/browse/COR-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ