### PR TITLE
Update FAISS to v1.15.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 3.12.12 (XXXX-XX-XX)
 --------------------
 
+* Update FAISS to v1.15.0.
+
 * Rebuilt included rclone v1.75.0 with go1.26.8 and non-vulnerable
   dependencies.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,7 @@
 3.12.12 (XXXX-XX-XX)
 --------------------
 
-* Update FAISS to v1.15.0.
+* Update FAISS to v1.15.0 patched with alubsan fix.
 
 * Rebuilt included rclone v1.75.0 with go1.26.8 and non-vulnerable
   dependencies.

--- a/LICENSES-OTHER-COMPONENTS.md
+++ b/LICENSES-OTHER-COMPONENTS.md
@@ -68,9 +68,9 @@ _Enterprise Edition only_
 ### faiss
 
 * Name: faiss
-* Version: 1.14.2
-* Date: 2026-05-22
-* Project Home:https://github.com/facebookresearch/faiss/
+* Version: 1.15.0
+* Date: 2026-08-03
+* Project Home:https://github.com/facebookresearch/faiss
 * License: https://github.com/facebookresearch/faiss/blob/main/LICENSE
 * License Name: MIT License
 * License Id: MIT


### PR DESCRIPTION
### Scope & Purpose

Update faiss to v1.15.0, but with the alubsan patch applied on the branch https://github.com/arangodb/faiss/tree/release/v1.15.0-patched

- [ ] :hankey: Bugfix
- [ ] :pizza: New feature
- [ ] :fire: Performance improvement
- [ ] :hammer: Refactoring/simplification

### Checklist

- [ ] Tests
  - [ ] **Regression tests**
  - [ ] C++ **Unit tests**
  - [ ] **integration tests**
  - [ ] **resilience tests**
- [x] :book: CHANGELOG entry made
- [ ] :books: documentation written (release notes, API changes, ...)
- [ ] Backports
  - [ ] Backport for 3.12.0: *(Please link PR)*
  - [ ] Backport for 3.11: *(Please link PR)*
  - [ ] Backport for 3.10: *(Please link PR)*

#### Related Information

*(Please reference tickets / specification / other PRs etc)*

- [ ] Docs PR: 
- [ ] Enterprise PR:
- [ ] GitHub issue / Jira ticket:
- [ ] Design document: 
