### PR TITLE
Suppress TSAN error

### DIFF
--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -57,7 +57,9 @@ race:std::__exception_ptr
 # of the same character race on that byte but write the identical value, so
 # the race is benign (GCC bug 77704). Triggered e.g. by std::regex compilation
 # in faiss::index_factory running on several maintenance threads at once.
-race:std::ctype<char>::narrow
+# The CI symbolizer reports the inlined narrow() frame unqualified, so match
+# the regex scanner frame that calls it instead.
+race:std::__detail::_Scanner<char>::_M_scan_normal
 
 # TODO - this should be removed once BTS-685 is fixed
 race:AllowImplicitCollectionsSwitcher

--- a/tsan_arangodb_suppressions.txt
+++ b/tsan_arangodb_suppressions.txt
@@ -52,6 +52,13 @@ deadlock:replication2::replicated_state::ReplicatedStateManager
 # drop to zero.
 race:std::__exception_ptr
 
+# std::ctype<char>::narrow lazily fills a per-facet cache (_M_narrow[]) on the
+# global classic locale without synchronization. Concurrent first-time lookups
+# of the same character race on that byte but write the identical value, so
+# the race is benign (GCC bug 77704). Triggered e.g. by std::regex compilation
+# in faiss::index_factory running on several maintenance threads at once.
+race:std::ctype<char>::narrow
+
 # TODO - this should be removed once BTS-685 is fixed
 race:AllowImplicitCollectionsSwitcher
 race:graph::RefactoredTraverserCache::appendVertex


### PR DESCRIPTION
### Scope & Purpose

Suppresses the TSAN error introduced by https://github.com/arangodb/arangodb/pull/23239. This error happens in libstdc++ and is a known issue https://gcc.gnu.org/bugzilla/show_bug.cgi?id=77704.

```
  ****> "all" failed:
SUT was aborted: 
Report of 'arangod' in /tmp/ArangoDB/0/arangosh_MqWtLz/shell_client_aql_vector/dbserver_0/tsan.log.arangod.480 contains: 
==================
WARNING: ThreadSanitizer: data race (pid=480)
  Read of size 1 at 0xffffa4974b0b by thread T145:
    #0 narrow /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/locale_facets.h:941 (arangod+0x29e5750) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #1 std::__detail::_Scanner<char>::_M_scan_normal() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_scanner.tcc:100 (arangod+0x29e5750)
    #2 _M_advance /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_scanner.tcc:79 (arangod+0x29ea7d8) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #3 _M_match_token /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:575 (arangod+0x29ea7d8)
    #4 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_try_char() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:562 (arangod+0x29ea7d8)
    #5 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_atom() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:310 (arangod+0x29e7b04) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #6 _M_term /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:133 (arangod+0x29e6e78) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #7 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:115 (arangod+0x29e6e78)
    #8 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #9 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #10 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #11 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #12 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #13 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #14 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_disjunction() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:91 (arangod+0x29e3658) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #15 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_Compiler(char const*, char const*, std::locale const&, std::regex_constants::syntax_option_type) /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:76 (arangod+0x29e2a34) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #16 _M_compile /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex.h:809 (arangod+0x338405c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #17 std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char>>::basic_regex<std::char_traits<char>, std::allocator<char>>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::regex_constants::syntax_option_type) /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex.h:522 (arangod+0x338405c)
    #18 faiss::(anonymous namespace)::re_match(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::match_results<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>>&) /root/project/3rdParty/faiss/faiss/index_factory.cpp:85 (arangod+0x7aa3e70) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #19 faiss::(anonymous namespace)::index_factory_sub(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, faiss::MetricType, bool) /root/project/3rdParty/faiss/faiss/index_factory.cpp:946 (arangod+0x7a9e4c0) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #20 faiss::index_factory(int, char const*, faiss::MetricType, bool) /root/project/3rdParty/faiss/faiss/index_factory.cpp:1202 (arangod+0x7a9e338) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #21 arangodb::vector::createIvfIndexFromFactory(arangodb::vector::UserDefinition const&, unsigned long) /root/project/arangod/VectorIndex/FaissFactory.cpp:47 (arangod+0x3390308) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #22 arangodb::vector::validateFactoryString(arangodb::vector::UserDefinition const&) /root/project/arangod/VectorIndex/FaissFactory.cpp:81 (arangod+0x3390b9c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #23 arangodb::IndexFactory::enhanceJsonIndexVector(arangodb::velocypack::Slice, arangodb::velocypack::Builder&, bool) /root/project/arangod/Indexes/IndexFactory.cpp:942 (arangod+0x338303c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #24 (anonymous namespace)::VectorIndexFactory::normalize(arangodb::velocypack::Builder&, arangodb::velocypack::Slice, bool, arangodb::Database const&) const /root/project/arangod/RocksDBEngine/RocksDBIndexFactory.cpp:382 (arangod+0x4d949a4) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #25 arangodb::IndexFactory::enhanceIndexDefinition(arangodb::velocypack::Slice, arangodb::velocypack::Builder&, bool, arangodb::Database const&) const /root/project/arangod/Indexes/IndexFactory.cpp:324 (arangod+0x337e48c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #26 arangodb::methods::Indexes::ensureIndex(arangodb::LogicalCollection&, arangodb::velocypack::Slice, bool, arangodb::velocypack::Builder&, std::shared_ptr<std::function<arangodb::Result (double)>>, fu2::abi_400::detail::function<fu2::abi_400::detail::config<true, false, fu2::capacity_default>, fu2::abi_400::detail::property<true, false, arangodb::futures::Future<arangodb::ResultT<arangodb::replication2::LogIndex>> ()>>) /root/project/arangod/VocBase/Methods/Indexes.cpp:506 (arangod+0x358d328) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #27 operator() /root/project/arangod/Cluster/EnsureIndex.cpp:176 (arangod+0x29bbef0) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #28 __invoke_impl<arangodb::Result, (lambda at /root/project/arangod/Cluster/EnsureIndex.cpp:168:28)> /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61 (arangod+0x29bbef0)
    #29 __invoke<(lambda at /root/project/arangod/Cluster/EnsureIndex.cpp:168:28)> /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96 (arangod+0x29bbef0)
    #30 invoke<(lambda at /root/project/arangod/Cluster/EnsureIndex.cpp:168:28)> /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/functional:113 (arangod+0x29bbef0)
    #31 arangodb::maintenance::EnsureIndex::first() /root/project/arangod/Cluster/EnsureIndex.cpp:168 (arangod+0x29bbef0)
    #32 arangodb::maintenance::Action::first() /root/project/arangod/Cluster/Action.cpp:157 (arangod+0x29aabc8) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #33 arangodb::maintenance::MaintenanceWorker::run() /root/project/arangod/Cluster/MaintenanceWorker.cpp:83 (arangod+0x29c1fac) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #34 arangodb::BasicThread::runMe() /root/project/lib/Basics/BasicThread.cpp:329 (arangod+0x8a1cb68) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #35 arangodb::BasicThread::startThread(void*) /root/project/lib/Basics/BasicThread.cpp:136 (arangod+0x8a1c784) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #36 ThreadStarter(void*) /root/project/lib/Basics/threads-posix.cpp:77 (arangod+0x8a5f59c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)

  Previous write of size 1 at 0xffffa4974b0b by thread T146:
    #0 narrow /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/locale_facets.h:945 (arangod+0x29e58d4) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #1 std::__detail::_Scanner<char>::_M_scan_normal() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_scanner.tcc:100 (arangod+0x29e58d4)
    #2 _M_advance /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_scanner.tcc:79 (arangod+0x29ea7d8) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #3 _M_match_token /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:575 (arangod+0x29ea7d8)
    #4 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_try_char() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:562 (arangod+0x29ea7d8)
    #5 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_atom() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:310 (arangod+0x29e7b04) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #6 _M_term /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:133 (arangod+0x29e6e78) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #7 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:115 (arangod+0x29e6e78)
    #8 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #9 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #10 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #11 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #12 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #13 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_alternative() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:118 (arangod+0x29e6f48) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #14 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_M_disjunction() /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:91 (arangod+0x29e3658) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #15 std::__detail::_Compiler<std::__cxx11::regex_traits<char>>::_Compiler(char const*, char const*, std::locale const&, std::regex_constants::syntax_option_type) /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex_compiler.tcc:76 (arangod+0x29e2a34) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #16 _M_compile /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex.h:809 (arangod+0x338405c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #17 std::__cxx11::basic_regex<char, std::__cxx11::regex_traits<char>>::basic_regex<std::char_traits<char>, std::allocator<char>>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::regex_constants::syntax_option_type) /usr/lib/gcc/aarch64-linux-gnu/13/../../../../include/c++/13/bits/regex.h:522 (arangod+0x338405c)
    #18 faiss::(anonymous namespace)::re_match(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::__cxx11::match_results<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::__cxx11::sub_match<__gnu_cxx::__normal_iterator<char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>>>>&) /root/project/3rdParty/faiss/faiss/index_factory.cpp:85 (arangod+0x7aa3e70) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #19 faiss::(anonymous namespace)::index_factory_sub(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, faiss::MetricType, bool) /root/project/3rdParty/faiss/faiss/index_factory.cpp:946 (arangod+0x7a9e4c0) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #20 faiss::index_factory(int, char const*, faiss::MetricType, bool) /root/project/3rdParty/faiss/faiss/index_factory.cpp:1202 (arangod+0x7a9e338) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #21 arangodb::vector::createIvfIndexFromFactory(arangodb::vector::UserDefinition const&, unsigned long) /root/project/arangod/VectorIndex/FaissFactory.cpp:47 (arangod+0x3390308) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #22 arangodb::vector::validateFactoryString(arangodb::vector::UserDefinition const&) /root/project/arangod/VectorIndex/FaissFactory.cpp:81 (arangod+0x3390b9c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #23 arangodb::IndexFactory::enhanceJsonIndexVector(arangodb::velocypack::Slice, arangodb::velocypack::Builder&, bool) /root/project/arangod/Indexes/IndexFactory.cpp:942 (arangod+0x338303c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #24 (anonymous namespace)::VectorIndexFactory::normalize(arangodb::velocypack::Builder&, arangodb::velocypack::Slice, bool, arangodb::Database const&) const /root/project/arangod/RocksDBEngine/RocksDBIndexFactory.cpp:382 (arangod+0x4d949a4) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
    #25 arangodb::IndexFactory::enhanceIndexDefinition(arangodb::velocypack::Slice, arangodb::velocypack::Builder&, bool, arangodb::Database const&) const /root/project/arangod/Indexes/IndexFactory.cpp:324 (arangod+0x337e48c) (BuildId: 030aa86a4ef0056481c2463b921cb4ad22151f42)
```

- [x] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [ ] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
