### PR TITLE
[cor-915] returnNew/returnOld are stored as document attributes in the _to_ shadow collection of a non-disjoint SmartGraph

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 3.12.12 (XXXX-XX-XX)
 --------------------
+* COR-915: returnNew/returnOld are stored as document attributes in the _to_ shadow 
+  collection of a non-disjoint SmartGraph.
+  Fix remote SmartGraph edge modifications so returnNew/returnOld response
+  data is not persisted in the _to shadow collection.
 
 * Rebuilt included rclone v1.75.0 with go1.26.8 and non-vulnerable
   dependencies.


### PR DESCRIPTION
Problem:
On a non-disjoint SmartGraph, inserting or updating a remote edge with returnNew or returnOld writes those response fields into the stored document in the to shadow collection. The from copy stays clean, so the two halves of the same edge end up with different attributes. No error is reported and the operation succeeds.

Root cause:
In enterprise/Enterprise/Transaction/MethodsEE.cpp, buildMirrorRequest() uses the from operation result to build the write request for the to shadow copy. As a result, response-only fields such as new, old, and _oldRev can unintentionally be copied into the to document.

Fix:
Updated buildMirrorRequest() to remove new, old, and _oldRev from the from result before merging it into the to request. Only the required identity and revision information is forwarded to the to shadow document.

Enterprise PR: https://github.com/arangodb/enterprise/pull/1708