### PR TITLE
Install clang-tidy in the build-image, this time for real.

### DIFF
--- a/.circleci/base_config.yml
+++ b/.circleci/base_config.yml
@@ -25,7 +25,7 @@ parameters:
     default: ""
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-554085737"
     description: "Docker image to use for building ArangoDB - only relevant when trying new build images"
   test-docker-image:
     type: string

--- a/.circleci/base_nightly_packages.yml
+++ b/.circleci/base_nightly_packages.yml
@@ -206,7 +206,7 @@ parameters:
     description: "Nightly date (YYYYMMDD), pinned once by the setup config so all jobs derive the same version even when the workflow runs across midnight. Cannot be set at trigger time (the setup config does not declare it)."
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-554085737"
     description: "Ubuntu build image (compiler toolchain + packaging/scan tools) the compile, packaging, scan, and sign jobs run in. The tag is bumped automatically by the infrastructure pipeline's build-image rebuild; override only to try a new build image."
   build-debian-packages:
     type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ parameters:
     description: "Docker image to use for testing ArangoDB - only relevant when trying new test images"
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-554085737"
     description: "Docker image to use for building ArangoDB - only relevant when trying new build images"
   # Rarely used options
   replication-two:

--- a/.circleci/nightly_packages.yml
+++ b/.circleci/nightly_packages.yml
@@ -36,7 +36,7 @@ parameters:
     description: "Enterprise repo branch to use. Defaults to the same branch as arangodb, falling back to devel."
   build-docker-image:
     type: string
-    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc"
+    default: "public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-554085737"
     description: "Ubuntu build image (compiler toolchain + packaging/scan tools) the compile, packaging, scan, and sign jobs run in. The tag is bumped automatically by the infrastructure pipeline's build-image rebuild; override only to try a new build image."
   build-debian-packages:
     type: boolean

--- a/scripts/docker/build/linux/Dockerfile.x86-64
+++ b/scripts/docker/build/linux/Dockerfile.x86-64
@@ -135,7 +135,7 @@ RUN apt-get update --fix-missing && \
   apt-get install -y gcc-${COMPILER_VERSION} g++-${COMPILER_VERSION} \
     clang-${CLANG_VERSION} lldb-${CLANG_VERSION} lld-${CLANG_VERSION} \
     libc++-${CLANG_VERSION}-dev libc++abi-${CLANG_VERSION}-dev libclang-common-${CLANG_VERSION}-dev \
-    libclang-rt-${CLANG_VERSION}-dev libomp-${CLANG_VERSION}-dev findutils && clang-tidy-${CLANG_VERSION} && \
+    libclang-rt-${CLANG_VERSION}-dev libomp-${CLANG_VERSION}-dev findutils clang-tidy-${CLANG_VERSION} && \
   rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 # make clang-tidy-VERSION available as clang-tidy standalone

--- a/scripts/docker/build/linux/Dockerfile.x86-64
+++ b/scripts/docker/build/linux/Dockerfile.x86-64
@@ -65,15 +65,11 @@ RUN apt-get update --fix-missing && \
   apt-get build-dep -y llvm-${CLANG_VERSION}-dev && \
   apt-get update --fix-missing && \
   apt-get install -y clang-${CLANG_VERSION} clang++-${CLANG_VERSION} && \
-  apt-get install -y clang-tidy-${CLANG_VERSION} && \
   rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 COPY patches/diff_llvm.patch .
 
 RUN ln -s $(echo llvm-toolchain-${CLANG_VERSION}-*) /llvm-toolchain-${CLANG_VERSION}
-
-RUN ln -s $(which clang-tidy-${CLANG_VERSION}) /usr/local/bin/clang-tidy
-RUN ln -s $(which run-clang-tidy-${CLANG_VERSION}.py) /usr/local/bin/run-clang-tidy.py
 
 WORKDIR /llvm-toolchain-${CLANG_VERSION}
 
@@ -139,8 +135,12 @@ RUN apt-get update --fix-missing && \
   apt-get install -y gcc-${COMPILER_VERSION} g++-${COMPILER_VERSION} \
     clang-${CLANG_VERSION} lldb-${CLANG_VERSION} lld-${CLANG_VERSION} \
     libc++-${CLANG_VERSION}-dev libc++abi-${CLANG_VERSION}-dev libclang-common-${CLANG_VERSION}-dev \
-    libclang-rt-${CLANG_VERSION}-dev libomp-${CLANG_VERSION}-dev findutils && \
+    libclang-rt-${CLANG_VERSION}-dev libomp-${CLANG_VERSION}-dev findutils && clang-tidy-${CLANG_VERSION} && \
   rm -rf /var/cache/apt/archives /var/lib/apt/lists
+
+# make clang-tidy-VERSION available as clang-tidy standalone
+RUN ln -s $(which clang-tidy-${CLANG_VERSION}) /usr/local/bin/clang-tidy
+RUN ln -s $(which run-clang-tidy-${CLANG_VERSION}.py) /usr/local/bin/run-clang-tidy.py
 
 # sccache for cloud compiler cache:
 

--- a/scripts/docker/build/linux/amd64-build-tag.txt
+++ b/scripts/docker/build/linux/amd64-build-tag.txt
@@ -1,1 +1,1 @@
-public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-4d87ba6dc
+public.ecr.aws/b0b8h2r4/arangodb/ubuntubuildarangodb-312:24.04-554085737


### PR DESCRIPTION
### Scope & Purpose

Made a mistake  and added clang-tidy to the wrong step.